### PR TITLE
flow-accounting: T3141: remove legacy jinja2 template

### DIFF
--- a/data/templates/netflow/uacctd.conf.tmpl
+++ b/data/templates/netflow/uacctd.conf.tmpl
@@ -19,28 +19,25 @@ syslog: {{ templatecfg['syslog-facility'] }}
 imt_path: /tmp/uacctd.pipe
 imt_mem_pools_number: 169
 {% endif %}
-plugins:
-{%- if templatecfg['netflow']['servers'] != none -%}
-    {%- for server in templatecfg['netflow']['servers'] -%}
-        {%- if loop.last -%}nfprobe[nf_{{ server['address'] }}]{%- else -%}nfprobe[nf_{{ server['address'] }}],{%- endif -%}
-    {%- endfor -%}
-    {%- set plugins_presented = true -%}
-{%- endif -%}
-{%- if templatecfg['sflow']['servers'] != none -%}
-    {%- if plugins_presented -%}
-        {%- for server in templatecfg['sflow']['servers'] -%}
-            ,sfprobe[sf_{{ server['address'] }}]
-        {%- endfor -%}
-    {%- else -%}
-        {%- for server in templatecfg['sflow']['servers'] -%}
-            {%- if loop.last -%}sfprobe[sf_{{ server['address'] }}]{%- else -%}sfprobe[sf_{{ server['address'] }}],{%- endif -%}
-        {%- endfor -%}
-    {%- endif -%}
-    {%- set plugins_presented = true -%}
-{%- endif -%}
-{%- if templatecfg['disable-imt'] == none %}
-    {%- if plugins_presented %},memory{%- else -%}memory{%- endif -%}
-{%- endif -%}
+plugins: {% if templatecfg['netflow']['servers'] != none %}
+{%   for server in templatecfg['netflow']['servers'] %}
+{%     if loop.last %}nfprobe[nf_{{ server['address'] }}]{% else %}nfprobe[nf_{{ server['address'] }}],{% endif %}
+{%   endfor %}
+{% set plugins_presented = true %}
+{% endif %}
+{% if templatecfg['sflow']['servers'] != none %}
+{%   if plugins_presented %}
+{%     for server in templatecfg['sflow']['servers'] %},sfprobe[sf_{{ server['address'] }}]{% endfor %}
+{%   else %}
+{%     for server in templatecfg['sflow']['servers'] %}
+{%       if loop.last %}sfprobe[sf_{{ server['address'] }}]{% else %}sfprobe[sf_{{ server['address'] }}],{% endif %}
+{%     endfor %}
+{%   endif %}
+{% set plugins_presented = true %}
+{% endif %}
+{% if templatecfg['disable-imt'] == none %}
+{%   if plugins_presented %},memory{% else %}memory{% endif %}
+{% endif %}
 
 {% if templatecfg['netflow']['servers'] != none %}
 {% for server in templatecfg['netflow']['servers'] %}


### PR DESCRIPTION
## Change Summary
Remove the legacy jinja2 whitespace control again and make it compatible with trim_blocks.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://phabricator.vyos.net/T3141

## Component(s) name
flow-accounting

## Proposed changes
Remove the legacy jinja2 whitespace control again and make it compatible with trim_blocks.

## How to test

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
