### PR TITLE
mpls-conf: T915: Add targeted LDP neighbors with parameters

### DIFF
--- a/data/templates/frr/ldpd.frr.tmpl
+++ b/data/templates/frr/ldpd.frr.tmpl
@@ -66,6 +66,30 @@ no session holdtime {{ old_ldp.ses_ipv4_hold }}
 {% if ldp.ses_ipv4_hold -%}
 session holdtime {{ ldp.ses_ipv4_hold }}
 {% endif -%}
+{% if old_ldp.target_ipv4_enable -%}
+no discovery targeted-hello accept
+{% endif -%}
+{% if ldp.target_ipv4_enable -%}
+discovery targeted-hello accept
+{% endif -%}
+{% if old_ldp.target_ipv4_hello_int -%}
+no discovery targeted-hello interval {{ old_ldp.target_ipv4_hello_int }}
+{% endif -%}
+{% if ldp.target_ipv4_hello_int -%}
+discovery targeted-hello interval {{ ldp.target_ipv4_hello_int }}
+{% endif -%}
+{% if old_ldp.target_ipv4_hello_hold -%}
+no discovery targeted-hello holdtime {{ old_ldp.target_ipv4_hello_hold }}
+{% endif -%}
+{% if ldp.target_ipv4_hello_hold -%}
+discovery targeted-hello holdtime {{ ldp.target_ipv4_hello_hold }}
+{% endif -%}
+{% for address in old_ldp.target_ipv4_addresses -%}
+no neighbor {{address}} targeted 
+{% endfor -%}
+{% for address in ldp.target_ipv4_addresses -%}
+neighbor {{address}} targeted 
+{% endfor -%}
 {% for interface in old_ldp.interfaces -%}
 no interface {{interface}}
 {% endfor -%}
@@ -109,6 +133,30 @@ no discovery hello interval {{ old_ldp.hello_ipv6_interval }}
 {% if ldp.hello_ipv6_interval -%}
 discovery hello interval {{ ldp.hello_ipv6_interval }}
 {% endif -%}
+{% if old_ldp.target_ipv6_enable -%}
+no discovery targeted-hello accept
+{% endif -%}
+{% if ldp.target_ipv6_enable -%}
+discovery targeted-hello accept
+{% endif -%}
+{% if old_ldp.target_ipv6_hello_int -%}
+no discovery targeted-hello interval {{ old_ldp.target_ipv6_hello_int }}
+{% endif -%}
+{% if ldp.target_ipv6_hello_int -%}
+discovery targeted-hello interval {{ ldp.target_ipv6_hello_int }}
+{% endif -%}
+{% if old_ldp.target_ipv6_hello_hold -%}
+no discovery targeted-hello holdtime {{ old_ldp.target_ipv6_hello_hold }}
+{% endif -%}
+{% if ldp.target_ipv6_hello_hold -%}
+discovery targeted-hello holdtime {{ ldp.target_ipv6_hello_hold }}
+{% endif -%}
+{% for address in old_ldp.target_ipv6_addresses -%}
+no neighbor {{address}} targeted 
+{% endfor -%}
+{% for address in ldp.target_ipv6_addresses -%}
+neighbor {{address}} targeted 
+{% endfor -%}
 {% for interface in old_ldp.interfaces -%}
 no interface {{interface}}
 {% endfor -%}

--- a/interface-definitions/protocols-mpls.xml.in
+++ b/interface-definitions/protocols-mpls.xml.in
@@ -180,6 +180,113 @@
                   </leafNode>
                 </children>
               </node>
