### PR TITLE
T1001: Bugfix: Handle backslashes in values with "show configuration commands"

### DIFF
--- a/src/utils/vyos-config-to-commands
+++ b/src/utils/vyos-config-to-commands
@@ -19,6 +19,14 @@ else:
     except OSError as e:
         print("Could not read config file {0}: {1}".format(file_name, e), file=sys.stderr)
 
+# This script is usually called with the output of "cli-shell-api showCfg", which does not
+# escape backslashes. "ConfigTree()" expects escaped backslashes when parsing a config
+# string (and also prints them itself). Therefore this script would fail.
+# Manually escape backslashes here to handle backslashes in any configuration strings
+# properly. The alternative would be to modify the output of "cli-shell-api showCfg",
+# but that may be break other things who rely on that specific output.
+config_string = config_string.replace("\\", "\\\\")
+
 try:
     config = ConfigTree(config_string)
     commands = config.to_commands()


### PR DESCRIPTION
…commands"

This script is usually called with the output of "cli-shell-api showCfg", which does not escape backslashes. "ConfigTree()" expects escaped backslashes when parsing a config string (and also prints them itself). Therefore this script would fail.
Manually escape backslashes here to handle backslashes in any configuration strings properly. The alternative would be to modify the output of "cli-shell-api showCfg", but that may be break other things who rely on that specific output.

This fixes https://phabricator.vyos.net/T1001