### PR TITLE
T836: syslog messages split accross multiple files 

### DIFF
--- a/data/templates/rsyslog/rsyslog.conf
+++ b/data/templates/rsyslog/rsyslog.conf
@@ -1,0 +1,59 @@
+#  /etc/rsyslog.conf    Configuration file for rsyslog.
+#
+
+#################
+#### MODULES ####
+#################
+
+$ModLoad imuxsock # provides support for local system logging
+$ModLoad imklog   # provides kernel logging support (previously done by rklogd)
+#$ModLoad immark  # provides --MARK-- message capability
+
+$OmitLocalLogging no
+$SystemLogSocketName /run/systemd/journal/syslog
+
+$KLogPath /proc/kmsg
+
+# provides UDP syslog reception
+#$ModLoad imudp
+#$UDPServerRun 514
+
+# provides TCP syslog reception
+#$ModLoad imtcp
+#$InputTCPServerRun 514
+
+###########################
+#### GLOBAL DIRECTIVES ####
+###########################
+
+#
+# Use traditional timestamp format.
+# To enable high precision timestamps, comment out the following line.
+#
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+
+# Filter duplicated messages
+$RepeatedMsgReduction on
+
+#
+# Set the default permissions for all log files.
+#
+$FileOwner root
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+
+
+#
+# Include all config files in /etc/rsyslog.d/
+#
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+###############
+#### RULES ####
+###############
+# Emergencies are sent to everybody logged in.
+
+*.emerg                         :omusrmsg:*
+

--- a/src/conf_mode/syslog.py
+++ b/src/conf_mode/syslog.py
@@ -93,7 +93,7 @@ def get_config():
   config_data['files'].update(
     {
       'global'  : {
-        'log-file' : '/var/log/vyos-rsyslog',
+        'log-file' : '/var/log/messages',
         'max-size'  : 262144,
         'action-on-max-size'  : '/usr/sbin/logrotate /etc/logrotate.d/vyos-rsyslog',
         'selectors'  : '*.notice;local7.debug',
@@ -229,6 +229,18 @@ def generate(c):
     f.write(config_text)
 
 def verify(c):
+  #
+  # /etc/rsyslog.conf is generated somewhere and copied over the original (exists in /opt/vyatta/etc/rsyslog.conf)
+  # it interferes with the global logging, to make sure we are using a single base, template is enforced here 
+  #
+
+  if not os.path.islink('/etc/rsyslog.conf'):
+    os.remove('/etc/rsyslog.conf')
+    os.symlink('/usr/share/vyos/templates/rsyslog/rsyslog.conf', '/etc/rsyslog.conf')
+
+  # /var/log/vyos-rsyslog were the old files, we may want to clean those up, but currently there
+  # is a chance that someone still needs it, so I don't automatically remove them 
+
   if c == None:
     return None
 


### PR DESCRIPTION
- logs now only to /var/log/messages per default
- enforces the global template from /usr/share/vyos/rsyslog/rsyslog.conf

Something is generating/copying rsyslogd.conf from opt/vyatta/etc, the python conf script makes sure that the template from  /usr/share/vyos/rsyslog/rsyslog.conf is always being used.