### PR TITLE
bgp: T1711: remove ASN tagNode and move to "local-as"

### DIFF
--- a/data/templates/frr/bgp.frr.tmpl
+++ b/data/templates/frr/bgp.frr.tmpl
@@ -185,7 +185,7 @@
 {%   endif %}
 {% endmacro %}
 !
-router bgp {{ asn }} {{ 'vrf ' + vrf if vrf is defined and vrf is not none }}
+router bgp {{ local_as }} {{ 'vrf ' + vrf if vrf is defined and vrf is not none }}
 {% if parameters is defined and parameters.ebgp_requires_policy is defined %}
  bgp ebgp-requires-policy
 {% else %}

--- a/interface-definitions/include/bgp/bgp-common-config.xml.i
+++ b/interface-definitions/include/bgp/bgp-common-config.xml.i
@@ -280,7 +280,7 @@
 </node>
 <node name="listen">
   <properties>
-    <help>Listen for and accept BGP dynamic neighbors from range</help>
+    <help>BGP dynamic neighbors listen commands</help>
   </properties>
   <children>
     <leafNode name="limit">
@@ -297,7 +297,7 @@
     </leafNode>
     <tagNode name="range">
       <properties>
-        <help>BGP dynamic neighbors listen range</help>
+        <help>Dynamic neighbors listen range</help>
         <valueHelp>
           <format>ipv4net</format>
           <description>IPv4 dynamic neighbors listen range</description>
@@ -317,6 +317,18 @@
     </tagNode>
   </children>
 </node>
+<leafNode name="local-as">
+  <properties>
+    <help>Autonomous System Number (ASN)</help>
+    <valueHelp>
+      <format>u32:1-4294967294</format>
+      <description>Autonomous System Number</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-4294967294"/>
+    </constraint>
+  </properties>
+</leafNode>
 <tagNode name="neighbor">
   <properties>
     <help>BGP neighbor</help>

--- a/interface-definitions/protocols-bgp.xml.in
+++ b/interface-definitions/protocols-bgp.xml.in
@@ -2,22 +2,15 @@
 <interfaceDefinition>
   <node name="protocols">
     <children>
-      <tagNode name="bgp" owner="${vyos_conf_scripts_dir}/protocols_bgp.py">
+      <node name="bgp" owner="${vyos_conf_scripts_dir}/protocols_bgp.py">
         <properties>
           <help>Border Gateway Protocol (BGP)</help>
           <priority>820</priority>
-          <valueHelp>
-            <format>u32:1-4294967294</format>
-            <description>Autonomous System Number</description>
-          </valueHelp>
-          <constraint>
-            <validator name="numeric" argument="--range 1-4294967294"/>
-          </constraint>
         </properties>
         <children>
           #include <include/bgp/bgp-common-config.xml.i>
         </children>
-      </tagNode>
+      </node>
     </children>
   </node>
 </interfaceDefinition>

--- a/interface-definitions/vrf.xml.in
+++ b/interface-definitions/vrf.xml.in
@@ -33,22 +33,15 @@
               <help>Routing protocol parameters</help>
             </properties>
             <children>
-              <tagNode name="bgp" owner="${vyos_conf_scripts_dir}/protocols_bgp.py $VAR(../../@)">
+              <node name="bgp" owner="${vyos_conf_scripts_dir}/protocols_bgp.py $VAR(../../@)">
                 <properties>
                   <help>Border Gateway Protocol (BGP)</help>
                   <priority>821</priority>
-                  <valueHelp>
-                    <format>u32:1-4294967294</format>
-                    <description>Autonomous System Number</description>
-                  </valueHelp>
-                  <constraint>
-                    <validator name="numeric" argument="--range 1-4294967294"/>
-                  </constraint>
                 </properties>
                 <children>
                   #include <include/bgp/bgp-common-config.xml.i>
                 </children>
-              </tagNode>
+              </node>
               <node name="isis" owner="${vyos_conf_scripts_dir}/protocols_isis.py $VAR(../../@)">
                 <properties>
                   <help>Intermediate System to Intermediate System (IS-IS)</help>

--- a/src/migration-scripts/bgp/0-to-1
+++ b/src/migration-scripts/bgp/0-to-1
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T3417: migrate IS-IS tagNode to node as we can only have one IS-IS process
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+
+if (len(argv) < 1):
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['protocols', 'bgp']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+
+# Only one BGP process is supported, thus this operation is savea
+asn = config.list_nodes(base)
+bgp_base = base + asn
+print(asn)
+
+# We need a temporary copy of the config
+tmp_base = ['protocols', 'bgp2']
+config.copy(bgp_base, tmp_base)
+
+# Now it's save to delete the old configuration
+config.delete(base)
+
+# Rename temporary copy to new final config and set new "local-as" option
+config.rename(tmp_base, 'bgp')
+config.set(base + ['local-as'], value=asn[0])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print(f'Failed to save the modified config: {e}')
+    exit(1)

--- a/src/migration-scripts/isis/0-to-1
+++ b/src/migration-scripts/isis/0-to-1
@@ -47,12 +47,13 @@ config.copy(isis_base, tmp_base)
 # Now it's save to delete the old configuration
 config.delete(base)
 
-# Rename temporary copy to new final config and set domain key
+# Rename temporary copy to new final config (IS-IS domain key is static and no
+# longer required to be set via CLI)
 config.rename(tmp_base, 'isis')
 
 try:
     with open(file_name, 'w') as f:
         f.write(config.to_string())
 except OSError as e:
-    print("Failed to save the modified config: {}".format(e))
-    sys.exit(1)
+    print(f'Failed to save the modified config: {e}')
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
 Every time when set configuration bgp, you need set AS number. There is very less benefit in this system so the AS number is moved from a tagNode level down to a leafNode with the name "local-as", same as on the neighbor or peer-group level.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T1711

## Related PRs
* https://github.com/vyos/vyatta-cfg-system/pull/143
* https://github.com/vyos/vyos-documentation/pull/492

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
BGP

## Proposed changes
<!--- Describe your changes in detail -->

This changes the CLI configuration from:

```
set protocols bgp 100 neighbor 10.10.1.2 remote-as 200
```

to

```
set protocols bgp local-as 100
set protocols bgp neighbor 10.10.1.2 remote-as 200
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
