### PR TITLE
conf-mode: T2938: Add format octet-counted for syslog

### DIFF
--- a/data/templates/syslog/rsyslog.conf.tmpl
+++ b/data/templates/syslog/rsyslog.conf.tmpl
@@ -22,19 +22,23 @@ $outchannel {{file}},{{files[file]['log-file']}},{{files[file]['max-size']}},{{f
 {% if hosts %}
 ## remote logging
 {% for host in hosts %}
-{% if hosts[host]['proto'] == 'tcp' %}
-{% if hosts[host]['port'] %}
+{%   if hosts[host]['proto'] == 'tcp' %}
+{%     if hosts[host]['port'] %}
+{%       if hosts[host]['oct_count'] %}
+{{hosts[host]['selectors']}} @@(o){{host}}:{{hosts[host]['port']}};RSYSLOG_SyslogProtocol23Format
+{%       else %}
 {{hosts[host]['selectors']}} @@{{host}}:{{hosts[host]['port']}}
-{% else %}
+{%       endif %}
+{%     else %}
 {{hosts[host]['selectors']}} @@{{host}}
-{% endif %}
-{% else %}
-{% if hosts[host]['port'] %}
+{%     endif %}
+{%   else %}
+{%     if hosts[host]['port'] %}
 {{hosts[host]['selectors']}} @{{host}}:{{hosts[host]['port']}}
-{% else %}
+{%     else %}
 {{hosts[host]['selectors']}} @{{host}}
-{% endif %}
-{% endif %}
+{%     endif %}
+{%   endif %}
 {% endfor %}
 {% endif %}
 {% if user %}

--- a/interface-definitions/system-syslog.xml.in
+++ b/interface-definitions/system-syslog.xml.in
@@ -382,6 +382,19 @@
                   </leafNode>
                 </children>
               </tagNode>
+              <node name="format">
+                <properties>
+                  <help>Logging format</help>
+                </properties>
+                <children>
+                  <leafNode name="octet-counted">
+                    <properties>
+                      <help>Allows for the transmission of all characters inside a syslog message</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
             </children>
           </tagNode>
           <node name="global">

--- a/src/conf_mode/system-syslog.py
+++ b/src/conf_mode/system-syslog.py
@@ -146,6 +146,12 @@ def get_config(config=None):
                 config_data['hosts'][rhost][
                     'port'] = c.return_value(['host', rhost, 'port'])
 
+            # set system syslog host x.x.x.x format octet-counted
+            if c.exists('host ' + rhost + ' format octet-counted'):
+                config_data['hosts'][rhost]['oct_count'] = True
+            else:
+                config_data['hosts'][rhost]['oct_count'] = False
+
     # set system syslog user
     if c.exists('user'):
         usrs = c.list_nodes('user')


### PR DESCRIPTION
Add octet-counted option for syslog.
RFC5424 
option: RSYSLOG_SyslogProtocol23Format