### PR TITLE
dhcp: T2562: add "listen-address" CLI node for better DHCP relay support

### DIFF
--- a/data/templates/dhcp-server/dhcpd.conf.tmpl
+++ b/data/templates/dhcp-server/dhcpd.conf.tmpl
@@ -62,6 +62,14 @@ failover peer "{{ subnet_config.failover.name }}" {
 {%     endif %}
 {%   endfor %}
 {% endif %}
+{% if listen_address is defined and listen_address is not none %}
+
+# DHCP server serving relay subnet, we need a connector to the real world
+{%   for address in listen_address %}
+# Connected subnet statement for listen-address {{ address }}
+subnet {{ address | network_from_ipv4 }} netmask {{ address | netmask_from_ipv4 }} { }
+{%   endfor %}
+{% endif %}
 
 # Shared network configration(s)
 {% if shared_network_name is defined and shared_network_name is not none %}

--- a/interface-definitions/dhcp-server.xml.in
+++ b/interface-definitions/dhcp-server.xml.in
@@ -11,13 +11,13 @@
         <children>
           <leafNode name="disable">
             <properties>
-              <help>Option to disable DHCP server</help>
+              <help>Disable DHCP server</help>
               <valueless/>
             </properties>
           </leafNode>
           <leafNode name="dynamic-dns-update">
             <properties>
-              <help>DHCP server to dynamically update the Domain Name System (DNS)</help>
+              <help>Dynamically update Domain Name System (RFC4702)</help>
               <valueless/>
             </properties>
           </leafNode>
@@ -32,19 +32,20 @@
           </leafNode>
           <leafNode name="hostfile-update">
             <properties>
-              <help>Enable DHCP server updating /etc/hosts (per client lease)</help>
+              <help>Updating /etc/hosts file (per client lease)</help>
               <valueless/>
             </properties>
           </leafNode>
           <leafNode name="host-decl-name">
             <properties>
-              <help>Instruct server to use host declaration name for forward DNS name</help>
+              <help>Use host declaration name for forward DNS name</help>
               <valueless/>
             </properties>
           </leafNode>
+          #include <include/listen-address.xml.i>
           <tagNode name="shared-network-name">
             <properties>
-              <help>DHCP shared network name [REQUIRED]</help>
+              <help>Name of DHCP shared network</help>
               <constraint>
                 <regex>[-_a-zA-Z0-9.]+</regex>
               </constraint>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Running ISC DHCP server as backend server for multiple pools served to relay
agents requires DHCPd to explicitly listen on give interfaces or a "transit"
subnet declaration facing the network where we receive the DHCPREQ messages on.

This implements a new "listen-address" CLI node, the given address is validated
if it is assigned to the system and upon success, a proper "subnet { }" statement
is added into dhcpd.conf

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://phabricator.vyos.net/T2562

## Component(s) name
DHCP

## Proposed changes
<!--- Describe your changes in detail -->
`set service dhcp-server listen-address '172.18.201.10'`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
```
set service dhcp-server listen-address '172.18.201.10'
set service dhcp-server shared-network-name LAN subnet 192.168.0.0/24 default-router '192.168.0.1'
set service dhcp-server shared-network-name LAN subnet 192.168.0.0/24 dns-server '192.168.0.1'
set service dhcp-server shared-network-name LAN subnet 192.168.0.0/24 domain-name 'vyos.net'
set service dhcp-server shared-network-name LAN subnet 192.168.0.0/24 lease '86400'
set service dhcp-server shared-network-name LAN subnet 192.168.0.0/24 range 0 start '192.168.0.9'
set service dhcp-server shared-network-name LAN subnet 192.168.0.0/24 range 0 stop '192.168.0.254'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

Awaiting feedback from @kroy-the-rabbit 