### PR TITLE
frr: T3217: Ability to save routing configs

### DIFF
--- a/python/vyos/frr.py
+++ b/python/vyos/frr.py
@@ -69,6 +69,7 @@ import tempfile
 import re
 from vyos import util
 from vyos.util import chown
+from vyos.util import cmd
 import logging
 from logging.handlers import SysLogHandler
 import os
@@ -209,28 +210,14 @@ def reload_configuration(config, daemon=None):
     return output
 
 
-def save_configuration(daemon=None):
-    """Save FRR configuration to /run/frr/{daemon}.conf
-       It save configuration on each commit.
+def save_configuration():
+    """Save FRR configuration to /run/frr/config/frr.conf
+       It save configuration on each commit. T3217
     """
-    if daemon and daemon not in _frr_daemons:
-        raise ValueError(f'The specified daemon type is not supported {repr(daemon)}')
 
-    cmd = f"{path_vtysh} -d {daemon} -c 'show run no-header'"
-    output, code = util.popen(cmd, stderr=util.STDOUT)
-    if code:
-        raise OSError(code, output)
+    cmd(f'{path_vtysh} -n -w')
 
-    daemon_conf = f'{path_config}/{daemon}.conf'
-
-    with open(daemon_conf, "w") as f:
-        f.write(output)
-    # Set permissions (frr:frr) for /run/frr/{daemon}.conf
-    if os.path.exists(daemon_conf):
-        chown(daemon_conf, 'frr', 'frr')
-    config = output
-
-    return config
+    return
 
 
 def execute(command):

--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -213,8 +213,8 @@ def apply(bgp):
         for a in range(5):
             frr_cfg.commit_configuration(frr_daemon)
 
-    # Save configuration to /run/frr/{daemon}.conf
-    frr.save_configuration(frr_daemon)
+    # Save configuration to /run/frr/config/frr.conf
+    frr.save_configuration()
 
     return None
 

--- a/src/conf_mode/protocols_isis.py
+++ b/src/conf_mode/protocols_isis.py
@@ -209,8 +209,8 @@ def apply(isis):
         for a in range(5):
             frr_cfg.commit_configuration(frr_daemon)
 
-    # Save configuration to /run/frr/{daemon}.conf
-    frr.save_configuration(frr_daemon)
+    # Save configuration to /run/frr/config/frr.conf
+    frr.save_configuration()
 
     return None
 

--- a/src/conf_mode/protocols_ospf.py
+++ b/src/conf_mode/protocols_ospf.py
@@ -200,8 +200,8 @@ def apply(ospf):
         for a in range(5):
             frr_cfg.commit_configuration(frr_daemon)
 
-    # Save configuration to /run/frr/{daemon}.conf
-    frr.save_configuration(frr_daemon)
+    # Save configuration to /run/frr/config/frr.conf
+    frr.save_configuration()
 
     return None
 

--- a/src/conf_mode/protocols_ospfv3.py
+++ b/src/conf_mode/protocols_ospfv3.py
@@ -91,8 +91,8 @@ def apply(ospfv3):
         for a in range(5):
             frr_cfg.commit_configuration(frr_daemon)
 
-    # Save configuration to /run/frr/{daemon}.conf
-    frr.save_configuration(frr_daemon)
+    # Save configuration to /run/frr/config/frr.conf
+    frr.save_configuration()
 
     return None
 

--- a/src/conf_mode/protocols_rip.py
+++ b/src/conf_mode/protocols_rip.py
@@ -116,8 +116,8 @@ def apply(rip):
         for a in range(5):
             frr_cfg.commit_configuration(frr_daemon)
 
-    # Save configuration to /run/frr/{daemon}.conf
-    frr.save_configuration(frr_daemon)
+    # Save configuration to /run/frr/config/frr.conf
+    frr.save_configuration()
 
     return None
 

--- a/src/conf_mode/protocols_ripng.py
+++ b/src/conf_mode/protocols_ripng.py
@@ -115,8 +115,8 @@ def apply(ripng):
         for a in range(5):
             frr_cfg.commit_configuration(frr_daemon)
 
-    # Save configuration to /run/frr/{daemon}.conf
-    frr.save_configuration(frr_daemon)
+    # Save configuration to /run/frr/config/frr.conf
+    frr.save_configuration()
 
     return None
 

--- a/src/conf_mode/protocols_static.py
+++ b/src/conf_mode/protocols_static.py
@@ -97,8 +97,8 @@ def apply(static):
         for a in range(5):
             frr_cfg.commit_configuration(frr_daemon)
 
-    # Save configuration to /run/frr/{daemon}.conf
-    frr.save_configuration(frr_daemon)
+    # Save configuration to /run/frr/config/frr.conf
+    frr.save_configuration()
 
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Ability to save routing configs 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3217

Related PR
https://github.com/vyos/vyatta-cfg/pull/34

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
frr

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add routing configuration and restart or kill routing daemon
```
set protocols bgp local-as '65001'
set protocols bgp neighbor 203.0.113.2 remote-as '65003'
set protocols ospf redistribute isis
set protocols static route 0.0.0.0/0 next-hop 192.168.122.1

```
Restart bgpd
```
/usr/lib/frr/watchfrr.sh restart bgpd
```
Check config after restart
```
root@r5-roll:/home/vyos# vtysh -c "show run bgpd"
Building configuration...

Current configuration:
!
frr version 7.5.1-20210330-01-g242f2f5a2
frr defaults traditional
hostname r5-roll
log syslog
log facility local7
service integrated-vtysh-config
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp network import-check
 neighbor 203.0.113.2 remote-as 65003
!
line vty
!
end

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
