### PR TITLE
fixes T1679 (parsing MAC address as base-10)

### DIFF
--- a/python/vyos/ifconfig.py
+++ b/python/vyos/ifconfig.py
@@ -210,7 +210,7 @@ class Interface:
 
         # validate against the first mac address byte if it's a multicast
         # address
-        if int(mac.split(':')[0]) & 1:
+        if int(mac.split(':')[0], 16) & 1:
             raise ValueError('{} is a multicast MAC address'.format(mac))
 
         # overall mac address is not allowed to be 00:00:00:00:00:00


### PR DESCRIPTION
During bootup (with certain MAC addresses):

```
ValueError: invalid literal for int() with base 10: '3c'
```

<img width="798" alt="Screenshot 2019-09-23 at 14 58 34" src="https://user-images.githubusercontent.com/9492487/65437160-34090380-de1b-11e9-9072-0890f176ae92.png">