+              <node name="targeted-neighbor">
+                <properties>
+                  <help>Targeted LDP neighbor/session parameters</help>
+                </properties>
+                <children>
+                  <node name="ipv4">
+                    <properties>
+                      <help>Targeted IPv4 neighbor/session parameters</help>
+                    </properties>
+                    <children>
+                      <leafNode name="address">
+                        <properties>
+                          <help>Neighbor/session address</help>
+                          <valueHelp>
+                            <format>ipv4</format>
+                            <description>Neighbor/session address</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="ipv4-address"/>
+                          </constraint>
+                          <multi/>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="enable">
+                        <properties>
+                          <help>Accept and respond to targeted hellos</help>
+                          <valueless/>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="hello-interval">
+                        <properties>
+                          <help>Hello interval</help>
+                          <valueHelp>
+                            <format>1-65535</format>
+                            <description>Time in seconds</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-65535"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="hello-holdtime">
+                        <properties>
+                          <help>Hello holdtime</help>
+                          <valueHelp>
+                            <format>1-65535</format>
+                            <description>Time in seconds</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-65535"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </node>
+                  <node name="ipv6">
+                    <properties>
+                      <help>Targeted IPv6 neighbor/session parameters</help>
+                    </properties>
+                    <children>
+                      <leafNode name="address">
+                        <properties>
+                          <help>Neighbor/session address</help>
+                          <valueHelp>
+                            <format>ipv6</format>
+                            <description>Neighbor/session address</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="ipv6-address"/>
+                          </constraint>
+                          <multi/>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="enable">
+                        <properties>
+                          <help>Accept and respond to targeted hellos</help>
+                          <valueless/>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="hello-interval">
+                        <properties>
+                          <help>Hello interval</help>
+                          <valueHelp>
+                            <format>1-65535</format>
+                            <description>Time in seconds</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-65535"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="hello-holdtime">
+                        <properties>
+                          <help>Hello holdtime</help>
+                          <valueHelp>
+                            <format>1-65535</format>
+                            <description>Time in seconds</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-65535"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </node>
+                </children>
+              </node>
               <node name="export">
                 <properties>
                   <help>Export parameters</help>

--- a/src/conf_mode/protocols_mpls.py
+++ b/src/conf_mode/protocols_mpls.py
@@ -38,32 +38,48 @@ def get_config(config=None):
         'router_id'  : None,
         'mpls_ldp'   : False,
         'old_ldp'    : {
-                'interfaces'               : [],
-                'neighbors'                : {},
-                'd_transp_ipv4'            : None,
-                'd_transp_ipv6'            : None,
-                'hello_ipv4_holdtime'      : None,
-                'hello_ipv4_interval'      : None,
-                'hello_ipv6_holdtime'      : None,
-                'hello_ipv6_interval'      : None,
-                'ses_ipv4_hold'            : None,
-                'ses_ipv6_hold'            : None,
-                'export_ipv4_exp'          : False,
-                'export_ipv6_exp'          : False
+                'interfaces'                  : [],
+                'neighbors'                   : {},
+                'd_transp_ipv4'               : None,
+                'd_transp_ipv6'               : None,
+                'hello_ipv4_holdtime'         : None,
+                'hello_ipv4_interval'         : None,
+                'hello_ipv6_holdtime'         : None,
+                'hello_ipv6_interval'         : None,
+                'ses_ipv4_hold'               : None,
+                'ses_ipv6_hold'               : None,
+                'export_ipv4_exp'             : False,
+                'export_ipv6_exp'             : False,
+                'target_ipv4_addresses'       : [],
+                'target_ipv6_addresses'       : [],
+                'target_ipv4_enable'          : False,
+                'target_ipv6_enable'          : False,
+                'target_ipv4_hello_int'       : None,
+                'target_ipv6_hello_int'       : None,
+                'target_ipv4_hello_hold'      : None,
+                'target_ipv6_hello_hold'      : None
         },
         'ldp'        : {
-                'interfaces'               : [],
-                'neighbors'                : {},
-                'd_transp_ipv4'            : None,
-                'd_transp_ipv6'            : None,
-                'hello_ipv4_holdtime'      : None,
-                'hello_ipv4_interval'      : None,
-                'hello_ipv6_holdtime'      : None,
-                'hello_ipv6_interval'      : None,
-                'ses_ipv4_hold'            : None,
-                'ses_ipv6_hold'            : None,
-                'export_ipv4_exp'          : False,
-                'export_ipv6_exp'          : False
+                'interfaces'                  : [],
+                'neighbors'                   : {},
+                'd_transp_ipv4'               : None,
+                'd_transp_ipv6'               : None,
+                'hello_ipv4_holdtime'         : None,
+                'hello_ipv4_interval'         : None,
+                'hello_ipv6_holdtime'         : None,
+                'hello_ipv6_interval'         : None,
+                'ses_ipv4_hold'               : None,
+                'ses_ipv6_hold'               : None,
+                'export_ipv4_exp'             : False,
+                'export_ipv6_exp'             : False,
+                'target_ipv4_addresses'       : [],
+                'target_ipv6_addresses'       : [],
+                'target_ipv4_enable'          : False,
+                'target_ipv6_enable'          : False,
+                'target_ipv4_hello_int'       : None,
+                'target_ipv6_hello_int'       : None,
+                'target_ipv4_hello_hold'      : None,
+                'target_ipv6_hello_hold'      : None
         }
     }
     if not (conf.exists('protocols mpls') or conf.exists_effective('protocols mpls')):
