### PR TITLE
wireless: T2211: bugfix: vht_oper_chwidth was not set in hostapd config

### DIFF
--- a/src/conf_mode/interfaces-wireless.py
+++ b/src/conf_mode/interfaces-wireless.py
@@ -797,7 +797,7 @@ default_config_data = {
     'cap_vht_beamform' : '',
     'cap_vht_center_freq_1' : '',
     'cap_vht_center_freq_2' : '',
-    'cap_vht_chan_set_width' : '0',
+    'cap_vht_chan_set_width' : '',
     'cap_vht_ldpc' : False,
     'cap_vht_link_adaptation' : False,
     'cap_vht_max_mpdu_exp' : '',

--- a/src/conf_mode/interfaces-wireless.py
+++ b/src/conf_mode/interfaces-wireless.py
@@ -239,6 +239,10 @@ uapsd_advertisement_enabled=1
 require_ht=1
 {% endif %}
 
+{%- if cap_vht_chan_set_width -%}
+vht_oper_chwidth={{ cap_vht_chan_set_width }}
+{%- endif -%}
+
 # vht_capab: VHT capabilities (list of flags)
 #
 # vht_max_mpdu_len: [MAX-MPDU-7991] [MAX-MPDU-11454]
@@ -365,10 +369,6 @@ vht_capab=
 {%- endif -%}
 
 {%- if cap_vht_max_mpdu_exp -%}
-[MAX-A-MPDU-LEN-EXP{{ cap_vht_max_mpdu_exp }}]
-{%- endif -%}
-
-{%- if cap_vht_chan_set_width -%}
 [MAX-A-MPDU-LEN-EXP{{ cap_vht_max_mpdu_exp }}]
 {%- endif -%}
 
@@ -797,7 +797,7 @@ default_config_data = {
     'cap_vht_beamform' : '',
     'cap_vht_center_freq_1' : '',
     'cap_vht_center_freq_2' : '',
-    'cap_vht_chan_set_width' : '',
+    'cap_vht_chan_set_width' : '0',
     'cap_vht_ldpc' : False,
     'cap_vht_link_adaptation' : False,
     'cap_vht_max_mpdu_exp' : '',


### PR DESCRIPTION
When operating in certain modes, channel width must be configured for
WiFi interfaces. The hostapd config does this in two separate lines
which must both be configured:

vht_oper_chwidth=(0|1|2|3)
vht_capab+=[VHT160] for 160MHz in one block or
vht_capab+=[VHT160-80PLUS80] for 160MHz as 2x 80MHz in two separate
blocks.