### PR TITLE
tunnel: T2028: fix issue when booting without gre remote

### DIFF
--- a/src/conf_mode/interfaces-tunnel.py
+++ b/src/conf_mode/interfaces-tunnel.py
@@ -584,11 +584,17 @@ def apply(conf):
         if changes['section'] in 'create' and option in tunnel.options:
             # it was setup at creation
             continue
+        if not options[option]:
+            # remote can be set to '' and it would generate an invalide command
+            continue
         tunnel.set_interface(option, options[option])
 
     # set other interface properties
     for option in ('alias', 'mtu', 'link_detect', 'multicast', 'allmulticast',
                    'vrf', 'ipv6_autoconf', 'ipv6_forwarding', 'ipv6_dad_transmits'):
+        if not options[option]:
+            # should never happen but better safe
+            continue
         tunnel.set_interface(option, options[option])
 
     # Configure interface address(es)


### PR DESCRIPTION
when using GRE without a remote endpoint, the command generate could be invalid.
This fixes this issue.