### PR TITLE
bgp: T2174: Fix Template. Update to use FRRConfig framework

### DIFF
--- a/data/templates/frr/bgp.frr.tmpl
+++ b/data/templates/frr/bgp.frr.tmpl
@@ -114,9 +114,9 @@
 {%       endif %}
 {%       if config.address_family[af].prefix_list is defined and config.address_family[af].prefix_list is not none %}
 {%         if config.address_family[af].prefix_list.export is defined and config.address_family[af].prefix_list.export is not none %}
-  neighbor {{ neighbor }} route-map {{ config.address_family[af].prefix_list.export }} out
+  neighbor {{ neighbor }} prefix-list  {{ config.address_family[af].prefix_list.export }} out
 {%         elif config.address_family[af].prefix_list.import is defined and config.address_family[af].prefix_list.import is not none %}
-  neighbor {{ neighbor }} route-map {{ config.address_family[af].prefix_list.export }} in
+  neighbor {{ neighbor }} prefix-list  {{ config.address_family[af].prefix_list.import }} in
 {%         endif %}
 {%       endif %}
 {%       if config.address_family[af].soft_reconfiguration is defined and config.address_family[af].soft_reconfiguration.inbound is defined %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixing frr bgp template, which used route-map instead prefix-list.
Fixing prefix-list import.
Allow bgp to use updated frr.py framework for "FRRConfig".
## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T2174, T2850
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp new format. Not integrated yet.
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
