### PR TITLE
vyos: T3274: Handle EOF in ask_yes_no()

### DIFF
--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -554,16 +554,19 @@ def ask_yes_no(question, default=False) -> bool:
     from sys import stdout
     default_msg = "[Y/n]" if default else "[y/N]"
     while True:
-        stdout.write("%s %s " % (question, default_msg))
-        c = input().lower()
-        if c == '':
-            return default
-        elif c in ("y", "ye", "yes"):
-            return True
-        elif c in ("n", "no"):
-            return False
-        else:
-            stdout.write("Please respond with yes/y or no/n\n")
+        try:
+            stdout.write("%s %s " % (question, default_msg))
+            c = input().lower()
+            if c == '':
+                return default
+            elif c in ("y", "ye", "yes"):
+                return True
+            elif c in ("n", "no"):
+                return False
+            else:
+                stdout.write("Please respond with yes/y or no/n\n")
+        except EOFError:
+            stdout.write("\nPlease respond with yes/y or no/n\n")
 
 
 def is_admin() -> bool:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Handle EOF input at `ask_yes_no()` prompts.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3274

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->
Add a simple `EOFError` handler.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Enter `^D` at `ask_yes_no()` prompt, such as `$ poweroff`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
