### PR TITLE
[op-mode] T1607 rewrite 'reset conntrack' and 'reset & show ip[v6]' to python/xml syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,9 @@ op_mode_definitions:
 	rm -f $(OP_TMPL_DIR)/show/node.def
 	rm -f $(OP_TMPL_DIR)/show/interfaces/node.def
 	rm -f $(OP_TMPL_DIR)/show/ip/node.def
-	rm -f $(OP_TMPL_DIR)/reset/node.def
+	rm -f $(OP_TMPL_DIR)/show/ip/route/node.def
+	rm -f $(OP_TMPL_DIR)/show/ipv6/node.def
+	rm -f $(OP_TMPL_DIR)/show/ipv6/route/node.def
 	rm -f $(OP_TMPL_DIR)/restart/node.def
 	rm -f $(OP_TMPL_DIR)/monitor/node.def
 	rm -f $(OP_TMPL_DIR)/generate/node.def

--- a/op-mode-definitions/dns-forwarding.xml
+++ b/op-mode-definitions/dns-forwarding.xml
@@ -42,6 +42,9 @@
     </children>
   </node>
   <node name="reset">
+    <properties>
+      <help>Reset a service</help>
+    </properties>
     <children>
       <node name="dns">
         <properties>

--- a/op-mode-definitions/ipv4-route.xml
+++ b/op-mode-definitions/ipv4-route.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="show">
+    <properties>
+      <help>Show system information</help>
+    </properties>
+    <children>
+      <node name="ip">
+        <properties>
+          <help>Show IPv4 information</help>
+        </properties>
+        <children>
+          <leafNode name="groups">
+            <properties>
+              <help>Show IP multicast group membership</help>
+            </properties>
+            <command>netstat -gn4</command>
+          </leafNode>
+
+          <node name="route">
+            <properties>
+              <help>Show IP routes</help>
+            </properties>
+            <children>
+              <node name="cache">
+                <properties>
+                  <help>Show kernel route cache</help>
+                </properties>
+                <command>ip -s route list cache</command>
+              </node>
+              <tagNode name="cache">
+                <properties>
+                  <help>Show kernel route cache for a given route</help>
+                  <completionHelp>
+                    <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>ip -s route list cache $5</command>
+              </tagNode>
+              <node name="forward">
+                <properties>
+                  <help>Show kernel route table</help>
+                </properties>
+                <command>ip route list</command>
+              </node>
+              <tagNode name="forward">
+                <properties>
+                  <help>Show kernel route table for a given route</help>
+                  <completionHelp>
+                    <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>ip -s route list $5</command>
+              </tagNode>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+
+  <node name="reset">
+    <properties>
+      <help>Reset a service</help>
+    </properties>
+    <children>
+      <node name="ip">
+        <properties>
+          <help>Reset Internet Protocol (IP) parameters</help>
+        </properties>
+        <children>
+          <node name="arp">
+            <properties>
+              <help>Reset Address Resolution Protocol (ARP) cache</help>
+            </properties>
+            <children>
+              <tagNode name="address">
+                <properties>
+                  <help>Reset ARP cache for an IPv4 address</help>
+                  <completionHelp>
+                    <list>&lt;x.x.x.x&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>sudo /sbin/ip neigh flush to "$5"</command>
+              </tagNode>
+              <tagNode name="interface">
+                <properties>
+                  <help>Reset ARP cache for interface</help>
+                  <completionHelp>
+                    <script>${vyos_completion_dir}/list_interfaces.py</script>
+                  </completionHelp>
+                </properties>
+                <command>sudo /sbin/ip neigh flush dev "$5"</command>
+              </tagNode>
+            </children>
+          </node>
+
+          <node name="route">
+            <properties>
+              <help>Reset IP route</help>
+            </properties>
+            <children>
+              <leafNode name= "cache">
+                <properties>
+                  <help>Flush the kernel route cache</help>
+                </properties>
+                <command>sudo /sbin/ip route flush cache</command>
+              </leafNode>
+
+              <tagNode name="cache">
+                <properties>
+                  <help>Flush the kernel route cache for a given route</help>
+                  <completionHelp>
+                    <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>sudo /sbin/ip route flush cache "$5"</command>
+              </tagNode>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/op-mode-definitions/ipv6-route.xml
+++ b/op-mode-definitions/ipv6-route.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="show">
+    <properties>
+      <help>Show system information</help>
+    </properties>
+    <children>
+      <node name="ipv6">
+        <properties>
+          <help>Show IPv6 routing information</help>
+        </properties>
+        <children>
+          <leafNode name="groups">
+            <properties>
+              <help>Show IPv6 multicast group membership</help>
+            </properties>
+            <command>netstat -gn6</command>
+          </leafNode>
+
+          <leafNode name="neighbors">
+            <properties>
+              <help>Show IPv6 Neighbor Discovery (ND) information</help>
+            </properties>
+            <command>ip -f inet6 neigh list</command>
+          </leafNode>
+
+          <node name="route">
+            <properties>
+              <help>Show IPv6 routes</help>
+            </properties>
+            <children>
+              <node name="cache">
+                <properties>
+                  <help>Show kernel IPv6 route cache</help>
+                </properties>
+                <command>ip -s -f inet6 route list cache</command>
+              </node>
+              <tagNode name="cache">
+                <properties>
+                  <help>Show kernel IPv6 route cache for a given route</help>
+                  <completionHelp>
+                    <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>ip -s -f inet6 route list cache $5</command>
+              </tagNode>
+              <node name="forward">
+                <properties>
+                  <help>Show kernel IPv6 route table</help>
+                </properties>
+                <command>ip -f inet6 route list</command>
+              </node>
+              <tagNode name="forward">
+                <properties>
+                  <help>Show kernel IPv6 route table for a given route</help>
+                  <completionHelp>
+                    <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>ip -s -f inet6 route list $5</command>
+              </tagNode>
+            </children>
+          </node>
+
+        </children>
+      </node>
+    </children>
+  </node>
+
+  <node name="reset">
+    <properties>
+      <help>Reset a service</help>
+    </properties>
+    <children>
+      <node name="ipv6">
+        <properties>
+          <help>Reset Internet Protocol version 6 (IPv6) parameters</help>
+        </properties>
+        <children>
+          <node name="neighbors">
+            <properties>
+              <help>Reset IPv6 Neighbor Discovery (ND) cache</help>
+            </properties>
+            <children>
+              <tagNode name="address">
+                <properties>
+                  <help>Reset ND cache for an IPv6 address</help>
+                  <completionHelp>
+                    <list>&lt;h:h:h:h:h:h:h:h&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>sudo ip -f inet6 neigh flush to "$5"</command>
+              </tagNode>
+              <tagNode name="interface">
+                <properties>
+                  <help>Reset IPv6 ND cache for interface</help>
+                  <completionHelp>
+                    <script>${vyos_completion_dir}/list_interfaces.py</script>
+                  </completionHelp>
+                </properties>
+                <command>sudo ip -f inet6 neigh flush dev "$5"</command>
+              </tagNode>
+            </children>
+          </node>
+
+          <node name="route">
+            <properties>
+              <help>Reset IPv6 route</help>
+            </properties>
+            <children>
+              <leafNode name= "cache">
+                <properties>
+                  <help>Flush the kernel IPv6 route cache</help>
+                </properties>
+                <command>sudo ip -f inet6 route flush cache</command>
+              </leafNode>
+
+              <tagNode name="cache">
+                <properties>
+                  <help>Flush the kernel IPv6 route cache for a given route</help>
+                  <completionHelp>
+                    <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>sudo ip -f inet6 route flush cache "$5"</command>
+              </tagNode>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/op-mode-definitions/openvpn.xml
+++ b/op-mode-definitions/openvpn.xml
@@ -46,6 +46,9 @@
     </children>
   </node>
   <node name="reset">
