### PR TITLE
T427, T783 minor bugfixes

### DIFF
--- a/interface-definitions/wireguard.xml
+++ b/interface-definitions/wireguard.xml
@@ -72,7 +72,7 @@
                 <properties>
                   <help>how often send keep alives in seconds</help>
                   <constraint>
-                    <regex>^(1|[1-9][0-9]{0,5})$</regex>
+                    <regex>^(1|[1-9][0-9]{1,5})$</regex>
                   </constraint>
                   <constraintErrorMessage>keepliave timer has to be between 1 and 99999 seconds</constraintErrorMessage>
                 </properties>

--- a/src/conf_mode/wireguard.py
+++ b/src/conf_mode/wireguard.py
@@ -209,13 +209,9 @@ def apply(c):
         if val_eff and not val:
           c['interfaces'][intf]['peer'][p]['persistent-keepalive'] = 0 
         
-        ### set ne keepalive value
+        ### set new keepalive value
         if not val_eff and val:
           c['interfaces'][intf]['peer'][p]['persistent-keepalive'] = val
-  
-        ## config == effective config, no change
-        if val_eff == val:
-          del c['interfaces'][intf]['peer'][p]['persistent-keepalive']
 
       ## wg command call
       configure_interface(c,intf)


### PR DESCRIPTION
- fixes the regex, now at least 1 digit is required to set (1 sec for instance)
- fixes an issue if persistent-keepalive isn't set and an update on the config is done, it would show a keyerror for it since it's not set in the config dict.