### PR TITLE
validators: T2431: rewrite validate-value.py in bash

### DIFF
--- a/scripts/build-command-templates
+++ b/scripts/build-command-templates
@@ -149,7 +149,7 @@ def get_properties(p):
 
         regex_args = " ".join(map(lambda s: "--regex \\\'{0}\\\'".format(s), regexes))
         validator_args = " ".join(map(lambda s: "--exec \\\"{0}\\\"".format(s), validators))
-        validator_script = '${vyos_libexec_dir}/validate-value.py'
+        validator_script = '${vyos_libexec_dir}/validate-value.sh'
         validator_string = "exec \"{0} {1} {2} --value \\\'$VAR(@)\\\'\"; \"{3}\"".format(validator_script, regex_args, validator_args, error_msg)
 
         props["constraint"] = validator_string

--- a/src/helpers/validate-value.sh
+++ b/src/helpers/validate-value.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+debug=false
+regexes=()
+execes=()
+value=
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--regex)
+			regexes+=("$2")
+			;;
+		--exec)
+			execes+=("$2")
+			;;
+		--value)
+			value="$2"
+			;;
+		--debug)
+			debug=true
+			;;
+	esac
+	shift
+done
+
+for re in "${regexes[@]}"; do
+	echo "$value" | grep -Px -e "$re" - 2>&1 >/dev/null
+	case $? in
+		0)
+			exit 0
+			;;
+		2)
+			$debug && echo "error in regex \"$re\" value \"$value\""
+			;;
+	esac
+done
+
+for ex in "${execes[@]}"; do
+	$debug && echo "$ex $value"
+	eval "$ex" "$value"
+	e=$?
+	case $e in
+		0)
+			exit 0
+			;;
+		*)
+			$debug && echo "exit status $e"
+			;;
+	esac
+done
+
+exit 1


### PR DESCRIPTION
It is approximately 12-14 times faster than validate-value.py.
Speed still depends on the speed of the executed program or given regex.

It uses 'grep -Px', so it is similar enough to Python's re.fullmatch
(both are based on PCRE) to not cause any issues with existing regexes.

```
$ time sudo bash -c ' for ((n=0;n<1000;n++)); do
  ./validate-value.sh
  --exec /usr/libexec/vyos/validators/ip-prefix
  --value "192.0.2.1/24"; done'

real	0m9.606s
user	0m5.576s
sys	0m4.285s

$ time sudo bash -c ' for ((n=0;n<1000;n++)); do
  /usr/libexec/vyos/validate-value.py
  --exec /usr/libexec/vyos/validators/ip-prefix
  --value "192.0.2.1/24"; done'

real	1m58.335s
user	1m34.704s
sys	0m24.341s

$ time sudo bash -c ' for ((n=0;n<1000;n++)); do
  ./validate-value.sh
  --regex "([0-9A-Fa-f]{1,2}[:])*([0-9A-Fa-f]{1,2})"
  --value "ff:ff:ff:ff:ff:ff"; done'

real	0m7.455s
user	0m4.264s
sys	0m3.900s

$ time sudo bash -c ' for ((n=0;n<1000;n++)); do
  /usr/libexec/vyos/validate-value.py
  --regex "([0-9A-Fa-f]{1,2}[:])*([0-9A-Fa-f]{1,2})"
  --value "ff:ff:ff:ff:ff:ff"; done'

real	1m45.868s
user	1m28.573s
sys	0m17.378s
```
I tested it on an existing system, rebooting and loading config worked without errors. (firewall, nat, interfaces ethernet, vif, bond, bridge, dhcp(6)-server, dns forwarding, system ...). As the regex parser changed, all validators may need to be rechecked. I tested some of the most common regex ones and they returned true/false correctly, so probably all validators will work without changes.
My reboot time has shrunk from approx. 220-250s before to 194s after this patch.