### PR TITLE
pppoe: ipv6: T2693: Fix a bug in dhcp6c for PPPoE

### DIFF
--- a/data/templates/pppoe/ipv6-up.script.tmpl
+++ b/data/templates/pppoe/ipv6-up.script.tmpl
@@ -42,7 +42,7 @@ echo 1 > /proc/sys/net/ipv6/conf/{{ ifname }}/autoconf
 
 {% if dhcpv6_options is defined and dhcpv6_options.prefix_delegation is defined %}
 # Start wide dhcpv6 client
-systemctl start dhcp6c@{{ ifname }}.service
+systemctl restart dhcp6c@{{ ifname }}.service
 {% endif %}
 
 


### PR DESCRIPTION
Commit 03fb97 (pppoe: ipv6: T2681: script bugfix after get_config_dict() migration )
After the PPPoE link is reset, dhcp6c cannot be restarted,
which may cause the prefix delegation of IPv6 to fail to restart.
This submission will restart dhcp6c after the IPv6 of PPPoE is up again