### PR TITLE
 mpls-conf: T915: Add MPLS misc parameters, add LDP misc parameters

### DIFF
--- a/data/templates/frr/ldpd.frr.tmpl
+++ b/data/templates/frr/ldpd.frr.tmpl
@@ -7,6 +7,18 @@ no router-id {{ old_router_id }}
 {% if router_id -%}
 router-id {{ router_id }}
 {% endif -%}
+{% if old_ldp.cisco_interop_tlv -%}
+no dual-stack cisco-interop
+{% endif -%}
+{% if ldp.cisco_interop_tlv -%}
+dual-stack cisco-interop
+{% endif -%}
+{% if old_ldp.transport_prefer_ipv4 -%}
+no dual-stack transport-connection prefer ipv4
+{% endif -%}
+{% if ldp.transport_prefer_ipv4 -%}
+dual-stack transport-connection prefer ipv4
+{% endif -%}
 {% for neighbor_id in old_ldp.neighbors -%}
 no neighbor {{neighbor_id}} password {{old_ldp.neighbors[neighbor_id].password}}
 {% if 'ttl_security' is defined -%}

--- a/interface-definitions/protocols-mpls.xml.in
+++ b/interface-definitions/protocols-mpls.xml.in
@@ -11,15 +11,15 @@
         <children>
           <node name="ldp">
             <properties>
-              <help>LDP options</help>
+              <help>Label Distribution Protocol (LDP)</help>
             </properties>
             <children>
               <leafNode name="router-id">
                 <properties>
-                  <help>x.x.x.x Label Switch Router (LSR) id</help>
+                  <help>Label Distribution Protocol (LDP) router ID</help>
                   <valueHelp>
                     <format>ipv4</format>
-                    <description>LSR ipv4 id</description>
+                    <description>LDP IPv4 ID</description>
                   </valueHelp>
                   <constraint>
                     <validator name="ipv4-address"/>
@@ -28,10 +28,10 @@
               </leafNode>
               <tagNode name="neighbor">
                 <properties>
-                  <help>LDP Id of neighbor</help>
+                  <help>LDP neighbor parameters</help>
                   <valueHelp>
                     <format>ipv4</format>
-                    <description>neighbor IPv4 id</description>
+                    <description>Neighbor IPv4 address</description>
                   </valueHelp>
                   <constraint>
                     <validator name="ipv4-address"/>
@@ -40,7 +40,7 @@
                 <children>
                   <leafNode name="password">
                     <properties>
-                      <help>Peer password</help>
+                      <help>Neighbor password</help>
                     </properties>
                   </leafNode>
                   <leafNode name="ttl-security">
@@ -61,7 +61,7 @@
                   </leafNode>
                   <leafNode name="session-holdtime">
                     <properties>
-                      <help>Session ipv4 holdtime</help>
+                      <help>Session IPv4 hold time</help>
                       <valueHelp>
                         <format>15-65535</format>
                         <description>Time in seconds</description>
@@ -84,7 +84,7 @@
                 <children>
                   <leafNode name="hello-ipv4-holdtime">
                     <properties>
-                      <help>Hello ipv4 holdtime</help>
+                      <help>Hello IPv4 hold time</help>
                       <valueHelp>
                         <format>1-65535</format>
                         <description>Time in seconds</description>
@@ -96,7 +96,7 @@
                   </leafNode>
                   <leafNode name="hello-ipv4-interval">
                     <properties>
-                      <help>Hello ipv4 interval</help>
+                      <help>Hello IPv4 interval</help>
                       <valueHelp>
                         <format>1-65535</format>
                         <description>Time in seconds</description>
@@ -108,7 +108,7 @@
                   </leafNode>
                   <leafNode name="hello-ipv6-holdtime">
                     <properties>
-                      <help>Hello ipv6 holdtime</help>
+                      <help>Hello IPv6 hold time</help>
                       <valueHelp>
                         <format>1-65535</format>
                         <description>Time in seconds</description>
@@ -120,7 +120,7 @@
                   </leafNode>
                   <leafNode name="hello-ipv6-interval">
                     <properties>
-                      <help>Hello ipv6 interval</help>
+                      <help>Hello IPv6 interval</help>
                       <valueHelp>
                         <format>1-65535</format>
                         <description>Time in seconds</description>
