### PR TITLE
T3470: enable bgp as-override

### DIFF
--- a/data/templates/frr/bgp.frr.tmpl
+++ b/data/templates/frr/bgp.frr.tmpl
@@ -104,6 +104,9 @@
 {%       if afi_config.allowas_in is defined and afi_config.allowas_in is not none %}
   neighbor {{ neighbor }} allowas-in {{ afi_config.allowas_in.number if afi_config.allowas_in.number is defined }}
 {%       endif %}
+{%       if afi_config.as_override is defined %}
+  neighbor {{ neighbor }} as-override
+{%       endif %}
 {%       if afi_config.remove_private_as is defined %}
   neighbor {{ neighbor }} remove-private-AS
 {%       endif %}

--- a/data/templates/frr/bgp.frr.tmpl
+++ b/data/templates/frr/bgp.frr.tmpl
@@ -104,7 +104,7 @@
 {%       if afi_config.allowas_in is defined and afi_config.allowas_in is not none %}
   neighbor {{ neighbor }} allowas-in {{ afi_config.allowas_in.number if afi_config.allowas_in.number is defined }}
 {%       endif %}
-{%      if afi_config.as_override is defined %}
+{%       if afi_config.as_override is defined %}
   neighbor {{ neighbor }} as-override
 {%       endif %}
 {%       if afi_config.remove_private_as is defined %}

--- a/data/templates/frr/bgp.frr.tmpl
+++ b/data/templates/frr/bgp.frr.tmpl
@@ -104,7 +104,7 @@
 {%       if afi_config.allowas_in is defined and afi_config.allowas_in is not none %}
   neighbor {{ neighbor }} allowas-in {{ afi_config.allowas_in.number if afi_config.allowas_in.number is defined }}
 {%       endif %}
-{%       if afi_config.as_override is defined %}
+{%      if afi_config.as_override is defined %}
   neighbor {{ neighbor }} as-override
 {%       endif %}
 {%       if afi_config.remove_private_as is defined %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
as-override wasn't in bgp template so it wasn't applied to running config in FRR

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3470

## Component(s) name
frr / bgp

## Proposed changes
added as-override to bgp template

## How to test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
