### PR TITLE
pppoe: T3386: Fix client ip-pool stop range

### DIFF
--- a/data/templates/accel-ppp/config_ip_pool.j2
+++ b/data/templates/accel-ppp/config_ip_pool.j2
@@ -4,7 +4,7 @@
 gw-ip-address={{ gateway_address }}
 {%   endif %}
 {%   if client_ip_pool.start is defined and client_ip_pool.stop is defined and client_ip_pool.start is not none and client_ip_pool.stop is not none %}
-{{ client_ip_pool.start }}-{{ client_ip_pool.stop }}
+{{ client_ip_pool.start }}-{{ client_ip_pool.stop.split('.')[3] }}
 {%   endif %}
 {%   if client_ip_pool.subnet is defined and client_ip_pool.subnet is not none %}
 {%     for subnet in client_ip_pool.subnet %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix client-ip-pool stop for accel-ppp pppoe template
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T3386
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe, accel-ppp
## Proposed changes
<!--- Describe your changes in detail -->
Return the last octet from stop pool
## How to test
VyOS config
```
set service pppoe-server access-concentrator 'ACN'
set service pppoe-server authentication local-users username foo password 'bar'
set service pppoe-server authentication local-users username foo rate-limit download '20480'
set service pppoe-server authentication local-users username foo rate-limit upload '10240'
set service pppoe-server authentication mode 'local'
set service pppoe-server client-ip-pool start '10.1.1.100'
set service pppoe-server client-ip-pool stop '10.1.1.111'
set service pppoe-server gateway-address '10.1.1.1'
set service pppoe-server interface eth0
```
Expected pool start-stop x.x.x.x-**x**
```
[ip-pool]
gw-ip-address=10.1.1.1
10.1.1.100-111

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
