### PR TITLE
bgp-new: T2174: Fix abbility to del global route-map param

### DIFF
--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -32,8 +32,13 @@ def get_config():
     conf = Config()
     base = ['protocols', 'nbgp']
     bgp = conf.get_config_dict(base, key_mangling=('-', '_'))
+
     if not conf.exists(base):
         bgp = {}
+        call('vtysh -c \"conf t\" -c \"no ip protocol bgp\" ')
+
+    if not conf.exists(base + ['route-map']):
+        call('vtysh -c \"conf t\" -c \"no ip protocol bgp\" ')
 
     from pprint import pprint
     pprint(bgp)


### PR DESCRIPTION
Ability to delete FRR global parameter "route-map".
I have to use this ugly trick for now, because it located not in "router bgp" configuration.

```if not conf.exists(base + ['route-map']):```

```
set policy route-map RMAP rule 10 action 'permit'
set protocols nbgp 65001 neighbor 203.0.113.2 remote-as '65002'
set protocols nbgp 65001 route-map 'RMAP'
```
In that config route-map applied in the FRR, not in the "router bgp" section 
```
!
router bgp 65001
 no bgp default ipv4-unicast
 neighbor 203.0.113.2 remote-as 65002
!
ip protocol bgp route-map RMAP
!

```

Another option, it replaces this command from section bgp, because it related to "zebra" daemon
from
```set protocols nbgp 65001 route-map 'RMAP'``` 
to
```set policy import bgp route-map RMAP```

