### PR TITLE
[op-mode]: T2032: Bandwidth rate in bps

### DIFF
--- a/op-mode-definitions/bandwidth-monitor.xml
+++ b/op-mode-definitions/bandwidth-monitor.xml
@@ -8,7 +8,7 @@
         </properties>
         <children>
           <tagNode name="interface">
-            <command>bmon -p $4</command>
+            <command>bmon -b -p $4</command>
             <properties>
               <help>Monitor bandwidth usage on specified interface</help>
               <completionHelp>


### PR DESCRIPTION
By default bmon show Bytes  instead of bits.
Flag "-b "  - Show rates in bits per second