### PR TITLE
dhcp-server, dhcpv6-server: T2432: chown lease file to nobody:nogroup

### DIFF
--- a/src/systemd/isc-dhcp-server.service
+++ b/src/systemd/isc-dhcp-server.service
@@ -7,12 +7,11 @@ After=vyos-router.service
 
 [Service]
 WorkingDirectory=/run/dhcp-server
-# The leases files need to be root:vyattacfg even when dropping privileges
 ExecStart=/bin/sh -ec '\
     CONFIG_FILE=/run/dhcp-server/dhcpd.conf; \
     [ -e /config/dhcpd.leases ] || touch /config/dhcpd.leases; \
-    chown root:vyattacfg /config/dhcpd.leases; \
-    chmod 664 /config/dhcpd.leases; \
+    chown nobody:nogroup /config/dhcpd.leases*; \
+    chmod 664 /config/dhcpd.leases*; \
     exec /usr/sbin/dhcpd -user nobody -group nogroup -f -4 -pf /run/dhcp-server/dhcpd.pid -cf $CONFIG_FILE -lf /config/dhcpd.leases'
 
 [Install]

--- a/src/systemd/isc-dhcp-server6.service
+++ b/src/systemd/isc-dhcp-server6.service
@@ -7,11 +7,10 @@ After=vyos-router.service
 
 [Service]
 WorkingDirectory=/run/dhcp-server
-# The leases files need to be root:vyattacfg even when dropping privileges
 ExecStart=/bin/sh -ec '\
     [ -e /config/dhcpdv6.leases ] || touch /config/dhcpdv6.leases; \
-    chown root:vyattacfg /config/dhcpdv6.leases; \
-    chmod 664 /config/dhcpdv6.leases; \
+    chown nobody:nogroup /config/dhcpdv6.leases*; \
+    chmod 664 /config/dhcpdv6.leases*; \
     exec /usr/sbin/dhcpd -user nobody -group nogroup -f -6 -pf /run/dhcp-server/dhcpdv6.pid -cf /run/dhcp-server/dhcpdv6.conf -lf /config/dhcpdv6.leases'
 
 [Install]


### PR DESCRIPTION
Commits f37194604 and 0cbad2850 migrated isc-dhcp-server(6) from
SysVInit to SystemD, changing the user and group dhcpd is started as.
This caused a permission error when dhcpd tried to write to lease files:

  dhcpd[2829]: Can't create new lease file: Permission denied

As dhcpd is started as nobody:nogroup, setting the permissions on the
lease files to 664 root:vyattacfg would make dhcpd unable to write to
them. We can't make the files other-writable, as that would be a big
security issue, so we need to set either the owner or group of the files
to be dhcpd writeble. There should be no harm in changing both to
nobody:nogroup, as they were previously root:root.

If some other VyOS code doesn't like the ownership of these files in
/config, they can be either excluded from the check (possibly moved into
their own directory), or changed back to root:vyattacfg and vyattacfg added
to nogroup.