### PR TITLE
T720: filter is now the same like in useradd(8) including the debian …

### DIFF
--- a/interface-definitions/ssh.xml
+++ b/interface-definitions/ssh.xml
@@ -21,12 +21,20 @@
                   <leafNode name="group">
                     <properties>
                       <help>Allow members of a group to login</help>
+                        <constraint>
+                          <regex>^[a-z_][a-z0-9_-]{1,31}[$]?</regex>
+                        </constraint>
+                        <constraintErrorMessage>illegal characters or more than 32 characters</constraintErrorMessage>
                       <multi/>
                     </properties>
                   </leafNode>
                   <leafNode name="user">
                     <properties>
                       <help>Allow specific users to login</help>
+                      <constraint>
+                        <regex>^[a-z_][a-z0-9_-]{1,31}[$]?</regex>
+                      </constraint>
+                      <constraintErrorMessage>illegal characters or more than 32 characters</constraintErrorMessage>
                       <multi/>
                     </properties>
                   </leafNode>
@@ -37,12 +45,20 @@
                   <leafNode name="group">
                     <properties>
                       <help>Disallow members of a group to login</help>
+                      <constraint>
+                        <regex>^[a-z_][a-z0-9_-]{1,31}[$]?</regex>
+                      </constraint>
+                      <constraintErrorMessage>illegal characters or more than 32 characters</constraintErrorMessage>
                       <multi/>
                     </properties>
                   </leafNode>
                   <leafNode name="user">
                     <properties>
                       <help>Disallow specific users to login</help>
+                      <constraint>
+                        <regex>^[a-z_][a-z0-9_-]{1,31}[$]?</regex>
+                      </constraint>
+                      <constraintErrorMessage>illegal characters or more than 32 characters</constraintErrorMessage>
                       <multi/>
                     </properties>
                   </leafNode>


### PR DESCRIPTION
I'm going to focus on user name only, for the snmp community the restriction is 100 chars but I have a look into the parser and try to fix it there. For any group or user account, I'm going to implement the useradd(8) restrictions and the debian restrictions, unless you guys have a problem with that.