### PR TITLE
dns: T2675: fix recursor.vyos-hostsd.conf.lua

### DIFF
--- a/data/templates/dns-forwarding/recursor.vyos-hostsd.conf.lua.tmpl
+++ b/data/templates/dns-forwarding/recursor.vyos-hostsd.conf.lua.tmpl
@@ -17,7 +17,7 @@ addNTA("{{ a }}.", "{{ tag }} alias")
 -- from 'service dns forwarding domain'
 {%- for zone, zonedata in forward_zones.items() %}
 {%- if zonedata['addNTA'] %}
-addNTA("{{ zone }}.", "static")
+addNTA("{{ zone }}", "static")
 {%- endif %}
 {%- endfor %}
 {%- endif %}


### PR DESCRIPTION
When users use the standard fully qualified domain name writing method,
 there will be an extra point after the actual domain name. 
In order to ensure that the standard writing method is supported,
 it should not be mandatory to add this point in Lua script