### PR TITLE
pppoe: T3273: Leave default-route in place if 'default-route' is set to 'none'

### DIFF
--- a/data/templates/pppoe/ip-down.script.tmpl
+++ b/data/templates/pppoe/ip-down.script.tmpl
@@ -23,10 +23,12 @@ if [ -d /sys/class/net/{{ ifname }}/upper_* ]; then
     VRF_NAME="vrf ${VRF_NAME}"
 fi
 
-# Always delete default route when interface goes down
+{%   if default_route != 'none' %}
+# Always delete default route when interface goes down if we installed it
 vtysh -c "conf t" ${VRF_NAME} -c "no ip route 0.0.0.0/0 {{ ifname }} ${VRF_NAME}"
-{%   if ipv6 is defined and ipv6.address is defined and ipv6.address.autoconf is defined %}
+{%      if ipv6 is defined and ipv6.address is defined and ipv6.address.autoconf is defined %}
 vtysh -c "conf t" ${VRF_NAME} -c "no ipv6 route ::/0 {{ ifname }} ${VRF_NAME}"
+{%      endif %}
 {%   endif %}
 {% endif %}
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
As of the fixes made in T2502, any manual default-routes configured on a PPPoE interface will be deleted when the interface is torn down, even if they weren't added by setting 'interface pppoe pppoeX default-route' to 'auto' or 'force'.

The ip-up.script.tmpl template skips added a default-route when 'interface pppoe pppoeX default-route' to 'none' (As expected), this change reflects this behaviour in ip-down.script.tmpl.


## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3273

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* pppoe

## Proposed changes
<!--- Describe your changes in detail -->
As per the description.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
To test, set up a a PPPoE server and then configure a VyOS router with the following (or similar) config:

```
set interfaces ethernet eth0 address dhcp
set interfaces pppoe pppoe0 authentication password 'testuser1'
set interfaces pppoe pppoe0 authentication user 'testuser1'
set interfaces pppoe pppoe0 default-route 'none'
set interfaces pppoe pppoe0 source-interface 'eth0'
set interfaces pppoe pppoe1 authentication password 'testuser2'
set interfaces pppoe pppoe1 authentication user 'testuser2'
set interfaces pppoe pppoe1 default-route 'auto'
set interfaces pppoe pppoe1 source-interface 'eth0'
set protocols static interface-route 0.0.0.0/0 next-hop-interface pppoe0 distance '254'
set protocols static interface-route 0.0.0.0/0 next-hop-interface pppoe1 distance '253'
```

The DHCP interface is intentional to demonstrate `default-route 'auto'` not re-installing a default-route.

**BEFORE** this change the behaviour will be as follows:
1. On boot, both PPPoE will come up and there will be three default-routes installed
```
vyos@vyos:~$ show ip route
S>* 0.0.0.0/0 [1/0] via 10.99.19.65, eth0, 00:01:17
S   0.0.0.0/0 [253/0] is directly connected, pppoe1, 00:01:17
S   0.0.0.0/0 [254/0] is directly connected, pppoe0, 00:01:18
```

2. Disconnect and reconnect the PPPoE interfaces - this will result in the default-routes installed for pppoe0 and pppoe1 to be removed and not reinstalled.  This can also be confirmed with the following command (Looking at the underlying FRR config); there will be no result.
```
vyos@vyos:~$ show ip route
S>* 0.0.0.0/0 [1/0] via 10.99.19.65, eth0, 00:01:37

vtysh -c 'show run' | match 'ip route'
```

**AFTER** this change the behaviour changes to:
1. On boot, both PPPoE will come up and there will be three default-routes installed
```
S>* 0.0.0.0/0 [1/0] via 10.99.19.65, eth0, 00:01:17
S   0.0.0.0/0 [253/0] is directly connected, pppoe1, 00:01:17
S   0.0.0.0/0 [254/0] is directly connected, pppoe0, 00:01:18
```

2. Disconnect and reconnect the PPPoE interfaces - this will result in the default-routes installed for pppoe0 and pppoe1 to be removed however this time the default-route will remain in place for pppoe0.  pppoe1's default-route is still removed as expected; this behaviour is not ideal but it's by design and not a regression.  Again, confirm via vtysh:
```
vyos@vyos:~$ show ip route
S   0.0.0.0/0 [254/0] is directly connected, pppoe0, 00:00:09
S>* 0.0.0.0/0 [1/0] via 10.99.19.65, eth0, 00:01:37

vyos@vyos:~$ vtysh -c 'show run' | match 'ip route'
ip route 0.0.0.0/0 pppoe0 254
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
