### PR TITLE
ifconfig: T2101: Fix VXLAN config option parsing

### DIFF
--- a/python/vyos/ifconfig.py
+++ b/python/vyos/ifconfig.py
@@ -2020,7 +2020,7 @@ class VXLANIf(Interface):
         group = 'group {}'.format(self.config['group'])
 
         # if remote host is specified we ignore the multicast address
-        if config['remote']:
+        if self.config['remote']:
             group = 'remote {}'.format(self.config['remote'])
 
         # an underlay device is not always specified

--- a/python/vyos/ifconfig.py
+++ b/python/vyos/ifconfig.py
@@ -2002,6 +2002,8 @@ class VXLANIf(Interface):
     https://www.kernel.org/doc/Documentation/networking/vxlan.txt
     """
 
+    options = ['group', 'remote', 'dev', 'port', 'vni']
+
     default = {
         'type': 'vxlan',
         'vni': 0,


### PR DESCRIPTION
Need to fix undefined reference, wrong variable from config['remote'] to self.config['remote']
Need to fix VXLAN parser to self.config, need fill self.options in VXLANIf because of

```
for k in self.options:
    if k in kargs:
        self.config[k] = kargs[k]
```