### PR TITLE
bgp: T3320: Add checks for peer-group

### DIFF
--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -96,7 +96,7 @@ def verify(bgp):
                 # Check if the configure peer-group exists
                 if 'peer_group' in peer_config:
                     peer_group = peer_config['peer_group']
-                    if peer_group not in asn_config['peer_group']:
+                    if 'peer_group' not in asn_config or peer_group not in asn_config['peer_group']:
                         raise ConfigError(f'Specified peer-group "{peer_group}" for '\
                                           f'neighbor "{neighbor}" does not exist!')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Adding checks for peer-group, If peer-group doesn't exist.
```
set protocols bgp xxx peer-group xxxxx
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add peer-group to a neighbor, but not create peer-group, it should be an error message.
```
set protocols bgp 64501 neighbor 203.0.113.1 remote-as 65001
set protocols bgp 64501 neighbor 203.0.113.1 peer-group FOO

vyos@r-roll01# commit
[ protocols bgp 64501 ]
Specified peer-group "FOO" does not exist!

[[protocols bgp 64501]] failed

```
Add peer-group and commit should be applied without any error
```
set protocols bgp 64501 peer-group FOO
```
Frr config:
```
!
router bgp 64501
 no bgp ebgp-requires-policy
 no bgp network import-check
 neighbor FOO peer-group
 neighbor 203.0.113.1 remote-as 65001
 neighbor 203.0.113.1 peer-group FOO
!
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
