### PR TITLE
mpls-conf: T915: Add LDP local label allocation control

### DIFF
--- a/data/templates/frr/ldpd.frr.tmpl
+++ b/data/templates/frr/ldpd.frr.tmpl
@@ -33,7 +33,17 @@ neighbor {{neighbors}} session holdtime {{ldp.neighbor[neighbors].session_holdti
 {%     if ldp.discovery is defined %}
 {%         if ldp.discovery.transport_ipv4_address is defined %}
 address-family ipv4
+{%             if ldp.allocation is defined %}
+{%               if ldp.allocation.ipv4 is defined %}
+{%                 if ldp.allocation.ipv4.access_list is defined %}
+label local allocate for {{ ldp.allocation.ipv4.access_list }}
+{%                 endif %}
 label local allocate host-routes
+{%               endif %}
+label local allocate host-routes
+{%             else %}
+label local allocate host-routes
+{%             endif %}
 {%             if ldp.discovery.transport_ipv4_address is defined %}
 discovery transport-address {{ ldp.discovery.transport_ipv4_address }}
 {%             endif %}
@@ -77,7 +87,17 @@ no address-family ipv4
 {%     if ldp.discovery is defined %}
 {%         if ldp.discovery.transport_ipv6_address is defined %}
 address-family ipv6
+{%             if ldp.allocation is defined %}
+{%               if ldp.allocation.ipv6 is defined %}
+{%                 if ldp.allocation.ipv6.access_list6 is defined %}
+label local allocate for {{ ldp.allocation.ipv6.access_list6 }}
+{%                 endif %}
 label local allocate host-routes
+{%               endif %}
+label local allocate host-routes
+{%             else %}
+label local allocate host-routes
+{%             endif %}
 {%             if ldp.discovery.transport_ipv6_address is defined %}
 discovery transport-address {{ ldp.discovery.transport_ipv6_address }}
 {%             endif %}

--- a/interface-definitions/protocols-mpls.xml.in
+++ b/interface-definitions/protocols-mpls.xml.in
@@ -26,6 +26,51 @@
                   </constraint>
                 </properties>
               </leafNode>
+              <node name="allocation">
+                <properties>
+                  <help>Forwarding equivalence class (FEC) allocation from local routes</help>
+                </properties>
+                <children>
+                  <node name="ipv4">
+                    <properties>
+                      <help>IPv4 routes</help>
+                    </properties>
+                    <children>
+                      <leafNode name="access-list">
+                        <properties>
+                          <help>Access-list number</help>
+                          <valueHelp>
+                            <format>1-2699</format>
+                            <description>Access list number</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-2699"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </node>
+                  <node name="ipv6">
+                    <properties>
+                      <help>IPv6 routes</help>
+                    </properties>
+                    <children>
+                      <leafNode name="access-list6">
+                        <properties>
+                          <help>Access-list6 number</help>
+                          <valueHelp>
+                            <format>1-2699</format>
+                            <description>Access list number</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-2699"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </node>
+                </children>
+              </node>
               <tagNode name="neighbor">
                 <properties>
                   <help>LDP neighbor parameters</help>


### PR DESCRIPTION
In this commit we added the ability to control the local label allocation
control for FECs. It allows for the router to not allocate a label for every
interface, just the interfaces that are desired by the operator.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
This specific PR adds the ability to specify an access list which then is added to LDP so that it is able to control the local label allocations of the router for LDP. This type of configuration is useful for being able to only allocate labels for the interfaces that are going to be useful for label operations and to also conserve the label space that is available. This operates with an access list created for IPv4 or IPv6 and then must be attached to LDP itself. Afterwards, LDP neighborships will need to be reset. But it does change the local allocation of labels per the access list that is referenced.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T915

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
Label Distribution Protocol (LDP)

## Proposed changes
<!--- Describe your changes in detail -->
The changes here are just additions to the current XML tree and Jinja2 template.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

I tested this in a lab with multiple VyOS instances. Local labels for FECs were properly withdrawn and not re-advertised. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
