### PR TITLE
T716: allow only alphanumerical chars, underscore and hyphen

### DIFF
--- a/interface-definitions/snmp.xml
+++ b/interface-definitions/snmp.xml
@@ -13,9 +13,9 @@
             <properties>
               <help>Community name [REQUIRED]</help>
               <constraint>
-                <regex>^[^%]+$</regex>
+                <regex>^[a-zA-Z0-9\-_]{1,100}</regex>
               </constraint>
-              <constraintErrorMessage>Community string may not contain '%'</constraintErrorMessage>
+              <constraintErrorMessage>Community string is limited to alphanumerical characters only with a total lenght of 100</constraintErrorMessage>
             </properties>
             <children>
               <leafNode name="authorization">


### PR DESCRIPTION
T717, T716 - parent task: T253.
I set a regext to limit the snmp community string to alphanumerical chars only, plus hyphen and underscore and the entire string is limited to 100 chars in total. If the string is longer than 247 characters it breaks something in the parser, the snmp config is written with no issue and working too, but you wouldn't be able to delete it via cli.

This time I built the package rather than a file copy :).
Let me know what you think.

cheers
 