### PR TITLE
mpls-conf: T915: Add TTL security for static LDP neighbors

### DIFF
--- a/data/templates/frr/ldpd.frr.tmpl
+++ b/data/templates/frr/ldpd.frr.tmpl
@@ -9,9 +9,23 @@ router-id {{ router_id }}
 {% endif -%}
 {% for neighbor_id in old_ldp.neighbors -%}
 no neighbor {{neighbor_id}} password {{old_ldp.neighbors[neighbor_id].password}}
+{% if 'ttl_security' is defined -%}
+{%   if 'disable' in old_ldp.neighbors[neighbor_id].ttl_security %}
+no neighbor {{neighbor_id}} ttl-security disable
+{%   else -%}
+no neighbor {{neighbor_id}} ttl-security hops {{old_ldp.neighbors[neighbor_id].ttl_security}}
+{%   endif -%}
+{% endif -%}
 {% endfor -%}
 {% for neighbor_id in ldp.neighbors -%}
 neighbor {{neighbor_id}} password {{ldp.neighbors[neighbor_id].password}}
+{% if 'ttl_security' is defined -%}
+{%   if 'disable' in ldp.neighbors[neighbor_id].ttl_security %}
+neighbor {{neighbor_id}} ttl-security disable
+{%   else -%}
+neighbor {{neighbor_id}} ttl-security hops {{ldp.neighbors[neighbor_id].ttl_security}}
+{%   endif -%}
+{% endif -%}
 {% endfor -%}
 !
 address-family ipv4

--- a/interface-definitions/protocols-mpls.xml.in
+++ b/interface-definitions/protocols-mpls.xml.in
@@ -43,6 +43,22 @@
                       <help>Peer password</help>
                     </properties>
                   </leafNode>
+                  <leafNode name="ttl-security">
+                    <properties>
+                      <help>Neighbor TTL security</help>
+                      <completionHelp>
+                        <list>disable</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>&lt;1-254&gt;</format>
+                        <description>TTL</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>disable</format>
+                        <description>Disable neighbor TTL security</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
                 </children>
               </tagNode>
               <node name="discovery">

--- a/src/conf_mode/protocols_mpls.py
+++ b/src/conf_mode/protocols_mpls.py
@@ -161,14 +161,16 @@ def get_config(config=None):
     for neighbor in conf.list_effective_nodes('neighbor'):
         mpls_conf['old_ldp']['neighbors'].update({
             neighbor : {
-                'password' : conf.return_effective_value('neighbor {0} password'.format(neighbor))
+                'password' : conf.return_effective_value('neighbor {0} password'.format(neighbor), default=''),
+                'ttl_security' : conf.return_effective_value('neighbor {0} ttl-security'.format(neighbor), default=''),
             }
         })
 
     for neighbor in conf.list_nodes('neighbor'):
         mpls_conf['ldp']['neighbors'].update({
             neighbor : {
-                'password' : conf.return_value('neighbor {0} password'.format(neighbor))
+                'password' : conf.return_value('neighbor {0} password'.format(neighbor), default=''),
+                'ttl_security' : conf.return_value('neighbor {0} ttl-security'.format(neighbor), default=''),
             }
         })
 


### PR DESCRIPTION
The commit has to do with the addition of TTL security for LDP neighbors. The code was 90% done by Viascheslav. I modified it a little bit to get it to properly work.

We added more parameters to the neighbors loop. Once this is merged then we should be able to add more for the static neighbor statements.

The way that this works is to have either TTL disabled, or to add the amount of hops accepted for the neighbor.