### PR TITLE
dhcpv6: T3262: don't run DHCPv6 client when only dhcpv6-options is configured

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1102,9 +1102,10 @@ class Interface(Control):
             self.del_addr('dhcp')
 
         # always ensure DHCPv6 client is stopped (when not configured as client
-        # for IPv6 address or prefix delegation
+        # for IPv6 address or prefix delegation)
         dhcpv6pd = dict_search('dhcpv6_options.pd', config)
-        if 'dhcpv6' not in new_addr or dhcpv6pd == None:
+        dhcpv6pd = dhcpv6pd != None and len(dhcpv6pd) != 0
+        if 'dhcpv6' not in new_addr and not dhcpv6pd:
             self.del_addr('dhcpv6')
 
         # determine IP addresses which are assigned to the interface and build a
@@ -1124,7 +1125,7 @@ class Interface(Control):
             self.add_addr(addr)
 
         # start DHCPv6 client when only PD was configured
-        if dhcpv6pd != None:
+        if dhcpv6pd:
             self.set_dhcpv6(True)
 
         # There are some items in the configuration which can only be applied


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Don't run DHCPv6 client when only dhcpv6-options is configured.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3262

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcpv6

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Boot the ISO and configure as follows:
```
set interfaces ethernet eth0 dhcpv6-options
commit
```

Verify `dhcp6c` is not running by running `ps ax | grep dhcp6c`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
