### PR TITLE
is-is: T3210: Fix three-way-handshake

### DIFF
--- a/data/templates/frr/isis.frr.tmpl
+++ b/data/templates/frr/isis.frr.tmpl
@@ -168,8 +168,8 @@ interface {{ iface }}
 {%     if iface_config.psnp_interval is defined and iface_config.psnp_interval is not none %}
  isis psnp-interval {{ iface_config.psnp_interval }}
 {%     endif %}
-{%     if iface_config.three_way_handshake is defined %}
- isis three-way-handshake
+{%     if iface_config.no_three_way_handshake is defined %}
+ no isis three-way-handshake
 {%     endif %}
 {%   endfor %}
 {% endif %}

--- a/interface-definitions/protocols-isis.xml.in
+++ b/interface-definitions/protocols-isis.xml.in
@@ -758,9 +758,9 @@
                   </constraint>
                 </properties>
               </leafNode>
-              <leafNode name="three-way-handshake">
+              <leafNode name="no-three-way-handshake">
                 <properties>
-                  <help>Enable/Disable three-way handshake</help>
+                  <help>Disable three-way handshake</help>
                   <valueless/>
                 </properties>
               </leafNode>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix isis three-way-handshake for an interface which enabled by default, but hidden in frr config.
## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T3210
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
isis
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

```
set protocols isis FOO interface eth1 no-three-way-handshake
set protocols isis FOO net '49.0001.1921.6800.1002.00'
```
FRR
```
!
interface eth1
 ip router isis FOO
 no isis three-way-handshake
!
router isis FOO
 net 49.0001.1921.6800.1002.00
!

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
