### PR TITLE
bgp: T2387: Fix template for bgp redistribute proto ospfv3

### DIFF
--- a/data/templates/frr/bgp.frr.tmpl
+++ b/data/templates/frr/bgp.frr.tmpl
@@ -152,7 +152,11 @@ router bgp {{ asn }}
 {%         if protocol == 'table' %}
   redistribute table {{ address_family[af].redistribute[protocol].table }}
 {%         else %}
-  redistribute {{ protocol }}{% if address_family[af].redistribute[protocol].metric is defined %} metric {{ address_family[af].redistribute[protocol].metric }}{% endif %}{% if address_family[af].redistribute[protocol].route_map is defined %} route-map {{ address_family[af].redistribute[protocol].route_map }}{% endif %}
+{%           set redistribution_protocol = protocol %}
+{%             if protocol == 'ospfv3' %}
+{%               set redistribution_protocol = 'ospf6' %}
+{%             endif %}
+  redistribute {{ redistribution_protocol }}{% if address_family[af].redistribute[protocol].metric is defined %} metric {{ address_family[af].redistribute[protocol].metric }}{% endif %}{% if address_family[af].redistribute[protocol].route_map is defined %} route-map {{ address_family[af].redistribute[protocol].route_map }}{% endif %}
 {#######   we need this blank line!! #######}
 
 {%         endif %}

--- a/interface-definitions/protocols-bgp.xml.in
+++ b/interface-definitions/protocols-bgp.xml.in
@@ -198,9 +198,9 @@
                           #include <include/bgp-afi-redistribute-metric-route-map.xml.i>
                         </children>
                       </node>
-                      <node name="ospf">
+                      <node name="ospfv3">
                         <properties>
-                          <help>Redistribute OSPF routes into BGP</help>
+                          <help>Redistribute OSPFv3 routes into BGP</help>
                         </properties>
                         <children>
                           #include <include/bgp-afi-redistribute-metric-route-map.xml.i>
@@ -282,7 +282,7 @@
               <constraint>
                 <validator name="ipv4-address"/>
                 <validator name="ipv6-address"/>
-                <regex>(br|bond|dum|en|eth|gnv|lo|peth|tun|vti|vxlan|wg|wlan)[0-9]+</regex>
+                <regex>(br|bond|dum|en|eth|gnv|peth|tun|vti|vxlan|wg|wlan)[0-9]+|lo</regex>
               </constraint>
             </properties>
             <children>
@@ -641,7 +641,7 @@
                   <constraint>
                     <validator name="ipv4-address"/>
                     <validator name="ipv6-address"/>
-                    <regex>(br|bond|dum|en|eth|gnv|lo|peth|tun|vti|vxlan|wg|wlan)[0-9]+</regex>
+                    <regex>(br|bond|dum|en|eth|gnv|peth|tun|vti|vxlan|wg|wlan)[0-9]+|lo</regex>
                   </constraint>
                 </properties>
               </leafNode>
@@ -1152,7 +1152,7 @@
                   <constraint>
                     <validator name="ipv4-address"/>
                     <validator name="ipv6-address"/>
-                    <regex>(br|bond|dum|en|eth|gnv|lo|peth|tun|vti|vxlan|wg|wlan)[0-9]+</regex>
+                    <regex>(br|bond|dum|en|eth|gnv|peth|tun|vti|vxlan|wg|wlan)[0-9]+|lo</regex>
                   </constraint>
                 </properties>
               </leafNode>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Fix FRR template for bgp (new format) address-family ipv6 unicast redistribute ospfv3.
Fix update source "lo" interface
## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T2387
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp
## Proposed changes
<!--- Describe your changes in detail -->
It was no possible to set update-source "lo" interface because it expected [0-9] on the interface end name ethX, vtiX, brX.
Also, it fixes the template for FRR bgp **ospfv3**
```
set protocols nbgp 65001 address-family ipv6-unicast redistribute ospfv3
```
In FRR format it should be **ospf6**
```
redistribute ospf6
```
## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

```
set protocols nbgp 65001 address-family ipv6-unicast redistribute ospfv3
set protocols nbgp 65001 address-family ipv6-unicast redistribute static
set protocols nbgp 65001 neighbor 100.64.0.2 remote-as '65002'
set protocols nbgp 65001 neighbor 100.64.0.2 update-source 'lo'
```
FRR
```
!
router bgp 65001
 no bgp default ipv4-unicast
 neighbor 100.64.0.2 remote-as 65002
 neighbor 100.64.0.2 update-source lo
 !
 address-family ipv6 unicast
  redistribute static
  redistribute ospf6
 exit-address-family
!
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
