### PR TITLE
mpls: T915: Add ordered control for LDP

### DIFF
--- a/data/templates/frr/ldpd.frr.tmpl
+++ b/data/templates/frr/ldpd.frr.tmpl
@@ -11,6 +11,9 @@ dual-stack cisco-interop
 {%         if ldp.parameters.transport_prefer_ipv4 is defined%}
 dual-stack transport-connection prefer ipv4
 {%         endif %}
+{%         if ldp.parameters.ordered_control is defined%}
+ordered-control
+{%         endif %}
 {%     endif %}
 {%     if ldp.neighbor is defined %}
 {%         for neighbors in ldp.neighbor %}

--- a/interface-definitions/protocols-mpls.xml.in
+++ b/interface-definitions/protocols-mpls.xml.in
@@ -349,6 +349,12 @@
                       <valueless/>
                     </properties>
                   </leafNode>
+                  <leafNode name="ordered-control">
+                    <properties>
+                      <help>Enable LDP ordered label distribution control mode</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
                 </children>
               </node>
               <node name="export">


### PR DESCRIPTION
In here we are adding the latest FRR update to
allow for LDP label distribution to operate in
ordered control mode.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The only real change is the addition of one command. It's fairly straightforward and takes properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T915

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
LDP

## Proposed changes
<!--- Describe your changes in detail -->
Just an addition of the "ordered-control" command on the root of the LDP configuration tree in
FRR. It's just an on/off. Nothing else was added.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
This change was tested in a lab in GNS3. It *seems* to work as expected but it's kind of difficult
to really verify for sure without packet captures. The command however in LDP does take inside
of FRR.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
