### PR TITLE
smoketest: T3211: Extend smoketest for redistribute isis

### DIFF
--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -260,7 +260,7 @@ class TestProtocolsBGP(unittest.TestCase):
         }
 
         # We want to redistribute ...
-        redistributes = ['connected', 'kernel', 'ospf', 'rip', 'static']
+        redistributes = ['connected', 'isis', 'kernel', 'ospf', 'rip', 'static']
         for redistribute in redistributes:
             self.session.set(base_path + ['address-family', 'ipv4-unicast',
                                           'redistribute', redistribute])

--- a/smoketest/scripts/cli/test_protocols_rip.py
+++ b/smoketest/scripts/cli/test_protocols_rip.py
@@ -71,7 +71,7 @@ class TestProtocolsRIP(unittest.TestCase):
         interfaces = Section.interfaces('ethernet')
         neighbors = ['1.2.3.4', '1.2.3.5', '1.2.3.6']
         networks = ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16']
-        redistribute = ['bgp', 'connected', 'kernel', 'ospf', 'static']
+        redistribute = ['bgp', 'connected', 'isis', 'kernel', 'ospf', 'static']
         timer_garbage = '888'
         timer_timeout = '1000'
         timer_update = '90'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Extend smoketest for redistributing protocol isis into bgp/rip
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T3211
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
isis, bgp, rip, smoketest
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
