### PR TITLE
ipsec: T3333: Fix status for SA state op-mode

### DIFF
--- a/src/op_mode/show_ipsec_sa.py
+++ b/src/op_mode/show_ipsec_sa.py
@@ -67,7 +67,7 @@ status_data = []
 
 for conn in connections:
     status = subprocess.check_output("ipsec statusall {0}".format(conn), shell=True).decode()
-    if not re.search(r'ESTABLISHED', status):
+    if not re.search(r'(:\s+ESTABLISHED).*(:\s+INSTALLED)', status, re.S):
         status_line = [conn, "down", None, None, None, None, None]
     else:
         try:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add checks for ESP child as. Crux.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3333

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add VPN ipsec configuration with correct IKE setting, but random ESP settings
and "show vpn ipsec sa" 
The tunnel should be in "down" state
Before patch
```
vyos@r2-lts:~$ show vpn ipsec sa
Connection                   State    Up          Bytes In/Out    Remote address    Remote ID    Proposal
---------------------------  -------  ----------  --------------  ----------------  -----------  ------------------------------------------------
peer-192.0.2.1-tunnel-vti    up       23 minutes  N/A             192.0.2.1         N/A          AES_CBC_256/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
peer-203.0.113.1-tunnel-vti  up       22 minutes  0B/0B           203.0.113.1       N/A          AES_CBC_256/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024

```
As we can see it show tunnel state "UP" for 192.0.2.1, but real it "down"
Tunnel 203.0.113.1 in "UP" state, and real it "up"
Output from swanctl
```
vyos@r2-lts:~$ sudo swanctl -l | grep peer-192.0.2.1-tunnel-vti -A 22
peer-192.0.2.1-tunnel-vti: #3, ESTABLISHED, IKEv1, 0ab8c2ee5815350e_i 271fba46aab245da_r*
  local  '192.0.2.2' @ 192.0.2.2[500]
  remote '192.0.2.1' @ 192.0.2.1[500]
  AES_CBC-256/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
  established 1581s ago, reauth in 953s
vyos@r2-lts:~$ 

```
```
vyos@r2-lts:~$ sudo swanctl -l | grep peer-203.0.113.1-tunnel-vti -A 22
peer-203.0.113.1-tunnel-vti: #4, ESTABLISHED, IKEv1, fb693e19705fabcd_i* 4bd11cb911e81fe8_r
  local  '203.0.113.2' @ 203.0.113.2[500]
  remote '203.0.113.1' @ 203.0.113.1[500]
  AES_CBC-256/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
  established 1726s ago, reauth in 1159s
  peer-203.0.113.1-tunnel-vti: #6, reqid 1, REKEYED, TUNNEL, ESP:AES_CBC-256/HMAC_SHA1_96/MODP_1024
    installed 1281s ago, rekeying in -514s, expires in 519s
    in  cba6651d (0x00900002),      0 bytes,     0 packets
    out c95ed0b0 (0x00900002),      0 bytes,     0 packets
    local  0.0.0.0/0
    remote 0.0.0.0/0
  peer-203.0.113.1-tunnel-vti: #7, reqid 1, INSTALLED, TUNNEL, ESP:AES_CBC-256/HMAC_SHA1_96/MODP_1024
    installed 514s ago, rekeying in 434s, expires in 1286s
    in  cffc3893 (0x00900002),      0 bytes,     0 packets
    out cf2bf6cb (0x00900002),      0 bytes,     0 packets
    local  0.0.0.0/0
    remote 0.0.0.0/0

```
After patch
```
vyos@r2-lts:~$ show vpn ipsec sa
Connection                   State    Up          Bytes In/Out    Remote address    Remote ID    Proposal
---------------------------  -------  ----------  --------------  ----------------  -----------  ------------------------------------------------
peer-192.0.2.1-tunnel-vti    down     N/A         N/A             N/A               N/A          N/A
peer-203.0.113.1-tunnel-vti  up       33 minutes  0B/0B           203.0.113.1       N/A          AES_CBC_256/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
vyos@r2-lts:~$ 

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
