### PR TITLE
mpls-conf: T915: Add ethernet vif sub interface MPLS enable

### DIFF
--- a/src/conf_mode/protocols_mpls.py
+++ b/src/conf_mode/protocols_mpls.py
@@ -18,11 +18,13 @@ import os
 
 from sys import exit
 
+from glob import glob
 from vyos.config import Config
 from vyos.configdict import node_changed
 from vyos.template import render_to_string
 from vyos.util import call
 from vyos.util import dict_search
+from vyos.util import read_file
 from vyos import ConfigError
 from vyos import frr
 from vyos import airbag
@@ -118,22 +120,28 @@ def apply(mpls):
     # Enable and disable MPLS processing on interfaces per configuration
     if 'interface' in mpls:
         system_interfaces = []
-        system_interfaces.append(((os.popen('sysctl net.mpls.conf').read()).split('\n')))
-        del system_interfaces[0][-1]
-        for configured_interface in mpls['interface']:
-            for system_interface in system_interfaces[0]:
-                if configured_interface in system_interface:
-                    call(f'sysctl -wq net.mpls.conf.{configured_interface}.input=1')
-                elif system_interface.endswith(' = 1'):
-                    system_interface = system_interface.replace(' = 1', '=0')
-                    call(f'sysctl -wq {system_interface}')
+        # Populate system interfaces list with local MPLS capable interfaces
+        for interface in glob('/proc/sys/net/mpls/conf/*'):
+            system_interfaces.append(os.path.basename(interface))   
+        # This is where the comparison is done on if an interface needs to be enabled/disabled.
+        for system_interface in system_interfaces:
+            interface_state = read_file(f'/proc/sys/net/mpls/conf/{system_interface}/input')
+            if '1' in interface_state:
+                if system_interface not in mpls['interface']:
+                    system_interface = system_interface.replace('.', '/')
+                    call(f'sysctl -wq net.mpls.conf.{system_interface}.input=0')
+            elif '0' in interface_state:
+                if system_interface in mpls['interface']:
+                    system_interface = system_interface.replace('.', '/')
+                    call(f'sysctl -wq net.mpls.conf.{system_interface}.input=1')
     else:
-        # If MPLS interfaces are not configured, set MPLS processing disabled
         system_interfaces = []
-        system_interfaces.append(((os.popen('sysctl net.mpls.conf').read()).replace(" = 1", "=0")).split('\n'))
-        del system_interfaces[0][-1]
-        for interface in (system_interfaces[0]):
-            call(f'sysctl -wq {interface}')
+        # If MPLS interfaces are not configured, set MPLS processing disabled
+        for interface in glob('/proc/sys/net/mpls/conf/*'):
+            system_interfaces.append(os.path.basename(interface)) 
+        for system_interface in system_interfaces:
+            system_interface = system_interface.replace('.', '/')
+            call(f'sysctl -wq net.mpls.conf.{system_interface}.input=0')
 
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

In this commit ethernet sub interface MPLS processing enablement is done. Per request by @bbs2web.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->

Phabricator task: https://phabricator.vyos.net/T915

## Component(s) name

## Proposed changes
<!--- Describe your changes in detail -->

What this will enable is for ethernet sub interfaces that are configured as VLAN sub interfaces to be able to also process
MPLS packets. This allowing for a switched network with VLANs and routers on the edges to speak MPLS with each other. It does so by also checking the ethernet sub interface configurations as well as main ethernet interface configurations. This check is done on the available kernel interfaces when querying said interfaces.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

My testing environment is a virtual machine. The way I tested my changes is by adding and removing MPLS interfaces for main ethernet interfaces as well as the ethernet sub interfaces. I did verify that the enable/disable of said MPLS processing on input was properly working in the kernel. Now whether or not the packet is properly formatted will be a different test. However that specifically I have not been able to test. That being said though, the specific addition to sub interfaces should not affect main interface MPLS processing. So if the sub interfaces are not properly formatted by the kernel, the main interfaces should work properly and not break any previous functionality. This I was able to verify working in my lab.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
