### PR TITLE
ifconfig: T2057: explicity name state functions

### DIFF
--- a/python/vyos/ifconfig/bond.py
+++ b/python/vyos/ifconfig/bond.py
@@ -101,7 +101,7 @@ class BondIf(Interface):
         for s in self.get_slaves():
             slave = {
                 'ifname': s,
-                'state': Interface(s).get_state()
+                'state': Interface(s).get_admin_state()
             }
             slave_list.append(slave)
 
@@ -112,7 +112,7 @@ class BondIf(Interface):
         # physical interface
         for slave in slave_list:
              i = Interface(slave['ifname'])
-             i.set_state(slave['state'])
+             i.set_admin_state(slave['state'])
 
     def set_hash_policy(self, mode):
         """
@@ -211,7 +211,7 @@ class BondIf(Interface):
         # An interface can only be added to a bond if it is in 'down' state. If
         # interface is in 'up' state, the following Kernel error will  be thrown:
         # bond0: eth1 is up - this may be due to an out of date ifenslave.
-        Interface(interface).set_state('down')
+        Interface(interface).set_admin_state('down')
         return self.set_interface('bond_add_port', f'+{interface}')
 
     def del_port(self, interface):

--- a/python/vyos/ifconfig/control.py
+++ b/python/vyos/ifconfig/control.py
@@ -44,7 +44,7 @@ class Control(Register):
         Using the defined names, set data write to sysfs.
         """
         cmd = self._command_get[name]['shellcmd'].format(**config)
-        return self._cmd(cmd)
+        return self._command_get[name].get('format', lambda _: _)(self._cmd(cmd))
 
     def _set_command(self, config, name, value):
         """
@@ -70,7 +70,7 @@ class Control(Register):
         config = {**config, **{'value': value}}
 
         cmd = self._command_set[name]['shellcmd'].format(**config)
-        return self._cmd(cmd)
+        return self._command_set[name].get('format', lambda _: _)(self._cmd(cmd))
 
     _sysfs_get = {}
     _sysfs_set = {}

--- a/python/vyos/ifconfig/geneve.py
+++ b/python/vyos/ifconfig/geneve.py
@@ -49,7 +49,7 @@ class GeneveIf(Interface):
         self._cmd(cmd)
 
         # interface is always A/D down. It needs to be enabled explicitly
-        self.set_state('down')
+        self.set_admin_state('down')
 
     @classmethod
     def get_config(cls):

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -49,8 +49,15 @@ class Interface(DHCP):
         'bridgeable':  False,
     }
 
+    _command_get = {
+        'admin_state': {
+            'shellcmd': 'ip -json link show dev {ifname}',
+            'format': lambda j: 'up' if 'UP' in json.loads(j)[0]['flags'] else 'down',
+        }
+    }
+
     _command_set = {
-        'state': {
+        'admin_state': {
             'validate': lambda v: assert_list(v, ['up', 'down']),
             'shellcmd': 'ip link set dev {ifname} {value}',
         },
@@ -71,6 +78,9 @@ class Interface(DHCP):
         },
         'mtu': {
             'location': '/sys/class/net/{ifname}/mtu',
+        },
+        'oper_state':{
+            'location': '/sys/class/net/{ifname}/operstate',
         },
     }
 
@@ -265,9 +275,9 @@ class Interface(DHCP):
             return None
 
         # MAC address can only be changed if interface is in 'down' state
-        prev_state = self.get_state()
+        prev_state = self.get_admin_state()
         if prev_state == 'up':
-            self.set_state('down')
+            self.set_admin_state('down')
 
         self.set_interface('mac', mac)
 
@@ -398,36 +408,41 @@ class Interface(DHCP):
         """
         self.set_interface('alias', ifalias)
 
-    def get_state(self):
+    def get_admin_state(self):
         """
         Get interface administrative state. Function will return 'up' or 'down'
 
         Example:
         >>> from vyos.ifconfig import Interface
-        >>> Interface('eth0').get_state()
+        >>> Interface('eth0').get_admin_state()
         'up'
         """
-        cmd = 'ip -json link show dev {}'.format(self.config['ifname'])
-        tmp = self._cmd(cmd)
-        out = json.loads(tmp)
+        return self.get_interface('admin_state')
 
