### PR TITLE
T2465: Permissions on vyos-hostsd socket incorrect

### DIFF
--- a/src/services/vyos-hostsd
+++ b/src/services/vyos-hostsd
@@ -278,7 +278,11 @@ if __name__ == '__main__':
 
     context = zmq.Context()
     socket = context.socket(zmq.REP)
+    
+    # Set the right permissions on the socket, then change it back
+    o_mask = os.umask(0)
     socket.bind(SOCKET_PATH)
+    os.umask(o_mask)
 
     while True:
         #  Wait for next request from client


### PR DESCRIPTION
The DHCP server is unable to apply entries to the hosts file because the permissions on the socket are getting created wrong.

```
$ ls -al /run/vyos-hostsd.sock
srwxrwxrwx 1 root vyattacfg 0 May 20 01:38 /run/vyos-hostsd.sock

```

This gives it the correct permissions so that the nobody/nobody user/group can change it.