### PR TITLE
Correcting typo in validation of SSH key-type

### DIFF
--- a/interface-definitions/system-login-user.xml.in
+++ b/interface-definitions/system-login-user.xml.in
@@ -90,7 +90,7 @@
                             <description/>
                           </valueHelp>
                           <constraint>
-                            <regex>(ssh-dss|ssh-rsa|ecdsa-sha2-nistp256|ecdsa-sha2-nistp384|ecdsa-sha2-nistp521|ssh-ed25519s)</regex>
+                            <regex>(ssh-dss|ssh-rsa|ecdsa-sha2-nistp256|ecdsa-sha2-nistp384|ecdsa-sha2-nistp521|ssh-ed25519)</regex>
                           </constraint>
                         </properties>
                       </leafNode>


### PR DESCRIPTION
Additional “s” in regex constraint prevents configuration of “ssh-ed25519” keys