### PR TITLE
util: T2226: convert all call to use vyos.util.{popen, cmd, run}

### DIFF
--- a/python/vyos/authutils.py
+++ b/python/vyos/authutils.py
@@ -15,16 +15,14 @@
 
 import re
 
-from subprocess import Popen, PIPE, STDOUT
+from vyos.util import cmd
 
 
 def make_password_hash(password):
     """ Makes a password hash for /etc/shadow using mkpasswd """
 
-    mkpasswd = Popen(['mkpasswd', '--method=sha-512', '--stdin'], stdout=PIPE, stdin=PIPE, stderr=PIPE)
-    hash = mkpasswd.communicate(input=password.encode(), timeout=5)[0].decode().strip()
-
-    return hash
+    mkpassword = 'mkpasswd --method=sha-512 --stdin'
+    return cmd(mkpassword, input=password.encode(), timeout=5)
 
 def split_ssh_public_key(key_string, defaultname=""):
     """ Splits an SSH public key into its components """

--- a/python/vyos/ifconfig/ethernet.py
+++ b/python/vyos/ifconfig/ethernet.py
@@ -18,7 +18,7 @@ import re
 
 from vyos.ifconfig.interface import Interface
 from vyos.ifconfig.vlan import VLAN
-from vyos.util import popen
+from vyos.util import run
 from vyos.validate import *
 
 
@@ -45,7 +45,7 @@ class EthernetIf(Interface):
 
     @staticmethod
     def feature(ifname, option, value):
