### PR TITLE
feature: T2306: Add new cipher suites to the WiFi configuration

### DIFF
--- a/data/templates/wifi/hostapd.conf.tmpl
+++ b/data/templates/wifi/hostapd.conf.tmpl
@@ -572,6 +572,16 @@ wpa_pairwise={{ sec_wpa_cipher | join(" ") }}
 {%- endif -%}
 {% endif %}
 
+{% if sec_wpa_group_cipher -%}
+# Optional override for automatic group cipher selection
+# This can be used to select a specific group cipher regardless of which
+# pairwise ciphers were enabled for WPA and RSN. It should be noted that
+# overriding the group cipher with an unexpected value can result in
+# interoperability issues and in general, this parameter is mainly used for
+# testing purposes.
+group_cipher={{ sec_wpa_group_cipher | join(" ") }}
+{% endif %}
+
 {% if sec_wpa_passphrase -%}
 # IEEE 802.11 specifies two authentication algorithms. hostapd can be
 # configured to allow both of these or only one. Open system authentication

--- a/interface-definitions/interfaces-wireless.xml.in
+++ b/interface-definitions/interfaces-wireless.xml.in
@@ -605,22 +605,66 @@
                 <children>
                   <leafNode name="cipher">
                     <properties>
-                      <help>Cipher suite for WPA</help>
+                      <help>Cipher suite for WPA unicast packets</help>
                       <completionHelp>
-                        <list>TKIP CCMP</list>
+                        <list>GCMP-256 GCMP CCMP-256 CCMP TKIP</list>
                       </completionHelp>
                       <valueHelp>
+                        <format>GCMP-256</format>
+                        <description>AES in Galois/counter mode with 256-bit key</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>GCMP</format>
+                        <description>AES in Galois/counter mode with 128-bit key</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>CCMP-256</format>
+                        <description>AES in Counter mode with CBC-MAC with 256-bit key</description>
+                      </valueHelp>
+                      <valueHelp>
                         <format>CCMP</format>
-                        <description>AES in Counter mode with CBC-MAC [RFC 3610, IEEE 802.11i/D7.0]</description>
+                        <description>AES in Counter mode with CBC-MAC [RFC 3610, IEEE 802.11i/D7.0] (supported on all WPA2 APs)</description>
                       </valueHelp>
                       <valueHelp>
                         <format>TKIP</format>
                         <description>Temporal Key Integrity Protocol [IEEE 802.11i/D7.0]</description>
                       </valueHelp>
                       <constraint>
-                        <regex>(CCMP|TKIP)</regex>
+                        <regex>(GCMP-256|GCMP|CCMP-256|CCMP|TKIP)</regex>
                       </constraint>
-                      <constraintErrorMessage>Invalid WEP key</constraintErrorMessage>
+                      <constraintErrorMessage>Invalid cipher selection</constraintErrorMessage>
+                      <multi/>
+                    </properties>
+                  <leafNode name="group-cipher">
+                    <properties>
+                      <help>Cipher suite for WPA multicast and broadcast packets</help>
+                      <completionHelp>
+                        <list>GCMP-256 GCMP CCMP-256 CCMP TKIP</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>GCMP-256</format>
+                        <description>AES in Galois/counter mode with 256-bit key</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>GCMP</format>
+                        <description>AES in Galois/counter mode with 128-bit key</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>CCMP-256</format>
+                        <description>AES in Counter mode with CBC-MAC with 256-bit key</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>CCMP</format>
+                        <description>AES in Counter mode with CBC-MAC [RFC 3610, IEEE 802.11i/D7.0] (supported on all WPA2 APs)</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>TKIP</format>
+                        <description>Temporal Key Integrity Protocol [IEEE 802.11i/D7.0]</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>(GCMP-256|GCMP|CCMP-256|CCMP|TKIP)</regex>
+                      </constraint>
+                      <constraintErrorMessage>Invalid group cipher selection</constraintErrorMessage>
                       <multi/>
                     </properties>
                   </leafNode>

--- a/interface-definitions/interfaces-wireless.xml.in
+++ b/interface-definitions/interfaces-wireless.xml.in
@@ -635,6 +635,7 @@
                       <constraintErrorMessage>Invalid cipher selection</constraintErrorMessage>
                       <multi/>
                     </properties>
+                  </leafNode>
                   <leafNode name="group-cipher">
                     <properties>
                       <help>Cipher suite for WPA multicast and broadcast packets</help>

--- a/src/conf_mode/interfaces-wireless.py
+++ b/src/conf_mode/interfaces-wireless.py
@@ -442,6 +442,10 @@ def get_config():
             wifi['sec_wpa_cipher'].append('CCMP')
             wifi['sec_wpa_cipher'].append('TKIP')
 
+    # WPA Group Cipher suite
+    if conf.exists('security wpa group-cipher'):
+        wifi['sec_wpa_group_cipher'] = conf.return_values('security wpa group-cipher')
+
     # WPA personal shared pass phrase
     if conf.exists('security wpa passphrase'):
         wifi['sec_wpa_passphrase'] = conf.return_value('security wpa passphrase')


### PR DESCRIPTION
    Yet, VyOS knows these two encryption schemes for WiFi:

        1. CCMP = AES in Counter mode with CBC-MAC (CCMP-128)
        2. TKIP = Temporal Key Integrity Protocol

    These encryption schemes are new and especially the Galois counter mode
    cipher suites are very desirable!

        1. CCMP-256 = AES in Counter mode with CBC-MAC with 256-bit key
        2. GCMP = Galois/counter mode protocol (GCMP-128)
        3. GCMP-256 = Galois/counter mode protocol with 256-bit key

    CCMP is supported by all WPA2 compatible NICs, so this remains the
    default cipher for bidirectional and group packets while using WPA2.

    Use 'iw list' to figure out which cipher suites your cards support
    prior to configuring other cipher suites than CCMP. AP NICs and
    STA NICs must both support at least one common cipher in a given
    list in order to associate successfully.