-        state = 'down'
-        if 'UP' in out[0]['flags']:
-            state = 'up'
-
-        return state
-
-    def set_state(self, state):
+    def set_admin_state(self, state):
         """
         Set interface administrative state to be 'up' or 'down'
 
         Example:
         >>> from vyos.ifconfig import Interface
-        >>> Interface('eth0').set_state('down')
-        >>> Interface('eth0').get_state()
+        >>> Interface('eth0').set_admin_state('down')
+        >>> Interface('eth0').get_admin_state()
         'down'
         """
-        return self.set_interface('state', state)
+        return self.set_interface('admin_state', state)
+
+    def get_oper_state(self):
+        """
+        Get interface operational state
+
+        Example:
+        >>> from vyos.ifconfig import Interface
+        >>> Interface('eth0').get_oper_sate()
+        'up'
+        """
+        # https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-net
+        # "unknown", "notpresent", "down", "lowerlayerdown", "testing", "dormant", "up"
+        return self.get_interface('oper_state')
 
     def set_proxy_arp(self, enable):
         """

--- a/python/vyos/ifconfig/l2tpv3.py
+++ b/python/vyos/ifconfig/l2tpv3.py
@@ -62,7 +62,7 @@ class L2TPv3If(Interface):
         self._cmd(cmd)
 
         # interface is always A/D down. It needs to be enabled explicitly
-        self.set_state('down')
+        self.set_admin_state('down')
 
     def remove(self):
         """
@@ -76,7 +76,7 @@ class L2TPv3If(Interface):
 
         if os.path.exists('/sys/class/net/{}'.format(self.config['ifname'])):
             # interface is always A/D down. It needs to be enabled explicitly
