### PR TITLE
[service http]: add passthrough support for save command

### DIFF
--- a/python/vyos/configsession.py
+++ b/python/vyos/configsession.py
@@ -23,6 +23,7 @@ DELETE = '/opt/vyatta/sbin/my_delete'
 COMMENT = '/opt/vyatta/sbin/my_comment'
 COMMIT = '/opt/vyatta/sbin/my_commit'
 DISCARD = '/opt/vyatta/sbin/my_discard'
+SAVE = '/opt/vyatta/sbin/vyatta-save-config.pl'
 SHOW_CONFIG = ['/bin/cli-shell-api', 'showConfig']
 
 # Default "commit via" string
@@ -149,9 +150,11 @@ class ConfigSession(object):
     def discard(self):
         self.__run_command([DISCARD])
 
+    def save(self):
+        self.__run_command([SAVE])
+
     def show_config(self, path, format='raw'):
         config_data = self.__run_command(SHOW_CONFIG + path)
 
         if format == 'raw':
             return config_data
-

--- a/src/services/vyos-http-api-server
+++ b/src/services/vyos-http-api-server
@@ -104,10 +104,12 @@ def configure():
             if not isinstance(c, dict):
                 raise ConfigSessionError("Malformed command \"{0}\": any command must be a dict".format(json.dumps(c)))
 
-            # Missing op or path is a show stopper
+            # Missing op is a show stopper
+            op = c['op']
+
             if not ('op' in c):
                 raise ConfigSessionError("Malformed command \"{0}\": missing \"op\" field".format(json.dumps(c)))
-            if not ('path' in c):
+            if not ('path' in c) and not (op == 'save'):
                 raise ConfigSessionError("Malformed command \"{0}\": missing \"path\" field".format(json.dumps(c)))
 
             # Missing value is fine, substitute for empty string
@@ -116,8 +118,11 @@ def configure():
             else:
                 value = ""
 
-            op = c['op']
-            path = c['path']
+            # Missing path is fine for save operation, substitute array with empty string
+            if 'path' in c:
+                path = c['path']
+            else:
+                path = [""]
 
             if not path:
                 raise ConfigSessionError("Malformed command \"{0}\": empty path".format(json.dumps(c)))
@@ -150,10 +155,13 @@ def configure():
                 session.delete(path, value=value)
             elif op == 'comment':
                 session.comment(path, value=value)
+            elif op == 'save':
+                session.save()
             else:
                 raise ConfigSessionError("\"{0}\" is not a valid operation".format(op))
         # end for
-        session.commit()
+        if op != 'save':
+            session.commit()
         print("Configuration modified via HTTP API using key \"{0}\"".format(id))
     except ConfigSessionError as e:
         session.discard()


### PR DESCRIPTION
 curl -X POST -F data='{"op": "save"}' -F key=key http://vyos-http-api:8080/configure