### PR TITLE
service lldp: T2019: modify handling of interface 'all'

### DIFF
--- a/src/conf_mode/lldp.py
+++ b/src/conf_mode/lldp.py
@@ -39,7 +39,7 @@ vyos_tmpl = """
 configure system platform VyOS
 configure system description "VyOS {{ options.description }}"
 {% if options.listen_on -%}
-configure system interface pattern "{{ options.listen_on | join(",") }}"
+configure system interface pattern "{{ ( options.listen_on | select('equalto','all') | map('replace','all','*') | list + options.listen_on | select('equalto','!all') | map('replace','!all','!*') | list + options.listen_on | reject('equalto','all') | reject('equalto','!all') | list ) | unique | join(",") }}"
 {%- endif %}
 {% if options.mgmt_addr -%}
 configure system ip management pattern {{ options.mgmt_addr | join(",") }}


### PR DESCRIPTION
Modify lldpd config template in './src/conf_mode/lldp.py'.
conf_mode uses 'all' to specify all interfaces.
lldpd config file uses '*' to specify all interfaces.
Both use an exclamation mark ('!') as prefix to disable lldp on an interface, eg. '!eth1' or '!all'.

Add jinja2 template filters to create and merge following sub-lists
a) take list of conf_mode lldp interfaces, remove every interface except 'all', replace 'all' with '*'
   -> support interface all
b) take list of conf_mode lldp interfaces, remove every interface except '!all', replace '!all' with '!*'
   -> support interface all disabled
c) take list of conf_mode lldp interfaces, remove every interface named 'all' or '!all'
   -> support any other interface