### PR TITLE
[op-mode] T1590 xml-style rewrite of 'show system' operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ op_mode_definitions:
 	rm -f $(OP_TMPL_DIR)/monitor/node.def
 	rm -f $(OP_TMPL_DIR)/generate/node.def
 	rm -f $(OP_TMPL_DIR)/show/vpn/node.def
+	rm -f $(OP_TMPL_DIR)/show/system/node.def
 
 .PHONY: all
 all: clean interface_definitions op_mode_definitions

--- a/op-mode-definitions/show-system-info.xml
+++ b/op-mode-definitions/show-system-info.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="show">
+    <children>
+      <node name="system">
+        <properties>
+          <help>Show system information</help>
+        </properties>
+        <children>
+
+          <node name="connections">
+            <properties>
+              <help>Show active network connections on the system</help>
+            </properties>
+            <command>netstat -an</command>
+            <children>
+              <node name="tcp">
+                <properties>
+                  <help>Show TCP connection information</help>
+                </properties>
+                <command>ss -t -r</command>
+                <children>
+                  <leafNode name="all">
+                    <properties>
+                      <help>Show all TCP connections</help>
+                    </properties>
+                    <command>ss -t -a</command>
+                  </leafNode>
+                  <leafNode name="numeric">
+                    <properties>
+                      <help>Show TCP connection without resolving names</help>
+                    </properties>
+                    <command>ss -t -n</command>
+                  </leafNode>
+                </children>
+              </node>
+              <node name="udp">
+                <properties>
+                  <help>Show UDP socket information</help>
+                </properties>
+                <command>ss -u -a -r</command>
+                <children>
+                  <leafNode name="numeric">
+                    <properties>
+                      <help>Show UDP socket information without resolving names</help>
+                    </properties>
+                    <command>ss -u -a -n</command>
+                  </leafNode>
+                </children>
+              </node>
+            </children>
+          </node>
+
+          <leafNode name="kernel-messages">
+            <properties>
+              <help>Show messages in kernel ring buffer</help>
+            </properties>
+            <command>sudo dmesg</command>
+          </leafNode>
+
+          <node name="login">
+            <properties>
+              <help>Show user accounts</help>
+            </properties>
+            <children>
+              <node name="users">
+                <properties>
+                  <help>Show user account information</help>
+                </properties>
+                <command>${vyos_libexec_dir}/vyos-sudo.py ${vyos_op_scripts_dir}/show_users.py</command>
+                <children>
+                  <leafNode name="all">
+                    <properties>
+                      <help>Show information about all accounts</help>
+                    </properties>
+                    <command>${vyos_libexec_dir}/vyos-sudo.py ${vyos_op_scripts_dir}/show_users.py all</command>
+                  </leafNode>
+                  <leafNode name="locked">
+                    <properties>
+                      <help>Show information about locked accounts</help>
+                    </properties>
+                    <command>${vyos_libexec_dir}/vyos-sudo.py ${vyos_op_scripts_dir}/show_users.py locked</command>
+                  </leafNode>
+                  <leafNode name="other">
+                    <properties>
+                      <help>Show information about non VyOS user accounts</help>
+                    </properties>
+                    <command>${vyos_libexec_dir}/vyos-sudo.py ${vyos_op_scripts_dir}/show_users.py other</command>
+                  </leafNode>
+                  <leafNode name="vyos">
+                    <properties>
+                      <help>Show information about VyOS user accounts</help>
+                    </properties>
+                    <command>${vyos_libexec_dir}/vyos-sudo.py ${vyos_op_scripts_dir}/show_users.py vyos</command>
+                  </leafNode>
+                </children>
+              </node>
+            </children>
+          </node>
+
+          <node name="memory">
+            <properties>
+              <help>Show system memory usage</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/show_ram.sh</command>
+            <children>
+              <leafNode name="cache">
+                <properties>
+                  <help>Show kernel cache information</help>
+                </properties>
+                <command>sudo slabtop -o</command>
+              </leafNode>
+              <leafNode name="detail">
+                <properties>
+                  <help>Show detailed system memory usage</help>
+                </properties>
+                <command>cat /proc/meminfo</command>
+              </leafNode>
+            </children>
+          </node>
+
+          <node name="processes">
+            <properties>
+              <help>Show system processes</help>
+            </properties>
+            <command>ps ax</command>
+            <children>
+              <leafNode name="extensive">
+                <properties>
+                  <help>Show extensive process info</help>
+                </properties>
+                <command>top -b -n1</command>
+              </leafNode>
+              <leafNode name="summary">
+                <properties>
+                  <help>Show summary of system processes</help>
+                </properties>
+                <command>uptime</command>
+              </leafNode>
+              <leafNode name="tree">
+                <properties>
+                  <help>Show process tree</help>
+                </properties>
+                <command>ps -ejH</command>
+              </leafNode>
+            </children>
+          </node>
+
+          <leafNode name="storage">
+            <properties>
+              <help>Show filesystem usage</help>
+            </properties>
+            <command>df -h -x squashfs</command>
+          </leafNode>
+
+          <leafNode name="uptime">
+            <properties>
+              <help>Show how long the system has been up</help>
+            </properties>
+            <command>uptime</command>
+          </leafNode>
+
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/src/helpers/vyos-sudo.py
+++ b/src/helpers/vyos-sudo.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+import getpass
+import grp
+import os
+import sys
+
+
+def is_admin() -> bool:
+    """Look if current user is in sudo group"""
+    current_user = getpass.getuser()
+    (_, _, _, admin_group_members) = grp.getgrnam('sudo')
+    return current_user in admin_group_members
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print('Missing command argument')
+        sys.exit(1)
+
+    if not is_admin():
+        print('This account is not authorized to run this command')
+        sys.exit(1)
+
+    os.execvp('sudo', ['sudo'] + sys.argv[1:])

