### PR TITLE
routing: T3211: Add redistribute protocol IS-IS to bgp ospf rip

### DIFF
--- a/interface-definitions/protocols-bgp.xml.in
+++ b/interface-definitions/protocols-bgp.xml.in
@@ -75,6 +75,14 @@
                           #include <include/bgp-afi-redistribute-metric-route-map.xml.i>
                         </children>
                       </node>
+                      <node name="isis">
+                        <properties>
+                          <help>Redistribute IS-IS routes into BGP</help>
+                        </properties>
+                        <children>
+                          #include <include/bgp-afi-redistribute-metric-route-map.xml.i>
+                        </children>
+                      </node>
                       <node name="kernel">
                         <properties>
                           <help>Redistribute kernel routes into BGP</help>

--- a/interface-definitions/protocols-ospf.xml.in
+++ b/interface-definitions/protocols-ospf.xml.in
@@ -39,6 +39,10 @@
                     <description>Filter connected routes</description>
                   </valueHelp>
                   <valueHelp>
+                    <format>isis</format>
+                    <description>Filter IS-IS routes</description>
+                  </valueHelp>
+                  <valueHelp>
                     <format>kernel</format>
                     <description>Filter Kernel routes</description>
                   </valueHelp>
@@ -51,7 +55,7 @@
                     <description>Filter static routes</description>
                   </valueHelp>
                   <constraint>
-                    <regex>^(bgp|connected|kernel|rip|static)$</regex>
+                    <regex>^(bgp|connected|isis|kernel|rip|static)$</regex>
                   </constraint>
                   <constraintErrorMessage>Must be bgp, connected, kernel, rip, or static</constraintErrorMessage>
                   <multi/>
@@ -692,6 +696,16 @@
               <node name="connected">
                 <properties>
                   <help>Redistribute connected routes</help>
+                </properties>
+                <children>
+                  #include <include/ospf-metric.xml.i>
+                  #include <include/ospf-metric-type.xml.i>
+                  #include <include/ospf-route-map.xml.i>
+                </children>
+              </node>
+              <node name="isis">
+                <properties>
+                  <help>Redistribute IS-IS routes</help>
                 </properties>
                 <children>
                   #include <include/ospf-metric.xml.i>

--- a/interface-definitions/protocols-rip.xml.in
+++ b/interface-definitions/protocols-rip.xml.in
@@ -176,6 +176,14 @@
                   #include <include/rip-redistribute.xml.i>
                 </children>
               </node>
+              <node name="isis">
+                <properties>
+                  <help>Redistribute IS-IS routes</help>
+                </properties>
+                <children>
+                  #include <include/rip-redistribute.xml.i>
+                </children>
+              </node>
               <node name="kernel">
                 <properties>
                   <help>Redistribute kernel routes</help>

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -388,7 +388,7 @@ class TestProtocolsBGP(unittest.TestCase):
         }
 
         # We want to redistribute ...
-        redistributes = ['connected', 'kernel', 'ospf', 'rip', 'static']
+        redistributes = ['connected', 'isis', 'kernel', 'ospf', 'rip', 'static']
         for redistribute in redistributes:
             self.session.set(base_path + ['address-family', 'ipv4-unicast',
                                           'redistribute', redistribute])

--- a/smoketest/scripts/cli/test_protocols_ospf.py
+++ b/smoketest/scripts/cli/test_protocols_ospf.py
@@ -88,7 +88,7 @@ class TestProtocolsOSPF(unittest.TestCase):
     def test_ospf_03_access_list(self):
         acl = '100'
         seq = '10'
-        protocols = ['bgp', 'connected', 'kernel', 'rip', 'static']
+        protocols = ['bgp', 'connected', 'isis', 'kernel', 'rip', 'static']
 
         self.session.set(['policy', 'access-list', acl, 'rule', seq, 'action', 'permit'])
         self.session.set(['policy', 'access-list', acl, 'rule', seq, 'source', 'any'])
@@ -215,7 +215,7 @@ class TestProtocolsOSPF(unittest.TestCase):
     def test_ospf_08_redistribute(self):
         metric = '15'
         metric_type = '1'
-        redistribute = ['bgp', 'connected', 'kernel', 'rip', 'static']
+        redistribute = ['bgp', 'connected', 'isis', 'kernel', 'rip', 'static']
 
         for protocol in redistribute:
             self.session.set(base_path + ['redistribute', protocol, 'metric', metric])

--- a/smoketest/scripts/cli/test_protocols_rip.py
+++ b/smoketest/scripts/cli/test_protocols_rip.py
@@ -71,7 +71,7 @@ class TestProtocolsRIP(unittest.TestCase):
         interfaces = Section.interfaces('ethernet')
         neighbors = ['1.2.3.4', '1.2.3.5', '1.2.3.6']
         networks = ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16']
-        redistribute = ['bgp', 'connected', 'kernel', 'ospf', 'static']
+        redistribute = ['bgp', 'connected', 'isis', 'kernel', 'ospf', 'static']
         timer_garbage = '888'
         timer_timeout = '1000'
         timer_update = '90'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add option for redistribute protocol IS-IS to bgp/ospf/rip
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T3211
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
routing, bgp, ospf, rip, isis
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set protocols bgp 65530 address-family ipv4-unicast redistribute isis
set protocols bgp 65530 neighbor 100.64.0.2 remote-as '65002'
set protocols ospf redistribute isis
set protocols rip interface eth1
set protocols rip redistribute isis
```
It should generate the next FRR configuration:
```
!
router rip
 network eth1
 redistribute isis
!
router bgp 65530
 no bgp ebgp-requires-policy
 no bgp network import-check
 neighbor 100.64.0.2 remote-as 65002
 !
 address-family ipv4 unicast
  redistribute isis
 exit-address-family
!
router ospf
 auto-cost reference-bandwidth 100
 timers throttle spf 200 1000 10000
 redistribute isis
!

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
