### PR TITLE
ifconfig: T2057: skip required check if we do not create the interface

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -166,13 +166,15 @@ class Interface(Control):
             if k in kargs:
                 self.config[k] = kargs[k]
 
-        for k in self.required:
-            if k not in kargs:
-                raise ConfigError('missing required option {} for {}'.format(k,self.__class__))
-
         if not os.path.exists('/sys/class/net/{}'.format(self.config['ifname'])):
             if not self.config['type']:
                 raise Exception('interface "{}" not found'.format(self.config['ifname']))
+
+            for k in self.required:
+                if k not in kargs:
+                    name = self.default['type']
+                    raise ConfigError(f'missing required option {k} for {name} {ifname} creation')
+
             self._create()
 
         # per interface DHCP config files


### PR DESCRIPTION
Only the name should be required when we delete an interface.