### PR TITLE
xml: T2582: rename xml tags

### DIFF
--- a/python/vyos/xml/kw.py
+++ b/python/vyos/xml/kw.py
@@ -27,12 +27,12 @@ def found(word):
 
 # root
 
-version = '(version)'
-tree = '(tree)'
-priorities = '(priorities)'
-owners = '(owners)'
-tags = '(tags)'
-default = '(default)'
+version = '[version]'
+tree = '[tree]'
+priorities = '[priorities]'
+owners = '[owners]'
+tags = '[tags]'
+default = '[default]'
 
 # nodes
 


### PR DESCRIPTION
The current use of () does not allow to use found()
Converting to [] like all other tags