### PR TITLE
ipsec: T3333: Fix status for SA state op-mode

### DIFF
--- a/src/op_mode/show_ipsec_sa.py
+++ b/src/op_mode/show_ipsec_sa.py
@@ -43,8 +43,11 @@ for sa in sas:
     # list_sas() returns a list of single-item dicts
     for peer in sa:
         parent_sa = sa[peer]
+        child_sas = parent_sa["child-sas"]
+        installed_sas = {k: v for k, v in child_sas.items() if v["state"] == b"INSTALLED"}
 
-        if parent_sa["state"] == b"ESTABLISHED":
+        # parent_sa["state"] = IKE state, child_sas["state"] = ESP state
+        if parent_sa["state"] == b"ESTABLISHED" and installed_sas:
             state = "up"
         else:
             state = "down"
@@ -61,9 +64,6 @@ for sa in sas:
             remote_id = "N/A"
 
         # The counters can only be obtained from the child SAs
-        child_sas = parent_sa["child-sas"]
-        installed_sas = {k: v for k, v in child_sas.items() if v["state"] == b"INSTALLED"}
-
         if not installed_sas:
             data = [peer, state, "N/A", "N/A", "N/A", "N/A", "N/A", "N/A"]
             sa_data.append(data)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add checks for  ESP sa state.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3333

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec
## Proposed changes
<!--- Describe your changes in detail -->
Additional check for ESP state, without it only IKE state was checked.
## How to test
Add VPN ipsec with correct ESP configuration and check 
```
vyos@r5-roll:~$ show vpn ipsec sa
Connection                State    Uptime    Bytes In/Out    Packets In/Out    Remote address    Remote ID    Proposal
------------------------  -------  --------  --------------  ----------------  ----------------  -----------  ----------------------------------
peer-100.64.0.2-tunnel-0  up       11m54s    0B/0B           0/0               100.64.0.2        N/A          AES_CBC_256/HMAC_SHA1_96/MODP_1024
```
Then change ESP settings with random values, that SA should be in "down" state:
Before patch (unexpected "UP" state):
```
vyos@r5-roll:~$ show vpn ipsec sa
Connection                State    Uptime    Bytes In/Out    Packets In/Out    Remote address    Remote ID    Proposal
------------------------  -------  --------  --------------  ----------------  ----------------  -----------  ----------------------------------
peer-100.64.0.2-tunnel-0  up       11m55s    0B/0B           0/0               100.64.0.2        N/A          AES_CBC_256/HMAC_SHA1_96/MODP_1024
vyos@r5-roll:~$
```
After patch (expected state "DOWN"):
```
vyos@r5-roll:~$ show vpn ipsec sa
Connection                State    Uptime    Bytes In/Out    Packets In/Out    Remote address    Remote ID    Proposal
------------------------  -------  --------  --------------  ----------------  ----------------  -----------  ----------
peer-100.64.0.2-tunnel-0  down     N/A       N/A             N/A               N/A               N/A          N/A
vyos@r5-roll:~$
```
As we see only IKE is established, but not ESP
```
vyos@r5-roll:~$ sudo swanctl -l
peer-100.64.0.2-tunnel-0: #3, ESTABLISHED, IKEv1, 95f37f353ad3ad72_i 8e6cdd7bc264fe23_r*
  local  '100.64.0.1' @ 100.64.0.1[500]
  remote '100.64.0.2' @ 100.64.0.2[500]
  AES_CBC-256/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
  established 819s ago, reauth in 1742s
vyos@r5-roll:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
