### PR TITLE
dhcp-server: Allow configure bootstrap root path

### DIFF
--- a/interface-definitions/dhcp-server.xml.in
+++ b/interface-definitions/dhcp-server.xml.in
@@ -94,6 +94,11 @@
                       <help>Bootstrap file name</help>
                     </properties>
                   </leafNode>
+                  <leafNode name="bootfile-rootpath">
+                    <properties>
+                      <help>This option specifies the path-name that contains the client's root disk.</help>
+                    </properties>
+                  </leafNode>
                   <leafNode name="bootfile-server">
                     <properties>
                       <help>Server (IP address or domain name) from which the initial

--- a/src/conf_mode/dhcp_server.py
+++ b/src/conf_mode/dhcp_server.py
@@ -167,6 +167,9 @@ shared-network {{ network.name }} {
         option bootfile-name "{{ subnet.bootfile_name }}";
         filename "{{ subnet.bootfile_name }}";
         {%- endif -%}
+        {%- if subnet.bootfile_rootpath %}
+        option root-path "{{ subnet.bootfile_rootpath }}";
+        {%- endif -%}
         {%- if subnet.bootfile_server %}
         next-server {{ subnet.bootfile_server }};
         {%- endif -%}
@@ -392,6 +395,7 @@ def get_config():
                         'address': str(ip_network(net).network_address),
                         'netmask': str(ip_network(net).netmask),
                         'bootfile_name': '',
+                        'bootfile_rootpath': '',
                         'bootfile_server': '',
                         'client_prefix_length': '',
                         'default_router': '',
@@ -425,6 +429,9 @@ def get_config():
                     # Used to identify a bootstrap file
                     if conf.exists('bootfile-name'):
                         subnet['bootfile_name'] = conf.return_value('bootfile-name')
+
+                    if conf.exists('bootfile-rootpath'):
+                        subnet['bootfile_rootpath'] = conf.return_value('bootfile-rootpath')
 
                     # Specify host address of the server from which the initial boot file
                     # (specified above) is to be loaded. Should be a numeric IP address or


### PR DESCRIPTION
You can set the root path for tftpboot.

http://www.networksorcery.com/enp/protocol/bootp/option017.htm
