### PR TITLE
dhcp-server: T2062: Fix static route bytes

### DIFF
--- a/src/conf_mode/dhcp_server.py
+++ b/src/conf_mode/dhcp_server.py
@@ -594,17 +594,14 @@ def get_config():
                         # add netmask
                         string = str(net.prefixlen) + ','
                         # add network bytes
-                        bytes = str(net.network_address).split('.')
-                        for b in bytes:
-                            if b != '0':
-                                string += b + ','
+                        if net.prefixlen:
+                            width = net.prefixlen // 8
+                            if net.prefixlen % 8:
+                                width += 1
+                            string += ','.join(map(str,tuple(net.network_address.packed)[:width])) + ','
 
                         # add router bytes
-                        bytes = subnet['static_router'].split('.')
-                        for b in bytes:
-                            string += b
-                            if b is not bytes[-1]:
-                                string += ','
+                        string += ','.join(subnet['static_router'].split('.'))
 
                         subnet['static_route'] = string
 


### PR DESCRIPTION
Network bytes calculated wrong here:
https://github.com/vyos/vyos-1x/blob/current/src/conf_mode/dhcp_server.py#L596-L600

if the network_address (with /24 netmask) is 10.10.0.X or 10.0.10.X, the resulted string will be same: "10, 10,"

https://phabricator.vyos.net/T2062