### PR TITLE
Bridge's Priority: T2924: Bridge interface's commit priority is fixed for reboot

### DIFF
--- a/interface-definitions/interfaces-bridge.xml.in
+++ b/interface-definitions/interfaces-bridge.xml.in
@@ -5,7 +5,7 @@
       <tagNode name="bridge" owner="${vyos_conf_scripts_dir}/interfaces-bridge.py">
         <properties>
           <help>Bridge Interface</help>
-          <priority>489</priority>
+          <priority>320</priority>
           <constraint>
             <regex>^br[0-9]+$</regex>
           </constraint>


### PR DESCRIPTION
This change is made in the "interfaces-bridge.xml.in" script where the priority is increased from 489 to 320 so that the bridge interface address could be added before the policy route-map(whose priority is 470) in a single commit.
Before the change was added, using bridge for 'set src' in a route-map invalidates it as part of a subsequent reboot and removes from the running configuration
However, higher priority has completely fixed for the ipv4 address whereas double commit for ipv6 works as a workaround.

```
vyos@vyos# set interfaces bridge br0 address '2001:db8::dead:beef/64'
[edit]
vyos@vyos# set interfaces bridge br0 member interface eth0.15
[edit]
vyos@vyos# set interfaces ethernet eth0 vif 15
[edit]
vyos@vyos# set policy route-map bgp-in rule 10 action 'permit'
[edit]
vyos@vyos# set policy route-map bgp-in rule 10 set src '2001:db8::dead:beef'
[edit]
vyos@vyos# commit
[ policy route-map bgp-in rule 10 set src 2001:db8::dead:beef ]
% not a local address

[[policy route-map bgp-in]] failed
Commit failed
[edit]
vyos@vyos# commit
[edit]

vyos@vyos:~$ sh conf comm | grep bgp-in
set policy route-map bgp-in rule 10 action 'permit'
set policy route-map bgp-in rule 10 set src '2001:db8::dead:beef'
```
