### PR TITLE
nat: T2709: remove 'translation address' mandatory check

### DIFF
--- a/src/conf_mode/nat.py
+++ b/src/conf_mode/nat.py
@@ -79,9 +79,6 @@ def verify_rule(rule, err_msg):
                              'statically maps a whole network of addresses onto another\n' \
                              'network of addresses')
 
-    if not rule['exclude'] and not rule['translation_address']:
-        raise ConfigError(f'{err_msg} translation address not specified')
-
 
 def parse_configuration(conf, source_dest):
     """ Common wrapper to read in both NAT source and destination CLI """


### PR DESCRIPTION
Rules without a translation address are also valid, they'll modify just
the port and leave the address intact.

This also used to be a valid syntax and it caused an error on upgrade.