### PR TITLE
dhcpv6: T2961: support stateless dhcpv6 clients

### DIFF
--- a/data/templates/dhcpv6-server/dhcpdv6.conf.tmpl
+++ b/data/templates/dhcpv6-server/dhcpdv6.conf.tmpl
@@ -12,6 +12,15 @@ option dhcp6.preference {{ preference }};
 {% for network in shared_network %}
 {%- if not network.disabled -%}
 shared-network {{ network.name }} {
+    {%- if network.common.info_refresh_time %}
+    option dhcp6.info-refresh-time {{ network.common.info_refresh_time }};
+    {%- endif %}
+    {%- if network.common.domain_search %}
+    option dhcp6.domain-search "{{ network.common.domain_search | join('", "') }}";
+    {%- endif %}
+    {%- if network.common.dns_server %}
+    option dhcp6.name-servers {{ network.common.dns_server | join(', ') }};
+    {%- endif %}
     {%- for subnet in network.subnet %}
     subnet6 {{ subnet.network }} {
         {%- for range in subnet.range6_prefix %}

--- a/interface-definitions/dhcpv6-server.xml.in
+++ b/interface-definitions/dhcpv6-server.xml.in
@@ -43,6 +43,48 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <node name="common-options">
+                <properties>
+                  <help>Common options to distribute to all clients, including stateless clients</help>
+                </properties>
+                <children>
+                  <leafNode name="info-refresh-time">
+                    <properties>
+                      <help>Time (in seconds) that stateless clients should wait between refreshing the information they were given</help>
+                      <valueHelp>
+                        <format>1-4294967295</format>
+                        <description>DHCPv6 information refresh time</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-4294967295"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="domain-search">
+                    <properties>
+                      <help>Domain name for client to search</help>
+                      <constraint>
+                        <regex>[-_a-zA-Z0-9.]+</regex>
+                      </constraint>
+                      <constraintErrorMessage>Invalid domain name. May only contain letters, numbers and .-_</constraintErrorMessage>
+                      <multi/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="name-server">
+                    <properties>
+                      <help>IPv6 address of a Recursive DNS Server</help>
+                      <valueHelp>
+                        <format>ipv6</format>
+                        <description>IPv6 address of DNS name server</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="ipv6-address"/>
+                      </constraint>
+                      <multi/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
               <tagNode name="subnet">
                 <properties>
                   <help>IPv6 DHCP subnet for this shared network [REQUIRED]</help>


### PR DESCRIPTION
**Task reference:** [T2961](https://phabricator.vyos.net/T2961)

## Description

This pull request adds support for configuring the DHCPv6 server to serve "stateless" DHCPv6 clients (those that send an information-request message and do not request an address).

The change introduces a `common-options` node at the `shared-network-name` level, which allows specifying options applicable to clients regardless of subnet assigned (or in the case of stateless clients, when no subnet is assigned). Parameters specified at the subnet level take precedence over those set at the shared-network level.

Presently, only parameters that are meaningful to stateless clients have been exposed under `common-options`, as there is no precedent of exposing parameters at multiple levels under the current DHCPv4 or DHCPv6 configuration syntax. If desired, additional parameters could certainly be added with relative ease.

## Testing

You can test this PR by using the following example configuration:

```
set service dhcpv6-server shared-network-name LANv6 common-options domain-search 'mydomain.com'
set service dhcpv6-server shared-network-name LANv6 common-options name-server 'fdcc:2200:a8ee:401::1'
set service dhcpv6-server shared-network-name LANv6 subnet fdcc:2200:a8ee:401::0/64
```

This assumes you have an interface on your system with an address in the subnet `fdcc:2200:a8ee:401::0/64` configured on it. The DHCPv6 server will serve info-request messages on any interface that has an address within one of the shared-network's configured subnets.

Well behaved IPv6 hosts will additionally only request DHCPv6 information if the `other-config-flag` is set in the router-advertisement.