### PR TITLE
T2029 Switch to new syntax for config file component versions

### DIFF
--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -24,10 +24,10 @@ def escape_backslash(string: str) -> str:
     result = p.sub(r'\\\\', string)
     return result
 
-def strip_version(s):
-    """ Split a config string into the config section and the version string """
+def extract_version(s):
+    """ Extract the version string from the config string """
     t = re.split('(^//)', s, maxsplit=1, flags=re.MULTILINE)
-    return (t[0], ''.join(t[1:]))
+    return (s, ''.join(t[1:]))
 
 def check_path(path):
     # Necessary type checking
@@ -126,7 +126,7 @@ class ConfigTree(object):
         self.__destroy = self.__lib.destroy
         self.__destroy.argtypes = [c_void_p]
 
-        config_section, version_section = strip_version(config_string)
+        config_section, version_section = extract_version(config_string)
         config_section = escape_backslash(config_section)
         config = self.__from_string(config_section.encode())
         if config is None:

--- a/python/vyos/migrator.py
+++ b/python/vyos/migrator.py
@@ -25,7 +25,7 @@ class MigratorError(Exception):
     pass
 
 class Migrator(object):
-    def __init__(self, config_file, force=False, set_vintage=None):
+    def __init__(self, config_file, force=False, set_vintage='vyos'):
         self._config_file = config_file
         self._force = force
         self._set_vintage = set_vintage
@@ -204,9 +204,6 @@ class Migrator(object):
         return self._changed
 
 class VirtualMigrator(Migrator):
-    def __init__(self, config_file, vintage='vyos'):
-        super().__init__(config_file, set_vintage = vintage)
-
     def run(self):
         cfg_file = self._config_file
 

--- a/python/vyos/migrator.py
+++ b/python/vyos/migrator.py
@@ -61,9 +61,6 @@ class Migrator(object):
         if self._set_vintage:
             self._config_file_vintage = self._set_vintage
 
-        if not self._config_file_vintage:
-            self._config_file_vintage = vyos.defaults.cfg_vintage
-
         if self._config_file_vintage not in ['vyatta', 'vyos']:
             raise MigratorError("Unknown vintage.")
 

--- a/python/vyos/migrator.py
+++ b/python/vyos/migrator.py
@@ -209,8 +209,7 @@ class VirtualMigrator(Migrator):
 
         cfg_versions = self.read_config_file_versions()
         if not cfg_versions:
-            raise MigratorError("Config file has no version information;"
-                                " virtual migration not possible.")
+            return
 
         if self.update_vintage():
             self._changed = True

--- a/src/helpers/run-config-migration.py
+++ b/src/helpers/run-config-migration.py
@@ -69,15 +69,22 @@ def main():
         sys.exit(1)
 
     if not virtual:
-        migration = Migrator(config_file_name, force=force_on,
-                             set_vintage=vintage)
+        virtual_migration = VirtualMigrator(config_file_name)
+        virtual_migration.run()
+
+        migration = Migrator(config_file_name, force=force_on)
+        migration.run()
+
+        if not migration.config_changed():
+            os.remove(backup_file_name)
     else:
-        migration = VirtualMigrator(config_file_name, set_vintage=vintage)
+        virtual_migration = VirtualMigrator(config_file_name,
+                                            set_vintage=vintage)
 
-    migration.run()
+        virtual_migration.run()
 
-    if not migration._changed:
-        os.remove(backup_file_name)
+        if not virtual_migration.config_changed():
+            os.remove(backup_file_name)
 
 if __name__ == '__main__':
     main()

--- a/src/helpers/run-config-migration.py
+++ b/src/helpers/run-config-migration.py
@@ -72,7 +72,7 @@ def main():
         migration = Migrator(config_file_name, force=force_on,
                              set_vintage=vintage)
     else:
-        migration = VirtualMigrator(config_file_name)
+        migration = VirtualMigrator(config_file_name, set_vintage=vintage)
 
     migration.run()
 

--- a/tests/data/config.valid
+++ b/tests/data/config.valid
@@ -35,5 +35,5 @@ empty-node {
 
 trailing-leaf-node-without-value
 
-/* Trailing commend */
-/* Another trailing comment */
+// Trailing comment
+// Another trailing comment


### PR DESCRIPTION
This PR changes the syntax of the trailing version string of the config file (cf. T2029 for example), as represented _during config migration_, and the parsing by which configtree splits the config file into the config section proper and the version string.

The version string is written to the config file on two occasions:
(1) During migration, which happens on boot of livecd, load config, or merge config.
(2) On configuration save.

This PR enforces the separation of the two mechanisms, and addresses (1). As the syntax is updated before running any migration scripts (virtual- or meta- migration), there is no issue in ignoring (2) for the moment, and hence retaining the classic syntax on save; this will maintain portability and expected output for now.

N.B. one will see the following: on first boot of livecd or installed image, the config file will have the new syntax, as 'save' has not occurred. As soon as the config is saved, it will have the classic syntax. The choice of syntax written on save is determined by the string 'vintage' (one of ['vyatta', 'vyos']) in python/vyos/defaults.py.