### PR TITLE
conf_mode: T3047: fix for ospf virtual-link to function when passive-interface default is set.

### DIFF
--- a/interface-definitions/protocols-ospf.xml.in
+++ b/interface-definitions/protocols-ospf.xml.in
@@ -713,7 +713,7 @@
                 <description>Interface to be passive (i.e. suppress routing updates)</description>
               </valueHelp>
               <constraint>
-                <regex>^(br|bond|dum|en|eth|gnv|peth|tun|vti|vxlan|wg|wlan)[0-9]+|lo$</regex>
+                <regex>^(br|bond|dum|en|eth|gnv|peth|tun|vti|vxlan|wg|wlan|VLINK)[0-9]+|lo$</regex>
               </constraint>
               <multi/>
             </properties>


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

When an area is not directly connected to the backbone area, then the virtual link is used to connect those areas.
But when the passive-interface default is set then the VLINK disconnects and the network becomes unreachable.

In order to fix the issue, 'VLINK' parameter is added to the file "interface-definitions/protocols-ospf.xml.in"
and allows to set this command "set proto ospf passive-interface-exclude VLINK0"

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->

https://phabricator.vyos.net/T3047

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

protocol ospf

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Before change:

set protocols ospf area 1 network '192.168.0.0/30'
set protocols ospf area 1 virtual-link 2.2.2.2
set protocols ospf area 118 network '10.118.1.0/24'
set protocols ospf log-adjacency-changes
set protocols ospf parameters router-id '1.1.1.1'
set protocols ospf passive-interface 'default'
set protocols ospf passive-interface-exclude 'eth0'
set protocols ospf passive-interface-exclude 'eth1'
vyos@R1# run sh ip ospf neigh

Neighbor ID     Pri State           Dead Time Address         Interface        L
2.2.2.2           1 Full/DR           33.580s 192.168.0.2     eth1:192.168.0.1 0
4.4.4.4           1 Full/DR           33.048s 10.118.1.2      eth0:10.118.1.1  0


After modifying the config file, I can set the VLINK interface to be non-passive interface.

vyos@R1# run sh conf comm | grep ospf
set protocols ospf area 1 network '192.168.0.0/30'
set protocols ospf area 1 virtual-link 2.2.2.2
set protocols ospf area 118 network '10.118.1.0/24'
set protocols ospf log-adjacency-changes
set protocols ospf parameters router-id '1.1.1.1'
set protocols ospf passive-interface 'default'
set protocols ospf passive-interface-exclude 'eth0'
set protocols ospf passive-interface-exclude 'eth1'
set protocols ospf passive-interface-exclude 'VLINK0'

vyos@R1# run sh ip ospf neighbor

Neighbor ID     Pri State           Dead Time Address         Interface                        RXmtL RqstL DBsmL
2.2.2.2           1 Full/DR           35.420s 192.168.0.2     eth1:192.168.0.1                     0     0     0
4.4.4.4           1 Full/DR           34.812s 10.118.1.2      eth0:10.118.1.1                      0     0     0
2.2.2.2           1 Full/DROther      33.732s 192.168.0.2     VLINK0                               0     0     0




## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
