### PR TITLE
bfd: T3310: migrate to get_config_dict() and FRR reload

### DIFF
--- a/data/configd-include.json
+++ b/data/configd-include.json
@@ -32,6 +32,7 @@
 "nat66.py",
 "ntp.py",
 "policy-local-route.py",
+"protocols_bfd.py",
 "protocols_bgp.py",
 "protocols_igmp.py",
 "protocols_isis.py",

--- a/data/templates/frr/bfd.frr.tmpl
+++ b/data/templates/frr/bfd.frr.tmpl
@@ -1,15 +1,35 @@
 !
 bfd
+{% if profile is defined and profile is not none %}
+{%   for profile_name, profile_config in profile.items() %}
+ profile {{ profile_name }}
+  detect-multiplier {{ profile_config.interval.multiplier }}
+  receive-interval {{ profile_config.interval.receive }}
+  transmit-interval {{ profile_config.interval.transmit }}
+{%     if profile_config.interval['echo-interval'] is defined and profile_config.interval['echo-interval'] is not none %}
+  echo-interval {{ profile_config.interval['echo-interval'] }}
+{%     endif %}
+{%     if profile_config['echo-mode'] is defined %}
+  echo-mode
+{%     endif %}
+{%     if profile_config.shutdown is defined %}
+  shutdown
+{%     else %}
+  no shutdown
+{%     endif %}
+  exit
+{%   endfor %}
+{% endif %}
 {% if peer is defined and peer is not none %}
 {%   for peer_name, peer_config in peer.items() %}
  peer {{ peer_name }}{{ ' multihop' if peer_config.multihop is defined }}{{ ' local-address ' + peer_config.source.address if peer_config.source is defined and peer_config.source.address is defined }}{{ ' interface ' + peer_config.source.interface if peer_config.source is defined and peer_config.source.interface is defined }}
   detect-multiplier {{ peer_config.interval.multiplier }}
   receive-interval {{ peer_config.interval.receive }}
   transmit-interval {{ peer_config.interval.transmit }}
-{%     if peer_config.interval.echo_interval is defined and peer_config.interval.echo_interval is not none %}
- echo-interval {{ peer_config.interval.echo_interval }}
+{%     if peer_config.interval['echo-interval'] is defined and peer_config.interval['echo-interval'] is not none %}
+ echo-interval {{ peer_config.interval['echo-interval'] }}
 {%     endif %}
-{%     if peer_config.echo_mode is defined %}
+{%     if peer_config['echo-mode'] is defined %}
   echo-mode
 {%     endif %}
 {%     if peer_config.shutdown is defined %}
@@ -17,7 +37,8 @@ bfd
 {%     else %}
   no shutdown
 {%     endif %}
- !
+  exit
 {%   endfor %}
 {% endif %}
+ exit
 !

--- a/data/templates/frr/bfd.frr.tmpl
+++ b/data/templates/frr/bfd.frr.tmpl
@@ -1,22 +1,23 @@
 !
 bfd
-{% for peer in old_peers %}
- no peer {{ peer.remote }}{% if peer.multihop %} multihop{% endif %}{% if peer.src_addr %} local-address {{ peer.src_addr }}{% endif %}{% if peer.src_if %} interface {{ peer.src_if }}{% endif %}
-
-{% endfor %}
-!
-{% for peer in new_peers %}
- peer {{ peer.remote }}{% if peer.multihop %} multihop{% endif %}{% if peer.src_addr %} local-address {{ peer.src_addr }}{% endif %}{% if peer.src_if %} interface {{ peer.src_if }}{% endif %}
-
- detect-multiplier {{ peer.multiplier }}
- receive-interval {{ peer.rx_interval }}
- transmit-interval {{ peer.tx_interval }}
-{% if peer.echo_mode %}
- echo-mode
+{% if peer is defined and peer is not none %}
+{%   for peer_name, peer_config in peer.items() %}
+ peer {{ peer_name }}{{ ' multihop' if peer_config.multihop is defined }}{{ ' local-address ' + peer_config.source.address if peer_config.source is defined and peer_config.source.address is defined }}{{ ' interface ' + peer_config.source.interface if peer_config.source is defined and peer_config.source.interface is defined }}
+  detect-multiplier {{ peer_config.interval.multiplier }}
+  receive-interval {{ peer_config.interval.receive }}
+  transmit-interval {{ peer_config.interval.transmit }}
+{%     if peer_config.interval.echo_interval is defined and peer_config.interval.echo_interval is not none %}
+ echo-interval {{ peer_config.interval.echo_interval }}
+{%     endif %}
+{%     if peer_config.echo_mode is defined %}
+  echo-mode
+{%     endif %}
+{%     if peer_config.shutdown is defined %}
+  shutdown
+{%     else %}
+  no shutdown
+{%     endif %}
+ !
+{%   endfor %}
 {% endif %}
