### PR TITLE
pppoe: T3353: Remove regex for listen interface vlan-id

### DIFF
--- a/data/templates/accel-ppp/pppoe.config.tmpl
+++ b/data/templates/accel-ppp/pppoe.config.tmpl
@@ -102,8 +102,10 @@ ac-name={{ access_concentrator }}
 interface={{ iface }}
 {%     endif %}
 {%     if iface_config.vlan_id is defined and iface_config.vlan_range is not defined %}
-vlan-mon={{ iface }},{{ iface_config.vlan_id | join(',') }}
-interface=re:{{ iface | replace('.', '\\.') }}\.\d+
+{%       for vlan in iface_config.vlan_id %}
+interface={{ iface }}.{{ vlan }}
+vlan-mon={{ iface }},{{ vlan }}
+{%       endfor %}
 {%     endif %}
 {%     if iface_config.vlan_range is defined and iface_config.vlan_id is not defined %}
 vlan-mon={{ iface }},{{ iface_config.vlan_range | join(',') }}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Delete regex for interface when we use interface vlan-id 
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T3353
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
accel-ppp, pppoe
## Proposed changes
<!--- Describe your changes in detail -->
After commit https://github.com/vyos/vyos-1x/commit/cf93fec3b38ac3df5d2e77dc1ae8c37bb6971d83 we get wrong regular expression in section [pppoe] for an interface, if we use vlan-id
## How to test
If we use vlan-id, the configuration shouldn't contain interface regex
Tested configuration
```
set interfaces ethernet eth1 vif 1000
set service pppoe-server authentication mode 'radius'
set service pppoe-server authentication protocols 'chap'
set service pppoe-server authentication radius server 192.168.0.1 key 'xxx'
set service pppoe-server client-ip-pool subnet '100.64.0.0/16'
set service pppoe-server gateway-address '10.0.0.1'
set service pppoe-server interface eth1.1000 vlan-range '1-4095'
set service pppoe-server name-server '1.1.1.1'
set service pppoe-server name-server '8.8.8.8'
set service pppoe-server service-name 'test'
set service pppoe-server interface eth2 vlan-id '50'
set service pppoe-server interface eth2 vlan-id '60'

```
Check
```
[pppoe]
verbose=1
ac-name=vyos-ac

vlan-mon=eth1.1000,1-4095
interface=re:eth1\.1000\.\d+
interface=eth2.50
vlan-mon=eth2,50
interface=eth2.60
vlan-mon=eth2,60
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
