### PR TITLE
T784: Added update dns dynamic operation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ op_mode_definitions:
 	# XXX: delete top level op mode node.def's that now live in other packages
 	rm -f $(OP_TMPL_DIR)/set/node.def
 	rm -f $(OP_TMPL_DIR)/show/node.def
-	rm -f $(OP_TMPL_DIR)/show/dns/node.def
 	rm -f $(OP_TMPL_DIR)/reset/node.def
 	rm -f $(OP_TMPL_DIR)/restart/node.def
 	rm -f $(OP_TMPL_DIR)/monitor/node.def

--- a/op-mode-definitions/dns-forwarding.xml
+++ b/op-mode-definitions/dns-forwarding.xml
@@ -4,6 +4,9 @@
   <node name="show">
     <children>
       <node name="dns">
+        <properties>
+          <help>Show DNS information</help>
+        </properties>
         <children>
           <node name="forwarding">
             <properties>

--- a/op-mode-definitions/dynamic-dns.xml
+++ b/op-mode-definitions/dynamic-dns.xml
@@ -4,6 +4,9 @@
   <node name="show">
     <children>
       <node name="dns">
+        <properties>
+          <help>Show DNS information</help>
+        </properties>
         <children>
           <node name="dynamic">
             <properties>
@@ -14,9 +17,29 @@
                 <properties>
                   <help>Show Dynamic DNS status</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/dynamic_dns_status.py</command>
+                <command>sudo ${vyos_op_scripts_dir}/dynamic_dns.py --status</command>
               </leafNode>
             </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+  <node name="update">
+    <properties>
+      <help>Update data for a service</help>
+    </properties>
+    <children>
+      <node name="dns">
+        <properties>
+          <help>Update DNS information</help>
+        </properties>
+        <children>
+          <node name="dynamic">
+            <properties>
+              <help>Update Dynamic DNS information</help>
+            </properties>
+            <command>sudo ${vyos_op_scripts_dir}/dynamic_dns.py --update</command>
           </node>
         </children>
       </node>

--- a/src/op_mode/dynamic_dns.py
+++ b/src/op_mode/dynamic_dns.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-
+import os
+import argparse
 import jinja2
 import sys
 import time
@@ -18,7 +19,8 @@ update-status: {{ entry.status }}
 {% endfor -%}
 """
 
-if __name__ == '__main__':
+
+def show_status():
     # Do nothing if service is not configured
     c = Config()
     if not c.exists_effective('service dns dynamic'):
@@ -65,3 +67,26 @@ if __name__ == '__main__':
 
     tmpl = jinja2.Template(OUT_TMPL_SRC)
     print(tmpl.render(data))
+
+
+def update_ddns():
+    os.system('systemctl stop ddclient')
+    os.remove(cache_file)
+    os.system('systemctl start ddclient')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--status", help="Show DDNS status", action="store_true")
+    group.add_argument("--update", help="Update DDNS on a given interface", action="store_true")
+    args = parser.parse_args()
+
+    if args.status:
+        show_status()
+    elif args.update:
+        update_ddns()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Notes:
1. `show dns` op subtree was missing due to Makefile exclusion and there is no corresponding node in the `vyatta-op` anymore, so the op was not visible/callable in the current rolling version. Thus the exclusion was removed
2. op-mode `dynamic_dns_status.py` script now has additional function to forcibly update the DDNS status, thus it was renamed to just `dynamic_dns.py`
3. The [original DDNS updater](https://github.com/vyos/vyatta-cfg-system/blob/9b469f3c5734c086fc30b097405ea46ec2cee725/scripts/dynamic-dns/vyatta-dynamic-dns.pl#L99) required a specific interface argument to update. It was possible due to multiple ddclient daemons running in multi-interface configurations. Currently multi-interface configurations run within a single daemon with a single cache file, thus making it impossible to selectively restart/wipe/update ddclients for specific interface.
4. Correspoing vyatta-op cleanup PR is [here](https://github.com/vyos/vyatta-op/pull/15)

Questions:
 - both [`systemd`](https://github.com/vyos/vyos-1x/blob/ce35b9830e538bce50b42272bb457201dfae102e/src/op_mode/powerctrl.py#L49) and [`init.d`](https://github.com/vyos/vyos-1x/blob/078b328685493e27c2ea48206b3f72a3a0c42e20/src/conf_mode/dynamic_dns.py#L246) calls are being used for service manipulations already. Should one be favoured for consistency (e.g. systemd)?

How this was tested?
 - manual tests were performed on version `1.2.0-rolling+201808171128`
 - `noip` service was setup:
```
service dns dynamic interface eth0 {
  service noip {
    host-name vyos-123.ddns.net
    login ****************
    password ****************
  }
}
```
 - checked the output of `show dns dynamic status`
 - run the `update dns dynamic`
 - checked the ddclient daemon logs to ensure the restart happened
 - checked the ddclient cache file time
 - checked the last update time at the `noip` admin web interface
