### PR TITLE
T689: Rewritten poweroff/reboot script to use systemd-shutdownd service

### DIFF
--- a/op-mode-definitions/poweroff.xml
+++ b/op-mode-definitions/poweroff.xml
@@ -16,31 +16,41 @@
 
       <leafNode name="cancel">
         <properties>
-          <help>Cancel a pending reboot</help>
+          <help>Cancel a pending poweroff</help>
         </properties>
         <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --cancel</command>
       </leafNode>
 
     <tagNode name="in">
       <properties>
-        <help>Reboot in X minutes</help>
+        <help>Poweroff in X minutes</help>
         <completionHelp>
-          <list>Minutes</list>
+          <list>&lt;Minutes&gt;</list>
         </completionHelp>
       </properties>
-      <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --poweroff '$3'</command>
+      <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --poweroff $3 $4</command>
 
     </tagNode>
 
     <tagNode name="at">
       <properties>
-        <help>Reboot at a specific time</help>
+        <help>Poweroff at a specific time</help>
         <completionHelp>
           <list>HH:MM</list>
         </completionHelp>
       </properties>
-      <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --poweroff '$3'</command>
-
+      <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --poweroff $3</command>
+      <children>
+        <tagNode name="date">
+          <properties>
+            <help>Poweroff at a specific date</help>
+            <completionHelp>
+              <list>&lt;DDMMYYYY&gt; &lt;DD/MM/YYYY&gt; &lt;DD.MM.YYYY&gt; &lt;DD:MM:YYYY&gt;</list>
+            </completionHelp>
+          </properties>
+          <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --poweroff $3 $5</command>
+        </tagNode>
+      </children>
     </tagNode>
 
     </children>

--- a/op-mode-definitions/poweroff.xml
+++ b/op-mode-definitions/poweroff.xml
@@ -36,7 +36,7 @@
       <properties>
         <help>Poweroff at a specific time</help>
         <completionHelp>
-          <list>HH:MM</list>
+          <list>&lt;HH:MM&gt;</list>
         </completionHelp>
       </properties>
       <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --poweroff $3</command>

--- a/op-mode-definitions/poweroff.xml
+++ b/op-mode-definitions/poweroff.xml
@@ -2,14 +2,14 @@
 <interfaceDefinition>
   <node name="poweroff">
     <properties>
-      <help>Shutdown the system</help>
+      <help>Poweroff the system</help>
     </properties>
     <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --poweroff now</command>
 
     <children>
       <leafNode name="now">
         <properties>
-          <help>Shutdown the system imidiently</help>
+          <help>Poweroff the system without confirmation</help>
         </properties>
         <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --poweroff now</command>
       </leafNode>

--- a/op-mode-definitions/poweroff.xml
+++ b/op-mode-definitions/poweroff.xml
@@ -2,37 +2,45 @@
 <interfaceDefinition>
   <node name="poweroff">
     <properties>
-      <help>Poweroff the system</help>
+      <help>Shutdown the system</help>
     </properties>
-    <command>/opt/vyatta/bin/sudo-users/vyatta-poweroff.pl --action poweroff</command>
+    <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --poweroff now</command>
+
     <children>
       <leafNode name="now">
         <properties>
-          <help>Poweroff the system without confirmation</help>
+          <help>Shutdown the system imidiently</help>
         </properties>
-        <command>/opt/vyatta/bin/sudo-users/vyatta-poweroff.pl --action poweroff --now</command>
-      </leafNode>
-      
-      <leafNode name="cancel">
-        <properties>
-          <help>Cancel a pending poweroff</help>
-        </properties>
-        <command>/opt/vyatta/bin/sudo-users/vyatta-poweroff.pl --action poweroff_cancel</command>
+        <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --poweroff now</command>
       </leafNode>
 
