### PR TITLE
interfaces: T3114: Fix VLAN-aware bridge setting failure

### DIFF
--- a/python/vyos/ifconfig/bridge.py
+++ b/python/vyos/ifconfig/bridge.py
@@ -21,6 +21,7 @@ from vyos.validate import assert_boolean
 from vyos.validate import assert_positive
 from vyos.util import cmd
 from vyos.util import dict_search
+from vyos.configdict import get_vlan_ids
 
 @Interface.register
 class BridgeIf(Interface):
@@ -44,6 +45,14 @@ class BridgeIf(Interface):
             'broadcast': True,
             'vlan': True,
         },
+    }
+    
+    _sysfs_get = {
+        **Interface._sysfs_get,**{
+            'vlan_filter': {
+                'location': '/sys/class/net/{ifname}/bridge/vlan_filtering'
+            }
+        }
     }
 
     _sysfs_set = {**Interface._sysfs_set, **{
@@ -93,6 +102,13 @@ class BridgeIf(Interface):
             'shellcmd': 'ip link set dev {value} nomaster',
         },
     }}
+    
+    def get_vlan_filter(self):
+        """
+        Get the status of the bridge VLAN filter
+        """
+        
+        return self.get_interface('vlan_filter')
 
 
     def set_ageing_time(self, time):
@@ -209,35 +225,6 @@ class BridgeIf(Interface):
         """
         return self.set_interface('del_port', interface)
 
-    def get_vlan_ids(self):
-        """
-        Get the VLAN ID of the interface bound to the bridge
-        
-        is_trunk is 1 means to obtain the VLAN ID of Trunk mode, otherwise obtain the VLAN ID of Access mode
-
-        Example:
-        >>> from vyos.ifconfig import BridgeIf
-        >>> Interface('br0').get_vlan_id()
-        None
-        """
-        interface = self.config['ifname']
-        
-        vlan_ids = []
-        
-        bridge_status = cmd('bridge -j vlan show', shell=True)
-        vlan_filter_status = json.loads(bridge_status)
-        
-        if vlan_filter_status is not None:
-            for interface_status in vlan_filter_status:
-                ifname = interface_status['ifname']
-                if interface == ifname:
-                    vlans_status = interface_status['vlans']
-                    for vlan_status in vlans_status:
-                        vlan_id = vlan_status['vlan']
-                        vlan_ids.append(vlan_id)
-        
-        return vlan_ids
-
     def update(self, config):
         """ General helper function which works on a dictionary retrived by
         get_config_dict(). It's main intention is to consolidate the scattered
@@ -290,6 +277,14 @@ class BridgeIf(Interface):
 
         tmp = dict_search('member.interface', config)
         if tmp:
+            if self.get_vlan_filter():
+                bridge_vlan_ids = get_vlan_ids(ifname)
+                # Delete VLAN ID for the bridge
+                if 1 in bridge_vlan_ids:
+                    bridge_vlan_ids.remove(1)
+                for vlan in bridge_vlan_ids:
+                    vlan_del.add(str(vlan))
+            
             for interface, interface_config in tmp.items():
                 # if interface does yet not exist bail out early and
                 # add it later
@@ -340,32 +335,31 @@ class BridgeIf(Interface):
                     self._cmd(cmd)
                     vlan_id = interface_config['native_vlan']
                     if int(vlan_id) != 1:
+                        if 1 in vlan_add:
+                            vlan_add.remove(1)
                         vlan_del.add(1)
                     cmd = f'bridge vlan add dev {interface} vid {vlan_id} pvid untagged master'
                     self._cmd(cmd)
                     vlan_add.add(vlan_id)
+                    if vlan_id in vlan_del:
+                        vlan_del.remove(vlan_id)
 
                 if 'allowed_vlan' in interface_config:
                     vlan_filter = 1
                     if 'native_vlan' not in interface_config:
                         cmd = f'bridge vlan del dev {interface} vid 1'
                         self._cmd(cmd)
+                        vlan_del.add(1)
                     for vlan in interface_config['allowed_vlan']:
                         cmd = f'bridge vlan add dev {interface} vid {vlan} master'
                         self._cmd(cmd)
                         vlan_add.add(vlan)