@@ -132,7 +132,7 @@
                   </leafNode>
                   <leafNode name="session-ipv4-holdtime">
                     <properties>
-                      <help>Session ipv4 holdtime</help>
+                      <help>Session IPv4 hold time</help>
                       <valueHelp>
                         <format>15-65535</format>
                         <description>Time in seconds</description>
@@ -144,7 +144,7 @@
                   </leafNode>
                   <leafNode name="session-ipv6-holdtime">
                     <properties>
-                      <help>Session ipv6 holdtime</help>
+                      <help>Session IPv6 hold time</help>
                       <valueHelp>
                         <format>15-65535</format>
                         <description>Time in seconds</description>
@@ -156,7 +156,7 @@
                   </leafNode>
                   <leafNode name="transport-ipv4-address">
                     <properties>
-                      <help>Transport ipv4 address</help>
+                      <help>Transport IPv4 address</help>
                       <valueHelp>
                         <format>ipv4</format>
                         <description>IPv4 bind as transport</description>
@@ -168,7 +168,7 @@
                   </leafNode>
                   <leafNode name="transport-ipv6-address">
                     <properties>
-                      <help>Transport ipv6 address</help>
+                      <help>Transport IPv6 address</help>
                       <valueHelp>
                         <format>ipv6</format>
                         <description>IPv6 bind as transport</description>
@@ -223,7 +223,7 @@
                       </leafNode>
                       <leafNode name="hello-holdtime">
                         <properties>
-                          <help>Hello holdtime</help>
+                          <help>Hello hold time</help>
                           <valueHelp>
                             <format>1-65535</format>
                             <description>Time in seconds</description>
@@ -273,7 +273,7 @@
                       </leafNode>
                       <leafNode name="hello-holdtime">
                         <properties>
-                          <help>Hello holdtime</help>
+                          <help>Hello hold time</help>
                           <valueHelp>
                             <format>1-65535</format>
                             <description>Time in seconds</description>
@@ -285,6 +285,25 @@
                       </leafNode>
                     </children>
                   </node>
+                </children>
+              </node>
+              <node name="parameters">
+                <properties>
+                  <help>Label Distribution Protocol (LDP) miscellaneous parameters</help>
+                </properties>
+                <children>
+                  <leafNode name="cisco-interop-tlv">
+                    <properties>
+                      <help>Enable Cisco non-compliant format capability TLV</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="transport-prefer-ipv4">
+                    <properties>
+                      <help>Prefer IPv4 for TCP peer transport connection</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
                 </children>
               </node>
               <node name="export">
@@ -322,11 +341,36 @@
               </node>
               <leafNode name="interface">
                 <properties>
-                  <help>Listen interface for LDP</help>
+                  <help>Enable LDP and neighbor discovery on interface</help>
                   <completionHelp>
                     <script>${vyos_completion_dir}/list_interfaces.py</script>
                   </completionHelp>
                   <multi/>
+                </properties>
+              </leafNode>
+            </children>
+          </node>
+          <node name="parameters">
+            <properties>
+              <help>Multiprotocol Label Switching (MPLS) miscellaneous parameters</help>
+            </properties>
+            <children>
+              <leafNode name="no-propagate-ttl">
+                <properties>
+                  <help>Disable copy of IP TTL to MPLS TTL</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="maximum-ttl">
+                <properties>
+                  <help>Maximum TTL for MPLS packets</help>
+                  <valueHelp>
+                    <format>1-255</format>
+                    <description>Maximum hops allowed</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 1-255"/>
+                  </constraint>
                 </properties>
               </leafNode>
             </children>

