### PR TITLE
T3165: use a separate file for "base" CLI nodes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ $(BUILD_DIR):
 interface_definitions: $(BUILD_DIR) $(obj)
 	mkdir -p $(TMPL_DIR)
 
+	# Build "base" templates (service, interfaces, other high-level nodes)
+	$(CURDIR)/scripts/build-command-templates $(CURDIR)/interface-definitions/base/base.xml $(CURDIR)/schema/interface_definition.rng $(TMPL_DIR)
+
 	find $(BUILD_DIR)/interface-definitions -type f -name "*.xml" | xargs -I {} $(CURDIR)/scripts/build-command-templates {} $(CURDIR)/schema/interface_definition.rng $(TMPL_DIR) || exit 1
 
 	# XXX: delete top level node.def's that now live in other packages

--- a/interface-definitions/base/base.xml
+++ b/interface-definitions/base/base.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="interfaces">
+    <properties>
+      <help>Network interfaces</help>
+    </properties>
+  </node>
+  <node name="high-availability">
+    <properties>
+      <help>High availability mechanisms</help>
+    </properties>
+  </node>
+  <node name="nat">
+    <properties>
+      <help>Network address translation</help>
+    </properties>
+  </node>
+  <node name="service">
+    <properties>
+      <help>Network and system services</help>
+    </properties>
+  </node>
+</interfaceDefinition>

--- a/scripts/build-command-op-templates
+++ b/scripts/build-command-op-templates
@@ -193,6 +193,7 @@ def process_node(n, tmpl_dir):
                 f.write('help: {0}\n'.format(props['help']))
         else:
             # Something has already generated this file
+            print("Warning: refusing to overwrite already existing file {}".format(nodedef_path))
             pass
 
         # Create the inner node.tag part

--- a/scripts/build-command-templates
+++ b/scripts/build-command-templates
@@ -3,7 +3,7 @@
 #    build-command-template: converts new style command definitions in XML
 #      to the old style (bunch of dirs and node.def's) command templates
 #
-#    Copyright (C) 2017 VyOS maintainers <maintainers@vyos.net>
+#    Copyright (C) 2017,2021 VyOS maintainers <maintainers@vyos.net>
 #
 #    This library is free software; you can redistribute it and/or
 #    modify it under the terms of the GNU Lesser General Public
@@ -279,19 +279,26 @@ def process_node(n, tmpl_dir):
             f.write(make_node_def(props))
     else:
         # Something has already generated that file
+        print("Warning: refusing to overwrite already existing file {}".format(nodedef_path))
         pass
 
 
-    if node_type == "node":
+    if (node_type == "node") and (children is None):
+        print("Warning: non-leaf, non-tag <node> without children may be incomplete ({})".format(nodedef_path))
+        pass
+    elif node_type == "node":
         inner_nodes = children.iterfind("*")
         for inner_n in inner_nodes:
             process_node(inner_n, my_tmpl_dir)
-    if node_type == "tagNode":
+    elif node_type == "tagNode":
+        if children is None:
+            raise ValueError("A <tagNode> without children is not allowed")
+
+        inner_nodes = children.iterfind("*")
         my_tmpl_dir.append("node.tag")
         if debug:
             print("Created path for the tagNode:", end="")
         os.makedirs(make_path(my_tmpl_dir), exist_ok=True)
-        inner_nodes = children.iterfind("*")
         for inner_n in inner_nodes:
             process_node(inner_n, my_tmpl_dir)
     else:


### PR DESCRIPTION
Needs a bit of a clean-up to move all top level nodes to the base file.