### PR TITLE
mpls-conf: T915: Separate IPv4 and IPv6 hello timers, add IPv6 timers

### DIFF
--- a/data/templates/frr/ldpd.frr.tmpl
+++ b/data/templates/frr/ldpd.frr.tmpl
@@ -13,6 +13,7 @@ no neighbor {{neighbor_id}} password {{old_ldp.neighbors[neighbor_id].password}}
 {% for neighbor_id in ldp.neighbors -%}
 neighbor {{neighbor_id}} password {{ldp.neighbors[neighbor_id].password}}
 {% endfor -%}
+!
 address-family ipv4
 label local allocate host-routes
 {% if old_ldp.export_ipv4_exp -%}
@@ -27,20 +28,20 @@ no discovery transport-address {{ old_ldp.d_transp_ipv4 }}
 {% if ldp.d_transp_ipv4 -%}
 discovery transport-address {{ ldp.d_transp_ipv4 }}
 {% endif -%}
-{% if old_ldp.hello_holdtime -%}
-no  discovery hello holdtime {{ old_ldp.hello_holdtime }}
+{% if old_ldp.hello_ipv4_holdtime -%}
+no discovery hello holdtime {{ old_ldp.hello_ipv4_holdtime }}
 {% endif -%}
-{% if ldp.hello_holdtime -%}
-discovery hello holdtime {{ ldp.hello_holdtime }}
+{% if ldp.hello_ipv4_holdtime -%}
+discovery hello holdtime {{ ldp.hello_ipv4_holdtime }}
 {% endif -%}
-{% if old_ldp.hello_interval -%}
-no discovery hello interval {{ old_ldp.hello_interval }}
+{% if old_ldp.hello_ipv4_interval -%}
+no discovery hello interval {{ old_ldp.hello_ipv4_interval }}
 {% endif -%}
-{% if ldp.hello_interval -%}
-discovery hello interval {{ ldp.hello_interval }}
+{% if ldp.hello_ipv4_interval -%}
+discovery hello interval {{ ldp.hello_ipv4_interval }}
 {% endif -%}
 {% if old_ldp.ses_ipv4_hold -%}
-no  session holdtime {{ old_ldp.ses_ipv4_hold }}
+no session holdtime {{ old_ldp.ses_ipv4_hold }}
 {% endif -%}
 {% if ldp.ses_ipv4_hold -%}
 session holdtime {{ ldp.ses_ipv4_hold }}
@@ -65,7 +66,7 @@ no label local advertise explicit-null
 label local advertise explicit-null
 {% endif -%}
 {% if old_ldp.ses_ipv6_hold -%}
-no  session holdtime {{ old_ldp.ses_ipv6_hold }}
+no session holdtime {{ old_ldp.ses_ipv6_hold }}
 {% endif -%}
 {% if ldp.ses_ipv6_hold -%}
 session holdtime {{ ldp.ses_ipv6_hold }}
@@ -75,6 +76,18 @@ no discovery transport-address {{ old_ldp.d_transp_ipv6 }}
 {% endif -%}
 {% if ldp.d_transp_ipv6 -%}
 discovery transport-address {{ ldp.d_transp_ipv6 }}
+{% endif -%}
+{% if old_ldp.hello_ipv6_holdtime -%}
+no discovery hello holdtime {{ old_ldp.hello_ipv6_holdtime }}
+{% endif -%}
+{% if ldp.hello_ipv6_holdtime -%}
+discovery hello holdtime {{ ldp.hello_ipv6_holdtime }}
+{% endif -%}
+{% if old_ldp.hello_ipv6_interval -%}
+no discovery hello interval {{ old_ldp.hello_ipv6_interval }}
+{% endif -%}
+{% if ldp.hello_ipv6_interval -%}
+discovery hello interval {{ ldp.hello_ipv6_interval }}
 {% endif -%}
 {% for interface in old_ldp.interfaces -%}
 no interface {{interface}}

--- a/interface-definitions/protocols-mpls.xml.in
+++ b/interface-definitions/protocols-mpls.xml.in
@@ -54,9 +54,9 @@
                   </valueHelp>
                 </properties>
                 <children>
-                  <leafNode name="hello-holdtime">
+                  <leafNode name="hello-ipv4-holdtime">
                     <properties>
-                      <help>Hello holdtime</help>
+                      <help>Hello ipv4 holdtime</help>
                       <valueHelp>
                         <format>1-65535</format>
                         <description>Time in seconds</description>
@@ -66,9 +66,33 @@
                       </constraint>
                     </properties>
                   </leafNode>
-                  <leafNode name="hello-interval">
+                  <leafNode name="hello-ipv4-interval">
                     <properties>
-                      <help>Hello interval</help>
+                      <help>Hello ipv4 interval</help>
+                      <valueHelp>
+                        <format>1-65535</format>
+                        <description>Time in seconds</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-65535"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="hello-ipv6-holdtime">
+                    <properties>
+                      <help>Hello ipv6 holdtime</help>
+                      <valueHelp>
+                        <format>1-65535</format>
+                        <description>Time in seconds</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-65535"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="hello-ipv6-interval">
+                    <properties>
+                      <help>Hello ipv6 interval</help>
                       <valueHelp>
                         <format>1-65535</format>
                         <description>Time in seconds</description>

