### PR TITLE
bridge:T3067: Fix VLAN aware setting failure under WLAN

### DIFF
--- a/python/vyos/ifconfig/bridge.py
+++ b/python/vyos/ifconfig/bridge.py
@@ -309,15 +309,12 @@ class BridgeIf(Interface):
                     vlan_filter = 1
                     cmd = f'bridge vlan del dev {interface} vid 1'
                     self._cmd(cmd)
-                    vlan_del.add(1)
                     vlan_id = interface_config['native_vlan']
+                    if vlan_id != 1:
+                        vlan_del.add(1)
                     cmd = f'bridge vlan add dev {interface} vid {vlan_id} pvid untagged master'
                     self._cmd(cmd)
                     vlan_add.add(vlan_id)
-                else:
-                    cmd = f'bridge vlan del dev {interface} vid 1'
-                    self._cmd(cmd)
-                    vlan_del.add(1)
                 
                 if 'allowed_vlan' in interface_config:
                     vlan_filter = 1
@@ -325,6 +322,11 @@ class BridgeIf(Interface):
                         cmd = f'bridge vlan add dev {interface} vid {vlan} master'
                         self._cmd(cmd)
                         vlan_add.add(vlan)
+                
+                if vlan_filter:
+                    if 'native_vlan' not in interface_config:
+                        cmd = f'bridge vlan del dev {interface} vid 1'
+                        self._cmd(cmd)
         
         
         for vlan in vlan_del:

--- a/src/conf_mode/interfaces-bridge.py
+++ b/src/conf_mode/interfaces-bridge.py
@@ -123,11 +123,11 @@ def get_config(config=None):
             
             # VLAN-aware bridge members must not have VLAN interface configuration
             if 'native_vlan' in interface_config:
-                if 'disable' not in interface_config['native_vlan']:
-                    vlan_aware = True
+                vlan_aware = True
             
             if 'allowed_vlan' in interface_config:
                 vlan_aware = True
+            
             
             if vlan_aware:
                 tmp = has_vlan_subinterface_configured(conf,interface)
@@ -142,6 +142,8 @@ def verify(bridge):
 
     verify_dhcpv6(bridge)
     verify_vrf(bridge)
+    
+    vlan_aware = False 
 
     if dict_search('member.interface', bridge):
         for interface, interface_config in bridge['member']['interface'].items():
@@ -167,6 +169,16 @@ def verify(bridge):
             
             if 'has_vlan' in interface_config:
                 raise ConfigError(error_msg + 'it has an VLAN subinterface assigned!')
+            
+            # VLAN-aware bridge members must not have VLAN interface configuration
+            if 'native_vlan' in interface_config:
+                vlan_aware = True
+            
+            if 'allowed_vlan' in interface_config:
+                vlan_aware = True
+            
+            if vlan_aware and 'wlan' in interface:
+                raise ConfigError(error_msg + 'VLAN aware cannot be set!')
             
             if 'allowed_vlan' in interface_config:
                 for vlan in interface_config['allowed_vlan']:


### PR DESCRIPTION
In the implementation of T3042, it will cause two problems:
    
1. Even if VLAN awareness is not enabled, the VLAN settings of the
       vlan filter will be modified. When the bridge member has a WLAN interface,
       the error is exposed, so repair it here. You should not modify the
      related settings when the VLAN awareness mode is not enabled
    
2. Even if VLAN awareness is not enabled, the VLAN settings of the
       vlan filter will be modified. When the bridge member has a WLAN interface,
        due to special settings, the bridge mode cannot be entered and the settings
       cannot be completed directly. Therefore, the WLAN interface should be rejected
       Enter the bridge with VLAN awareness