### PR TITLE
tunnel: T3173: Add nopmtudisc parameter for tunnels conf-mode

### DIFF
--- a/interface-definitions/interfaces-tunnel.xml.in
+++ b/interface-definitions/interfaces-tunnel.xml.in
@@ -177,6 +177,25 @@
                   <help>IPv4 specific tunnel parameters</help>
                 </properties>
                 <children>
+                  <leafNode name="pmtu-discovery">
+                    <properties>
+                      <help>Path MTU Discovery parameters</help>
+                      <completionHelp>
+                        <list>disable enable</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>disable</format>
+                        <description>Disable Path MTU Discovery for tunnel</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>enable</format>
+                        <description>Enable Path MTU Discovery for tunnel (by default)</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>^(disable|enable)$</regex>
+                      </constraint>
+                    </properties>
+                  </leafNode>
                   <leafNode name="ttl">
                     <properties>
                       <help>Time to live field</help>

--- a/python/vyos/ifconfig/tunnel.py
+++ b/python/vyos/ifconfig/tunnel.py
@@ -72,16 +72,22 @@ class _Tunnel(Interface):
 
         # add " option-name option-name-value ..." for all options set
         options = " ".join(["{} {}".format(k, self.config[k])
-                            for k in self.options if k in self.config and self.config[k]])
+                            for k in self.options if k in self.config and self.config[k] and k is not 'pmtud'])
         self._cmd('{} {}'.format(create.format(**self.config), options))
         self.set_admin_state('down')
 
     def change_options(self):
-        change = 'ip tunnel cha {ifname} mode {type}'
+        change = 'ip tunnel cha {ifname} mode {type} pmtudisc'
 
         # add " option-name option-name-value ..." for all options set
+        # option 'pmtud' doesn't has any value like 'ttl' or 'key' (ip tunnel cha tunX [no]pmtudisc)
         options = " ".join(["{} {}".format(k, self.config[k])
-                            for k in self.options if k in self.config and self.config[k]])
+                            for k in self.options if k in self.config and self.config[k] and k is not 'pmtud'])
+
+        # set interfaces tunnel tunX parameters ip pmtu-discovery disable
+        if 'disable' in self.config['pmtud']:
+            change = 'ip tunnel cha {ifname} mode {type} nopmtudisc'
+
         self._cmd('{} {}'.format(change.format(**self.config), options))
 
     @classmethod
@@ -142,7 +148,7 @@ class GREIf(_Tunnel):
     """
 
     default = {'type': 'gre'}
-    options = ['local', 'remote', 'dev', 'ttl', 'tos', 'key']
+    options = ['local', 'remote', 'dev', 'ttl', 'tos', 'key', 'pmtud']
 
 # GreTap also called GRE Bridge
 class GRETapIf(_Tunnel):

--- a/src/conf_mode/interfaces-tunnel.py
+++ b/src/conf_mode/interfaces-tunnel.py
@@ -126,6 +126,11 @@ def verify(tunnel):
     if 'source_interface' in tunnel:
         verify_interface_exists(tunnel['source_interface'])
 
+    # ttl != 0 and nopmtudisc are incompatible
+    if 'pmtu_discovery' in tunnel['parameters']['ip']:
+        if 'disable' in tunnel['parameters']['ip']['pmtu_discovery'] and "0" not in tunnel['parameters']['ip']['ttl']:
+            raise ConfigError('ip ttl should be set to "0" with option "pmtu-discovery disable"')
+
 def generate(tunnel):
     return None
 
@@ -164,6 +169,7 @@ def apply(tunnel):
         'local_ip'                   : 'local',
         'remote_ip'                  : 'remote',
         'source_interface'           : 'dev',
+        'parameters.ip.pmtu_discovery' : 'pmtud',
         'parameters.ip.ttl'          : 'ttl',
         'parameters.ip.tos'          : 'tos',
         'parameters.ip.key'          : 'key',


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add "nopmtudisc" option for tunnel interface
## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T3173
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
tunnels
## Proposed changes
<!--- Describe your changes in detail -->

That feature adding option "nopmtudisc" for tunnel

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Add next configuration
```
set interfaces tunnel tun0 address '10.5.2.1/30'
set interfaces tunnel tun0 encapsulation 'gre'
set interfaces tunnel tun0 local-ip '192.168.122.15'
set interfaces tunnel tun0 multicast 'enable'
set interfaces tunnel tun0 parameters ip ttl '0'
set interfaces tunnel tun0 remote-ip '192.168.122.1'
set interfaces tunnel tun0 parameters ip pmtu-discovery 'disable'
```
And check tunnel options. "nopmtudisc" should be in the configuration
```
vyos@r5-roll# sudo ip -d tunnel show tun0
tun0: gre/ip remote 192.168.122.1 local 192.168.122.15 ttl inherit tos inherit nopmtudisc
```

When delete it or "set pmtu-discovery enable" we don't see option
```
vyos@r5-roll# set interfaces tunnel tun0 parameters ip pmtu-discovery enable 
[edit]
vyos@r5-roll# commit
[edit]
vyos@r5-roll# sudo ip -d tunnel show tun0
tun0: gre/ip remote 192.168.122.1 local 192.168.122.15 ttl inherit tos inherit
[edit]

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
