### PR TITLE
T3170: check if any generated node.def files are empty.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ interface_definitions: $(BUILD_DIR) $(obj)
 	cp $(TMPL_DIR)/interfaces/ethernet/node.tag/ip/node.def $(TMPL_DIR)/interfaces/vti/node.tag/ip
 	cp $(TMPL_DIR)/interfaces/ethernet/node.tag/ipv6/node.def $(TMPL_DIR)/interfaces/vti/node.tag/ipv6
 
+	find $(TMPL_DIR) -name node.def -empty && sh -c 'echo "There are empty node.def files! Check your interface definitions." && exit 1'
+
 .PHONY: op_mode_definitions
 .ONESHELL:
 op_mode_definitions:
@@ -84,6 +86,8 @@ op_mode_definitions:
 	# XXX: ping must be able to recursivly call itself as the
 	# options are provided from the script itself
 	ln -s ../node.tag $(OP_TMPL_DIR)/ping/node.tag/node.tag/
+
+	find $(op_TMPL_DIR) -name node.def -empty && sh -c 'echo "There are empty node.def files! Check your interface definitions." && exit 1'
 
 .PHONY: component_versions
 .ONESHELL:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary

Fail the build if there are empty `node.def` files

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 

- [x] Other (please describe): stricter build sanity checks.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Note that right now the build **will** fail because there **are** empty `node.def` files. This should not be merged until there are none.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
