### PR TITLE
smoketest: T3261: Add check PPPoE interface disable state

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_pppoe.py
+++ b/smoketest/scripts/cli/test_interfaces_pppoe.py
@@ -97,6 +97,27 @@ class PPPoEInterfaceTest(unittest.TestCase):
 
             self.assertTrue(running)
 
+
+    def test_pppoe_clent_disabled_interface(self):
+        # Check if PPPoE Client can be disabled
+        for interface in self._interfaces:
+            self.session.set(base_path + [interface, 'authentication', 'user', 'vyos'])
+            self.session.set(base_path + [interface, 'authentication', 'password', 'vyos'])
+            self.session.set(base_path + [interface, 'source-interface', self._source_interface])
+            self.session.set(base_path + [interface, 'disable'])
+
+            self.session.commit()
+
+        # Validate PPPoE client process
+        running = False
+        for interface in self._interfaces:
+            for proc in process_iter():
+                if interface in proc.cmdline():
+                    running = True
+
+        self.assertFalse(running)
+
+
     def test_pppoe_dhcpv6pd(self):
         # Check if PPPoE dialer can be configured with DHCPv6-PD
         address = '1'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):
Add smoktest check PPPoE interface disabled state

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