+      <leafNode name="cancel">
+        <properties>
+          <help>Cancel a pending reboot</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --cancel</command>
+      </leafNode>
+
+    <tagNode name="in">
+      <properties>
+        <help>Reboot in X minutes</help>
+        <completionHelp>
+          <list>Minutes</list>
+        </completionHelp>
+      </properties>
+      <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --poweroff '$3'</command>
+
+    </tagNode>
 
     <tagNode name="at">
       <properties>
-        <help>Poweroff at a specific time</help>
+        <help>Reboot at a specific time</help>
         <completionHelp>
           <list>HH:MM</list>
-          <list>MMDDYY</list>
-          <list>midnight</list>
-          <list>noon</list>
         </completionHelp>
       </properties>
-      <command>/opt/vyatta/bin/sudo-users/vyatta-poweroff.pl --action poweroff_at --at_time '$3'</command>
-      
+      <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --poweroff '$3'</command>
+
     </tagNode>
 
     </children>

--- a/op-mode-definitions/reboot.xml
+++ b/op-mode-definitions/reboot.xml
@@ -4,35 +4,43 @@
     <properties>
       <help>Reboot the system</help>
     </properties>
-    <command>/opt/vyatta/bin/sudo-users/vyatta-reboot.pl --action reboot</command>
+    <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --reboot now</command>
+
     <children>
       <leafNode name="now">
         <properties>
-          <help>Reboot the system without confirmation</help>
+          <help>Reboot the system imidiently</help>
         </properties>
-        <command>/opt/vyatta/bin/sudo-users/vyatta-reboot.pl --action reboot --now</command>
+        <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --reboot now</command>
       </leafNode>
-      
+
       <leafNode name="cancel">
         <properties>
           <help>Cancel a pending reboot</help>
         </properties>
-        <command>/opt/vyatta/bin/sudo-users/vyatta-reboot.pl --action reboot_cancel</command>
+        <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --cancel</command>
       </leafNode>
 
+    <tagNode name="in">
+      <properties>
+        <help>Reboot in X minutes</help>
+        <completionHelp>
+          <list>Minutes</list>
+        </completionHelp>
+      </properties>
+      <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --reboot $3</command>
+
+    </tagNode>
 
     <tagNode name="at">
       <properties>
         <help>Reboot at a specific time</help>
         <completionHelp>
           <list>HH:MM</list>
-          <list>MMDDYY</list>
-          <list>midnight</list>
-          <list>noon</list>
         </completionHelp>
       </properties>
-      <command>/opt/vyatta/bin/sudo-users/vyatta-reboot.pl --action reboot_at --at_time '$3'</command>
-      
+      <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --reboot $3</command>
+
     </tagNode>
 
     </children>

--- a/op-mode-definitions/reboot.xml
+++ b/op-mode-definitions/reboot.xml
@@ -36,7 +36,7 @@
       <properties>
         <help>Reboot at a specific time</help>
         <completionHelp>
-          <list>HH:MM</list>
+          <list>&lt;HH:MM&gt;</list>
         </completionHelp>
       </properties>
       <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --reboot $3</command>

--- a/op-mode-definitions/reboot.xml
+++ b/op-mode-definitions/reboot.xml
@@ -25,10 +25,10 @@
       <properties>
         <help>Reboot in X minutes</help>
         <completionHelp>
-          <list>Minutes</list>
+          <list>&lt;Minutes&gt;</list>
         </completionHelp>
       </properties>
-      <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --reboot $3</command>
+      <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --reboot $3 $4</command>
 
     </tagNode>
 
@@ -40,7 +40,17 @@
         </completionHelp>
       </properties>
       <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --reboot $3</command>
-
+      <children>
+        <tagNode name="date">
+          <properties>
+            <help>Reboot at a specific date</help>
+            <completionHelp>
+              <list>&lt;DDMMYYYY&gt; &lt;DD/MM/YYYY&gt; &lt;DD.MM.YYYY&gt; &lt;DD:MM:YYYY&gt;</list>
+            </completionHelp>
+          </properties>
+          <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --reboot $3 $5</command>
+        </tagNode>
+      </children>
     </tagNode>
 
     </children>

