### PR TITLE
T2508 Enable user to configure LUA script that alters recursor resolving

### DIFF
--- a/data/templates/dns-forwarding/recursor.conf.tmpl
+++ b/data/templates/dns-forwarding/recursor.conf.tmpl
@@ -13,6 +13,11 @@ non-local-bind=yes
 query-local-address=0.0.0.0
 query-local-address6=::
 
+{% if lua_dns_script -%}
+# lua dns script
+lua-dns-script={{ lua_dns_script }}
+{% endif %}
+
 # cache-size
 max-cache-entries={{ cache_size }}
 

--- a/interface-definitions/dns-forwarding.xml.in
+++ b/interface-definitions/dns-forwarding.xml.in
@@ -132,6 +132,18 @@
                   </constraint>
                 </properties>
               </leafNode>
+              <leafNode name="lua-dns-script">
+                <properties>
+                  <help>You must use a file suitable for the pdns-recursor lua-dns-script configuration. Any errors in the file will result in a service failure. Check the system log for errors after modifying.</help>
+                  <valueHelp>
+                    <format>file</format>
+                    <description>Path to file in the /config directory</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="file-exists"/>
+                  </constraint>
+                </properties>
+              </leafNode>
               <leafNode name="negative-ttl">
                 <properties>
                   <help>Maximum amount of time negative entries are cached</help>

--- a/src/conf_mode/dns_forwarding.py
+++ b/src/conf_mode/dns_forwarding.py
@@ -38,6 +38,7 @@ default_config_data = {
     'cache_size': 10000,
     'export_hosts_file': 'yes',
     'listen_on': [],
+    'lua_dns_script': '',
     'name_servers': [],
     'negative_ttl': 3600,
     'domains': [],
@@ -62,6 +63,9 @@ def get_config(arguments):
 
     if conf.exists(['allow-from']):
         dns['allow_from'] = conf.return_values(['allow-from'])
+
+    if conf.exists('lua-dns-script'):
+        dns['lua_dns_script'] = conf.return_value('lua-dns-script')
 
     if conf.exists(['cache-size']):
         cache_size = conf.return_value(['cache-size'])


### PR DESCRIPTION
This is something I currently use on my VyOS install so I can take advantage of LUA scripts that alter the behaviour of the server.

You can find a few examples here: https://github.com/PowerDNS/pdns/tree/master/pdns/recursordist/examples

There isn't a phabricator for this work. If required to get this accepted I could setup an account and link this PR to a feature request.