### PR TITLE
conf-mode: T2915: Adding lost option proxy-arp-pvlan for vlan

### DIFF
--- a/interface-definitions/include/vif.xml.i
+++ b/interface-definitions/include/vif.xml.i
@@ -50,6 +50,7 @@
         #include <include/interface-enable-arp-announce.xml.i>
         #include <include/interface-enable-arp-ignore.xml.i>
         #include <include/interface-enable-proxy-arp.xml.i>
+        #include <include/interface-proxy-arp-pvlan.xml.i>
       </children>
     </node>
     <node name="ipv6">


### PR DESCRIPTION
Add option "proxy-arp-pvlan" that was lost after rewriting interfaces.
It's present in 1.2.5 and not present in 1.3
That commit fixes it.