--- a/src/op_mode/show_ram.sh
+++ b/src/op_mode/show_ram.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Module: vyos-show-ram.sh
+# Displays memory usage information in minimalistic format
+#
+# Copyright (C) 2019 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+MB_DIVISOR=1024
+
+TOTAL=$(cat /proc/meminfo | grep -E "^MemTotal:" | awk -F ' ' '{print $2}')
+FREE=$(cat /proc/meminfo | grep -E "^MemFree:" | awk -F ' ' '{print $2}')
+BUFFERS=$(cat /proc/meminfo | grep -E "^Buffers:" | awk -F ' ' '{print $2}')
+CACHED=$(cat /proc/meminfo | grep -E "^Cached:" | awk -F ' ' '{print $2}')
+
+DISPLAY_FREE=$(( ($FREE + $BUFFERS + $CACHED) / $MB_DIVISOR ))
+DISPLAY_TOTAL=$(( $TOTAL / $MB_DIVISOR ))
+DISPLAY_USED=$(( $DISPLAY_TOTAL - $DISPLAY_FREE ))
+
+echo "Total: $DISPLAY_TOTAL"
+echo "Free:  $DISPLAY_FREE"
+echo "Used:  $DISPLAY_USED"

--- a/src/op_mode/show_users.py
+++ b/src/op_mode/show_users.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2019 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import argparse
+import pwd
+import spwd
+import struct
+import sys
+from time import ctime
+
+from tabulate import tabulate
+from vyos.config import Config
+
+
+class UserInfo:
+    def __init__(self, uid, name, user_type, is_locked, login_time, tty, host):
+        self.uid = uid
+        self.name = name
+        self.user_type = user_type
+        self.is_locked = is_locked
+        self.login_time = login_time
+        self.tty = tty
+        self.host = host
+
+
+filters = {
+    'default': lambda user: not user.is_locked,  # Default is everything but locked accounts
+    'vyos': lambda user: user.user_type == 'vyos',
+    'other': lambda user: user.user_type != 'vyos',
+    'locked': lambda user: user.is_locked,
+    'all': lambda user: True
+}
+
+
+def is_locked(user_name: str) -> bool:
+    """Check if a given user has password in shadow db"""
+
+    try:
+        encrypted_password = spwd.getspnam(user_name)[1]
+        return encrypted_password == '*' or encrypted_password.startswith('!')
+    except (KeyError, PermissionError):
+        print('Cannot access shadow database, ensure this script is run with sufficient permissions')
+        sys.exit(1)
+
+
+def decode_lastlog(lastlog_file, uid: int):
+    """Decode last login info of a given user uid from the lastlog file"""
+
+    struct_fmt = '=L32s256s'
+    recordsize = struct.calcsize(struct_fmt)
+    lastlog_file.seek(recordsize * uid)
+    buf = lastlog_file.read(recordsize)
+    if len(buf) < recordsize:
+        return None
+    (time, tty, host) = struct.unpack(struct_fmt, buf)
+    time = 'never logged in' if time == 0 else ctime(time)
+    tty = tty.strip(b'\x00')
+    host = host.strip(b'\x00')
+    return time, tty, host
+
+
+def list_users():
+    cfg = Config()
+    vyos_users = cfg.list_effective_nodes('system login user')
+    users = []
+    with open('/var/log/lastlog', 'rb') as lastlog_file:
+        for (name, _, uid, _, _, _, _) in pwd.getpwall():
+            lastlog_info = decode_lastlog(lastlog_file, uid)
+            if lastlog_info is None:
+                continue
+            user_info = UserInfo(
+                uid, name,
+                user_type='vyos' if name in vyos_users else 'other',
+                is_locked=is_locked(name),
+                login_time=lastlog_info[0],
+                tty=lastlog_info[1],
+                host=lastlog_info[2])
+            users.append(user_info)
+    return users
+
+
+def main():
+    parser = argparse.ArgumentParser(prog=sys.argv[0], add_help=False)
+    parser.add_argument('type', nargs='?', choices=['all', 'vyos', 'other', 'locked'])
+    args = parser.parse_args()
+
+    filter_type = args.type if args.type is not None else 'default'
+    filter_expr = filters[filter_type]
+
+    headers = ['Username', 'Type', 'Locked', 'Tty', 'From', 'Last login']
+    table_data = []
+    for user in list_users():
+        if filter_expr(user):
+            table_data.append([user.name, user.user_type, user.is_locked, user.tty, user.host, user.login_time])
+    print(tabulate(table_data, headers, tablefmt='simple'))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Please review this port of few vyatta-op commands into xml/python style.
The only operation left under `show system` node is related to `image` manipulation and seems it's  better to address it in a separate task, due to complexity.

