### PR TITLE
bgp: T3225: Checks if neighbor configured as system address

### DIFF
--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -23,6 +23,7 @@ from vyos.configdict import dict_merge
 from vyos.template import render_to_string
 from vyos.util import call
 from vyos.util import dict_search
+from vyos.validate import is_addr_assigned
 from vyos import ConfigError
 from vyos import frr
 from vyos import airbag
@@ -106,6 +107,10 @@ def verify(bgp):
                 # Check spaces in the password
                 if 'password' in peer_config and ' ' in peer_config['password']:
                     raise ConfigError('You can\'t use spaces in the password')
+
+                # Check if neighbor address is assigned as system interface address
+                if is_addr_assigned(peer):
+                    raise ConfigError(f'Can\'t configure local address as neighbor "{peer}"')
 
                 # Some checks can/must only be done on a neighbor and not a peer-group
                 if neighbor == 'neighbor':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Adding checks. IP address for neighbor shouldn't be configured as system address.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T3225
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces loopback lo address 192.0.2.1/32
set protocols bgp 65530 neighbor 192.0.2.1 remote-as 65531

vyos@r-roll01# commit
Can't configure local address as neighbor "192.0.2.1"

[[protocols bgp 65530]] failed
Commit failed
[edit]
vyos@r-roll01# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
