### PR TITLE
configd: T3411: Extend redirect_stdout to subprocesses

### DIFF
--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -25,7 +25,7 @@ import logging
 import signal
 import importlib.util
 import zmq
-from contextlib import redirect_stdout, redirect_stderr
+from contextlib import contextmanager
 
 from vyos.defaults import directories
 from vyos.configsource import ConfigSourceString, ConfigSourceError
@@ -108,6 +108,23 @@ conf_mode_scripts = dict(zip(imports, modules))
 exclude_set = {key_name_from_file_name(f) for f in filenames if f not in include}
 include_set = {key_name_from_file_name(f) for f in filenames if f in include}
 
+@contextmanager
+def stdout_redirected(filename, mode):
+    saved_stdout_fd = None
+    destination_file = None
+    try:
+        sys.stdout.flush()
+        saved_stdout_fd = os.dup(sys.stdout.fileno())
+        destination_file = open(filename, mode)
+        os.dup2(destination_file.fileno(), sys.stdout.fileno())
+        yield
+    finally:
+        if saved_stdout_fd is not None:
+            os.dup2(saved_stdout_fd, sys.stdout.fileno())
+            os.close(saved_stdout_fd)
+        if destination_file is not None:
+            destination_file.close()
+
 def explicit_print(path, mode, msg):
     try:
         with open(path, mode) as f:
@@ -118,12 +135,10 @@ def explicit_print(path, mode, msg):
 def run_script(script, config) -> int:
     config.set_level([])
     try:
-        with open(session_out, session_mode) as f, redirect_stdout(f):
-            with redirect_stderr(f):
-                c = script.get_config(config)
-                script.verify(c)
-                script.generate(c)
-                script.apply(c)
+        c = script.get_config(config)
+        script.verify(c)
+        script.generate(c)
+        script.apply(c)
     except ConfigError as e:
         logger.critical(e)
         explicit_print(session_out, session_mode, str(e))
@@ -206,7 +221,8 @@ def process_node_data(config, data) -> int:
     if script_name in exclude_set:
         return R_PASS
 
-    result = run_script(conf_mode_scripts[script_name], config)
+    with stdout_redirected(session_out, session_mode):
+        result = run_script(conf_mode_scripts[script_name], config)
 
     return result
 

--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -108,6 +108,12 @@ conf_mode_scripts = dict(zip(imports, modules))
 exclude_set = {key_name_from_file_name(f) for f in filenames if f not in include}
 include_set = {key_name_from_file_name(f) for f in filenames if f in include}
 
+def explicit_print(path, mode, msg):
+    try:
+        with open(path, mode) as f:
+            f.write(f"\n{msg}\n\n")
+    except OSError:
+        logger.critical("error explicit_print")
 
 def run_script(script, config) -> int:
     config.set_level([])
@@ -120,8 +126,7 @@ def run_script(script, config) -> int:
                 script.apply(c)
     except ConfigError as e:
         logger.critical(e)
-        with open(session_out, session_mode) as f, redirect_stdout(f):
-            print(f"{e}\n")
+        explicit_print(session_out, session_mode, str(e))
         return R_ERROR_COMMIT
     except Exception as e:
         logger.critical(e)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Extend the redirect_stdout contextmanager in vyos-configd to redirect stdout from subprocesses.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3411

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->
Instead of using the contextlib provided redirect_stdout, we provide a simple contextmanager which will additionally redirect stdout from subprocesses.
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
touch /config/vyos.ifconfig.debug
set interfaces ethernet eth0 description 'TEST'
[one will see full debug info in console]
reboot
[one will find full debug info in /tmp/vyos-configd-script-stdout]
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
