### PR TITLE
bgp: T2100: Changing RFC8212 behavior and option toggle

### DIFF
--- a/data/templates/frr/bgp.frr.tmpl
+++ b/data/templates/frr/bgp.frr.tmpl
@@ -178,9 +178,11 @@
 {% endmacro %}
 !
 router bgp {{ asn }}
-{# Disable eBGP policy by default until there is a CLI option #}
-{# Workaround for T3183 until we have decided about a migration script #}
+{% if parameters is defined and parameters.ebgp_requires_policy is defined %}
+ bgp ebgp-requires-policy
+{% else %}
  no bgp ebgp-requires-policy
+{% endif %}
 {# Workaround for T2100 until we have decided about a migration script #}
  no bgp network import-check
 {% if address_family is defined and address_family is not none %}

--- a/interface-definitions/protocols-bgp.xml.in
+++ b/interface-definitions/protocols-bgp.xml.in
@@ -805,6 +805,12 @@
                   </tagNode>
                 </children>
               </node>
+              <leafNode name="ebgp-requires-policy">
+                <properties>
+                  <help>Enable RFC8212 functionality</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
               <node name="graceful-restart">
                 <properties>
                   <help>Graceful restart capability parameters</help>

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -221,12 +221,13 @@ class TestProtocolsBGP(unittest.TestCase):
 
         self.session.set(base_path + ['parameters', 'router-id', router_id])
         self.session.set(base_path + ['parameters', 'log-neighbor-changes'])
-        # Default local preference (higher=more preferred)
+        # Default local preference (higher = more preferred, default value is 100)
         self.session.set(base_path + ['parameters', 'default', 'local-pref', local_pref])
         # Deactivate IPv4 unicast for a peer by default
         self.session.set(base_path + ['parameters', 'default', 'no-ipv4-unicast'])
         self.session.set(base_path + ['parameters', 'graceful-restart', 'stalepath-time', stalepath_time])
         self.session.set(base_path + ['parameters', 'graceful-shutdown'])
+        self.session.set(base_path + ['parameters', 'ebgp-requires-policy'])
 
         # commit changes
         self.session.commit()
@@ -240,6 +241,7 @@ class TestProtocolsBGP(unittest.TestCase):
         self.assertIn(f' no bgp default ipv4-unicast', frrconfig)
         self.assertIn(f' bgp graceful-restart stalepath-time {stalepath_time}', frrconfig)
         self.assertIn(f' bgp graceful-shutdown', frrconfig)
+        self.assertIn(f' bgp ebgp-requires-policy', frrconfig)
 
 
     def test_bgp_02_neighbors(self):


### PR DESCRIPTION
In this commit we add the default operation within BGP
to have RFC8212 disabled for eBGP routes. This default
should preserve the normal behavior for VyOS from earlier
releases of FRR to the current latest release. Another
option that we add is the ability to toggle whether or
not RFC8212 is enabled or disabled.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This commit changes the default behavior for VyOS to match up to pre-FRR 7.4/7.5 functionality by
changing the RFC8212 operation that has been added to FRR 7.4/7.5. Now it is disabled by default
and allows for an option to enable this functionality by adding it within the parameters stanza. That is
the second portion of the commit is adding the ability to enable/disable RFC8212 functionality with
a command under parameters. Lastly, I added the smoketest for this so that it always gets tested.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T2100, T3183

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
BGP

## Proposed changes
<!--- Describe your changes in detail -->

Please see above. There's really not much more detail than this.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

This was tested within a VyOS VM. 

Normally configuring BGP without this option we see:

```
vyos@vyos:~$ vtysh -c "show run bgp"
Building configuration...

Current configuration:
!
frr version 7.5-20210212-00-gbc460d132
frr defaults traditional
hostname vyos
service integrated-vtysh-config
!
router bgp 1
 no bgp ebgp-requires-policy
 no bgp network import-check
!
line vty
!
end
vyos@vyos:~$
vyos@vyos:~$
vyos@vyos:~$
vyos@vyos:~$ vtysh -c "show run bgp"
Building configuration...

Current configuration:
!
frr version 7.5-20210212-00-gbc460d132
frr defaults traditional
hostname vyos
service integrated-vtysh-config
!
router bgp 1
 no bgp ebgp-requires-policy      <--- Default behavior disabling RFC8212 operation
 no bgp network import-check
!
line vty
!
end
```

Enabling RFC8212 operation:

```
vyos@vyos# set protocols bgp 1 parameters ebgp-requires-policy
[edit]
vyos@vyos# compare
[edit protocols bgp 1]
+parameters {
+    ebgp-requires-policy
+}
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# exit
Warning: configuration changes have not been saved.
exit

vyos@vyos:~$ vtysh -c "show run bgp"
Building configuration...

Current configuration:
!
frr version 7.5-20210212-00-gbc460d132
frr defaults traditional
hostname vyos
service integrated-vtysh-config
!
router bgp 1
 no bgp network import-check
!                                                  <---- It is no longer here, therefore it is enabled
line vty
!
end
```

Deleting, and restoring default disabled RFC8212 operation:

```
vyos@vyos# delete protocols bgp 1 parameters
[edit]
vyos@vyos# compare
[edit protocols bgp 1]
-parameters {
-    ebgp-requires-policy
-}
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# exit
Warning: configuration changes have not been saved.
exit

vyos@vyos:~$ vtysh -c "show run bgp"
Building configuration...

Current configuration:
!
frr version 7.5-20210212-00-gbc460d132
frr defaults traditional
hostname vyos
service integrated-vtysh-config
!
router bgp 1
 no bgp ebgp-requires-policy      <--- Default behavior of disabling RFC8212 operation returned
 no bgp network import-check
!
line vty
!
end
```



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
https://github.com/vyos/vyos-documentation/pull/463
