### PR TITLE
ntp: T2718: Change template for correct server names

### DIFF
--- a/data/templates/ntp/ntp.conf.tmpl
+++ b/data/templates/ntp/ntp.conf.tmpl
@@ -19,7 +19,7 @@ restrict -6 ::1
 {%     set options = options + 'noselect ' if server[srv].noselect is defined else '' %}
 {%     set options = options + 'preempt ' if server[srv].preempt is defined else '' %}
 {%     set options = options + 'prefer ' if server[srv].prefer is defined else '' %}
-server {{ srv }} iburst {{ options }}
+server {{ srv | replace('_', '-') }} iburst {{ options }}
 {%   endfor %}
 {% endif %}
 


### PR DESCRIPTION
It replaces "_" to "-" for NTP server names configuration.