### PR TITLE
macvlan: T2057: fix creation of interface

### DIFF
--- a/python/vyos/ifconfig.py
+++ b/python/vyos/ifconfig.py
@@ -1411,7 +1411,7 @@ class MACVLANIf(VLANIf):
         super().__init__(ifname, **kargs)
 
     def _create(self):
-        cmd = 'ip link add {intf} link {link} type macvlan mode {mode}'.format(**self.config)
+        cmd = 'ip link add {ifname} link {link} type macvlan mode {mode}'.format(**self.config)
         self._cmd(cmd)
 
     @staticmethod


### PR DESCRIPTION
fix a typo in the create command for the macvlan interface introduced with T2057