### PR TITLE
[vyos-hostsd] T1812: Reload pdns on dhcp client update

### DIFF
--- a/src/system/on-dhcp-event.sh
+++ b/src/system/on-dhcp-event.sh
@@ -45,11 +45,13 @@ case "$action" in
     # add host
     /usr/bin/vyos-hostsd-client --add-hosts --tag "DHCP-$client_ip" --host "$client_fqdn_name,$client_ip"
     ;;
+    ((changes++))
 
   release) # delete mapping for released address
     # delete host
     /usr/bin/vyos-hostsd-client --delete-hosts --tag "DHCP-$client_ip"
     ;;
+    ((changes++))
 
   *)
     logger -s -t on-dhcp-event "Invalid command \"$1\""


### PR DESCRIPTION
It appears that this incrementer wasn't being incremented which caused pdns_recursor to not reload on DHCP client updates