--- a/op-mode-definitions/reboot.xml
+++ b/op-mode-definitions/reboot.xml
@@ -9,7 +9,7 @@
     <children>
       <leafNode name="now">
         <properties>
-          <help>Reboot the system imidiently</help>
+          <help>Reboot the system without confirmation</help>
         </properties>
         <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --reboot now</command>
       </leafNode>

--- a/src/op_mode/powerctrl.py
+++ b/src/op_mode/powerctrl.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import os
+import sys
+import argparse
+from datetime import datetime, timedelta, time as type_time, date as type_date
+from subprocess import check_output,CalledProcessError,STDOUT
+import re
+
+def yn(msg, default=False):
+    default_msg = "[Y/n]" if default else "[y/N]"
+    while True:
+        sys.stdout.write("%s %s "  % (msg,default_msg))
+        c = input().lower()
+        if c == '':
+            return default
+        elif c in ("y", "ye","yes"):
+            return True
+        elif c in ("n", "no"):
+            return False
+        else:
+            sys.stdout.write("Please respond with yes/y or no/n\n")
+
+
+def valid_time(s):
+    try:
+        a = datetime.strptime(s, "%H:%M")
+        return True
+    except ValueError:
+        return False
+
+
+def check_shutdown():
+    try:
+        cmd = check_output(["/bin/systemctl","status","systemd-shutdownd.service"])
+        #Shutodwn is scheduled
+        r = re.findall(r'Status: \"(.*)\"\n', cmd.decode())[0]
+        print(r)
+    except CalledProcessError as e:
+        #Shutdown is not scheduled
+        print("Shutdown is not scheduled")
+
+def cancel_shutdown():
+    try:
+        cmd = check_output(["/sbin/shutdown","-c"])
+    except CalledProcessError as e:
+        sys.exit("Error aborting shutdown: %s" % e)
+
+def execute_shutdown(time, reboot = True, ask=True):
+    if not ask:
+        action = "reboot" if reboot else "poweroff"
+        if not yn("Are you sure you want to %s this system?" % action):
+            sys.exit(0)
+
+    if not (time.isdigit() or valid_time(time) or time.lower() == "now"):
+        sys.exit("minutes (45), valid time (12:34) or 'now' needs to be specified")
+
+    action = "-r" if reboot else "-P"
+    cmd = check_output(["/sbin/shutdown",action,time],stderr=STDOUT)
+
+    print(cmd.decode().split(",",1)[0])
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--yes", "-y",
+                        help="dont as for shutdown",
+                        action="store_true",
+                        dest="yes")
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument("--reboot", "-r",
+                        help="Reboot the system",
+                        nargs="?",
+                        metavar="Minutes|HH:MM")
+
+    action.add_argument("--poweroff", "-p",
+                        help="Poweroff the system",
+                        nargs="?",
+                        metavar="Minutes|HH:MM")
+
+    action.add_argument("--cancel", "-c",
+                        help="Cancel pending shutdown",
+                        action="store_true")
+
+    action.add_argument("--check",
+                        help="Check pending chutdown",
+                        action="store_true")
+    args = parser.parse_args()
+
+    try:
+        if args.reboot:
+            execute_shutdown(args.reboot, reboot=True, ask=args.yes)
+        if args.poweroff:
+            execute_shutdown(args.poweroff, reboot=False,ask=args.yes)
+        if args.cancel:
+            cancel_shutdown()
+        if args.check:
+            check_shutdown()
+    except KeyboardInterrupt:
+        sys.exit("Interrupted")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
After rewriting xml of poweroff/reboot script the perl script was not rewritten. 
I've rewritten it in python to make use of the systemd-shutdownd service instead of scheduling with AT.