### PR TITLE
[OpenVPN]: T1688: Add support for using encryption aes128gcm, aes192gcm and aes25gcm

### DIFF
--- a/interface-definitions/interfaces-openvpn.xml
+++ b/interface-definitions/interfaces-openvpn.xml
@@ -106,7 +106,7 @@
             <properties>
               <help>Data Encryption Algorithm</help>
               <completionHelp>
-                <list>des 3des bf128 bf256 aes128 aes192 aes256</list>
+                <list>des 3des bf128 bf256 aes128 aes128gcm aes192 aes192gcm aes256 aes256gcm</list>
               </completionHelp>
               <valueHelp>
                 <format>des</format>
@@ -126,18 +126,30 @@
               </valueHelp>
               <valueHelp>
                 <format>aes128</format>
-                <description>AES algorithm with 128-bit key</description>
+                <description>AES algorithm with 128-bit key CBC</description>
+              </valueHelp>
+              <valueHelp>
+                <format>aes128gcm</format>
+                <description>AES algorithm with 128-bit key GCM</description>
               </valueHelp>
               <valueHelp>
                 <format>aes192</format>
-                <description>AES algorithm with 192-bit key</description>
+                <description>AES algorithm with 192-bit key CBC</description>
+              </valueHelp>
+              <valueHelp>
+                <format>aes192gcm</format>
+                <description>AES algorithm with 192-bit key GCM</description>
               </valueHelp>
               <valueHelp>
                 <format>aes256</format>
-                <description>AES algorithm with 256-bit key</description>
+                <description>AES algorithm with 256-bit key CBC</description>
+              </valueHelp>
+              <valueHelp>
+                <format>aes256gcm</format>
+                <description>AES algorithm with 256-bit key GCM</description>
               </valueHelp>
               <constraint>
-                <regex>(des|3des|bf128|bf256|aes128|aes192|aes256)</regex>
+                <regex>(des|3des|bf128|bf256|aes128|aes128gcm|aes192|aes192gcm|aes256|aes256gcm)</regex>
               </constraint>
             </properties>
           </leafNode>

--- a/src/conf_mode/interface-openvpn.py
+++ b/src/conf_mode/interface-openvpn.py
@@ -735,6 +735,9 @@ def verify(openvpn):
     # TLS/encryption
     #
     if openvpn['shared_secret_file']:
+        if openvpn['encryption'] in ['aes128gcm', 'aes192gcm', 'aes256gcm']:
+            raise ConfigError('GCM encryption with shared-secret-key-file is not supported')
+        
         if not checkCertHeader('-----BEGIN OpenVPN Static key V1-----', openvpn['shared_secret_file']):
             raise ConfigError('Specified shared-secret-key-file "{}" is not valid'.format(openvpn['shared_secret_file']))
 

--- a/src/conf_mode/interface-openvpn.py
+++ b/src/conf_mode/interface-openvpn.py
@@ -207,10 +207,16 @@ keysize 128
 {%- elif 'bf256' in encryption %}
 cipher bf-cbc
 keysize 25
+{%- elif 'aes128gcm' in encryption %}
+cipher aes-128-gcm
 {%- elif 'aes128' in encryption %}
 cipher aes-128-cbc
+{%- elif 'aes192gcm' in encryption %}
+cipher aes-192-gcm
 {%- elif 'aes192' in encryption %}
 cipher aes-192-cbc
+{%- elif 'aes256gcm' in encryption %}
+cipher aes-256-gcm
 {%- elif 'aes256' in encryption %}
 cipher aes-256-cbc
 {% endif %}


### PR DESCRIPTION
```
vyos@vyos-lab-edge-1# set int open vtun0 encryption
Possible completions:
   des          DES algorithm
   3des         DES algorithm with triple encryption
   bf128        Blowfish algorithm with 128-bit key
   bf256        Blowfish algorithm with 256-bit key
   aes128       AES algorithm with 128-bit key CBC
   aes128gcm    AES algorithm with 128-bit key GCM
   aes192       AES algorithm with 192-bit key CBC
   aes192gcm    AES algorithm with 192-bit key GCM
   aes256       AES algorithm with 256-bit key CBC
   aes256gcm    AES algorithm with 256-bit key GCM

```