### PR TITLE
tunnel: erspan: T3030: Fixed tunnel option missing

### DIFF
--- a/interface-definitions/include/tunnel-parameters-ip.xml.i
+++ b/interface-definitions/include/tunnel-parameters-ip.xml.i
@@ -1,49 +1,42 @@
 <!-- included start from tunnel-parameters-ip.xml.i -->
-<node name="ip">
+<leafNode name="ttl">
   <properties>
-    <help>IPv4 specific tunnel parameters</help>
+    <help>Time to live field</help>
+    <valueHelp>
+      <format>0-255</format>
+      <description>Time to live (default 255)</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 0-255"/>
+    </constraint>
+    <constraintErrorMessage>TTL must be between 0 and 255</constraintErrorMessage>
   </properties>
-  <children>
-    <leafNode name="ttl">
-      <properties>
-        <help>Time to live field</help>
-        <valueHelp>
-          <format>0-255</format>
-          <description>Time to live (default 255)</description>
-        </valueHelp>
-        <constraint>
-          <validator name="numeric" argument="--range 0-255"/>
-        </constraint>
-        <constraintErrorMessage>TTL must be between 0 and 255</constraintErrorMessage>
-      </properties>
-      <defaultValue>255</defaultValue>
-    </leafNode>
-    <leafNode name="tos">
-      <properties>
-        <help>Type of Service (TOS)</help>
-        <valueHelp>
-          <format>0-99</format>
-          <description>Type of Service (TOS)</description>
-        </valueHelp>
-        <constraint>
-          <validator name="numeric" argument="--range 0-99"/>
-        </constraint>
-        <constraintErrorMessage>TOS must be between 0 and 99</constraintErrorMessage>
-      </properties>
-      <defaultValue>inherit</defaultValue>
-    </leafNode>
-    <leafNode name="key">
-      <properties>
-        <help>Tunnel key</help>
-        <valueHelp>
-          <format>u32</format>
-          <description>Tunnel key</description>
-        </valueHelp>
-        <constraint>
-          <validator name="numeric" argument="--range 0-4294967295"/>
-        </constraint>
-        <constraintErrorMessage>key must be between 0-4294967295</constraintErrorMessage>
-      </properties>
-    </leafNode>
-  </children>
-</node>
+  <defaultValue>255</defaultValue>
+</leafNode>
+<leafNode name="tos">
+  <properties>
+    <help>Type of Service (TOS)</help>
+    <valueHelp>
+      <format>0-99</format>
+      <description>Type of Service (TOS)</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 0-99"/>
+    </constraint>
+    <constraintErrorMessage>TOS must be between 0 and 99</constraintErrorMessage>
+  </properties>
+  <defaultValue>inherit</defaultValue>
+</leafNode>
+<leafNode name="key">
+  <properties>
+    <help>Tunnel key</help>
+    <valueHelp>
+      <format>u32</format>
+      <description>Tunnel key</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 0-4294967295"/>
+    </constraint>
+    <constraintErrorMessage>key must be between 0-4294967295</constraintErrorMessage>
+  </properties>
+</leafNode>

--- a/interface-definitions/interfaces-erspan.xml.in
+++ b/interface-definitions/interfaces-erspan.xml.in
@@ -46,7 +46,14 @@
               <help>ERSPAN Tunnel parameters</help>
             </properties>
             <children>
-              #include <include/tunnel-parameters-ip.xml.i>
+              <node name="ip">
+                <properties>
+                  <help>IPv4 specific tunnel parameters</help>
+                </properties>
+                <children>
+                  #include <include/tunnel-parameters-ip.xml.i>
+                </children>
+              </node>
               <leafNode name="version">
                 <properties>
                   <help>ERSPAN version number setting(default:1)</help>

--- a/interface-definitions/interfaces-tunnel.xml.in
+++ b/interface-definitions/interfaces-tunnel.xml.in
@@ -140,7 +140,20 @@
               <help>Tunnel parameters</help>
             </properties>
             <children>
-              #include <include/tunnel-parameters-ip.xml.i>
+              <node name="ip">
+                <properties>
+                  <help>IPv4 specific tunnel parameters</help>
+                </properties>
+                <children>
+                  <leafNode name="no-pmtu-discovery">
+                    <properties>
+                      <help>Disable path MTU discovery</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  #include <include/tunnel-parameters-ip.xml.i>
+                </children>
+              </node>
               <node name="ipv6">
                 <properties>
                   <help>IPv6 specific tunnel parameters</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed tunnel option missing

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3030

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
erspan, tunnel

## Proposed changes
<!--- Describe your changes in detail -->
In 8413278c, we left out a parameter in the tunnel that caused the tunnel smoke test to fail. Now, let's add it

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
