### PR TITLE
flow-accounting: T3141: Fixing wrongly formatted config

### DIFF
--- a/data/templates/netflow/uacctd.conf.tmpl
+++ b/data/templates/netflow/uacctd.conf.tmpl
@@ -20,27 +20,28 @@ imt_path: /tmp/uacctd.pipe
 imt_mem_pools_number: 169
 {% endif %}
 plugins:
-{% if templatecfg['netflow']['servers'] != none %}
-    {% for server in templatecfg['netflow']['servers'] %}
-        {% if loop.last %}nfprobe[nf_{{ server['address'] }}]{% else %}nfprobe[nf_{{ server['address'] }}],{% endif %}
-    {% endfor %}
-    {% set plugins_presented = true %}
-{% endif %}
-{% if templatecfg['sflow']['servers'] != none %}
-    {% if plugins_presented %}
-        {% for server in templatecfg['sflow']['servers'] %}
+{%- if templatecfg['netflow']['servers'] != none -%}
+    {%- for server in templatecfg['netflow']['servers'] -%}
+        {%- if loop.last -%}nfprobe[nf_{{ server['address'] }}]{%- else -%}nfprobe[nf_{{ server['address'] }}],{%- endif -%}
+    {%- endfor -%}
+    {%- set plugins_presented = true -%}
+{%- endif -%}
+{%- if templatecfg['sflow']['servers'] != none -%}
+    {%- if plugins_presented -%}
+        {%- for server in templatecfg['sflow']['servers'] -%}
             ,sfprobe[sf_{{ server['address'] }}]
-        {% endfor %}
-    {% else %}
-        {% for server in templatecfg['sflow']['servers'] %}
-            {% if loop.last %}sfprobe[sf_{{ server['address'] }}]{% else %}sfprobe[sf_{{ server['address'] }}],{% endif %}
-        {% endfor %}
-    {% endif %}
-    {% set plugins_presented = true %}
-{% endif %}
-{% if templatecfg['disable-imt'] == none %}
-    {% if plugins_presented %},memory{% else %}memory{% endif %}
-{% endif %}
+        {%- endfor -%}
+    {%- else -%}
+        {%- for server in templatecfg['sflow']['servers'] -%}
+            {%- if loop.last -%}sfprobe[sf_{{ server['address'] }}]{%- else -%}sfprobe[sf_{{ server['address'] }}],{%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+    {%- set plugins_presented = true -%}
+{%- endif -%}
+{%- if templatecfg['disable-imt'] == none %}
+    {%- if plugins_presented %},memory{%- else -%}memory{%- endif -%}
+{%- endif -%}
+
 {% if templatecfg['netflow']['servers'] != none %}
 {% for server in templatecfg['netflow']['servers'] %}
 nfprobe_receiver[nf_{{ server['address'] }}]: {{ server['address'] }}:{{ server['port'] }}
@@ -62,6 +63,7 @@ nfprobe_timeouts[nf_{{ server['address'] }}]: {{ templatecfg['netflow']['timeout
 {% endif %}
 {% endfor %}
 {% endif %}
+
 {% if templatecfg['sflow']['servers'] != none %}
 {% for server in templatecfg['sflow']['servers'] %}
 sfprobe_receiver[sf_{{ server['address'] }}]: {{ server['address'] }}:{{ server['port'] }}


### PR DESCRIPTION
## Change Summary
With trim blocks enabled newlines after {% endif %} blocks are removed. Added the required newlines.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://phabricator.vyos.net/T3141

## Component(s) name
flow-accounting

## Proposed changes
As trim blocks was turned on breaks the ufacctd config. This PR adds new lines after the {% endif  %}.
It also suppresses the vertical spacing for the `plugins:` line. As this is also formatted wrongly, see task in phabricator. 

## How to test
I update a lab router to the latest rolling release, copied the new template and applied flow-accounting. Then checked `//etc/pmacct/uacctd.conf` for right formatting. Checked also with `systemctl status uacctd` that there are no parsing errors.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
