### PR TITLE
T689: Reboot/Poweroff now not working after last changes

### DIFF
--- a/op-mode-definitions/poweroff.xml
+++ b/op-mode-definitions/poweroff.xml
@@ -4,14 +4,14 @@
     <properties>
       <help>Poweroff the system</help>
     </properties>
-    <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --poweroff now</command>
+    <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --poweroff</command>
 
     <children>
       <leafNode name="now">
         <properties>
           <help>Poweroff the system without confirmation</help>
         </properties>
-        <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --poweroff now</command>
+        <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --poweroff</command>
       </leafNode>
 
       <leafNode name="cancel">

--- a/op-mode-definitions/reboot.xml
+++ b/op-mode-definitions/reboot.xml
@@ -4,14 +4,14 @@
     <properties>
       <help>Reboot the system</help>
     </properties>
-    <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --reboot now</command>
+    <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --reboot</command>
 
     <children>
       <leafNode name="now">
         <properties>
           <help>Reboot the system without confirmation</help>
         </properties>
-        <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --reboot now</command>
+        <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --reboot</command>
       </leafNode>
 
       <leafNode name="cancel">

--- a/src/op_mode/powerctrl.py
+++ b/src/op_mode/powerctrl.py
@@ -126,9 +126,9 @@ def main():
     args = parser.parse_args()
 
     try:
-        if args.reboot:
+        if  args.reboot is not None:
             execute_shutdown(args.reboot, reboot=True, ask=args.yes)
-        if args.poweroff:
+        if args.poweroff is not None:
             execute_shutdown(args.poweroff, reboot=False,ask=args.yes)
         if args.cancel:
             cancel_shutdown()


### PR DESCRIPTION
reboot/poweroff now  fails because python threats a empty list as False. and then the script doesn't match on the reboot/poweroff command. there is also a "typo" in xml "now" should not be the command.