### PR TITLE
pppoe: ipv6: T2693: Fix a bug in dhcp6c for PPPoE

### DIFF
--- a/data/templates/pppoe/ip-down.script.tmpl
+++ b/data/templates/pppoe/ip-down.script.tmpl
@@ -30,7 +30,7 @@ vtysh -c "conf t" ${VRF_NAME} -c "no ipv6 route ::/0 {{ ifname }} ${VRF_NAME}"
 {%   endif %}
 {% endif %}
 
-{% if dhcpv6_pd_interfaces %}
-# Start wide dhcpv6 client
+{% if dhcpv6_options is defined and dhcpv6_options.prefix_delegation is defined %}
+# Stop wide dhcpv6 client
 systemctl stop dhcp6c@{{ ifname }}.service
 {% endif %}


### PR DESCRIPTION
Commit 03fb97 (pppoe: ipv6: T2681: script bugfix after get_config_dict() migration )
After the PPPoE link is reset, dhcp6c cannot be restarted,
which may cause the prefix delegation of IPv6 to fail to restart.
This submission will restart dhcp6c after the IPv6 of PPPoE is up again