### PR TITLE
bgp: T2771: Adding address families in BGP

### DIFF
--- a/data/templates/frr/bgp.frr.tmpl
+++ b/data/templates/frr/bgp.frr.tmpl
@@ -88,13 +88,29 @@
  !
 {%   if config.address_family is defined and config.address_family is not none %}
 {%     for afi, afi_config in config.address_family.items() %}
-{%       if afi == 'ipv4_unicast' %}
+{%     if afi == 'ipv4_unicast' %}
  address-family ipv4 unicast
-{%       elif afi == 'ipv6_unicast' %}
+{%     elif afi == 'ipv4_multicast' %}
+ address-family ipv4 multicast
+{%     elif afi == 'ipv4_labeled_unicast' %}
+ address-family ipv4 labeled-unicast
+{%     elif afi == 'ipv4_vpn' %}
+ address-family ipv4 vpn
+{%     elif afi == 'ipv4_flowspec' %}
+ address-family ipv4 flowspec
+{%     elif afi == 'ipv6_unicast' %}
  address-family ipv6 unicast
-{%       elif afi == 'l2vpn_evpn' %}
+{%     elif afi == 'ipv6_multicast' %}
+ address-family ipv6 multicast
+{%     elif afi == 'ipv6_labeled_unicast' %}
+ address-family ipv6 labeled-unicast
+{%     elif afi == 'ipv6_vpn' %}
+ address-family ipv6 vpn
+{%     elif afi == 'ipv6_flowspec' %}
+ address-family ipv6 flowspec
+{%     elif afi == 'l2vpn_evpn' %}
  address-family l2vpn evpn
-{%       endif %}
+{%     endif %}
 {%       if afi_config.addpath_tx_all is defined %}
   neighbor {{ neighbor }} addpath-tx-all-paths
 {%       endif %}
@@ -198,8 +214,24 @@ router bgp {{ asn }} {{ 'vrf ' + vrf if vrf is defined and vrf is not none }}
  !
 {%     if afi == 'ipv4_unicast' %}
  address-family ipv4 unicast
+{%     elif afi == 'ipv4_multicast' %}
+ address-family ipv4 multicast
+{%     elif afi == 'ipv4_labeled_unicast' %}
+ address-family ipv4 labeled-unicast
+{%     elif afi == 'ipv4_vpn' %}
+ address-family ipv4 vpn
+{%     elif afi == 'ipv4_flowspec' %}
+ address-family ipv4 flowspec
 {%     elif afi == 'ipv6_unicast' %}
  address-family ipv6 unicast
+{%     elif afi == 'ipv6_multicast' %}
+ address-family ipv6 multicast
+{%     elif afi == 'ipv6_labeled_unicast' %}
+ address-family ipv6 labeled-unicast
+{%     elif afi == 'ipv6_vpn' %}
+ address-family ipv6 vpn
+{%     elif afi == 'ipv6_flowspec' %}
+ address-family ipv6 flowspec
 {%     elif afi == 'l2vpn_evpn' %}
  address-family l2vpn evpn
 {%     endif %}
@@ -231,9 +263,24 @@ router bgp {{ asn }} {{ 'vrf ' + vrf if vrf is defined and vrf is not none }}
 {%     endif %}
 {%     if afi_config.network is defined and afi_config.network is not none %}
 {%       for network in afi_config.network %}