--- a/src/conf_mode/protocols_mpls.py
+++ b/src/conf_mode/protocols_mpls.py
@@ -37,6 +37,14 @@ def get_config(config=None):
     mpls_conf = {
         'router_id'  : None,
         'mpls_ldp'   : False,
+        'old_parameters' : {
+                'no-ttl-propagation'          : False,
+                'maximum_ttl'                 : None
+        },
+        'parameters' : {
+                'no-ttl-propagation'          : False,
+                'maximum_ttl'                 : None
+        },
         'old_ldp'    : {
                 'interfaces'                  : [],
                 'neighbors'                   : {},
@@ -50,6 +58,8 @@ def get_config(config=None):
                 'ses_ipv6_hold'               : None,
                 'export_ipv4_exp'             : False,
                 'export_ipv6_exp'             : False,
+                'cisco_interop_tlv'           : False,
+                'transport_prefer_ipv4'       : False,
                 'target_ipv4_addresses'       : [],
                 'target_ipv6_addresses'       : [],
                 'target_ipv4_enable'          : False,
@@ -72,6 +82,8 @@ def get_config(config=None):
                 'ses_ipv6_hold'               : None,
                 'export_ipv4_exp'             : False,
                 'export_ipv6_exp'             : False,
+                'cisco_interop_tlv'           : False,
+                'transport_prefer_ipv4'       : False,
                 'target_ipv4_addresses'       : [],
                 'target_ipv6_addresses'       : [],
                 'target_ipv4_enable'          : False,
@@ -84,15 +96,35 @@ def get_config(config=None):
     }
     if not (conf.exists('protocols mpls') or conf.exists_effective('protocols mpls')):
         return None
-
+    
+    # If LDP is defined then enable LDP portion of code
     if conf.exists('protocols mpls ldp'):
         mpls_conf['mpls_ldp'] = True
 
+    # Set to MPLS hierarchy configuration level
+    conf.set_level('protocols mpls')
+        
+    # Get no-ttl-propagation
+    if conf.exists_effective('parameters no-propagate-ttl'):
+        mpls_conf['old_parameters']['no-ttl-propagation'] = True
+
+    if conf.exists('parameters no-propagate-ttl'):
+        mpls_conf['parameters']['no-ttl-propagation'] = True
+
+    # Get maximum_ttl
+    if conf.exists_effective('parameters maximum-ttl'):
+        mpls_conf['old_parameters']['maximum_ttl'] = conf.return_effective_value('parameters maximum-ttl')
+
+    if conf.exists('parameters maximum-ttl'):
+        mpls_conf['parameters']['maximum_ttl'] = conf.return_value('parameters maximum-ttl')
+
+    # Set to LDP hierarchy configuration level
     conf.set_level('protocols mpls ldp')
 
     # Get router-id
     if conf.exists_effective('router-id'):
         mpls_conf['old_router_id'] = conf.return_effective_value('router-id')
+        
     if conf.exists('router-id'):
         mpls_conf['router_id'] = conf.return_value('router-id')
 
@@ -222,6 +254,20 @@ def get_config(config=None):
     if conf.exists('targeted-neighbor ipv6 hello-holdtime'):
         mpls_conf['ldp']['target_ipv6_hello_hold'] = conf.return_value('targeted-neighbor ipv6 hello-holdtime')
 
+    # Get parameters cisco-interop-tlv
+    if conf.exists_effective('parameters cisco-interop-tlv'):
+        mpls_conf['old_ldp']['cisco_interop_tlv'] = True
+
+    if conf.exists('parameters cisco-interop-tlv'):
+        mpls_conf['ldp']['cisco_interop_tlv'] = True
+
+    # Get parameters transport-prefer-ipv4
+    if conf.exists_effective('parameters transport-prefer-ipv4'):
+        mpls_conf['old_ldp']['transport_prefer_ipv4'] = True
+
+    if conf.exists('parameters transport-prefer-ipv4'):
+        mpls_conf['ldp']['transport_prefer_ipv4'] = True
+
     # Get interfaces
     if conf.exists_effective('interface'):
         mpls_conf['old_ldp']['interfaces'] = conf.return_effective_values('interface')
@@ -264,15 +310,15 @@ def verify(mpls):
         return None
 
     if mpls['mpls_ldp']:
-        # Requre router-id
+        # Require router-id
         if not mpls['router_id']:
             raise ConfigError(f"MPLS ldp router-id is mandatory!")
 
-        # Requre discovery transport-address
+        # Require discovery transport-address
         if not mpls['ldp']['d_transp_ipv4'] and not mpls['ldp']['d_transp_ipv6']:
             raise ConfigError(f"MPLS ldp discovery transport address is mandatory!")
 
-        # Requre interface
+        # Require interface
         if not mpls['ldp']['interfaces']:
             raise ConfigError(f"MPLS ldp interface is mandatory!")
 
@@ -287,15 +333,24 @@ def apply(mpls):
     if mpls is None:
         return None
 
-     # Set number of entries in the platform label table
+    # Set number of entries in the platform label table
     if mpls['mpls_ldp']:
         sysctl('net.mpls.platform_labels', '1048575')
     else:
         sysctl('net.mpls.platform_labels', '0')
 
-    # Do not copy IP TTL to MPLS header
-    sysctl('net.mpls.ip_ttl_propagate', '0')
-
+    # Choose whether to copy IP TTL to MPLS header TTL
+    if mpls['parameters']['no-ttl-propagation']:
+        sysctl('net.mpls.ip_ttl_propagate', '0')
+    else:
+        sysctl('net.mpls.ip_ttl_propagate', '1')
+        
+    # Choose whether to limit maximum MPLS header TTL
+    if mpls['parameters']['maximum_ttl']:
+        sysctl('net.mpls.default_ttl', '%s' %(mpls['parameters']['maximum_ttl']))
+    else:
+        sysctl('net.mpls.default_ttl', '255')    
+    
     # Allow mpls on interfaces
     operate_mpls_on_intfc(mpls['ldp']['interfaces'], 1)
 

--- a/src/conf_mode/protocols_mpls.py
+++ b/src/conf_mode/protocols_mpls.py
@@ -38,11 +38,11 @@ def get_config(config=None):
         'router_id'  : None,
         'mpls_ldp'   : False,
         'old_parameters' : {
-                'no-ttl-propagation'          : False,
+                'no_ttl_propagation'          : False,
                 'maximum_ttl'                 : None
         },
         'parameters' : {
-                'no-ttl-propagation'          : False,
+                'no_ttl_propagation'          : False,
                 'maximum_ttl'                 : None
         },
         'old_ldp'    : {
@@ -104,12 +104,12 @@ def get_config(config=None):
     # Set to MPLS hierarchy configuration level
     conf.set_level('protocols mpls')
         
-    # Get no-ttl-propagation
+    # Get no_ttl_propagation
     if conf.exists_effective('parameters no-propagate-ttl'):
-        mpls_conf['old_parameters']['no-ttl-propagation'] = True
+        mpls_conf['old_parameters']['no_ttl_propagation'] = True
 
     if conf.exists('parameters no-propagate-ttl'):
-        mpls_conf['parameters']['no-ttl-propagation'] = True
+        mpls_conf['parameters']['no_ttl_propagation'] = True
 
     # Get maximum_ttl
     if conf.exists_effective('parameters maximum-ttl'):
@@ -340,7 +340,7 @@ def apply(mpls):
         sysctl('net.mpls.platform_labels', '0')
 
     # Choose whether to copy IP TTL to MPLS header TTL
-    if mpls['parameters']['no-ttl-propagation']:
+    if mpls['parameters']['no_ttl_propagation']:
         sysctl('net.mpls.ip_ttl_propagate', '0')
     else:
         sysctl('net.mpls.ip_ttl_propagate', '1')


### PR DESCRIPTION
This commit has to do with the addition of miscellaneous MPLS parameters, as well as miscellaneous LDP parameters. Per c-po, for miscellaneous options and whatnot that do not fit anywhere we will put them into a specific "parameters" node.

I also did some global linux kernel configuration changes here. Changes to kernel options "net.mpls.ip_ttl_propagate" and "net.mpls.default_ttl" which should allow the behavior of VyOS to have the same as routers from the big vendors. I made a global change here as well. Originally net.mpls.ip_ttl_propagate was set to 0. This goes against what MPLS router vendors usually have configured. Router vendors by default have net.mpls.ip_ttl_propagate set to 1. So therefore I made it 1 by default with the option of going to 0 per a configuration option.

I added two LDP options for cisco interoperation TLV and for a dual stack preference.

Lastly, I went through and changed some of the help/description fields in the definitions page because I just felt they weren't uniform and the words seemed to not properly explain what they were doing. I also did some code clean up (or tried to...) with comments and whatnot.

Please let me know what you guys think.

Thank you