### PR TITLE
Syntax version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 TMPL_DIR := templates-cfg
 OP_TMPL_DIR := templates-op
 BUILD_DIR := build
+DATA_DIR := data
 CFLAGS :=
 
 src = $(wildcard interface-definitions/*.xml.in)
@@ -77,8 +78,13 @@ op_mode_definitions:
 	rm -f $(OP_TMPL_DIR)/reset/vpn/node.def
 	rm -f $(OP_TMPL_DIR)/show/system/node.def
 
+.PHONY: component_versions
+.ONESHELL:
+component_versions: $(BUILD_DIR) $(obj)
+	$(CURDIR)/scripts/build-component-versions $(BUILD_DIR)/interface-definitions $(DATA_DIR)
+
 .PHONY: all
-all: clean interface_definitions op_mode_definitions
+all: clean interface_definitions op_mode_definitions component_versions
 
 .PHONY: clean
 clean:

--- a/python/vyos/defaults.py
+++ b/python/vyos/defaults.py
@@ -29,6 +29,8 @@ cfg_vintage = 'vyatta'
 
 commit_lock = '/opt/vyatta/config/.lock'
 
+version_file = '/usr/share/vyos/component-versions.json'
+
 https_data = {
     'listen_addresses' : { '*': ['_'] }
 }

--- a/schema/interface_definition.rnc
+++ b/schema/interface_definition.rnc
@@ -24,7 +24,14 @@
 # Interface definition starts with interfaceDefinition tag that may contain node tags
 start = element interfaceDefinition
 {
+    syntaxVersion*,
     node*
+}
+
+# interfaceDefinition may contain syntax version attribute lists.
+syntaxVersion = element syntaxVersion
+{
+    (componentAttr & versionAttr)
 }
 
 # node tag may contain node, leafNode, or tagNode tags
@@ -95,6 +102,16 @@ properties = element properties
 
     # These are meaningful only for tag nodes
     (element keepChildOrder { empty })?
+}
+
+componentAttr = attribute component
+{
+    text
+}
+
+versionAttr = attribute version
+{
+    text
 }
 
 # All nodes must have "name" attribute

--- a/schema/interface_definition.rng
+++ b/schema/interface_definition.rng
@@ -29,10 +29,22 @@
   <start>
     <element name="interfaceDefinition">
       <zeroOrMore>
+        <ref name="syntaxVersion"/>
+      </zeroOrMore>
+      <zeroOrMore>
         <ref name="node"/>
       </zeroOrMore>
     </element>
   </start>
+  <!-- interfaceDefinition may contain syntax version attribute lists. -->
+  <define name="syntaxVersion">
+    <element name="syntaxVersion">
+      <interleave>
+        <ref name="componentAttr"/>
+        <ref name="versionAttr"/>
+      </interleave>
+    </element>
+  </define>
   <!--
     node tag may contain node, leafNode, or tagNode tags
     Those are intermediate configuration nodes that may only contain
@@ -183,6 +195,12 @@
         </optional>
       </interleave>
     </element>
+  </define>
+  <define name="componentAttr">
+    <attribute name="component"/>
+  </define>
+  <define name="versionAttr">
+    <attribute name="version"/>
   </define>
   <!-- All nodes must have "name" attribute -->
   <define name="nodeNameAttr">

--- a/scripts/build-command-templates
+++ b/scripts/build-command-templates
@@ -295,4 +295,6 @@ root = xml.getroot()
 
 nodes = root.iterfind("*")
 for n in nodes:
+    if n.tag == "syntaxVersion":
+        continue
     process_node(n, [output_dir])

--- a/scripts/build-component-versions
+++ b/scripts/build-component-versions
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import argparse
+import json
+
+from lxml import etree as ET
+
+parser = argparse.ArgumentParser()
+parser.add_argument('INPUT_DIR', type=str,
+                    help="Directory containing XML interface definition files")
+parser.add_argument('OUTPUT_DIR', type=str,
+                    help="Output directory for JSON file")
+
+args = parser.parse_args()
+
+input_dir = args.INPUT_DIR
+output_dir = args.OUTPUT_DIR
+
+version_dict = {}
+
+for filename in os.listdir(input_dir):
+    filepath = os.path.join(input_dir, filename)
+    print(filepath)
+    try:
+        xml = ET.parse(filepath)
+    except Exception as e:
+        print("Failed to load interface definition file {0}".format(filename))
+        print(e)
+        sys.exit(1)
+
+    root = xml.getroot()
+    version_data = root.iterfind("syntaxVersion")
+    for ver in version_data:
+        component = ver.get("component")
+        version = int(ver.get("version"))
+
+        v = version_dict.get(component)
+        if v is None:
+            version_dict[component] = version
+        elif version > v:
+            version_dict[component] = version
+
+out_file = os.path.join(output_dir, 'component-versions.json')
+with open(out_file, 'w') as f:
+    json.dump(version_dict, f, indent=4, sort_keys=True)


### PR DESCRIPTION
Add syntax version to schema, so that the information used for migration is tightly coupled to the xml interface definitions; add script to collect syntax version during build; add function to read resulting versions from JSON, in addition to reading from vyatta directory.