### PR TITLE
dhclient: T3471: Fixed process search for IPv4

### DIFF
--- a/src/etc/dhcp/dhclient-enter-hooks.d/02-vyos-stopdhclient
+++ b/src/etc/dhcp/dhclient-enter-hooks.d/02-vyos-stopdhclient
@@ -2,26 +2,35 @@
 if [ -z ${CONTROLLED_STOP} ] ; then
     # stop dhclient for this interface, if it is not current one
     # get PID for current dhclient
-    current_dhclient=`ps --no-headers --format ppid --pid $$ | awk '{ print $1 }'`
+    current_dhclient=`ps --no-headers --format ppid --pid $$ | awk '{ print \$1 }'`
 
     # get PID for master process (current can be a fork)
-    master_dhclient=`ps --no-headers --format ppid --pid $current_dhclient | awk '{ print $1 }'`
+    master_dhclient=`ps --no-headers --format ppid --pid $current_dhclient | awk '{ print \$1 }'`
 
     # get IP version for current dhclient
-    ipversion_arg=`ps --no-headers --format args --pid $current_dhclient | awk '{ print $2 }'`
+    ipversion_arg=`ps --no-headers --format args --pid $current_dhclient | awk 'match(\$0, /\s-(4|6)\s/, IPV) { printf("%s", IPV[1]) }'`
 
     # get list of all dhclient running for current interface
-    dhclients_pids=(`pgrep -f "dhclient $ipversion_arg.* $interface(\s|$)"`)
+    if [[ $ipversion_arg == "6" ]]; then
+        dhclients_pids=(`pgrep -f "dhclient.*\s-6\s.*\s$interface(\s|$)"`)
+    else
+        dhclients_pids=(`ps --no-headers --format pid,args -C dhclient | awk "{ if(match(\\$0, /\s${interface}(\s|$)/) && !match(\\$0, /\s-6\s/)) printf(\"%s\n\", \\$1) }"`)
+    fi
 
     logmsg info "Current dhclient PID: $current_dhclient, Parent PID: $master_dhclient, IP version: $ipversion_arg, All dhclients for interface $interface: ${dhclients_pids[@]}"
     # stop all dhclients for current interface, except current one
     for dhclient in ${dhclients_pids[@]}; do
         if ([ $dhclient -ne $current_dhclient ] && [ $dhclient -ne $master_dhclient ]); then
-            logmsg info "Stopping dhclient with PID: ${dhclient}"
             # get path to PID-file of dhclient process
-            local dhclient_pidfile=`ps --no-headers --format args --pid $dhclient | awk 'match($0, ".*-pf (/.*pid) .*", PF) { print PF[1] }'`
+            local dhclient_pidfile=`ps --no-headers --format args --pid $dhclient | awk 'match(\$0, ".*-pf (/.*pid) .*", PF) { print PF[1] }'`
             # stop dhclient with native command - this will run dhclient-script with correct reason unlike simple kill
-            dhclient -e CONTROLLED_STOP=yes -x -pf $dhclient_pidfile
+            logmsg info "Stopping dhclient with PID: ${dhclient}, PID file: $dhclient_pidfile"
+            if [[ -e $dhclient_pidfile ]]; then
+                dhclient -e CONTROLLED_STOP=yes -x -pf $dhclient_pidfile
+            else
+                logmsg error "PID file $dhclient_pidfile does not exists, killing dhclient with SIGTERM signal"
+                kill -s 15 ${dhclient}
+            fi
         fi
     done
 fi


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This change extends abilities to detect all the dhclient instances for an interface in non-common situations.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3471

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhclient

## Proposed changes
<!--- Describe your changes in detail -->
Some software starts dhclient without IP protocol flag (`-4`, `-6`), this commit adds the ability to find such processes as well as with a protocol flag.
Additionally, to handle rare situations when PID file may not exists (most likely, when multiple dhclient processes started with the same PID file path), added last-resort action to kill such dhclients.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
1. Configure DHCP on any interface.
2. Get the dhclient process with arguments line, using `ps` output.
3. Run the same dhclient command, but without `-4` option.
4. There must be only one dhclient process after this.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly