### PR TITLE
vxlan: T1961: Adjusting MTU limits

### DIFF
--- a/interface-definitions/include/interface-mtu-1200-9000.xml.i
+++ b/interface-definitions/include/interface-mtu-1200-9000.xml.i
@@ -1,0 +1,13 @@
+<leafNode name="mtu">
+  <properties>
+    <help>Maximum Transmission Unit (MTU)</help>
+    <valueHelp>
+      <format>1200-9000</format>
+      <description>Maximum Transmission Unit</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1200-9000"/>
+    </constraint>
+    <constraintErrorMessage>MTU must be between 1200 and 9000</constraintErrorMessage>
+  </properties>
+</leafNode>

--- a/interface-definitions/interfaces-vxlan.xml.in
+++ b/interface-definitions/interfaces-vxlan.xml.in
@@ -57,7 +57,7 @@
               </completionHelp>
             </properties>
           </leafNode>
-          #include <include/interface-mtu-1450-9000.xml.i>
+          #include <include/interface-mtu-1200-9000.xml.i>
           <leafNode name="remote">
             <properties>
               <help>Remote address of VXLAN tunnel</help>


### PR DESCRIPTION
The minimum 1450 MTU limit here prevented VXLAN from being used over anything other than a normal ethernet interface (like wireguard).  This adds a new MTU range to be able to accommodate this.
