### PR TITLE
ifconfig: T2205: silence ethtool harmless failures

### DIFF
--- a/python/vyos/ifconfig/ethernet.py
+++ b/python/vyos/ifconfig/ethernet.py
@@ -18,7 +18,7 @@ import re
 
 from vyos.ifconfig.interface import Interface
 from vyos.ifconfig.vlan import VLAN
-
+from vyos.util import popen
 from vyos.validate import *
 
 
@@ -43,27 +43,36 @@ class EthernetIf(Interface):
         }
     }
 
+    @staticmethod
+    def feature(ifname, option, value):
+        out, code = popen(f'/sbin/ethtool -K {ifname} {option} {value}','ifconfig')
+        return False
 
     _command_set = {**Interface._command_set, **{
         'gro': {
             'validate': lambda v: assert_list(v, ['on', 'off']),
-            'shellcmd': '/sbin/ethtool -K {ifname} gro {value}',
+            'possible': lambda i, v: EthernetIf.feature(i, 'gro', v),
+            # 'shellcmd': '/sbin/ethtool -K {ifname} gro {value}',
         },
         'gso': {
             'validate': lambda v: assert_list(v, ['on', 'off']),
-            'shellcmd': '/sbin/ethtool -K {ifname} gso {value}',
+            'possible': lambda i, v: EthernetIf.feature(i, 'gso', v),
+            # 'shellcmd': '/sbin/ethtool -K {ifname} gso {value}',
         },
         'sg': {
             'validate': lambda v: assert_list(v, ['on', 'off']),
-            'shellcmd': '/sbin/ethtool -K {ifname} sg {value}',
+            'possible': lambda i, v: EthernetIf.feature(i, 'sg', v),
+            # 'shellcmd': '/sbin/ethtool -K {ifname} sg {value}',
         },
         'tso': {
             'validate': lambda v: assert_list(v, ['on', 'off']),
-            'shellcmd': '/sbin/ethtool -K {ifname} tso {value}',
+            'possible': lambda i, v: EthernetIf.feature(i, 'tso', v),
+            # 'shellcmd': '/sbin/ethtool -K {ifname} tso {value}',
         },
         'ufo': {
             'validate': lambda v: assert_list(v, ['on', 'off']),
-            'shellcmd': '/sbin/ethtool -K {ifname} ufo {value}',
+            'possible': lambda i, v: EthernetIf.feature(i, 'ufo', v),
+            # 'shellcmd': '/sbin/ethtool -K {ifname} ufo {value}',
         },
     }}
 
@@ -245,8 +254,4 @@ class EthernetIf(Interface):
         >>> i = EthernetIf('eth0')
         >>> i.set_udp_offload('on')
         """
-        if state not in ['on', 'off']:
-            raise ValueError('state must be "on" or "off"')
-
-        cmd = '/sbin/ethtool -K {} ufo {}'.format(self.config['ifname'], state)
-        return self._cmd(cmd)
+        return self.set_interface('ufo', state)

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -16,6 +16,44 @@
 import os
 import re
 import sys
+from subprocess import Popen, PIPE, STDOUT
+
+
+# debugging
+
+
+def debug(flag):
+    return flag if os.path.isfile(f'/tmp/vyos.{flag}.debug') else ''
+
+
+def debug_msg(message, section=''):
+    if section:
+        print(f'DEBUG/{section:<6} {message}')
+
+
+#  commands
+
+
+def popen(command, section=''):
+    p = Popen(command, stdout=PIPE, stderr=STDOUT, shell=True)
+    tmp = p.communicate()[0].strip()
+    debug_msg(f"cmd '{command}'", section)
+    decoded = tmp.decode()
+    if decoded:
+        debug_msg(f"returned:\n{decoded}", section)
+    return decoded, p.returncode
+
+
+def cmd(command, section=''):
+    decoded, code = popen(command, section)
+    if code != 0:
+        # error code can be recovered with .errno
+        raise OSError(code, f'{command}\nreturned: {decoded}')
+    return decoded
+
+
+# file manipulation
+
 
 def read_file(path):
     """ Read a file to string """


### PR DESCRIPTION
Not all interfaces are capable of all features. Since commands are
now checked for valid completion, ethtool command failure must
be ignored.