### PR TITLE
T1694 NTPd: Do not listen on all interfaces by default

### DIFF
--- a/src/conf_mode/ntp.py
+++ b/src/conf_mode/ntp.py
@@ -42,6 +42,8 @@ restrict default noquery nopeer notrap nomodify
 restrict 127.0.0.1
 restrict -6 ::1
 
+# Do not listen on any interface address by default
+interface ignore wildcard
 #
 # Configurable section
 #
@@ -63,7 +65,6 @@ restrict {{ n.address }} mask {{ n.netmask }} nomodify notrap nopeer
 
 {% if listen_address -%}
 # NTP should listen on configured addresses only
-interface ignore wildcard
 {% for a in listen_address -%}
 interface listen {{ a }}
 {% endfor -%}


### PR DESCRIPTION
NTPd should not listen on all interfaces by default, e.g. if the directive
`set system ntp listen-address (IPv4|IPv6)`
is not set. We should move the NTPd option interface ignore wildcard to the Non-configurable defaults section of ntp.py