-        out, code = popen(f'/sbin/ethtool -K {ifname} {option} {value}','ifconfig')
+        run(f'/sbin/ethtool -K {ifname} {option} {value}','ifconfig')
         return False
 
     _command_set = {**Interface._command_set, **{

--- a/python/vyos/ifconfig/wireguard.py
+++ b/python/vyos/ifconfig/wireguard.py
@@ -16,7 +16,6 @@
 
 import os
 import time
-import subprocess
 from datetime import timedelta
 
 from vyos.config import Config

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -261,12 +261,11 @@ def commit_in_progress():
     # Since this will be used in scripts that modify the config outside of the CLI
     # framework, those knowingly have root permissions.
     # For everything else, we add a safeguard.
-    from subprocess import check_output
     from psutil import process_iter, NoSuchProcess
     from vyos.defaults import commit_lock
 
-    id = check_output(['/usr/bin/id', '-u']).decode().strip()
-    if id != '0':
+    idu = cmd('/usr/bin/id -u')
+    if idu != '0':
         raise OSError("This functions needs root permissions to return correct results")
 
     for proc in process_iter():

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -89,14 +89,6 @@ def cmd(command, section='', shell=None, input=None, timeout=None, env=None, uni
     return decoded
 
 
-# This is now deprecated
-def subprocess_cmd(command):
-    """ execute arbitrary command via Popen """
-    from subprocess import Popen, PIPE
-    p = Popen(command, stdout=PIPE, shell=True)
-    p.communicate()
-
-
 # file manipulation
 
 

--- a/src/completion/list_dumpable_interfaces.py
+++ b/src/completion/list_dumpable_interfaces.py
@@ -3,12 +3,10 @@
 # Extract the list of interfaces available for traffic dumps from tcpdump -D
 
 import re
-import subprocess
+
+from vyos.util import cmd
 
 if __name__ == '__main__':
-    out = subprocess.check_output(['/usr/sbin/tcpdump', '-D']).decode().strip()
-    out = out.split("\n")
-
+    out = cmd('/usr/sbin/tcpdump -D').split('\n')
     intfs = " ".join(map(lambda s: re.search(r'\d+\.(\S+)\s', s).group(1), out))
-
     print(intfs)

--- a/src/completion/list_local.py
+++ b/src/completion/list_local.py
@@ -2,7 +2,8 @@
 
 import json
 import argparse
-import subprocess
+
+from vyos.util import cmd
 
 # [{"ifindex":1,"ifname":"lo","flags":["LOOPBACK","UP","LOWER_UP"],"mtu":65536,"qdisc":"noqueue","operstate":"UNKNOWN","group":"default","txqlen":1000,"link_type":"loopback","address":"00:00:00:00:00:00","broadcast":"00:00:00:00:00:00","addr_info":[{"family":"inet","local":"127.0.0.1","prefixlen":8,"scope":"host","label":"lo","valid_life_time":4294967295,"preferred_life_time":4294967295},{"family":"inet6","local":"::1","prefixlen":128,"scope":"host","valid_life_time":4294967295,"preferred_life_time":4294967295}]},{"ifindex":2,"ifname":"eth0","flags":["BROADCAST","MULTICAST","UP","LOWER_UP"],"mtu":1500,"qdisc":"pfifo_fast","operstate":"UP","group":"default","txqlen":1000,"link_type":"ether","address":"08:00:27:fa:12:53","broadcast":"ff:ff:ff:ff:ff:ff","addr_info":[{"family":"inet","local":"10.0.2.15","prefixlen":24,"broadcast":"10.0.2.255","scope":"global","label":"eth0","valid_life_time":4294967295,"preferred_life_time":4294967295},{"family":"inet6","local":"fe80::a00:27ff:fefa:1253","prefixlen":64,"scope":"link","valid_life_time":4294967295,"preferred_life_time":4294967295}]},{"ifindex":3,"ifname":"eth1","flags":["BROADCAST","MULTICAST","UP","LOWER_UP"],"mtu":1500,"qdisc":"pfifo_fast","operstate":"UP","group":"default","txqlen":1000,"link_type":"ether","address":"08:00:27:0d:25:dc","broadcast":"ff:ff:ff:ff:ff:ff","addr_info":[{"family":"inet6","local":"fe80::a00:27ff:fe0d:25dc","prefixlen":64,"scope":"link","valid_life_time":4294967295,"preferred_life_time":4294967295}]},{"ifindex":4,"ifname":"eth2","flags":["BROADCAST","MULTICAST","UP","LOWER_UP"],"mtu":1500,"qdisc":"pfifo_fast","operstate":"UP","group":"default","txqlen":1000,"link_type":"ether","address":"08:00:27:68:d0:b1","broadcast":"ff:ff:ff:ff:ff:ff","addr_info":[{"family":"inet6","local":"fe80::a00:27ff:fe68:d0b1","prefixlen":64,"scope":"link","valid_life_time":4294967295,"preferred_life_time":4294967295}]},{"ifindex":5,"ifname":"eth3","flags":["BROADCAST","MULTICAST","UP","LOWER_UP"],"mtu":1500,"qdisc":"pfifo_fast","operstate":"UP","group":"default","txqlen":1000,"link_type":"ether","address":"08:00:27:f0:17:c5","broadcast":"ff:ff:ff:ff:ff:ff","addr_info":[{"family":"inet6","local":"fe80::a00:27ff:fef0:17c5","prefixlen":64,"scope":"link","valid_life_time":4294967295,"preferred_life_time":4294967295}]}]
 
@@ -10,8 +11,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group()
 
-    cmd = 'ip -j address show'
-    out = subprocess.check_output(cmd.split()).decode().strip()
+    out = cmd('ip -j address show')
     data = json.loads(out)
 
 

--- a/src/conf_mode/arp.py
+++ b/src/conf_mode/arp.py
@@ -20,9 +20,9 @@ import sys
 import os
 import re
 import syslog as sl
-import subprocess
 
 from vyos.config import Config
+from vyos.util import run
 from vyos import ConfigError
 
 arp_cmd = '/usr/sbin/arp'
@@ -82,11 +82,12 @@ def generate(c):
 def apply(c):
   for ip_addr in c['remove']:
     sl.syslog(sl.LOG_NOTICE, "arp -d " + ip_addr)
-    subprocess.call([arp_cmd + ' -d ' + ip_addr + ' >/dev/null 2>&1'], shell=True)
+    run(f'{arp_cmd} -d {ip_addr} >/dev/null 2>&1')
 
   for ip_addr in c['update']:
     sl.syslog(sl.LOG_NOTICE, "arp -s " + ip_addr + " " + c['update'][ip_addr])
-    subprocess.call([arp_cmd + ' -s ' + ip_addr + ' ' + c['update'][ip_addr] ], shell=True)
+    updated = c['update'][ip_addr]
+    run(f'{arp_cmd} -s {ip_addr} {updated}')
 
 
 if __name__ == '__main__':

--- a/src/conf_mode/bcast_relay.py
+++ b/src/conf_mode/bcast_relay.py
@@ -24,6 +24,7 @@ from jinja2 import FileSystemLoader, Environment
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
 
 config_file = r'/etc/default/udp-broadcast-relay'
 
@@ -154,7 +155,7 @@ def generate(relay):
 
 def apply(relay):
     # first stop all running services
-    os.system('sudo systemctl stop udp-broadcast-relay@{1..99}')
+    run('sudo systemctl stop udp-broadcast-relay@{1..99}')
 
     if (relay is None) or relay['disabled']:
         return None
@@ -164,7 +165,7 @@ def apply(relay):
         # Don't start individual instance when it's disabled
         if r['disabled']:
             continue
-        os.system('sudo systemctl start udp-broadcast-relay@{0}'.format(r['id']))
+        run('sudo systemctl start udp-broadcast-relay@{0}'.format(r['id']))
 
     return None
 

--- a/src/conf_mode/dhcp_relay.py
+++ b/src/conf_mode/dhcp_relay.py
@@ -22,6 +22,7 @@ from sys import exit
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
 
 config_file = r'/etc/default/isc-dhcp-relay'
 
@@ -112,10 +113,10 @@ def generate(relay):
 
 def apply(relay):
     if relay is not None:
-        os.system('sudo systemctl restart isc-dhcp-relay.service')
+        run('sudo systemctl restart isc-dhcp-relay.service')
     else:
         # DHCP relay support is removed in the commit
-        os.system('sudo systemctl stop isc-dhcp-relay.service')
+        run('sudo systemctl stop isc-dhcp-relay.service')
         os.unlink(config_file)
 
     return None

--- a/src/conf_mode/dhcp_server.py
+++ b/src/conf_mode/dhcp_server.py
@@ -26,6 +26,8 @@ from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos.validate import is_subnet_connected
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file = r'/etc/dhcp/dhcpd.conf'
 lease_file = r'/config/dhcpd.leases'
@@ -626,7 +628,7 @@ def generate(dhcp):
 def apply(dhcp):
     if (dhcp is None) or dhcp['disabled']:
         # DHCP server is removed in the commit
-        os.system('sudo systemctl stop isc-dhcpv4-server.service')
+        run('sudo systemctl stop isc-dhcpv4-server.service')
         if os.path.exists(config_file):
             os.unlink(config_file)
         if os.path.exists(daemon_config_file):
@@ -636,7 +638,7 @@ def apply(dhcp):
         if not os.path.exists(lease_file):
             os.mknod(lease_file)
 
-        os.system('sudo systemctl restart isc-dhcpv4-server.service')
+        run('sudo systemctl restart isc-dhcpv4-server.service')
 
     return None
 

--- a/src/conf_mode/dhcpv6_relay.py
+++ b/src/conf_mode/dhcpv6_relay.py
@@ -23,6 +23,8 @@ from jinja2 import FileSystemLoader, Environment
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file = r'/etc/default/isc-dhcpv6-relay'
 
@@ -98,10 +100,10 @@ def generate(relay):
 
 def apply(relay):
     if relay is not None:
-        os.system('sudo systemctl restart isc-dhcpv6-relay.service')
+        run('sudo systemctl restart isc-dhcpv6-relay.service')
     else:
         # DHCPv6 relay support is removed in the commit
-        os.system('sudo systemctl stop isc-dhcpv6-relay.service')
+        run('sudo systemctl stop isc-dhcpv6-relay.service')
         os.unlink(config_file)
 
     return None

--- a/src/conf_mode/dhcpv6_server.py
+++ b/src/conf_mode/dhcpv6_server.py
@@ -25,6 +25,8 @@ from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos.validate import is_subnet_connected
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file = r'/etc/dhcp/dhcpdv6.conf'
 lease_file = r'/config/dhcpdv6.leases'
@@ -362,7 +364,7 @@ def generate(dhcpv6):
 def apply(dhcpv6):
     if (dhcpv6 is None) or dhcpv6['disabled']:
         # DHCP server is removed in the commit
-        os.system('sudo systemctl stop isc-dhcpv6-server.service')
+        run('sudo systemctl stop isc-dhcpv6-server.service')
         if os.path.exists(config_file):
             os.unlink(config_file)
         if os.path.exists(daemon_config_file):
@@ -372,7 +374,7 @@ def apply(dhcpv6):
         if not os.path.exists(lease_file):
             os.mknod(lease_file)
 
-        os.system('sudo systemctl restart isc-dhcpv6-server.service')
+        run('sudo systemctl restart isc-dhcpv6-server.service')
 
     return None
 

--- a/src/conf_mode/dns_forwarding.py
+++ b/src/conf_mode/dns_forwarding.py
@@ -26,6 +26,7 @@ from vyos.defaults import directories as vyos_data_dir
 from vyos.hostsd_client import Client as hostsd_client
 from vyos.util import wait_for_commit_lock
 from vyos import ConfigError
+from vyos.util import run
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--dhclient", action="store_true",
@@ -166,11 +167,11 @@ def generate(dns):
 def apply(dns):
     if dns is None:
         # DNS forwarding is removed in the commit
-        os.system("systemctl stop pdns-recursor")
+        run("systemctl stop pdns-recursor")
         if os.path.isfile(config_file):
             os.unlink(config_file)
     else:
-        os.system("systemctl restart pdns-recursor")
+        run("systemctl restart pdns-recursor")
 
 if __name__ == '__main__':
     args = parser.parse_args()

--- a/src/conf_mode/dynamic_dns.py
+++ b/src/conf_mode/dynamic_dns.py
@@ -24,6 +24,8 @@ from stat import S_IRUSR, S_IWUSR
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file = r'/etc/ddclient/ddclient.conf'
 cache_file = r'/var/cache/ddclient/ddclient.cache'
@@ -255,11 +257,11 @@ def apply(dyndns):
         os.unlink('/etc/ddclient.conf')
 
     if dyndns['deleted']:
-        os.system('/etc/init.d/ddclient stop')
+        run('/etc/init.d/ddclient stop')
         if os.path.exists(dyndns['pid_file']):
             os.unlink(dyndns['pid_file'])
     else:
-        os.system('/etc/init.d/ddclient restart')
+        run('/etc/init.d/ddclient restart')
 
     return None
 

--- a/src/conf_mode/firewall_options.py
+++ b/src/conf_mode/firewall_options.py
@@ -21,6 +21,8 @@ import copy
 
 from vyos.config import Config
 from vyos import ConfigError
+from vyos.util import run
+
 
 default_config_data = {
     'intf_opts': [],
@@ -85,19 +87,19 @@ def apply(tcp):
     target = 'VYOS_FW_OPTIONS'
 
     # always cleanup iptables
-    os.system('iptables --table mangle --delete FORWARD --jump {} >&/dev/null'.format(target))
-    os.system('iptables --table mangle --flush {} >&/dev/null'.format(target))
-    os.system('iptables --table mangle --delete-chain {} >&/dev/null'.format(target))
+    run('iptables --table mangle --delete FORWARD --jump {} >&/dev/null'.format(target))
+    run('iptables --table mangle --flush {} >&/dev/null'.format(target))
+    run('iptables --table mangle --delete-chain {} >&/dev/null'.format(target))
 
     # always cleanup ip6tables
-    os.system('ip6tables --table mangle --delete FORWARD --jump {} >&/dev/null'.format(target))
-    os.system('ip6tables --table mangle --flush {} >&/dev/null'.format(target))
-    os.system('ip6tables --table mangle --delete-chain {} >&/dev/null'.format(target))
+    run('ip6tables --table mangle --delete FORWARD --jump {} >&/dev/null'.format(target))
+    run('ip6tables --table mangle --flush {} >&/dev/null'.format(target))
+    run('ip6tables --table mangle --delete-chain {} >&/dev/null'.format(target))
 
     # Setup new iptables rules
     if tcp['new_chain4']:
-        os.system('iptables --table mangle --new-chain {} >&/dev/null'.format(target))
-        os.system('iptables --table mangle --append FORWARD --jump {} >&/dev/null'.format(target))
+        run('iptables --table mangle --new-chain {} >&/dev/null'.format(target))
+        run('iptables --table mangle --append FORWARD --jump {} >&/dev/null'.format(target))
 
         for opts in tcp['intf_opts']:
             intf = opts['intf']
@@ -109,13 +111,13 @@ def apply(tcp):
 
             # adjust TCP MSS per interface
             if mss:
-                os.system('iptables --table mangle --append {} --out-interface {} --protocol tcp ' \
+                run('iptables --table mangle --append {} --out-interface {} --protocol tcp ' \
                           '--tcp-flags SYN,RST SYN --jump TCPMSS --set-mss {} >&/dev/null'.format(target, intf, mss))
 
     # Setup new ip6tables rules
     if tcp['new_chain6']:
-        os.system('ip6tables --table mangle --new-chain {} >&/dev/null'.format(target))
-        os.system('ip6tables --table mangle --append FORWARD --jump {} >&/dev/null'.format(target))
+        run('ip6tables --table mangle --new-chain {} >&/dev/null'.format(target))
+        run('ip6tables --table mangle --append FORWARD --jump {} >&/dev/null'.format(target))
 
         for opts in tcp['intf_opts']:
             intf = opts['intf']
@@ -127,8 +129,8 @@ def apply(tcp):
 
             # adjust TCP MSS per interface
             if mss:
-                os.system('ip6tables --table mangle --append {} --out-interface {} --protocol tcp ' \
-                          '--tcp-flags SYN,RST SYN --jump TCPMSS --set-mss {} >&/dev/null'.format(target, intf, mss))
+                run('ip6tables --table mangle --append {} --out-interface {} --protocol tcp '
+                    '--tcp-flags SYN,RST SYN --jump TCPMSS --set-mss {} >&/dev/null'.format(target, intf, mss))
 
     return None
 

--- a/src/conf_mode/http-api.py
+++ b/src/conf_mode/http-api.py
@@ -96,11 +96,7 @@ def apply(http_api):
         run('sudo systemctl stop vyos-http-api.service')
 
     for dep in dependencies:
-        cmd = '{0}/{1}'.format(vyos_conf_scripts_dir, dep)
-        try:
-            subprocess.check_call(cmd, shell=True)
-        except subprocess.CalledProcessError as err:
-            raise ConfigError("{}.".format(err))
+        cmd(f'{vyos_conf_scripts_dir}/{dep}', raising=ConfigError)
 
 if __name__ == '__main__':
     try:

--- a/src/conf_mode/http-api.py
+++ b/src/conf_mode/http-api.py
@@ -18,13 +18,13 @@
 
 import sys
 import os
-import subprocess
 import json
 from copy import deepcopy
 
 import vyos.defaults
 from vyos.config import Config
 from vyos import ConfigError
+from vyos.util import cmd, run
 
 config_file = '/etc/vyos/http-api.conf'
 
@@ -91,9 +91,9 @@ def generate(http_api):
 
 def apply(http_api):
     if http_api is not None:
-        os.system('sudo systemctl restart vyos-http-api.service')
+        run('sudo systemctl restart vyos-http-api.service')
     else:
-        os.system('sudo systemctl stop vyos-http-api.service')
+        run('sudo systemctl stop vyos-http-api.service')
 
     for dep in dependencies:
         cmd = '{0}/{1}'.format(vyos_conf_scripts_dir, dep)

--- a/src/conf_mode/https.py
+++ b/src/conf_mode/https.py
@@ -26,6 +26,8 @@ import vyos.certbot_util
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file = '/etc/nginx/sites-available/default'
 
@@ -144,9 +146,9 @@ def generate(https):
 
 def apply(https):
     if https is not None:
-        os.system('sudo systemctl restart nginx.service')
+        run('sudo systemctl restart nginx.service')
     else:
-        os.system('sudo systemctl stop nginx.service')
+        run('sudo systemctl stop nginx.service')
 
 if __name__ == '__main__':
     try:

--- a/src/conf_mode/igmp_proxy.py
+++ b/src/conf_mode/igmp_proxy.py
@@ -24,6 +24,8 @@ from netifaces import interfaces
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file = r'/etc/igmpproxy.conf'
 
@@ -129,11 +131,11 @@ def generate(igmp_proxy):
 def apply(igmp_proxy):
     if igmp_proxy is None or igmp_proxy['disable']:
          # IGMP Proxy support is removed in the commit
-         os.system('sudo systemctl stop igmpproxy.service')
+         run('sudo systemctl stop igmpproxy.service')
          if os.path.exists(config_file):
              os.unlink(config_file)
     else:
-        os.system('systemctl restart igmpproxy.service')
+        run('systemctl restart igmpproxy.service')
 
     return None
 

--- a/src/conf_mode/interfaces-bonding.py
+++ b/src/conf_mode/interfaces-bonding.py
@@ -25,6 +25,8 @@ from vyos.ifconfig_vlan import apply_vlan_config, verify_vlan_config
 from vyos.configdict import list_diff, vlan_to_dict
 from vyos.config import Config
 from vyos import ConfigError
+from vyos.util import run
+
 
 default_config_data = {
     'address': [],
@@ -90,7 +92,7 @@ def get_config():
     if not os.path.isfile('/sys/class/net/bonding_masters'):
         import syslog
         syslog.syslog(syslog.LOG_NOTICE, "loading bonding kernel module")
-        if os.system('modprobe bonding max_bonds=0 miimon=250') != 0:
+        if run('modprobe bonding max_bonds=0 miimon=250') != 0:
             syslog.syslog(syslog.LOG_NOTICE, "failed loading bonding kernel module")
             raise ConfigError("failed loading bonding kernel module")
 

--- a/src/conf_mode/interfaces-l2tpv3.py
+++ b/src/conf_mode/interfaces-l2tpv3.py
@@ -22,6 +22,7 @@ from copy import deepcopy
 from vyos.config import Config
 from vyos.ifconfig import L2TPv3If, Interface
 from vyos import ConfigError
+from vyos.util import run
 from netifaces import interfaces
 
 default_config_data = {
@@ -50,7 +51,7 @@ def check_kmod():
     modules = ['l2tp_eth', 'l2tp_netlink', 'l2tp_ip', 'l2tp_ip6']
     for module in modules:
         if not os.path.exists(f'/sys/module/{module}'):
-            if os.system(f'modprobe {module}') != 0:
+            if run(f'modprobe {module}') != 0:
                 raise ConfigError(f'Loading Kernel module {module} failed')
 
 def get_config():

--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -25,14 +25,13 @@ from grp import getgrnam
 from ipaddress import ip_address,ip_network,IPv4Interface
 from netifaces import interfaces
 from pwd import getpwnam
-from subprocess import Popen, PIPE
 from time import sleep
 from shutil import rmtree
 
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos.ifconfig import VTunIf
-from vyos.util import process_running
+from vyos.util import process_running, cmd
 from vyos.validate import is_addr_assigned
 from vyos import ConfigError
 
@@ -96,9 +95,6 @@ default_config_data = {
     'gid': group,
 }
 
-def subprocess_cmd(command):
-    p = Popen(command, stdout=PIPE, shell=True)
-    p.communicate()
 
 def get_config_name(intf):
     cfg_file = r'/opt/vyatta/etc/openvpn/openvpn-{}.conf'.format(intf)
@@ -744,12 +740,12 @@ def apply(openvpn):
     # service as the configuration is not re-read. Stop daemon only if it's
     # running - it could have died or killed by someone evil
     if process_running(pidfile):
-        cmd = 'start-stop-daemon'
-        cmd += ' --stop '
-        cmd += ' --quiet'
-        cmd += ' --oknodo'
-        cmd += ' --pidfile ' + pidfile
-        subprocess_cmd(cmd)
+        command = 'start-stop-daemon'
+        command += ' --stop '
+        command += ' --quiet'
+        command += ' --oknodo'
+        command += ' --pidfile ' + pidfile
+        cmd(command)
 
     # cleanup old PID file
     if os.path.isfile(pidfile):
@@ -780,19 +776,19 @@ def apply(openvpn):
 
     # No matching OpenVPN process running - maybe it got killed or none
     # existed - nevertheless, spawn new OpenVPN process
-    cmd = 'start-stop-daemon'
-    cmd += ' --start '
-    cmd += ' --quiet'
-    cmd += ' --oknodo'
-    cmd += ' --pidfile ' + pidfile
-    cmd += ' --exec /usr/sbin/openvpn'
+    command = 'start-stop-daemon'
+    command += ' --start '
+    command += ' --quiet'
+    command += ' --oknodo'
+    command += ' --pidfile ' + pidfile
+    command += ' --exec /usr/sbin/openvpn'
     # now pass arguments to openvpn binary
-    cmd += ' --'
-    cmd += ' --daemon openvpn-' + openvpn['intf']
-    cmd += ' --config ' + get_config_name(openvpn['intf'])
+    command += ' --'
+    command += ' --daemon openvpn-' + openvpn['intf']
+    command += ' --config ' + get_config_name(openvpn['intf'])
 
     # execute assembled command
-    subprocess_cmd(cmd)
+    cmd(command)
 
     # better late then sorry ... but we can only set interface alias after
     # OpenVPN has been launched and created the interface

--- a/src/conf_mode/interfaces-pppoe.py
+++ b/src/conf_mode/interfaces-pppoe.py
@@ -24,7 +24,7 @@ from netifaces import interfaces
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos.ifconfig import Interface
-from vyos.util import chown_file, chmod_x, subprocess_cmd
+from vyos.util import chown_file, chmod_x, cmd
 from vyos import ConfigError
 
 default_config_data = {
@@ -182,8 +182,7 @@ def generate(pppoe):
             os.mkdir(dirname)
 
     # Always hang-up PPPoE connection prior generating new configuration file
-    cmd = f'systemctl stop ppp@{intf}.service'
-    subprocess_cmd(cmd)
+    cmd(f'systemctl stop ppp@{intf}.service')
 
     if pppoe['deleted']:
         # Delete PPP configuration files
@@ -238,8 +237,7 @@ def apply(pppoe):
     if not pppoe['disable']:
         # "dial" PPPoE connection
         intf = pppoe['intf']
-        cmd = f'systemctl start ppp@{intf}.service'
-        subprocess_cmd(cmd)
+        cmd(f'systemctl start ppp@{intf}.service')
 
         # make logfile owned by root / vyattacfg
         chown_file(pppoe['logfile'], 'root', 'vyattacfg')

--- a/src/conf_mode/interfaces-wirelessmodem.py
+++ b/src/conf_mode/interfaces-wirelessmodem.py
@@ -156,8 +156,7 @@ def generate(wwan):
             os.mkdir(dirname)
 
     # Always hang-up WWAN connection prior generating new configuration file
-    cmd = f'systemctl stop ppp@{intf}.service'
-    subprocess_cmd(cmd)
+    cmd(f'systemctl stop ppp@{intf}.service')
 
     if wwan['deleted']:
         # Delete PPP configuration files
@@ -211,9 +210,7 @@ def apply(wwan):
     if not wwan['disable']:
         # "dial" WWAN connection
         intf = wwan['intf']
-        cmd = f'systemctl start ppp@{intf}.service'
-        subprocess_cmd(cmd)
-
+        cmd(f'systemctl start ppp@{intf}.service')
         # make logfile owned by root / vyattacfg
         chown_file(wwan['logfile'], 'root', 'vyattacfg')
 

--- a/src/conf_mode/interfaces-wirelessmodem.py
+++ b/src/conf_mode/interfaces-wirelessmodem.py
@@ -23,7 +23,7 @@ from netifaces import interfaces
 
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
-from vyos.util import chown_file, chmod_x, subprocess_cmd
+from vyos.util import chown_file, chmod_x, cmd, run
 from vyos import ConfigError
 
 default_config_data = {
@@ -48,7 +48,7 @@ def check_kmod():
     modules = ['option', 'usb_wwan', 'usbserial']
     for module in modules:
         if not os.path.exists(f'/sys/module/{module}'):
-            if os.system(f'modprobe {module}') != 0:
+            if run(f'modprobe {module}') != 0:
                 raise ConfigError(f'Loading Kernel module {module} failed')
 
 def get_config():

--- a/src/conf_mode/ipsec-settings.py
+++ b/src/conf_mode/ipsec-settings.py
@@ -24,6 +24,7 @@ from sys import exit
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
 
 ra_conn_name = "remote-access"
 charon_conf_file = "/etc/strongswan.d/charon.conf"
@@ -98,7 +99,7 @@ def get_config():
 
 ### Remove config from file by delimiter
 def remove_confs(delim_begin, delim_end, conf_file):
-    os.system("sed -i '/"+delim_begin+"/,/"+delim_end+"/d' "+conf_file)
+    run("sed -i '/"+delim_begin+"/,/"+delim_end+"/d' "+conf_file)
 
 
 ### Checking certificate storage and notice if certificate not in /config directory
@@ -111,7 +112,7 @@ def check_cert_file_store(cert_name, file_path, dts_path):
     else:
       ### Cpy file to /etc/ipsec.d/certs/ /etc/ipsec.d/cacerts/
       # todo make check
-      ret = os.system('cp -f '+file_path+' '+dts_path)
+      ret = run('cp -f '+file_path+' '+dts_path)
       if ret:
          raise ConfigError("L2TP VPN configuration error: Cannot copy "+file_path)
 
@@ -192,12 +193,12 @@ def generate(data):
         remove_confs(delim_ipsec_l2tp_begin, delim_ipsec_l2tp_end, ipsec_conf_flie)
 
 def restart_ipsec():
-    os.system('ipsec restart >&/dev/null')
+    run('ipsec restart >&/dev/null')
     # counter for apply swanctl config
     counter = 10
     while counter <= 10:
         if os.path.exists(charon_pidfile):
-            os.system('swanctl -q >&/dev/null')
+            run('swanctl -q >&/dev/null')
             break
         counter -=1
         sleep(1)

--- a/src/conf_mode/le_cert.py
+++ b/src/conf_mode/le_cert.py
@@ -23,6 +23,8 @@ import subprocess
 import vyos.defaults
 from vyos.config import Config
 from vyos import ConfigError
+from vyos.util import cmd, run
+
 
 vyos_conf_scripts_dir = vyos.defaults.directories['conf_mode']
 
@@ -84,9 +86,9 @@ def generate(cert):
 
     # certbot will attempt to reload nginx, even with 'certonly';
     # start nginx if not active
-    ret = os.system('systemctl is-active --quiet nginx.ervice')
+    ret = run('systemctl is-active --quiet nginx.ervice')
     if ret:
-        os.system('sudo systemctl start nginx.service')
+        run('sudo systemctl start nginx.service')
 
     ret = request_certbot(cert)
     if ret:

--- a/src/conf_mode/lldp.py
+++ b/src/conf_mode/lldp.py
@@ -26,6 +26,8 @@ from vyos.validate import is_addr_assigned,is_loopback_addr
 from vyos.defaults import directories as vyos_data_dir
 from vyos.version import get_version_data
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file = "/etc/default/lldpd"
 vyos_config_file = "/etc/lldpd.d/01-vyos.conf"
@@ -239,10 +241,10 @@ def generate(lldp):
 def apply(lldp):
     if lldp:
         # start/restart lldp service
-        os.system('sudo systemctl restart lldpd.service')
+        run('sudo systemctl restart lldpd.service')
     else:
         # LLDP service has been terminated
-        os.system('sudo systemctl stop lldpd.service')
+        run('sudo systemctl stop lldpd.service')
         os.unlink(config_file)
         os.unlink(vyos_config_file)
 

--- a/src/conf_mode/mdns_repeater.py
+++ b/src/conf_mode/mdns_repeater.py
@@ -24,6 +24,8 @@ from netifaces import ifaddresses, AF_INET
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file = r'/etc/default/mdns-repeater'
 
@@ -94,11 +96,11 @@ def generate(mdns):
 
 def apply(mdns):
     if (mdns is None) or mdns['disabled']:
-        os.system('sudo systemctl stop mdns-repeater')
+        run('sudo systemctl stop mdns-repeater')
         if os.path.exists(config_file):
             os.unlink(config_file)
     else:
-        os.system('sudo systemctl restart mdns-repeater')
+        run('sudo systemctl restart mdns-repeater')
 
     return None
 

--- a/src/conf_mode/ntp.py
+++ b/src/conf_mode/ntp.py
@@ -24,6 +24,8 @@ from sys import exit
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file = r'/etc/ntp.conf'
 
@@ -112,10 +114,10 @@ def generate(ntp):
 
 def apply(ntp):
     if ntp is not None:
-        os.system('sudo systemctl restart ntp.service')
+        run('sudo systemctl restart ntp.service')
     else:
         # NTP support is removed in the commit
-        os.system('sudo systemctl stop ntp.service')
+        run('sudo systemctl stop ntp.service')
         os.unlink(config_file)
 
     return None

--- a/src/conf_mode/protocols_bfd.py
+++ b/src/conf_mode/protocols_bfd.py
@@ -24,6 +24,8 @@ from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos.validate import is_ipv6_link_local, is_ipv6
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file = r'/tmp/bfd.frr'
 
@@ -205,7 +207,16 @@ def apply(bfd):
     if bfd is None:
         return None
 
+<<<<<<< HEAD
     os.system(f'vtysh -d bfdd -f {config_file}')
+=======
+    tmpl = jinja2.Template(config_tmpl)
+    config_text = tmpl.render(bfd)
+    with open(config_file, 'w') as f:
+        f.write(config_text)
+
+    run("sudo vtysh -d bfdd -f " + config_file)
+>>>>>>> util: T2226: covert most calls from os.system to util
     if os.path.exists(config_file):
         os.remove(config_file)
 

--- a/src/conf_mode/protocols_igmp.py
+++ b/src/conf_mode/protocols_igmp.py
@@ -23,6 +23,8 @@ from sys import exit
 from vyos import ConfigError
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
+from vyos.util import run
+
 
 config_file = r'/tmp/igmp.frr'
 
@@ -103,7 +105,7 @@ def apply(igmp):
         return None
 
     if os.path.exists(config_file):
-        os.system("sudo vtysh -d pimd -f " + config_file)
+        run("sudo vtysh -d pimd -f " + config_file)
         os.remove(config_file)
 
     return None

--- a/src/conf_mode/protocols_mpls.py
+++ b/src/conf_mode/protocols_mpls.py
@@ -21,11 +21,13 @@ from jinja2 import FileSystemLoader, Environment
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file = r'/tmp/ldpd.frr'
 
 def sysctl(name, value):
-    os.system('sysctl -wq {}={}'.format(name, value))
+    run('sysctl -wq {}={}'.format(name, value))
 
 def get_config():
     conf = Config()
@@ -160,7 +162,7 @@ def apply(mpls):
     operate_mpls_on_intfc(diactive_ifaces, 0)
 
     if os.path.exists(config_file):
-        os.system("sudo vtysh -d ldpd -f " + config_file)
+        run("sudo vtysh -d ldpd -f " + config_file)
         os.remove(config_file)
 
     return None

--- a/src/conf_mode/protocols_pim.py
+++ b/src/conf_mode/protocols_pim.py
@@ -23,6 +23,8 @@ from sys import exit
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file = r'/tmp/pimd.frr'
 
@@ -130,7 +132,11 @@ def apply(pim):
         return None
 
     if os.path.exists(config_file):
+<<<<<<< HEAD
         os.system("vtysh -d pimd -f " + config_file)
+=======
+        run("sudo vtysh -d pimd -f " + config_file)
+>>>>>>> util: T2226: covert most calls from os.system to util
         os.remove(config_file)
 
     return None

--- a/src/conf_mode/salt-minion.py
+++ b/src/conf_mode/salt-minion.py
@@ -26,6 +26,8 @@ from urllib3 import PoolManager
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file = r'/etc/salt/minion'
 
@@ -124,10 +126,10 @@ def generate(salt):
 
 def apply(salt):
     if salt is not None:
-        os.system("sudo systemctl restart salt-minion")
+        run("sudo systemctl restart salt-minion")
     else:
         # Salt access is removed in the commit
-        os.system("sudo systemctl stop salt-minion")
+        run("sudo systemctl stop salt-minion")
         os.unlink(config_file)
 
     return None

--- a/src/conf_mode/service-ipoe.py
+++ b/src/conf_mode/service-ipoe.py
@@ -16,7 +16,6 @@
 
 import os
 import re
-import subprocess
 
 from jinja2 import FileSystemLoader, Environment
 from socket import socket, AF_INET, SOCK_STREAM
@@ -26,6 +25,7 @@ from time import sleep
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
 
 ipoe_cnf_dir = r'/etc/accel-ppp/ipoe'
 ipoe_cnf = ipoe_cnf_dir + r'/ipoe.config'
@@ -64,15 +64,8 @@ def _chk_con():
                 break
 
 
-def _accel_cmd(cmd=''):
-    if not cmd:
-        return None
-    try:
-        ret = subprocess.check_output(
-            ['/usr/bin/accel-cmd', '-p', cmd_port, cmd]).decode().strip()
-        return ret
-    except:
-        return 1
+def _accel_cmd(command):
+    return run('/usr/bin/accel-cmd -p {cmd_port} {command}')
 
 ##### Inline functions end ####
 
@@ -306,8 +299,7 @@ def apply(c):
         return None
 
     if not os.path.exists(pidfile):
-        ret = subprocess.call(
-            ['/usr/sbin/accel-pppd', '-c', ipoe_cnf, '-p', pidfile, '-d'])
+        ret = run(f'/usr/sbin/accel-pppd -c {ipoe_cnf} -p {pidfile} -d')
         _chk_con()
         if ret != 0 and os.path.exists(pidfile):
             os.remove(pidfile)

--- a/src/conf_mode/service-pppoe.py
+++ b/src/conf_mode/service-pppoe.py
@@ -16,7 +16,6 @@
 
 import os
 import re
-import subprocess
 
 from jinja2 import FileSystemLoader, Environment
 from socket import socket, AF_INET, SOCK_STREAM
@@ -26,6 +25,7 @@ from time import sleep
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
 
 pidfile = r'/var/run/accel_pppoe.pid'
 pppoe_cnf_dir = r'/etc/accel-ppp/pppoe'
@@ -57,15 +57,8 @@ def _chk_con():
                 raise("failed to start pppoe server")
 
 
-def _accel_cmd(cmd=''):
-    if not cmd:
-        return None
-    try:
-        ret = subprocess.check_output(
-            ['/usr/bin/accel-cmd', cmd]).decode().strip()
-        return ret
-    except:
-        return 1
+def _accel_cmd(command):
+    return run(f'/usr/bin/accel-cmd {command}')
 
 
 def get_config():
@@ -426,8 +419,7 @@ def apply(c):
         return None
 
     if not os.path.exists(pidfile):
-        ret = subprocess.call(
-            ['/usr/sbin/accel-pppd', '-c', pppoe_conf, '-p', pidfile, '-d'])
+        ret = run(f'/usr/sbin/accel-pppd -c {pppoe_conf} -p {pidfile} -d')
         _chk_con()
         if ret != 0 and os.path.exists(pidfile):
             os.remove(pidfile)

--- a/src/conf_mode/service-router-advert.py
+++ b/src/conf_mode/service-router-advert.py
@@ -23,6 +23,8 @@ from sys import exit
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file = r'/etc/radvd.conf'
 
@@ -156,13 +158,13 @@ def generate(rtradv):
 def apply(rtradv):
     if not rtradv['interfaces']:
         # bail out early - looks like removal from running config
-        os.system('systemctl stop radvd.service')
+        run('systemctl stop radvd.service')
         if os.path.exists(config_file):
             os.unlink(config_file)
 
         return None
 
-    os.system('systemctl restart radvd.service')
+    run('systemctl restart radvd.service')
     return None
 
 if __name__ == '__main__':

--- a/src/conf_mode/snmp.py
+++ b/src/conf_mode/snmp.py
@@ -27,6 +27,8 @@ from vyos.defaults import directories as vyos_data_dir
 from vyos.validate import is_ipv4, is_addr_assigned
 from vyos.version import get_version_data
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file_client  = r'/etc/snmp/snmp.conf'
 config_file_daemon  = r'/etc/snmp/snmpd.conf'
@@ -507,7 +509,7 @@ def generate(snmp):
     #
     # As we are manipulating the snmpd user database we have to stop it first!
     # This is even save if service is going to be removed
-    os.system("systemctl stop snmpd.service")
+    run('systemctl stop snmpd.service')
     config_files = [config_file_client, config_file_daemon, config_file_access,
                     config_file_user]
     for file in config_files:
@@ -552,7 +554,7 @@ def apply(snmp):
         return None
 
     # start SNMP daemon
-    os.system("systemctl restart snmpd.service")
+    run("systemctl restart snmpd.service")
 
     # Passwords are not available immediately in the configuration file,
     # after daemon startup - we wait until they have been processed by
@@ -593,15 +595,15 @@ def apply(snmp):
 
                 # Now update the running configuration
                 #
-                # Currently when executing os.system() the environment does not
+                # Currently when executing run() the environment does not
                 # have the vyos_libexec_dir variable set, see Phabricator T685.
-                os.system('/opt/vyatta/sbin/my_set service snmp v3 user "{0}" auth encrypted-key "{1}" > /dev/null'.format(cfg['user'], cfg['auth_pw']))
-                os.system('/opt/vyatta/sbin/my_set service snmp v3 user "{0}" privacy encrypted-key "{1}" > /dev/null'.format(cfg['user'], cfg['priv_pw']))
-                os.system('/opt/vyatta/sbin/my_delete service snmp v3 user "{0}" auth plaintext-key > /dev/null'.format(cfg['user']))
-                os.system('/opt/vyatta/sbin/my_delete service snmp v3 user "{0}" privacy plaintext-key > /dev/null'.format(cfg['user']))
+                run('/opt/vyatta/sbin/my_set service snmp v3 user "{0}" auth encrypted-key "{1}" > /dev/null'.format(cfg['user'], cfg['auth_pw']))
+                run('/opt/vyatta/sbin/my_set service snmp v3 user "{0}" privacy encrypted-key "{1}" > /dev/null'.format(cfg['user'], cfg['priv_pw']))
+                run('/opt/vyatta/sbin/my_delete service snmp v3 user "{0}" auth plaintext-key > /dev/null'.format(cfg['user']))
+                run('/opt/vyatta/sbin/my_delete service snmp v3 user "{0}" privacy plaintext-key > /dev/null'.format(cfg['user']))
 
     # Enable AgentX in FRR
-    os.system('vtysh -c "configure terminal" -c "agentx" >/dev/null')
+    run('vtysh -c "configure terminal" -c "agentx" >/dev/null')
 
     return None
 

--- a/src/conf_mode/ssh.py
+++ b/src/conf_mode/ssh.py
@@ -21,6 +21,8 @@ from sys import exit
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file = r'/etc/ssh/sshd_config'
 
@@ -131,10 +133,10 @@ def generate(ssh):
 
 def apply(ssh):
     if ssh is not None and 'port' in ssh.keys():
-        os.system("sudo systemctl restart ssh.service")
+        run("sudo systemctl restart ssh.service")
     else:
         # SSH access is removed in the commit
-        os.system("sudo systemctl stop ssh.service")
+        run("sudo systemctl stop ssh.service")
         if os.path.isfile(config_file):
             os.unlink(config_file)
 

--- a/src/conf_mode/system-ip.py
+++ b/src/conf_mode/system-ip.py
@@ -20,6 +20,8 @@ from sys import exit
 from copy import deepcopy
 from vyos.config import Config
 from vyos import ConfigError
+from vyos.util import run
+
 
 default_config_data = {
     'arp_table': 8192,
@@ -29,7 +31,7 @@ default_config_data = {
 }
 
 def sysctl(name, value):
-    os.system('sysctl -wq {}={}'.format(name, value))
+    run('sysctl -wq {}={}'.format(name, value))
 
 def get_config():
     ip_opt = deepcopy(default_config_data)

--- a/src/conf_mode/system-ipv6.py
+++ b/src/conf_mode/system-ipv6.py
@@ -21,6 +21,8 @@ from sys import exit
 from copy import deepcopy
 from vyos.config import Config
 from vyos import ConfigError
+from vyos.util import run
+
 
 ipv6_disable_file = '/etc/modprobe.d/vyos_disable_ipv6.conf'
 
@@ -35,7 +37,7 @@ default_config_data = {
 }
 
 def sysctl(name, value):
-    os.system('sysctl -wq {}={}'.format(name, value))
+    run('sysctl -wq {}={}'.format(name, value))
 
 def get_config():
     ip_opt = deepcopy(default_config_data)

--- a/src/conf_mode/system-options.py
+++ b/src/conf_mode/system-options.py
@@ -20,6 +20,7 @@ from sys import exit
 from copy import deepcopy
 from vyos.config import Config
 from vyos import ConfigError
+from vyos.util import run
 
 systemd_ctrl_alt_del = '/lib/systemd/system/ctrl-alt-del.target'
 
@@ -51,9 +52,9 @@ def generate(opt):
 def apply(opt):
     # Beep action
     if opt['beep_if_fully_booted']:
-        os.system('systemctl enable vyos-beep.service >/dev/null 2>&1')
+        run('systemctl enable vyos-beep.service >/dev/null 2>&1')
     else:
-        os.system('systemctl disable vyos-beep.service >/dev/null 2>&1')
+        run('systemctl disable vyos-beep.service >/dev/null 2>&1')
 
     # Ctrl-Alt-Delete action
     if opt['ctrl_alt_del'] == 'ignore':

--- a/src/conf_mode/system-syslog.py
+++ b/src/conf_mode/system-syslog.py
@@ -22,7 +22,6 @@ from sys import exit
 
 from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
-from vyos.util import subprocess_cmd
 from vyos import ConfigError
 from vyos.util import run
 

--- a/src/conf_mode/system-syslog.py
+++ b/src/conf_mode/system-syslog.py
@@ -24,6 +24,7 @@ from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos.util import subprocess_cmd
 from vyos import ConfigError
+from vyos.util import run
 
 def get_config():
     c = Config()
@@ -253,10 +254,8 @@ def verify(c):
 
 def apply(c):
     if not c:
-        subprocess_cmd('systemctl stop syslog')
-        return None
-
-    subprocess_cmd('systemctl restart syslog')
+        return run('systemctl stop syslog')
+    return run('systemctl restart syslog')
 
 if __name__ == '__main__':
     try:

--- a/src/conf_mode/system-timezone.py
+++ b/src/conf_mode/system-timezone.py
@@ -20,6 +20,8 @@ import os
 from copy import deepcopy
 from vyos.config import Config
 from vyos import ConfigError
+from vyos.util import run
+
 
 default_config_data = {
     'name': 'UTC'
@@ -40,9 +42,7 @@ def generate(tz):
     pass
 
 def apply(tz):
-    cmd = '/usr/bin/timedatectl set-timezone {}'.format(tz['name'])
-    os.system(cmd)
-    pass
+    run('/usr/bin/timedatectl set-timezone {}'.format(tz['name']))
 
 if __name__ == '__main__':
     try:

--- a/src/conf_mode/tftp_server.py
+++ b/src/conf_mode/tftp_server.py
@@ -27,6 +27,8 @@ from vyos.config import Config
 from vyos.defaults import directories as vyos_data_dir
 from vyos.validate import is_ipv4, is_addr_assigned
 from vyos import ConfigError
+from vyos.util import run
+
 
 config_file = r'/etc/default/tftpd'
 
@@ -113,7 +115,7 @@ def generate(tftpd):
 
 def apply(tftpd):
     # stop all services first - then we will decide
-    os.system('systemctl stop tftpd@{0..20}')
+    run('systemctl stop tftpd@{0..20}')
 
     # bail out early - e.g. service deletion
     if tftpd is None:
@@ -138,7 +140,7 @@ def apply(tftpd):
 
     idx = 0
     for listen in tftpd['listen']:
-        os.system('systemctl restart tftpd@{0}.service'.format(idx))
+        run('systemctl restart tftpd@{0}.service'.format(idx))
         idx = idx + 1
 
     return None

--- a/src/conf_mode/vpn_sstp.py
+++ b/src/conf_mode/vpn_sstp.py
@@ -26,7 +26,7 @@ from jinja2 import FileSystemLoader, Environment
 from vyos.config import Config
 from vyos import ConfigError
 from vyos.defaults import directories as vyos_data_dir
-from vyos.util import process_running, subprocess_cmd
+from vyos.util import process_running
 from vyos.util import process_running, cmd, run
 
 pidfile = r'/var/run/accel_sstp.pid'

--- a/src/conf_mode/vrf.py
+++ b/src/conf_mode/vrf.py
@@ -20,13 +20,12 @@ from sys import exit
 from copy import deepcopy
 from jinja2 import FileSystemLoader, Environment
 from json import loads
-from subprocess import check_output, CalledProcessError
 
 from vyos.config import Config
 from vyos.configdict import list_diff
 from vyos.defaults import directories as vyos_data_dir
 from vyos.ifconfig import Interface
-from vyos.util import read_file
+from vyos.util import read_file, cmd
 from vyos import ConfigError
 
 config_file = r'/etc/iproute2/rt_tables.d/vyos-vrf.conf'
@@ -40,14 +39,11 @@ default_config_data = {
 }
 
 def _cmd(command):
-    try:
-        check_output(command.split())
-    except CalledProcessError as e:
-        raise ConfigError(f'Error changing VRF: {e}')
+    cmd(command, raising=ConfigError, message='Error changing VRF')
 
 def list_rules():
     command = 'ip -j -4 rule show'
-    answer = loads(check_output(command.split()).decode())
+    answer = loads(cmd(command))
     return [_ for _ in answer if _]
 
 def vrf_interfaces(c, match):

--- a/src/conf_mode/vrrp.py
+++ b/src/conf_mode/vrrp.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import subprocess
 
 from sys import exit
 from ipaddress import ip_address, ip_interface, IPv4Interface, IPv6Interface, IPv4Address, IPv6Address
@@ -28,6 +27,7 @@ import vyos.keepalived
 
 from vyos.defaults import directories as vyos_data_dir
 from vyos import ConfigError
+from vyos.util import run
 
 daemon_file = "/etc/default/keepalived"
 config_file = "/etc/keepalived/keepalived.conf"
@@ -242,17 +242,17 @@ def apply(data):
 
         if not vyos.keepalived.vrrp_running():
             print("Starting the VRRP process")
-            ret = subprocess.call("sudo systemctl restart keepalived.service", shell=True)
+            ret = run("sudo systemctl restart keepalived.service")
         else:
             print("Reloading the VRRP process")
-            ret = subprocess.call("sudo systemctl reload keepalived.service", shell=True)
+            ret = run("sudo systemctl reload keepalived.service")
 
         if ret != 0:
             raise ConfigError("keepalived failed to start")
     else:
         # VRRP is removed in the commit
         print("Stopping the VRRP process")
-        subprocess.call("sudo systemctl stop keepalived.service", shell=True)
+        run("sudo systemctl stop keepalived.service")
         os.unlink(config_file)
 
     return None

--- a/src/etc/vmware-tools/scripts/resume-vm-default.d/ether-resume.py
+++ b/src/etc/vmware-tools/scripts/resume-vm-default.d/ether-resume.py
@@ -15,11 +15,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
-import subprocess
 import syslog as sl
 
 from vyos.config import Config
 from vyos import ConfigError
+from vyos.util import run
 
 
 def get_config():
@@ -45,7 +45,7 @@ def apply(config):
         # bring the interface up
         cmd = ["ip", "link", "set", "dev", intf, "up"]
         sl.syslog(sl.LOG_NOTICE, " ".join(cmd))
-        subprocess.call(cmd)
+        run(cmd)
 
         # add configured addresses to interface
         for addr in addresses:
@@ -54,7 +54,7 @@ def apply(config):
             else:
                 cmd = ["ip", "address", "add", addr, "dev", intf]
             sl.syslog(sl.LOG_NOTICE, " ".join(cmd))
-            subprocess.call(cmd)
+            run(cmd)
 
 
 if __name__ == '__main__':

--- a/src/helpers/run-config-migration.py
+++ b/src/helpers/run-config-migration.py
@@ -19,7 +19,8 @@ import os
 import sys
 import argparse
 import datetime
-import subprocess
+
+from vyos.util import cmd
 from vyos.migrator import Migrator, VirtualMigrator
 
 def main():
@@ -61,12 +62,7 @@ def main():
             '{0:%Y-%m-%d-%H%M%S}'.format(datetime.datetime.now()),
             'pre-migration'])
 
-    try:
-        subprocess.check_call(['cp', '-p', config_file_name,
-                backup_file_name])
-    except subprocess.CalledProcessError as err:
-        print("Called process error: {}.".format(err))
-        sys.exit(1)
+    cmd(f'cp -p {config_file_name} {backup_file_name}')
 
     if not virtual:
         virtual_migration = VirtualMigrator(config_file_name)

--- a/src/helpers/validate-value.py
+++ b/src/helpers/validate-value.py
@@ -5,6 +5,8 @@ import os
 import sys
 import argparse
 
+from vyos.util import run
+
 parser = argparse.ArgumentParser()
 parser.add_argument('--regex', action='append')
 parser.add_argument('--exec', action='append')
@@ -31,7 +33,7 @@ try:
         cmd = "{0} {1}".format(cmd, args.value)
         if debug:
             print(cmd)
-        res = os.system(cmd)
+        res = run(cmd)
         if res == 0:
             sys.exit(0)
 except Exception as exn:

--- a/src/helpers/vyos-boot-config-loader.py
+++ b/src/helpers/vyos-boot-config-loader.py
@@ -20,13 +20,13 @@ import os
 import sys
 import pwd
 import grp
-import subprocess
 import traceback
 from datetime import datetime
 
 from vyos.defaults import directories
 from vyos.configsession import ConfigSession, ConfigSessionError
 from vyos.configtree import ConfigTree
+from vyos.util import cmd
 
 STATUS_FILE = '/tmp/vyos-config-status'
 TRACE_FILE = '/tmp/boot-config-trace'
@@ -102,12 +102,7 @@ def failsafe(config_file_name):
                                       'authentication',
                                       'encrypted-password'])
 
-    cmd = ("useradd -s /bin/bash -G 'users,sudo' -m -N -p '{0}' "
-           "vyos".format(passwd))
-    try:
-        subprocess.check_call(cmd, shell=True)
-    except subprocess.CalledProcessError as e:
-        sys.exit("{0}".format(e))
+    cmd(f"useradd -s /bin/bash -G 'users,sudo' -m -N -p '{passwd}' vyos")
 
 if __name__ == '__main__':
     if len(sys.argv) < 2:

--- a/src/helpers/vyos-bridge-sync.py
+++ b/src/helpers/vyos-bridge-sync.py
@@ -21,16 +21,12 @@
 # to the bridge automatically once it's available
 
 import argparse
-import subprocess
-
 from sys import exit
 from time import sleep
-from vyos.config import Config
 
-def subprocess_cmd(command):
-    process = subprocess.Popen(command,stdout=subprocess.PIPE, shell=True)
-    proc_stdout = process.communicate()[0].strip()
-    pass
+from vyos.config import Config
+from vyos.util import cmd, run
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -45,9 +41,11 @@ if __name__ == '__main__':
         for bridge in conf.list_nodes('interfaces bridge'):
             for member_if in conf.list_nodes('interfaces bridge {} member interface'.format(bridge)):
                 if args.interface == member_if:
-                    cmd = 'brctl addif "{}" "{}"'.format(bridge, args.interface)
+                    command = 'brctl addif "{}" "{}"'.format(bridge, args.interface)
                     # let interfaces etc. settle - especially required for OpenVPN bridged interfaces
                     sleep(4)
-                    subprocess_cmd(cmd)
+                    # XXX: This is ignoring any issue, should be cmd but kept as it
+                    # XXX: during the migration to not cause any regression
+                    run(command)
 
     exit(0)

--- a/src/helpers/vyos-load-config.py
+++ b/src/helpers/vyos-load-config.py
@@ -30,24 +30,18 @@ import vyos.remote
 from vyos.config import Config, VyOSError
 from vyos.migrator import Migrator, VirtualMigrator, MigratorError
 
-system_config_file = 'config.boot'
-
 class LoadConfig(Config):
     """A subclass for calling 'loadFile'.
     This does not belong in config.py, and only has a single caller.
     """
-    def load_config(self, file_path):
-        cmd = [self._cli_shell_api, 'loadFile', file_path]
-        self._run(cmd)
+    def load_config(self, path):
+        return self._run(['/bin/cli-shell-api','loadFile',path])
 
-if len(sys.argv) > 1:
-    file_name = sys.argv[1]
-else:
-    file_name = system_config_file
 
+file_name = sys.argv[1] if len(sys.argv) > 1 else 'config.boot'
 configdir = vyos.defaults.directories['config']
-
 protocols = ['scp', 'sftp', 'http', 'https', 'ftp', 'tftp']
+
 
 if any(x in file_name for x in protocols):
     config_file = vyos.remote.get_remote_config(file_name)

--- a/src/helpers/vyos-merge-config.py
+++ b/src/helpers/vyos-merge-config.py
@@ -17,13 +17,13 @@
 
 import sys
 import os
-import subprocess
 import tempfile
 import vyos.defaults
 import vyos.remote
 from vyos.config import Config
 from vyos.configtree import ConfigTree
 from vyos.migrator import Migrator, VirtualMigrator
+from vyos.util import cmd
 
 
 if (len(sys.argv) < 2):
@@ -100,12 +100,10 @@ if path:
     add_cmds = [ cmd for cmd in add_cmds if path in cmd ]
 
 for cmd in add_cmds:
-    cmd = "/opt/vyatta/sbin/my_" + cmd
-
     try:
-        subprocess.check_call(cmd, shell=True)
-    except subprocess.CalledProcessError as err:
-        print("Called process error: {}.".format(err))
+        cmd(f'/opt/vyatta/sbin/my_{cmd}', message='Called process error')
+    except OSError as err:
+        print(err)
 
 if effective_config.session_changed():
     print("Merge complete. Use 'commit' to make changes effective.")

--- a/src/migration-scripts/system/12-to-13
+++ b/src/migration-scripts/system/12-to-13
@@ -12,12 +12,8 @@ import re
 import sys
 
 from vyos.configtree import ConfigTree
-from subprocess import Popen, PIPE, STDOUT
+from vyos.util import cmd
 
-def _cmd(cmd):
-    p = Popen(cmd, stdout=PIPE, stderr=STDOUT, shell=True)
-    tmp = p.communicate()[0].strip()
-    return tmp.decode()
 
 if (len(sys.argv) < 1):
     print("Must specify file name!")
@@ -37,8 +33,11 @@ else:
     tz = config.return_value(tz_base)
 
     # retrieve all valid timezones
-    tz_data = _cmd('find /usr/share/zoneinfo/posix -type f -or -type l | sed -e s:/usr/share/zoneinfo/posix/::')
-    tz_data = tz_data.split('\n')
+    try:
+        tz_datas = cmd('find /usr/share/zoneinfo/posix -type f -or -type l | sed -e s:/usr/share/zoneinfo/posix/::')
+    except OSError:
+        tz_datas = ''
+    tz_data = tz_datas.split('\n')
 
     if re.match(r'[Ll][Oo][Ss].+', tz):
         tz = 'America/Los_Angeles'

--- a/src/op_mode/clear_conntrack.py
+++ b/src/op_mode/clear_conntrack.py
@@ -14,13 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import subprocess
 import sys
 
 from vyos.util import ask_yes_no
+from vyos.util import cmd, DEVNULL
 
 if not ask_yes_no("This will clear all currently tracked and expected connections. Continue?"):
     sys.exit(1)
 else:
-    subprocess.check_call(['/usr/sbin/conntrack -F'], shell=True, stderr=subprocess.DEVNULL)
-    subprocess.check_call(['/usr/sbin/conntrack -F expect'], shell=True, stderr=subprocess.DEVNULL)
+    cmd('/usr/sbin/conntrack -F', stderr=DEVNULL)
+    cmd('/usr/sbin/conntrack -F expect', stderr=DEVNULL)

--- a/src/op_mode/connect_disconnect.py
+++ b/src/op_mode/connect_disconnect.py
@@ -21,6 +21,9 @@ from sys import exit
 from psutil import process_iter
 from time import strftime, localtime, time
 
+from vyos.util import run
+
+
 PPP_LOGFILE = '/var/log/vyatta/ppp_{}.log'
 
 def check_interface(interface):
@@ -56,8 +59,7 @@ def connect(interface):
         tm = strftime("%a %d %b %Y %I:%M:%S %p %Z", localtime(time()))
         with open(PPP_LOGFILE.format(interface), 'a') as f:
             f.write('{}: user {} started PPP daemon for {} by connect command\n'.format(tm, user, interface))
-            cmd = 'umask 0; setsid sh -c "nohup /usr/sbin/pppd call {0} > /tmp/{0}.log 2>&1 &"'.format(interface)
-            os.system(cmd)
+            run('umask 0; setsid sh -c "nohup /usr/sbin/pppd call {0} > /tmp/{0}.log 2>&1 &"'.format(interface))
 
 
 def disconnect(interface):
@@ -75,8 +77,7 @@ def disconnect(interface):
         tm = strftime("%a %d %b %Y %I:%M:%S %p %Z", localtime(time()))
         with open(PPP_LOGFILE.format(interface), 'a') as f:
             f.write('{}: user {} stopped PPP daemon for {} by disconnect command\n'.format(tm, user, interface))
-            cmd = '/usr/bin/poff "{}"'.format(interface)
-            os.system(cmd)
+            run('/usr/bin/poff "{}"'.format(interface))
 
 def main():
     parser = argparse.ArgumentParser()

--- a/src/op_mode/dns_forwarding_reset.py
+++ b/src/op_mode/dns_forwarding_reset.py
@@ -25,6 +25,8 @@ import sys
 import argparse
 
 import vyos.config
+from vyos.util import run
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-a", "--all", action="store_true", help="Reset all cache")
@@ -40,10 +42,10 @@ if __name__ == '__main__':
         sys.exit(0)
 
     if args.all:
-        os.system("rec_control wipe-cache \'.$\'")
+        run("rec_control wipe-cache \'.$\'")
         sys.exit(1)
     elif args.domain:
-        os.system("rec_control wipe-cache \'{0}$\'".format(args.domain))
+        run("rec_control wipe-cache \'{0}$\'".format(args.domain))
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/op_mode/dns_forwarding_statistics.py
+++ b/src/op_mode/dns_forwarding_statistics.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
-import subprocess
 import jinja2
 import sys
 
 from vyos.config import Config
+from vyos.config import cmd
 
 PDNS_CMD='/usr/bin/rec_control'
 
@@ -26,8 +26,8 @@ if __name__ == '__main__':
 
     data = {}
 
-    data['cache_entries'] = subprocess.check_output([PDNS_CMD, 'get cache-entries']).decode()
-    data['cache_size'] = "{0:.2f}".format( int(subprocess.check_output([PDNS_CMD, 'get cache-bytes']).decode()) / 1024 )
+    data['cache_entries'] = cmd(f'{PDNS_CMD} get cache-entries')
+    data['cache_size'] = "{0:.2f}".format( int(cmd(f'{PDNS_CMD} get cache-bytes')) / 1024 )
 
     tmpl = jinja2.Template(OUT_TMPL_SRC)
     print(tmpl.render(data))

--- a/src/op_mode/dynamic_dns.py
+++ b/src/op_mode/dynamic_dns.py
@@ -21,6 +21,8 @@ import sys
 import time
 
 from vyos.config import Config
+from vyos.util import run
+
 
 cache_file = r'/var/cache/ddclient/ddclient.cache'
 
@@ -84,9 +86,9 @@ def show_status():
 
 
 def update_ddns():
-    os.system('systemctl stop ddclient')
+    run('systemctl stop ddclient')
     os.remove(cache_file)
-    os.system('systemctl start ddclient')
+    run('systemctl start ddclient')
 
 
 def main():

--- a/src/op_mode/generate_ssh_server_key.py
+++ b/src/op_mode/generate_ssh_server_key.py
@@ -14,14 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import subprocess
 import sys
 
 from vyos.util import ask_yes_no
+from vyos.util import cmd
 
 if not ask_yes_no('Do you really want to remove the existing SSH host keys?'):
     sys.exit(0)
-else:
-    subprocess.check_call(['sudo rm -v /etc/ssh/ssh_host_*'], shell=True)
-    subprocess.check_call(['sudo dpkg-reconfigure openssh-server'], shell=True)
-    subprocess.check_call(['sudo systemctl restart ssh'], shell=True)
+
+cmd('sudo rm -v /etc/ssh/ssh_host_*')
+cmd('sudo dpkg-reconfigure openssh-server')
+cmd('sudo systemctl restart ssh')

--- a/src/op_mode/lldp_op.py
+++ b/src/op_mode/lldp_op.py
@@ -20,8 +20,9 @@ import jinja2
 
 from xml.dom import minidom
 from sys import exit
-from subprocess import Popen, PIPE, STDOUT
 from tabulate import tabulate
+
+from vyos.util import popen
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-a", "--all", action="store_true", help="Show LLDP neighbors on all interfaces")
@@ -40,9 +41,8 @@ Device ID                 Local     Proto  Cap   Platform             Port ID
 
 def _get_neighbors():
     command = '/usr/sbin/lldpcli -f xml show neighbors'
-    p = Popen(command, stdout=PIPE, stderr=STDOUT, shell=True)
-    tmp = p.communicate()[0].strip()
-    return tmp.decode()
+    out,_ = popen(command)
+    return out
 
 def extract_neighbor(neighbor):
     """

--- a/src/op_mode/reset_vpn.py
+++ b/src/op_mode/reset_vpn.py
@@ -16,52 +16,53 @@
 
 # import os
 import sys
-import subprocess
 import argparse
 #import re
 
-pptp_cmd = ["/usr/bin/accel-cmd", "-p 2003"]
-l2tp_cmd = ["/usr/bin/accel-cmd", "-p 2004"]
+from vyos.util import run, DEVNULL
+
+pptp_base = '/usr/bin/accel-cmd -p 2003 terminate {} {}'
+l2tp_base = '/usr/bin/accel-cmd -p 2004 terminate {} {}'
 
 def terminate_sessions(username='', interface='', protocol=''):
     if username:
         if username == "all_users":
             if protocol == "pptp":
-                pptp_cmd.append("terminate all")
-                subprocess.call(pptp_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                pptp_cmd = pptp_base.format('all','')
+                run(pptp_cmd, stdout=DEVNULL, stderr=DEVNULL)
                 return
             elif protocol == "l2tp":
-                l2tp_cmd.append("terminate all")
-                subprocess.call(l2tp_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                l2tp_cmd = l2tp_base.format('all', '')
+                run(l2tp_cmd, stdout=DEVNULL, stderr=DEVNULL)
                 return
             else:
-                pptp_cmd.append("terminate all")
-                subprocess.call(pptp_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-                l2tp_cmd.append("terminate all")
-                subprocess.call(l2tp_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                pptp_cmd = pptp_base.format('all', '')
+                run(pptp_cmd, stdout=DEVNULL, stderr=DEVNULL)
+                l2tp_cmd = l2tp_base.format('all', '')
+                run(l2tp_cmd, stdout=DEVNULL, stderr=DEVNULL)
                 return
 
         if protocol == "pptp":
-            pptp_cmd.append("terminate username {0}".format(username))
-            subprocess.call(pptp_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            pptp_cmd = pptp_base.format('username', username)
+            run(pptp_cmd, stdout=DEVNULL, stderr=DEVNULL)
             return
         elif protocol == "l2tp":
-            l2tp_cmd.append("terminate username {0}".format(username))
-            subprocess.call(l2tp_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            l2tp_cmd = l2tp_base.format('username', username)
+            run(l2tp_cmd, stdout=DEVNULL, stderr=DEVNULL)
             return
         else:
-            pptp_cmd.append("terminate username {0}".format(username))
-            subprocess.call(pptp_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            pptp_cmd = pptp_base.format('username', username)
+            run(pptp_cmd, stdout=DEVNULL, stderr=DEVNULL)
             l2tp_cmd.append("terminate username {0}".format(username))
-            subprocess.call(l2tp_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            run(l2tp_cmd, stdout=DEVNULL, stderr=DEVNULL)
             return
 
     # rewrite `terminate by interface` if pptp will have pptp%d interface naming
     if interface:
-        pptp_cmd.append("terminate if {0}".format(interface))
-        subprocess.call(pptp_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        l2tp_cmd.append("terminate if {0}".format(interface))
-        subprocess.call(l2tp_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        pptp_cmd = pptp_base.format('if', interface)
+        run(pptp_cmd, stdout=DEVNULL, stderr=DEVNULL)
+        l2tp_cmd = l2tp_base.format('if', interface)
+        run(l2tp_cmd, stdout=DEVNULL, stderr=DEVNULL)
        
 
 def main():

--- a/src/op_mode/restart_dhcp_relay.py
+++ b/src/op_mode/restart_dhcp_relay.py
@@ -23,6 +23,8 @@ import argparse
 import os
 
 import vyos.config
+from vyos.util import run
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--ipv4", action="store_true", help="Restart IPv4 DHCP relay")
@@ -37,7 +39,7 @@ if __name__ == '__main__':
         if not c.exists_effective('service dhcp-relay'):
             print("DHCP relay service not configured")
         else:
-            os.system('sudo systemctl restart isc-dhcp-relay.service')
+            run('sudo systemctl restart isc-dhcp-relay.service')
 
         sys.exit(0)
     elif args.ipv6:
@@ -45,7 +47,7 @@ if __name__ == '__main__':
         if not c.exists_effective('service dhcpv6-relay'):
             print("DHCPv6 relay service not configured")
         else:
-            os.system('sudo systemctl restart isc-dhcpv6-relay.service')
+            run('sudo systemctl restart isc-dhcpv6-relay.service')
 
         sys.exit(0)
     else:

--- a/src/op_mode/restart_frr.py
+++ b/src/op_mode/restart_frr.py
@@ -17,11 +17,12 @@
 
 import sys
 import argparse
-import subprocess
 import logging
 from logging.handlers import SysLogHandler
 from pathlib import Path
 import psutil
+
+from vyos.util import run
 
 # some default values
 watchfrr = '/usr/lib/frr/watchfrr.sh'
@@ -86,7 +87,7 @@ def _write_config():
     Path(frrconfig_tmp).mkdir(parents=False, exist_ok=True)
     # save frr.conf to it
     command = "{} -n -w --config_dir {} 2> /dev/null".format(vtysh, frrconfig_tmp)
-    return_code = subprocess.call(command, shell=True)
+    return_code = run(command)
     if not return_code == 0:
         logger.error("Failed to save active config: \"{}\" returned exit code: {}".format(command, return_code))
         return False
@@ -108,7 +109,7 @@ def _cleanup():
 # check if daemon is running
 def _daemon_check(daemon):
     command = "{} print_status {}".format(watchfrr, daemon)
-    return_code = subprocess.call(command, shell=True)
+    return_code = run(command)
     if not return_code == 0:
         logger.error("Daemon \"{}\" is not running".format(daemon))
         return False
@@ -119,7 +120,7 @@ def _daemon_check(daemon):
 # restart daemon
 def _daemon_restart(daemon):
     command = "{} restart {}".format(watchfrr, daemon)
-    return_code = subprocess.call(command, shell=True)
+    return_code = run(command)
     if not return_code == 0:
         logger.error("Failed to restart daemon \"{}\"".format(daemon))
         return False
@@ -135,7 +136,7 @@ def _reload_config(daemon):
     else:
         command = "{} -n -b --config_dir {} 2> /dev/null".format(vtysh, frrconfig_tmp)
 
-    return_code = subprocess.call(command, shell=True)
+    return_code = run(command)
     if not return_code == 0:
         logger.error("Failed to reinstall configuration")
         return False

--- a/src/op_mode/show_acceleration.py
+++ b/src/op_mode/show_acceleration.py
@@ -21,6 +21,8 @@ import re
 import argparse
 import subprocess
 from vyos.config import Config
+from vyos.util import popen, run
+
 
 def detect_qat_dev():
     ret = subprocess.Popen(['sudo', 'lspci',  '-nn'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -97,20 +99,20 @@ args = parser.parse_args()
 if args.hw:
     detect_qat_dev()
     # Show availible Intel QAT devices
-    os.system('sudo lspci -nn | egrep -e \'8086:37c8|8086:19e2|8086:0435|8086:6f54\'')
+    run('sudo lspci -nn | egrep -e \'8086:37c8|8086:19e2|8086:0435|8086:6f54\'')
 elif args.flow and args.dev:
     check_qat_if_conf()
-    os.system('sudo cat '+get_qat_proc_path(args.dev)+"fw_counters")
+    run('sudo cat '+get_qat_proc_path(args.dev)+"fw_counters")
 elif args.interrupts:
     check_qat_if_conf()
     # Delete _dev from args.dev
-    os.system('sudo cat /proc/interrupts | grep qat')
+    run('sudo cat /proc/interrupts | grep qat')
 elif args.status:
     check_qat_if_conf()
     show_qat_status()
 elif args.conf and args.dev:
     check_qat_if_conf()
-    os.system('sudo cat '+get_qat_proc_path(args.dev)+"dev_cfg")
+    run('sudo cat '+get_qat_proc_path(args.dev)+"dev_cfg")
 elif args.dev_list:
     get_qat_devices()
 else:

--- a/src/op_mode/show_acceleration.py
+++ b/src/op_mode/show_acceleration.py
@@ -19,16 +19,15 @@ import sys
 import os
 import re
 import argparse
-import subprocess
+
 from vyos.config import Config
 from vyos.util import popen, run
 
 
 def detect_qat_dev():
-    ret = subprocess.Popen(['sudo', 'lspci',  '-nn'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    (output, err) = ret.communicate()
+    output, err = popen('sudo lspci -nn', decode='utf-8')
     if not err:
-        data = re.findall('(8086:19e2)|(8086:37c8)|(8086:0435)|(8086:6f54)', output.decode("utf-8"))
+        data = re.findall('(8086:19e2)|(8086:37c8)|(8086:0435)|(8086:6f54)', output)
         #If QAT devices found
         if data:
             return
@@ -44,15 +43,12 @@ def show_qat_status():
         sys.exit(1)
 
     # Show QAT service
-    os.system('sudo /etc/init.d/vyos-qat-utilities status')
+    run('sudo /etc/init.d/vyos-qat-utilities status')
 
 # Return QAT devices
 def get_qat_devices():
-    ret = subprocess.Popen(['sudo', '/etc/init.d/vyos-qat-utilities',  'status'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    (output, err) = ret.communicate()
+    data_st, err = popen('sudo /etc/init.d/vyos-qat-utilities status', decode='utf-8')
     if not err:
-        #print(output)
-        data_st = output.decode("utf-8")
         elm_lst = re.findall('qat_dev\d', data_st)
         print('\n'.join(elm_lst))
 
@@ -60,11 +56,10 @@ def get_qat_devices():
 def get_qat_proc_path(qat_dev):
     q_type = ""
     q_bsf  = ""
-    ret = subprocess.Popen(['sudo', '/etc/init.d/vyos-qat-utilities',  'status'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    (output, err) = ret.communicate()
+    output, err = popen('sudo /etc/init.d/vyos-qat-utilities status', decode='utf-8')
     if not err:
         # Parse QAT service output
-        data_st = output.decode("utf-8").split("\n")
+        data_st = output.split("\n")
         for elm_str in range(len(data_st)):
             if re.search(qat_dev, data_st[elm_str]):
                 elm_list = data_st[elm_str].split(", ")

--- a/src/op_mode/show_dhcp.py
+++ b/src/op_mode/show_dhcp.py
@@ -24,8 +24,11 @@ import collections
 import os
 from datetime import datetime
 
-from vyos.config import Config
 from isc_dhcp_leases import Lease, IscDhcpLeases
+
+from vyos.config import Config
+from vyos.util import run
+
 
 lease_file = "/config/dhcpd.leases"
 pool_key = "shared-networkname"
@@ -190,7 +193,7 @@ if __name__ == '__main__':
         sys.exit(0)
 
     # if dhcp server is down, inactive leases may still be shown as active, so warn the user.
-    if os.system('systemctl -q is-active isc-dhcpv4-server.service') != 0:
+    if run('systemctl -q is-active isc-dhcpv4-server.service') != 0:
         print("WARNING: DHCP server is configured but not started. Data may be stale.")
 
     if args.leases:

--- a/src/op_mode/show_dhcpv6.py
+++ b/src/op_mode/show_dhcpv6.py
@@ -24,8 +24,10 @@ import collections
 import os
 from datetime import datetime
 
-from vyos.config import Config
 from isc_dhcp_leases import Lease, IscDhcpLeases
+
+from vyos.config import Config
+from vyos.util import run
 
 lease_file = "/config/dhcpdv6.leases"
 pool_key = "shared-networkname"
@@ -177,7 +179,7 @@ if __name__ == '__main__':
         sys.exit(0)
 
     # if dhcp server is down, inactive leases may still be shown as active, so warn the user.
-    if os.system('systemctl -q is-active isc-dhcpv6-server.service') != 0:
+    if run('systemctl -q is-active isc-dhcpv6-server.service') != 0:
         print("WARNING: DHCPv6 server is configured but not started. Data may be stale.")
 
     if args.leases:

--- a/src/op_mode/show_vpn_ra.py
+++ b/src/op_mode/show_vpn_ra.py
@@ -17,8 +17,8 @@
 import os
 import sys
 import re
-import subprocess
-# from subprocess import Popen, PIPE
+
+from vyos.util import popen
 
 # chech connection to pptp and l2tp daemon
 def get_sessions():
@@ -31,18 +31,16 @@ def get_sessions():
     len_def_header = 170
     
     # Check pptp
-    ret = subprocess.Popen(pptp_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    (output, err) = ret.communicate()
-    if not err and len(output.decode("utf-8")) > len_def_header and not re.search(err_pattern, output.decode("utf-8")):
-        print(output.decode("utf-8"))
+    output, err = popen(pptp_cmd, decode='utf-8')
+    if not err and len(output) > len_def_header and not re.search(err_pattern, output):
+        print(output)
     else:
         absent_pptp = True
 
     # Check l2tp
-    ret = subprocess.Popen(l2tp_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    (output, err) = ret.communicate()
-    if not err and len(output.decode("utf-8")) > len_def_header and not re.search(err_pattern, output.decode("utf-8")):
-        print(output.decode("utf-8"))
+    output, err = popen(l2tp_cmd, decode='utf-8')
+    if not err and len(output) > len_def_header and not re.search(err_pattern, output):
+        print(output)
     else:
         absent_l2tp = True
 

--- a/src/op_mode/show_vrf.py
+++ b/src/op_mode/show_vrf.py
@@ -16,9 +16,9 @@
 
 import argparse
 import jinja2
-
-from subprocess import check_output
 from json import loads
+
+from vyos.util import cmd
 
 vrf_out_tmpl = """
 VRF name          state     mac address        flags                     interfaces
@@ -31,12 +31,12 @@ VRF name          state     mac address        flags                     interfa
 
 def list_vrfs():
     command = 'ip -j -br link show type vrf'
-    answer = loads(check_output(command.split()).decode())
+    answer = loads(cmd(command))
     return [_ for _ in answer if _]
 
 def list_vrf_members(vrf):
     command = f'ip -j -br link show master {vrf}'
-    answer = loads(check_output(command.split()).decode())
+    answer = loads(cmd(command))
     return [_ for _ in answer if _]
 
 parser = argparse.ArgumentParser()

--- a/src/op_mode/show_wireless.py
+++ b/src/op_mode/show_wireless.py
@@ -19,19 +19,15 @@ import re
 
 from sys import exit
 from copy import deepcopy
-from subprocess import Popen, PIPE, STDOUT
 
 from vyos.config import Config
+from vyos.util import popen
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-s", "--scan", help="Scan for Wireless APs on given interface, e.g. 'wlan0'")
 parser.add_argument("-b", "--brief", action="store_true", help="Show wireless configuration")
 parser.add_argument("-c", "--stations", help="Show wireless clients connected on interface, e.g. 'wlan0'")
 
-def _cmd(command):
-    p = Popen(command, stdout=PIPE, stderr=STDOUT, shell=True)
-    tmp = p.communicate()[0].strip()
-    return tmp.decode()
 
 def show_brief():
     config = Config()
@@ -57,7 +53,8 @@ def show_brief():
     return interfaces
 
 def ssid_scan(intf):
-    tmp = _cmd('/sbin/iw dev {} scan ap-force'.format(intf))
+    # XXX: This ignores errors
+    tmp, _ = popen(f'/sbin/iw dev {intf} scan ap-force')
     networks = []
     data = {
         'ssid': '',
@@ -89,7 +86,8 @@ def ssid_scan(intf):
     return networks
 
 def show_clients(intf):
-    tmp = _cmd('/sbin/iw dev {} station dump'.format(intf))
+    # XXX: This ignores errors
+    tmp, _ = popen(f'/sbin/iw dev {intf} station dump')
     clients = []
     data = {
         'mac': '',

--- a/src/op_mode/snmp.py
+++ b/src/op_mode/snmp.py
@@ -24,6 +24,7 @@ import sys
 import argparse
 
 from vyos.config import Config
+from vyos.util import run
 
 config_file_daemon = r'/etc/snmp/snmpd.conf'
 
@@ -53,7 +54,7 @@ def show_all():
 
 def show_community(c, h):
     print('Status of SNMP community {0} on {1}'.format(c, h), flush=True)
-    os.system('/usr/bin/snmpstatus -t1 -v1 -c {0} {1}'.format(c, h))
+    run('/usr/bin/snmpstatus -t1 -v1 -c {0} {1}'.format(c, h))
 
 if __name__ == '__main__':
     args = parser.parse_args()

--- a/src/op_mode/system_integrity.py
+++ b/src/op_mode/system_integrity.py
@@ -18,10 +18,11 @@
 
 import sys
 import os
-import subprocess
 import re
 import itertools
 from datetime import datetime, timedelta
+
+from vyos.util import cmd
 
 verf = r'/usr/libexec/vyos/op_mode/version.py'
 
@@ -29,7 +30,7 @@ def get_sys_build_version():
   if not os.path.exists(verf):
     return None
 
-  a = subprocess.check_output(['/usr/libexec/vyos/op_mode/version.py']).decode()
+  a = cmd('/usr/libexec/vyos/op_mode/version.py')
   if re.search('^Built on:.+',a, re.M) == None:
     return None
 

--- a/src/system/keepalived-fifo.py
+++ b/src/system/keepalived-fifo.py
@@ -20,13 +20,14 @@ import time
 import signal
 import argparse
 import threading
-import subprocess
 import re
 import json
 from pathlib import Path
 from queue import Queue
 import logging
 from logging.handlers import SysLogHandler
+
+from vyos.util import cmd
 
 # configure logging
 logger = logging.getLogger(__name__)
@@ -84,14 +85,11 @@ class KeepalivedFifo:
 
     # run command
     def _run_command(self, command):
+        logger.debug("Running the command: {}".format(command))
         try:
-            logger.debug("Running the command: {}".format(command))
-            process = subprocess.Popen(command.split(' '), stdout=subprocess.PIPE, stdin=subprocess.PIPE, universal_newlines=True)
-            stdout, stderr = process.communicate()
-            if process.returncode != 0:
-                raise Exception("The command \"{}\" returned status {}. Error: {}".format(command, process.returncode, stderr))
-        except Exception as err:
-            logger.error("Unable to execute command \"{}\": {}".format(command, err))
+            cmd(command, universal_newlines=True)
+        except OSError as err:
+            logger.error(f'Unable to execute command "{command}": {err}')
 
     # create FIFO pipe
     def pipe_create(self):

--- a/src/validators/timezone
+++ b/src/validators/timezone
@@ -17,12 +17,8 @@
 import argparse
 
 from sys import exit
-from subprocess import Popen, PIPE, STDOUT
 
-def _cmd(cmd):
-    p = Popen(cmd, stdout=PIPE, stderr=STDOUT, shell=True)
-    tmp = p.communicate()[0].strip()
-    return tmp.decode()
+from vyos.util import cmd
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--validate", action="store", help="Check if timezone is valid")
@@ -31,7 +27,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.validate:
-        tz_data = _cmd('find /usr/share/zoneinfo/posix -type f -or -type l | sed -e s:/usr/share/zoneinfo/posix/::')
+        tz_data = cmd('find /usr/share/zoneinfo/posix -type f -or -type l | sed -e s:/usr/share/zoneinfo/posix/::')
         tz_data = tz_data.split('\n')
         # if timezone can't be found in list it's invalid
         if args.validate not in tz_data:


### PR DESCRIPTION
In order to be able to log and/or nicefy error messages returned on command failure.
It will also make it easier to use to detect when exceptions and return code not handled. 