### PR TITLE
conf_mode/interfaces-wireless.py: fix typos in wireless VLAN code

### DIFF
--- a/src/conf_mode/interfaces-wireless.py
+++ b/src/conf_mode/interfaces-wireless.py
@@ -777,7 +777,7 @@ def apply(wifi):
 
         # remove no longer required VLAN interfaces (vif)
         for vif in wifi['vif_remove']:
-            e.del_vlan(vif)
+            w.del_vlan(vif)
 
         # create VLAN interfaces (vif)
         for vif in wifi['vif']:
@@ -787,11 +787,11 @@ def apply(wifi):
                 try:
                     # on system bootup the above condition is true but the interface
                     # does not exists, which throws an exception, but that's legal
-                    e.del_vlan(vif['id'])
+                    w.del_vlan(vif['id'])
                 except:
                     pass
 
-            vlan = e.add_vlan(vif['id'])
+            vlan = w.add_vlan(vif['id'])
             apply_vlan_config(vlan, vif)
 
         # Enable/Disable interface - interface is always placed in


### PR DESCRIPTION
The typos cause the configurator to throw an exception when a wireless VLAN is specified:
```
Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/interfaces-wireless.py", line 1463, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/interfaces-wireless.py", line 1433, in apply
    vlan = e.add_vlan(vif['id'])
NameError: name 'e' is not defined
```