### PR TITLE
T979: Allow spaces in wireguard interface descriptions

### DIFF
--- a/interface-definitions/wireguard.xml
+++ b/interface-definitions/wireguard.xml
@@ -18,7 +18,7 @@
         <children>
           <leafNode name="address">
             <properties>
-              <help>IP address</help> 
+              <help>IP address</help>
               <valueHelp>
                 <format>ipv4net</format>
                 <description>IPv4 address and prefix length</description>
@@ -34,7 +34,7 @@
             <properties>
               <help>description</help>
               <constraint>
-                <regex>[^ ]{1,100}$</regex>
+                <regex>^.{1,100}$</regex>
               </constraint>
               <constraintErrorMessage>interface description is too long (limit 100 characters)</constraintErrorMessage>
             </properties>
@@ -110,7 +110,7 @@
                 <properties>
                   <help>how often send keep alives in seconds</help>
                   <constraint>
-                    <validator name="numeric" argument="--range 1-65535"/> 
+                    <validator name="numeric" argument="--range 1-65535"/>
                   </constraint>
                 </properties>
               </leafNode>

--- a/interface-definitions/wireguard.xml
+++ b/interface-definitions/wireguard.xml
@@ -18,7 +18,7 @@
         <children>
           <leafNode name="address">
             <properties>
-              <help>IP address</help>
+              <help>IP address</help> 
               <valueHelp>
                 <format>ipv4net</format>
                 <description>IPv4 address and prefix length</description>
@@ -110,7 +110,7 @@
                 <properties>
                   <help>how often send keep alives in seconds</help>
                   <constraint>
-                    <validator name="numeric" argument="--range 1-65535"/>
+                    <validator name="numeric" argument="--range 1-65535"/> 
                   </constraint>
                 </properties>
               </leafNode>


### PR DESCRIPTION
Previous to this pull request, setting a Wireguard interface description would result in a validation error similar to the following:

```
brooks@border# set interfaces wireguard wg0 description "Tunnel"
[edit]
brooks@border# set interfaces wireguard wg0 description "Tunnel tunnel
tunnel"

  interface description is too long (limit 100 characters)
  Value validation failed
  Set failed

[edit]
```

This commit makes the regex less restrictive up to 100 characters.