-            self.set_state('down')
+            self.set_admin_state('down')
 
             if self._config['tunnel_id'] and self._config['session_id']:
                 cmd = 'ip l2tp del session tunnel_id {} '.format(

--- a/python/vyos/ifconfig/tunnel.py
+++ b/python/vyos/ifconfig/tunnel.py
@@ -98,10 +98,10 @@ class _Tunnel(Interface):
         options = " ".join(["{} {}".format(k, self.config[k])
                             for k in self.options if k in self.config and self.config[k]])
         self._cmd('{} {}'.format(self.create.format(**self.config), options))
-        self.set_interface('state', 'down')
+        self.set_admin_state('down')
 
     def _delete(self):
-        self.set_interface('state', 'down')
+        self.set_admin_state('down')
         cmd = self.delete.format(**self.config)
         return self._cmd(cmd)
 

--- a/python/vyos/ifconfig_vlan.py
+++ b/python/vyos/ifconfig_vlan.py
@@ -76,9 +76,9 @@ def apply_vlan_config(vlan, config):
 
     # enable/disable VLAN interface
     if config['disable']:
-        vlan.set_state('down')
+        vlan.set_admin_state('down')
     else:
-        vlan.set_state('up')
+        vlan.set_admin_state('up')
 
     # Configure interface address(es)
     # - not longer required addresses get removed first

--- a/src/conf_mode/interfaces-bonding.py
+++ b/src/conf_mode/interfaces-bonding.py
@@ -431,7 +431,7 @@ def apply(bond):
         # Some parameters can not be changed when the bond is up.
         if bond['shutdown_required']:
             # Disable bond prior changing of certain properties
-            b.set_state('down')
+            b.set_admin_state('down')
 
             # The bonding mode can not be changed when there are interfaces enslaved
             # to this bond, thus we will free all interfaces from the bond first!
@@ -449,9 +449,9 @@ def apply(bond):
         # parameters we will only re-enable the interface if it is not
         # administratively disabled
         if not bond['disable']:
-            b.set_state('up')
+            b.set_admin_state('up')
         else:
-            b.set_state('down')
+            b.set_admin_state('down')
 
         # Configure interface address(es)
         # - not longer required addresses get removed first

--- a/src/conf_mode/interfaces-bridge.py
+++ b/src/conf_mode/interfaces-bridge.py
@@ -243,7 +243,7 @@ def apply(bridge):
         br.remove()
     else:
         # enable interface
-        br.set_state('up')
+        br.set_admin_state('up')
         # set ageing time
         br.set_ageing_time(bridge['aging'])
         # set bridge forward delay
@@ -313,7 +313,7 @@ def apply(bridge):
 
         # up/down interface
         if bridge['disable']:
-            br.set_state('down')
+            br.set_admin_state('down')
 
         # Configure interface address(es)
         # - not longer required addresses get removed first

--- a/src/conf_mode/interfaces-dummy.py
+++ b/src/conf_mode/interfaces-dummy.py
@@ -110,9 +110,9 @@ def apply(dummy):
 
         # disable interface on demand
         if dummy['disable']:
-            d.set_state('down')
+            d.set_admin_state('down')
         else:
-            d.set_state('up')
+            d.set_admin_state('up')
 
     return None
 

--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -357,9 +357,9 @@ def apply(eth):
 
         # Enable/Disable interface
         if eth['disable']:
-            e.set_state('down')
+            e.set_admin_state('down')
         else:
-            e.set_state('up')
+            e.set_admin_state('up')
 
         # Configure interface address(es)
         # - not longer required addresses get removed first

--- a/src/conf_mode/interfaces-geneve.py
+++ b/src/conf_mode/interfaces-geneve.py
@@ -148,7 +148,7 @@ def apply(geneve):
         # parameters we will only re-enable the interface if it is not
         # administratively disabled
         if not geneve['disable']:
-            g.set_state('up')
+            g.set_admin_state('up')
 
     return None
 

--- a/src/conf_mode/interfaces-l2tpv3.py
+++ b/src/conf_mode/interfaces-l2tpv3.py
@@ -204,7 +204,7 @@ def apply(l2tpv3):
         # we will only re-enable the interface if it is not  administratively
         # disabled
         if not l2tpv3['disable']:
-            l.set_state('up')
+            l.set_admin_state('up')
 
     return None
 

--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -1043,7 +1043,7 @@ def apply(openvpn):
     # TAP interface needs to be brought up explicitly
     if openvpn['type'] == 'tap':
         if not openvpn['disable']:
-            VTunIf(openvpn['intf']).set_state('up')
+            VTunIf(openvpn['intf']).set_admin_state('up')
 
     return None
 

--- a/src/conf_mode/interfaces-pseudo-ethernet.py
+++ b/src/conf_mode/interfaces-pseudo-ethernet.py
@@ -309,9 +309,9 @@ def apply(peth):
 
     # Enable/Disable interface
     if peth['disable']:
-        p.set_state('down')
+        p.set_admin_state('down')
     else:
-        p.set_state('up')
+        p.set_admin_state('up')
 
     # Configure interface address(es)
     # - not longer required addresses get removed first

--- a/src/conf_mode/interfaces-tunnel.py
+++ b/src/conf_mode/interfaces-tunnel.py
@@ -478,7 +478,7 @@ def apply(conf):
         tunnel.add_addr(addr)
 
     # now bring it up (or not)
-    tunnel.set_state(options['state'])
+    tunnel.set_admin_state(options['state'])
 
 
 if __name__ == '__main__':

--- a/src/conf_mode/interfaces-vxlan.py
+++ b/src/conf_mode/interfaces-vxlan.py
@@ -212,7 +212,7 @@ def apply(vxlan):
         # parameters we will only re-enable the interface if it is not
         # administratively disabled
         if not vxlan['disable']:
-            v.set_state('up')
+            v.set_admin_state('up')
 
     return None
 

--- a/src/conf_mode/interfaces-wireguard.py
+++ b/src/conf_mode/interfaces-wireguard.py
@@ -269,7 +269,7 @@ def apply(c):
         intfc.update()
 
     # interface state
-    intfc.set_state(c['state'])
+    intfc.set_admin_state(c['state'])
 
     return None
 

--- a/src/conf_mode/interfaces-wireless.py
+++ b/src/conf_mode/interfaces-wireless.py
@@ -1518,7 +1518,7 @@ def apply(wifi):
         # Enable/Disable interface - interface is always placed in
         # administrative down state in WiFiIf class
         if not wifi['disable']:
-            w.set_state('up')
+            w.set_admin_state('up')
 
 
     # Physical interface is now configured. Proceed by starting hostapd or


### PR DESCRIPTION
The Interface get_state/set_state were not clear about
if they edited the admin or operational state.

functions are now using admin_state and oper_state
for clarity.