### PR TITLE
openvpn: T2339: fix for IPv4 local-host addresses

### DIFF
--- a/data/templates/openvpn/server.conf.tmpl
+++ b/data/templates/openvpn/server.conf.tmpl
@@ -18,7 +18,7 @@ dev {{ intf }}
 persist-key
 iproute /usr/libexec/vyos/system/unpriv-ip
 
-proto {% if 'tcp-active' in protocol -%}tcp6-client{% elif 'tcp-passive' in protocol -%}tcp6-server{% else %}udp6{% endif %}
+proto {{ protocol_real }}
 
 {%- if local_host %}
 local {{ local_host }}


### PR DESCRIPTION
Commit bb9f998 introduced a bug where openvpn fails to start if
'local-host' is an IPv4 address due to 'proto' wanting a IPv6 socket.
This adds a conditional check and uses normal proto if it's IPv4.