### PR TITLE
systemd: T421: Fix the patch for dhcp6c service boot failure.

### DIFF
--- a/src/systemd/dhcp6c@.service
+++ b/src/systemd/dhcp6c@.service
@@ -10,7 +10,6 @@ Type=forking
 PIDFile=/run/dhcp6c/dhcp6c.%i.pid
 ExecStart=/usr/sbin/dhcp6c -D -k /run/dhcp6c/dhcp6c.%i.sock -c /run/dhcp6c/dhcp6c.%i.conf -p /run/dhcp6c/dhcp6c.%i.pid %i
 
-
 Restart=on-failure
 
 StartLimitIntervalSec=0

--- a/src/systemd/dhcp6c@.service
+++ b/src/systemd/dhcp6c@.service
@@ -10,6 +10,7 @@ Type=forking
 PIDFile=/run/dhcp6c/dhcp6c.%i.pid
 ExecStart=/usr/sbin/dhcp6c -D -k /run/dhcp6c/dhcp6c.%i.sock -c /run/dhcp6c/dhcp6c.%i.conf -p /run/dhcp6c/dhcp6c.%i.pid %i
 
+
 Restart=on-failure
 
 StartLimitIntervalSec=0

--- a/src/systemd/dhcp6c@.service
+++ b/src/systemd/dhcp6c@.service
@@ -10,7 +10,11 @@ Type=forking
 PIDFile=/run/dhcp6c/dhcp6c.%i.pid
 ExecStart=/usr/sbin/dhcp6c -D -k /run/dhcp6c/dhcp6c.%i.sock -c /run/dhcp6c/dhcp6c.%i.conf -p /run/dhcp6c/dhcp6c.%i.pid %i
 
-Restart=always
+Restart=on-failure
+
+StartLimitIntervalSec=0
+
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
During the first load after boot, some interfaces may not be initialized, which will lead to the failure of dhcp6c startup. Using this setting, you can restart automatically after a period of time after startup failure to complete the fault recovery of dhcp6c.

Adding infinite failure restart recovery to dhcp6c ensures that dhcp6c can recover from failure after all interfaces are initialized.