### PR TITLE
T1844 Fix interface configuration

### DIFF
--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -130,7 +130,7 @@ def get_config():
         print("Interface not specified")
 
     # check if ethernet interface has been removed
-    cfg_base = ['interfaces', 'ethernet', eth['intf']]
+    cfg_base = 'interfaces ethernet ' + eth['intf']
     if not conf.exists(cfg_base):
         eth['deleted'] = True
         # we can not bail out early as ethernet interface can not be removed


### PR DESCRIPTION
Revert an extraneous change from T1762 which changed the
parameter to conf.exists() from a string to a list

https://phabricator.vyos.net/T1844
https://phabricator.vyos.net/T1762