### PR TITLE
T689: Moved force arp ops from vyatta-op

### DIFF
--- a/op-mode-definitions/force-arp.xml
+++ b/op-mode-definitions/force-arp.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="force">
+    <properties>
+      <help>Force an operation</help>
+    </properties>
+    <children>
+      <node name="arp">
+        <properties>
+          <help>Send gratuitous ARP request or reply</help>
+        </properties>
+        <children>
+          <node name="reply">
+            <properties>
+              <help>Send gratuitous ARP reply</help>
+            </properties>
+            <children>
+              <tagNode name="interface">
+                <properties>
+                  <help>Send gratuitous ARP reply on specified interface</help>
+                  <completionHelp>
+                    <script>${vyos_completion_dir}/list_interfaces.py --broadcast</script>
+                  </completionHelp>
+                </properties>
+                <children>
+                  <tagNode name="address">
+                    <properties>
+                      <help>Send gratuitous ARP reply for specified address</help>
+                    </properties>
+                    <command>sudo arping -I $5 -c 1 -A $7</command>
+                    <children>
+                      <tagNode name="count">
+                        <properties>
+                          <help>Send specified number of ARP replies</help>
+                        </properties>
+                        <command>sudo arping -I $5 -c $9 -A $7</command>
+                      </tagNode>
+                    </children>
+                  </tagNode>
+                </children>
+              </tagNode>
+            </children>
+          </node>
+          <node name="request">
+            <properties>
+              <help>Send gratuitous ARP request</help>
+            </properties>
+            <children>
+              <tagNode name="interface">
+                <properties>
+                  <help>Send gratuitous ARP request on specified interface</help>
+                  <completionHelp>
+                    <script>${vyos_completion_dir}/list_interfaces.py --broadcast</script>
+                  </completionHelp>
+                </properties>
+                <children>
+                  <tagNode name="address">
+                    <properties>
+                      <help>Send gratuitous ARP request for specified address</help>
+                    </properties>
+                    <command>sudo arping -I $5 -c 1 -U $7</command>
+                    <children>
+                      <tagNode name="count">
+                        <properties>
+                          <help>Send specified number of ARP requests</help>
+                        </properties>
+                        <command>sudo arping -I $5 -c $9 -U $7</command>
+                      </tagNode>
+                    </children>
+                  </tagNode>
+                </children>
+              </tagNode>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>


### PR DESCRIPTION
Notes:
 - vyatta-op cleanup PR is [here](https://github.com/vyos/vyatta-op/pull/17)
 - `force arp` was the only operation under the `force` subtree, thus it was removed from vyatta-op
 - fresh live install fails this operation with `bind: cannot assign requested address` error. To make arping work I had to configure `ip_nonlocal_bind` via sysctl first. Should this be set during live-build?

How it was tested:
 -  EC2 vyos instance was provisioned from `1.2.0-rolling+201808210337` version, `ip: 10.44.1.10`
 - another linux instance was provisioned in the same subnet, `ip: 10.44.1.200`
 - run `echo 1 | sudo tee /proc/sys/net/ipv4/ip_nonlocal_bind` on vyos instance
 - run ops:
```
vyos@VyOS-AMI:~$ force arp request interface eth0 address 10.44.1.200 count 3
ARPING 10.44.1.200 from 10.44.1.200 eth0
Unicast reply from 10.44.1.200 [0A:1E:B8:BF:D2:66]  0.653ms
Unicast reply from 10.44.1.200 [0A:1E:B8:BF:D2:66]  0.627ms
Sent 3 probes (1 broadcast(s))
Received 2 response(s)

vyos@VyOS-AMI:~$ force arp reply interface eth0 address 10.44.1.200 count 3
ARPING 10.44.1.200 from 10.44.1.200 eth0
Sent 3 probes (3 broadcast(s))
Received 0 response(s)
```