### PR TITLE
T1846 Fix Config-object being affected by the shell env

### DIFF
--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -137,7 +137,13 @@ class Config(object):
         if self.__session_env:
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE, env=self.__session_env)
         else:
-            p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+            # Clear out the VYATTA_*_LEVEL variables to ensure that we are operating on
+            # the full configuration instead of a child node based on the edit level
+            # of the caller.
+            env = os.environ
+            env['VYATTA_TEMPLATE_LEVEL'] = '/'
+            env['VYATTA_EDIT_LEVEL'] = '/'
+            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, env=env)
         out = p.stdout.read()
         p.wait()
         if p.returncode != 0:


### PR DESCRIPTION
The Config-object and the contained ConfigTree seems to be expected
to be absolute paths from the root of the tree. However the way it
uses cli-shell-api with an inherited environment means that the
session_config only contains configuration nodes under the current
[edit ...] level. Override the edit-level environment variables.

https://phabricator.vyos.net/T1846