### PR TITLE
T1787: escape isolated single backslashes in output of showConfig

### DIFF
--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -69,6 +69,7 @@ import json
 import subprocess
 
 import vyos.configtree
+import vyos.util
 
 
 class VyOSError(Exception):
@@ -110,6 +111,11 @@ class Config(object):
             session_config_text = self._run([self._cli_shell_api, '--show-working-only', '--show-show-defaults', 'showConfig'])
         else:
             session_config_text = running_config_text
+
+        # The output of showConfig does not escape backslashes, as is expected
+        # by ConfigTree().
+        session_config_text = vyos.util.escape_backslash(session_config_text)
+        running_config_text = vyos.util.escape_backslash(running_config_text)
 
         self._session_config = vyos.configtree.ConfigTree(session_config_text)
         self._running_config = vyos.configtree.ConfigTree(running_config_text)

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -199,3 +199,9 @@ def is_admin() -> bool:
     current_user = getpass.getuser()
     (_, _, _, admin_group_members) = grp.getgrnam('sudo')
     return current_user in admin_group_members
+
+def escape_backslash(string: str) -> str:
+    """Escape single backslashes in string that are not in escape sequence"""
+    p = re.compile(r'(?<!\\)[\\](?!b|f|n|r|t|\\)')
+    result = p.sub(r'\\\\', string)
+    return result

--- a/src/services/vyos-http-api-server
+++ b/src/services/vyos-http-api-server
@@ -24,6 +24,7 @@ import traceback
 import threading
 
 import vyos.config
+import vyos.util
 
 import bottle
 
@@ -212,6 +213,7 @@ def get_value():
                 config_format = command['configFormat']
 
             res = session.show_config(path=command['path'])
+            res = vyos.util.escape_backslash(res)
             if config_format == 'json':
                 config_tree = vyos.configtree.ConfigTree(res)
                 res = json.loads(config_tree.to_json())


### PR DESCRIPTION
Escape isolated single backslashes in output of showConfig before passing to ConfigTree().