### PR TITLE
OpenVPN: T2907: Option to disable encryption

### DIFF
--- a/data/templates/openvpn/server.conf.tmpl
+++ b/data/templates/openvpn/server.conf.tmpl
@@ -196,6 +196,8 @@ tls-server
 
 # Encryption options
 {%- if encryption %}
+{% if encryption == 'none' -%}
+cipher none
 {% if encryption == 'des' -%}
 cipher des-cbc
 {%- elif encryption == '3des' -%}

--- a/data/templates/openvpn/server.conf.tmpl
+++ b/data/templates/openvpn/server.conf.tmpl
@@ -196,7 +196,7 @@ tls-server
 
 # Encryption options
 {%- if encryption %}
-{%- if encryption == 'none' -%}
+{% if encryption == 'none' -%}
 cipher none
 {%- elif encryption == 'des' -%}
 cipher des-cbc

--- a/data/templates/openvpn/server.conf.tmpl
+++ b/data/templates/openvpn/server.conf.tmpl
@@ -196,9 +196,9 @@ tls-server
 
 # Encryption options
 {%- if encryption %}
-{% if encryption == 'none' -%}
+{%- if encryption == 'none' -%}
 cipher none
-{% if encryption == 'des' -%}
+{%- elif encryption == 'des' -%}
 cipher des-cbc
 {%- elif encryption == '3des' -%}
 cipher des-ede3-cbc

--- a/interface-definitions/interfaces-openvpn.xml.in
+++ b/interface-definitions/interfaces-openvpn.xml.in
@@ -63,8 +63,12 @@
                 <properties>
                   <help>Standard Data Encryption Algorithm</help>
                   <completionHelp>
-                    <list>des 3des bf128 bf256 aes128 aes128gcm aes192 aes192gcm aes256 aes256gcm</list>
+                    <list>none des 3des bf128 bf256 aes128 aes128gcm aes192 aes192gcm aes256 aes256gcm</list>
                   </completionHelp>
+                  <valueHelp>
+                    <format>none</format>
+                    <description>Disable encryption</description>
+                  </valueHelp>
                   <valueHelp>
                     <format>des</format>
                     <description>DES algorithm</description>
@@ -106,7 +110,7 @@
                     <description>AES algorithm with 256-bit key GCM</description>
                   </valueHelp>
                   <constraint>
-                    <regex>(des|3des|bf128|bf256|aes128|aes128gcm|aes192|aes192gcm|aes256|aes256gcm)</regex>
+                    <regex>(none|des|3des|bf128|bf256|aes128|aes128gcm|aes192|aes192gcm|aes256|aes256gcm)</regex>
                   </constraint>
                 </properties>
               </leafNode>
@@ -114,8 +118,12 @@
                 <properties>
                   <help>Cipher negotiation list for use in server or client mode</help>
                   <completionHelp>
-                    <list>des 3des aes128 aes128gcm aes192 aes192gcm aes256 aes256gcm</list>
+                    <list>none des 3des aes128 aes128gcm aes192 aes192gcm aes256 aes256gcm</list>
                   </completionHelp>
+                  <valueHelp>
+                    <format>none</format>
+                    <description>Disable encryption</description>
+                  </valueHelp>
                   <valueHelp>
                     <format>des</format>
                     <description>DES algorithm</description>
@@ -149,7 +157,7 @@
                     <description>AES algorithm with 256-bit key GCM</description>
                   </valueHelp>
                   <constraint>
-                    <regex>(des|3des|aes128|aes128gcm|aes192|aes192gcm|aes256|aes256gcm)</regex>
+                    <regex>(none|des|3des|aes128|aes128gcm|aes192|aes192gcm|aes256|aes256gcm)</regex>
                   </constraint>
                   <multi/>
                 </properties>

--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -256,7 +256,10 @@ def get_config(config=None):
     if conf.exists('encryption ncp-ciphers'):
         _ncp_ciphers = []
         for enc in conf.return_values('encryption ncp-ciphers'):
-            if enc == 'des':
+            if enc == 'none':
+                _ncp_ciphers.append('none')
+                _ncp_ciphers.append('NONE')
+            elif enc == 'des':
                 _ncp_ciphers.append('des-cbc')
                 _ncp_ciphers.append('DES-CBC')
             elif enc == '3des':

--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -946,6 +946,9 @@ def verify(openvpn):
             else:
                 print('Diffie-Hellman prime file is unspecified, assuming ECDH')
 
+    if openvpn['encryption'] == 'none':
+        print('Warning: "encryption none" was specified. NO encryption will be performed and tunnelled data WILL be transmitted in clear text over the network!')
+
     #
     # Auth user/pass
     #


### PR DESCRIPTION
Added support for selectiing 'encryption none' option for OpenVPN, setting the cipher to 'none'. Displays a warning on commit similar to the OpenVPN warning.