### PR TITLE
openvpn: T2241: fix wrong indent caused by 66e15005

### DIFF
--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -632,7 +632,7 @@ def verify(openvpn):
             raise ConfigError((
                 f'Cannot delete interface "{openvpn["intf"]}" as it is a '
                 f'member of bridge "{openvpn["is_bridge_menber"]}"!'))
-       return None
+        return None
 
 
     if not openvpn['mode']:


### PR DESCRIPTION
Fixes commit error on openvpn