### PR TITLE
[pdns-recursor] T1469 - specified dns forwarding not work

### DIFF
--- a/src/conf_mode/dns_forwarding.py
+++ b/src/conf_mode/dns_forwarding.py
@@ -60,16 +60,6 @@ export-etc-hosts={{ export_hosts_file }}
 # listen-on
 local-address={{ listen_on | join(',') }}
 
-# domain ... server ...
-{% if domains -%}
-
-forward-zones-recurse={% for d in domains %}
-{{ d.name }}={{ d.servers | join(";") }}
-{{- "," if not loop.last -}}
-{% endfor %}
-
-{% endif %}
-
 # dnssec
 dnssec={{ dnssec }}
 
@@ -78,6 +68,16 @@ dnssec={{ dnssec }}
 forward-zones-recurse=.={{ name_servers | join(';') }}
 {% else %}
 # no name-servers specified - start full recursor
+{% endif %}
+
+# domain ... server ...
+{% if domains -%}
+
+forward-zones-recurse={% for d in domains %}
+{{ d.name }}={{ d.servers | join(";") }}
+{{- "," if not loop.last -}}
+{% endfor %}
+
 {% endif %}
 
 """


### PR DESCRIPTION
when conflict exists between forward-zone-recurse entry,
the lower one hides the upper one, which leads to inactive dns forwarding configuration