### PR TITLE
Wireguard: Added handling of fwmark setting

### DIFF
--- a/src/conf_mode/wireguard.py
+++ b/src/conf_mode/wireguard.py
@@ -298,7 +298,7 @@ def configure_interface(c, intf):
     ## optional settings
     # listen-port
     if c['interfaces'][intf]['lport']:
-      wg_config['port'] = c['interfaces'][intf]['lport']     
+      wg_config['port'] = c['interfaces'][intf]['lport']
 
     ## fwmark
     if c['interfaces'][intf]['fwmark']:

--- a/src/conf_mode/wireguard.py
+++ b/src/conf_mode/wireguard.py
@@ -63,6 +63,7 @@ def get_config():
                 'lport'       : '',
                 'status'      : 'exists',
                 'state'       : 'enabled',
+                'fwmark'         : 0x00,
                 'mtu'         : '1420',
                 'peer'        : {}
             }
@@ -95,6 +96,9 @@ def get_config():
       ### listen port
       if c.exists(cnf + ' port'):
         config_data['interfaces'][intfc]['lport'] = c.return_value(cnf + ' port')
+      ### fwmark
+      if c.exists(cnf + ' fwmark'):
+        config_data['interfaces'][intfc]['fwmark'] = c.return_value(cnf + ' fwmark')
       ### description
       if c.exists(cnf + ' description'):
         config_data['interfaces'][intfc]['descr'] = c.return_value(cnf + ' description')
@@ -294,8 +298,12 @@ def configure_interface(c, intf):
     ## optional settings
     # listen-port
     if c['interfaces'][intf]['lport']:
-      wg_config['port'] = c['interfaces'][intf]['lport']
+      wg_config['port'] = c['interfaces'][intf]['lport']     
 
+    ## fwmark
+    if c['interfaces'][intf]['fwmark']:
+      wg_config['fwmark'] = c['interfaces'][intf]['fwmark']
+      
     ## endpoint
     if c['interfaces'][intf]['peer'][p]['endpoint']:
       wg_config['endpoint'] = c['interfaces'][intf]['peer'][p]['endpoint']
@@ -314,6 +322,7 @@ def configure_interface(c, intf):
     ### assemble wg command
     cmd = "sudo wg set " + intf
     cmd += " listen-port " + str(wg_config['port'])
+    cmd += " fwmark " + str(wg_config['fwmark'])
     cmd += " private-key " + wg_config['private-key']
     cmd += " peer " + wg_config['pubkey']
     cmd += " preshared-key " + wg_config['psk']


### PR DESCRIPTION
The fwmark setting for wireguard interfaces is currently not honored. This pull requests adds support for the fwmark setting.

Current behaviour:
- Set the fwmark setting for a wireguard interface
- When using "wg show", no fwmark setting is applied.

Fixed behaviour:
- When using "wg show" the fwmark is properly applied.
