### PR TITLE
util: T2226: multiple improvements

### DIFF
--- a/python/vyos/airbag.py
+++ b/python/vyos/airbag.py
@@ -26,6 +26,17 @@ from vyos.version import get_full_version_data
 DISABLE = False
 
 
+_noteworthy = []
+
+def noteworthy(msg):
+    """
+    noteworthy can be use to take note things which we may not want to
+    report to the user may but be worth including in bug report
+    if something goes wrong later on
+    """
+    _noteworthy.append(msg)
+
+
 # emulate a file object
 class _IO(object):
     def __init__(self, std, log):
@@ -58,11 +69,16 @@ def bug_report(dtype, value, trace):
 
     information = get_full_version_data()
     trace = '\n'.join(format_exception(dtype, value, trace)).replace('\n\n','\n')
+    note = ''
+    if _noteworthy:
+        note = 'noteworthy:\n'
+        note += '\n'.join(_noteworthy)
 
     information.update({
         'date': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
         'trace': trace,
         'instructions': COMMUNITY if 'rolling' in get_version() else SUPPORTED,
+        'note': note,
     })
 
     sys.stdout.write(INTRO.format(**information))
@@ -145,6 +161,7 @@ Hardware S/N:     {hardware_serial}
 Hardware UUID:    {hardware_uuid}
 
 {trace}
+{note}
 """
 
 INTRO = """\

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -123,13 +123,14 @@ def run(command, flag='', shell=None, input=None, timeout=None, env=None,
 
 def cmd(command, flag='', shell=None, input=None, timeout=None, env=None,
         stdout=PIPE, stderr=PIPE, decode='utf-8',
-        raising=None, message=''):
+        raising=None, message='', expect=[0]):
     """
     A wrapper around vyos.util.popen, which returns the stdout and
     will raise the error code of a command
 
     raising: specify which call should be used when raising (default is OSError)
              the class should only require a string as parameter
+    expect:  a list of error codes to consider as normal
     """
     decoded, code = popen(
         command, flag,
@@ -138,7 +139,7 @@ def cmd(command, flag='', shell=None, input=None, timeout=None, env=None,
         env=env, shell=shell,
         decode=decode,
     )
-    if code != 0:
+    if code not in expect:
         feedback = message + '\n' if message else ''
         feedback += f'failed to run command: {command}\n'
         feedback += f'returned: {decoded}\n'


### PR DESCRIPTION
patch 1:

    Do not agreggate stderr with stdout. So if a command reports
    a message on stderr but does not report an error, it will
    not be send to the user to confuse him.

    Explicitely set encoding to utf-8, which does not change
    the code behaviour but simplify the code.

patch 2:

    add an option to cmd() allowing to define a list of error codes
    which are expected when runnin the command. the default is only
    to expect zero (no error).

patch 3:

    debug.noteworthy can be used to record noteworhy event during
    the lifetime of the program. Should anything then cause the
    program to fail and cause an airbag report to the user,
    then this information will also be included.

