### PR TITLE
T1256: Execute "show ipsec vpn ipsec sa" returns incorrect results

### DIFF
--- a/src/op_mode/show_ipsec_sa.py
+++ b/src/op_mode/show_ipsec_sa.py
@@ -67,7 +67,7 @@ status_data = []
 
 for conn in connections:
     status = subprocess.check_output("ipsec statusall {0}".format(conn), shell=True).decode()
-    if re.search(r'no match|CONNECTING', status):
+    if not re.search(r'ESTABLISHED', status):
         status_line = [conn, "down", None, None, None, None, None]
     else:
         try:


### PR DESCRIPTION
Not sure it's a normal case scenario, the one highlighted in T1256.
To manage it I changed the "if" logic.