### PR TITLE
T2610: default-lifetime is not reflected in the RA message

### DIFF
--- a/src/conf_mode/service_router-advert.py
+++ b/src/conf_mode/service_router-advert.py
@@ -66,8 +66,8 @@ def get_config():
         if conf.exists(['hop-limit']):
             intf['hop_limit'] = conf.return_value(['hop-limit'])
 
-        if conf.exists(['default-lifetim']):
-            intf['default_lifetime'] = conf.return_value(['default-lifetim'])
+        if conf.exists(['default-lifetime']):
+            intf['default_lifetime'] = conf.return_value(['default-lifetime'])
 
         if conf.exists(['default-preference']):
             intf['default_preference'] = conf.return_value(['default-preference'])


### PR DESCRIPTION
Fix typo in service_router-advert.py to recognize default-lifetime param.