### PR TITLE
T3356: remote: Add support for obtaining the size of a remote file

### DIFF
--- a/python/vyos/remote.py
+++ b/python/vyos/remote.py
@@ -22,57 +22,74 @@ import urllib.parse
 import urllib.request
 
 from vyos.util import cmd
+from vyos.version import get_version
 from paramiko import SSHClient
 
 
-def upload_ftp(local_path, hostname, remote_path,\
-               username='anonymous', password='', port=21, source=None):
-    with open(local_path, 'rb') as file:
-        with FTP(source_address=source) as conn:
-            conn.connect(hostname, port)
-            conn.login(username, password)
-            conn.storbinary(f'STOR {remote_path}', file)
-
-def download_ftp(local_path, hostname, remote_path,\
+## FTP routines
+def transfer_ftp(mode, local_path, hostname, remote_path,\
                  username='anonymous', password='', port=21, source=None):
-    with open(local_path, 'wb') as file:
-        with FTP(source_address=source) as conn:
-            conn.connect(hostname, port)
-            conn.login(username, password)
-            conn.retrbinary(f'RETR {remote_path}', file.write)
+    with FTP(source_address=source) as conn:
+        conn.connect(hostname, port)
+        conn.login(username, password)
+        if mode == 'upload':
+            with open(local_path, 'rb') as file:
+                conn.storbinary(f'STOR {remote_path}', file)
+        elif mode == 'download':
+            with open(local_path, 'wb') as file:
+                conn.retrbinary(f'RETR {remote_path}', file.write)
+        elif mode == 'size':
+            size = conn.size(remote_path)
+            if size:
+                return size
+            else:
+                # SIZE is an extension to the FTP specification, although it's extremely common.
+                raise ValueError('Failed to receive file size from FTP server. \
+                Perhaps the server does not implement the SIZE command?')
 
-def upload_sftp(local_path, hostname, remote_path,\
-                username=None, password=None, port=22, source=None):
-    sock = None
-    if source:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.bind((source, 0))
-        sock.connect((hostname, port))
-    with SSHClient() as ssh:
-        ssh.load_system_host_keys()
-        ssh.connect(hostname, port, username, password, sock=sock)
-        with ssh.open_sftp() as sftp:
-            sftp.put(local_path, remote_path)
-    if sock:
-        sock.shutdown()
-        sock.close()
+def upload_ftp(*args, **kwargs):
+    transfer_ftp('upload', *args, **kwargs)
 
-def download_sftp(local_path, hostname, remote_path,\
+def download_ftp(*args, **kwargs):
+    transfer_ftp('download', *args, **kwargs)
+
+def get_ftp_file_size(*args, **kwargs):
+    return transfer_ftp('size', None, *args, **kwargs)
+
+## SFTP/SCP routines
+def transfer_sftp(mode, local_path, hostname, remote_path,\
                   username=None, password=None, port=22, source=None):
     sock = None
     if source:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.bind((source, 0))
         sock.connect((hostname, port))
-    with SSHClient() as ssh:
-        ssh.load_system_host_keys()
-        ssh.connect(hostname, port, username, password, sock=sock)
-        with ssh.open_sftp() as sftp:
-            sftp.get(remote_path, local_path)
-    if sock:
-        sock.shutdown()
-        sock.close()
+    try:
+        with SSHClient() as ssh:
+            ssh.load_system_host_keys()
+            ssh.connect(hostname, port, username, password, sock=sock)
+            with ssh.open_sftp() as sftp:
+                if mode == 'upload':
+                    sftp.put(local_path, remote_path)
+                elif mode == 'download':
+                    sftp.get(remote_path, local_path)
+                elif mode == 'size':
+                    return sftp.stat(remote_path).st_size
+    finally:
+        if sock:
+            sock.shutdown()
+            sock.close()
 
+def upload_sftp(*args, **kwargs):
+    transfer_sftp('upload', *args, **kwargs)
+
+def download_sftp(*args, **kwargs):
+    transfer_sftp('download', *args, **kwargs)
+
+def get_sftp_file_size(*args, **kwargs):
+    return transfer_sftp('size', None, *args, **kwargs)
+
+## TFTP routines
 def upload_tftp(local_path, hostname, remote_path, port=69, source=None):
     source_option = f'--interface {source}' if source else ''
     with open(local_path, 'rb') as file:
@@ -85,11 +102,27 @@ def download_tftp(local_path, hostname, remote_path, port=69, source=None):
         file.write(cmd(f'curl {source_option} -s tftp://{hostname}:{port}/{remote_path}',\
                        stderr=None).encode())
 
+# get_tftp_file_size() is unimplemented because there is no way to obtain a file's size through TFTP,
+# as TFTP does not specify a SIZE command.
+
+## HTTP(S) routines
 def download_http(urlstring, local_path):
+    request = urllib.request.Request(urlstring, headers={'User-Agent': 'VyOS/' + get_version()})
     with open(local_path, 'wb') as file:
-        with urllib.request.urlopen(urlstring) as response:
+        with urllib.request.urlopen(request) as response:
             file.write(response.read())
 
+def get_http_file_size(urlstring):
+    request = urllib.request.Request(urlstring, headers={'User-Agent': 'VyOS/' + get_version()})
+    with urllib.request.urlopen(request) as response:
+        size = response.getheader('Content-Length')
+        if size:
+            return int(size)
+        # The server didn't send 'Content-Length' in the response headers.
+        else:
+            raise ValueError('Failed to receive file size from HTTP server.')
+
+# Dynamic dispatchers
 def download(local_path, urlstring, source=None):
     """
     Dispatch the appropriate download function for the given URL and save to local path.
@@ -97,7 +130,7 @@ def download(local_path, urlstring, source=None):
     url = urllib.parse.urlparse(urlstring)
     if url.scheme == 'http' or url.scheme == 'https':
         if source:
-            print("Warning: Custom source address not supported for HTTP connections.", file=sys.stderr)
+            print('Warning: Custom source address not supported for HTTP connections.', file=sys.stderr)
         download_http(urlstring, local_path)
     elif url.scheme == 'ftp':
         username = url.username if url.username else 'anonymous'
@@ -107,7 +140,7 @@ def download(local_path, urlstring, source=None):
     elif url.scheme == 'tftp':
         download_tftp(local_path, url.hostname, url.path, source=source)
     else:
-        ValueError(f'Unsupported URL scheme: {url.scheme}')
+        raise ValueError(f'Unsupported URL scheme: {url.scheme}')
 
 def upload(local_path, urlstring, source=None):
     """
@@ -122,9 +155,24 @@ def upload(local_path, urlstring, source=None):
     elif url.scheme == 'tftp':
         upload_tftp(local_path, url.hostname, url.path, source=source)
     else:
-        ValueError(f'Unsupported URL scheme: {url.scheme}')
+        raise ValueError(f'Unsupported URL scheme: {url.scheme}')
 
-def get_remote_config(urlstring):
+def get_remote_file_size(urlstring, source=None):
+    """
+    Return the size of the remote file in bytes.
+    """
+    url = urllib.parse.urlparse(urlstring)
+    if url.scheme == 'http' or url.scheme == 'https':
+        return get_http_file_size(urlstring)
+    elif url.scheme == 'ftp':
+        username = url.username if url.username else 'anonymous'
+        return get_ftp_file_size(url.hostname, url.path, username, url.password, source=source)
+    elif url.scheme == 'sftp' or url.scheme == 'scp':
+        return get_sftp_file_size(url.hostname, url.path, url.username, url.password, source=source)
+    else:
+        raise ValueError(f'Unsupported URL scheme: {url.scheme}')
+
+def get_remote_config(urlstring, source=None):
     """
     Download remote (config) file and return the contents.
         Args:
@@ -139,7 +187,7 @@ def get_remote_config(urlstring):
     url = urllib.parse.urlparse(urlstring)
     temp = tempfile.NamedTemporaryFile(delete=False).name
     try:
-        download(temp, urlstring)
+        download(temp, urlstring, source)
         with open(temp, 'r') as file:
             return file.read()
     finally:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Adds routines for getting the size of a remote file.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3356

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
remote, util

## Proposed changes
<!--- Describe your changes in detail -->
It's mostly in preparation of [T3508](https://phabricator.vyos.net/T3508) to check if we have enough storage space in advance.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
> vyos.remote.get_remote_file_size('ftp://ftp.example.org/file.txt')
> vyos.remote.get_remote_file_size('https://www.example.org/file.txt')
> vyos.remote.get_remote_file_size('sftp://user:pass@example.org/home/user/file.txt')
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
