### PR TITLE
T2140: openvpn: fix checkCertHeader function return value

### DIFF
--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -365,7 +365,7 @@ def fixup_permission(filename, permission=S_IRUSR):
 def checkCertHeader(header, filename):
     """
     Verify if filename contains specified header.
-    Returns True on success or on file not found to not trigger the exceptions
+    Returns True if match is found, False if no match or file is not found
     """
     if not os.path.isfile(filename):
         return False
@@ -375,7 +375,7 @@ def checkCertHeader(header, filename):
             if re.match(header, line):
                 return True
 
-    return True
+    return False
 
 def get_config():
     openvpn = deepcopy(default_config_data)


### PR DESCRIPTION
This function returned True even if no match in the certificate file
was found, causing all checks using it to erroneously pass.