### PR TITLE
accel-ppp: T2918: Add accounting interim jitter option

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.tmpl
+++ b/data/templates/accel-ppp/ipoe.config.tmpl
@@ -80,6 +80,10 @@ verbose=1
 server={{ r.server }},{{ r.key }},auth-port={{ r.port }},acct-port={{ r.acct_port }},req-limit=0,fail-time={{ r.fail_time }}
 {% endfor -%}
 
+{% if radius_acct_inter_jitter %}
+acct-interim-jitter={{ radius_acct_inter_jitter }}
+{% endif %}
+
 acct-timeout={{ radius_acct_tmo }}
 timeout={{ radius_timeout }}
 max-try={{ radius_max_try }}

--- a/data/templates/accel-ppp/l2tp.config.tmpl
+++ b/data/templates/accel-ppp/l2tp.config.tmpl
@@ -86,6 +86,10 @@ verbose=1
 server={{ r.server }},{{ r.key }},auth-port={{ r.port }},acct-port={{ r.acct_port }},req-limit=0,fail-time={{ r.fail_time }}
 {% endfor -%}
 
+{% if radius_acct_inter_jitter %}
+acct-interim-jitter={{ radius_acct_inter_jitter }}
+{% endif %}
+
 acct-timeout={{ radius_acct_tmo }}
 timeout={{ radius_timeout }}
 max-try={{ radius_max_try }}

--- a/data/templates/accel-ppp/pppoe.config.tmpl
+++ b/data/templates/accel-ppp/pppoe.config.tmpl
@@ -96,6 +96,10 @@ verbose=1
 server={{ r.server }},{{ r.key }},auth-port={{ r.port }},acct-port={{ r.acct_port }},req-limit=0,fail-time={{ r.fail_time }}
 {% endfor -%}
 
+{% if radius_acct_inter_jitter %}
+acct-interim-jitter={{ radius_acct_inter_jitter }}
+{% endif %}
+
 acct-timeout={{ radius_acct_tmo }}
 timeout={{ radius_timeout }}
 max-try={{ radius_max_try }}

--- a/data/templates/accel-ppp/pptp.config.tmpl
+++ b/data/templates/accel-ppp/pptp.config.tmpl
@@ -69,6 +69,10 @@ verbose=1
 server={{ r.server }},{{ r.key }},auth-port={{ r.port }},acct-port={{ r.acct_port }},req-limit=0,fail-time={{ r.fail_time }}
 {% endfor -%}
 
+{% if radius_acct_inter_jitter %}
+acct-interim-jitter={{ radius_acct_inter_jitter }}
+{% endif %}
+
 acct-timeout={{ radius_acct_tmo }}
 timeout={{ radius_timeout }}
 max-try={{ radius_max_try }}

--- a/interface-definitions/include/accel-radius-additions.xml.i
+++ b/interface-definitions/include/accel-radius-additions.xml.i
@@ -1,5 +1,18 @@
 <node name="radius">
   <children>
+    <leafNode name="acct-interim-jitter">
+      <properties>
+        <help>Maximum jitter value in seconds to be applied to accounting information interval</help>
+        <valueHelp>
+          <format>1-60</format>
+          <description>Maximum jitter value in seconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-60"/>
+        </constraint>
+        <constraintErrorMessage>Jitter value must be between 1 and 60 seconds</constraintErrorMessage>
+      </properties>
+    </leafNode>
     <tagNode name="server">
       <children>
         <leafNode name="acct-port">

--- a/src/conf_mode/service_ipoe-server.py
+++ b/src/conf_mode/service_ipoe-server.py
@@ -43,6 +43,7 @@ default_config_data = {
     'client_ipv6_pool': [],
     'client_ipv6_delegate_prefix': [],
     'radius_server': [],
+    'radius_acct_inter_jitter': '',
     'radius_acct_tmo': '3',
     'radius_max_try': '3',
     'radius_timeout': '3',
@@ -174,6 +175,10 @@ def get_config(config=None):
     #
     # advanced radius-setting
     conf.set_level(base_path + ['authentication', 'radius'])
+
+    if conf.exists(['acct-interim-jitter']):
+        ipoe['radius_acct_inter_jitter'] = conf.return_value(['acct-interim-jitter'])
+
     if conf.exists(['acct-timeout']):
         ipoe['radius_acct_tmo'] = conf.return_value(['acct-timeout'])
 

--- a/src/conf_mode/service_pppoe-server.py
+++ b/src/conf_mode/service_pppoe-server.py
@@ -72,6 +72,7 @@ default_config_data = {
     'ppp_preallocate_vif': False,
 
     'radius_server': [],
+    'radius_acct_inter_jitter': '',
     'radius_acct_tmo': '3',
     'radius_max_try': '3',
     'radius_timeout': '3',
@@ -270,6 +271,9 @@ def get_config(config=None):
         #
         # advanced radius-setting
         conf.set_level(base_path + ['authentication', 'radius'])
+
+        if conf.exists(['acct-interim-jitter']):
+            pppoe['radius_acct_inter_jitter'] = conf.return_value(['acct-interim-jitter'])
 
         if conf.exists(['acct-timeout']):
             pppoe['radius_acct_tmo'] = conf.return_value(['acct-timeout'])

--- a/src/conf_mode/vpn_l2tp.py
+++ b/src/conf_mode/vpn_l2tp.py
@@ -56,6 +56,7 @@ default_config_data = {
     'ppp_echo_interval' : '30',
     'ppp_echo_timeout': '0',
     'radius_server': [],
+    'radius_acct_inter_jitter': '',
     'radius_acct_tmo': '3',
     'radius_max_try': '3',
     'radius_timeout': '3',
@@ -178,6 +179,9 @@ def get_config(config=None):
         #
         # advanced radius-setting
         conf.set_level(base_path + ['authentication', 'radius'])
+
+        if conf.exists(['acct-interim-jitter']):
+            l2tp['radius_acct_inter_jitter'] = conf.return_value(['acct-interim-jitter'])
 
         if conf.exists(['acct-timeout']):
             l2tp['radius_acct_tmo'] = conf.return_value(['acct-timeout'])

--- a/src/conf_mode/vpn_pptp.py
+++ b/src/conf_mode/vpn_pptp.py
@@ -36,6 +36,7 @@ default_pptp = {
     'auth_mode' : 'local',
     'local_users' : [],
     'radius_server' : [],
+    'radius_acct_inter_jitter': '',
     'radius_acct_tmo' : '30',
     'radius_max_try' : '3',
     'radius_timeout' : '30',
@@ -138,6 +139,9 @@ def get_config(config=None):
         #
         # advanced radius-setting
         conf.set_level(base_path + ['authentication', 'radius'])
+
+        if conf.exists(['acct-interim-jitter']):
+            pptp['radius_acct_inter_jitter'] = conf.return_value(['acct-interim-jitter'])
 
         if conf.exists(['acct-timeout']):
             pptp['radius_acct_tmo'] = conf.return_value(['acct-timeout'])


### PR DESCRIPTION
Add accounting interim jitter option for Accel-lll (pppoe, l2tp, pptp, ipoe)