### PR TITLE
routing: T3217: Save configs of daemon per commit

### DIFF
--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -234,6 +234,9 @@ def apply(bgp):
         for a in range(5):
             frr_cfg.commit_configuration(frr_daemon)
 
+    # Save configuration to /run/frr/{daemon}.conf
+    frr.save_configuration(frr_daemon)
+
     return None
 
 if __name__ == '__main__':

--- a/src/conf_mode/protocols_isis.py
+++ b/src/conf_mode/protocols_isis.py
@@ -209,6 +209,9 @@ def apply(isis):
         for a in range(5):
             frr_cfg.commit_configuration(frr_daemon)
 
+    # Save configuration to /run/frr/{daemon}.conf
+    frr.save_configuration(frr_daemon)
+
     return None
 
 if __name__ == '__main__':

--- a/src/conf_mode/protocols_ospf.py
+++ b/src/conf_mode/protocols_ospf.py
@@ -200,6 +200,9 @@ def apply(ospf):
         for a in range(5):
             frr_cfg.commit_configuration(frr_daemon)
 
+    # Save configuration to /run/frr/{daemon}.conf
+    frr.save_configuration(frr_daemon)
+
     return None
 
 if __name__ == '__main__':

--- a/src/conf_mode/protocols_ospfv3.py
+++ b/src/conf_mode/protocols_ospfv3.py
@@ -91,6 +91,9 @@ def apply(ospfv3):
         for a in range(5):
             frr_cfg.commit_configuration(frr_daemon)
 
+    # Save configuration to /run/frr/{daemon}.conf
+    frr.save_configuration(frr_daemon)
+
     return None
 
 if __name__ == '__main__':

--- a/src/conf_mode/protocols_rip.py
+++ b/src/conf_mode/protocols_rip.py
@@ -116,6 +116,9 @@ def apply(rip):
         for a in range(5):
             frr_cfg.commit_configuration(frr_daemon)
 
+    # Save configuration to /run/frr/{daemon}.conf
+    frr.save_configuration(frr_daemon)
+
     return None
 
 if __name__ == '__main__':

--- a/src/conf_mode/protocols_ripng.py
+++ b/src/conf_mode/protocols_ripng.py
@@ -120,6 +120,9 @@ def apply(ripng):
         for a in range(5):
             frr_cfg.commit_configuration(frr_daemon)
 
+    # Save configuration to /run/frr/{daemon}.conf
+    frr.save_configuration(frr_daemon)
+
     return None
 
 if __name__ == '__main__':

--- a/src/conf_mode/protocols_static.py
+++ b/src/conf_mode/protocols_static.py
@@ -97,6 +97,9 @@ def apply(static):
         for a in range(5):
             frr_cfg.commit_configuration(frr_daemon)
 
+    # Save configuration to /run/frr/{daemon}.conf
+    frr.save_configuration(frr_daemon)
+
     return None
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add Ability to save routing configuration per commit to file.
It only saves configs to /run/frr/{damon}.conf and **not restore it yet via watchfrr.**

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3217

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
routing, bgp, isis, static, rip, ripng, ospf, ospfv3
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure or edit protocol and check that configuration is saved 
```
set protocols bgp 65001 neighbor 100.64.0.55 description 'foo'
set protocols bgp 65001 neighbor 100.64.0.55 remote-as '65002'

```
Config saved to /run/frr/bgpd.conf
```
vyos@r1-roll# sudo cat /run/frr/bgpd.conf 
frr version 7.5.1-20210317-02-g301dee3fd
frr defaults traditional
hostname r1-roll
log syslog
log facility local7
service integrated-vtysh-config
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp network import-check
 neighbor 100.64.0.55 remote-as 65002
 neighbor 100.64.0.55 description foo
!
line vty
!
end
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
