### PR TITLE
airbag: T2186: report friendly user message and log to syslog

### DIFF
--- a/python/vyos/airbag.py
+++ b/python/vyos/airbag.py
@@ -1,0 +1,170 @@
+# Copyright 2019-2020 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import logging
+import logging.handlers
+from datetime import datetime
+
+from vyos.config import Config
+from vyos.version import get_version
+from vyos.util import run
+from vyos.util import debug
+
+
+# during the session, system-versions-foot is called to generate
+# the config footer, the code currently use stdout, so to do not
+# get a copy of that, we allow to disable the extra logging
+DISABLE = False
+
+
+# emulate a file object
+class _IO(object):
+    def __init__(self, std, log):
+        self.std = std
+        self.log = log
+
+    def write(self, message):
+        self.std.write(message)
+        if DISABLE:
+            return
+        for line in message.split('\n'):
+            s = line.rstrip()
+            if s:
+                self.log(s)
+
+    def flush(self):
+        self.std.flush()
+
+    def close(self):
+        pass
+
+
+# The function which will be used to report information
+# to users when an exception is unhandled
+def bug_report(dtype, value, trace):
+    from traceback import format_exception
+
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+    information = {
+        'date': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+        'version': get_version(),
+        'trace': format_exception(dtype, value, trace),
+        'instructions': COMMUNITY if 'rolling' in get_version() else SUPPORTED,
+    }
+
+    sys.stdout.write(INTRO.format(**information))
+    sys.stdout.flush()
+
+    sys.stderr.write(FAULT.format(**information))
+    sys.stderr.flush()
+
+
+# define an exception handler to be run when an exception
+# reach the end of __main__ and was not intercepted
+def intercepter(dtype, value, trace):
+    bug_report(dtype, value, trace)
+    if debug('developer') not in [None, '0', '']:
+        import pdb
+        pdb.pm()
+
+
+def InterceptingLogger(address, _singleton=[False]):
+    skip = _singleton.pop()
+    _singleton.append(True)
+    if skip:
+        return
+
+    logger = logging.getLogger('VyOS')
+    logger.setLevel(logging.DEBUG)
+    handler = logging.handlers.SysLogHandler(address='/dev/log', facility='syslog')
+    logger.addHandler(handler)
+
+    # log to syslog any message sent to stderr
+    sys.stderr = _IO(sys.stderr, logger.critical)
+
+
+# lists as default arguments in function is normally dangerous
+# as they will keep any modification performed, unless this is
+# what you want to do (in that case to only run the code once)
+def InterceptingException(excepthook,_singleton=[False]):
+    skip = _singleton.pop()
+    _singleton.append(True)
+    if skip:
+        return
+
+    # install the handler to replace the default behaviour
+    # which just prints the exception trace on screen
+    sys.excepthook = excepthook
+
+
+# Do not attempt the extra logging for operational commands
+try:
+    # This fails during boot
+    insession = Config().in_session()
+except:
+    # we save info on boot to help debugging
+    insession = True
+
+
+# Installing the interception, it currently does not work when
+# running testing so we are checking that we are on the router
+# as otherwise it prevents dpkg-buildpackage to work
+if get_version() and insession:
+    InterceptingLogger('/run/systemd/journal/dev-log')
+    InterceptingException(intercepter)
+
+
+# Messages to print
+
+FAULT = """\
+Date:       {date}
+VyOS image: {version}
+
+{trace}
+"""
+
+INTRO = """\
+VyOS had an issue completing a command.
+
+We are sorry that you encountered a problem with VyOS.
+There are a few things you can do to help us (and yourself):
+{instructions}
+
+PLEASE, when reporting, do include as much information as you can:
+- do not obfuscate any data (feel free to send us a private communication with
+  the extra information if your business policy is strict on information sharing)
+- and include all the information presented below
+
+"""
+
+COMMUNITY = """\
+- Make sure you are running the latest version of the code available at
+  https://downloads.vyos.io/rolling/current/amd64/vyos-rolling-latest.iso
+- Consult the forum to see how to handle this issue
+  https://forum.vyos.io
+- Join our community on slack where our users exchange help and advice
+  https://vyos.slack.com
+""".strip()
+
+SUPPORTED = """\
+- Make sure you are running the latest stable version of VyOS
+  the code is available at https://downloads.vyos.io/?dir=release/current
+- Contact us on our online help desk
+  https://support.vyos.io/
+""".strip()

--- a/python/vyos/airbag.py
+++ b/python/vyos/airbag.py
@@ -25,9 +25,7 @@ from vyos.util import run
 from vyos.util import debug
 
 
-# during the session, system-versions-foot is called to generate
-# the config footer, the code currently use stdout, so to do not
-# get a copy of that, we allow to disable the extra logging
+# we allow to disable the extra logging
 DISABLE = False
 
 
