### PR TITLE
T791: wireguard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ clean:
 
 .PHONY: test
 test:
-	PYTHONPATH=python/ python3 -m "nose" --with-xunit src --with-coverage --cover-erase --cover-xml --cover-package src/conf_mode,src/op_mode,src/completion,src/helpers,src/validators --verbose
+#	PYTHONPATH=python/ python3 -m "nose" --with-xunit src --with-coverage --cover-erase --cover-xml --cover-package src/conf_mode,src/op_mode,src/completion,src/helpers,src/validators --verbose
 
 .PHONY: sonar
 sonar:

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ clean:
 
 .PHONY: test
 test:
-#	PYTHONPATH=python/ python3 -m "nose" --with-xunit src --with-coverage --cover-erase --cover-xml --cover-package src/conf_mode,src/op_mode,src/completion,src/helpers,src/validators --verbose
+	PYTHONPATH=python/ python3 -m "nose" --with-xunit src --with-coverage --cover-erase --cover-xml --cover-package src/conf_mode,src/op_mode,src/completion,src/helpers,src/validators --verbose
 
 .PHONY: sonar
 sonar:

--- a/interface-definitions/wireguard.xml
+++ b/interface-definitions/wireguard.xml
@@ -56,7 +56,7 @@
               <constraintErrorMessage>input limited to 100 alphanumerical characters</constraintErrorMessage>
             </properties>
             <children>
-              <leafNode name="peer-pubkey">
+              <leafNode name="pubkey">
                 <properties>
                   <help>base64 encoded public key</help>
                   <constraint>

--- a/interface-definitions/wireguard.xml
+++ b/interface-definitions/wireguard.xml
@@ -51,6 +51,9 @@
           <leafNode name="listen-port">
             <properties>
               <help>Local port number to accept connections</help>
+              <constraint>
+                <validator name="numeric" argument="--range 1024-65535"/>
+              </constraint>
             </properties>
           </leafNode>
           <tagNode name="peer">

--- a/interface-definitions/wireguard.xml
+++ b/interface-definitions/wireguard.xml
@@ -90,9 +90,8 @@
                 <properties>
                   <help>how often send keep alives in seconds</help>
                   <constraint>
-                    <regex>^(1|[1-9][0-9]{1,5})$</regex>
+                    <validator name="numeric" argument="--range 1-65535"/> 
                   </constraint>
-                  <constraintErrorMessage>keepliave timer has to be between 1 and 99999 seconds</constraintErrorMessage>
                 </properties>
               </leafNode>
             </children>

--- a/interface-definitions/wireguard.xml
+++ b/interface-definitions/wireguard.xml
@@ -49,7 +49,6 @@
           </leafNode>
           <tagNode name="peer">
             <properties>
-<<<<<<< HEAD
               <help>peer alias</help>
               <constraint>
                 <regex>^[0-9a-zA-Z]{1,100}</regex>
@@ -66,32 +65,18 @@
                   <constraintErrorMessage>Key is not valid 44-character (32-bytes) base64</constraintErrorMessage>
                 </properties>
               </leafNode>
-=======
-              <help>Base64 encoded public key</help>
-              <constraint>
-                <regex>^[0-9a-zA-Z\+/]{43}=$</regex>
-              </constraint>
-              <constraintErrorMessage>Key is not valid 44-character (32-bytes) base64</constraintErrorMessage>
-            </properties>
-            <children>
->>>>>>> upstream/current
               <leafNode name="allowed-ips">
                 <properties>
                   <help>IP addresses allowed to traverse the peer</help>
                 <multi/>
                 </properties>
               </leafNode>
-<<<<<<< HEAD
-=======
               <!--  check format IP:port -->
->>>>>>> upstream/current
               <leafNode name="endpoint">
                 <properties>
                   <help>Remote endpoint</help>
                 </properties>
               </leafNode>
-<<<<<<< HEAD
-=======
               <leafNode name="persistent-keepalive">
                 <properties>
                   <help>how often send keep alives in seconds</help>
@@ -101,8 +86,6 @@
                   <constraintErrorMessage>keepliave timer has to be between 1 and 99999 seconds</constraintErrorMessage>
                 </properties>
               </leafNode>
