### PR TITLE
nat: T3307: fix destination nat generation

### DIFF
--- a/data/templates/firewall/nftables-nat.tmpl
+++ b/data/templates/firewall/nftables-nat.tmpl
@@ -24,9 +24,9 @@
 {%     if config.translation is defined and config.translation.address is defined and config.translation.address is not none %}
 {#       support 1:1 network translation #}
 {%       if config.translation.address | is_ip_network %}
-{%         set trns_addr = 'dnat ip prefix to ip daddr map { ' + config.source.address + ' : ' + config.translation.address + ' }' %}
-{#         we can now clear out the src_addr part as it's already covered in aboves map #}
-{%         set src_addr  = '' %}
+{%         set trns_addr = 'dnat ip prefix to ip daddr map { ' + config.destination.address + ' : ' + config.translation.address + ' }' %}
+{#         we can now clear out the dst_addr part as it's already covered in aboves map #}
+{%         set dst_addr  = '' %}
 {%       else %}
 {%         set trns_addr = 'dnat to ' + config.translation.address %}
 {%       endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix 1:1 prefix destination NAT rule generation and commit failing on a jinja2 template error due to trying to map from source->translation in a DNAT rule instead of the expected destination->translation.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3307


## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
On vanilla 1.4-rolling-202102121338-amd64 to confirm issue:
```
configure
edit nat destination rule 1
set inbound-interface eth0
set destination address 10.0.0.0/24
set translation address 10.1.0.0/24
commit
```
-> Commit fails

Tested by replacing the modified file in place:
`curl https://raw.githubusercontent.com/varesa/vyos-1x/4a0504a96cf0f3078e964ed201f196fb55172e00/data/templates/firewall/nftables-nat.tmpl | sudo tee /usr/share/vyos/templates/firewall/nftables-nat.tmpl`

Above commit succeeds. Incoming packets get translated correctly. Nftables rules look believable, even though I'm not 100% familiar with the syntax.

```
vyos@vyos# sudo tcpdump -i any icmp
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on any, link-type LINUX_SLL (Linux cooked), capture size 262144 bytes
21:57:49.087615 IP 192.168.122.181 > 10.0.0.123: ICMP echo request, id 5237, seq 10, length 64
21:57:49.087645 IP 192.168.122.181 > 10.1.0.123: ICMP echo request, id 5237, seq 10, length 64
21:57:50.111609 IP 192.168.122.181 > 10.0.0.123: ICMP echo request, id 5237, seq 11, length 64
21:57:50.111672 IP 192.168.122.181 > 10.1.0.123: ICMP echo request, id 5237, seq 11, length 64
```

```
table ip nat {
	chain PREROUTING {
		type nat hook prerouting priority dstnat; policy accept;
		iifname "eth0" counter packets 201 bytes 14192 dnat ip prefix to ip daddr map { 10.0.0.0/24 : 10.1.0.0/24 } comment "DST-NAT-1"
	}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
