### PR TITLE
XML: T2910: add support for override of tag 'defaultValue' values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ op_xml_obj = $(op_xml_src:.xml.in=.xml)
 interface_definitions: $(config_xml_obj)
 	mkdir -p $(TMPL_DIR)
 
+	$(CURDIR)/scripts/override-default $(BUILD_DIR)/interface-definitions
+
 	find $(BUILD_DIR)/interface-definitions -type f -name "*.xml" | xargs -I {} $(CURDIR)/scripts/build-command-templates {} $(CURDIR)/schema/interface_definition.rng $(TMPL_DIR) || exit 1
 
 	# XXX: delete top level node.def's that now live in other packages

--- a/scripts/override-default
+++ b/scripts/override-default
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+#
+# override-default: preprocessor for XML interface definitions to interpret
+# redundant entries (relative to path) with tag 'defaultValue' as an override
+# directive. Must be called before build-command-templates, as the schema
+# disallows redundancy.
+#
+# Copyright (C) 2021 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+# Use lxml xpath capability to find multiple elements with tag defaultValue
+# relative to path; replace and remove to override the value.
+
+import sys
+import glob
+import logging
+from lxml import etree
+
+debug = False
+
+logger = logging.getLogger(__name__)
+logs_handler = logging.StreamHandler()
+logger.addHandler(logs_handler)
+
+if debug:
+    logger.setLevel(logging.DEBUG)
+else:
+    logger.setLevel(logging.INFO)
+
+def override_element(l: list):
+    """
+    Allow multiple override elements; use the final one (in document order).
+    """
+    if len(l) < 2:
+        logger.debug("passing list of single element to override_element")
+        return
+
+    # assemble list of leafNodes of overriding defaultValues, for later removal
+    parents = []
+    for el in l[1:]:
+        parents.append(el.getparent())
+
+    # replace element with final override
+    l[0].getparent().replace(l[0], l[-1])
+
+    # remove all but overridden element
+    for el in parents:
+        el.getparent().remove(el)
+
+def collect_and_override(dir_name):
+    """
+    Collect elements with defaultValue tag into dictionary indexed by tuple
+    of (name, str(ancestor path)); the second component must be immutable for
+    tuple to act as key, hence str().
+    """
+    for fname in glob.glob(f'{dir_name}/*.xml'):
+        tree = etree.parse(fname)
+        root = tree.getroot()
+        defv = {}
+
+        xpath_str = f'//defaultValue'
+        xp = tree.xpath(xpath_str)
+
+        for element in xp:
+            ap = element.xpath('ancestor::*[@name]')
+            defv.setdefault((ap[-1].get("name"), str(ap[:-1])), []).append(element)
+
+        for k, v in defv.items():
+            if len(v) > 1:
+                logger.debug(f'overridding default in {k[0]}')
+                override_element(v)
+
+        revised_str = etree.tostring(root, encoding='unicode', pretty_print=True)
+
+        with open(f'{fname}', 'w') as f:
+            f.write(revised_str)
+
+def main():
+    if len(sys.argv) < 2:
+        logger.critical('Must specify XML directory!')
+        sys.exit(1)
+
+    dir_name = sys.argv[1]
+
+    collect_and_override(dir_name)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add preprocessing script to support overriding defaultValue entries in interface-definitions.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T2910

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
xml

## Proposed changes
<!--- Describe your changes in detail -->
A Python script is called during compile to support overriding 'defaultValue' elements.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
```
--- a/interface-definitions/interfaces-pppoe.xml.in
+++ b/interface-definitions/interfaces-pppoe.xml.in
@@ -125,6 +125,9 @@
             </properties>
           </leafNode>
           #include <include/interface-mtu-68-1500.xml.i>
+          <leafNode name="mtu">
+            <defaultValue>1492</defaultValue>
+          </leafNode>
           <leafNode name="no-peer-dns">
             <properties>
               <help>Do not use DNS servers provided by the peer</help>
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
