### PR TITLE
Fix ifconfig mac parse

### DIFF
--- a/python/vyos/ifconfig.py
+++ b/python/vyos/ifconfig.py
@@ -210,7 +210,7 @@ class Interface:
 
         # validate against the first mac address byte if it's a multicast
         # address
-        if int(mac.split(':')[0]) & 1:
+        if int(mac.split(':')[0], 16) & 1:
             raise ValueError('{} is a multicast MAC address'.format(mac))
 
         # overall mac address is not allowed to be 00:00:00:00:00:00


### PR DESCRIPTION
Hiya!

There appears to have been a minor oversight with the recent refactor of the `ifconfig` module in https://github.com/vyos/vyos-1x/commit/dff5f3f38f60b9da8e791593998e6f614da6e5ec. I ran up against this with an interface with a hardware address beginning with `d0`:

```
jriley@vyos# commit
[ interfaces ethernet eth0 ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/interface-ethernet.py", line 379, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/interface-ethernet.py", line 296, in apply
    e.mac = eth['hw_id']
  File "/usr/lib/python3/dist-packages/vyos/ifconfig.py", line 213, in mac
    if int(mac.split(':')[0]) & 1:
ValueError: invalid literal for int() with base 10: 'd0'
```

I am unable to bring this interface up with the current builds as a result, and have had to roll back, so figured I'd PR this up and hopefully be able to jump on a new nightly soon. I don't see tests for this module in this repo, but if some exist please feel free to point me at them and I'll add a test for this case to help prevent regressions. Happy to write some up as well, just not familiar with how this repo is structured (yet). :)

Cheers!
James