### PR TITLE
T1523  Fix bind param if outside-address not present

### DIFF
--- a/src/conf_mode/accel_pptp.py
+++ b/src/conf_mode/accel_pptp.py
@@ -84,7 +84,9 @@ wins2={{wins[1]}}
 {% endif %}
 
 [pptp]
+{% if outside_addr %}
 bind={{outside_addr}}
+{% endif %}
 verbose=5
 ppp-max-mtu={{mtu}}
 mppe={{authentication['mppe']}}


### PR DESCRIPTION
If in config exist `bind=` without value, accel-ppp listen wrong ip address 255.255.255.255:1723. If need default behavior with listening on 0.0.0.0:1723 we don't set empty bind option.