### PR TITLE
WIP: Make config scripts more testable

### DIFF
--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -88,7 +88,7 @@ class Config(object):
     the only state it keeps is relative *config path* for convenient access to config
     subtrees.
     """
-    def __init__(self, session_env=None):
+    def __init__(self, session_env=None, config_file='/opt/vyatta/etc/config/config.boot'):
         self._cli_shell_api = "/bin/cli-shell-api"
         self._level = []
         if session_env:
@@ -101,7 +101,7 @@ class Config(object):
         if os.path.isfile('/tmp/vyos-config-status'):
             running_config_text = self._run([self._cli_shell_api, '--show-active-only', '--show-show-defaults', '--show-ignore-edit', 'showConfig'])
         else:
-            with open('/opt/vyatta/etc/config/config.boot') as f:
+            with open(config_file) as f:
                 running_config_text = f.read()
 
         # Session config ("active") only exists in conf mode.

--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -90,7 +90,7 @@ class ConfigTreeError(Exception):
 
 
 class ConfigTree(object):
-    def __init__(self, config_string, libpath='/usr/lib/libvyosconfig.so.0'):
+    def __init__(self, config_string, libpath='libvyosconfig.so.0'):
         self.__config = None
         self.__lib = cdll.LoadLibrary(libpath)
 

--- a/src/conf_mode/dhcp_server.py
+++ b/src/conf_mode/dhcp_server.py
@@ -803,7 +803,10 @@ def verify(dhcp):
 
     return None
 
-def generate(dhcp):
+def joinpath(prefix, path):
+    return os.path.join(prefix, path.lstrip('/'))
+
+def generate(dhcp, prefix='/'):
     if dhcp is None:
         return None
 
@@ -818,12 +821,12 @@ def generate(dhcp):
     # we can pass to ISC DHCPd
     config_text = config_text.replace("&quot;",'"')
 
-    with open(config_file, 'w') as f:
+    with open(joinpath(prefix, config_file), 'w') as f:
         f.write(config_text)
 
     tmpl = jinja2.Template(daemon_tmpl)
     config_text = tmpl.render(dhcp)
-    with open(daemon_config_file, 'w') as f:
+    with open(joinpath(prefix, daemon_config_file), 'w') as f:
         f.write(config_text)
 
     return None

--- a/src/conf_mode/dhcp_server.py
+++ b/src/conf_mode/dhcp_server.py
@@ -798,7 +798,7 @@ def verify(dhcp):
 
     if not listen_ok:
         raise ConfigError('DHCP server configuration error!\n' \
-                          'None of configured DHCP subnets does not have appropriate\n' \
+                          'None of configured DHCP subnets has an appropriate\n' \
                           'primary IP address on any broadcast interface.')
 
     return None

--- a/src/conf_mode/dhcp_server.py
+++ b/src/conf_mode/dhcp_server.py
@@ -335,9 +335,10 @@ def dhcp_static_route(static_subnet, static_router):
 
     return string
 
-def get_config():
+def get_config(conf=None):
+    if conf is None:
+        conf = Config()
     dhcp = default_config_data
-    conf = Config()
     if not conf.exists('service dhcp-server'):
         return None
     else:


### PR DESCRIPTION
This series of patches comes from me not having a sacrificial VyOS setup for testing DHCP.

Seeing how configuring DHCP in VyOS is a matter of turning a text file into some text files, I was rather surprised that the scripts can't run in a standalone fashion. After applying this, I managed to actually achieve this.

Applying this wider opens up the possibility to do some integration testing for individual config scripts, e.g. in a CI system.

To test, use the commit https://github.com/rhn/vyos-1x/commit/f3661b4ef97cecf7e9c114a9ac2a8bcc773a689a and follow the instructions in the commit message.

Completely untested on anything live.