### PR TITLE
vrrp: T2933: Add option virtual-address-excluded

### DIFF
--- a/data/templates/vrrp/keepalived.conf.tmpl
+++ b/data/templates/vrrp/keepalived.conf.tmpl
@@ -70,6 +70,14 @@ vrrp_instance {{ group.name }} {
     {% endfor -%}
     }
 
+    {% if group.virtual_addresses_excluded -%}
+    virtual_ipaddress_excluded {
+    {% for addr in group.virtual_addresses_excluded -%}
+        {{ addr }}
+    {% endfor -%}
+    }
+    {% endif -%}
+
     {% if group.health_check_script -%}
     track_script {
         healthcheck_{{ group.name }}

--- a/interface-definitions/vrrp.xml.in
+++ b/interface-definitions/vrrp.xml.in
@@ -222,6 +222,25 @@
                   </valueHelp>
                 </properties>
               </leafNode>
+              <leafNode name="virtual-address-excluded">
+                <properties>
+                  <help>Virtual address (If you need additional IPv4 and IPv6 in same group)</help>
+                  <valueHelp>
+                    <format>ipv4</format>
+                    <description>IP address</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ipv6</format>
+                    <description>IPv6 address</description>
+                  </valueHelp>
+                  <multi/>
+                  <constraint>
+                    <validator name="ipv4-host"/>
+                    <validator name="ipv6-host"/>
+                  </constraint>
+                  <constraintErrorMessage>Virtual address must be a valid IPv4 or IPv6 address with prefix length (e.g. 192.0.2.3/24 or 2001:db8:ff::10/64)</constraintErrorMessage>
+                </properties>
+              </leafNode>
               <leafNode name="vrid">
                 <properties>
                   <help>Virtual router identifier</help>

--- a/src/conf_mode/vrrp.py
+++ b/src/conf_mode/vrrp.py
@@ -62,6 +62,7 @@ def get_config(config=None):
         group["sync_group"] = config.return_value("sync-group")
         group["preempt_delay"] = config.return_value("preempt-delay")
         group["virtual_addresses"] = config.return_values("virtual-address")
+        group["virtual_addresses_excluded"] = config.return_values("virtual-address-excluded")
 
         group["auth_password"] = config.return_value("authentication password")
         group["auth_type"] = config.return_value("authentication type")


### PR DESCRIPTION
To decrease the number of packets sent in adverts, you can exclude most IPs from adverts." It also mentions a secondary IPv4+IPv6 use case.