-  network {{ network }}{% if afi_config.network[network].route_map is defined %} route-map {{ afi_config.network[network].route_map }}{% endif %}{% if afi_config.network[network].backdoor is defined %} backdoor{% endif %}
+  network {{ network }}{% if afi_config.network[network].route_map is defined %} route-map {{ afi_config.network[network].route_map }}{% endif %}{% if afi_config.network[network].backdoor is defined %} backdoor{% endif %}{% if afi_config.network[network].rd is defined and afi_config.network[network].label is defined%} rd {{ afi_config.network[network].rd }} label {{ afi_config.network[network].label }}{% endif %}
 {#######   we need this blank line!! #######}
 
+{%       endfor %}
+{%     endif %}
+{%     if afi_config.distance is defined and afi_config.distance is not none %}
+{%       if afi_config.distance is defined and afi_config.distance.external is defined and afi_config.distance.internal is defined and afi_config.distance.local is defined %}
+ distance bgp {{ afi_config.distance.external }} {{ afi_config.distance.internal }} {{ afi_config.distance.local }}
+{%       endif %}
+{%       if afi_config.distance.prefix is defined and afi_config.distance.prefix is not none %}
+{%         for prefix in afi_config.distance.prefix %}
+ distance {{ afi_config.distance.prefix[prefix].distance }} {{ prefix }}
+{%         endfor %}
+{%       endif %}
+{%     endif %}
+{%     if afi_config.local_install is defined and afi_config.local_install is not none %}
+{%       for interface in afi_config.local_install.interface %}
+ local-install {{ interface }}
 {%       endfor %}
 {%     endif %}
 {%     if afi_config.advertise_all_vni is defined %}
@@ -367,8 +414,6 @@ router bgp {{ asn }} {{ 'vrf ' + vrf if vrf is defined and vrf is not none }}
  bgp deterministic-med
 {%   endif %}
 {%   if parameters.distance is defined and parameters.distance is not none %}
- !
- address-family ipv4 unicast
 {%     if parameters.distance.global is defined and parameters.distance.global.external is defined and parameters.distance.global.internal is defined and parameters.distance.global.local is defined %}
   distance bgp {{ parameters.distance.global.external }} {{ parameters.distance.global.internal }} {{ parameters.distance.global.local }}
 {%     endif %}
@@ -377,8 +422,6 @@ router bgp {{ asn }} {{ 'vrf ' + vrf if vrf is defined and vrf is not none }}
   distance {{ parameters.distance.prefix[prefix].distance }} {{ prefix }}
 {%       endfor %}
 {%     endif %}
- exit-address-family
- !
 {%   endif %}
 {%   if parameters.graceful_restart is defined %}
  bgp graceful-restart {{ 'stalepath-time ' + parameters.graceful_restart.stalepath_time if parameters.graceful_restart.stalepath_time is defined }}

--- a/interface-definitions/include/bgp/bgp-afi-common-flowspec.xml.i
+++ b/interface-definitions/include/bgp/bgp-afi-common-flowspec.xml.i
@@ -1,0 +1,29 @@
+<!-- included start from bgp-afi-common-flowspec.xml.i -->
+<node name="filter-list">
+  <properties>
+    <help>as-path-list to filter route updates to/from this peer</help>
+  </properties>
+  <children>
+    <leafNode name="export">
+      <properties>
+        <help>As-path-list to filter outgoing route updates to this peer</help>
+        <completionHelp>
+          <path>policy as-path-list</path>
+        </completionHelp>
+      </properties>
+    </leafNode>
+    <leafNode name="import">
+      <properties>
+        <help>As-path-list to filter incoming route updates from this peer</help>
+        <completionHelp>
+          <path>policy as-path-list</path>
+        </completionHelp>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+#include <include/bgp/bgp-afi-route-map.xml.i>
+#include <include/bgp/bgp-afi-route-reflector-client.xml.i>
+#include <include/bgp/bgp-afi-route-server-client.xml.i>
+#include <include/bgp/bgp-afi-soft-reconfiguration.xml.i>
+<!-- included end -->

--- a/interface-definitions/include/bgp/bgp-afi-common-vpn.xml.i
+++ b/interface-definitions/include/bgp/bgp-afi-common-vpn.xml.i
@@ -1,0 +1,144 @@
+<!-- include start from bgp-afi-common-vpn.xml.i -->
+<leafNode name="addpath-tx-all">
+  <properties>
+    <help>Use addpath to advertise all paths to a neighbor</help>
+    <valueless/>
+  </properties>
+</leafNode>
+<leafNode name="addpath-tx-per-as">
+  <properties>
+    <help>Use addpath to advertise the bestpath per each neighboring AS</help>
+    <valueless/>
+  </properties>
+</leafNode>
+#include <include/bgp/bgp-afi-allowas-in.xml.i>
+<leafNode name="as-override">
+  <properties>
+    <help>AS for routes sent to this peer to be the local AS</help>
+    <valueless/>
+  </properties>
+</leafNode>
+#include <include/bgp/bgp-afi-attribute-unchanged.xml.i>
+<node name="disable-send-community">
+  <properties>
+    <help>Disable sending community attributes to this peer</help>
+  </properties>
+  <children>
+    <leafNode name="extended">
+      <properties>
+        <help>Disable sending extended community attributes to this peer</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+    <leafNode name="standard">
+      <properties>
+        <help>Disable sending standard community attributes to this peer</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<node name="distribute-list">
+  <properties>
+    <help>Access-list to filter route updates to/from this peer-group</help>
+  </properties>
+  <children>
+    <leafNode name="export">
+      <properties>
+        <help>Access-list to filter outgoing route updates to this peer-group</help>
+        <completionHelp>
+          <path>policy access-list</path>
+        </completionHelp>
+        <valueHelp>
+          <format>u32:1-65535</format>
+          <description>Access-list to filter outgoing route updates to this peer-group</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-65535"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="import">
+      <properties>
+        <help>Access-list to filter incoming route updates from this peer-group</help>
+        <completionHelp>
+          <path>policy access-list</path>
+        </completionHelp>
+        <valueHelp>
+          <format>u32:1-65535</format>
+          <description>Access-list to filter incoming route updates from this peer-group</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-65535"/>
+        </constraint>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<node name="filter-list">
+  <properties>
+    <help>as-path-list to filter route updates to/from this peer</help>
+  </properties>
+  <children>
+    <leafNode name="export">
+      <properties>
+        <help>As-path-list to filter outgoing route updates to this peer</help>
+        <completionHelp>
+          <path>policy as-path-list</path>
+        </completionHelp>
+      </properties>
+    </leafNode>
+    <leafNode name="import">
+      <properties>
+        <help>As-path-list to filter incoming route updates from this peer</help>
+        <completionHelp>
+          <path>policy as-path-list</path>
+        </completionHelp>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<leafNode name="maximum-prefix">
+  <properties>
+    <help>Maximum number of prefixes to accept from this peer</help>
+    <valueHelp>
+      <format>u32:1-4294967295</format>
+      <description>Prefix limit</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-4294967295"/>
+    </constraint>
+  </properties>
+</leafNode>
+#include <include/bgp/bgp-afi-nexthop-self.xml.i>
+<leafNode name="remove-private-as">
+  <properties>
+    <help>Remove private AS numbers from AS path in outbound route updates</help>
+    <valueless/>
+  </properties>
+</leafNode>
+#include <include/bgp/bgp-afi-route-map.xml.i>
+#include <include/bgp/bgp-afi-route-reflector-client.xml.i>
+#include <include/bgp/bgp-afi-route-server-client.xml.i>
+#include <include/bgp/bgp-afi-soft-reconfiguration.xml.i>
+<leafNode name="unsuppress-map">
+  <properties>
+    <help>Route-map to selectively unsuppress suppressed routes</help>
+    <completionHelp>
+      <path>policy route-map</path>
+    </completionHelp>
+  </properties>
+</leafNode>
+<leafNode name="weight">
+  <properties>
+    <help>Default weight for routes from this peer</help>
+    <valueHelp>
+      <format>u32:1-65535</format>
+      <description>Default weight</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-65535"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- included end -->

--- a/interface-definitions/include/bgp/bgp-common-config.xml.i
+++ b/interface-definitions/include/bgp/bgp-common-config.xml.i
@@ -24,6 +24,75 @@
             #include <include/bgp/bgp-afi-aggregate-address.xml.i>
           </children>
         </tagNode>
+        <node name="distance">
+          <properties>
+            <help>Administrative distances for BGP routes</help>
+          </properties>
+          <children>
+            <leafNode name="external">
+              <properties>
+                <help>eBGP routes administrative distance</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                  <description>eBGP routes administrative distance</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+            </leafNode>
+            <leafNode name="internal">
+              <properties>
+                <help>iBGP routes administrative distance</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                  <description>iBGP routes administrative distance</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+            </leafNode>
+            <leafNode name="local">
+              <properties>
+                <help>Locally originated BGP routes administrative distance</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                  <description>Locally originated BGP routes administrative distance</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+            </leafNode>
+            <tagNode name="prefix">
+              <properties>
+                <help>Administrative distance for a specific BGP prefix</help>
+                <valueHelp>
+                  <format>ipv4net</format>
+                  <description>Administrative distance for a specific BGP prefix</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="ipv4-prefix"/>
+                </constraint>
+              </properties>
+              <children>
+                <leafNode name="distance">
+                  <properties>
+                    <help>Administrative distance for prefix</help>
+                    <valueHelp>
+                      <format>u32:1-255</format>
+                      <description>Administrative distance for external BGP routes</description>
+                    </valueHelp>
+                    <constraint>
+                      <validator name="numeric" argument="--range 1-255"/>
+                    </constraint>
+                  </properties>
+                </leafNode>
+              </children>
+            </tagNode>
+          </children>
+        </node>
         <tagNode name="network">
           <properties>
             <help>BGP network</help>
@@ -108,6 +177,229 @@
         </node>
       </children>
     </node>
+    <node name="ipv4-multicast">
+      <properties>
+        <help>Multicast IPv4 BGP settings</help>
+      </properties>
+      <children>
+        <tagNode name="aggregate-address">
+          <properties>
+            <help>BGP aggregate network/prefix</help>
+            <valueHelp>
+              <format>ipv4net</format>
+              <description>BGP aggregate network/prefix</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ipv4-prefix"/>
+            </constraint>
+          </properties>
+          <children>
+            #include <include/bgp/bgp-afi-aggregate-address.xml.i>
+          </children>
+        </tagNode>
+        <node name="distance">
+          <properties>
+            <help>Administrative distances for BGP routes</help>
+          </properties>
+          <children>
+            <leafNode name="external">
+              <properties>
+                <help>eBGP routes administrative distance</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                  <description>eBGP routes administrative distance</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+            </leafNode>
+            <leafNode name="internal">
+              <properties>
+                <help>iBGP routes administrative distance</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                  <description>iBGP routes administrative distance</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+            </leafNode>
+            <leafNode name="local">
+              <properties>
+                <help>Locally originated BGP routes administrative distance</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                  <description>Locally originated BGP routes administrative distance</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+            </leafNode>
+            <tagNode name="prefix">
+              <properties>
+                <help>Administrative distance for a specific BGP prefix</help>
+                <valueHelp>
+                  <format>ipv4net</format>
+                  <description>Administrative distance for a specific BGP prefix</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="ipv4-prefix"/>
+                </constraint>
+              </properties>
+              <children>
+                <leafNode name="distance">
+                  <properties>
+                    <help>Administrative distance for prefix</help>
+                    <valueHelp>
+                      <format>u32:1-255</format>
+                      <description>Administrative distance for external BGP routes</description>
+                    </valueHelp>
+                    <constraint>
+                      <validator name="numeric" argument="--range 1-255"/>
+                    </constraint>
+                  </properties>
+                </leafNode>
+              </children>
+            </tagNode>
+          </children>
+        </node>
+        <tagNode name="network">
+          <properties>
+            <help>Import BGP network/prefix into multicast IPv4 RIB</help>
+            <valueHelp>
+              <format>ipv4net</format>
+              <description>Multicast IPv4 BGP network/prefix</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ipv4-prefix"/>
+            </constraint>
+          </properties>
+          <children>
+            <leafNode name="backdoor">
+              <properties>
+                <help>Use BGP network/prefix as a backdoor route</help>
+                <valueless/>
+              </properties>
+            </leafNode>
+            #include <include/route-map.xml.i>
+          </children>
+        </tagNode>
+      </children>
+    </node>
+    <node name="ipv4-labeled-unicast">
+      <properties>
+        <help>Labeled Unicast IPv4 BGP settings</help>
+      </properties>
+      <children>
+        <tagNode name="aggregate-address">
+          <properties>
+            <help>BGP aggregate network/prefix</help>
+            <valueHelp>
+              <format>ipv4net</format>
+              <description>BGP aggregate network/prefix</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ipv4-prefix"/>
+            </constraint>
+          </properties>
+          <children>
+            #include <include/bgp/bgp-afi-aggregate-address.xml.i>
+          </children>
+        </tagNode>
+        <tagNode name="network">
+          <properties>
+            <help>Import BGP network/prefix into labeled unicast IPv4 RIB</help>
+            <valueHelp>
+              <format>ipv4net</format>
+              <description>Labeled Unicast IPv4 BGP network/prefix</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ipv4-prefix"/>
+            </constraint>
+          </properties>
+          <children>
+            <leafNode name="backdoor">
+              <properties>
+                <help>Use BGP network/prefix as a backdoor route</help>
+                <valueless/>
+              </properties>
+            </leafNode>
+            #include <include/route-map.xml.i>
+          </children>
+        </tagNode>
+      </children>
+    </node>
+    <node name="ipv4-flowspec">
+      <properties>
+        <help>Flowspec IPv4 BGP settings</help>
+      </properties>
+      <children>
+        <node name="local-install">
+          <properties>
+            <help>Apply local policy routing to interface</help>
+          </properties>
+          <children>
+            <leafNode name="interface">
+              <properties>
+                <help>Interface</help>
+                <completionHelp>
+                  <script>${vyos_completion_dir}/list_interfaces.py</script>
+                </completionHelp>
+                <multi/>
+              </properties>
+            </leafNode>
+          </children>
+        </node>
+      </children>
+    </node>
+    <node name="ipv4-vpn">
+      <properties>
+        <help>Unicast VPN IPv4 BGP settings</help>
+      </properties>
+      <children>
+        <tagNode name="network">
+          <properties>
+            <help>Import BGP network/prefix into unicast VPN IPv4 RIB</help>
+            <valueHelp>
+              <format>ipv4net</format>
+              <description>Unicast VPN IPv4 BGP network/prefix</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ipv4-prefix"/>
+            </constraint>
+          </properties>
+          <children>
+            <leafNode name="rd">
+              <properties>
+                <help>Route Distinguisher</help>
+                <valueHelp>
+                  <format>txt</format>
+                  <description>Route Distinguisher, asn:xxx</description>
+                </valueHelp>
+                <constraint>
+                  <regex>^[0-9]{1,10}:[0-9]{1,5}$</regex>
+                </constraint>
+              </properties>
+            </leafNode>
+            <leafNode name="label">
+              <properties>
+                <help>MPLS label value assigned to route</help>
+                <valueHelp>
+                  <format>u32:0-1048575</format>
+                  <description>MPLS label value</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 0-1048575"/>
+                </constraint>
+              </properties>
+            </leafNode>
+          </children>
+        </tagNode>
+      </children>
+    </node>
     <node name="ipv6-unicast">
       <properties>
         <help>IPv6 BGP settings</help>
@@ -128,6 +420,75 @@
             #include <include/bgp/bgp-afi-aggregate-address.xml.i>
           </children>
         </tagNode>
+        <node name="distance">
+          <properties>
+            <help>Administrative distances for BGP routes</help>
+          </properties>
+          <children>
+            <leafNode name="external">
+              <properties>
+                <help>eBGP routes administrative distance</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                  <description>eBGP routes administrative distance</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+            </leafNode>
+            <leafNode name="internal">
+              <properties>
+                <help>iBGP routes administrative distance</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                  <description>iBGP routes administrative distance</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+            </leafNode>
+            <leafNode name="local">
+              <properties>
+                <help>Locally originated BGP routes administrative distance</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                  <description>Locally originated BGP routes administrative distance</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+            </leafNode>
+            <tagNode name="prefix">
+              <properties>
+                <help>Administrative distance for a specific BGP prefix</help>
+                <valueHelp>
+                  <format>ipv6net</format>
+                  <description>Administrative distance for a specific BGP prefix</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="ipv6-prefix"/>
+                </constraint>
+              </properties>
+              <children>
+                <leafNode name="distance">
+                  <properties>
+                    <help>Administrative distance for prefix</help>
+                    <valueHelp>
+                      <format>u32:1-255</format>
+                      <description>Administrative distance for external BGP routes</description>
+                    </valueHelp>
+                    <constraint>
+                      <validator name="numeric" argument="--range 1-255"/>
+                    </constraint>
+                  </properties>
+                </leafNode>
+              </children>
+            </tagNode>
+          </children>
+        </node>
         <tagNode name="network">
           <properties>
             <help>BGP network</help>
@@ -208,6 +569,235 @@
             </leafNode>
           </children>
         </node>
+      </children>
+    </node>
+    <node name="ipv6-multicast">
+      <properties>
+        <help>Multicast IPv6 BGP settings</help>
+      </properties>
+      <children>
+        <tagNode name="aggregate-address">
+          <properties>
+            <help>BGP aggregate network/prefix</help>
+            <valueHelp>
+              <format>ipv6net</format>
+              <description>BGP aggregate network/prefix</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ipv6-prefix"/>
+            </constraint>
+          </properties>
+          <children>
+            #include <include/bgp/bgp-afi-aggregate-address.xml.i>
+          </children>
+        </tagNode>
+        <node name="distance">
+          <properties>
+            <help>Administrative distances for BGP routes</help>
+          </properties>
+          <children>
+            <leafNode name="external">
+              <properties>
+                <help>eBGP routes administrative distance</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                  <description>eBGP routes administrative distance</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+            </leafNode>
+            <leafNode name="internal">
+              <properties>
+                <help>iBGP routes administrative distance</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                  <description>iBGP routes administrative distance</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+            </leafNode>
+            <leafNode name="local">
+              <properties>
+                <help>Locally originated BGP routes administrative distance</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                  <description>Locally originated BGP routes administrative distance</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+            </leafNode>
+            <tagNode name="prefix">
+              <properties>
+                <help>Administrative distance for a specific BGP prefix</help>
+                <valueHelp>
+                  <format>ipv6net</format>
+                  <description>Administrative distance for a specific BGP prefix</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="ipv6-prefix"/>
+                </constraint>
+              </properties>
+              <children>
+                <leafNode name="distance">
+                  <properties>
+                    <help>Administrative distance for prefix</help>
+                    <valueHelp>
+                      <format>u32:1-255</format>
+                      <description>Administrative distance for external BGP routes</description>
+                    </valueHelp>
+                    <constraint>
+                      <validator name="numeric" argument="--range 1-255"/>
+                    </constraint>
+                  </properties>
+                </leafNode>
+              </children>
+            </tagNode>
+          </children>
+        </node>
+        <tagNode name="network">
+          <properties>
+            <help>Import BGP network/prefix into multicast IPv6 RIB</help>
+            <valueHelp>
+              <format>ipv6net</format>
+              <description>Multicast IPv6 BGP network/prefix</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ipv6-prefix"/>
+            </constraint>
+          </properties>
+          <children>
+            <leafNode name="path-limit">
+              <properties>
+                <help>AS-path hopcount limit</help>
+                <valueHelp>
+                  <format>u32:0-255</format>
+                  <description>AS path hop count limit</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 0-255"/>
+                </constraint>
+              </properties>
+            </leafNode>
+            #include <include/route-map.xml.i>
+          </children>
+        </tagNode>
+      </children>
+    </node>
+    <node name="ipv6-labeled-unicast">
+      <properties>
+        <help>Labeled Unicast IPv6 BGP settings</help>
+      </properties>
+      <children>
+        <tagNode name="aggregate-address">
+          <properties>
+            <help>BGP aggregate network/prefix</help>
+            <valueHelp>
+              <format>ipv6net</format>
+              <description>BGP aggregate network/prefix</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ipv6-prefix"/>
+            </constraint>
+          </properties>
+          <children>
+            #include <include/bgp/bgp-afi-aggregate-address.xml.i>
+          </children>
+        </tagNode>
+        <tagNode name="network">
+          <properties>
+            <help>Import BGP network/prefix into labeled unicast IPv6 RIB</help>
+            <valueHelp>
+              <format>ipv6net</format>
+              <description>Labeled Unicast IPv6 BGP network/prefix</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ipv6-prefix"/>
+            </constraint>
+          </properties>
+          <children>
+            <leafNode name="backdoor">
+              <properties>
+                <help>Use BGP network/prefix as a backdoor route</help>
+                <valueless/>
+              </properties>
+            </leafNode>
+            #include <include/route-map.xml.i>
+          </children>
+        </tagNode>
+      </children>
+    </node>
+    <node name="ipv6-flowspec">
+      <properties>
+        <help>Flowspec IPv6 BGP settings</help>
+      </properties>
+      <children>
+        <node name="local-install">
+          <properties>
+            <help>Apply local policy routing to interface</help>
+          </properties>
+          <children>
+            <leafNode name="interface">
+              <properties>
+                <help>Interface</help>
+                <completionHelp>
+                  <script>${vyos_completion_dir}/list_interfaces.py</script>
+                </completionHelp>
+                <multi/>
+              </properties>
+            </leafNode>
+          </children>
+        </node>
+      </children>
+    </node>
+    <node name="ipv6-vpn">
+      <properties>
+        <help>Unicast VPN IPv6 BGP settings</help>
+      </properties>
+      <children>
+        <tagNode name="network">
+          <properties>
+            <help>Import BGP network/prefix into unicast VPN IPv6 RIB</help>
+            <valueHelp>
+              <format>ipv6net</format>
+              <description>Unicast VPN IPv6 BGP network/prefix</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ipv6-prefix"/>
+            </constraint>
+          </properties>
+          <children>
+            <leafNode name="rd">
+              <properties>
+                <help>Route Distinguisher</help>
+                <valueHelp>
+                  <format>txt</format>
+                  <description>Route Distinguisher, asn:xxx</description>
+                </valueHelp>
+                <constraint>
+                  <regex>^[0-9]{1,10}:[0-9]{1,5}$</regex>
+                </constraint>
+              </properties>
+            </leafNode>
+            <leafNode name="label">
+              <properties>
+                <help>MPLS label value assigned to route</help>
+                <valueHelp>
+                  <format>u32:0-1048575</format>
+                  <description>MPLS label value</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 0-1048575"/>
+                </constraint>
+              </properties>
+            </leafNode>
+          </children>
+        </tagNode>
       </children>
     </node>
     <node name="l2vpn-evpn">
@@ -346,6 +936,14 @@
       <children>
         #include <include/bgp/bgp-neighbor-afi-ipv4-unicast.xml.i>
         #include <include/bgp/bgp-neighbor-afi-ipv6-unicast.xml.i>
+        #include <include/bgp/bgp-neighbor-afi-ipv4-labeled-unicast.xml.i>
+        #include <include/bgp/bgp-neighbor-afi-ipv6-labeled-unicast.xml.i>
+        #include <include/bgp/bgp-neighbor-afi-ipv4-vpn.xml.i>
+        #include <include/bgp/bgp-neighbor-afi-ipv6-vpn.xml.i>
+        #include <include/bgp/bgp-neighbor-afi-ipv4-flowspec.xml.i>
+        #include <include/bgp/bgp-neighbor-afi-ipv6-flowspec.xml.i>
+        #include <include/bgp/bgp-neighbor-afi-ipv4-multicast.xml.i>
+        #include <include/bgp/bgp-neighbor-afi-ipv6-multicast.xml.i>
         #include <include/bgp/bgp-neighbor-afi-l2vpn-evpn.xml.i>
       </children>
     </node>

--- a/interface-definitions/include/bgp/bgp-neighbor-afi-ipv4-flowspec.xml.i
+++ b/interface-definitions/include/bgp/bgp-neighbor-afi-ipv4-flowspec.xml.i
@@ -1,0 +1,11 @@
+<!-- included start from bgp-neighbor-afi-ipv4-flowspec.xml.i -->
+<node name="ipv4-flowspec">
+  <properties>
+    <help>IPv4 Flow Specification BGP neighbor parameters</help>
+  </properties>
+  <children>
+    #include <include/bgp/bgp-afi-ipv4-prefix-list.xml.i>
+    #include <include/bgp/bgp-afi-common-flowspec.xml.i>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/bgp/bgp-neighbor-afi-ipv4-labeled-unicast.xml.i
+++ b/interface-definitions/include/bgp/bgp-neighbor-afi-ipv4-labeled-unicast.xml.i
@@ -1,0 +1,19 @@
+<!-- included start from bgp-neighbor-afi-ipv4-labeled-unicast.xml.i -->
+<node name="ipv4-labeled-unicast">
+  <properties>
+    <help>IPv4 Labeled Unicast BGP neighbor parameters</help>
+  </properties>
+  <children>
+    <node name="capability">
+      <properties>
+        <help>Advertise capabilities to this neighbor (IPv4)</help>
+      </properties>
+      <children>
+        #include <include/bgp/bgp-afi-capability-orf.xml.i>
+      </children>
+    </node>
+    #include <include/bgp/bgp-afi-ipv4-prefix-list.xml.i>
+    #include <include/bgp/bgp-afi-common.xml.i>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/bgp/bgp-neighbor-afi-ipv4-multicast.xml.i
+++ b/interface-definitions/include/bgp/bgp-neighbor-afi-ipv4-multicast.xml.i
@@ -1,0 +1,19 @@
+<!-- included start from bgp-neighbor-afi-ipv4-multicast.xml.i -->
+<node name="ipv4-multicast">
+  <properties>
+    <help>IPv4 Multicast BGP neighbor parameters</help>
+  </properties>
+  <children>
+    <node name="capability">
+      <properties>
+        <help>Advertise capabilities to this neighbor (IPv4)</help>
+      </properties>
+      <children>
+        #include <include/bgp/bgp-afi-capability-orf.xml.i>
+      </children>
+    </node>
+    #include <include/bgp/bgp-afi-ipv4-prefix-list.xml.i>
+    #include <include/bgp/bgp-afi-common.xml.i>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/bgp/bgp-neighbor-afi-ipv4-vpn.xml.i
+++ b/interface-definitions/include/bgp/bgp-neighbor-afi-ipv4-vpn.xml.i
@@ -1,0 +1,11 @@
+<!-- included start from bgp-neighbor-afi-ipv4-vpn.xml.i -->
+<node name="ipv4-vpn">
+  <properties>
+    <help>IPv4 VPN BGP neighbor parameters</help>
+  </properties>
+  <children>
+    #include <include/bgp/bgp-afi-ipv4-prefix-list.xml.i>
+    #include <include/bgp/bgp-afi-common-vpn.xml.i>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/bgp/bgp-neighbor-afi-ipv6-flowspec.xml.i
+++ b/interface-definitions/include/bgp/bgp-neighbor-afi-ipv6-flowspec.xml.i
@@ -1,0 +1,11 @@
+<!-- included start from bgp-neighbor-afi-ipv6-flowspec.xml.i -->
+<node name="ipv6-flowspec">
+  <properties>
+    <help>IPv6 Flow Specification BGP neighbor parameters</help>
+  </properties>
+  <children>
+    #include <include/bgp/bgp-afi-ipv6-prefix-list.xml.i>
+    #include <include/bgp/bgp-afi-common-flowspec.xml.i>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/bgp/bgp-neighbor-afi-ipv6-labeled-unicast.xml.i
+++ b/interface-definitions/include/bgp/bgp-neighbor-afi-ipv6-labeled-unicast.xml.i
@@ -1,0 +1,20 @@
+<!-- included start from bgp-neighbor-afi-ipv6-labeled-unicast.xml.i -->
+<node name="ipv6-labeled-unicast">
+  <properties>
+    <help>IPv6 Labeled Unicast BGP neighbor parameters</help>
+  </properties>
+  <children>
+    <node name="capability">
+      <properties>
+        <help>Advertise capabilities to this neighbor (IPv6)</help>
+      </properties>
+      <children>
+        #include <include/bgp/bgp-afi-capability-orf.xml.i>
+      </children>
+    </node>
+    #include <include/bgp/bgp-afi-ipv6-nexthop-local.xml.i>
+    #include <include/bgp/bgp-afi-ipv6-prefix-list.xml.i>
+    #include <include/bgp/bgp-afi-common.xml.i>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/bgp/bgp-neighbor-afi-ipv6-multicast.xml.i
+++ b/interface-definitions/include/bgp/bgp-neighbor-afi-ipv6-multicast.xml.i
@@ -1,0 +1,12 @@
+<!-- included start from bgp-neighbor-afi-ipv6-multicast.xml.i -->
+<node name="ipv6-multicast">
+  <properties>
+    <help>IPv6 Multicast BGP neighbor parameters</help>
+  </properties>
+  <children>
+    #include <include/bgp/bgp-afi-ipv6-nexthop-local.xml.i>
+    #include <include/bgp/bgp-afi-ipv6-prefix-list.xml.i>
+    #include <include/bgp/bgp-afi-common.xml.i>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/bgp/bgp-neighbor-afi-ipv6-vpn.xml.i
+++ b/interface-definitions/include/bgp/bgp-neighbor-afi-ipv6-vpn.xml.i
@@ -1,0 +1,12 @@
+<!-- included start from bgp-neighbor-afi-ipv6-vpn.xml.i -->
+<node name="ipv6-vpn">
+  <properties>
+    <help>IPv6 VPN BGP neighbor parameters</help>
+  </properties>
+  <children>
+    #include <include/bgp/bgp-afi-ipv6-nexthop-local.xml.i>
+    #include <include/bgp/bgp-afi-ipv6-prefix-list.xml.i>
+    #include <include/bgp/bgp-afi-common-vpn.xml.i>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/bgp/bgp-route-map.xml.i
+++ b/interface-definitions/include/bgp/bgp-route-map.xml.i
@@ -1,0 +1,10 @@
+<!-- included start from bgp-route-map.xml.i -->
+<leafNode name="route-map">
+  <properties>
+    <help>Route-map to modify route attributes</help>
+    <completionHelp>
+      <path>policy route-map</path>
+    </completionHelp>
+  </properties>
+</leafNode>
+<!-- included end -->


### PR DESCRIPTION
In this commit we add more address families within
BGP. This should bring VyOS the ability to enable
the rest of the capabilities within FRR.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

We are going to be adding the following address families here.

IPv4 Labeled Unicast
IPv4 Multicast
IPv4 VPN
IPv4 Flowspec
IPv6 Labeled Unicast
IPv6 Multicast
IPv6 VPN
IPv6 Flowspec

The administrative distances are also added for existing and new address families
including a check to make sure everything is properly commit and not missing
when specifying said distances.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T2771

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
BGP

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics 

-->

```
Here's the configuration that was added:

set protocols bgp 1 address-family ipv4-flowspec local-install interface 'lo'
set protocols bgp 1 address-family ipv4-flowspec local-install interface 'eth0'
set protocols bgp 1 address-family ipv4-multicast distance external '25'
set protocols bgp 1 address-family ipv4-multicast distance internal '30'
set protocols bgp 1 address-family ipv4-multicast distance local '35'
set protocols bgp 1 address-family ipv4-multicast distance prefix 10.0.0.0/24 distance '110'
set protocols bgp 1 address-family ipv4-unicast distance external '10'
set protocols bgp 1 address-family ipv4-unicast distance internal '15'
set protocols bgp 1 address-family ipv4-unicast distance local '20'
set protocols bgp 1 address-family ipv4-unicast distance prefix 10.0.0.0/24 distance '110'
set protocols bgp 1 address-family ipv6-multicast distance external '45'
set protocols bgp 1 address-family ipv6-multicast distance internal '50'
set protocols bgp 1 address-family ipv6-multicast distance local '55'
set protocols bgp 1 address-family ipv6-multicast distance prefix 2001::/64 distance '110'
set protocols bgp 1 address-family ipv6-unicast distance external '60'
set protocols bgp 1 address-family ipv6-unicast distance internal '65'
set protocols bgp 1 address-family ipv6-unicast distance local '70'
set protocols bgp 1 address-family ipv6-unicast distance prefix 2001::/64 distance '110'
set protocols bgp 1 neighbor 10.0.0.1 address-family ipv4-flowspec
set protocols bgp 1 neighbor 10.0.0.1 remote-as '1'
set protocols bgp 1 neighbor 10.0.0.2 address-family ipv4-vpn
set protocols bgp 1 neighbor 10.0.0.2 remote-as '2'
set protocols bgp 1 neighbor 10.0.0.3 address-family ipv4-labeled-unicast
set protocols bgp 1 neighbor 10.0.0.3 remote-as 3
set protocols bgp 1 neighbor 10.0.0.4 address-family ipv4-unicast
set protocols bgp 1 neighbor 10.0.0.4 remote-as '4'
set protocols bgp 1 neighbor 10.0.0.5 address-family ipv4-multicast
set protocols bgp 1 neighbor 10.0.0.5 remote-as '5'
set protocols bgp 1 neighbor 10.0.0.55 address-family ipv4-unicast allowas-in number '5'
set protocols bgp 1 neighbor 10.0.0.55 address-family ipv4-unicast as-override
set protocols bgp 1 neighbor 10.0.0.55 address-family ipv4-unicast attribute-unchanged as-path
set protocols bgp 1 neighbor 10.0.0.55 address-family ipv4-unicast attribute-unchanged med
set protocols bgp 1 neighbor 10.0.0.55 address-family ipv4-unicast attribute-unchanged next-hop
set protocols bgp 1 neighbor 10.0.0.55 address-family ipv4-unicast maximum-prefix '5000'
set protocols bgp 1 neighbor 10.0.0.55 address-family ipv4-unicast nexthop-self
set protocols bgp 1 neighbor 10.0.0.55 address-family ipv4-unicast route-server-client
set protocols bgp 1 neighbor 10.0.0.55 address-family ipv4-unicast soft-reconfiguration inbound
set protocols bgp 1 neighbor 10.0.0.55 address-family ipv4-unicast weight '100'
set protocols bgp 1 neighbor 10.0.0.55 remote-as '500'
set protocols bgp 1 neighbor 10.0.0.55 timers connect '10'
set protocols bgp 1 neighbor 10.0.0.55 timers holdtime '20'
set protocols bgp 1 neighbor 10.0.0.55 timers keepalive '30'
set protocols bgp 1 neighbor 2001::1 address-family ipv6-flowspec
set protocols bgp 1 neighbor 2001::1 remote-as '1'
set protocols bgp 1 neighbor 2001::2 address-family ipv6-vpn
set protocols bgp 1 neighbor 2001::2 remote-as '2'
set protocols bgp 1 neighbor 2001::3 address-family ipv6-labeled-unicast
set protocols bgp 1 neighbor 2001::3 remote-as '3'
set protocols bgp 1 neighbor 2001::4 address-family ipv6-unicast
set protocols bgp 1 neighbor 2001::4 remote-as '4'
set protocols bgp 1 neighbor 2001::5 address-family ipv6-multicast
set protocols bgp 1 neighbor 2001::5 remote-as '5'
set protocols bgp 1 parameters always-compare-med
set protocols bgp 1 parameters bestpath as-path multipath-relax
set protocols bgp 1 parameters bestpath compare-routerid
set protocols bgp 1 parameters bestpath med missing-as-worst
set protocols bgp 1 parameters cluster-id '10.0.0.67'
set protocols bgp 1 parameters dampening half-life '30'
set protocols bgp 1 parameters dampening max-suppress-time '200'
set protocols bgp 1 parameters dampening re-use '10000'
set protocols bgp 1 parameters dampening start-suppress-time '15000'
set protocols bgp 1 parameters default local-pref '100'
set protocols bgp 1 parameters deterministic-med
set protocols bgp 1 parameters distance global external '170'
set protocols bgp 1 parameters distance global internal '170'
set protocols bgp 1 parameters distance global local '170'
set protocols bgp 1 parameters graceful-restart stalepath-time '300'
set protocols bgp 1 parameters log-neighbor-changes
set protocols bgp 1 parameters network-import-check
set protocols bgp 1 parameters no-client-to-client-reflection
set protocols bgp 1 parameters no-fast-external-failover
set protocols bgp 1 parameters router-id '10.0.0.67'
set protocols bgp 1 peer-group testing remote-as '500'
delete protocols bgp 1 neighbor 10.0.0.3
```


```
Here's how the actual configuration looks under FRR:

vyos@vyos:~$ vtysh -c "show run bgp"
Building configuration...

Current configuration:
!
frr version 7.5.1-20210317-02-g301dee3fd
frr defaults traditional
hostname debian
log syslog
log facility local7
hostname vyos
service integrated-vtysh-config
!
router bgp 1
 no bgp fast-external-failover
 bgp router-id 10.0.0.67
 bgp log-neighbor-changes
 bgp always-compare-med
 no bgp ebgp-requires-policy
 no bgp client-to-client reflection
 bgp cluster-id 10.0.0.67
 bgp deterministic-med
 bgp graceful-restart stalepath-time 300
 bgp bestpath as-path multipath-relax
 bgp bestpath compare-routerid
 bgp bestpath med missing-as-worst
 neighbor testing peer-group
 neighbor testing remote-as 500
 neighbor 10.0.0.1 remote-as 1
 neighbor 10.0.0.2 remote-as 2
 neighbor 10.0.0.4 remote-as 4
 neighbor 10.0.0.5 remote-as 5
 neighbor 10.0.0.55 remote-as 500
 neighbor 10.0.0.55 timers 6 20
 neighbor 10.0.0.55 timers connect 10
 neighbor 2001::1 remote-as 1
 neighbor 2001::2 remote-as 2
 neighbor 2001::3 remote-as 3
 neighbor 2001::4 remote-as 4
 neighbor 2001::5 remote-as 5
 !
 address-family ipv4 unicast
  distance bgp 10 15 20
  distance 110 10.0.0.0/24
  bgp dampening 30 10000 15000 200
  neighbor 10.0.0.55 next-hop-self
  neighbor 10.0.0.55 soft-reconfiguration inbound
  neighbor 10.0.0.55 maximum-prefix 5000
  neighbor 10.0.0.55 route-server-client
  neighbor 10.0.0.55 allowas-in 5
  neighbor 10.0.0.55 weight 100
  neighbor 10.0.0.55 attribute-unchanged as-path next-hop med
 exit-address-family
 !
 address-family ipv4 multicast
  distance bgp 25 30 35
  distance 110 10.0.0.0/24
  neighbor 10.0.0.5 activate
 exit-address-family
 !
 address-family ipv4 vpn
  neighbor 10.0.0.2 activate
 exit-address-family
 !
 address-family ipv4 flowspec
  neighbor 10.0.0.1 activate
  local-install eth0
  local-install lo
 exit-address-family
 !
 address-family ipv6 unicast
  distance bgp 60 65 70
  distance 110 2001::/64
  neighbor 2001::4 activate
 exit-address-family
 !
 address-family ipv6 multicast
  distance bgp 45 50 55
  distance 110 2001::/64
  neighbor 2001::5 activate
 exit-address-family
 !
 address-family ipv6 labeled-unicast
  neighbor 2001::3 activate
 exit-address-family
 !
 address-family ipv6 vpn
  neighbor 2001::2 activate
 exit-address-family
 !
 address-family ipv6 flowspec
  neighbor 2001::1 activate
 exit-address-family
!
line vty
!
end
```

There however *IS* a problem that is an FRR problem. Therefore I have to ask that we hold onto this addition until we are able to have FRR fix the problem that is seen [here](https://github.com/FRRouting/frr/issues/8246). Please don't merge yet.

Also, I will be needing more help for smoketests. I figure it might be easier to add said smoketests separately but I am unsure.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

I will add documentation later as I just don't want to blast all of that in one go. But I will be doing that.
