### PR TITLE
dhcp-server: T2717: Fix DHCP pool size in statistics

### DIFF
--- a/src/op_mode/show_dhcp.py
+++ b/src/op_mode/show_dhcp.py
@@ -161,7 +161,8 @@ def get_pool_size(config, pool):
             start = config.return_effective_value("service dhcp-server shared-network-name {0} subnet {1} range {2} start".format(pool, s, r))
             stop = config.return_effective_value("service dhcp-server shared-network-name {0} subnet {1} range {2} stop".format(pool, s, r))
 
-            size += int(ip_address(stop)) - int(ip_address(start))
+            # Add +1 because both range boundaries are inclusive
+            size += int(ip_address(stop)) - int(ip_address(start)) + 1
 
     return size
 


### PR DESCRIPTION
The calculated size of DHCP server address pools was not corrent. The
fact that both boundaries of address ranges are inclusive wasn't
accounted for, so the calculated size was too small by 1 address
per range.