### PR TITLE
Update Ethernet hw-id to be clear

### DIFF
--- a/interface-definitions/interfaces-ethernet.xml.in
+++ b/interface-definitions/interfaces-ethernet.xml.in
@@ -58,10 +58,10 @@
           </leafNode>
           <leafNode name="hw-id">
             <properties>
-              <help>Media Access Control (MAC) address</help>
+              <help>Map to Media Access Control (MAC) address</help>
               <valueHelp>
                 <format>h:h:h:h:h:h</format>
-                <description>Hardware (MAC) address</description>
+                <description>Map this Interface to device with this Hardware (MAC) address (Requires Reboot)</description>
               </valueHelp>
               <constraint>
                 <validator name="mac-address"/>


### PR DESCRIPTION
hw-id currently has the same help text as the "mac" command.  Update the text to make it clear how the hw-id mac address is different