### PR TITLE
ethernet: T3291: Disable RPS on single-core processors(KVM Only)

### DIFF
--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -18,7 +18,6 @@ import os
 
 from glob import glob
 from sys import exit
-from multiprocessing import cpu_count
 
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
@@ -78,7 +77,9 @@ def verify(ethernet):
 
     # verify offloading capabilities
     if 'offload' in ethernet and 'rps' in ethernet['offload']:
-        if not os.path.exists(f'/sys/class/net/{ifname}/queues/rx-0/rps_cpus') or cpu_count() < 2:
+        if os.cpu_count() < 2:
+            raise ConfigError('RPS cannot be enabled on a system with only 1 logical CPU!')
+        if not os.path.exists(f'/sys/class/net/{ifname}/queues/rx-0/rps_cpus'):
             raise ConfigError('Interface does not suport RPS!')
 
     # XDP requires multiple TX queues

--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -18,6 +18,7 @@ import os
 
 from glob import glob
 from sys import exit
+from multiprocessing import cpu_count
 
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
@@ -77,7 +78,7 @@ def verify(ethernet):
 
     # verify offloading capabilities
     if 'offload' in ethernet and 'rps' in ethernet['offload']:
-        if not os.path.exists(f'/sys/class/net/{ifname}/queues/rx-0/rps_cpus'):
+        if not os.path.exists(f'/sys/class/net/{ifname}/queues/rx-0/rps_cpus') or cpu_count() < 2:
             raise ConfigError('Interface does not suport RPS!')
 
     # XDP requires multiple TX queues

--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -36,6 +36,7 @@ from vyos.util import call
 from vyos.util import dict_search
 from vyos import ConfigError
 from vyos import airbag
+from vyos.version import get_full_version_data
 airbag.enable()
 
 # XXX: wpa_supplicant works on the source interface
@@ -74,11 +75,13 @@ def verify(ethernet):
     verify_vrf(ethernet)
     verify_eapol(ethernet)
     verify_mirror(ethernet)
+    
+    information = get_full_version_data()
 
     # verify offloading capabilities
     if 'offload' in ethernet and 'rps' in ethernet['offload']:
-        if os.cpu_count() < 2:
-            raise ConfigError('RPS cannot be enabled on a system with only 1 logical CPU!')
+        if information['system_type'] == 'KVM guest' and os.cpu_count() < 2:
+            raise ConfigError('In a single-core KVM system, RPS cannot be used!')
         if not os.path.exists(f'/sys/class/net/{ifname}/queues/rx-0/rps_cpus'):
             raise ConfigError('Interface does not suport RPS!')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Disable RPS on single-core processors(KVM Only)

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3291

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ethernet, rps

## Proposed changes
<!--- Describe your changes in detail -->
In existing RPS implementations, the mask is set to not use CPU0,which causes the RPS to be unable to set when the user only has CPU0,so add validation logic to disable RPS(KVM Only)

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
