### PR TITLE
bridge: T3137: When setting a VLAN-aware bridge, the VLAN ID of the parent interface is always 1

### DIFF
--- a/python/vyos/ifconfig/bridge.py
+++ b/python/vyos/ifconfig/bridge.py
@@ -368,6 +368,10 @@ class BridgeIf(Interface):
         for vlan in vlan_add:
             cmd = f'bridge vlan add dev {ifname} vid {vlan} self'
             self._cmd(cmd)
+        
+        # Always set VLAN 1 to the parent bridge interface
+        cmd = f'bridge vlan add dev {ifname} vid 1 pvid untagged self'
+        self._cmd(cmd)
 
         # enable/disable Vlan Filter
         self.set_vlan_filter(vlan_filter)

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -938,6 +938,10 @@ class Interface(Control):
                 for vlan in vlan_add:
                     cmd = f'bridge vlan add dev {bridge} vid {vlan} self'
                     self._cmd(cmd)
+                
+                # Always set VLAN 1 to the parent bridge interface
+                cmd = f'bridge vlan add dev {bridge} vid 1 pvid untagged self'
+                self._cmd(cmd)
 
                 # enable/disable Vlan Filter
                 # When the VLAN aware option is not detected, the setting of `bridge` should not be overwritten

--- a/smoketest/scripts/cli/test_interfaces_bridge.py
+++ b/smoketest/scripts/cli/test_interfaces_bridge.py
@@ -89,7 +89,7 @@ class BridgeInterfaceTest(BasicInterfaceTest.BaseTest):
         # Add member interface to bridge and set VLAN filter
         for interface in self._interfaces:
             base = self._base_path + [interface]
-            self.session.set(base + ['vif', '1', 'address', '192.0.2.1/24'])
+            self.session.set(base + ['address', '192.0.2.1/24'])
             self.session.set(base + ['vif', '2', 'address', '192.0.3.1/24'])
 
             vlan_id = 101

--- a/src/conf_mode/interfaces-bridge.py
+++ b/src/conf_mode/interfaces-bridge.py
@@ -191,6 +191,11 @@ def verify(bridge):
                     else:
                         if int(vlan) <1 and int(vlan)>4094:
                             raise ConfigError('VLAN ID must be between 1 and 4094')
+    
+    # When the VLAN-aware mode bridge is started, it is not allowed to configure the address on the parent interface
+    if vlan_aware and dict_search('vif.1', bridge):
+        ifname = bridge['ifname']
+        raise ConfigError(f'The bridge {ifname} is a VLAN-aware bridge, please set VLAN 1 on the parent interface!')
 
     return None
 

--- a/src/migration-scripts/interfaces/18-to-19
+++ b/src/migration-scripts/interfaces/18-to-19
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2020 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# VLAN 1 command line migration for bridge aware
+# https://phabricator.vyos.net/T3137
+
+import sys
+from vyos.configtree import ConfigTree
+
+if __name__ == '__main__':
+    if (len(sys.argv) < 1):
+        print("Must specify file name!")
+        sys.exit(1)
+
+    file_name = sys.argv[1]
+
+    with open(file_name, 'r') as f:
+        config_file = f.read()
+
+    config = ConfigTree(config_file)
+    base = ['interfaces', 'bridge']
+    if not config.exists(base):
+        # Nothing to do
+        sys.exit(0)
+    
+    for interface in config.list_nodes(base):
+        vif_1_old_base = base + [interface, 'vif', '1']
+        if config.exists(vif_1_old_base):
+            address_base = vif_1_old_base + ['address']
+            if config.exists(address_base):
+                address = config.return_values(address_base)
+                for addr in address:
+                    config.set(base + [interface, 'address'],addr,False)
+            config.delete(vif_1_old_base)
+    
+    try:
+        with open(file_name, 'w') as f:
+            f.write(config.to_string())
+    except OSError as e:
+        print("Failed to save the modified config: {}".format(e))
+        sys.exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
When setting a VLAN-aware bridge, the VLAN ID of the parent interface is always 1

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3137

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bridge

## Proposed changes
<!--- Describe your changes in detail -->
When setting a VLAN-aware bridge, the VLAN ID of the parent interface is always 1

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

```
set interfaces bridge br1 member interface eth0 allowed-vlan 2
set interfaces bridge br1 member interface eth0 native-vlan 1
set interfaces bridge br1 address 1.1.1.1/32
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
