### PR TITLE
op-mode: lldp: T2993: Fix 'show lldp neighbors'

### DIFF
--- a/src/op_mode/lldp_op.py
+++ b/src/op_mode/lldp_op.py
@@ -47,32 +47,31 @@ def get_neighbors():
 
 def parse_data(data):
     output = []
-    for tmp in data:
-        for local_if, values in tmp.items():
-            for chassis, c_value in values.get('chassis', {}).items():
-                capabilities = c_value['capability']
-                if isinstance(capabilities, dict):
-                    capabilities = [capabilities]
+    for local_if, values in data.items():
+        for chassis, c_value in values.get('chassis', {}).items():
+            capabilities = c_value['capability']
+            if isinstance(capabilities, dict):
+                capabilities = [capabilities]
 
-                cap = ''
-                for capability in capabilities:
-                    if capability['enabled']:
-                        if capability['type'] == 'Router':
-                            cap += 'R'
-                        if capability['type'] == 'Bridge':
-                            cap += 'B'
-                        if capability['type'] == 'Wlan':
-                            cap += 'W'
-                        if capability['type'] == 'Station':
-                            cap += 'S'
-                        if capability['type'] == 'Repeater':
-                            cap += 'r'
-                        if capability['type'] == 'Telephone':
-                            cap += 'T'
-                        if capability['type'] == 'Docsis':
-                            cap += 'D'
-                        if capability['type'] == 'Other':
-                            cap += 'O'
+            cap = ''
+            for capability in capabilities:
+                if capability['enabled']:
+                    if capability['type'] == 'Router':
+                        cap += 'R'
+                    if capability['type'] == 'Bridge':
+                        cap += 'B'
+                    if capability['type'] == 'Wlan':
+                        cap += 'W'
+                    if capability['type'] == 'Station':
+                        cap += 'S'
+                    if capability['type'] == 'Repeater':
+                        cap += 'r'
+                    if capability['type'] == 'Telephone':
+                        cap += 'T'
+                    if capability['type'] == 'Docsis':
+                        cap += 'D'
+                    if capability['type'] == 'Other':
+                        cap += 'O'
 
 
         remote_if = 'Unknown'
@@ -109,10 +108,9 @@ if __name__ == '__main__':
         if args.all:
             neighbors = tmp['lldp']['interface']
         elif args.interface:
-            neighbors = []
-            for neighbor in tmp['lldp']['interface']:
-                if args.interface in neighbor:
-                    neighbors.append(neighbor)
+            neighbors = dict()
+            if args.interface in tmp['lldp']['interface']:
+                neighbors[args.interface] = tmp['lldp']['interface'][args.interface]
 
     else:
         parser.print_help()


### PR DESCRIPTION
'show lldp neighbors' fails with:

Traceback (most recent call last):
  File "./lldp_op.py", line 122, in <module>
    config_text = tmpl.render(parse_data(neighbors))
  File "./lldp_op.py", line 51, in parse_data
    for local_if, values in tmp.items():
AttributeError: 'str' object has no attribute 'items'

`parse_data` was expecting data to be provided as a dict within an array
which doesn't match the format from the parsed json output of lldpcli.

Change `parse_data` and `main` to use a dict alone for passing interface
neighbors for rendering.