+    <properties>
+      <help>Reset a service</help>
+    </properties>
     <children>
       <node name="openvpn">
         <children>

--- a/op-mode-definitions/reset-conntrack.xml
+++ b/op-mode-definitions/reset-conntrack.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="reset">
+    <properties>
+      <help>Reset a service</help>
+    </properties>
+    <children>
+      <node name="conntrack">
+        <properties>
+          <help>Reset all currently tracked connections</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/clear_conntrack.py</command>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -18,6 +18,7 @@ import re
 import grp
 import time
 import subprocess
+import sys
 
 import psutil
 
@@ -176,3 +177,17 @@ def wait_for_commit_lock():
     while commit_in_progress():
         time.sleep(1)
 
+def ask_yes_no(question, default=False) -> bool:
+    """Ask a yes/no question via input() and return their answer."""
+    default_msg = "[Y/n]" if default else "[y/N]"
+    while True:
+        sys.stdout.write("%s %s " % (question, default_msg))
+        c = input().lower()
+        if c == '':
+            return default
+        elif c in ("y", "ye", "yes"):
+            return True
+        elif c in ("n", "no"):
+            return False
+        else:
+            sys.stdout.write("Please respond with yes/y or no/n\n")

--- a/src/op_mode/clear_conntrack.py
+++ b/src/op_mode/clear_conntrack.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2019 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import subprocess
+import sys
+
+from vyos.util import ask_yes_no
+
+if not ask_yes_no("This will clear all currently tracked and expected connections. Continue?"):
+    sys.exit(1)
+else:
+    subprocess.check_call(['/usr/sbin/conntrack -F'], shell=True, stderr=subprocess.DEVNULL)
+    subprocess.check_call(['/usr/sbin/conntrack -F expect'], shell=True, stderr=subprocess.DEVNULL)

