### PR TITLE
op-mode: T3215: Fix show ipv6 route overlaps in nodes

### DIFF
--- a/op-mode-definitions/ipv6-route.xml.in
+++ b/op-mode-definitions/ipv6-route.xml.in
@@ -24,44 +24,6 @@
             <command>ip -f inet6 neigh list</command>
           </leafNode>
 
-          <node name="route">
-            <properties>
-              <help>Show IPv6 routes</help>
-            </properties>
-            <children>
-              <node name="cache">
-                <properties>
-                  <help>Show kernel IPv6 route cache</help>
-                </properties>
-                <command>ip -s -f inet6 route list cache</command>
-              </node>
-              <tagNode name="cache">
-                <properties>
-                  <help>Show kernel IPv6 route cache for a given route</help>
-                  <completionHelp>
-                    <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
-                  </completionHelp>
-                </properties>
-                <command>ip -s -f inet6 route list cache $5</command>
-              </tagNode>
-              <node name="forward">
-                <properties>
-                  <help>Show kernel IPv6 route table</help>
-                </properties>
-                <command>ip -f inet6 route list</command>
-              </node>
-              <tagNode name="forward">
-                <properties>
-                  <help>Show kernel IPv6 route table for a given route</help>
-                  <completionHelp>
-                    <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
-                  </completionHelp>
-                </properties>
-                <command>ip -s -f inet6 route list $5</command>
-              </tagNode>
-            </children>
-          </node>
-
         </children>
       </node>
     </children>

--- a/op-mode-definitions/show-ipv6-route.xml.in
+++ b/op-mode-definitions/show-ipv6-route.xml.in
@@ -19,12 +19,42 @@
                 </properties>
                 <command>vtysh -c "show ipv6 route bgp"</command>
               </node>
+              <node name="cache">
+                <properties>
+                  <help>Show kernel IPv6 route cache</help>
+                </properties>
+                <command>ip -s -f inet6 route list cache</command>
+              </node>
+              <tagNode name="cache">
+                <properties>
+                  <help>Show kernel IPv6 route cache for a given route</help>
+                  <completionHelp>
+                    <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>ip -s -f inet6 route list cache $5</command>
+              </tagNode>
               <node name="connected">
                 <properties>
                   <help>Show IPv6 connected routes</help>
                 </properties>
                 <command>vtysh -c "show ipv6 route connected"</command>
               </node>
+              <node name="forward">
+                <properties>
+                  <help>Show kernel IPv6 route table</help>
+                </properties>
+                <command>ip -f inet6 route list</command>
+              </node>
+              <tagNode name="forward">
+                <properties>
+                  <help>Show kernel IPv6 route table for a given route</help>
+                  <completionHelp>
+                    <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>ip -s -f inet6 route list $5</command>
+              </tagNode>
               <node name="isis">
                 <properties>
                   <help>Show IPv6 IS-IS routes</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Move "show ipv6 route cache" and "show ipv6 route forward" to XML "show-ipv6-route.xml.in"
Because node ipv6 "route" overlapped in 2 XML files.
## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T3215
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->
Move XML "show ipv6 route" from ipv6-route.xml.in  to show-ipv6-route.xml.in
Delete node "route" for  ipv6-route.xml.in
## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

```
vyos@r5-roll:~$ show ipv6 route 
Codes: K - kernel route, C - connected, S - static, R - RIPng,
       O - OSPFv3, I - IS-IS, B - BGP, N - NHRP, T - Table,
       v - VNC, V - VNC-Direct, A - Babel, D - SHARP, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued route, r - rejected route

C * fe80::/64 is directly connected, eth2, 00:57:40
C * fe80::/64 is directly connected, eth0, 00:57:41
C * fe80::/64 is directly connected, eth1, 00:57:41
C * fe80::/64 is directly connected, tun0, 00:57:42
C>* fe80::/64 is directly connected, lo, 00:57:43


vyos@r5-roll:~$ show ipv6 route forward 
::1 dev lo proto kernel metric 256 pref medium
fe80::/64 dev lo proto kernel metric 256 pref medium
fe80::/64 dev eth1 proto kernel metric 256 pref medium
fe80::/64 dev eth0 proto kernel metric 256 pref medium
fe80::/64 dev eth2 proto kernel metric 256 pref medium
fe80::/64 dev tun0 proto kernel metric 256 pref medium

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
