### PR TITLE
Revert "T3068: Automatic generation of IPv6 link local addresses for tunnel interfaces"

### DIFF
--- a/python/vyos/ifconfig/tunnel.py
+++ b/python/vyos/ifconfig/tunnel.py
@@ -22,10 +22,6 @@ from vyos.ifconfig.interface import Interface
 from vyos.ifconfig.afi import IP4, IP6
 from vyos.validate import assert_list
 
-import random
-from random import seed, getrandbits
-from ipaddress import IPv6Network, IPv6Address
-
 def enable_to_on(value):
     if value == 'enable':
         return 'on'
@@ -126,16 +122,6 @@ class _Tunnel(Interface):
     @classmethod
     def get_config(cls):
         return dict(zip(cls.options, ['']*len(cls.options)))
-        
-    def generate_link_local():
-        # Linux Kernel does not generate IPv6 Link Local address do to missing MAC
-        # We have to generate address manually and assign to interface
-        net = IPv6Network("FE80::/16")
-        rand_net = IPv6Network((net.network_address + (random.getrandbits(64 - net.prefixlen) << 64 ),64))
-        network = IPv6Network(rand_net)
-        address = str(IPv6Address(network.network_address + getrandbits(network.max_prefixlen - network.prefixlen)))+'/'+str(network.prefixlen)
-        
-        return address
 
 
 class GREIf(_Tunnel):
@@ -168,12 +154,6 @@ class GREIf(_Tunnel):
     create = 'ip tunnel add {ifname} mode {type}'
     change = 'ip tunnel cha {ifname}'
     delete = 'ip tunnel del {ifname}'
-    
-    
-    def _create(self):
-        super()._create(self)
-        # Assign generated IPv6 Link Local address to the interface
-        self.add_addr(self.generate_link_local())
 
 
 # GreTap also called GRE Bridge
@@ -239,11 +219,6 @@ class IP6GREIf(_Tunnel):
     # sudo ip tunnel cha tun100 local: : 2
     # Error: an IP address is expected rather than "::2"
     # works if mode is explicit
-    
-    def _create(self):
-        super()._create(self)
-        # Assign generated IPv6 Link Local address to the interface
-        self.add_addr(self.generate_link_local())
 
 
 class IPIPIf(_Tunnel):
@@ -295,11 +270,6 @@ class IPIP6If(_Tunnel):
     create = 'ip -6 tunnel add {ifname} mode {type}'
     change = 'ip -6 tunnel cha {ifname}'
     delete = 'ip -6 tunnel del {ifname}'
-    
-    def _create(self):
-        super()._create(self)
-        # Assign generated IPv6 Link Local address to the interface
-        self.add_addr(self.generate_link_local())
 
 
 class IP6IP6If(IPIP6If):
@@ -313,11 +283,6 @@ class IP6IP6If(IPIP6If):
     ip = [IP6,]
 
     default = {'type': 'ip6ip6'}
-    
-    def _create(self):
-        super()._create(self)
-        # Assign generated IPv6 Link Local address to the interface
-        self.add_addr(self.generate_link_local())
 
 
 class SitIf(_Tunnel):
@@ -341,11 +306,6 @@ class SitIf(_Tunnel):
     create = 'ip tunnel add {ifname} mode {type}'
     change = 'ip tunnel cha {ifname}'
     delete = 'ip tunnel del {ifname}'
-    
-    def _create(self):
-        super()._create(self)
-        # Assign generated IPv6 Link Local address to the interface
-        self.add_addr(self.generate_link_local())
 
 
 class Sit6RDIf(SitIf):


### PR DESCRIPTION
Reverts vyos/vyos-1x#603

Jenkins smoketests do not run to completion, see PR message for error(s).