### PR TITLE
smoketest: mirror: T3169: Reimplement smoke test of span (mirror)

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_bonding.py
+++ b/smoketest/scripts/cli/test_interfaces_bonding.py
@@ -30,6 +30,7 @@ class BondingInterfaceTest(BasicInterfaceTest.BaseTest):
 
         self._base_path = ['interfaces', 'bonding']
         self._interfaces = ['bond0']
+        self._mirror_interfaces = ['dum10010']
         self._test_mtu = True
         self._test_vlan = True
         self._test_qinq = True
@@ -49,6 +50,18 @@ class BondingInterfaceTest(BasicInterfaceTest.BaseTest):
         self._options['bond0'] = []
         for member in self._members:
             self._options['bond0'].append(f'member interface {member}')
+
+        # Creating test interfaces for port mirroring
+        for mon_intf in self._mirror_interfaces:
+            if 'dum' in mon_intf:
+                self.session.set(['interfaces', 'dummy', mon_intf])
+    
+    def tearDown(self):
+        # Delete the dependent interface of port mirroring
+        for mon_intf in self._mirror_interfaces:
+            if 'dum' in mon_intf:
+                self.session.delete(['interfaces', 'dummy', mon_intf])
+        super().tearDown()
 
 
     def test_add_single_ip_address(self):

--- a/smoketest/scripts/cli/test_interfaces_bridge.py
+++ b/smoketest/scripts/cli/test_interfaces_bridge.py
@@ -39,6 +39,7 @@ class BridgeInterfaceTest(BasicInterfaceTest.BaseTest):
         self._interfaces = ['br0']
 
         self._members = []
+        self._mirror_interfaces = []
         # we need to filter out VLAN interfaces identified by a dot (.)
         # in their name - just in case!
         if 'TEST_ETH' in os.environ:
@@ -48,9 +49,22 @@ class BridgeInterfaceTest(BasicInterfaceTest.BaseTest):
                 if not '.' in tmp:
                     self._members.append(tmp)
 
+            for dep_intf in ['dum10001', 'dum10002']:
+                if 'dum' in dep_intf:
+                    self.session.set(['interfaces', 'dummy', dep_intf])
+                    self.session.set(['interfaces', 'bonding', 'bond10001', 'member', 'interface', dep_intf])
+            self._mirror_interfaces.append('bond10001')
+
         self._options['br0'] = []
         for member in self._members:
             self._options['br0'].append(f'member interface {member}')
+    
+    def tearDown(self):
+        self.session.delete(['interfaces', 'bonding', 'bond10001'])
+        for dep_intf in ['dum10001', 'dum10002']:
+            if 'dum' in dep_intf:
+                self.session.delete(['interfaces', 'dummy', dep_intf])
+        super().tearDown()
 
 
     def test_add_remove_bridge_member(self):
@@ -189,4 +203,3 @@ class BridgeInterfaceTest(BasicInterfaceTest.BaseTest):
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)
-

--- a/smoketest/scripts/cli/test_interfaces_ethernet.py
+++ b/smoketest/scripts/cli/test_interfaces_ethernet.py
@@ -38,6 +38,7 @@ class EthernetInterfaceTest(BasicInterfaceTest.BaseTest):
         super().setUp()
 
         self._base_path = ['interfaces', 'ethernet']
+        self._mirror_interfaces = ['dum10100']
         self._test_ip = True
         self._test_mtu = True
         self._test_vlan = True
@@ -66,6 +67,11 @@ class EthernetInterfaceTest(BasicInterfaceTest.BaseTest):
                 mac = read_file(f'/sys/class/net/{interface}/address')
             self._macs[interface] = mac
 
+        # Creating test interfaces for port mirroring
+        for mon_intf in self._mirror_interfaces:
+            if 'dum' in mon_intf:
+                self.session.set(['interfaces', 'dummy', mon_intf])
+
 
     def tearDown(self):
         for interface in self._interfaces:
@@ -76,6 +82,11 @@ class EthernetInterfaceTest(BasicInterfaceTest.BaseTest):
             self.session.set(self._base_path + [interface, 'duplex', 'auto'])
             self.session.set(self._base_path + [interface, 'speed', 'auto'])
             self.session.set(self._base_path + [interface, 'hw-id', self._macs[interface]])
+        
+        # Delete the dependent interface of port mirroring
+        for mon_intf in self._mirror_interfaces:
+            if 'dum' in mon_intf:
+                self.session.delete(['interfaces', 'dummy', mon_intf])
 
         super().tearDown()
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Reimplement smoke test of span (mirror)

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): ENHANCEMENT

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3169

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
mirror

## Proposed changes
<!--- Describe your changes in detail -->
In the submission of ef629504, the smoke test was deleted for various reasons. Now, it's time to re implement it




## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Pass smoke test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
