### PR TITLE
pim: igmp: igmp-proxy: T2744: Add check to prevent pimd and igmp-prox…

### DIFF
--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -191,3 +191,12 @@ def ask_yes_no(question, default=False) -> bool:
             return False
         else:
             sys.stdout.write("Please respond with yes/y or no/n\n")
+
+def process_named_running(name):
+    """ Checks if process with given name is running and returns its PID.
+    If Process is not running, return None
+    """
+    for p in psutil.process_iter():
+        if name in p.name():
+            return p.pid
+    return None

--- a/src/conf_mode/igmp_proxy.py
+++ b/src/conf_mode/igmp_proxy.py
@@ -76,6 +76,13 @@ default_config_data = {
 def get_config():
     igmp_proxy = default_config_data
     conf = Config()
+
+    if conf.exists('protocols igmp'):
+        igmp_proxy['igmp_configured'] = True
+
+    if conf.exists('protocols pim'):
+        igmp_proxy['pim_configured'] = True
+
     if not conf.exists('protocols igmp-proxy'):
         return None
     else:
@@ -124,6 +131,10 @@ def verify(igmp_proxy):
     # bail out early - service is disabled
     if igmp_proxy['disable']:
         return None
+
+    if 'igmp_configured' in igmp_proxy or 'pim_configured' in igmp_proxy:
+        raise ConfigError('Can not configure both IGMP proxy and PIM '\
+                          'at the same time')
 
     # at least two interfaces are required, one upstream and one downstream
     if len(igmp_proxy['interfaces']) < 2:


### PR DESCRIPTION
…y conflict

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
