### PR TITLE
xen_netfront errors with ethtool pause

### DIFF
--- a/python/vyos/ifconfig/ethernet.py
+++ b/python/vyos/ifconfig/ethernet.py
@@ -142,7 +142,7 @@ class EthernetIf(VLANIf):
         if duplex not in ['auto', 'full', 'half']:
             raise ValueError("Value out of range (duplex)")
 
-        if self.get_driver_name() in ['vmxnet3', 'virtio_net']:
+        if self.get_driver_name() in ['vmxnet3', 'virtio_net', 'xen_netfront']:
             self._debug_msg('{} driver does not support changing speed/duplex settings!'
                             .format(self.get_driver_name()))
             return

--- a/python/vyos/ifconfig/ethernet.py
+++ b/python/vyos/ifconfig/ethernet.py
@@ -90,7 +90,7 @@ class EthernetIf(VLANIf):
         if enable not in ['on', 'off']:
             raise ValueError("Value out of range")
 
-        if self.get_driver_name() in ['vmxnet3', 'virtio_net']:
+        if self.get_driver_name() in ['vmxnet3', 'virtio_net', 'xen_netfront']:
             self._debug_msg('{} driver does not support changing flow control settings!'
                             .format(self.get_driver_name()))
             return


### PR DESCRIPTION
Add xen_netfront to the list of network interface types that will error out when trying to perform ethtool operations to disable pause/etc. Without this, cannot activate ethernet interfaces on Xen hosts.