### PR TITLE
pdns_recursor: T2964: Expose query-local-address to dns config.

### DIFF
--- a/data/templates/dns-forwarding/recursor.conf.tmpl
+++ b/data/templates/dns-forwarding/recursor.conf.tmpl
@@ -10,8 +10,8 @@ threads=1
 allow-from={{ allow_from | join(',') }}
 log-common-errors=yes
 non-local-bind=yes
-query-local-address=0.0.0.0
-query-local-address6=::
+query-local-address={{ source_address_v4 | join(',') }}
+query-local-address6={{ source_address_v6 | join(',') }}
 lua-config-file=recursor.conf.lua
 
 # cache-size

--- a/interface-definitions/dns-forwarding.xml.in
+++ b/interface-definitions/dns-forwarding.xml.in
@@ -177,6 +177,27 @@
                   </constraint>
                 </properties>
               </leafNode>
+              <leafNode name="source-address">
+                <properties>
+                  <help>Local addresses from which to send DNS queries.
+                If unspecified, the querier will use any available address on
+                the outbound interface.</help>
+                  <valueHelp>
+                    <format>ipv4</format>
+                    <description>IPv4 address from which to send traffic</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ipv6</format>
+                    <description>IPv6 address from which to send traffic</description>
+                  </valueHelp>
+                  <multi/>
+                  <constraint>
+                    <validator name="ipv4-address"/>
+                    <validator name="ipv6-address"/>
+                  </constraint>
+                </properties>
+                <defaultValue>0.0.0.0 ::</defaultValue>
+              </leafNode>
               <leafNode name="system">
                 <properties>
                   <help>Use system name servers</help>


### PR DESCRIPTION
**Task reference:** [T2964](https://phabricator.vyos.net/T2964)

## Description

In certain split DNS configurations, there is a need for more fine-grained control over the local address DNS forwarding uses to issue queries. The current pdns_recursor configuration allows the recursor to send queries from any available address on the interface the OS selects for the query, with no option to limit queries to a particular address or set of addresses.

This commit exposes the `query-local-address` option in `recursor.conf` to users via the `service` `dns` `forwarding` `query-source-address` config node.

If the parameter is unspecified, the default value of 0.0.0.0 (any IPv4 address) and :: (any IPv6 address) are used to match current behavior.

Users who want more control can specify one or more IPv4 and IPv6 addresses to issue queries from. Per pdns_recursor docs, the recursor will load balance queries between any available addresses in the pools. Since IPv4 and IPv6 are different pools, note that specifying only one type of address will disable issuing queries for the other address family.

## Changes

* Added new property `query-source-address` to dns forwarding config mode definiton

## Testing

You can test this PR by using the following example configuration (assuming the router has an IPv4 address of 10.5.1.1 that can be used to reach _some_ resolver):

```
service {
     dns {
         forwarding {
             ...
             query-source-address 10.5.1.1
             query-source-address ::
         }
     }
}
```

## Additional Notes

I have not located an obvious way to set the source address per-downstream resolver (as is possible in dnsmasq, see the ticket). If anyone more familiar knowns of any pdns lua wizardry, I'm all ears.

The current pdns_recursor 4.3.4 distributed with VyOS requires the source addresses to be specified in two different parameters `query-local-address` (for IPv4 addresses) and `query-local-address6` (for IPv6 addresses). The configuration code accommodates this transparently for the user, allowing them to specify both address families in the same `query-source-address` node and appropriately splitting the addresses out into separate entries when rendering the config file.

Release notes indicate starting with pdns_recursor 4.4.0 both address families can be specified in the same `query-local-address` parameter and the `query-local-address6` parameter will be deprecated and removed in 4.5.0. A [comment](https://github.com/vyos/vyos-1x/compare/current...lucasec:dns-source-address?expand=1#diff-8a02a913c1bce8194ca5022936c488b8R72) was added so hopefully someone remembers this when we inevitably upgrade to a newer release.