### PR TITLE
router bytes zeros

### DIFF
--- a/src/conf_mode/dhcp_server.py
+++ b/src/conf_mode/dhcp_server.py
@@ -572,10 +572,9 @@ def get_config():
                         # add router bytes
                         bytes = subnet['static_router'].split('.')
                         for b in bytes:
-                            if b != '0':
-                                string += b
-                                if b is not bytes[-1]:
-                                    string += ','
+                            string += b
+                            if b is not bytes[-1]:
+                                string += ','
 
                         subnet['static_route'] = string
 


### PR DESCRIPTION
In the push classless route part the script removes zeros from the router bytes. This is not the desired behavior.
For example this

```
static-route {
    destination-subnet "172.22.128.0/17"
    router "172.22.0.12"
}
```
will create this in the `dhcpd.conf`:
```
option rfc3442-static-route 17,172,22,128,172,22,12;
option windows-static-route 17,172,22,128,172,22,12;
```
(The zero disappeared in the router address)