### PR TITLE
Update config.py

### DIFF
--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -194,7 +194,8 @@ class Config(object):
         else:
             # libvyosconfig exists() works only for _nodes_, not _values_
             # libvyattacfg one also worked for values, so we emulate that case here
-            path = re.split(r'\s*', path)
+            if isinstance(path, str):
+                path = re.split(r'\s*', path)
             path_without_value = path[:-1]
             path_str = " ".join(path_without_value)
             try:


### PR DESCRIPTION
fix for crash of the form

```
Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/interfaces-ethernet.py", line 447, in <module>
    c = get_config()
  File "/usr/libexec/vyos/conf_mode/interfaces-ethernet.py", line 135, in get_config
    if not conf.exists(cfg_base):
  File "/usr/lib/python3/dist-packages/vyos/config.py", line 200, in exists
    path = re.split(r'\s*', path)
  File "/usr/lib/python3.4/re.py", line 196, in split
    return _compile(pattern, flags).split(string, maxsplit)
TypeError: expected string or buffer
```