### PR TITLE
config: T2499: expose showConfig

### DIFF
--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -91,10 +91,7 @@ class Config(object):
     def __init__(self, session_env=None):
         self._cli_shell_api = "/bin/cli-shell-api"
         self._level = []
-        if session_env:
-            self.__session_env = session_env
-        else:
-            self.__session_env = None
+        self.__session_env = session_env
 
         running_config_text = self.get_active()
         session_config_text = self.get_working() or running_config_text

--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -88,8 +88,11 @@ class Config(object):
     the only state it keeps is relative *config path* for convenient access to config
     subtrees.
     """
+    _cli_shell_api = "/bin/cli-shell-api"
+    _show_active =  '/bin/cli-shell-api --show-active-only --show-show-defaults --show-ignore-edit showConfig'
+    _show_working = '/bin/cli-shell-api --show-working-only --show-show-defaults --show-ignore-edit showConfig'
+
     def __init__(self, session_env=None):
-        self._cli_shell_api = "/bin/cli-shell-api"
         self._level = []
         self.__session_env = session_env
 
@@ -108,14 +111,14 @@ class Config(object):
         # before initialization, set to empty string
         if not os.path.isfile('/tmp/vyos-config-status'):
             return ''
-        return self._run([self._cli_shell_api, '--show-active-only', '--show-show-defaults', '--show-ignore-edit', 'showConfig'])
+        return self._run(self._show_active.split())
 
     def get_working(self):
         # Session config ("active") only exists in conf mode.
         # In op mode, we'll just use the same running config for both active and session configs.
         if not self.in_session():
             return ''
-        return self._run([self._cli_shell_api, '--show-working-only', '--show-show-defaults', '--show-ignore-edit', 'showConfig'])
+        return self._run(self._show_working.split())
 
     def _make_command(self, op, path):
         args = path.split()

--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -137,17 +137,13 @@ class Config(object):
         return (self._level + path)
 
     def _run(self, cmd):
-        if self.__session_env:
-            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, env=self.__session_env)
-        else:
-            p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, env=self.__session_env)
         out = p.stdout.read()
         p.wait()
         p.communicate()
         if p.returncode != 0:
             raise VyOSError()
-        else:
-            return out.decode('ascii')
+        return out.decode('ascii')
 
     def set_level(self, path):
         """


### PR DESCRIPTION
The patchset tidy a bit Config and expose the cli-shell-api showConfig functions which are used to set up the class at boot.