### PR TITLE
show log:T2872:"Show log" options for nat and openvpn got inter-mixed

### DIFF
--- a/op-mode-definitions/show-log.xml
+++ b/op-mode-definitions/show-log.xml
@@ -135,7 +135,7 @@
             </properties>
             <command>egrep -i "kernel:.*\[NAT-[A-Z]{3,}-[0-9]+(-MASQ)?\]" $(find /var/log -maxdepth 1 -type f -name messages\* | sort -t. -k2nr)</command>
           </leafNode>
-          <leafNode name="nat">
+          <leafNode name="openvpn">
             <properties>
               <help>Show log for OpenVPN</help>
             </properties>


### PR DESCRIPTION
The possible completion of the "show log" shows only nat and the description shows for openvpn. Corrected the duplicate entry