### PR TITLE
op-mode: T1117: Add show ipv6 bgp route-map

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ op_mode_definitions:
 	rm -f $(OP_TMPL_DIR)/show/node.def
 	rm -f $(OP_TMPL_DIR)/show/interfaces/node.def
 	rm -f $(OP_TMPL_DIR)/show/ipv6/node.def
+	rm -f $(OP_TMPL_DIR)/show/ipv6/bgp/node.def
 	rm -f $(OP_TMPL_DIR)/show/ipv6/route/node.def
 	rm -f $(OP_TMPL_DIR)/restart/node.def
 	rm -f $(OP_TMPL_DIR)/monitor/node.def

--- a/op-mode-definitions/show-ipv6-bgp.xml
+++ b/op-mode-definitions/show-ipv6-bgp.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="show">
+    <children>
+      <node name="ipv6">
+        <children>
+          <node name="bgp">
+            <children>
+              <tagNode name="route-map">
+                <properties>
+                  <help>Show BGP routes matching the specified route map</help>
+                  <completionHelp>
+                    <path>policy route-map</path>
+                  </completionHelp>
+                </properties>
+                <command>/usr/bin/vtysh -c "show bgp ipv6 route-map $5"</command>
+              </tagNode>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>


### PR DESCRIPTION
Add "route-map" option for op-mode ipv6 bgp

```
vyos@r1-roll:~$ show ipv6 bgp route-map 
Possible completions:
  IPV6-IN       Show BGP routes matching the specified route map

```