### PR TITLE
T2436: Adding offline python compile to fetch syntax faults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ clean:
 
 .PHONY: test
 test:
+	set -e; python3 -m compileall -q .
 	PYTHONPATH=python/ python3 -m "nose" --with-xunit src --with-coverage --cover-erase --cover-xml --cover-package src/conf_mode,src/op_mode,src/completion,src/helpers,src/validators,src/tests --verbose
 
 .PHONY: sonar


### PR DESCRIPTION
In the past there have been quite a few tickets regarding python syntax errors on scripts rewritten to python.
To make a quickfix on some of these faults we could make a Jenkins step that executes: python3 -m compileall -q . to do a offline compile of the python files.