### PR TITLE
T2949: Fix restart methodology for pdns on static host mapping

### DIFF
--- a/src/conf_mode/host_name.py
+++ b/src/conf_mode/host_name.py
@@ -170,7 +170,7 @@ def apply(config):
 
     # restart pdns if it is used
     if os.system("/usr/bin/rec_control ping >/dev/null 2>&1") == 0:
-        os.system("/etc/init.d/pdns-recursor restart >/dev/null")
+        os.system("/bin/systemctl restart pdns-recursor.service >/dev/null")
 
     return None
 


### PR DESCRIPTION
pdns update removed the /etc/init.d script