### PR TITLE
T3171: Ethernet RPS support

### DIFF
--- a/interface-definitions/interfaces-ethernet.xml.in
+++ b/interface-definitions/interfaces-ethernet.xml.in
@@ -77,6 +77,12 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <leafNode name="rps">
+                <properties>
+                  <help>Enable Receive Packet Steering</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
               <leafNode name="sg">
                 <properties>
                   <help>Enable Scatter-Gather</help>

--- a/interface-definitions/interfaces-ethernet.xml.in
+++ b/interface-definitions/interfaces-ethernet.xml.in
@@ -99,13 +99,13 @@
           </node>
           <leafNode name="speed">
             <properties>
-              <help>Link speed</help>
+              <help>Link speed (default: auto)</help>
               <completionHelp>
                 <list>auto 10 100 1000 2500 5000 10000 25000 40000 50000 100000</list>
               </completionHelp>
               <valueHelp>
                 <format>auto</format>
-                <description>Auto negotiation (default)</description>
+                <description>Auto negotiation</description>
               </valueHelp>
               <valueHelp>
                 <format>10</format>
@@ -163,7 +163,7 @@
                 <properties>
                   <help>RX ring buffer</help>
                   <valueHelp>
-                    <format>80-16384</format>
+                    <format>u32:80-16384</format>
                     <description>ring buffer size</description>
                   </valueHelp>
                   <constraint>
@@ -175,7 +175,7 @@
                 <properties>
                   <help>TX ring buffer</help>
                   <valueHelp>
-                    <format>80-16384</format>
+                    <format>u32:80-16384</format>
                     <description>ring buffer size</description>
                   </valueHelp>
                   <constraint>

--- a/python/vyos/validate.py
+++ b/python/vyos/validate.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2018-2021 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -165,7 +165,7 @@ def assert_boolean(b):
 
 
 def assert_range(value, lower=0, count=3):
-    if int(value) not in range(lower,lower+count):
+    if int(value, 16) not in range(lower, lower+count):
         raise ValueError("Value out of range")
 
 

--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2020 VyOS maintainers and contributors
+# Copyright (C) 2019-2021 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -75,9 +75,15 @@ def verify(ethernet):
     verify_vrf(ethernet)
     verify_eapol(ethernet)
 
+    ifname = ethernet['ifname']
+    # verify offloading capabilities
+    if 'offload' in ethernet and 'rps' in ethernet['offload']:
+        if not os.path.exists(f'/sys/class/net/{ifname}/queues/rx-0/rps_cpus'):
+            raise ConfigError('Interface does not suport RPS!')
+
     # XDP requires multiple TX queues
     if 'xdp' in ethernet:
-        queues = glob('/sys/class/net/{ifname}/queues/tx-*'.format(**ethernet))
+        queues = glob(f'/sys/class/net/{ifname}/queues/tx-*')
         if len(queues) < 2:
             raise ConfigError('XDP requires additional TX queues, too few available!')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
RPS is not enabled by default, same for VyOS 1.2, thus add a new CLI node set interfaces ethernet <interface> offload rps

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3171

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ethernet

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
