### PR TITLE
flow-accounting: T3132: enable egress traffic accounting

### DIFF
--- a/data/templates/netflow/uacctd.conf.tmpl
+++ b/data/templates/netflow/uacctd.conf.tmpl
@@ -5,7 +5,11 @@ pidfile: /var/run/uacctd.pid
 uacctd_group: 2
 uacctd_nl_size: 2097152
 snaplen: {{ snaplen }}
+{% if templatecfg['enable-egress'] != none %}
+aggregate: in_iface,out_iface,src_mac,dst_mac,vlan,src_host,dst_host,src_port,dst_port,proto,tos,flows
+{% else %}
 aggregate: in_iface,src_mac,dst_mac,vlan,src_host,dst_host,src_port,dst_port,proto,tos,flows
+{% endif %}
 plugin_pipe_size: {{ templatecfg['plugin_pipe_size'] }}
 plugin_buffer_size: {{ templatecfg['plugin_buffer_size'] }}
 {% if templatecfg['syslog-facility'] != none %}

--- a/interface-definitions/flow-accounting-conf.xml.in
+++ b/interface-definitions/flow-accounting-conf.xml.in
@@ -21,6 +21,12 @@
               </constraint>
             </properties>
           </leafNode>
+          <leafNode name="enable-egress">
+            <properties>
+              <help>Enable egress flow accounting</help>
+              <valueless />
+            </properties>
+          </leafNode>
           <leafNode name="disable-imt">
             <properties>
               <help>Disable in memory table plugin</help>


### PR DESCRIPTION
## Change Summary
Ability to enable egress flow accounting

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://phabricator.vyos.net/T3132

## Component(s) name
flow-accounting

## Proposed changes
Give the ability to enable egress flow accounting for the interfaces.
This could be done via `set system flow-accounting enable-egress`

## How to test
I've tested it on my lab router. I've copied the changed files to the router and enabled/disabled the egress flow-accounting.
The iptables entries gotten written/removed correctly. The sflow collector got packets with right outgoing ifindex.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
