### PR TITLE
T253 limited all usernames to alphanumerical only

### DIFF
--- a/interface-definitions/snmp.xml
+++ b/interface-definitions/snmp.xml
@@ -13,7 +13,7 @@
             <properties>
               <help>Community name [REQUIRED]</help>
               <constraint>
-                <regex>^[a-zA-Z0-9\-_]{1,100}</regex>
+                <regex>^[a-zA-Z0-9]{1,100}</regex>
               </constraint>
               <constraintErrorMessage>Community string is limited to alphanumerical characters only with a total lenght of 100</constraintErrorMessage>
             </properties>
@@ -393,6 +393,10 @@
                   <leafNode name="user">
                     <properties>
                       <help>Defines username for authentication</help>
+                      <constraint>
+                        <regex>^[a-zA-Z0-9]{1,100}</regex>
+                      </constraint>
+                      <constraintErrorMessage>Illegal characters in usernamename</constraintErrorMessage>
                       <completionHelp>
                         <path>service snmp v3 user</path>
                       </completionHelp>
@@ -433,7 +437,7 @@
                 <properties>
                   <help>Specifies the user with name username</help>
                   <constraint>
-                    <regex>^[^\(\)\|\-]+$</regex>
+                    <regex>^[a-zA-Z0-9]{1,100}</regex>
                   </constraint>
                   <constraintErrorMessage>Illegal characters in name</constraintErrorMessage>
                 </properties>
@@ -491,6 +495,10 @@
                   <leafNode name="group">
                     <properties>
                       <help>Specifies group for user name</help>
+                      <constraint>
+                        <regex>^[a-zA-Z0-9]{1,100}</regex>
+                      </constraint>
+                      <constraintErrorMessage>Illegal characters in group</constraintErrorMessage>
                       <completionHelp>
                         <path>service snmp v3 group</path>
                       </completionHelp>

--- a/interface-definitions/ssh.xml
+++ b/interface-definitions/ssh.xml
@@ -21,12 +21,20 @@
                   <leafNode name="group">
                     <properties>
                       <help>Allow members of a group to login</help>
+                        <constraint>
+                          <regex>^[a-zA-Z0-9]{1,100}</regex>
+                        </constraint>
+                        <constraintErrorMessage>Input limited to 100 alphanumerical characters</constraintErrorMessage>
                       <multi/>
                     </properties>
                   </leafNode>
                   <leafNode name="user">
                     <properties>
                       <help>Allow specific users to login</help>
+                      <constraint>
+                        <regex>^[a-zA-Z0-9]{1,100}</regex>
+                      </constraint>
+                      <constraintErrorMessage>Input limited to 100 alphanumerical characters</constraintErrorMessage>
                       <multi/>
                     </properties>
                   </leafNode>
@@ -37,12 +45,20 @@
                   <leafNode name="group">
                     <properties>
                       <help>Disallow members of a group to login</help>
+                      <constraint>
+                        <regex>^[a-zA-Z0-9]{1,100}</regex>
+                      </constraint>
+                      <constraintErrorMessage>Input limited to 100 alphanumerical characters</constraintErrorMessage>
                       <multi/>
                     </properties>
                   </leafNode>
                   <leafNode name="user">
                     <properties>
                       <help>Disallow specific users to login</help>
+                      <constraint>
+                        <regex>^[a-zA-Z0-9]{1,100}</regex>
+                      </constraint>
+                      <constraintErrorMessage>Input limited to 100 alphanumerical characters</constraintErrorMessage>
                       <multi/>
                     </properties>
                   </leafNode>


### PR DESCRIPTION
Limited input to avoid issues with white-spaces as well as the parser has issues if the the string has more than 246 characters.