### PR TITLE
T3354: Handle user break and prematurely closed stdin in strip-private

### DIFF
--- a/python/vyos/remote.py
+++ b/python/vyos/remote.py
@@ -57,11 +57,11 @@ def download_sftp(local_path, hostname, remote_path,\
 
 def upload_tftp(local_path, hostname, remote_path, port=69):
     with open(local_path, 'rb') as file:
-        cmd(f'curl -s -T - tftp://{hostname}:{port}/{remote_path}', stderr=None, input=file.read())
+        cmd(f'curl -s -T - tftp://{hostname}:{port}/{remote_path}', stderr=None, input=file.read()).encode()
 
 def download_tftp(local_path, hostname, remote_path, port=69):
     with open(local_path, 'wb') as file:
-        file.write(cmd(f'curl -s tftp://{hostname}:{port}/{remote_path}', stderr=None))
+        file.write(cmd(f'curl -s tftp://{hostname}:{port}/{remote_path}', stderr=None).encode())
 
 def download_http(urlstring, local_path):
     with open(local_path, 'wb') as file:

--- a/python/vyos/remote.py
+++ b/python/vyos/remote.py
@@ -79,10 +79,6 @@ def download(local_path, urlstring):
         username = url.username if url.username else 'anonymous'
         download_ftp(local_path, url.hostname, url.path, username, url.password)
     elif url.scheme == 'sftp' or url.scheme == 'scp':
-        # None means we don't want to use password authentication.
-        # An empty string (what urlparse returns when a password doesn't
-        # exist in the URL) means the password is an empty string.
-        password = url.password if url.password else None
         download_sftp(local_path, url.hostname, url.path, url.username, password)
     elif url.scheme == 'tftp':
         download_tftp(local_path, url.hostname, url.path)
@@ -98,7 +94,6 @@ def upload(local_path, urlstring):
         username = url.username if url.username else 'anonymous'
         upload_ftp(local_path, url.hostname, url.path, username, url.password)
     elif url.scheme == 'sftp' or url.scheme == 'scp':
-        password = url.password if url.password else None
         upload_sftp(local_path, url.hostname, url.path, url.username, password)
     elif url.scheme == 'tftp':
         upload_tftp(local_path, url.hostname, url.path)

--- a/src/helpers/strip-private.py
+++ b/src/helpers/strip-private.py
@@ -79,13 +79,18 @@ def strip_lines(rules: tuple) -> None:
     """
     Read stdin line by line and apply the given stripping rules.
     """
-    for line in sys.stdin:
-        if not args.keep_address:
-            line = strip_address(line)
-        for (condition, regexp, subst) in rules:
-            if condition:
-                line = regexp.sub(subst, line)
-        print(line, end='')
+    try:
+        for line in sys.stdin:
+            if not args.keep_address:
+                line = strip_address(line)
+            for (condition, regexp, subst) in rules:
+                if condition:
+                    line = regexp.sub(subst, line)
+            print(line, end='')
+    # stdin can be cut for any reason, such as user interrupt or the pager terminating before the text can be read.
+    # All we can do is gracefully exit.
+    except (BrokenPipeError, EOFError, KeyboardInterrupt):
+        sys.exit(1)
 
 if __name__ == "__main__":
     args = parser.parse_args()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
If stdin is closed prematurely, strip-private throws an error on exit. This is harmless but ugly.
strip-private should just take all text it can take, print the results and exit if nothing more can be read.

The next commits fix TFTP transfers that would break because `cmd` returns string when bytes is expected for transfer and get rid of redundant empty password check for SSH.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3354

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
util

## Proposed changes
<!--- Describe your changes in detail -->
Gracefully exit on `EOFError`, `BrokenPipeError` and `KeyboardInterrupt`.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Kill the pager that is reading text through strip-private through `:q` or `^C`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
