### PR TITLE
vyos.config: T1764: config.exists, argument can be string or list

### DIFF
--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -191,6 +191,8 @@ class Config(object):
         else:
             # libvyosconfig exists() works only for _nodes_, not _values_
             # libvyattacfg one also worked for values, so we emulate that case here
+            if isinstance(path, list):
+                path = " ".join(path)
             path = re.split(r'\s*', path)
             path_without_value = path[:-1]
             path_str = " ".join(path_without_value)


### PR DESCRIPTION
config.exists(['path', 'to', 'node']) did raise an exception if the node didn't exist. if the argument is a string it always worked and returned False.