### PR TITLE
T733: snmp.py: set IPv6 community string

### DIFF
--- a/src/conf_mode/snmp.py
+++ b/src/conf_mode/snmp.py
@@ -148,6 +148,7 @@ agentaddress unix:/run/snmpd.socket{% if listen_on %}{% for li in listen_on %},{
 {% endfor %}
 {% else %}
 {{ c.authorization }}community {{ c.name }}
+{{ c.authorization }}community6 {{ c.name }}
 {% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Gah. Ok. Last fix was a half-arsed job, apparently. New fix - 

Also fixed it to correctly set an IPv6 community string, even if you don't specify the network it's working on.