### PR TITLE
dhcpv6-server: T3379: Add option global-parameters

### DIFF
--- a/data/templates/dhcp-server/dhcpdv6.conf.tmpl
+++ b/data/templates/dhcp-server/dhcpdv6.conf.tmpl
@@ -8,6 +8,12 @@ log-facility local7;
 option dhcp6.preference {{ preference }};
 {% endif %}
 
+{% if global_parameters is defined and global_parameters.name_server is defined and global_parameters.name_server is not none %}
+{%   for nameserver in global_parameters.name_server %}
+option dhcp6.name-servers {{ nameserver }};
+{%   endfor %}
+{% endif %}
+
 # Shared network configration(s)
 {% if shared_network_name is defined and shared_network_name is not none %}
 {%   for network, network_config in shared_network_name.items() if network_config.disable is not defined %}

--- a/interface-definitions/dhcpv6-server.xml.in
+++ b/interface-definitions/dhcpv6-server.xml.in
@@ -10,6 +10,26 @@
         </properties>
         <children>
           #include <include/generic-disable-node.xml.i>
+          <node name="global-parameters">
+            <properties>
+              <help>Additional global parameters for DHCPv6 server</help>
+            </properties>
+            <children>
+              <leafNode name="name-server">
+                <properties>
+                  <help>IPv6 address of a Recursive DNS Server</help>
+                  <valueHelp>
+                    <format>ipv6</format>
+                    <description>IPv6 address of DNS name server</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="ipv6-address"/>
+                  </constraint>
+                  <multi/>
+                </properties>
+              </leafNode>
+            </children>
+          </node>
           <leafNode name="preference">
             <properties>
               <help>Preference of this DHCPv6 server compared with others</help>

--- a/smoketest/scripts/cli/test_service_dhcpv6-server.py
+++ b/smoketest/scripts/cli/test_service_dhcpv6-server.py
@@ -151,5 +151,26 @@ class TestServiceDHCPServer(unittest.TestCase):
         # Check for running process
         self.assertTrue(process_named_running(PROCESS_NAME))
 
+    def test_global_nameserver(self):
+        shared_net_name = 'SMOKE-3'
+        ns_global_1 = '2001:db8::1111'
+        ns_global_2 = '2001:db8::2222'
+
+        self.session.set(base_path + ['global-parameters', 'name-server', ns_global_1])
+        self.session.set(base_path + ['global-parameters', 'name-server', ns_global_2])
+        self.session.set(base_path + ['shared-network-name', shared_net_name, 'subnet', subnet])
+
+        # commit changes
+        self.session.commit()
+
+        config = read_file(DHCPD_CONF)
+        self.assertIn(f'option dhcp6.name-servers {ns_global_1};', config)
+        self.assertIn(f'option dhcp6.name-servers {ns_global_2};', config)
+        self.assertIn(f'subnet6 {subnet}' + r' {', config)
+        self.assertIn(f'set shared-networkname = "{shared_net_name}";', config)
+
+        # Check for running process
+        self.assertTrue(process_named_running(PROCESS_NAME))
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add options for configuration "global-parameters" name-server.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T3379
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcpv6-server
## Proposed changes
<!--- Describe your changes in detail -->
Add ability to configure global option "name-server" for dhcpv6-server,
## How to test
VyOS configuration
```
set interfaces ethernet eth1 address '2001:db8::1/48'
set service dhcpv6-server global-parameters name-server '2001:db8::1'
set service dhcpv6-server global-parameters name-server '2001:db8::2'
set service dhcpv6-server shared-network-name SHARED subnet 2001:db8::/48
```
dhcpdv6.conf
```

log-facility local7;

option dhcp6.name-servers 2001:db8::1;
option dhcp6.name-servers 2001:db8::2;

# Shared network configration(s)
shared-network SHARED {
    subnet6 2001:db8::/48 {
    }
    on commit {
        set shared-networkname = "SHARED";
    }
}


```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
