### PR TITLE
smoketest: T3108: Fix regex for count pattern Config

### DIFF
--- a/smoketest/scripts/cli/test_configd_inspect.py
+++ b/smoketest/scripts/cli/test_configd_inspect.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import re
 import json
 import unittest
 import warnings
@@ -78,7 +79,8 @@ class TestConfigdInclude(unittest.TestCase):
                 if not f:
                     continue
                 str_f = getsource(f)
-                n = str_f.count('Config()')
+                # Regex not XXXConfig() T3108
+                n = len(re.findall(r'[^a-zA-Z]Config\(\)', str_f))
                 if i == 'get_config':
                     self.assertEqual(n, 1,
                             f"'{s}': '{i}' no instance of Config")
@@ -91,7 +93,8 @@ class TestConfigdInclude(unittest.TestCase):
         for s in self.inc_list:
             m = import_script(s)
             str_m = getsource(m)
-            n = str_m.count('Config()')
+            # Regex not XXXConfig T3108
+            n = len(re.findall(r'[^a-zA-Z]Config\(\)', str_m))
             self.assertEqual(n, 1,
                     f"'{s}' more than one instance of Config")
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Change regex for find pattern "Config()". It should not count **XXXConfig()** or **FOOConfig()**
## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T3108
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
