### PR TITLE
T786: Add tagNode value as a Env.variable passed into config script

### DIFF
--- a/scripts/build-command-templates
+++ b/scripts/build-command-templates
@@ -226,7 +226,10 @@ def make_node_def(props):
         node_def += "syntax:expression: {0}\n".format(props["constraint"])
 
     if "owner" in props:
-        node_def += "end: sudo sh -c \"{0}\"\n".format(props["owner"])
+        if "tag" in props:
+            node_def += "end: sudo sh -c \"VALUE='$VAR(@)' {0}\"\n".format(props["owner"])
+        else:
+            node_def += "end: sudo sh -c \"{0}\"\n".format(props["owner"])
 
     if debug:
         print("The contents of the node.def file:\n", node_def)


### PR DESCRIPTION
reference: https://phabricator.vyos.net/T786

Implemented passing tagNode value as a env.variable into the conf-mode script.