### PR TITLE
T1802: Wireguard QR code pkg dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -105,7 +105,10 @@ Depends: python3,
   nftables (>= 0.9.3),
   conntrack,
   libatomic1,
-  fastnetmon
+  fastnetmon,
+  qrencode,
+  libpng16-16,
+  libqrencode4
 Description: VyOS configuration scripts and data
  VyOS configuration scripts, interface definitions, and everything
 


### PR DESCRIPTION
This is used for adding QR codes for wireguard tunnels for mobile clients via the CLI for easy setup.
as mentioned on
https://phabricator.vyos.net/T1802