-{% if peer.echo_interval != '' %}
- echo-interval {{ peer.echo_interval }}
-{% endif %}
- {% if not peer.shutdown %}no {% endif %}shutdown
-{% endfor %}
 !

--- a/interface-definitions/include/bfd-common.xml.i
+++ b/interface-definitions/include/bfd-common.xml.i
@@ -1,0 +1,72 @@
+<!-- included start from bfd-common.xml.i -->
+<leafNode name="echo-mode">
+  <properties>
+    <help>Enables the echo transmission mode</help>
+    <valueless/>
+  </properties>
+</leafNode>
+<node name="interval">
+  <properties>
+    <help>Configure timer intervals</help>
+  </properties>
+  <children>
+    <leafNode name="receive">
+      <properties>
+        <help>Minimum interval of receiving control packets</help>
+        <valueHelp>
+          <format>10-60000</format>
+          <description>Interval in milliseconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 10-60000"/>
+        </constraint>
+      </properties>
+      <defaultValue>300</defaultValue>
+    </leafNode>
+    <leafNode name="transmit">
+      <properties>
+        <help>Minimum interval of transmitting control packets</help>
+        <valueHelp>
+          <format>10-60000</format>
+          <description>Interval in milliseconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 10-60000"/>
+        </constraint>
+      </properties>
+      <defaultValue>300</defaultValue>
+    </leafNode>
+    <leafNode name="multiplier">
+      <properties>
+        <help>Multiplier to determine packet loss</help>
+        <valueHelp>
+          <format>2-255</format>
+          <description>Remote transmission interval will be multiplied by this value</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 2-255"/>
+        </constraint>
+      </properties>
+      <defaultValue>3</defaultValue>
+    </leafNode>
+    <leafNode name="echo-interval">
+      <properties>
+        <help>Echo receive transmission interval</help>
+        <valueHelp>
+          <format>10-60000</format>
+          <description>The minimal echo receive transmission interval that this system is capable of handling</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 10-60000"/>
+        </constraint>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<leafNode name="shutdown">
+  <properties>
+    <help>Disable this peer</help>
+    <valueless/>
+  </properties>
+</leafNode>
+<!-- included end -->

--- a/interface-definitions/protocols-bfd.xml.in
+++ b/interface-definitions/protocols-bfd.xml.in
@@ -11,7 +11,7 @@
         <children>
           <tagNode name="peer">
             <properties>
-              <help>Configures a new BFD peer to listen and talk to</help>
+              <help>Configures BFD peer to listen and talk to</help>
               <valueHelp>
                 <format>ipv4</format>
                 <description>BFD peer IPv4 address</description>
@@ -26,6 +26,18 @@
               </constraint>
             </properties>
             <children>
+              <leafNode name="profile">
+                <properties>
+                  <help>Use settings from BFD profile</help>
+                  <completionHelp>
+                    <path>protocols bfd profile</path>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>BFD profile name</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
               <node name="source">
                 <properties>
                   <help>Bind listener to specified interface/address, mandatory for IPv6</help>
@@ -61,82 +73,28 @@
                   </leafNode>
                 </children>
               </node>
-              <node name="interval">
-                <properties>
-                  <help>Configure timer intervals</help>
-                </properties>
-                <children>
-                  <leafNode name="receive">
-                    <properties>
-                      <help>Minimum interval of receiving control packets</help>
-                      <valueHelp>
-                        <format>10-60000</format>
-                        <description>Interval in milliseconds</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 10-60000"/>
-                      </constraint>
-                    </properties>
-                    <defaultValue>300</defaultValue>
-                  </leafNode>
-                  <leafNode name="transmit">
-                    <properties>
-                      <help>Minimum interval of transmitting control packets</help>
-                      <valueHelp>
-                        <format>10-60000</format>
-                        <description>Interval in milliseconds</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 10-60000"/>
-                      </constraint>
-                    </properties>
-                    <defaultValue>300</defaultValue>
-                  </leafNode>
-                  <leafNode name="multiplier">
-                    <properties>
-                      <help>Multiplier to determine packet loss</help>
-                      <valueHelp>
-                        <format>2-255</format>
-                        <description>Remote transmission interval will be multiplied by this value</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 2-255"/>
-                      </constraint>
-                    </properties>
-                    <defaultValue>3</defaultValue>
-                  </leafNode>
-                  <leafNode name="echo-interval">
-                    <properties>
-                      <help>Echo receive transmission interval</help>
-                      <valueHelp>
-                        <format>10-60000</format>
-                        <description>The minimal echo receive transmission interval that this system is capable of handling</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 10-60000"/>
-                      </constraint>
-                    </properties>
-                  </leafNode>
-                </children>
-              </node>
-              <leafNode name="shutdown">
-                <properties>
-                  <help>Disable this peer</help>
-                  <valueless/>
-                </properties>
-              </leafNode>
+              #include <include/bfd-common.xml.i>
               <leafNode name="multihop">
                 <properties>
                   <help>Allow this BFD peer to not be directly connected</help>
                   <valueless/>
                 </properties>
               </leafNode>
