### PR TITLE
openvpn: T3060: Remote-host is a required param for client

### DIFF
--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -320,7 +320,7 @@ def verify(openvpn):
         if 'local_port' in openvpn:
             raise ConfigError('Cannot specify "local-port" with "tcp-active"')
 
-        if 'remote_host' in openvpn:
+        if 'remote_host' not in openvpn:
             raise ConfigError('Must specify "remote-host" with "tcp-active"')
 
     # shared secret and TLS


### PR DESCRIPTION
Fixing the "remote-host" is a required parameter for the client-side.

Without it we get commit failed
It was before rewriting https://github.com/vyos/vyos-1x/blob/b2c61e2127d83cc0a0e27092462b62c2e8e7eaa1/src/conf_mode/interfaces-openvpn.py#L860-L861

```
vyos@r4-roll# commit
[ interfaces openvpn vtun10 ]
{'auth_user_pass_file': '/run/openvpn/vtun10.pw',
 'daemon_group': 'openvpn',
 'daemon_user': 'openvpn',
 'device_type': 'tun',
 'encryption': {'cipher': 'aes256gcm', 'disable_ncp': {}},
 'hash': 'sha512',
 'ifname': 'vtun10',
 'keep_alive': {'failure_count': '60', 'interval': '10'},
 'mode': 'client',
 'persistent_tunnel': {},
 'protocol': 'tcp-active',
 'remote_host': ['100.64.0.1'],
 'remote_port': '1194',
 'server': {'topology': 'net30'},
 'tls': {'ca_cert_file': '/config/auth/ovpn/ca.crt',
         'cert_file': '/config/auth/ovpn/branch1.crt',
         'key_file': '/config/auth/ovpn/branch1.key'},
 'use_lzo_compression': {}}
Must specify "remote-host" with "tcp-active"

[[interfaces openvpn vtun10]] failed
Commit failed
[edit]
vyos@r4-roll# 

```