### PR TITLE
T3029 Correct generated nginx content

### DIFF
--- a/data/templates/https/nginx.default.tmpl
+++ b/data/templates/https/nginx.default.tmpl
@@ -5,7 +5,7 @@ server {
         listen 80 default_server;
         listen [::]:80 default_server;
         server_name _;
-        return 301 https://$server_name$request_uri;
+        return 301 https://$host$request_uri;
 }
 
 {% for server in server_block_list %}


### PR DESCRIPTION
The redirection was using the wrong variable ($server_name),
making the browser going to https://_ instead of the right
variable.