### PR TITLE
bfd: T1949: fix verification logic for IPv6 BFD peers

### DIFF
--- a/python/vyos/validate.py
+++ b/python/vyos/validate.py
@@ -52,6 +52,17 @@ def is_ipv6(addr):
 
     return False
 
+def is_ipv6_link_local(addr):
+    """
+    Check addr if it is an IPv6 link-local address/network. Returns True/False
+    """
+
+    if is_ipv6(addr):
+        if ipaddress.IPv6Address(addr).is_link_local:
+            return True
+
+    return False
+
 def is_intf_addr_assigned(intf, addr):
     """
     Verify if the given IPv4/IPv6 address is assigned to specific interface.

--- a/src/conf_mode/protocols_bfd.py
+++ b/src/conf_mode/protocols_bfd.py
@@ -163,10 +163,15 @@ def verify(bfd):
     conf = Config()
 
     for peer in bfd['new_peers']:
-        # IPv6 peers require an explicit local address/interface combination
-        if vyos.validate.is_ipv6(peer['remote']):
+        # IPv6 link local peers require an explicit local address/interface
+        if vyos.validate.is_ipv6_link_local(peer['remote']):
             if not (peer['src_if'] and peer['src_addr']):
-                raise ConfigError('BFD IPv6 peers require explicit local address and interface setting')
+                raise ConfigError('BFD IPv6 link-local peers require explicit local address and interface setting')
+
+        # IPv6 peers require an explicit local address
+        if vyos.validate.is_ipv6(peer['remote']):
+            if not peer['src_addr']:
+                raise ConfigError('BFD IPv6 peers require explicit local address setting')
 
         # multihop require source address
         if peer['multihop'] and not peer['src_addr']:


### PR DESCRIPTION
As described in T1949 IPv6 BFD peers only require a source address to be configured.

[FRR Docs](http://docs.frrouting.org/en/latest/bfd.html#clicmd-peer%3CA.B.C.D|X:X::X:X%3E[{multihop|local-address%3CA.B.C.D|X:X::X:X%3E|interfaceIFNAME|vrfNAME}])