### PR TITLE
dns: T3277: DNS Forwarding - reverse zones for RFC1918 addresses

### DIFF
--- a/data/templates/dns-forwarding/recursor.conf.tmpl
+++ b/data/templates/dns-forwarding/recursor.conf.tmpl
@@ -29,5 +29,11 @@ local-address={{ listen_address | join(',') }}
 # dnssec
 dnssec={{ dnssec }}
 
+{# dns: T3277: #}
+{% if serve_rfc1918 is defined and serve_rfc1918 == 'no' %}
+# serve-rfc1918
+serve-rfc1918=no
+{% endif %}
+
 forward-zones-file=recursor.forward-zones.conf
 

--- a/data/templates/dns-forwarding/recursor.conf.tmpl
+++ b/data/templates/dns-forwarding/recursor.conf.tmpl
@@ -30,9 +30,12 @@ local-address={{ listen_address | join(',') }}
 dnssec={{ dnssec }}
 
 {# dns: T3277: #}
-{% if serve_rfc1918 is defined and serve_rfc1918 == 'no' %}
+{% if no_serve_rfc1918 is defined %}
 # serve-rfc1918
 serve-rfc1918=no
+{% else %}
+# serve-rfc1918
+serve-rfc1918=yes
 {% endif %}
 
 forward-zones-file=recursor.forward-zones.conf

--- a/interface-definitions/dns-forwarding.xml.in
+++ b/interface-definitions/dns-forwarding.xml.in
@@ -111,20 +111,10 @@
                   <valueless/>
                 </properties>
               </leafNode>
-              <leafNode name="serve-rfc1918">
+              <leafNode name="no-serve-rfc1918">
                 <properties>
-                  <help>Makes the server authoritatively aware of RFC1918 addresses</help>
-                  <completionHelp>
-                    <list>yes no</list>  
-                  </completionHelp>
-                  <valueHelp>
-                    <format>yes</format>
-		    <description>Authoritatively aware about RFC1918 addresses (Default)</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>no</format>
-		    <description>Authoritatively not aware about RFC1918 addresses</description>
-                  </valueHelp>
+                  <help>Makes the server authoritatively not aware of RFC1918 addresses</help>
+		  <valueless/>
                 </properties>
               </leafNode>
               <leafNode name="allow-from">

--- a/interface-definitions/dns-forwarding.xml.in
+++ b/interface-definitions/dns-forwarding.xml.in
@@ -111,6 +111,22 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <leafNode name="serve-rfc1918">
+                <properties>
+                  <help>Makes the server authoritatively aware of RFC1918 addresses</help>
+                  <completionHelp>
+                    <list>yes no</list>  
+                  </completionHelp>
+                  <valueHelp>
+                    <format>yes</format>
+		    <description>Authoritatively aware about RFC1918 addresses (Default)</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>no</format>
+		    <description>Authoritatively not aware about RFC1918 addresses</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
               <leafNode name="allow-from">
                 <properties>
                   <help>Networks allowed to query this server</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
Adding serve-rfc1918 toggle to PowerDNS recursor config
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3277

## Component(s) name
dns
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes

<!--- Describe your changes in detail -->

## How to test
With
```
set service dns forwarding allow-from '192.168.0.0/24'
set service dns forwarding listen-address '127.0.0.1'
set service dns forwarding no-serve-rfc1918
```
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
-->

```
less /run/powerdns/recursor.conf
### Autogenerated by dns_forwarding.py ###

# XXX: pdns recursor doesn't like whitespace near entry separators,
# especially in the semicolon-separated lists of name servers.
# Please be careful if you edit the template.
-------------------------------

# serve-rfc1918
serve-rfc1918=no
```

Without
```
set service dns forwarding allow-from '192.168.0.0/24'
set service dns forwarding listen-address '127.0.0.1'
```

```
less /run/powerdns/recursor.conf
### Autogenerated by dns_forwarding.py ###

# XXX: pdns recursor doesn't like whitespace near entry separators,
# especially in the semicolon-separated lists of name servers.
# Please be careful if you edit the template.
-------------------------------

# serve-rfc1918
serve-rfc1918=yes
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
