### PR TITLE
T790: wireguard: add status commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ op_mode_definitions:
 	# XXX: delete top level op mode node.def's that now live in other packages
 	rm -f $(OP_TMPL_DIR)/set/node.def
 	rm -f $(OP_TMPL_DIR)/show/node.def
-        rm -f $(TMPL_DIR)/interfaces/node.def
+	rm -f $(OP_TMPL_DIR)/show/interfaces/node.def
 	rm -f $(OP_TMPL_DIR)/reset/node.def
 	rm -f $(OP_TMPL_DIR)/restart/node.def
 	rm -f $(OP_TMPL_DIR)/monitor/node.def

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ clean:
 
 .PHONY: test
 test:
-#	PYTHONPATH=python/ python3 -m "nose" --with-xunit src --with-coverage --cover-erase --cover-xml --cover-package src/conf_mode,src/op_mode,src/completion,src/helpers,src/validators --verbose
+	PYTHONPATH=python/ python3 -m "nose" --with-xunit src --with-coverage --cover-erase --cover-xml --cover-package src/conf_mode,src/op_mode,src/completion,src/helpers,src/validators --verbose
 
 .PHONY: sonar
 sonar:

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ op_mode_definitions:
 	# XXX: delete top level op mode node.def's that now live in other packages
 	rm -f $(OP_TMPL_DIR)/set/node.def
 	rm -f $(OP_TMPL_DIR)/show/node.def
+        rm -f $(TMPL_DIR)/interfaces/node.def
 	rm -f $(OP_TMPL_DIR)/reset/node.def
 	rm -f $(OP_TMPL_DIR)/restart/node.def
 	rm -f $(OP_TMPL_DIR)/monitor/node.def
@@ -41,7 +42,7 @@ clean:
 
 .PHONY: test
 test:
-	PYTHONPATH=python/ python3 -m "nose" --with-xunit src --with-coverage --cover-erase --cover-xml --cover-package src/conf_mode,src/op_mode,src/completion,src/helpers,src/validators --verbose
+#	PYTHONPATH=python/ python3 -m "nose" --with-xunit src --with-coverage --cover-erase --cover-xml --cover-package src/conf_mode,src/op_mode,src/completion,src/helpers,src/validators --verbose
 
 .PHONY: sonar
 sonar:

--- a/op-mode-definitions/wireguard.xml
+++ b/op-mode-definitions/wireguard.xml
@@ -36,6 +36,40 @@
           </leafNode>
         </children>
       </node>
+      <node name="interfaces">
+        <children>
+          <tagNode name="wireguard">
+            <properties>
+              <help>show wireguard interface information</help>
+              <completionHelp>
+                <script>${vyos_completion_dir}/list_interfaces.py -t wireguard</script>
+              </completionHelp>
+            </properties>
+            <command>sudo wg show "$4"</command>
+            <children>
+              <leafNode name="allowed-ips">
+                <properties>
+                  <help>show all allowed-ips for the specified interface</help>
+                </properties>
+                <command>sudo wg show "$4" allowed-ips</command>
+              </leafNode>
+              <leafNode name="endpoints">
+                <properties>
+                  <help>show all endpoints for the specified interface</help>
+                </properties>
+                <command>sudo wg show "$4" endpoints</command>
+              </leafNode>
+              <leafNode name="peers">
+                <properties>
+                  <help>show all peer IDs for the specified interface</help>
+                </properties>
+                <command>sudo wg show "$4" peers</command>
+              </leafNode>
+             <!-- more commands upon request --> 
+            </children>
+          </tagNode>
+        </children>
+      </node>
     </children>
   </node>
 </interfaceDefinition>


### PR DESCRIPTION
more commands can be implemented upon request, wouldn't make much sense to display the same information under different trees.