@@ -149,6 +165,62 @@ def get_config(config=None):
 
     if conf.exists('export ipv6 explicit-null'):
         mpls_conf['ldp']['export_ipv6_exp'] = True
+
+    # Get target_ipv4_addresses
+    if conf.exists_effective('targeted-neighbor ipv4 address'):
+        mpls_conf['old_ldp']['target_ipv4_addresses'] = conf.return_effective_values('targeted-neighbor ipv4 address')
+
+    if conf.exists('targeted-neighbor ipv4 address'):
+        mpls_conf['ldp']['target_ipv4_addresses'] = conf.return_values('targeted-neighbor ipv4 address')
+
+    # Get target_ipv4_enable
+    if conf.exists_effective('targeted-neighbor ipv4 enable'):
+        mpls_conf['old_ldp']['target_ipv4_enable'] = True
+
+    if conf.exists('targeted-neighbor ipv4 enable'):
+        mpls_conf['ldp']['target_ipv4_enable'] = True
+
+    # Get target_ipv4_hello_int
+    if conf.exists_effective('targeted-neighbor ipv4 hello-interval'):
+        mpls_conf['old_ldp']['target_ipv4_hello_int'] = conf.return_effective_value('targeted-neighbor ipv4 hello-interval')
+
+    if conf.exists('targeted-neighbor ipv4 hello-interval'):
+        mpls_conf['ldp']['target_ipv4_hello_int'] = conf.return_value('targeted-neighbor ipv4 hello-interval')
+
+    # Get target_ipv4_hello_hold
+    if conf.exists_effective('targeted-neighbor ipv4 hello-holdtime'):
+        mpls_conf['old_ldp']['target_ipv4_hello_hold'] = conf.return_effective_value('targeted-neighbor ipv4 hello-holdtime')
+
+    if conf.exists('targeted-neighbor ipv4 hello-holdtime'):
+        mpls_conf['ldp']['target_ipv4_hello_hold'] = conf.return_value('targeted-neighbor ipv4 hello-holdtime')
+
+    # Get target_ipv6_addresses
+    if conf.exists_effective('targeted-neighbor ipv6 address'):
+        mpls_conf['old_ldp']['target_ipv6_addresses'] = conf.return_effective_values('targeted-neighbor ipv6 address')
+
+    if conf.exists('targeted-neighbor ipv6 address'):
+       mpls_conf['ldp']['target_ipv6_addresses'] = conf.return_values('targeted-neighbor ipv6 address')
+
+    # Get target_ipv6_enable
+    if conf.exists_effective('targeted-neighbor ipv6 enable'):
+        mpls_conf['old_ldp']['target_ipv6_enable'] = True
+
+    if conf.exists('targeted-neighbor ipv6 enable'):
+        mpls_conf['ldp']['target_ipv6_enable'] = True
+
+    # Get target_ipv6_hello_int
+    if conf.exists_effective('targeted-neighbor ipv6 hello-interval'):
+        mpls_conf['old_ldp']['target_ipv6_hello_int'] = conf.return_effective_value('targeted-neighbor ipv6 hello-interval')
+
+    if conf.exists('targeted-neighbor ipv6 hello-interval'):
+        mpls_conf['ldp']['target_ipv6_hello_int'] = conf.return_value('targeted-neighbor ipv6 hello-interval')
+
+    # Get target_ipv6_hello_hold
+    if conf.exists_effective('targeted-neighbor ipv6 hello-holdtime'):
+        mpls_conf['old_ldp']['target_ipv6_hello_hold'] = conf.return_effective_value('targeted-neighbor ipv6 hello-holdtime')
+
+    if conf.exists('targeted-neighbor ipv6 hello-holdtime'):
+        mpls_conf['ldp']['target_ipv6_hello_hold'] = conf.return_value('targeted-neighbor ipv6 hello-holdtime')
 
     # Get interfaces
     if conf.exists_effective('interface'):


### PR DESCRIPTION
The commit has to do with the addition of targeted LDP neighbors and parameters being added. FRR allows for this functionality and I just wanted to add it.

We have basically 4 options that are added. Enabling targeted LDP functionality, the targeted neighbor, the hello interval of targeted sessions, and the hold time of targeted sessions.  Both IPv4 and IPv6 has been coded in.