### PR TITLE
Sub dict

### DIFF
--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -364,6 +364,36 @@ def mangle_dict_keys(data, regex, replacement):
 
     return new_dict
 
+def _get_sub_dict(d, lpath):
+    k = lpath[0]
+    if k not in d.keys():
+        return {}
+    c = {k: d[k]}
+    lpath = lpath[1:]
+    if not lpath:
+        return c
+    elif not isinstance(c[k], dict):
+        return {}
+    return _get_sub_dict(c[k], lpath)
+
+def get_sub_dict(source, lpath):
+    """ Returns the sub-dict of a nested dict, defined by path of keys.
+
+    Args:
+        source (dict): Source dict to extract from
+        lpath (list[str]): sequence of keys
+
+    Returns: {key : source[..]..[key]} for key the last element of lpath, if exists
+             {} otherwise
+    """
+    if not isinstance(source, dict):
+        raise TypeError("source must be of type dict")
+    if not isinstance(lpath, list):
+        raise TypeError("path must be of type list")
+    if not lpath:
+        return source
+    return _get_sub_dict(source, lpath)
+
 def process_running(pid_file):
     """ Checks if a process with PID in pid_file is running """
     from psutil import pid_exists

--- a/src/conf_mode/interfaces-dummy.py
+++ b/src/conf_mode/interfaces-dummy.py
@@ -40,7 +40,7 @@ def get_config():
     ifname = os.environ['VYOS_TAGNODE_VALUE']
     base = ['interfaces', 'dummy', ifname]
 
-    dummy = conf.get_config_dict(base, key_mangling=('-', '_'))
+    dummy = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
     # Check if interface has been removed
     if dummy == {}:
         dummy.update({'deleted' : ''})

--- a/src/conf_mode/interfaces-loopback.py
+++ b/src/conf_mode/interfaces-loopback.py
@@ -35,7 +35,7 @@ def get_config():
     ifname = os.environ['VYOS_TAGNODE_VALUE']
     base = ['interfaces', 'loopback', ifname]
 
-    loopback = conf.get_config_dict(base, key_mangling=('-', '_'))
+    loopback = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
     # Check if interface has been removed
     if loopback == {}:
         loopback.update({'deleted' : ''})

--- a/src/conf_mode/interfaces-macsec.py
+++ b/src/conf_mode/interfaces-macsec.py
@@ -53,7 +53,7 @@ def get_config():
     ifname = os.environ['VYOS_TAGNODE_VALUE']
     base = base + [ifname]
 
-    macsec = conf.get_config_dict(base, key_mangling=('-', '_'))
+    macsec = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
     # Check if interface has been removed
     if macsec == {}:
         tmp = {

--- a/src/conf_mode/interfaces-wirelessmodem.py
+++ b/src/conf_mode/interfaces-wirelessmodem.py
@@ -62,7 +62,7 @@ def get_config():
     ifname = os.environ['VYOS_TAGNODE_VALUE']
     base = base + [ifname]
 
-    wwan = conf.get_config_dict(base, key_mangling=('-', '_'))
+    wwan = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
     # Check if interface has been removed
     if wwan == {}:
         wwan.update({'deleted' : ''})

--- a/src/conf_mode/ssh.py
+++ b/src/conf_mode/ssh.py
@@ -37,7 +37,7 @@ def get_config():
     if not conf.exists(base):
         return None
 
-    ssh = conf.get_config_dict(base, key_mangling=('-', '_'))
+    ssh = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
     # We have gathered the dict representation of the CLI, but there are default
     # options which we need to update into the dictionary retrived.
     default_values = defaults(base)

--- a/src/conf_mode/system_console.py
+++ b/src/conf_mode/system_console.py
@@ -31,7 +31,7 @@ def get_config():
     base = ['system', 'console']
 
     # retrieve configuration at once
-    console = conf.get_config_dict(base)
+    console = conf.get_config_dict(base, get_first_key=True)
 
     # bail out early if no serial console is configured
     if 'device' not in console.keys():

--- a/src/conf_mode/vrf.py
+++ b/src/conf_mode/vrf.py
@@ -52,7 +52,7 @@ def vrf_interfaces(c, match):
     matched = []
     old_level = c.get_level()
     c.set_level(['interfaces'])
-    section = c.get_config_dict([])
+    section = c.get_config_dict([], get_first_key=True)
     for type in section:
         interfaces = section[type]
         for name in interfaces:


### PR DESCRIPTION
T2667:
N.B.:
1) the utility function has been added to util.py instead of configdict.py, because until configdict.py is reorganized/rationalized, importing configidct.py in config.py leads to the nosetests pulling in extraneous build deps (e.g., netifaces).
2) @thomas-mangin may want to make use of these changes in interfaces-tunnel.py; the version as of yesterday required no change, but I see he has now reorganized, including a work-around for T2662; I reviewed and tested the earlier version for compatibility.
3) the reason for the form of the return value of get_sub_dict is in T2662; the reason that get_first_key is default False is leafNodes --- of course, it would be odd to get_config_dict with path a leafNode, but defaults should not allow corner-case error.