--- a/src/conf_mode/protocols_mpls.py
+++ b/src/conf_mode/protocols_mpls.py
@@ -38,30 +38,32 @@ def get_config(config=None):
         'router_id'  : None,
         'mpls_ldp'   : False,
         'old_ldp'    : {
-                'interfaces'          : [],
-                'neighbors'           : {},
-                'd_transp_ipv4'       : None,
-                'd_transp_ipv6'       : None,
-                'hello_holdtime'      : None,
-                'hello_interval'      : None,
-                'ses_ipv4_hold'       : None,
-                'ses_ipv6_hold'       : None,
-                'export_ipv4_exp'     : False,
-                'export_ipv6_exp'     : False
-
+                'interfaces'               : [],
+                'neighbors'                : {},
+                'd_transp_ipv4'            : None,
+                'd_transp_ipv6'            : None,
+                'hello_ipv4_holdtime'      : None,
+                'hello_ipv4_interval'      : None,
+                'hello_ipv6_holdtime'      : None,
+                'hello_ipv6_interval'      : None,
+                'ses_ipv4_hold'            : None,
+                'ses_ipv6_hold'            : None,
+                'export_ipv4_exp'          : False,
+                'export_ipv6_exp'          : False
         },
         'ldp'        : {
-                'interfaces'          : [],
-                'neighbors'           : {},
-                'd_transp_ipv4'       : None,
-                'd_transp_ipv6'       : None,
-                'hello_holdtime'      : None,
-                'hello_interval'      : None,
-                'ses_ipv4_hold'       : None,
-                'ses_ipv6_hold'       : None,
-                'export_ipv4_exp'     : False,
-                'export_ipv6_exp'     : False
-
+                'interfaces'               : [],
+                'neighbors'                : {},
+                'd_transp_ipv4'            : None,
+                'd_transp_ipv6'            : None,
+                'hello_ipv4_holdtime'      : None,
+                'hello_ipv4_interval'      : None,
+                'hello_ipv6_holdtime'      : None,
+                'hello_ipv6_interval'      : None,
+                'ses_ipv4_hold'            : None,
+                'ses_ipv6_hold'            : None,
+                'export_ipv4_exp'          : False,
+                'export_ipv6_exp'          : False
         }
     }
     if not (conf.exists('protocols mpls') or conf.exists_effective('protocols mpls')):
@@ -78,19 +80,33 @@ def get_config(config=None):
     if conf.exists('router-id'):
         mpls_conf['router_id'] = conf.return_value('router-id')
 
-    # Get hello holdtime
-    if conf.exists_effective('discovery hello-holdtime'):
-        mpls_conf['old_ldp']['hello_holdtime'] = conf.return_effective_value('discovery hello-holdtime')
+    # Get hello-ipv4-holdtime
+    if conf.exists_effective('discovery hello-ipv4-holdtime'):
+        mpls_conf['old_ldp']['hello_ipv4_holdtime'] = conf.return_effective_value('discovery hello-ipv4-holdtime')
 
-    if conf.exists('discovery hello-holdtime'):
-        mpls_conf['ldp']['hello_holdtime'] = conf.return_value('discovery hello-holdtime')
+    if conf.exists('discovery hello-ipv4-holdtime'):
+        mpls_conf['ldp']['hello_ipv4_holdtime'] = conf.return_value('discovery hello-ipv4-holdtime')
 
-    # Get hello interval
-    if conf.exists_effective('discovery hello-interval'):
-        mpls_conf['old_ldp']['hello_interval'] = conf.return_effective_value('discovery hello-interval')
+    # Get hello-ipv4-interval
+    if conf.exists_effective('discovery hello-ipv4-interval'):
+        mpls_conf['old_ldp']['hello_ipv4_interval'] = conf.return_effective_value('discovery hello-ipv4-interval')
 
-    if conf.exists('discovery hello-interval'):
-        mpls_conf['ldp']['hello_interval'] = conf.return_value('discovery hello-interval')
+    if conf.exists('discovery hello-ipv4-interval'):
+        mpls_conf['ldp']['hello_ipv4_interval'] = conf.return_value('discovery hello-ipv4-interval')
+        
+    # Get hello-ipv6-holdtime
+    if conf.exists_effective('discovery hello-ipv6-holdtime'):
+        mpls_conf['old_ldp']['hello_ipv6_holdtime'] = conf.return_effective_value('discovery hello-ipv6-holdtime')
+
+    if conf.exists('discovery hello-ipv6-holdtime'):
+        mpls_conf['ldp']['hello_ipv6_holdtime'] = conf.return_value('discovery hello-ipv6-holdtime')
+
+    # Get hello-ipv6-interval
+    if conf.exists_effective('discovery hello-ipv6-interval'):
+        mpls_conf['old_ldp']['hello_ipv6_interval'] = conf.return_effective_value('discovery hello-ipv6-interval')
+
+    if conf.exists('discovery hello-ipv6-interval'):
+        mpls_conf['ldp']['hello_ipv6_interval'] = conf.return_value('discovery hello-ipv6-interval')
 
     # Get session-ipv4-holdtime
     if conf.exists_effective('discovery session-ipv4-holdtime'):


### PR DESCRIPTION
The commit has to do with separating the hello/hold timers from being only IPv4 to being both IPv4 and IPv6.

I renamed the existing hello and hold timers with an "-ipv4" and added ones that were "-ipv6". I did verify that the commands properly commit under FRR as well. I also added some room on the protocols_mpls.py file for the different variables as it seems we're might end up having longer names. Removed some spaces that I found too that weren't needed on ldpd.frr.tmpl as well.