### PR TITLE
frr-isis: T1316: Add new routing feature ISIS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,6 @@ interface_definitions: $(BUILD_DIR) $(obj)
 	rm -f $(TMPL_DIR)/interfaces/wirelessmodem/node.tag/ipv6/node.def
 	rm -f $(TMPL_DIR)/protocols/node.def
 	rm -rf $(TMPL_DIR)/protocols/nbgp
-	rm -rf $(TMPL_DIR)/protocols/isis
 	rm -f $(TMPL_DIR)/protocols/static/node.def
 	rm -f $(TMPL_DIR)/system/node.def
 	rm -f $(TMPL_DIR)/vpn/node.def

--- a/interface-definitions/protocols-isis.xml.in
+++ b/interface-definitions/protocols-isis.xml.in
@@ -5,7 +5,7 @@
     <children>
       <tagNode name="isis" owner="${vyos_conf_scripts_dir}/protocols_isis.py">
         <properties>
-          <help>Intermediate System to Intermediate System (ISIS)</help>
+          <help>Intermediate System to Intermediate System (IS-IS)</help>
           <valueHelp>
             <format>text(TAG)</format>
             <description>ISO Routing area tag</description>
@@ -264,7 +264,7 @@
                   </node>
                   <node name="connected">
                     <properties>
-                      <help>Redistribute connected routes into ISIS</help>
+                      <help>Redistribute connected routes into IS-IS</help>
                     </properties>
                     <children>
                       #include <include/isis-redistribute-ipv4.xml.i>
@@ -272,7 +272,7 @@
                   </node>
                   <node name="kernel">
                     <properties>
-                      <help>Redistribute kernel routes into ISIS</help>
+                      <help>Redistribute kernel routes into IS-IS</help>
                     </properties>
                     <children>
                       #include <include/isis-redistribute-ipv4.xml.i>
@@ -280,7 +280,7 @@
                   </node>
                   <node name="ospf">
                     <properties>
-                      <help>Redistribute OSPF routes into ISIS</help>
+                      <help>Redistribute OSPF routes into IS-IS</help>
                     </properties>
                     <children>
                       #include <include/isis-redistribute-ipv4.xml.i>
@@ -288,7 +288,7 @@
                   </node>
                   <node name="rip">
                     <properties>
-                      <help>Redistribute RIP routes into ISIS</help>
+                      <help>Redistribute RIP routes into IS-IS</help>
                     </properties>
                     <children>
                       #include <include/isis-redistribute-ipv4.xml.i>
@@ -296,7 +296,7 @@
                   </node>
                   <node name="static">
                     <properties>
-                      <help>Redistribute static routes into ISIS</help>
+                      <help>Redistribute static routes into IS-IS</help>
                     </properties>
                     <children>
                       #include <include/isis-redistribute-ipv4.xml.i>

--- a/op-mode-definitions/show-ip-route.xml
+++ b/op-mode-definitions/show-ip-route.xml
@@ -55,6 +55,12 @@
                 </properties>
                 <command>ip -s route list $5</command>
               </tagNode>
+              <leafNode name="isis">
+                <properties>
+                  <help>Show IP IS-IS routes</help>
+                </properties>
+                <command>/usr/bin/vtysh -c "show ip route isis"</command>
+              </leafNode>
               <leafNode name="kernel">
                 <properties>
                   <help>Show IP kernel routes</help>

--- a/src/conf_mode/protocols_isis.py
+++ b/src/conf_mode/protocols_isis.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2017-2020 VyOS maintainers and contributors
+# Copyright (C) 2020 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -106,9 +106,6 @@ def generate(isis):
     process = list(isis.keys())[0]
     isis[process]['process'] = process
 
-    import pprint
-    pprint.pprint(isis[process])
-
     # render(config) not needed, its only for debug
     render(config_file, 'frr/isis.frr.tmpl', isis[process], trim_blocks=True)
 
@@ -122,15 +119,16 @@ def apply(isis):
     # Save original configration prior to starting any commit actions
     frr_cfg = {}
     frr_cfg['original_config'] = frr.get_configuration(daemon='isisd')
-    frr_cfg['modified_config'] = frr.replace_section(frr_cfg['original_config'], isis['new_frr_config'], from_re='router isis .*')
+    frr_cfg['modified_config'] = frr.replace_section(frr_cfg['original_config'], isis['new_frr_config'], from_re='interface .*')
 
     # Debugging
+    '''
     print('')
     print('--------- DEBUGGING ----------')
     print(f'Existing config:\n{frr_cfg["original_config"]}\n\n')
     print(f'Replacement config:\n{isis["new_frr_config"]}\n\n')
     print(f'Modified config:\n{frr_cfg["modified_config"]}\n\n')
-
+   '''
     # FRR mark configuration will test for syntax errors and throws an
     # exception if any syntax errors is detected
     frr.mark_configuration(frr_cfg['modified_config'])


### PR DESCRIPTION
Add ISIS routing feature

```
set protocols isis FOO interface eth1
set protocols isis FOO net '49.0000.0000.0000.0001.00'
set protocols isis FOO redistribute ipv4 connected level-2

```
```
vyos@r4-roll# run show ip route isis
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route, q - queued route, r - rejected route

I   100.64.0.0/24 [115/20] via 100.64.0.1, eth1 inactive, 00:06:07
I>* 100.64.222.0/24 [115/65] via 100.64.0.1, eth1, 00:06:07
I   192.168.122.0/24 [115/10] via 100.64.0.1, eth1, 00:06:07
I>* 203.0.113.0/24 [115/65] via 100.64.0.1, eth1, 00:06:07

```
