### PR TITLE
[op-mode]: T2512: Fix Make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,6 @@ op_mode_definitions:
 	rm -f $(OP_TMPL_DIR)/set/node.def
 	rm -f $(OP_TMPL_DIR)/show/node.def
 	rm -f $(OP_TMPL_DIR)/show/interfaces/node.def
-	rm -f $(OP_TMPL_DIR)/show/ip/node.def
-	rm -f $(OP_TMPL_DIR)/show/ip/route/node.def
 	rm -f $(OP_TMPL_DIR)/show/ipv6/node.def
 	rm -f $(OP_TMPL_DIR)/show/ipv6/route/node.def
 	rm -f $(OP_TMPL_DIR)/restart/node.def


### PR DESCRIPTION
Fix Make file.
it containe 2 stings
```	
rm -f $(OP_TMPL_DIR)/show/ip/node.def
rm -f $(OP_TMPL_DIR)/show/ip/route/node.def
```
Need to delete these lines.
Otherwise
```
vyos@r-roll:~$ show ip 
  Invalid command: show [ip]
```
