### PR TITLE
smoketest: bridge: T3226: Repair bridge smoke test damage

### DIFF
--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -272,9 +272,9 @@ def has_vlan_subinterface_configured(conf, intf):
     old_level = conf.get_level()
     conf.set_level([])
 
-    intfpath = 'interfaces ' + Section.get_config_path(intf)
-    if ( conf.exists(f'{intfpath} vif') or
-            conf.exists(f'{intfpath} vif-s')):
+    intfpath = ['interfaces', Section.section(intf), intf]
+    if ( conf.exists(intfpath + ['vif']) or
+            conf.exists(intfpath + ['vif-s'])):
         ret = True
 
     conf.set_level(old_level)

--- a/smoketest/scripts/cli/test_interfaces_bridge.py
+++ b/smoketest/scripts/cli/test_interfaces_bridge.py
@@ -202,6 +202,13 @@ class BridgeInterfaceTest(BasicInterfaceTest.BaseTest):
             # remove VLAN interfaces
             for vif in vifs:
                 self.session.delete(['interfaces', 'ethernet', member, 'vif', vif])
+        
+        # delete all members
+        for interface in self._interfaces:
+            for member in self._members:
+                for vif in vifs:
+                    self.session.delete(['interfaces', 'ethernet', member, 'vif', vif])
+                    self.session.delete(['interfaces', 'bridge', interface, 'member', 'interface', f'{member}.{vif}'])
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Repair bridge smoke test damage

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3226

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
smoketest: bridge

## Proposed changes
<!--- Describe your changes in detail -->
Repair bridge smoke test damage

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
