### PR TITLE
get_config_dict failed when configuration was empty/missing

### DIFF
--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -253,6 +253,9 @@ class Config(object):
             path = " ".join(path)
         try:
             out = self._run(self._make_command('showConfig', path))
+            # ugly but can not see a better way to handle this
+            if out == 'Configuration under specified path is empty\n':
+                return ''
             return out
         except VyOSError:
             return(default)


### PR DESCRIPTION
using get_config_dict failed when the configuration section was missing did return a string which could not be parsed to the JSON parser for deserialisation.