-              <leafNode name="echo-mode">
-                <properties>
-                  <help>Enables the echo transmission mode</help>
-                  <valueless/>
-                </properties>
-              </leafNode>
+            </children>
+          </tagNode>
+          <tagNode name="profile">
+            <properties>
+              <help>Configure BFD profile used by individual peer</help>
+              <valueHelp>
+                <format>txt</format>
+                <description>Name of BFD profile</description>
+              </valueHelp>
+              <constraint>
+                <regex>^[-_a-zA-Z0-9]{1,32}$</regex>
+              </constraint>
+            </properties>
+            <children>
+              #include <include/bfd-common.xml.i>
             </children>
           </tagNode>
         </children>

--- a/interface-definitions/protocols-bfd.xml.in
+++ b/interface-definitions/protocols-bfd.xml.in
@@ -42,6 +42,9 @@
                   <leafNode name="address">
                     <properties>
                       <help>Local address to bind our peer listener to</help>
+                      <completionHelp>
+                        <script>${vyos_completion_dir}/list_local_ips.sh --both</script>
+                      </completionHelp>
                       <valueHelp>
                         <format>ipv4</format>
                         <description>Local IPv4 address used to connect to the peer</description>
@@ -74,6 +77,7 @@
                         <validator name="numeric" argument="--range 10-60000"/>
                       </constraint>
                     </properties>
+                    <defaultValue>300</defaultValue>
                   </leafNode>
                   <leafNode name="transmit">
                     <properties>
@@ -86,6 +90,7 @@
                         <validator name="numeric" argument="--range 10-60000"/>
                       </constraint>
                     </properties>
+                    <defaultValue>300</defaultValue>
                   </leafNode>
                   <leafNode name="multiplier">
                     <properties>
@@ -98,6 +103,7 @@
                         <validator name="numeric" argument="--range 2-255"/>
                       </constraint>
                     </properties>
+                    <defaultValue>3</defaultValue>
                   </leafNode>
                   <leafNode name="echo-interval">
                     <properties>

--- a/src/conf_mode/protocols_bfd.py
+++ b/src/conf_mode/protocols_bfd.py
@@ -36,54 +36,55 @@ def get_config(config=None):
     else:
         conf = Config()
     base = ['protocols', 'bfd']
-    bfd = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
+    bfd = conf.get_config_dict(base, get_first_key=True)
 
     # Bail out early if configuration tree does not exist
     if not conf.exists(base):
         return bfd
 
+    # We have gathered the dict representation of the CLI, but there are
+    # default options which we need to update into the dictionary retrived.
+    # XXX: T2665: we currently have no nice way for defaults under tag
+    # nodes, thus we load the defaults "by hand"
+    default_values = defaults(base + ['peer'])
     if 'peer' in bfd:
-        # We have gathered the dict representation of the CLI, but there are
-        # default options which we need to update into the dictionary retrived.
-        # XXX: T2665: we currently have no nice way for defaults under tag
-        # nodes, thus we load the defaults "by hand"
-        default_values = defaults(base + ['peer'])
         for peer in bfd['peer']:
             bfd['peer'][peer] = dict_merge(default_values, bfd['peer'][peer])
+
+    if 'profile' in bfd:
+        for profile in bfd['profile']:
+            bfd['profile'][profile] = dict_merge(default_values, bfd['profile'][profile])
 
     return bfd
 
 def verify(bfd):
-    if not bfd or 'peer' not in bfd:
+    if not bfd:
         return None
 
