### PR TITLE
T2826: frr: frr python lib error in replace_section

### DIFF
--- a/python/vyos/frr.py
+++ b/python/vyos/frr.py
@@ -281,7 +281,7 @@ def replace_section(config, replacement, from_re, to_re=r'!', before_re=r'line v
 
     startline and endline tags will be automatically added to the resulting from_re/to_re and before_re regex'es
     """
-    return _replace_section(config, replacement, replace_re=rf'^{from_re}$.*?^{to_re}$', before_re=rf'^{before_re}$')
+    return _replace_section(config, replacement, replace_re=rf'^{from_re}$.*?^{to_re}$', before_re=rf'^({before_re})$')
 
 
 def remove_section(config, from_re, to_re='!'):


### PR DESCRIPTION
because of a bug in frr.py the default before_re will not be working.

it is by default without a group, but will be used in a match that needs a group.
The whole string could be matched in the group, so the fix is easy to implement.