### PR TITLE
bridge: T3042: Better fix implementation errors

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_bridge.py
+++ b/smoketest/scripts/cli/test_interfaces_bridge.py
@@ -87,7 +87,7 @@ class BridgeInterfaceTest(BasicInterfaceTest.BaseTest):
         """ Add member interface to bridge and set VLAN filter """
         for interface in self._interfaces:
             base = self._base_path + [interface]
-            self.session.set(base + ['address', '192.0.2.1/24'])
+            self.session.set(base + ['vif', '1','address', '192.0.2.1/24'])
             self.session.set(base + ['vif', '2','address','192.0.3.1/24'])
 
             vlan_id = 101


### PR DESCRIPTION
In #601, I provided a basic patch. Under this patch, I rely on vif to
detect the vlan id range that the bridge should flow through,
which may lead to greater redundancy in the configuration,
 so I am considering detecting effective vlan filters In setting the range
 of vlan id that is required to flow through the bridge,
I use `set()` to complete the deduplication of this vlan id
and set it to the bridge uniformly (at the same time,
 I slightly modified the smoke test script)