### PR TITLE
ifconfig: T2057: data conversion was lost, better error message

### DIFF
--- a/python/vyos/ifconfig/control.py
+++ b/python/vyos/ifconfig/control.py
@@ -55,13 +55,16 @@ class Control:
 
         validate = self._command_set[name].get('validate', None)
         if validate:
-            validate(value)
-
-        config = {**config, **{'value': value}}
+            try:
+                validate(value)
+            except Exception as e:
+                raise e.__class__(f'Could not set {name}. {e}')
 
         convert = self._command_set[name].get('convert', None)
         if convert:
             value = convert(value)
+
+        config = {**config, **{'value': value}}
 
         cmd = self._command_set[name]['shellcmd'].format(**config)
         return self._cmd(cmd)


### PR DESCRIPTION
When data needed conversion (unit change, string modification), the un-modified data was used and not the modified one.
It affected arp_cache_tmo, ageing_time, forward_delay, hello_time, max_age which needed multiplying by 100 with bond_primary and alias which also needed to be '\0' if the string is empty.

It also provides the name of the option when the input is validated and fails.
