### PR TITLE
FRRouting: T1514: Added commands to restart FRRouting daemon

### DIFF
--- a/op-mode-definitions/restart-frr.xml
+++ b/op-mode-definitions/restart-frr.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="restart">
+    <children>
+      <node name="frr">
+        <properties>
+          <help>Restart FRRouting daemons</help>
+        </properties>
+        <command>${vyos_op_scripts_dir}/restart_frr.py --action restart</command>
+        <children>
+          <leafNode name="bfdd">
+            <properties>
+              <help>Restart Bidirectional Forwarding Detection daemon</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon bfdd</command>
+          </leafNode>
+          <leafNode name="bgpd">
+            <properties>
+              <help>Restart Border Gateway Protocol daemon</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon bgpd</command>
+          </leafNode>
+          <leafNode name="ospfd">
+            <properties>
+              <help>Restart OSPFv2 daemon</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon ospfd</command>
+          </leafNode>
+          <leafNode name="ospf6d">
+            <properties>
+              <help>Restart OSPFv3 daemon</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon ospf6d</command>
+          </leafNode>
+          <leafNode name="ripd">
+            <properties>
+              <help>Restart Routing Information Protocol daemon</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon ripd</command>
+          </leafNode>
+          <leafNode name="ripngd">
+            <properties>
+              <help>Restart RIPng daemon</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon ripngd</command>
+          </leafNode>
+          <leafNode name="staticd">
+            <properties>
+              <help>Restart Static Route daemon</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon staticd</command>
+          </leafNode>
+          <leafNode name="zebra">
+            <properties>
+              <help>Restart IP routing manager daemon</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon zebra</command>
+          </leafNode>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/src/op_mode/restart_frr.py
+++ b/src/op_mode/restart_frr.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2019 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import sys
+import argparse
+import subprocess
+import logging
+from logging.handlers import SysLogHandler
+
+# some default values
+watchfrr = '/usr/lib/frr/watchfrr.sh'
+vtysh = '/usr/bin/vtysh'
+
+# configure logging
+logger = logging.getLogger(__name__)
+logs_handler = SysLogHandler('/dev/log')
+logs_handler.setFormatter(logging.Formatter('%(filename)s: %(message)s'))
+logger.addHandler(logs_handler)
+logger.setLevel(logging.INFO)
+
+# write active config to file
+def _write_config():
+    command = "sudo {} -n -c write ".format(vtysh)
+    return_code = subprocess.call(command, shell=True)
+    if not return_code == 0:
+        logger.error("Failed to save active config: \"{}\" returned exit code: {}".format(command, return_code))
+        print("Failed to save active config: \"{}\" returned exit code: {}".format(command, return_code))
+        sys.exit(1)
+    logger.info("Active config saved to /etc/frr/frr.conf")
+
+# check if daemon is running
+def _daemon_check(daemon):
+    command = "sudo {} print_status {}".format(watchfrr, daemon)
+    return_code = subprocess.call(command, shell=True)
+    if not return_code == 0:
+        logger.error("Daemon \"{}\" is not running".format(daemon))
+        return False
+
+    # return True if all checks were passed
+    return True
+
+# restart daemon
+def _daemon_restart(daemon):
+    command = "sudo {} restart {}".format(watchfrr, daemon)
+    return_code = subprocess.call(command, shell=True)
+    if not return_code == 0:
+        logger.error("Failed to restart daemon \"{}\"".format(daemon))
+        return False
+
+    # return True if restarted sucessfully
+    logger.info("Daemon \"{}\" restarted".format(daemon))
+    return True
+
+# check all daemons if they are running
+def _check_args_daemon(daemons):
+    for daemon in daemons:
+        if not _daemon_check(daemon):
+            return False
+    return True
+
+# define program arguments
+cmd_args_parser = argparse.ArgumentParser(description='restart frr daemons')
+cmd_args_parser.add_argument('--action', choices=['restart'], required=True, help='action to frr daemons')
+cmd_args_parser.add_argument('--daemon', choices=['bfdd', 'bgpd', 'ospfd', 'ospf6d', 'ripd', 'ripngd', 'staticd', 'zebra'], required=False,  nargs='*', help='select single or multiple daemons')
+# parse arguments
+cmd_args = cmd_args_parser.parse_args()
+
+
+# main logic
+# restart daemon
+if cmd_args.action == 'restart':
+    _write_config()
+    if cmd_args.daemon:
+        # check all daemons if they are running
+        if not _check_args_daemon(cmd_args.daemon):
+            print("Warning: some of listed daemons are not running")
+
+        # run command to restart daemon
+        for daemon in cmd_args.daemon:
+            if not _daemon_restart(daemon):
+                print("Failed to restart daemon: {}".format(daemon))
+                sys.exit(1)
+    else:
+        # run command to restart FRR
+        if not _daemon_restart(''):
+            print("Failed to restart FRRouting")
+            sys.exit(1)
+
+sys.exit(0)


### PR DESCRIPTION
It can be restarted the whole FRRouting (all running) daemons or only selected ones.
The configuration is saving during the restart process, so after it, the active config should be the same as before.
There are no checks for safety, so responsibility for the results of running command is fully on the operator.