### PR TITLE
T3135: bfd template missing newlines

### DIFF
--- a/data/templates/frr/bfd.frr.tmpl
+++ b/data/templates/frr/bfd.frr.tmpl
@@ -2,15 +2,21 @@
 bfd
 {% for peer in old_peers %}
  no peer {{ peer.remote }}{% if peer.multihop %} multihop{% endif %}{% if peer.src_addr %} local-address {{ peer.src_addr }}{% endif %}{% if peer.src_if %} interface {{ peer.src_if }}{% endif %}
+
 {% endfor %}
 !
 {% for peer in new_peers %}
  peer {{ peer.remote }}{% if peer.multihop %} multihop{% endif %}{% if peer.src_addr %} local-address {{ peer.src_addr }}{% endif %}{% if peer.src_if %} interface {{ peer.src_if }}{% endif %}
+
  detect-multiplier {{ peer.multiplier }}
  receive-interval {{ peer.rx_interval }}
  transmit-interval {{ peer.tx_interval }}
- {% if peer.echo_mode %}echo-mode{% endif %}
- {% if peer.echo_interval != '' %}echo-interval {{ peer.echo_interval }}{% endif %}
+{% if peer.echo_mode %}
+ echo-mode
+{% endif %}
+{% if peer.echo_interval != '' %}
+ echo-interval {{ peer.echo_interval }}
+{% endif %}
  {% if not peer.shutdown %}no {% endif %}shutdown
 {% endfor %}
 !


### PR DESCRIPTION
trim blocks removes newlines after {% endif %} blocks.  Added the required newlines.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
frr-bfdd

## Proposed changes
<!--- Describe your changes in detail -->
When trim blocks was turned on for the frr templates it broke bfd.  required new lines were removed. 
The changes to the template add the required newlines

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
I added these lines to the configuration and committed.
set protocols bfd peer 172.31.50.1 echo-mode
set protocols bfd peer 172.31.50.1 interval echo-interval '500'
set protocols bfd peer 172.31.50.1 interval multiplier '5'
set protocols bfd peer 172.31.50.1 interval receive '1000'
set protocols bfd peer 172.31.50.1 interval transmit '500'
set protocols bfd peer 172.31.50.1 source interface 'vtun0'
set protocols bfd peer 172.31.51.1 echo-mode
set protocols bfd peer 172.31.51.1 interval echo-interval '500'
set protocols bfd peer 172.31.51.1 interval multiplier '5'
set protocols bfd peer 172.31.51.1 interval receive '1000'
set protocols bfd peer 172.31.51.1 interval transmit '500'
set protocols bfd peer 172.31.51.1 source interface 'vtun1'
set protocols bfd peer 172.31.52.1 echo-mode
set protocols bfd peer 172.31.52.1 interval echo-interval '500'
set protocols bfd peer 172.31.52.1 interval multiplier '5'
set protocols bfd peer 172.31.52.1 interval receive '1000'
set protocols bfd peer 172.31.52.1 interval transmit '500'
set protocols bfd peer 172.31.52.1 source interface 'vtun2'
set protocols bfd peer 172.31.53.1 echo-mode
set protocols bfd peer 172.31.53.1 interval echo-interval '500'
set protocols bfd peer 172.31.53.1 interval multiplier '5'
set protocols bfd peer 172.31.53.1 interval receive '1000'
set protocols bfd peer 172.31.53.1 interval transmit '500'
set protocols bfd peer 172.31.53.1 source interface 'vtun3

To verify the configuration was applied I then ran:
vtysh
sh running

I then removed the configuration lines and did another commit

Then to verify the configuration was applied I then ran:
vtysh
sh running

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x ] I have linked this PR to one or more Phabricator Task(s)
- [x ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
