### PR TITLE
dynamic DNS: T1953: Relaxed service name check

### DIFF
--- a/interface-definitions/dns-dynamic.xml.in
+++ b/interface-definitions/dns-dynamic.xml.in
@@ -70,11 +70,11 @@
                     <properties>
                       <help>Service being used for Dynamic DNS [REQUIRED]</help>
                       <completionHelp>
-                        <list>custom afraid changeip cloudflare dnspark dslreports dyndns easydns namecheap noip sitelutions zoneedit</list>
+                        <list>&lt;custom&gt; afraid changeip cloudflare dnspark dslreports dyndns easydns namecheap noip sitelutions zoneedit</list>
                       </completionHelp>
                       <valueHelp>
-                        <format>custom</format>
-                        <description>Custom or predefined service</description>
+                        <format>&lt;custom&gt;</format>
+                        <description>Service with a custom name</description>
                       </valueHelp>
                       <valueHelp>
                         <format>afraid</format>
@@ -121,9 +121,9 @@
                         <description>zoneedit.com Services</description>
                       </valueHelp>
                       <constraint>
-                        <regex>(custom|afraid|changeip|cloudflare|dnspark|dslreports|dyndns|easydns|namecheap|noip|sitelutions|zoneedit)</regex>
+                        <regex>^(custom|afraid|changeip|cloudflare|dnspark|dslreports|dyndns|easydns|namecheap|noip|sitelutions|zoneedit|\w+)$</regex>
                       </constraint>
-                      <constraintErrorMessage>Please choose from the list of allowed services</constraintErrorMessage>
+                      <constraintErrorMessage>You can use only predefined list of services or word characters (_, a-z, A-Z, 0-9) as service name</constraintErrorMessage>
                     </properties>
                     <children>
                       <leafNode name="host-name">


### PR DESCRIPTION
Internally, we can accept more than one server of each type for sending dynamic DNS updates, but due to a strong check in CLI, it is not possible to add more than one server with the same protocol (except "custom", but it allows to add only one more server). The patch relaxing this limitation by allowing adding as many servers with the same protocol, as needed.