### PR TITLE
[pdns-recursor] T1469 - replace forward-zones with forward-zones-recurse

### DIFF
--- a/src/conf_mode/dns_forwarding.py
+++ b/src/conf_mode/dns_forwarding.py
@@ -63,7 +63,7 @@ local-address={{ listen_on | join(',') }}
 # domain ... server ...
 {% if domains -%}
 
-forward-zones={% for d in domains %}
+forward-zones-recurse={% for d in domains %}
 {{ d.name }}={{ d.servers | join(";") }}
 {{- "," if not loop.last -}}
 {% endfor %}


### PR DESCRIPTION
forward-zones-recurse behaves identically to dnsmasq server option
in legacy vyos 1.1.8, while forward-zones option disallow recursive
name resolving, which leads to dns lookup failure