### PR TITLE
pim-igmp: T2156: Commands for [op-mode] pim and igmp

### DIFF
--- a/op-mode-definitions/show-ip-igmp.xml
+++ b/op-mode-definitions/show-ip-igmp.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="show">
+    <children>
+      <node name="ip">
+        <children>
+          <node name="igmp">
+            <properties>
+              <help>Show IGMP (Internet Group Management Protocol) information</help>
+            </properties>
+            <children>
+              <leafNode name="groups">
+                <properties>
+                  <help>IGMP groups information</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip igmp groups"</command>
+              </leafNode>
+              <leafNode name="interfaces">
+                <properties>
+                  <help>IGMP interfaces information</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip igmp interface"</command>
+              </leafNode>
+              <leafNode name="join">
+                <properties>
+                  <help>IGMP static join information</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip igmp join"</command>
+              </leafNode>
+              <leafNode name="sources">
+                <properties>
+                  <help>IGMP sources information</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip igmp sources"</command>
+              </leafNode>
+              <leafNode name="statistics">
+                <properties>
+                  <help>IGMP statistics</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip igmp statistics"</command>
+              </leafNode>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/op-mode-definitions/show-ip-multicast.xml
+++ b/op-mode-definitions/show-ip-multicast.xml
@@ -21,6 +21,18 @@
                 </properties>
                 <command>if ps -C igmpproxy &amp;&gt;/dev/null; then ${vyos_op_scripts_dir}/show_igmpproxy.py --mfc; else echo IGMP proxy not configured; fi</command>
               </leafNode>
+              <leafNode name="summary">
+                <properties>
+                  <help>IP multicast information</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip multicast"</command>
+              </leafNode>
+              <leafNode name="route">
+                <properties>
+                  <help>IP multicast routing table</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip mroute"</command>
+              </leafNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-ip-pim.xml
+++ b/op-mode-definitions/show-ip-pim.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="show">
+    <children>
+      <node name="ip">
+        <children>
+          <node name="pim">
+            <properties>
+              <help>Show PIM (Protocol Independent Multicast) information</help>
+            </properties>
+            <children>
+              <leafNode name="interfaces">
+                <properties>
+                  <help>PIM interfaces information</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip pim interface"</command>
+              </leafNode>
+              <leafNode name="join">
+                <properties>
+                  <help>PIM join information</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip pim join"</command>
+              </leafNode>
+              <leafNode name="neighbor">
+                <properties>
+                  <help>PIM neighbor information</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip pim neighbor"</command>
+              </leafNode>
+              <leafNode name="nexthop">
+                <properties>
+                  <help>PIM cached nexthop rpf information</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip pim nexthop"</command>
+              </leafNode>
+              <leafNode name="state">
+                <properties>
+                  <help>PIM state information</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip pim state"</command>
+              </leafNode>
+              <leafNode name="statistics">
+                <properties>
+                  <help>PIM statistics</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip pim statistics"</command>
+              </leafNode>
+              <leafNode name="rp">
+                <properties>
+                  <help>PIM RP (Rendevous Point) information</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip pim rp-info"</command>
+              </leafNode>
+              <leafNode name="rpf">
+                <properties>
+                  <help>PIM cached source rpf information</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip pim rpf"</command>
+              </leafNode>
+              <leafNode name="upstream">
+                <properties>
+                  <help>PIM upstream information</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip pim upstream"</command>
+              </leafNode>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>


### PR DESCRIPTION
Add show commands for multicast, pim and igmp.
```
$ show ip multicast 
Possible completions:
...
  route         IP multicast routing table
  summary       IP multicast information


$ show ip igmp 
Possible completions:
  groups        IGMP groups information
  interfaces    IGMP interfaces information
  join          IGMP static join information
  sources       IGMP sources information
  statistics    IGMP statistics

$ show ip pim 
Possible completions:
  interfaces    PIM interfaces information
  join          PIM join information
  neighbor      PIM neighbor information
  nexthop       PIM cached nexthop rpf information
  rp            PIM RP (Rendevous Point) information
  rpf           PIM cached source rpf information
  state         PIM state information
  statistics    PIM statistics
  upstream      PIM upstream information
```