### PR TITLE
dns: T3121 Change DNS recursor template for correct server names

### DIFF
--- a/data/templates/dns-forwarding/recursor.forward-zones.conf.tmpl
+++ b/data/templates/dns-forwarding/recursor.forward-zones.conf.tmpl
@@ -22,7 +22,7 @@
 {% if forward_zones is defined %}
 # zones added via 'service dns forwarding domain'
 {%   for zone, zonedata in forward_zones.items() %}
-{{ "+" if zonedata['recursion_desired'] is defined }}{{ zone }}={{ zonedata['server']|join(', ') }}
+{{ "+" if zonedata['recursion_desired'] is defined }}{{ zone | replace('_', '-') }}={{ zonedata['server']|join(', ') }}
 {%   endfor %}
 {% endif %}
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
This change is required to fix error in dns_forwarder if domain name have '-' in it.

## Types of changes
 
- [x] New feature (non-breaking change which adds functionality)

## Related Task(s)
https://phabricator.vyos.net/T3121

## Component(s) name
DNS Forwarding

## Proposed changes
<!--- Describe your changes in detail -->
I propose this change, because if there is '-' **minus** symbol in **dns forwarding domain** current behaviour leads to wrong results which replaces '-' to '_' and as result domain forwarding does not work for such kind of domains.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
```
configure
set service dns forwarding domain +us-west-2.rds.amazonaws.com server 10.10.5.2
commit
```
Should render proper record in **/run/powerdns/recursor.forward-zones.conf**
`+us-west-2.amazonaws.com=10.10.5.2`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