+                        if vlan in vlan_del:
+                            vlan_del.remove(vlan)
 
         for vlan in vlan_del:
-            if isinstance(vlan,str) and vlan.isnumeric():
-                if int(vlan) == 1:
-                    cmd = f'bridge vlan del dev {ifname} vid {vlan} self'
-                    self._cmd(cmd)
-                else:
-                    cmd = f'bridge vlan del dev {ifname} vid {vlan} self'
-                    self._cmd(cmd)
-            else:
-                cmd = f'bridge vlan del dev {ifname} vid {vlan} self'
-                self._cmd(cmd)
+            cmd = f'bridge vlan del dev {ifname} vid {vlan} self'
+            self._cmd(cmd)
 
         for vlan in vlan_add:
             cmd = f'bridge vlan add dev {ifname} vid {vlan} self'

--- a/python/vyos/ifconfig/bridge.py
+++ b/python/vyos/ifconfig/bridge.py
@@ -347,13 +347,9 @@ class BridgeIf(Interface):
 
                 if 'allowed_vlan' in interface_config:
                     vlan_filter = 1
-
-                if vlan_filter:
                     if 'native_vlan' not in interface_config:
                         cmd = f'bridge vlan del dev {interface} vid 1'
                         self._cmd(cmd)
-
-                if 'allowed_vlan' in interface_config:
                     for vlan in interface_config['allowed_vlan']:
                         cmd = f'bridge vlan add dev {interface} vid {vlan} master'
                         self._cmd(cmd)

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -950,10 +950,6 @@ class Interface(Control):
                         if int(vlan_id) not in vlan_bridge_ids:
                             cmd = f'bridge vlan add dev {bridge} vid {vlan_id} self'
                             self._cmd(cmd)
-                else:
-                    if vlan not in vlan_bridge_ids:
-                        cmd = f'bridge vlan add dev {bridge} vid {vlan} self'
-                        self._cmd(cmd)
             
             # enable/disable Vlan Filter
             Section.klass(bridge)(bridge, create=True).set_vlan_filter(vlan_filter)

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -918,13 +918,9 @@ class Interface(Control):
 
             if 'allowed_vlan' in bridge_config:
                 vlan_filter = 1
-
-            if vlan_filter:
                 if 'native_vlan' not in bridge_config:
                     cmd = f'bridge vlan del dev {self.ifname} vid 1'
                     self._cmd(cmd)
-
-            if 'allowed_vlan' in bridge_config:
                 for vlan in bridge_config['allowed_vlan']:
                     cmd = f'bridge vlan add dev {self.ifname} vid {vlan} master'
                     self._cmd(cmd)

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -928,6 +928,8 @@ class Interface(Control):
             
             vlan_bridge_ids = Section.klass(bridge)(bridge, create=True).get_vlan_ids()
             
+            apply_vlan_ids = set()
+            
             # Delete VLAN ID for the bridge
             for vlan in vlan_del:
                 if int(vlan) == 1:
@@ -936,16 +938,16 @@ class Interface(Control):
             
             # Setting VLAN ID for the bridge
             for vlan in vlan_add:
-                if isinstance(vlan,str) and vlan.isnumeric():
-                    if int(vlan) not in vlan_bridge_ids:
-                        cmd = f'bridge vlan add dev {bridge} vid {vlan} self'
-                        self._cmd(cmd)
-                elif isinstance(vlan,str) and not vlan.isnumeric():
-                    vlan_range = vlan.split('-')
-                    for vlan_id in range(int(vlan_range[0]),int(vlan_range[1]) + 1):
+                vlan_range = vlan.split('-')
+                apply_vlan_ids.add(int(vlan_range[0]))
+                if(len(vlan_range) == 2):
+                    for vlan_id in range(int(vlan_range[0])+1,int(vlan_range[1]) + 1):
                         if int(vlan_id) not in vlan_bridge_ids:
-                            cmd = f'bridge vlan add dev {bridge} vid {vlan_id} self'
-                            self._cmd(cmd)
+                            apply_vlan_ids.add(int(vlan_id))
+            
+            for vlan in apply_vlan_ids:
+                cmd = f'bridge vlan add dev {bridge} vid {vlan} self'
+                self._cmd(cmd)
             
             # enable/disable Vlan Filter
             # When the VLAN aware option is not detected, the setting of `bridge` should not be overwritten

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -948,7 +948,9 @@ class Interface(Control):
                             self._cmd(cmd)
             
             # enable/disable Vlan Filter
-            Section.klass(bridge)(bridge, create=True).set_vlan_filter(vlan_filter)
+            # When the VLAN aware option is not detected, the setting of `bridge` should not be overwritten
+            if vlan_filter:
+                Section.klass(bridge)(bridge, create=True).set_vlan_filter(vlan_filter)
 
     def set_dhcp(self, enable):
         """

--- a/smoketest/scripts/cli/test_interfaces_bridge.py
+++ b/smoketest/scripts/cli/test_interfaces_bridge.py
@@ -45,10 +45,25 @@ class BridgeInterfaceTest(BasicInterfaceTest.BaseTest):
             for tmp in Section.interfaces("ethernet"):
                 if not '.' in tmp:
                     self._members.append(tmp)
+            
+            self.session.set(['interfaces','dummy','dum0'])
+            self.session.set(['interfaces','dummy','dum1'])
+            self.session.commit()
+            self.session.set(['interfaces','bonding','bond1','member','interface','dum0'])
+            self.session.set(['interfaces','bonding','bond1','member','interface','dum1'])
+            self.session.commit()
+            for tmp in Section.interfaces("bonding"):
+                if not '.' in tmp:
+                    self._members.append(tmp)
 
         self._options['br0'] = []
         for member in self._members:
             self._options['br0'].append(f'member interface {member}')
+    
+    def tearDown(self):
+        self.session.delete(['interfaces','bonding'])
+        self.session.delete(['interfaces','dummy'])
+        super().tearDown()
 
     def test_add_remove_member(self):
         """ Add member interfaces to bridge and set STP cost/priority """
@@ -56,6 +71,7 @@ class BridgeInterfaceTest(BasicInterfaceTest.BaseTest):
             base = self._base_path + [interface]
             self.session.set(base + ['stp'])
             self.session.set(base + ['address', '192.0.2.1/24'])
+            self.session.commit()
 
             cost = 1000
             priority = 10

--- a/smoketest/scripts/cli/test_interfaces_bridge.py
+++ b/smoketest/scripts/cli/test_interfaces_bridge.py
@@ -48,13 +48,9 @@ class BridgeInterfaceTest(BasicInterfaceTest.BaseTest):
             
             self.session.set(['interfaces','dummy','dum0'])
             self.session.set(['interfaces','dummy','dum1'])
-            self.session.commit()
             self.session.set(['interfaces','bonding','bond1','member','interface','dum0'])
             self.session.set(['interfaces','bonding','bond1','member','interface','dum1'])
-            self.session.commit()
-            for tmp in Section.interfaces("bonding"):
-                if not '.' in tmp:
-                    self._members.append(tmp)
+            self._members.append('bond1')
 
         self._options['br0'] = []
         for member in self._members:
@@ -71,7 +67,6 @@ class BridgeInterfaceTest(BasicInterfaceTest.BaseTest):
             base = self._base_path + [interface]
             self.session.set(base + ['stp'])
             self.session.set(base + ['address', '192.0.2.1/24'])
-            self.session.commit()
 
             cost = 1000
             priority = 10


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix VLAN-aware bridge setting failure

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3114

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bridge

## Proposed changes
<!--- Describe your changes in detail -->
Due to dependency issues, if a non-existent interface appears when creating a VLAN-aware bridge, the VLAN-aware parameters of this interface cannot be set. Therefore, the interface will complete the setting when waiting for the interface to be created.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
```
set interfaces bonding bond1 member interface eth0
set interfaces bonding bond1 member interface eth1
set interfaces bridge br1 member interface bond1 native-vlan 3
set interfaces bridge br1 member interface bond1 allowed-vlan 2
commit
run show int br vlan
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