**Notes and questions**
- `show system connections`: moved as is
- `show system storage`: moved as is
- `show system kernel-messages`: moved as is
- `show system boot-messages`: [original function](https://github.com/vyos/vyatta-op/blob/69c24c0ec2299cbe07d5f0ce0351f47286d5b095/templates/show/system/boot-messages/node.def) seems lost it's value, as it reads directly from `/var/log/dmesg`, which is always empty, due to `jessie` has moved to `jounrnald`. I didn't port this node. In the corresponding [vyatta-op PR](https://github.com/vyos/vyatta-op/pull/24) I've just removed it
- `show system memory`: moved as is, including short bash script `show_ram.sh`, is that ok?
- `show system uptime`: moved as is
- `show system processes`: moved as is. Should we drop `show system processes summary` as it is nothing more than an `uptime` call, which is available from previous op?
- `show system login`: is a python rewrite of two perl scripts: [show-users.pl](https://github.com/vyos/vyatta-op/blob/69c24c0ec2299cbe07d5f0ce0351f47286d5b095/scripts/show-users.pl) and [vyatta-sudo](https://github.com/vyos/vyatta-op/blob/69c24c0ec2299cbe07d5f0ce0351f47286d5b095/scripts/vyatta-sudo).
`vyatta-sudo` was used solely for calling `show-users.pl` with a questionable method of determining `admin` as a member of `sudo` group. It was [introduced](https://github.com/vyos/vyatta-op/commit/78be5135b674d8a321b5ff2f9497652831c88157) with a reference to a `Bug 5147`, which I don't have details for, thus I've ported this script verbatim. Regardign `show-users` script I've translated it to python with few modifications:
    - to check account lock status a `shadow` db is used, instead of original `passwd`, which leads to incorrect results in the default call
    - use `tabulate` with simple format for table output
    - add explicit column with locked status, instead of mangling user type with suffixes like `-` or `!`

**How it was tested?**
A `qemu` image was built from the rolling iso [`2019-08-16`](https://downloads.vyos.io/rolling/current/amd64/vyos-1.2-rolling-201908161413-amd64.iso). Output of each command was compared before and after the patched `vyos-1x` package installation.