### PR TITLE
smoketest: T3003: extend framework to load arbitrary config file

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -97,6 +97,10 @@ override_dh_auto_install:
 	mkdir -p $(DIR)/$(VYOS_LIBEXEC_DIR)/tests/smoke/
 	cp -r smoketest/scripts/* $(DIR)/$(VYOS_LIBEXEC_DIR)/tests/smoke
 
+	# Install smoke test configs
+	mkdir -p $(DIR)/$(VYOS_LIBEXEC_DIR)/tests/config/
+	cp -r smoketest/configs/* $(DIR)/$(VYOS_LIBEXEC_DIR)/tests/config
+
 	# Install system programs
 	mkdir -p $(DIR)/$(VYOS_BIN_DIR)
 	cp -r smoketest/bin/* $(DIR)/$(VYOS_BIN_DIR)

--- a/debian/vyos-1x-smoketest.install
+++ b/debian/vyos-1x-smoketest.install
@@ -1,2 +1,4 @@
 usr/bin/vyos-smoketest
+usr/bin/vyos-configtest
 usr/libexec/vyos/tests/smoke
+usr/libexec/vyos/tests/config

--- a/smoketest/bin/vyos-configtest
+++ b/smoketest/bin/vyos-configtest
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2020 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import time
+import logging
+import unittest
+
+from vyos.configsession import ConfigSession, ConfigSessionError
+from vyos import ConfigError
+
+config_dir = '/usr/libexec/vyos/tests/config'
+save_config = '/tmp/vyos-configtest-save'
+
+class DynamicClassBase(unittest.TestCase):
+    def setUp(self):
+        self._start_time = time.time()
+        self.session = ConfigSession(os.getpid())
+        self.session.save_config(save_config)
+
+    def tearDown(self):
+        self.session.migrate_and_load_config(save_config)
+        self.session.commit()
+        log.info(f" time: {time.time() - self._start_time:.3f}")
+        del self.session
+        try:
+            os.remove(save_config)
+        except OSError:
+            pass
+
+def make_test_function(filename):
+    def test_config_load(self):
+        config_path = os.path.join(config_dir, filename)
+        self.session.migrate_and_load_config(config_path)
+        try:
+            self.session.commit()
+        except (ConfigError, ConfigSessionError):
+            self.session.discard()
+            self.fail()
+    return test_config_load
+
+def class_name_from_func_name(s):
+    res = ''.join(str.capitalize(x) for x in s.split('_'))
+    return res
+
+if __name__ == '__main__':
+    logging.basicConfig(stream=sys.stdout, level=logging.DEBUG,
+                        format='%(message)s')
+    log = logging.getLogger("TestConfigLog")
+
+    start_time = time.time()
+    log.info("Generating tests")
+
+    (_, _, config_list) = next(iter(os.walk(config_dir)))
+    config_list.sort()
+
+    for config in config_list:
+        test_func = make_test_function(config)
+
+        func_name = config.replace('-', '_')
+        klassname = f'TestConfig{class_name_from_func_name(func_name)}'
+        globals()[klassname] = type(klassname,
+                                    (DynamicClassBase,),
+                                    {f'test_{func_name}': test_func})
+
+    log.info(f"... completed: {time.time() - start_time:.6f}")
+
+    unittest.main(verbosity=2)

--- a/smoketest/configs/pppoe-client
+++ b/smoketest/configs/pppoe-client
@@ -1,0 +1,62 @@
+interfaces {
+    ethernet eth0 {
+    }
+    loopback lo {
+    }
+    pppoe pppoe0 {
+        authentication {
+            password bar
+            user foo
+        }
+        connect-on-demand
+        default-route auto
+        mtu 1492
+        source-interface eth0
+    }
+}
+service {
+    ssh {
+    }
+}
+system {
+    config-management {
+        commit-revisions 100
+    }
+    console {
+        device ttyS0 {
+            speed 115200
+        }
+    }
+    host-name vyos
+    login {
+        user vyos {
+            authentication {
+                encrypted-password $6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/
+                plaintext-password ""
+            }
+        }
+    }
+    ntp {
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level info
+            }
+            facility protocols {
+                level debug
+            }
+        }
+    }
+}
+
+
+// Warning: Do not remove the following line.
+// vyos-config-version: "broadcast-relay@1:cluster@1:config-management@1:conntrack@1:conntrack-sync@1:dhcp-relay@2:dhcp-server@5:dhcpv6-server@1:dns-forwarding@3:firewall@5:https@2:interfaces@13:ipoe-server@1:ipsec@5:l2tp@3:lldp@1:mdns@1:nat@5:ntp@1:pppoe-server@5:pptp@2:qos@1:quagga@6:salt@1:snmp@2:ssh@2:sstp@3:system@19:vrrp@2:vyos-accel-ppp@2:wanloadbalance@3:webgui@1:webproxy@2:zone-policy@1"
+// Release version: 1.3-rolling-202010241631

--- a/smoketest/configs/pppoe-server
+++ b/smoketest/configs/pppoe-server
@@ -1,0 +1,94 @@
+interfaces {
+    ethernet eth0 {
+        address dhcp
+    }
+    ethernet eth1 {
+        address 192.168.0.1/24
+    }
+    ethernet eth2 {
+    }
+    loopback lo {
+    }
+}
+nat {
+    source {
+        rule 100 {
+            outbound-interface eth0
+            source {
+                address 192.168.0.0/24
+            }
+            translation {
+                address masquerade
+            }
+        }
+    }
+}
+service {
+    pppoe-server {
+        access-concentrator ACN
+        authentication {
+            local-users {
+                username foo {
+                    password bar
+                    rate-limit {
+                        download 20480
+                        upload 10240
+                    }
+                }
+            }
+            mode local
+        }
+        client-ip-pool {
+            start 192.168.0.100
+            stop 192.168.0.200
+        }
+        gateway-address 192.168.0.2
+        interface eth2 {
+        }
+        name-server 192.168.0.1
+    }
+    ssh {
+    }
+}
+system {
+    config-management {
+        commit-revisions 100
+    }
+    console {
+        device ttyS0 {
+            speed 115200
+        }
+    }
+    host-name vyos
+    login {
+        user vyos {
+            authentication {
+                encrypted-password $6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0
+                plaintext-password ""
+            }
+        }
+    }
+    ntp {
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level info
+            }
+            facility protocols {
+                level debug
+            }
+        }
+    }
+}
+
+
+// Warning: Do not remove the following line.
+// vyos-config-version: "broadcast-relay@1:cluster@1:config-management@1:conntrack@1:conntrack-sync@1:dhcp-relay@2:dhcp-server@5:dhcpv6-server@1:dns-forwarding@3:firewall@5:https@2:interfaces@13:ipoe-server@1:ipsec@5:l2tp@3:lldp@1:mdns@1:nat@5:ntp@1:pppoe-server@5:pptp@2:qos@1:quagga@6:salt@1:snmp@2:ssh@2:sstp@3:system@19:vrrp@2:vyos-accel-ppp@2:wanloadbalance@3:webgui@1:webproxy@2:zone-policy@1"
+// Release version: 1.3-rolling-202010260127


### PR DESCRIPTION
vyos-configtest generates unittest test classes for each config file in /usr/libexec/vyos/tests/config, and runs the respective test functions; this is integrated into scripts/check-qemu-install in PR129 for vyos-build. Example configs for pppoe-client/server are added here.