### PR TITLE
flow-accounting: T1895: add restriction to syslog facility

### DIFF
--- a/interface-definitions/flow-accounting-conf.xml.in
+++ b/interface-definitions/flow-accounting-conf.xml.in
@@ -33,6 +33,9 @@
               <completionHelp>
                 <list>auth authpriv cron daemon kern lpr mail mark news protocols security syslog user uucp local0 local1 local2 local3 local4 local5 local6 local7 all</list>
               </completionHelp>
+              <constraint>
+                <regex>auth|authpriv|cron|daemon|kern|lpr|mail|mark|news|protocols|security|syslog|user|uucp|local0|local1|local2|local3|local4|local5|local6|local7|all</regex>
+              </constraint>
               <valueHelp>
                 <format>auth</format>
                 <description>Authentication and authorization</description>


### PR DESCRIPTION
T1895 There is not restriction on selection of syslog facility
added in xml file