### PR TITLE
openvpn: T2261: re-add ccd to template (was removed by mistake)

### DIFF
--- a/data/templates/openvpn/server.conf.tmpl
+++ b/data/templates/openvpn/server.conf.tmpl
@@ -86,6 +86,10 @@ server {{ server_subnet }}
 max-clients {{ server_max_conn }}
 {%- endif %}
 
+{%- if client %}
+client-config-dir /opt/vyatta/etc/openvpn/ccd/{{ intf }}
+{%- endif %}
+
 {%- if server_reject_unconfigured %}
 ccd-exclusive
 {%- endif %}


### PR DESCRIPTION
Commit ef27cef0 mistakenly removed client-config-dir from the
server template.