->>>>>>> upstream/current
-
             </children>
           </tagNode>
         </children>

--- a/interface-definitions/wireguard.xml
+++ b/interface-definitions/wireguard.xml
@@ -49,6 +49,24 @@
           </leafNode>
           <tagNode name="peer">
             <properties>
+<<<<<<< HEAD
+              <help>peer alias</help>
+              <constraint>
+                <regex>^[0-9a-zA-Z]{1,100}</regex>
+              </constraint>
+              <constraintErrorMessage>input limited to 100 alphanumerical characters</constraintErrorMessage>
+            </properties>
+            <children>
+              <leafNode name="peer-pubkey">
+                <properties>
+                  <help>base64 encoded public key</help>
+                  <constraint>
+                    <regex>^[0-9a-zA-Z\+/]{43}=$</regex>
+                  </constraint>
+                  <constraintErrorMessage>Key is not valid 44-character (32-bytes) base64</constraintErrorMessage>
+                </properties>
+              </leafNode>
+=======
               <help>Base64 encoded public key</help>
               <constraint>
                 <regex>^[0-9a-zA-Z\+/]{43}=$</regex>
@@ -56,18 +74,24 @@
               <constraintErrorMessage>Key is not valid 44-character (32-bytes) base64</constraintErrorMessage>
             </properties>
             <children>
+>>>>>>> upstream/current
               <leafNode name="allowed-ips">
                 <properties>
                   <help>IP addresses allowed to traverse the peer</help>
                 <multi/>
                 </properties>
               </leafNode>
+<<<<<<< HEAD
+=======
               <!--  check format IP:port -->
+>>>>>>> upstream/current
               <leafNode name="endpoint">
                 <properties>
                   <help>Remote endpoint</help>
                 </properties>
               </leafNode>
+<<<<<<< HEAD
+=======
               <leafNode name="persistent-keepalive">
                 <properties>
                   <help>how often send keep alives in seconds</help>
@@ -77,6 +101,7 @@
                   <constraintErrorMessage>keepliave timer has to be between 1 and 99999 seconds</constraintErrorMessage>
                 </properties>
               </leafNode>
+>>>>>>> upstream/current
 
             </children>
           </tagNode>

--- a/interface-definitions/wireguard.xml
+++ b/interface-definitions/wireguard.xml
@@ -16,6 +16,12 @@
           </valueHelp>
         </properties>
         <children>
+  <!--
+          <leafNode name="mtu">
+            <properties>
+              <help>set interface mtu (default: 1420)</help>
+          </leafNode>
+  -->
           <leafNode name="address">
             <properties>
               <help>IP address</help> 
@@ -51,9 +57,9 @@
             <properties>
               <help>peer alias</help>
               <constraint>
-                <regex>^[0-9a-zA-Z]{1,100}</regex>
+                <regex>.[^ ]{1,100}$</regex>
               </constraint>
-              <constraintErrorMessage>input limited to 100 alphanumerical characters</constraintErrorMessage>
+              <constraintErrorMessage>peer alias too long (limit 100 characters)</constraintErrorMessage>
             </properties>
             <children>
               <leafNode name="pubkey">

--- a/src/conf_mode/wireguard.py
+++ b/src/conf_mode/wireguard.py
@@ -262,9 +262,7 @@ def configure_interface(c, intf):
 
     ### assemble wg command
     cmd = "sudo wg set " + intf
-    if wg_config['listen-port'] !=0:
-      cmd += " listen-port " + str(wg_config['listen-port'])
-
+    cmd += " listen-port " + str(wg_config['listen-port'])
     cmd += " private-key " + wg_config['private-key']
     cmd += " peer " + wg_config['peer']['pubkey']
     cmd += " allowed-ips "


### PR DESCRIPTION
change implementation (proposed by runar):
- set interfaces wireguard wg01 peer node2 ... instead of using the public key
- local-port config options is now optional
- persistent-keepalive is now a range check 1-65535
- prepared fwmark, mtu on wg interfaces and preshared-key (not active and usable yet)