### PR TITLE
pppoe: T3353: Modify template for vlan-mon and interface

### DIFF
--- a/data/templates/accel-ppp/pppoe.config.tmpl
+++ b/data/templates/accel-ppp/pppoe.config.tmpl
@@ -96,12 +96,22 @@ mtu={{ mtu }}
 verbose=1
 ac-name={{ access_concentrator }}
 
-{% if interface %}
-{%   for iface in interface %}
+{% if interface is defined and interface is not none %}
+{%   for iface, iface_config in interface.items() %}
+{%     if iface_config.vlan_id is not defined and iface_config.vlan_range is not defined %}
 interface={{ iface }}
-{%     if interface[iface].vlan_id is defined or interface[iface].vlan_range is defined %}
-vlan-mon={{ iface }},{{ interface[iface].vlan_id | join(',') }},{{ interface[iface].vlan_range | join(',') }}
-interface=re:{{ interface.name }}\.\d+
+{%     endif %}
+{%     if iface_config.vlan_id is defined and iface_config.vlan_range is not defined %}
+vlan-mon={{ iface }},{{ iface_config.vlan_id | join(',') }}
+interface=re:{{ iface | replace('.', '\\.') }}\.\d+
+{%     endif %}
+{%     if iface_config.vlan_range is defined and iface_config.vlan_id is not defined %}
+vlan-mon={{ iface }},{{ iface_config.vlan_range | join(',') }}
+interface=re:{{ iface | replace('.', '\\.') }}\.\d+
+{%     endif %}
+{%     if iface_config.vlan_id is defined and iface_config.vlan_range is defined %}
+vlan-mon={{ iface }},{{ iface_config.vlan_id | join(',') }},{{ iface_config.vlan_range | join(',') }}
+interface=re:{{ iface | replace('.', '\\.') }}\.\d+
 {%     endif %}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Modify template for pppoe service, vlan-mon and interface
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T3353
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe, vlan-mon
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces ethernet eth1 vif 1000
set service pppoe-server authentication mode 'radius'
set service pppoe-server authentication protocols 'chap'
set service pppoe-server authentication radius server 192.168.0.1 key 'xxx'
set service pppoe-server client-ip-pool subnet '100.64.0.0/16'
set service pppoe-server gateway-address '10.0.0.1'
set service pppoe-server interface eth1.1000 vlan-range '1-4095'
set service pppoe-server name-server '1.1.1.1'
set service pppoe-server name-server '8.8.8.8'
set service pppoe-server service-name 'test'
```
Expected configuration for vlan-mon and interface in /run/accel-pppd/pppoe.conf
```
vlan-mon=eth1.1000,1-4095
interface=re:eth1\.1000\.\d+
```
Getting configuration
```
vyos@r-roll01# cat /run/accel-pppd/pppoe.conf | grep pppoe] -A7
[pppoe]
verbose=1
ac-name=vyos-ac

interface=eth1.1000
vlan-mon=eth1.1000,1-4095
interface=re:eth1\.1000\.\d+

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
