### PR TITLE
T1638: generated hosts file fix for proper FQDN resolution

### DIFF
--- a/src/services/vyos-hostsd
+++ b/src/services/vyos-hostsd
@@ -43,7 +43,7 @@ hosts_tmpl_source = """
 
 # Local host
 127.0.0.1       localhost
-127.0.1.1       {{ host_name }}{% if domain_name %}.{{ domain_name }}{% endif %}
+127.0.1.1       {{ host_name }}{% if domain_name %}.{{ domain_name }} {{ host_name }}{% endif %}
 
 # The following lines are desirable for IPv6 capable hosts
 ::1             localhost ip6-localhost ip6-loopback


### PR DESCRIPTION
In the `/etc/hosts` file, for proper FQDN resolution, format must be:

```
127.0.1.1 hostname.domainname hostname
````