### PR TITLE
op-mode: T3384: Support UDP bandwidth testing

### DIFF
--- a/op-mode-definitions/monitor-bandwidth-test.xml.in
+++ b/op-mode-definitions/monitor-bandwidth-test.xml.in
@@ -7,12 +7,25 @@
           <help>Initiate or wait for bandwidth test</help>
         </properties>
         <children>
-          <leafNode name="accept">
+          <node name="accept">
             <properties>
-              <help>Wait for bandwidth test connections (port TCP/5001)</help>
+              <help>Wait for bandwidth test connections</help>
             </properties>
-            <command>/usr/bin/iperf -V -s</command>
-          </leafNode>
+            <children>
+              <leafNode name="tcp">
+                <properties>
+                  <help>Wait for bandwidth test connections (port TCP/5001)</help>
+                </properties>
+                <command>/usr/bin/iperf -V -s</command>
+              </leafNode>
+              <leafNode name="udp">
+                <properties>
+                  <help>Wait for bandwidth test connections (port UDP/5001)</help>
+                </properties>
+                <command>/usr/bin/iperf -V -s -u</command>
+              </leafNode>
+            </children>
+          </node>
           <tagNode name="initiate">
             <properties>
               <help>Initiate a bandwidth test to specified host (port TCP/5001)</help>

--- a/op-mode-definitions/monitor-bandwidth-test.xml.in
+++ b/op-mode-definitions/monitor-bandwidth-test.xml.in
@@ -9,8 +9,9 @@
         <children>
           <node name="accept">
             <properties>
-              <help>Wait for bandwidth test connections</help>
+              <help>Wait for bandwidth test connections (default: TCP)</help>
             </properties>
+            <command>/usr/bin/iperf -V -s</command>
             <children>
               <leafNode name="tcp">
                 <properties>

--- a/op-mode-definitions/monitor-bandwidth-test.xml.in
+++ b/op-mode-definitions/monitor-bandwidth-test.xml.in
@@ -26,15 +26,31 @@
               </leafNode>
             </children>
           </node>
-          <tagNode name="initiate">
+          <node name="initiate">
             <properties>
-              <help>Initiate a bandwidth test to specified host (port TCP/5001)</help>
-              <completionHelp>
-                <list>&lt;hostname&gt; &lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
-              </completionHelp>
+              <help>Initiate a bandwidth test to specified host</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/monitor_bandwidth_test.sh "$4"</command>
-          </tagNode>
+            <children>
+              <tagNode name="tcp">
+                <properties>
+                  <help>Initiate a bandwidth test to specified host (port TCP/5001)</help>
+                  <completionHelp>
+                    <list>&lt;hostname&gt; &lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/monitor_bandwidth_test.sh "$5"</command>
+              </tagNode>
+              <tagNode name="udp">
+                <properties>
+                  <help>Initiate a bandwidth test to specified host (port UDP/5001)</help>
+                  <completionHelp>
+                    <list>&lt;hostname&gt; &lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/monitor_bandwidth_test.sh "$5" "-u"</command>
+              </tagNode>
+            </children>
+          </node>
         </children>
       </node>
     </children>

--- a/src/op_mode/monitor_bandwidth_test.sh
+++ b/src/op_mode/monitor_bandwidth_test.sh
@@ -26,5 +26,5 @@ elif [[ $(dig $1 AAAA +short | grep -v '\.$' | wc -l) -gt 0 ]]; then
     OPT="-V"
 fi
 
-/usr/bin/iperf $OPT -c $1
+/usr/bin/iperf $OPT -c $1 $2
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Support UDP bandwidth testing

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3384

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
op-mode

## Proposed changes
<!--- Describe your changes in detail -->

Support UDP bandwidth testing

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
