### PR TITLE
op-mode: T2791: Add monitor traceroute explicit for ipv4-ipv6 and vrf

### DIFF
--- a/op-mode-definitions/traceroute.xml
+++ b/op-mode-definitions/traceroute.xml
@@ -165,6 +165,24 @@
       </tagNode>
       <node name="traceroute">
         <children>
+          <tagNode name="ipv4">
+            <properties>
+              <help>IPv4 fully qualified domain name (FQDN)</help>
+              <completionHelp>
+                <list>&lt;fqdn&gt;</list>
+              </completionHelp>
+            </properties>
+            <command>/usr/bin/mtr -4 "$4"</command>
+          </tagNode>
+          <tagNode name="ipv6">
+            <properties>
+              <help>IPv6 fully qualified domain name (FQDN)</help>
+              <completionHelp>
+                <list>&lt;fqdn&gt;</list>
+              </completionHelp>
+            </properties>
+            <command>/usr/bin/mtr -6 "$4"</command>
+          </tagNode>
           <tagNode name="vrf">
             <properties>
               <help>Monitor path to destination in realtime via given VRF</help>
@@ -173,8 +191,24 @@
               </completionHelp>
             </properties>
             <children>
-              <!-- we need an empty tagNode to pass in a plain fqdn/ip address and
-                   let traceroute decide how to handle this parameter -->
+              <tagNode name="ipv4">
+                <properties>
+                  <help>IPv4 fully qualified domain name (FQDN)</help>
+                  <completionHelp>
+                    <list>&lt;fqdn&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>sudo /usr/sbin/ip vrf exec "$4" /usr/bin/mtr -4 "$6"</command>
+              </tagNode>
+              <tagNode name="ipv6">
+                <properties>
+                  <help>IPv6 fully qualified domain name (FQDN)</help>
+                  <completionHelp>
+                    <list>&lt;fqdn&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>sudo /usr/sbin/ip vrf exec "$4" /usr/bin/mtr -6 "$6"</command>
+              </tagNode>
               <tagNode name="">
                 <properties>
                   <help>Track network path to specified node via given VRF</help>


### PR DESCRIPTION
Add trace feature for ipv4 ipv6 vrf
```
vyos@r4-roll:~$ monitor traceroute 
Possible completions:
  <hostname>    Monitor path to destination in realtime
  <x.x.x.x>
  <h:h:h:h:h:h:h:h>
  ipv4          IPv4 fully qualified domain name (FQDN)
  ipv6          IPv6 fully qualified domain name (FQDN)
  vrf           Monitor path to destination in realtime via given VRF

```