### PR TITLE
mpls-conf: T915: Add session hold time adjustment for LDP neighbors

### DIFF
--- a/data/templates/frr/ldpd.frr.tmpl
+++ b/data/templates/frr/ldpd.frr.tmpl
@@ -16,6 +16,9 @@ no neighbor {{neighbor_id}} ttl-security disable
 no neighbor {{neighbor_id}} ttl-security hops {{old_ldp.neighbors[neighbor_id].ttl_security}}
 {%   endif -%}
 {% endif -%}
+{% if 'session_holdtime' is defined -%}
+no neighbor {{neighbor_id}} session holdtime {{old_ldp.neighbors[neighbor_id].session_holdtime}}
+{% endif -%}
 {% endfor -%}
 {% for neighbor_id in ldp.neighbors -%}
 neighbor {{neighbor_id}} password {{ldp.neighbors[neighbor_id].password}}
@@ -25,6 +28,9 @@ neighbor {{neighbor_id}} ttl-security disable
 {%   else -%}
 neighbor {{neighbor_id}} ttl-security hops {{ldp.neighbors[neighbor_id].ttl_security}}
 {%   endif -%}
+{% endif -%}
+{% if 'session_holdtime' is defined -%}
+neighbor {{neighbor_id}} session holdtime {{ldp.neighbors[neighbor_id].session_holdtime}}
 {% endif -%}
 {% endfor -%}
 !

--- a/interface-definitions/protocols-mpls.xml.in
+++ b/interface-definitions/protocols-mpls.xml.in
@@ -59,6 +59,18 @@
                       </valueHelp>
                     </properties>
                   </leafNode>
+                  <leafNode name="session-holdtime">
+                    <properties>
+                      <help>Session ipv4 holdtime</help>
+                      <valueHelp>
+                        <format>15-65535</format>
+                        <description>Time in seconds</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 15-65535"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
                 </children>
               </tagNode>
               <node name="discovery">

--- a/src/conf_mode/protocols_mpls.py
+++ b/src/conf_mode/protocols_mpls.py
@@ -163,6 +163,7 @@ def get_config(config=None):
             neighbor : {
                 'password' : conf.return_effective_value('neighbor {0} password'.format(neighbor), default=''),
                 'ttl_security' : conf.return_effective_value('neighbor {0} ttl-security'.format(neighbor), default=''),
+                'session_holdtime' : conf.return_effective_value('neighbor {0} session-holdtime'.format(neighbor), default='')
             }
         })
 
@@ -171,6 +172,7 @@ def get_config(config=None):
             neighbor : {
                 'password' : conf.return_value('neighbor {0} password'.format(neighbor), default=''),
                 'ttl_security' : conf.return_value('neighbor {0} ttl-security'.format(neighbor), default=''),
+                'session_holdtime' : conf.return_value('neighbor {0} session-holdtime'.format(neighbor), default='')
             }
         })
 


### PR DESCRIPTION
The commit has to do with the addition of session hold time parameter for LDP neighbors. This allows for being able to change said hold time on a static neighbor.

The way that this works is to have it either delegated to a value (15-65535), or to just be default to whatever FRR stipulates or per the other session configuration values.

I opted to remove the "-ipv4-" only because we know it's an IPv4 session that one has to create first. I figure it's redundant to add it there so I removed it.