### PR TITLE
T2562: Make VyOS able to be a server for a dhcp relay

### DIFF
--- a/data/templates/dhcp-server/dhcpd.conf.tmpl
+++ b/data/templates/dhcp-server/dhcpd.conf.tmpl
@@ -75,6 +75,11 @@ shared-network {{ network.name }} {
     {%- if network.authoritative %}
     authoritative;
     {%- endif %}
+    {%- if network.relay_networks %}
+    {%- for relay_network in network.relay_networks %}
+    subnet {{ relay_network.network_address }} netmask {{ relay_network.netmask }} {}
+    {%- endfor %}
+    {%- endif %}
     {%- if network.network_parameters %}
     # The following {{ network.network_parameters | length }} line(s) were added as shared-network-parameters in the CLI and have not been validated
     {%- for param in network.network_parameters %}

--- a/interface-definitions/dhcp-server.xml.in
+++ b/interface-definitions/dhcp-server.xml.in
@@ -62,6 +62,15 @@
                   <help>Shared-network-name description</help>
                 </properties>
               </leafNode>
+              <leafNode name="relay-networks">
+                <properties>
+                  <help>Locally attached network prefix(es) facing a DHCP relay.</help>
+	          <constraint>
+                    <validator name="ipv4-prefix"/>
+	          </constraint>
+		  <multi/>
+                </properties>
+	      </leafNode>
               <leafNode name="disable">
                 <properties>
                   <help>Option to disable DHCP configuration for shared-network</help>

--- a/src/conf_mode/dhcp_server.py
+++ b/src/conf_mode/dhcp_server.py
@@ -196,7 +196,8 @@ def get_config():
 
             if conf.exists('relay-networks'):
                 for relay_net in conf.return_values('relay-networks'):
-                    config['relay_networks'].append({'network_address':str(ip_network(relay_net).network_address), 'netmask':str(ip_network(relay_net).netmask)})
+                    temp_net = ip_network(relay_net)
+                    config['relay_networks'].append({'network_address':str(temp_net.network_address), 'netmask':str(temp_net.netmask)})
 
             # check for multiple subnet configurations in a shared network
             # config segment


### PR DESCRIPTION
Currently it's impossible for VyOS to be used as a server for a DHCP relay.  This should correct it.

[This line](https://github.com/vyos/vyos-1x/compare/current...kroy-the-rabbit:dhcp-fixes?expand=1#diff-ea15ed988b548fe6ac1faafe011b7403R599) is the one line that I'm not sure about on the logic, and will be the most breaking change, if any.

As mentioned in the task, I'm not 100% convinced on the naming of the node