### PR TITLE
ifconfig: T2057: Do not set empty hw_id mac

### DIFF
--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -359,7 +359,7 @@ def apply(eth):
         # if custom mac is removed
         if eth['mac']:
             e.set_mac(eth['mac'])
-        else:
+        elif eth['hw_id']:
             e.set_mac(eth['hw_id'])
 
         # Maximum Transmission Unit (MTU)

--- a/src/conf_mode/interfaces-wireless.py
+++ b/src/conf_mode/interfaces-wireless.py
@@ -1496,7 +1496,7 @@ def apply(wifi):
         # if custom mac is removed
         if wifi['mac']:
             w.set_mac(wifi['mac'])
-        else:
+        elif wifi['hw_id']:
             w.set_mac(wifi['hw_id'])
 
         # configure ARP filter configuration


### PR DESCRIPTION
set_mac is validating the mac address passed, therefore passing
empty string will cause it to fail. if the hardware id could
not be found then it should not be attempted to be set