--- a/src/op_mode/powerctrl.py
+++ b/src/op_mode/powerctrl.py
@@ -22,20 +22,7 @@ import re
 
 from datetime import datetime, timedelta, time as type_time, date as type_date
 from subprocess import check_output, CalledProcessError, STDOUT
-
-def yn(msg, default=False):
-  default_msg = "[Y/n]" if default else "[y/N]"
-  while True:
-    sys.stdout.write("%s %s "  % (msg,default_msg))
-    c = input().lower()
-    if c == '':
-      return default
-    elif c in ("y", "ye","yes"):
-      return True
-    elif c in ("n", "no"):
-      return False
-    else:
-      sys.stdout.write("Please respond with yes/y or no/n\n")
+from vyos.util import ask_yes_no
 
 
 def valid_time(s):
@@ -80,7 +67,7 @@ def cancel_shutdown():
 def execute_shutdown(time, reboot = True, ask=True):
   if not ask:
     action = "reboot" if reboot else "poweroff"
-    if not yn("Are you sure you want to %s this system?" % action):
+    if not ask_yes_no("Are you sure you want to %s this system?" % action):
       sys.exit(0)
 
   action = "-r" if reboot else "-P"


### PR DESCRIPTION
Please, review another batch of trivial rewrites from vyatta-op and the corresponding [vyatta-op PR](https://github.com/vyos/vyatta-op/pull/26)

**Notes and questions:**
 - `reset ip[v6] cache/arp` moved as is
 - `show ip[v6] route` moved as is
 - `reset conntrack` originally [had a bash script](https://github.com/vyos/vyatta-op/blob/bbbbfe2452cb78c894209671114bf6575ca5007e/scripts/vyatta-clear-conntrack#L61) with yet another implementation of `yes/no` prompt. There is one in vyos-1x already, in powerctrl.py, which I've moved to utils. 
 - These were the only commands left under the [`reset` node in vyatta](https://github.com/vyos/vyatta-op/tree/bbbbfe2452cb78c894209671114bf6575ca5007e/templates/reset), thus in the Makefile the root node can be kept, without potential conflicts during .deb installation. Is that correct?