### PR TITLE
bgp: T3225: is_addr_assigned should check only ipv4 ipv6 neighbors

### DIFF
--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -20,6 +20,7 @@ from sys import exit
 
 from vyos.config import Config
 from vyos.configdict import dict_merge
+from vyos.template import is_ip
 from vyos.template import render_to_string
 from vyos.util import call
 from vyos.util import dict_search
@@ -115,8 +116,9 @@ def verify(bgp):
                     if not verify_remote_as(peer_config, asn_config):
                         raise ConfigError(f'Neighbor "{peer}" remote-as must be set!')
 
+                    # Only checks for ipv4 and ipv6 neighbors
                     # Check if neighbor address is assigned as system interface address
-                    if is_addr_assigned(peer):
+                    if is_ip(peer) and is_addr_assigned(peer):
                         raise ConfigError(f'Can\'t configure local address as neighbor "{peer}"')
 
                 for afi in ['ipv4_unicast', 'ipv6_unicast', 'l2vpn_evpn']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
is_addr_assigned should check only ipv4 and ipv6 neighbors and don't check "interface neighbors"
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T3225
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces ethernet eth1 address 192.0.2.1/24
set protocols bgp 64501 neighbor eth1 interface remote-as '64501'
set protocols bgp 64501 neighbor 192.0.2.1 remote-as 65002

vyos@r-roll01# commit
[ protocols bgp 64501 ]
Can't configure local address as neighbor "192.0.2.1"

[[protocols bgp 64501]] failed
Commit failed

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
