### PR TITLE
T2034: Disallow removal of default loopback addresses

### DIFF
--- a/python/vyos/ifconfig.py
+++ b/python/vyos/ifconfig.py
@@ -826,6 +826,9 @@ class LoopbackIf(Interface):
         """
         # remove all assigned IP addresses from interface
         for addr in self.get_addr():
+            if addr in ["127.0.0.1/8", "::1/128"]:
+                # Do not allow deletion of the default loopback addresses
+                continue
             self.del_addr(addr)
 
         # question: do we also delerte the loopback address? 127.0.0.1/8


### PR DESCRIPTION
The removal of interfaces loopback lo results in all address being
removed from the loopback interface. (also not cli controlled addresses)
In this process 127.0.0.1/8 and ::1/128 are also removed witch results
in error for services that are dependent on these adresses, this includes
eg. snmp and ssh

Removal of these addresses needs to be disallowed by the config backend
and removal of the whole config block interfaces loopback lo needs to
result in removal of all non-default addresses only.