### PR TITLE
op-mode: lldp: T2993: Fixup 'show lldp neighbors'

### DIFF
--- a/src/op_mode/lldp_op.py
+++ b/src/op_mode/lldp_op.py
@@ -104,13 +104,14 @@ if __name__ == '__main__':
         exit(0)
     elif args.all or args.interface:
         tmp = json.loads(get_neighbors())
+        neighbors = dict()
 
-        if args.all:
-            neighbors = tmp['lldp']['interface']
-        elif args.interface:
-            neighbors = dict()
-            if args.interface in tmp['lldp']['interface']:
-                neighbors[args.interface] = tmp['lldp']['interface'][args.interface]
+        if 'interface' in tmp.get('lldp'):
+            if args.all:
+                neighbors = tmp['lldp']['interface']
+            elif args.interface:
+                if args.interface in tmp['lldp']['interface']:
+                    neighbors[args.interface] = tmp['lldp']['interface'][args.interface]
 
     else:
         parser.print_help()


### PR DESCRIPTION
Add additional check that interfaces have been returned from lldpcli to prevent trace when no interfaces are enabled for LLDP or there are no neighbors present.