### PR TITLE
bridge: T3042: Fix VLAN filter invalid work

### DIFF
--- a/interface-definitions/interfaces-bridge.xml.in
+++ b/interface-definitions/interfaces-bridge.xml.in
@@ -40,6 +40,7 @@
           #include <include/interface-disable-link-detect.xml.i>
           #include <include/interface-disable.xml.i>
           #include <include/interface-vrf.xml.i>
+          #include <include/interface-mtu-68-16000.xml.i>
           <leafNode name="forwarding-delay">
             <properties>
               <help>Forwarding delay</help>

--- a/python/vyos/ifconfig/bridge.py
+++ b/python/vyos/ifconfig/bridge.py
@@ -317,6 +317,13 @@ class BridgeIf(Interface):
                         cmd = f'bridge vlan add dev {interface} vid {vlan} master'
                         self._cmd(cmd)
         
+        
+        vif = dict_search('vif', config)
+        if vif:
+            for vlan_id,vif_config in vif.items():
+                cmd = f'bridge vlan add dev {ifname} vid {vlan_id} self master'
+                self._cmd(cmd)
+        
         # enable/disable Vlan Filter
         self.set_vlan_filter(vlan_filter)
                         


### PR DESCRIPTION
1. Due to the previous focus on the implementation of VLAN filter, it was not considered to include MTU settings, which will lead to MTU setting errors in some cases
2. In order to make VLAN aware of the work of the bridge, it is necessary to specify the allowed VLAN ID range for the bridge itself, and forget to join it before