### PR TITLE
openvpn: T2283: move ccd to /run/openvpn

### DIFF
--- a/data/templates/openvpn/server.conf.tmpl
+++ b/data/templates/openvpn/server.conf.tmpl
@@ -85,7 +85,7 @@ max-clients {{ server_max_conn }}
 {%- endif %}
 
 {%- if client %}
-client-config-dir /opt/vyatta/etc/openvpn/ccd/{{ intf }}
+client-config-dir /run/openvpn/ccd/{{ intf }}
 {%- endif %}
 
 {%- if server_reject_unconfigured %}

--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -666,10 +666,10 @@ def generate(openvpn):
     directories = []
     directories.append(f'{directory}/status')
     directories.append(f'{directory}/ccd/{interface}')
-    for directory in directories:
-        if not os.path.exists(directory):
-            os.makedirs(directory, 0o755)
-        chown(directory, user, group)
+    for onedir in directories:
+        if not os.path.exists(onedir):
+            os.makedirs(onedir, 0o755)
+        chown(onedir, user, group)
 
     # Fix file permissons for keys
     fix_permissions = []


### PR DESCRIPTION
Commit a457c9d2 moved the config directory to /run/openvpn but didn't move
the client-config-dir in the template.