@@ -79,7 +77,8 @@ def bug_report(dtype, value, trace):
 # reach the end of __main__ and was not intercepted
 def intercepter(dtype, value, trace):
     bug_report(dtype, value, trace)
-    if debug('developer') not in [None, '0', '']:
+    # debug returns either '' or 'developer' if debuging is enabled
+    if debug('developer'):
         import pdb
         pdb.pm()
 

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -19,6 +19,12 @@ import sys
 from subprocess import Popen, PIPE, STDOUT, DEVNULL
 
 def debug(flag):
+    # this is to force all new flags to be registered here so that
+    # they can be documented:
+    # - developer: the code will drop into PBD on un-handled exception
+    # - ifconfig: prints command and sysfs access on stdout for interface
+    if flag not in ['developer', 'ifconfig']:
+        return False
     return flag if os.path.isfile(f'/tmp/vyos.{flag}.debug') else ''
 
 

--- a/python/vyos/version.py
+++ b/python/vyos/version.py
@@ -44,7 +44,7 @@ def get_version_data(file=version_file):
         file (str): path to the version file
 
     Returns:
-        dict: version data
+        dict: version data, if it can not be found and empty dict
 
     The optional ``file`` argument comes in handy in upgrade scripts
     that need to retrieve information from images other than the running image.
@@ -52,17 +52,20 @@ def get_version_data(file=version_file):
     is an implementation detail and may change in the future, while the interface
     of this module will stay the same.
     """
-    with open(file, 'r') as f:
-        version_data = json.load(f)
-    return version_data
+    try:
+        with open(file, 'r') as f:
+            version_data = json.load(f)
+        return version_data
+    except FileNotFoundError:
+        return {}
 
 def get_version(file=None):
     """
-    Get the version number
+    Get the version number, or an empty string if it could not be determined
     """
     version_data = None
     if file:
         version_data = get_version_data(file=file)
     else:
         version_data = get_version_data()
-    return version_data["version"]
+    return version_data.get('version','')


### PR DESCRIPTION
This is what is presented to the user, the message can be different for stable release and rolling.
```
vyos@vyos# commit
[ interfaces dummy dum0 ]
VyOS had an issue completing a command.

We are sorry that you encountered a problem with VyOS.
There are a few things you can do to help us (and yourself):
- Make sure you are running the latest version of the code available at
  https://downloads.vyos.io/rolling/current/amd64/vyos-rolling-latest.iso
- Consult the forum to see how to handle this issue
  https://forum.vyos.io
- Join our community on slack where our users exchange help and advice
  https://vyos.slack.com

PLEASE, when reporting, do include as much information as you can:
- do not obfuscate any data (feel free to send us a private communication with
  the extra information if your business policy is strict on information sharing)
- and include all the information presented below

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/interfaces-dummy.py", line 124, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/interfaces-dummy.py", line 95, in apply
    d.remove()
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 226, in remove
    self.del_addr(addr)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 703, in del_addr
    return self._cmd(cmd)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/control.py", line 47, in _cmd
    return cmd(command, self.debug)
  File "/usr/lib/python3/dist-packages/vyos/util.py", line 77, in cmd
    raise OSError(1,'bad')
PermissionError: [Errno 1] bad

delete [ interfaces dummy dum0 ] failed
Commit failed
```

This is what get sent to syslog on un-handled error
```
Apr 08 13:42:18 vyos python3[6395]: Traceback (most recent call last):
Apr 08 13:42:18 vyos python3[6395]:   File "/usr/libexec/vyos/conf_mode/interfaces-dummy.py", line 124, in <module>
Apr 08 13:42:18 vyos python3[6395]: apply(c)
Apr 08 13:42:18 vyos python3[6395]:   File "/usr/libexec/vyos/conf_mode/interfaces-dummy.py", line 95, in apply
Apr 08 13:42:18 vyos python3[6395]: d.remove()
Apr 08 13:42:18 vyos python3[6395]:   File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 226, in remove
Apr 08 13:42:18 vyos python3[6395]: self.del_addr(addr)
Apr 08 13:42:18 vyos python3[6395]:   File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 703, in del_addr
Apr 08 13:42:18 vyos python3[6395]: return self._cmd(cmd)
Apr 08 13:42:18 vyos python3[6395]:   File "/usr/lib/python3/dist-packages/vyos/ifconfig/control.py", line 47, in _cmd
Apr 08 13:42:18 vyos python3[6395]: return cmd(command, self.debug)
Apr 08 13:42:18 vyos python3[6395]:   File "/usr/lib/python3/dist-packages/vyos/util.py", line 77, in cmd
Apr 08 13:42:18 vyos python3[6395]: raise OSError(1,'bad')
Apr 08 13:42:18 vyos python3[6395]: PermissionError
Apr 08 13:42:18 vyos [6395]:
Apr 08 13:42:18 vyos python3[6395]: [Errno 1] bad
```