### PR TITLE
ifconfig: T2190: option to prevent Interface creation

### DIFF
--- a/src/op_mode/wireguard.py
+++ b/src/op_mode/wireguard.py
@@ -150,7 +150,7 @@ if __name__ == '__main__':
         if args.listkdir:
             list_key_dirs()
         if args.showinterface:
-            intf = WireGuardIf(args.showinterface, debug=False)
+            intf = WireGuardIf(args.showinterface, create=False, debug=False)
             intf.op_show_interface()
         if args.delkdir:
             if args.location:


### PR DESCRIPTION
a new option was added to the Interface class: "create".

By default, the value is set to True, and when an instance of the
class is created and the underlying interface does not exist, the
class will create it.

If the option "create" is set to False, the interface will not be
created and instead the class  will raise an error when it is
instantiated.