### PR TITLE
dhclient: T3392: Changed dhclient-script hooks for VRF

### DIFF
--- a/src/etc/dhcp/dhclient-enter-hooks.d/03-vyos-ipwrapper
+++ b/src/etc/dhcp/dhclient-enter-hooks.d/03-vyos-ipwrapper
@@ -3,6 +3,9 @@
 # default route distance
 IF_METRIC=${IF_METRIC:-210}
 
+# Check if interface is inside a VRF
+VRF_OPTION=$(/usr/sbin/ip -j -d link show ${interface} | awk '{if(match($0, /.*"master":"(\w+)".*"info_slave_kind":"vrf"/, IFACE_DETAILS)) printf("vrf %s", IFACE_DETAILS[1])}')
+
 # get status of FRR
 function frr_alive () {
     /usr/lib/frr/watchfrr.sh all_status
@@ -51,12 +54,7 @@ function iptovtysh () {
         shift 2
     fi
 
-    # Add route to VRF routing table
-    local VTYSH_VRF_NAME=$(/usr/sbin/ip link show dev $VTYSH_DEV | sed -nre '1s/.* master ([^ ]*) .*/\1/p')
-    if /usr/sbin/ip -d link show dev $VTYSH_DEV | grep -q "vrf_slave"; then
-        VTYSH_VRF="vrf $VTYSH_VRF_NAME"
-    fi
-    VTYSH_CMD="ip route $VTYSH_NETADDR $VTYSH_GATEWAY $VTYSH_DEV tag $VTYSH_TAG $VTYSH_DISTANCE $VTYSH_VRF"
+    VTYSH_CMD="ip route $VTYSH_NETADDR $VTYSH_GATEWAY $VTYSH_DEV tag $VTYSH_TAG $VTYSH_DISTANCE $VRF_OPTION"
 
     # delete route if the command is "del"
     if [ "$VTYSH_ACTION" == "del" ] ; then
@@ -67,10 +65,10 @@ function iptovtysh () {
 
 # delete the same route from kernel before adding new one
 function delroute () {
-    logmsg info "Checking if the route presented in kernel: $@"
-    if /usr/sbin/ip route show $@ | grep -qx "$1 " ; then
-        logmsg info "Deleting IP route: \"/usr/sbin/ip route del $@\""
-        /usr/sbin/ip route del $@
+    logmsg info "Checking if the route presented in kernel: $@ $VRF_OPTION"
+    if /usr/sbin/ip route show $@ $VRF_OPTION | grep -qx "$1 " ; then
+        logmsg info "Deleting IP route: \"/usr/sbin/ip route del $@ $VRF_OPTION\""
+        /usr/sbin/ip route del $@ $VRF_OPTION
     fi
 }
 
@@ -90,8 +88,7 @@ function ip () {
         else
             # add ip route to kernel
             logmsg info "Modifying routes in kernel: \"/usr/sbin/ip $@\""
-            /usr/sbin/ip $@
+            /usr/sbin/ip $@ $VRF_OPTION
         fi
     fi
 }
-

--- a/src/etc/dhcp/dhclient-exit-hooks.d/01-vyos-cleanup
+++ b/src/etc/dhcp/dhclient-exit-hooks.d/01-vyos-cleanup
@@ -17,14 +17,8 @@ if [[ $reason =~ (EXPIRE|FAIL|RELEASE|STOP) ]]; then
 
     # try to delete default ip route 
     for router in $old_routers; do
-        # check if we are bound to a VRF
-        local vrf_name=$(basename /sys/class/net/${interface}/upper_* | sed -e 's/upper_//')
-        if [ -n $vrf_name ]; then
-            vrf="vrf $vrf_name"
-        fi
-
-        logmsg info "Deleting default route: via $router dev ${interface} ${if_metric:+metric $if_metric} ${vrf}"
-        ip -4 route del default via $router dev ${interface} ${if_metric:+metric $if_metric} ${vrf}
+        logmsg info "Deleting default route: via $router dev ${interface} ${if_metric:+metric $if_metric}"
+        ip -4 route del default via $router dev ${interface} ${if_metric:+metric $if_metric}
 
         if_metric=$((if_metric+1))
     done


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
dhclient hooks were updated for a better integration with VRF.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3392
* https://phabricator.vyos.net/T2277

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhclient, VRF

## Proposed changes
<!--- Describe your changes in detail -->
There were two problems with VRF support inside dhclient-script:
- VRF check inside the `01-vyos-cleanup` hook was needless because it will be done inside the `03-vyos-ipwrapper` anyway, and it generates an error message for interfaces without VRF;
- VRF was ignored for in-kernel routes in `03-vyos-ipwrapper`. Theoretically, there must be no situation now when this can leads to a real problem, but better will be to keep both kernel and FRR backends in sync.

Also, the way to get and use a VRF name was changed to an easier one.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configure DHCP client on two interfaces - with VRF and without. Routes on both of them must be added properly without any error messages inside system logs.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
