### PR TITLE
op-mode: T3377: Fix show_interfaces bug with tunnels

### DIFF
--- a/src/op_mode/show_interfaces.py
+++ b/src/op_mode/show_interfaces.py
@@ -71,10 +71,7 @@ def filtered_interfaces(ifnames, iftypes, vif, vrrp):
         if ifnames and ifname not in ifnames:
             continue
 
-        # return the class which can handle this interface name
-        klass = Section.klass(ifname)
-        # connect to the interface
-        interface = klass(ifname, create=False, debug=False)
+        interface = Interface(ifname)
 
         if iftypes and interface.definition['section'] not in iftypes:
             continue


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix variable value for "interface" for op-mode "show interfaces"
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T3377
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
interfaces
## Proposed changes
<!--- Describe your changes in detail -->
The old value for "interface" tried to check args "encapsulation" which shouldn't be used for op-mode
## How to test
VyOS config
```
set interfaces tunnel tun1 address '10.20.30.1/30'
set interfaces tunnel tun1 encapsulation 'gre'
set interfaces tunnel tun1 source-address  '192.168.122.111'
set interfaces tunnel tun1 multicast 'disable'
set interfaces tunnel tun1 remote '192.168.122.12'

```
Expected "run show interface" without any error.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
