### PR TITLE
T1755: Python KeyError exceptions raised with 'show vpn ipsec sa' command under use of certain IPSEC cipher suites.

### DIFF
--- a/src/op_mode/show_ipsec_sa.py
+++ b/src/op_mode/show_ipsec_sa.py
@@ -82,7 +82,10 @@ for sa in sas:
                 pkts_str = re.sub(r'B', r'', pkts_str)
 
                 enc = isa["encr-alg"].decode()
-                key_size = isa["encr-keysize"].decode()
+                if "encr-keysize" in isa:
+                    key_size = isa["encr-keysize"].decode()
+                else:
+                    key_size = ""
                 if "integ-alg" in isa:
                     hash = isa["integ-alg"].decode()
                 else:
@@ -91,7 +94,10 @@ for sa in sas:
                     dh_group = isa["dh-group"].decode()
                 else:
                     dh_group = ""
-                proposal = "{0}_{1}".format(enc, key_size)
+
+                proposal = enc
+                if key_size:
+                    proposal = "{0}_{1}".format(proposal, key_size)
                 if hash:
                     proposal = "{0}/{1}".format(proposal, hash)
                 if dh_group:

--- a/src/op_mode/show_ipsec_sa.py
+++ b/src/op_mode/show_ipsec_sa.py
@@ -83,12 +83,17 @@ for sa in sas:
 
                 enc = isa["encr-alg"].decode()
                 key_size = isa["encr-keysize"].decode()
-                hash = isa["integ-alg"].decode()
+                if "integ-alg" in isa:
+                    hash = isa["integ-alg"].decode()
+                else:
+                    hash = ""
                 if "dh-group" in isa:
                     dh_group = isa["dh-group"].decode()
                 else:
                     dh_group = ""
-                proposal = "{0}_{1}/{2}".format(enc, key_size, hash)
+                proposal = "{0}_{1}".format(enc, key_size)
+                if hash:
+                    proposal = "{0}/{1}".format(proposal, hash)
                 if dh_group:
                     proposal = "{0}/{1}".format(proposal, dh_group)
 


### PR DESCRIPTION
Related to [T1755](https://phabricator.vyos.net/T1755)

- Commit c761e94 resolves the issue where integ-alg is complained about as a python KeyError exception when using proposals that don't use HMAC specifically (GCM, CHACHA20_POLY1305).
- Commit 915116e resolves the issue where encr-keysize is complained about as a python KeyError exception when using proposals that don't yield a keysize specifically (CHACHA20_POLY1305 for instance).