### PR TITLE
T2725: Fix config parse for users without passwords

### DIFF
--- a/src/conf_mode/system-login.py
+++ b/src/conf_mode/system-login.py
@@ -72,7 +72,7 @@ def get_config():
         user = {
             'name': username,
             'password_plaintext': '',
-            'password_encred': '!',
+            'password_encrypted': '!',
             'public_keys': [],
             'full_name': '',
             'home_dir': '/home/' + username,


### PR DESCRIPTION
Fix for https://phabricator.vyos.net/T2725

T2492 / a07e22377ab83104ac925e13d1824f241f0f8d4a
introduced a change which broke the initialization of
the user dict. In case the config contained an user
without an encrypted-password set, the property would
be missing and the commit would crash with
`KeyError: 'password_encrypted'`