### PR TITLE
Update search domain error message to match new validation logic

### DIFF
--- a/interface-definitions/include/dhcp-server-domain-search.xml.i
+++ b/interface-definitions/include/dhcp-server-domain-search.xml.i
@@ -5,7 +5,7 @@
     <constraint>
       <validator name="fqdn"/>
     </constraint>
-    <constraintErrorMessage>Invalid domain name (RFC 1123 section 2).\nMay only contain letters, numbers and .-_</constraintErrorMessage>
+     <constraintErrorMessage>Invalid domain name (RFC 1123 section 2).\nMay only contain letters, numbers, period, and underscore.</constraintErrorMessage>
     <multi/>
   </properties>
 </leafNode>


### PR DESCRIPTION
This should match the newer, stricter validation logic that was put in place.

I also converted the file to unix line endings. If we've already long given up hope on having consistent line endings, happy to remove that part in favor of diff readability.