### PR TITLE
dhcpv6-pd: T421: Start dhcp6c in all cases when DHCPv6-PD is configured

### DIFF
--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -234,9 +234,9 @@ def intf_to_dict(conf, default):
 
     # DHCPv6 prefix delegation (RFC3633)
     current_level = conf.get_level()
-    if conf.exists(['dhcpv6-options', 'delegate']):
-        for interface in conf.list_nodes(['dhcpv6-options', 'delegate']):
-            conf.set_level(current_level + ['dhcpv6-options', 'delegate', interface])
+    if conf.exists(['dhcpv6-options', 'prefix-delegation']):
+        for interface in conf.list_nodes(['dhcpv6-options', 'prefix-delegation', 'interface']):
+            conf.set_level(current_level + ['dhcpv6-options', 'prefix-delegation', 'interface', interface])
             pd = {
                 'ifname': interface,
                 'sla_id': '',

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -644,7 +644,7 @@ class Interface(Control):
               IPv4: add IPv4 address to interface
               IPv6: add IPv6 address to interface
               dhcp: start dhclient (IPv4) on interface
-              dhcpv6: start dhclient (IPv6) on interface
+              dhcpv6: start WIDE dhcp6c (IPv6) on interface
 
         Returns False if address is already assigned and wasn't re-added.
         Example:
@@ -757,3 +757,11 @@ class Interface(Control):
         # TODO: port config (STP)
 
         return True
+
+    def request_prefix_delegation(self):
+        """
+        Starts the DHCPv6 client in order to request a delegated IPv6 prefix.
+
+        Will raise an exception on failure.
+        """
+        self.dhcp.v6.set()

--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -294,6 +294,11 @@ def apply(eth):
         if eth['is_bridge_member']:
             e.add_to_bridge(eth['is_bridge_member'])
 
+        # If DHCPv6-PD is requested, and the IPv6 addresses are not being set
+        # via DHCPv6, then we still need to start dhcp6c.
+        if eth['dhcpv6_pd_interfaces'] and 'dhcpv6' not in eth['address']:
+            e.request_prefix_delegation()
+
         # apply all vlans to interface
         apply_all_vlans(e, eth)
 

--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -294,13 +294,15 @@ def apply(eth):
         if eth['is_bridge_member']:
             e.add_to_bridge(eth['is_bridge_member'])
 
-        # If DHCPv6-PD is requested, and the IPv6 addresses are not being set
-        # via DHCPv6, then we still need to start dhcp6c.
-        if eth['dhcpv6_pd_interfaces'] and 'dhcpv6' not in eth['address']:
-            e.request_prefix_delegation()
-
         # apply all vlans to interface
         apply_all_vlans(e, eth)
+
+        # If DHCPv6-PD is requested, and the IPv6 addresses are not being set
+        # via DHCPv6, then we still need to start dhcp6c. Do this after
+        # apply_all_vlans in case we are delegating to a vlan; in that case,
+        # dhcp6c would fail to start, since its config woula appear invalid.
+        if eth['dhcpv6_pd_interfaces'] and 'dhcpv6' not in eth['address']:
+            e.request_prefix_delegation()
 
     return None
 


### PR DESCRIPTION
This is actually two changes; the first cleans up a bit of config change that was left out of a recent change, and the second makes DHCPv6-PD work when the router isn't getting its ethernet IPv6 address via DHCPv6. This is probably the most common configuration, since in most cases, the router probably either gets its local network configuration from its upstream partner or is statically configured.