### PR TITLE
Admin State:T2673: Fix for admin state if the mac address is changed …

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -322,7 +322,11 @@ class Interface(Control):
             self.set_admin_state('down')
 
         self.set_interface('mac', mac)
-
+        
+        # Turn an interface to the 'up' state if it was changed to 'down' by this fucntion
+        if prev_state == 'up':
+            self.set_admin_state('up')
+    
     def set_vrf(self, vrf=''):
         """
         Add/Remove interface from given VRF instance.


### PR DESCRIPTION
…for an interface

	 Changes are made in the interface.py script in order to bring the admin state to 'UP' after the mac is manually added in system config.The script is marking the interface from up to down state(as the MAC address can only be changed if interface is in 'down' state) but it is not bringing it up after the change