### PR TITLE
ethernet interface: T2476: fix mac address override for bond members

### DIFF
--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -170,10 +170,6 @@ def verify(eth):
                     f'Interface "{eth["intf"]}" cannot be member of VRF "{eth["vrf"]}" '
                     f'and "{memberof}" at the same time!'))
 
-    if eth['mac'] and eth['is_bond_member']:
-        print('WARNING: "mac {0}" command will be ignored because {1} is a part of {2}'\
-            .format(eth['mac'], eth['intf'], eth['is_bond_member']))
-
     # use common function to verify VLAN configuration
     verify_vlan_config(eth)
     return None

--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -170,6 +170,10 @@ def verify(eth):
                     f'Interface "{eth["intf"]}" cannot be member of VRF "{eth["vrf"]}" '
                     f'and "{memberof}" at the same time!'))
 
+    if eth['mac'] and eth['is_bond_member']:
+        print('WARNING: "mac {0}" command will be ignored because {1} is a part of {2}'\
+            .format(eth['mac'], eth['intf'], eth['is_bond_member']))
+
     # use common function to verify VLAN configuration
     verify_vlan_config(eth)
     return None

--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -236,11 +236,12 @@ def apply(eth):
             e.del_ipv6_eui64_address(addr)
 
         # Change interface MAC address - re-set to real hardware address (hw-id)
-        # if custom mac is removed
-        if eth['mac']:
-            e.set_mac(eth['mac'])
-        elif eth['hw_id']:
-            e.set_mac(eth['hw_id'])
+        # if custom mac is removed. Skip if bond member.
+        if not eth['is_bond_member']:
+            if eth['mac']:
+                e.set_mac(eth['mac'])
+            elif eth['hw_id']:
+                e.set_mac(eth['hw_id'])
 
         # Add IPv6 EUI-based addresses
         for addr in eth['ipv6_eui64_prefix']:


### PR DESCRIPTION
skipping mac address changes for bond member interfaces