### PR TITLE
ifconfig: T2057: generalised Interface configuration

### DIFF
--- a/python/vyos/ifconfig_vlan.py
+++ b/python/vyos/ifconfig_vlan.py
@@ -21,7 +21,7 @@ def apply_vlan_config(vlan, config):
     to a VLAN interface
     """
 
-    if type(vlan) != type(VLANIf("lo")):
+    if vlan.__class__ != VLANIf:
         raise TypeError()
 
     # get DHCP config dictionary and update values

--- a/src/conf_mode/interfaces-geneve.py
+++ b/src/conf_mode/interfaces-geneve.py
@@ -127,7 +127,7 @@ def apply(geneve):
         conf['remote'] = geneve['remote']
 
         # Finally create the new interface
-        g = GeneveIf(geneve['intf'], config=conf)
+        g = GeneveIf(geneve['intf'], **conf)
         # update interface description used e.g. by SNMP
         g.set_alias(geneve['description'])
         # Maximum Transfer Unit (MTU)

--- a/src/conf_mode/interfaces-l2tpv3.py
+++ b/src/conf_mode/interfaces-l2tpv3.py
@@ -193,7 +193,7 @@ def apply(l2tpv3):
         # always delete it first.
         conf['session_id'] = l2tpv3['session_id']
         conf['tunnel_id'] = l2tpv3['tunnel_id']
-        l = L2TPv3If(l2tpv3['intf'], config=conf)
+        l = L2TPv3If(l2tpv3['intf'], **conf)
         l.remove()
 
     if not l2tpv3['deleted']:
@@ -208,7 +208,7 @@ def apply(l2tpv3):
         conf['peer_session_id'] = l2tpv3['peer_session_id']
 
         # Finally create the new interface
-        l = L2TPv3If(l2tpv3['intf'], config=conf)
+        l = L2TPv3If(l2tpv3['intf'], **conf)
         # update interface description used e.g. by SNMP
         l.set_alias(l2tpv3['description'])
         # Maximum Transfer Unit (MTU)

--- a/src/conf_mode/interfaces-pseudo-ethernet.py
+++ b/src/conf_mode/interfaces-pseudo-ethernet.py
@@ -232,7 +232,7 @@ def apply(peth):
 
         # It is safe to "re-create" the interface always, there is a sanity check
         # that the interface will only be create if its non existent
-        p = MACVLANIf(peth['intf'], config=conf)
+        p = MACVLANIf(peth['intf'], **conf)
     else:
         p = MACVLANIf(peth['intf'])
 

--- a/src/conf_mode/interfaces-vxlan.py
+++ b/src/conf_mode/interfaces-vxlan.py
@@ -180,7 +180,7 @@ def apply(vxlan):
         conf['port'] = vxlan['remote_port']
 
         # Finally create the new interface
-        v = VXLANIf(vxlan['intf'], config=conf)
+        v = VXLANIf(vxlan['intf'], **conf)
         # update interface description used e.g. by SNMP
         v.set_alias(vxlan['description'])
         # Maximum Transfer Unit (MTU)


### PR DESCRIPTION
Provides a consistent way to pass options to sub-classes of Interface. Using python **kwargs, parameters, options can be passed one by one or using a dict.

MACVLANIf("name0", option1=value1, option2=value2)

or 

options = { 'option1': value1, 'option2': value2, }
MAVLANIf("name0", **options)

The interface creation/deletion code was moved into a sub-function which was redefined by sub-classes, tidying the code.