### PR TITLE
bgp: T3365: Fix frr template for interface remote-as

### DIFF
--- a/data/templates/frr/bgp.frr.tmpl
+++ b/data/templates/frr/bgp.frr.tmpl
@@ -9,9 +9,9 @@
 {%   if config.remote_as is defined and config.remote_as is not none %}
  neighbor {{ neighbor }} remote-as {{ config.remote_as }}
 {%   endif %}
-{%     if config.interface.remote_as is defined and config.interface.remote_as is not none %}
+{%   if config.interface is defined and config.interface.remote_as is defined and config.interface.remote_as is not none %}
  neighbor {{ neighbor }} interface remote-as {{ config.interface.remote_as }}
-{%     endif %}
+{%   endif %}
 {%   if config.advertisement_interval is defined and config.advertisement_interval is not none %}
  neighbor {{ neighbor }} advertisement-interval {{ config.advertisement_interval }}
 {%   endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix template for bgp "interface remote-as". We need to check if "neighbor ethx interface" is defined, before apply configuration.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T3365
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp
## Proposed changes
<!--- Describe your changes in detail -->
After commit bf9c914
We get a bug, when "config.interface.remote_as" become out of the "config.interface" section checks.
This behavior was causing errors.

## How to test
Add any configuration not related "set protocols bgp xxxx neighbor ethx"
And commit
```
set protocols bgp 64501 neighbor 203.0.113.1 peer-group FOO
set protocols bgp 64501 peer-group FOO remote-as 65001
```
We shouldn't see any errors.
Then add  configuration, which include ("neigbhor interface"), and commit again
```
set protocols bgp 64501 neighbor eth1 capability extended-nexthop
set protocols bgp 64501 neighbor eth1 interface remote-as '64501'
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
