### PR TITLE
ntp: T2944: Fix ntp bug. Revert to previous behavior

### DIFF
--- a/data/templates/ntp/ntp.conf.tmpl
+++ b/data/templates/ntp/ntp.conf.tmpl
@@ -36,10 +36,4 @@ interface ignore wildcard
 {%   for address in listen_address %}
 interface listen {{ address }}
 {%   endfor %}
-interface listen 127.0.0.1
-interface listen ::1
-{% else %}
-interface ignore wildcard
-interface listen 127.0.0.1
-interface listen ::1
 {% endif %}

--- a/smoketest/scripts/cli/test_system_ntp.py
+++ b/smoketest/scripts/cli/test_system_ntp.py
@@ -76,7 +76,11 @@ class TestSystemNTP(unittest.TestCase):
         self.assertTrue(process_named_running(PROCESS_NAME))
 
     def test_ntp_clients(self):
-        # Test the allowed-networks statement
+        """ Test the allowed-networks statement """
+        listen_address = ['127.0.0.1', '::1']
+        for listen in listen_address:
+            self.session.set(base_path + ['listen-address', listen])
+
         networks = ['192.0.2.0/24', '2001:db8:1000::/64']
         for network in networks:
             self.session.set(base_path + ['allow-clients', 'address', network])
@@ -102,7 +106,9 @@ class TestSystemNTP(unittest.TestCase):
 
         # Check listen address
         tmp = get_config_value('interface')
-        test = ['ignore wildcard', 'listen 127.0.0.1', 'listen ::1']
+        test = ['ignore wildcard']
+        for listen in listen_address:
+            test.append(f'listen {listen}')
         self.assertEqual(tmp, test)
 
         # Check for running process


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Reverting to the previous behavior, when NTP by default was listening on each local IP address.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T2944
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ntp
## Proposed changes
<!--- Describe your changes in detail -->
I revert to the previous working commit because service NTP doesn't work if you get an address via DHCP and trying to set listen-address 0.0.0.0
## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

```
set system ntp allow-clients address '192.0.2.0/24'
set system ntp server 0.pool.ntp.org
set system ntp server 1.pool.ntp.org
set system ntp server 2.pool.ntp.org
```
And show ntp (with that pr)
```
vyos@r5-roll:~$ show ntp 
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
*5.9.57.158      129.69.1.170     2 u   49   64    3   44.168   -0.726   0.778
+135.181.58.21   94.16.116.137    3 u   47   64    3   70.078   -0.836   0.299
+162.159.200.1   10.20.10.78      3 u   47   64    3   42.072    0.380   0.333

```
WIthout it we don't get ntp updates
```
vyos@r5-roll:~$ show ntp 
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 217.145.98.135  .INIT.          16 u    -   64    0    0.000    0.000   0.000
 136.243.66.91   .INIT.          16 u    -   64    0    0.000    0.000   0.000
 144.76.43.40    .INIT.          16 u    -   64    0    0.000    0.000   0.000

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
