### PR TITLE
configquery: T3402: add library for querying config values from op mode

### DIFF
--- a/python/vyos/configquery.py
+++ b/python/vyos/configquery.py
@@ -1,0 +1,90 @@
+# Copyright 2021 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+'''
+A small library that allows querying existence or value(s) of config
+settings from op mode, and execution of arbitrary op mode commands.
+'''
+
+from subprocess import STDOUT
+from vyos.util import popen
+
+
+class ConfigQueryError(Exception):
+    pass
+
+class GenericConfigQuery:
+    def __init__(self):
+        pass
+
+    def exists(self, path: list):
+        raise NotImplementedError
+
+    def value(self, path: list):
+        raise NotImplementedError
+
+    def values(self, path: list):
+        raise NotImplementedError
+
+class GenericOpRun:
+    def __init__(self):
+        pass
+
+    def run(self, path: list, **kwargs):
+        raise NotImplementedError
+
+class CliShellApiConfigQuery(GenericConfigQuery):
+    def __init__(self):
+        super().__init__()
+
+    def exists(self, path: list):
+        cmd = ' '.join(path)
+        (_, err) = popen(f'cli-shell-api existsActive {cmd}')
+        if err:
+            return False
+        return True
+
+    def value(self, path: list):
+        cmd = ' '.join(path)
+        (out, err) = popen(f'cli-shell-api returnActiveValue {cmd}')
+        if err:
+            raise ConfigQueryError('No value for given path')
+        return out
+
+    def values(self, path: list):
+        cmd = ' '.join(path)
+        (out, err) = popen(f'cli-shell-api returnActiveValues {cmd}')
+        if err:
+            raise ConfigQueryError('No values for given path')
+        return out
+
+class VbashOpRun(GenericOpRun):
+    def __init__(self):
+        super().__init__()
+
+    def run(self, path: list, **kwargs):
+        cmd = ' '.join(path)
+        (out, err) = popen(f'.  /opt/vyatta/share/vyatta-op/functions/interpreter/vyatta-op-run; _vyatta_op_run {cmd}', stderr=STDOUT, **kwargs)
+        if err:
+            raise ConfigQueryError(out)
+        return out
+
+def query_context(config_query_class=CliShellApiConfigQuery,
+                  op_run_class=VbashOpRun):
+    query = config_query_class()
+    run = op_run_class()
+    return query, run
+
+


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
A small library that allows querying existence or value(s) of config
settings from op mode, and execution of arbitrary op mode commands.


<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3402

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail --->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
#!/usr/bin/env python3

from vyos.configquery import query_context, ConfigQueryError

config, op = query_context()
out = None

try:
    if config.exists(['service', 'ssh']):
        out = op.run(['restart', 'ssh'])
except ConfigQueryError as e:
    print(str(e))
else:
    print(out)
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
