### PR TITLE
bgp: T1875: Adding BGP listen range FRR feature

### DIFF
--- a/data/templates/frr/bgp.frr.tmpl
+++ b/data/templates/frr/bgp.frr.tmpl
@@ -203,6 +203,16 @@ router bgp {{ asn }}
 {%   endfor %}
 {% endif %}
  !
+{% if listen is defined %}
+{%   if listen.limit is defined and listen.limit is not none %}
+ bgp listen limit {{ listen.limit }}
+{%   endif %}
+{%   for prefix, options in listen.range.items() %}
+{%     if options.peer_group is defined and options.peer_group is not none %}
+ bgp listen range {{ prefix }} peer-group {{ options.peer_group }}
+{%     endif %}
+{%   endfor %}
+{% endif %}
 {% if parameters is defined %}
 {%   if parameters.always_compare_med is defined %}
  bgp always-compare-med

--- a/interface-definitions/protocols-bgp.xml.in
+++ b/interface-definitions/protocols-bgp.xml.in
@@ -250,6 +250,40 @@
               </leafNode>
             </children>
           </node>
+          <node name="listen">
+            <properties>
+              <help>Listen for and accept BGP dynamic neighbors from range</help>
+            </properties>
+            <children>
+              <leafNode name="limit">
+                <properties>
+                  <help>Maximum number of dynamic neighbors that can be created</help>
+                  <valueHelp>
+                    <format>u32:1-5000</format>
+                    <description>BGP neighbor limit</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 1-5000"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <tagNode name="range">
+                <properties>
+                  <help>IPv4/IPv6 prefix range</help>
+                  <completionHelp>
+                    <list>&lt;x.x.x.x/x&gt; &lt;h:h:h:h:h:h:h:h/h&gt;</list>
+                  </completionHelp>
+                  <constraint>
+                    <validator name="ipv4-prefix"/>
+                    <validator name="ipv6-prefix"/>
+                  </constraint>
+                </properties>
+                <children>
+                  #include <include/bgp-peer-group.xml.i>
+                </children>
+              </tagNode>
+            </children>
+          </node>
           <tagNode name="neighbor">
             <properties>
               <help>BGP neighbor</help>

--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -94,7 +94,7 @@ def verify(bgp):
                             if tmp not in afi_config['prefix_list']:
                                 # bail out early
                                 continue
-                            # get_config_dict() mangles all '-' characters to '_' this is legitim, thus all our
+                            # get_config_dict() mangles all '-' characters to '_' this is legitimate, thus all our
                             # compares will run on '_' as also '_' is a valid name for a prefix-list
                             prefix_list = afi_config['prefix_list'][tmp].replace('-', '_')
                             if afi == 'ipv4_unicast':
@@ -112,7 +112,13 @@ def verify(bgp):
                                 route_map = afi_config['route_map'][tmp].replace('-', '_')
                                 if dict_search(f'policy.route_map.{route_map}', asn_config) == None:
                                     raise ConfigError(f'route-map "{route_map}" used for "{tmp}" does not exist!')
-
+               
+        # Throw an error if a peer group is not configured for allow range
+        if 'listen' in asn_config:
+            if 'range' in asn_config['listen']:
+                for prefix in asn_config['listen']['range']:
+                    if not 'peer_group' in asn_config['listen']['range'].get(prefix):
+                        raise ConfigError(f'Listen range for prefix "{prefix}" has no peer group configured.')
 
     return None
 


### PR DESCRIPTION
In this commit we are adding the FRR BGP listen
range feature. Specifically it is useful for being
able to specify a range in which BGP peers can
connect to the local router.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

We added the FRR command of "bgp listen" under the BGP configuration with the hierarchy of "allow" under the main BGP stanza.
Within that there are 2 commands, 'range' and 'limit' which are used to control the ability to dynamic BGP sessions to be created.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T1875

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
BGP

## Proposed changes
<!--- Describe your changes in detail -->

As was said above, the changed add the "allow" stanza option within the main BGP hierarchy. Under that we have a tagNode that is used to ask for a prefix range and a peer-group. There's also an addition within the BGP handler to not allow for a range to be committed without a peer-group attached to it. 

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

The changes were tested on a VyOS VM and they seemed to take and work as expected.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
