### PR TITLE
T1077: Update show_ipsec_sa.py

### DIFF
--- a/src/op_mode/show_ipsec_sa.py
+++ b/src/op_mode/show_ipsec_sa.py
@@ -32,7 +32,7 @@ status_data = []
 
 for conn in connections:
     status = subprocess.check_output("ipsec statusall {0}".format(conn), shell=True).decode()
-    if re.search(r'no match', status):
+    if re.search(r'no match|CONNECTING', status):
         status_line = [conn, "down", None, None, None, None, None]
     else:
         try:


### PR DESCRIPTION
Updated show_ipsec_sa.py, it now considers the tunnel down when the ipsec statusall command shows the tunnel in CONNECTING state so that it doesn't parse the string looking for ESTABLISHED and doesn't raise the error :
Traceback (most recent call last):
File "/usr/libexec/vyos/op_mode/show_ipsec_sa.py", line 51, in
raise e
File "/usr/libexec/vyos/op_mode/show_ipsec_sa.py", line 39, in
time, _, _, ip, id = parse_conn_spec(status)
File "/usr/libexec/vyos/op_mode/show_ipsec_sa.py", line 11, in parse_conn_spec