### PR TITLE
ifconfig: T31: add skeleton VTI and input classes

### DIFF
--- a/python/vyos/ifconfig/input.py
+++ b/python/vyos/ifconfig/input.py
@@ -1,0 +1,31 @@
+# Copyright 2020 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from vyos.ifconfig.interface import Interface
+
+
+@Interface.register
+class InputIf(Interface):
+    default = {
+        'type': '',
+    }
+    definition = {
+        **Interface.definition,
+        **{
+            'section': 'input',
+            'prefixes': ['ifb', ],
+        },
+    }

--- a/python/vyos/ifconfig/section.py
+++ b/python/vyos/ifconfig/section.py
@@ -66,12 +66,6 @@ class Section:
         """
         name = cls._basename(name, vlan)
 
-        # XXX: To leave as long as vti and input are not moved to vyos
-        if name == 'vti':
-            return 'vti'
-        if name == 'ifb':
-            return 'input'
-
         if name in cls._prefixes:
             return cls._prefixes[name].definition['section']
         return ''
@@ -91,11 +85,6 @@ class Section:
         interfaces = netifaces.interfaces()
 
         for ifname in interfaces:
-            # XXX: Temporary hack as vti and input are not yet moved from vyatta to vyos
-            if ifname.startswith('vti') or ifname.startswith('input'):
-                yield ifname
-                continue
-
             ifsection = cls.section(ifname)
             if not ifsection:
                 continue
@@ -132,3 +121,11 @@ class Section:
         bondable, broadcast, bridgeable, ...
         """
         return list(cls._intf_with_feature(feature))
+
+    @classmethod
+    def reserved(cls):
+        """
+        return list with the interface name prefixes
+        eth, lo, vxlan, dum, ...
+        """
+        return list(cls._prefixes.keys())

--- a/python/vyos/ifconfig/vti.py
+++ b/python/vyos/ifconfig/vti.py
@@ -1,0 +1,31 @@
+# Copyright 2020 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from vyos.ifconfig.interface import Interface
+
+
+@Interface.register
+class VTIIf(Interface):
+    default = {
+        'type': 'vti',
+    }
+    definition = {
+        **Interface.definition,
+        **{
+            'section': 'vti',
+            'prefixes': ['vti', ],
+        },
+    }


### PR DESCRIPTION
also, it adds a function to Section which provides a list of reserved names
useful to figure out the reserved name of interfaces which can not be used.