### PR TITLE
dhcpv6-pd: T421:  Fix the py runtime error when executing DHCPv6 PD on Ethernet.

### DIFF
--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -202,7 +202,7 @@ def apply(eth):
             e.dhcp.v6.options['dhcpv6_temporary'] = True
 
         if eth['dhcpv6_pd']:
-            e.dhcp.v6.options['dhcpv6_pd'] = e['dhcpv6_pd']
+            e.dhcp.v6.options['dhcpv6_pd'] = eth['dhcpv6_pd']
 
         # ignore link state changes
         e.set_link_detect(eth['disable_link_detect'])


### PR DESCRIPTION
dhcpv6-pd: T421: Fix the py runtime error when executing DHCPv6 PD on Ethernet. 