### PR TITLE
smoketest: bridge: T3226: Remove redundant code

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_bridge.py
+++ b/smoketest/scripts/cli/test_interfaces_bridge.py
@@ -198,10 +198,6 @@ class BridgeInterfaceTest(BasicInterfaceTest.BaseTest):
                 for vif in vifs:
                     # member interface must be assigned to the bridge
                     self.assertTrue(os.path.exists(f'/sys/class/net/{interface}/lower_{member}.{vif}'))
-
-            # remove VLAN interfaces
-            for vif in vifs:
-                self.session.delete(['interfaces', 'ethernet', member, 'vif', vif])
         
         # delete all members
         for interface in self._interfaces:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Remove redundant code

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3226

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
smoketest: bridge

## Proposed changes
<!--- Describe your changes in detail -->
In 558e1ca9, we found that the interface created by a test case was not cleaned up completely, which led to the destruction of smoke test. But in fact, the test case function retained an invalid deletion configuration code. We added a repair patch and forgot to delete the invalid code. Now we delete it

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