-    for peer, peer_config in bfd['peer'].items():
-        # IPv6 link local peers require an explicit local address/interface
-        if is_ipv6_link_local(peer):
-            if 'source' not in peer_config or len(peer_config['source'] < 2):
-                raise ConfigError('BFD IPv6 link-local peers require explicit local address and interface setting')
+    if 'peer' in bfd:
+        for peer, peer_config in bfd['peer'].items():
+            # IPv6 link local peers require an explicit local address/interface
+            if is_ipv6_link_local(peer):
+                if 'source' not in peer_config or len(peer_config['source'] < 2):
+                    raise ConfigError('BFD IPv6 link-local peers require explicit local address and interface setting')
 
-        # IPv6 peers require an explicit local address
-        if is_ipv6(peer):
-            if 'source' not in peer_config or 'address' not in peer_config['source']:
-                raise ConfigError('BFD IPv6 peers require explicit local address setting')
+            # IPv6 peers require an explicit local address
+            if is_ipv6(peer):
+                if 'source' not in peer_config or 'address' not in peer_config['source']:
+                    raise ConfigError('BFD IPv6 peers require explicit local address setting')
 
-        if 'multihop' in peer_config:
-            # multihop require source address
-            if 'source' not in peer_config or 'address' not in peer_config['source']:
-                raise ConfigError('BFD multihop require source address')
+            if 'multihop' in peer_config:
+                # multihop require source address
+                if 'source' not in peer_config or 'address' not in peer_config['source']:
+                    raise ConfigError('BFD multihop require source address')
 
-            # multihop and echo-mode cannot be used together
-            if 'echo_mode' in peer_config:
-                raise ConfigError('Multihop and echo-mode cannot be used together')
+                # multihop and echo-mode cannot be used together
+                if 'echo_mode' in peer_config:
+                    raise ConfigError('Multihop and echo-mode cannot be used together')
 
-            # multihop doesn't accept interface names
-            if 'source' in peer_config and 'interface' in peer_config['source']:
-                raise ConfigError('Multihop and source interface cannot be used together')
-
-        # echo interval can be configured only with enabled echo-mode
-        if 'interval' in peer_config and 'echo_interval' in peer_config['interval'] and 'echo_mode' not in peer_config:
-            raise ConfigError('echo-interval can be configured only with enabled echo-mode')
+                # multihop doesn't accept interface names
+                if 'source' in peer_config and 'interface' in peer_config['source']:
+                    raise ConfigError('Multihop and source interface cannot be used together')
 
     return None
 
@@ -98,7 +99,7 @@ def apply(bfd):
     # Save original configuration prior to starting any commit actions
     frr_cfg = frr.FRRConfig()
     frr_cfg.load_configuration()
-    frr_cfg.modify_section('bfd', '')
+    frr_cfg.modify_section('^bfd', '')
     frr_cfg.add_before(r'(ip prefix-list .*|route-map .*|line vty)', bfd['new_frr_config'])
     frr_cfg.commit_configuration()
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3310

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* BFD

## Proposed changes
<!--- Describe your changes in detail -->
Migrate to FRR reload framework and `get_config_dict()`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
```
set protocols bfd profile foo echo-mode
set protocols bfd profile foo interval echo-interval 100
set protocols bfd profile foo interval multiplier 101
set protocols bfd profile foo interval receive 222
set protocols bfd profile foo interval transmit 333
set protocols bfd profile foo shutdown
set protocols bfd profile bar interval multiplier 102
set protocols bfd profile bar interval receive 444
set protocols bfd peer 192.0.2.1 interval transmit 600
set protocols bfd peer 192.0.2.1 multihop
set protocols bfd peer 192.0.2.1 source address 192.0.2.254
set protocols bfd peer 192.0.2.2 echo-mode
set protocols bfd peer 192.0.2.2 interval echo-interval 100
set protocols bfd peer 192.0.2.2 interval multiplier 111
set protocols bfd peer 192.0.2.2 interval receive 222
set protocols bfd peer 192.0.2.2 interval transmit 333
set protocols bfd peer 192.0.2.2 shutdown
set protocols bfd peer 192.0.2.2 source interface lo
set protocols bfd peer 2001:db8::1 source address fe80::1
set protocols bfd peer 2001:db8::1 source interface eth0
set protocols bfd peer 2001:db8::2 multihop
set protocols bfd peer 2001:db8::2 source address fe80::1
set protocols bfd peer 192.0.2.10 profile foo
```

Or use embedded smoketests.

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bfd.py
test_bfd_peer (__main__.TestProtocolsBFD) ... ok
test_bfd_profile (__main__.TestProtocolsBFD) ... ok

----------------------------------------------------------------------
Ran 2 tests in 43.300s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
