### PR TITLE
[l2tp ipsec] T1605: Changed ipsec marking only for inbound policy, al…

### DIFF
--- a/src/conf_mode/ipsec-settings.py
+++ b/src/conf_mode/ipsec-settings.py
@@ -62,7 +62,7 @@ conn {{ra_conn_name}}
   left={{outside_addr}}
   leftsubnet=%dynamic[/1701]
   rightsubnet=%dynamic
-  mark=%unique
+  mark_in=%unique
   auto=add
   ike=aes256-sha1-modp1024,3des-sha1-modp1024,3des-sha1-modp1024!
   dpddelay=15


### PR DESCRIPTION
…l functionality must saved
This allow l2tp over ipsec works with NAT rules and without NAT rules