### PR TITLE
validators: numeric: T2414: improve runtime performance

### DIFF
--- a/src/validators/numeric
+++ b/src/validators/numeric
@@ -19,7 +19,6 @@
 
 import sys
 import argparse
-import re
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-f", "--float", action="store_true", help="Accept floating point values")
@@ -50,8 +49,9 @@ if args.range:
     valid = False
     for r in args.range:
         try:
-            lower, upper = re.match(r'(\d+)\s*\-\s*(\d+)', r).groups()
-            lower, upper = int(lower), int(upper)
+            list = r.split('-')
+            lower = int(list[0])
+            upper = int(list[1])
         except:
             print("{0} is not a valid number range",format(args.range), file=sys.stderr)
             sys.exit(1)


### PR DESCRIPTION
```
$ time for i in {1..1000}; do /usr/libexec/vyos/validators/numeric --range 1-9999 666; done
real    0m56.933s
user    0m48.045s
sys     0m9.064s

$ time for i in {1..1000}; do /usr/libexec/vyos/validators/numeric--range 1-9999 666; done
real    0m44.552s
user    0m37.760s
sys     0m6.989s

```
This is a performance improvement of 21%, running in an ESXi VM with Quad
Intel(R) Xeon(R) CPU E5-2630L v3 @ 1.80GHz.