### PR TITLE
dhcpv6-pd: verify: T3193: fix DHCPv6 PD verification issues

### DIFF
--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -194,8 +194,8 @@ def verify_dhcpv6(config):
                                   'the delegated prefix!')
 
             for interface in interfaces:
-                sla_id = interfaces[interface].get('sla_id', None)
-                sla_ids.append(sla_id)
+                if 'sla_id' in interfaces[interface]:
+                    sla_ids.append(interfaces[interface]['sla_id'])
 
             # Check for duplicates
             duplicates = [x for n, x in enumerate(sla_ids) if x in sla_ids[:n]]

--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -187,14 +187,14 @@ def verify_dhcpv6(config):
         # assigned IPv6 subnet from a delegated prefix
         for pd in dict_search('dhcpv6_options.pd', config):
             sla_ids = []
+            interfaces = dict_search(f'dhcpv6_options.pd.{pd}.interface', config)
 
-            if not dict_search(f'dhcpv6_options.pd.{pd}.interface', config):
+            if not interfaces:
                 raise ConfigError('DHCPv6-PD requires an interface where to assign '
                                   'the delegated prefix!')
 
-            for interface in dict_search(f'dhcpv6_options.pd.{pd}.interface', config):
-                sla_id = dict_search(
-                    f'dhcpv6_options.pd.{pd}.interface.{interface}.sla_id', config)
+            for interface in interfaces:
+                sla_id = interfaces[interface].get('sla_id', None)
                 sla_ids.append(sla_id)
 
             # Check for duplicates

--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -193,9 +193,11 @@ def verify_dhcpv6(config):
                 raise ConfigError('DHCPv6-PD requires an interface where to assign '
                                   'the delegated prefix!')
 
-            for interface in interfaces:
+            for count, interface in enumerate(interfaces):
                 if 'sla_id' in interfaces[interface]:
                     sla_ids.append(interfaces[interface]['sla_id'])
+                else:
+                    sla_ids.append(str(count))
 
             # Check for duplicates
             duplicates = [x for n, x in enumerate(sla_ids) if x in sla_ids[:n]]


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
1. Allow more than one VLAN interface
2. Allow multiple auto-assigned SLA-IDs
3. Detect conflict between auto-assigned and configured SLA-IDs

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3193

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcpv6-pd
verify

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Boot the ISO and configure as follows:

Should succeed:
```
set interfaces ethernet eth0 vif 10
set interfaces ethernet eth0 vif 11
set interfaces ethernet eth0 dhcpv6-options pd 0 interface eth0.10 sla-id 0
set interfaces ethernet eth0 dhcpv6-options pd 0 interface eth0.11 sla-id 1
commit
```

Should succeed:
```
set interfaces ethernet eth0 dhcpv6-options pd 0 interface eth1
set interfaces ethernet eth0 dhcpv6-options pd 0 interface eth2
commit
```

Should fail:
```
set interfaces ethernet eth0 dhcpv6-options pd 0 interface eth1
set interfaces ethernet eth0 dhcpv6-options pd 0 interface eth2 sla-id 0
commit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly