### PR TITLE
OpenVPN: T2906: tls-auth missing key direction

### DIFF
--- a/data/templates/openvpn/server.conf.tmpl
+++ b/data/templates/openvpn/server.conf.tmpl
@@ -186,6 +186,7 @@ tls-auth {{tls_auth}} 1
 {%- elif mode == 'server' %}
 tls-auth {{tls_auth}} 0
 {%- endif %}
+{%- endif %}
 
 {%- if tls_role %}
 {%- if 'active' in tls_role %}

--- a/data/templates/openvpn/server.conf.tmpl
+++ b/data/templates/openvpn/server.conf.tmpl
@@ -181,7 +181,10 @@ dh {{ tls_dh }}
 {%- endif %}
 
 {%- if tls_auth %}
-tls-auth {{tls_auth}}
+{%- if mode == 'client' %}
+tls-auth {{tls_auth}} 1
+{%- elif mode == 'server' %}
+tls-auth {{tls_auth}} 0
 {%- endif %}
 
 {%- if tls_role %}


### PR DESCRIPTION
Fixes the missing key direction for the tls-auth setting in the OpenVPN config.