### PR TITLE
bgp: T3365: Fix remote-as ordering for neighbor

### DIFF
--- a/data/templates/frr/bgp.frr.tmpl
+++ b/data/templates/frr/bgp.frr.tmpl
@@ -9,6 +9,9 @@
 {%   if config.remote_as is defined and config.remote_as is not none %}
  neighbor {{ neighbor }} remote-as {{ config.remote_as }}
 {%   endif %}
+{%     if config.interface.remote_as is defined and config.interface.remote_as is not none %}
+ neighbor {{ neighbor }} interface remote-as {{ config.interface.remote_as }}
+{%     endif %}
 {%   if config.advertisement_interval is defined and config.advertisement_interval is not none %}
  neighbor {{ neighbor }} advertisement-interval {{ config.advertisement_interval }}
 {%   endif %}
@@ -72,9 +75,6 @@
 {%   if config.interface is defined and config.interface is not none %}
 {%     if config.interface.peer_group is defined and config.interface.peer_group is not none %}
  neighbor {{ neighbor }} interface peer-group {{ config.interface.peer_group }}
-{%     endif %}
-{%     if config.interface.remote_as is defined and config.interface.remote_as is not none %}
- neighbor {{ neighbor }} interface remote-as {{ config.interface.remote_as }}
 {%     endif %}
 {%     if config.interface.v6only is defined and config.interface.v6only is not none %}
 {%       if config.interface.v6only.peer_group is defined and config.interface.v6only.peer_group is not none %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix ordering in the bgp template for neighbor interface "remote-as"
"remote-as" should be declared before other options.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T3365
Also, that checks will be works fine after that PR https://github.com/vyos/vyos-1x/pull/751
Because it should check is_ip(peer)
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set protocols bgp 64501 neighbor eth1 capability extended-nexthop
set protocols bgp 64501 neighbor eth1 interface remote-as '64501'
```
Commit ordering
```
commit_configuration: new_config   8 !
commit_configuration: new_config   9 router bgp 64501
commit_configuration: new_config  10  no bgp ebgp-requires-policy
commit_configuration: new_config  11  no bgp network import-check
commit_configuration: new_config  12  !
commit_configuration: new_config  13  !
commit_configuration: new_config  14  !
commit_configuration: new_config  15  neighbor eth1 interface remote-as 64501
commit_configuration: new_config  16  neighbor eth1 capability extended-nexthop
commit_configuration: new_config  17  !
commit_configuration: new_config  18 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
