### PR TITLE
dhcp-server: T2927: Add empty args if does not possible to determine …

### DIFF
--- a/data/templates/dhcp-server/dhcpd.conf.tmpl
+++ b/data/templates/dhcp-server/dhcpd.conf.tmpl
@@ -8,16 +8,12 @@
 on release {
     set ClientName = pick-first-value(host-decl-name, option fqdn.hostname, option host-name);
     set ClientIp = binary-to-ascii(10, 8, ".",leased-address);
-    set ClientMac = binary-to-ascii(16, 8, ":",substring(hardware, 1, 6));
-    set ClientDomain = pick-first-value(config-option domain-name, "..YYZ!");
-    execute("/usr/libexec/vyos/system/on-dhcp-event.sh", "release", ClientName, ClientIp, ClientMac, ClientDomain);
+    execute("/usr/libexec/vyos/system/on-dhcp-event.sh", "release", "", ClientIp, "", "");
 }
 on expiry {
     set ClientName = pick-first-value(host-decl-name, option fqdn.hostname, option host-name);
     set ClientIp = binary-to-ascii(10, 8, ".",leased-address);
-    set ClientMac = binary-to-ascii(16, 8, ":",substring(hardware, 1, 6));
-    set ClientDomain = pick-first-value(config-option domain-name, "..YYZ!");
-    execute("/usr/libexec/vyos/system/on-dhcp-event.sh", "release", ClientName, ClientIp, ClientMac, ClientDomain);
+    execute("/usr/libexec/vyos/system/on-dhcp-event.sh", "release", "", ClientIp, "", "");
 }
 {% endif %}
 
@@ -201,11 +197,15 @@ shared-network {{ network | replace('_','-') }} {
     on commit {
         set shared-networkname = "{{ network | replace('_','-') }}";
 {%     if hostfile_update is defined %}
-        set ClientName = pick-first-value(host-decl-name, option fqdn.hostname, option host-name);
         set ClientIp = binary-to-ascii(10, 8, ".", leased-address);
         set ClientMac = binary-to-ascii(16, 8, ":", substring(hardware, 1, 6));
-        set ClientDomain = pick-first-value(config-option domain-name, "..YYZ!");
-        execute("/usr/libexec/vyos/system/on-dhcp-event.sh", "commit", ClientName, ClientIp, ClientMac, ClientDomain);
+        set ClientName = pick-first-value(host-decl-name, option fqdn.hostname, option host-name, "empty_hostname");
+        if not (ClientName = "empty_hostname") {
+            set ClientDomain = pick-first-value(config-option domain-name, "..YYZ!");
+            execute("/usr/libexec/vyos/system/on-dhcp-event.sh", "commit", ClientName, ClientIp, ClientMac, ClientDomain);
+        } else {
+            log(concat("Hostname is not defined for client with IP: ", ClientIP, " MAC: ", ClientMac));
+        }
 {%     endif %}
     }
 }

--- a/src/system/on-dhcp-event.sh
+++ b/src/system/on-dhcp-event.sh
@@ -21,21 +21,20 @@ client_mac=$4
 domain=$5
 hostsd_client="/usr/bin/vyos-hostsd-client"
 
-if [ -z "$client_name" ]; then
-    logger -s -t on-dhcp-event "Client name was empty, using MAC \"$client_mac\" instead"
-    client_name=$(echo "client-"$client_mac | tr : -)
-fi
-
-if [ "$domain" == "..YYZ!" ]; then
-    client_fqdn_name=$client_name
-    client_search_expr=$client_name
-else
-    client_fqdn_name=$client_name.$domain
-    client_search_expr="$client_name\\.$domain"
-fi
-
 case "$action" in
   commit) # add mapping for new lease
+    if [ -z "$client_name" ]; then
+        logger -s -t on-dhcp-event "Client name was empty, using MAC \"$client_mac\" instead"
+        client_name=$(echo "client-"$client_mac | tr : -)
+    fi
+
+    if [ "$domain" == "..YYZ!" ]; then
+        client_fqdn_name=$client_name
+        client_search_expr=$client_name
+    else
+        client_fqdn_name=$client_name.$domain
+        client_search_expr="$client_name\\.$domain"
+    fi
     $hostsd_client --add-hosts "$client_fqdn_name,$client_ip" --tag "dhcp-server-$client_ip" --apply
     exit 0
     ;;


### PR DESCRIPTION
…variables

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
