### PR TITLE
dhcpv6: T3240: send DUID when only DHCPv6 PD is configured

### DIFF
--- a/data/templates/dhcp-client/ipv6.tmpl
+++ b/data/templates/dhcp-client/ipv6.tmpl
@@ -2,10 +2,10 @@
 
 # man https://www.unix.com/man-page/debian/5/dhcp6c.conf/
 interface {{ ifname }} {
-{% if address is defined and 'dhcpv6' in address %}
-{%   if dhcpv6_options is defined and dhcpv6_options.duid is defined and dhcpv6_options.duid is not none %}
+{% if dhcpv6_options is defined and dhcpv6_options.duid is defined and dhcpv6_options.duid is not none %}
     send client-id {{ dhcpv6_options.duid }};
-{%   endif %}
+{% endif %}
+{% if address is defined and 'dhcpv6' in address %}
     request domain-name-servers;
     request domain-name;
 {%   if dhcpv6_options is defined and dhcpv6_options.parameters_only is defined %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Send DUID when only DHCPv6 PD is configured.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3240

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcpv6

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Boot the ISO and configure as follows:
```
set interfaces dummy dum0
set interfaces ethernet eth0 dhcpv6-options pd 0 interface dum0
set interfaces ethernet eth0 dhcpv6-options duid 00:01:00:01:27:71:db:f0:00:50:56:bf:c5:6d
commit
```

Run a packet capture for DHCPv6 packets and ensure the client DUID is as configured.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
