### PR TITLE
T1119: 'show vpn ipsec sa' shows tunnel twice in 1.2.0-RC11

### DIFF
--- a/src/op_mode/show_ipsec_sa.py
+++ b/src/op_mode/show_ipsec_sa.py
@@ -32,7 +32,7 @@ def parse_ike_line(s):
 # Get a list of all configured connections
 with open('/etc/ipsec.conf', 'r') as f:
     config = f.read()
-    connections = re.findall(r'conn\s([^\s]+)\s*\n', config)
+    connections = set(re.findall(r'conn\s([^\s]+)\s*\n', config))
     connections = list(filter(lambda s: s != '%default', connections))
 
 status_data = []


### PR DESCRIPTION
Removed duplicates from "connections" list.