### PR TITLE
wireless: T2213: bugfix: Use ieee80211n and ieee80211ac if require_vht not set

### DIFF
--- a/data/templates/wifi/hostapd.conf.tmpl
+++ b/data/templates/wifi/hostapd.conf.tmpl
@@ -73,7 +73,6 @@ channel={{ channel }}
 # offloaded ACS is used.
 {% if 'n' in mode -%}
 hw_mode=g
-ieee80211n=1
 {% elif 'ac' in mode -%}
 hw_mode=a
 ieee80211h=1
@@ -421,6 +420,12 @@ vht_capab=
 ieee80211n=0
 # Require stations to support VHT PHY (reject association if they do not)
 require_vht=1
+{% else -%}
+{% if 'n' in mode or 'ac' in mode -%}
+ieee80211n=1
+{% else -%}
+ieee80211n=0
+{%- endif %}
 {% endif %}
 
 {% if cap_vht_center_freq_1 -%}

--- a/src/conf_mode/interfaces-wireless.py
+++ b/src/conf_mode/interfaces-wireless.py
@@ -570,6 +570,9 @@ def verify(wifi):
     if not wifi['phy']:
         raise ConfigError('You must specify physical-device')
 
+    if not wifi['mode']:
+        raise ConfigError('You must specify a WiFi mode')
+
     if wifi['op_mode'] == 'ap':
         c = Config()
         if not c.exists('system wifi-regulatory-domain'):


### PR DESCRIPTION

Use WiFi modes ieee80211ac and ieee80211n if VHT capabilities are optional.
      ieee80211n = 1
      ieee80211ac = 1
Use only ieee80211ac if VHT capabilities are required (ieee80211n=0).
      ieee80211ac = 1
      ieee80211n = 0
      require_vht = 1
In order to make this decision, the desired WiFi operation mode needs to be
known. Therefore, we must require users to set the WiFi mode.
      mode = (a|b|g|n|ac)