### PR TITLE
[op-mode] T1596 rewrite 'telnet' and 'traceroute' operations to xml style

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -61,6 +61,9 @@ Depends: python3,
   openvpn,
   openvpn-auth-ldap,
   openvpn-auth-radius,
+  mtr-tiny,
+  telnet,
+  traceroute,
   ${shlibs:Depends},
   ${misc:Depends}
 Description: VyOS configuration scripts and data

--- a/op-mode-definitions/telnet.xml
+++ b/op-mode-definitions/telnet.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="telnet">
+    <properties>
+      <help>Telnet to a node</help>
+    </properties>
+    <children>
+      <tagNode name="">
+        <properties>
+          <help>Telnet to a host</help>
+          <completionHelp>
+            <list>&lt;hostname&gt; &lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
+          </completionHelp>
+        </properties>
+        <command>/usr/bin/telnet $2</command>
+        <children>
+          <tagNode name="">
+            <properties>
+              <help>Telnet to a host:port</help>
+              <completionHelp>
+                <list>&lt;0-65535&gt;</list>
+              </completionHelp>
+            </properties>
+            <command>/usr/bin/telnet $2 $3</command>
+          </tagNode>
+        </children>
+      </tagNode>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/op-mode-definitions/traceroute.xml
+++ b/op-mode-definitions/traceroute.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="traceroute">
+    <properties>
+      <help>Track network path to node</help>
+    </properties>
+    <children>
+      <tagNode name="">
+        <properties>
+          <help>Track network path to specified node</help>
+          <completionHelp>
+            <list>&lt;hostname&gt; &lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
+          </completionHelp>
+        </properties>
+        <command>/usr/bin/traceroute $2</command>
+      </tagNode>
+
+      <tagNode name="ipv4">
+        <properties>
+          <help>Track network path to &lt;hostname|IPv4 address&gt;</help>
+          <completionHelp>
+            <list>&lt;hostname&gt; &lt;x.x.x.x&gt;</list>
+          </completionHelp>
+        </properties>
+        <command>/usr/bin/traceroute -4 $3</command>
+      </tagNode>
+
+      <tagNode name="ipv6">
+        <properties>
+          <help>Track network path to &lt;hostname|IPv6 address&gt;</help>
+          <completionHelp>
+            <list>&lt;hostname&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
+          </completionHelp>
+        </properties>
+        <command>/usr/bin/traceroute -6 $3</command>
+      </tagNode>
+    </children>
+  </node>
+
+  <node name="monitor">
+    <children>
+      <tagNode name="traceroute">
+        <properties>
+          <help>Monitor the path to a destination in realtime</help>
+          <completionHelp>
+            <list>&lt;hostname&gt; &lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
+          </completionHelp>
+        </properties>
+        <command>/usr/bin/mtr $3</command>
+      </tagNode>
+    </children>
+  </node>
+</interfaceDefinition>


### PR DESCRIPTION
Please review these op-mode rewrites. See the corresponding PR in vyatta-op [here](https://github.com/vyos/vyatta-op/pull/25).

**Notes and questions**
1. Are [these](https://github.com/vyos/vyos-1x/pull/108/files#diff-611eddb10fca5cae1ad6194da734d881R8) [usages](https://github.com/vyos/vyos-1x/pull/108/files#diff-611eddb10fca5cae1ad6194da734d881R17) of 'nameless' `tagNode` valid? Didn't find other way to reproduce the original [node structure](https://github.com/vyos/vyatta-op/tree/437867584488ec3bf1bdd28ddfdd45410e9a5bf9/templates/telnet) as a series of `node.tag`s. Any named tagNode in xml creates two levels of nesting. Also the root node can't be tagged.

2. What was the point in doing hostname resolution manually in the [original traceroute scripts](https://github.com/vyos/vyatta-op/blob/437867584488ec3bf1bdd28ddfdd45410e9a5bf9/templates/traceroute/ipv4/node.tag/node.def#L14)? It seems that traceroute does that itself when a hostname is passed.

3. Should the required packages be specified as deb dependencies in the [control script](https://github.com/vyos/vyos-1x/pull/108/files#diff-d837a1c17de0268bcea321239ddbed47R64)? It seems like yes, but [vyatta-op listed](https://github.com/vyos/vyatta-op/pull/25/files#diff-d837a1c17de0268bcea321239ddbed47L14) only one tool