### PR TITLE
mpls-conf: T915: Add LDP import and export control

### DIFF
--- a/data/templates/frr/ldpd.frr.tmpl
+++ b/data/templates/frr/ldpd.frr.tmpl
@@ -34,13 +34,11 @@ neighbor {{neighbors}} session holdtime {{ldp.neighbor[neighbors].session_holdti
 {%         if ldp.discovery.transport_ipv4_address is defined %}
 address-family ipv4
 {%             if ldp.allocation is defined %}
-{%               if ldp.allocation.ipv4 is defined %}
-{%                 if ldp.allocation.ipv4.access_list is defined %}
+{%                 if ldp.allocation.ipv4 is defined %}
+{%                     if ldp.allocation.ipv4.access_list is defined %}
 label local allocate for {{ ldp.allocation.ipv4.access_list }}
+{%                     endif %}
 {%                 endif %}
-label local allocate host-routes
-{%               endif %}
-label local allocate host-routes
 {%             else %}
 label local allocate host-routes
 {%             endif %}
@@ -56,9 +54,33 @@ discovery hello interval {{ ldp.discovery.hello_ipv4_interval }}
 {%             if ldp.discovery.session_ipv4_holdtime is defined %}
 session holdtime {{ ldp.discovery.session_ipv4_holdtime }}
 {%             endif %}
+{%             if ldp.import is defined %}
+{%                 if ldp.import.ipv4 is defined %}
+{%                     if ldp.import.ipv4.import_filter is defined %}
+{%                         if ldp.import.ipv4.import_filter.filter_access_list is defined %}
+{%                             if ldp.import.ipv4.import_filter.neighbor_access_list is defined %}
+label remote accept for {{ ldp.import.ipv4.import_filter.filter_access_list }} from {{ ldp.import.ipv4.import_filter.neighbor_access_list }}
+{%                             else %}
+label remote accept for {{ ldp.import.ipv4.import_filter.filter_access_list }}
+{%                             endif %}
+{%                         endif %}
+{%                     endif %}
+{%                 endif %}
+{%             endif %}
 {%             if ldp.export is defined %}
-{%                 if ldp.export.ipv4.explicit_null is defined %}
+{%                 if ldp.export.ipv4 is defined %}
+{%                     if ldp.export.ipv4.explicit_null is defined %}
 label local advertise explicit-null
+{%                     endif %}
+{%                     if ldp.export.ipv4.export_filter is defined %}
+{%                         if ldp.export.ipv4.export_filter.filter_access_list is defined %}
+{%                             if ldp.export.ipv4.export_filter.neighbor_access_list is defined %}
+label local advertise for {{ ldp.export.ipv4.export_filter.filter_access_list }} to {{ ldp.export.ipv4.export_filter.neighbor_access_list }}
+{%                             else %}
+label local advertise for {{ ldp.export.ipv4.export_filter.filter_access_list }}
+{%                             endif %}
+{%                         endif %}
+{%                     endif %}
 {%                 endif %}
 {%             endif %}
 {%             if ldp.targeted_neighbor is defined %}
@@ -88,13 +110,11 @@ no address-family ipv4
 {%         if ldp.discovery.transport_ipv6_address is defined %}
 address-family ipv6
 {%             if ldp.allocation is defined %}
-{%               if ldp.allocation.ipv6 is defined %}
-{%                 if ldp.allocation.ipv6.access_list6 is defined %}
+{%                 if ldp.allocation.ipv6 is defined %}
+{%                     if ldp.allocation.ipv6.access_list6 is defined %}
 label local allocate for {{ ldp.allocation.ipv6.access_list6 }}
+{%                     endif %}
 {%                 endif %}
-label local allocate host-routes
-{%               endif %}
-label local allocate host-routes
 {%             else %}
 label local allocate host-routes
 {%             endif %}
@@ -110,9 +130,33 @@ discovery hello interval {{ ldp.discovery.hello_ipv6_interval }}
 {%             if ldp.discovery.session_ipv6_holdtime is defined %}
 session holdtime {{ ldp.discovery.session_ipv6_holdtime }}
 {%             endif %}
+{%             if ldp.import is defined %}
+{%                 if ldp.import.ipv6 is defined %}
+{%                     if ldp.import.ipv6.import_filter is defined %}
+{%                         if ldp.import.ipv6.import_filter.filter_access_list6 is defined %}
+{%                             if ldp.import.ipv6.import_filter.neighbor_access_list6 is defined %}
+label remote accept for {{ ldp.import.ipv6.import_filter.filter_access_list6 }} from {{ ldp.import.ipv6.import_filter.neighbor_access_list6 }}
+{%                             else %}
+label remote accept for {{ ldp.import.ipv6.import_filter.filter_access_list6 }}
+{%                             endif %}
+{%                         endif %}
+{%                     endif %}
+{%                 endif %}
+{%             endif %}
 {%             if ldp.export is defined %}
-{%                 if ldp.export.ipv6.explicit_null is defined %}
+{%                 if ldp.export.ipv6 is defined %}
+{%                     if ldp.export.ipv6.explicit_null is defined %}
 label local advertise explicit-null
+{%                     endif %}
+{%                     if ldp.export.ipv6.export_filter is defined %}
+{%                         if ldp.export.ipv6.export_filter.filter_access_list6 is defined %}
+{%                             if ldp.export.ipv6.export_filter.neighbor_access_list6 is defined %}
+label local advertise for {{ ldp.export.ipv6.export_filter.filter_access_list6 }} to {{ ldp.export.ipv6.export_filter.neighbor_access_list6 }}
+{%                             else %}
+label local advertise for {{ ldp.export.ipv6.export_filter.filter_access_list6 }}
+{%                             endif %}
+{%                         endif %}
+{%                     endif %}
 {%                 endif %}
 {%             endif %}
 {%             if ldp.targeted_neighbor is defined %}

--- a/interface-definitions/protocols-mpls.xml.in
+++ b/interface-definitions/protocols-mpls.xml.in
@@ -367,6 +367,37 @@
                           <valueless/>
                         </properties>
                       </leafNode>
+                      <node name="export-filter">
+                        <properties>
+                          <help>Forwarding equivalence class (FEC) export filter</help>
+                        </properties>
+                        <children>
+                          <leafNode name="filter-access-list">
+                            <properties>
+                              <help>Access-list number to apply FEC filtering</help>
+                                <valueHelp>
+                                  <format>1-2699</format>
+                                  <description>Access list number</description>
+                                </valueHelp>
+                                <constraint>
+                                  <validator name="numeric" argument="--range 1-2699"/>
+                                </constraint>
+                            </properties>
+                          </leafNode>
+                          <leafNode name="neighbor-access-list">
+                            <properties>
+                              <help>Access-list number for IPv4 neighbor selection to apply filtering</help>
+                              <valueHelp>
+                                <format>1-2699</format>
+                                <description>Access list number</description>
+                              </valueHelp>
+                              <constraint>
+                                <validator name="numeric" argument="--range 1-2699"/>
+                              </constraint>
+                            </properties>
+                          </leafNode>
+                        </children>
+                      </node>  
                     </children>
                   </node>
                   <node name="ipv6">
@@ -380,6 +411,120 @@
                           <valueless/>
                         </properties>
                       </leafNode>
+                      <node name="export-filter">
+                        <properties>
+                          <help>Forwarding equivalence class (FEC) export filter</help>
+                        </properties>
+                        <children>
+                          <leafNode name="filter-access-list6">
+                            <properties>
+                              <help>Access-list6 number to apply FEC filtering</help>
+                                <valueHelp>
+                                  <format>1-2699</format>
+                                  <description>Access list number</description>
+                                </valueHelp>
+                                <constraint>
+                                  <validator name="numeric" argument="--range 1-2699"/>
+                                </constraint>
+                            </properties>
+                          </leafNode>
+                          <leafNode name="neighbor-access-list6">
+                            <properties>
+                              <help>Access-list6 number for IPv6 neighbor selection to apply filtering</help>
+                              <valueHelp>
+                                <format>1-2699</format>
+                                <description>Access list number</description>
+                              </valueHelp>
+                              <constraint>
+                                <validator name="numeric" argument="--range 1-2699"/>
+                              </constraint>
+                            </properties>
+                          </leafNode>
+                        </children>
+                      </node>   
+                    </children>
+                  </node>
+                </children>
+              </node>
+              <node name="import">
+                <properties>
+                  <help>Import parameters</help>
+                </properties>
+                <children>
+                  <node name="ipv4">
+                    <properties>
+                      <help>IPv4 parameters</help>
+                    </properties>
+                    <children>
+                      <node name="import-filter">
+                        <properties>
+                          <help>Forwarding equivalence class (FEC) import filter</help>
+                        </properties>
+                        <children>
+                          <leafNode name="filter-access-list">
+                            <properties>
+                              <help>Access-list number to apply FEC filtering</help>
+                                <valueHelp>
+                                  <format>1-2699</format>
+                                  <description>Access list number</description>
+                                </valueHelp>
+                                <constraint>
+                                  <validator name="numeric" argument="--range 1-2699"/>
+                                </constraint>
+                            </properties>
+                          </leafNode>
+                          <leafNode name="neighbor-access-list">
+                            <properties>
+                              <help>Access-list number for IPv4 neighbor selection to apply filtering</help>
+                              <valueHelp>
+                                <format>1-2699</format>
+                                <description>Access list number</description>
+                              </valueHelp>
+                              <constraint>
+                                <validator name="numeric" argument="--range 1-2699"/>
+                              </constraint>
+                            </properties>
+                          </leafNode>
+                        </children>
+                      </node> 
+                    </children>
+                  </node>
+                  <node name="ipv6">
+                    <properties>
+                      <help>IPv6 parameters</help>
+                    </properties>
+                    <children>
+                      <node name="import-filter">
+                        <properties>
+                          <help>Forwarding equivalence class (FEC) export filter</help>
+                        </properties>
+                        <children>
+                          <leafNode name="filter-access-list6">
+                            <properties>
+                              <help>Access-list6 number to apply FEC filtering</help>
+                                <valueHelp>
+                                  <format>1-2699</format>
+                                  <description>Access list number</description>
+                                </valueHelp>
+                                <constraint>
+                                  <validator name="numeric" argument="--range 1-2699"/>
+                                </constraint>
+                            </properties>
+                          </leafNode>
+                          <leafNode name="neighbor-access-list6">
+                            <properties>
+                              <help>Access-list6 number for IPv6 neighbor selection to apply filtering</help>
+                              <valueHelp>
+                                <format>1-2699</format>
+                                <description>Access list number</description>
+                              </valueHelp>
+                              <constraint>
+                                <validator name="numeric" argument="--range 1-2699"/>
+                              </constraint>
+                            </properties>
+                          </leafNode>
+                        </children>
+                      </node>  
                     </children>
                   </node>
                 </children>


### PR DESCRIPTION
In this commit we added the ability to control import and export
of LDP FECs. This allows for an operator to specify which to
filter on ingress, and which to not announce on egress.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

In this change we are adding more functionality to LDP. We are specifically adding the ability to control the import and export of the routes that LDP deals with. this shouldn't break any existing functionality.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T915

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
LDP

## Proposed changes
<!--- Describe your changes in detail -->

We added the tie into FRR for access lists to be referenced and then added for import and export control. This functionality was added for both IPv4 and IPv6. Although the access list approach is a little bit cumbersome it does work as one expects.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

I tested the changes in a GNS3 lab with Junipers and VyOS routers. The VyOS routers did correctly import and export the routes properly once the access list was properly configured. That all being said, configuring access lists for imports seems to work as one expects but seems unwieldy. It does work as expected though.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
