### PR TITLE
op-mode: T2512: Fix conflict templates ipv4-route and show-ip-route

### DIFF
--- a/op-mode-definitions/ipv4-route.xml
+++ b/op-mode-definitions/ipv4-route.xml
@@ -16,44 +16,6 @@
             </properties>
             <command>netstat -gn4</command>
           </leafNode>
-
-          <node name="route">
-            <properties>
-              <help>Show IP routes</help>
-            </properties>
-            <children>
-              <node name="cache">
-                <properties>
-                  <help>Show kernel route cache</help>
-                </properties>
-                <command>ip -s route list cache</command>
-              </node>
-              <tagNode name="cache">
-                <properties>
-                  <help>Show kernel route cache for a given route</help>
-                  <completionHelp>
-                    <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt;</list>
-                  </completionHelp>
-                </properties>
-                <command>ip -s route list cache $5</command>
-              </tagNode>
-              <node name="forward">
-                <properties>
-                  <help>Show kernel route table</help>
-                </properties>
-                <command>ip route list</command>
-              </node>
-              <tagNode name="forward">
-                <properties>
-                  <help>Show kernel route table for a given route</help>
-                  <completionHelp>
-                    <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt;</list>
-                  </completionHelp>
-                </properties>
-                <command>ip -s route list $5</command>
-              </tagNode>
-            </children>
-          </node>
         </children>
       </node>
     </children>

--- a/op-mode-definitions/show-ip-route.xml
+++ b/op-mode-definitions/show-ip-route.xml
@@ -19,12 +19,42 @@
                 </properties>
                 <command>/usr/bin/vtysh -c "show ip route bgp"</command>
               </leafNode>
+              <node name="cache">
+                <properties>
+                  <help>Show kernel route cache</help>
+                </properties>
+                <command>ip -s route list cache</command>
+              </node>
+              <tagNode name="cache">
+                <properties>
+                  <help>Show kernel route cache for a given route</help>
+                  <completionHelp>
+                    <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>ip -s route list cache $5</command>
+              </tagNode>
               <leafNode name="connected">
                 <properties>
                   <help>Show IP connected routes</help>
                 </properties>
                 <command>/usr/bin/vtysh -c "show ip route connected"</command>
               </leafNode>
+              <node name="forward">
+                <properties>
+                  <help>Show kernel route table</help>
+                </properties>
+                <command>ip route list</command>
+              </node>
+              <tagNode name="forward">
+                <properties>
+                  <help>Show kernel route table for a given route</help>
+                  <completionHelp>
+                    <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>ip -s route list $5</command>
+              </tagNode>
               <leafNode name="kernel">
                 <properties>
                   <help>Show IP kernel routes</help>


### PR DESCRIPTION
Remove conflict/duplicate node "show ip route" from ipv4-route.xml
Add "show ip route cache" and "show ip route forward" to show-ip-route.xml

It commit fixes https://phabricator.vyos.net/T2512#65360
```
vyos@r-roll:~$ show ip route 

  Incomplete command: show ip route

```