### PR TITLE
smoketest: T3526: Add seq x for policy tests

### DIFF
--- a/smoketest/scripts/cli/test_policy.py
+++ b/smoketest/scripts/cli/test_policy.py
@@ -371,7 +371,7 @@ class TestPolicy(unittest.TestCase):
                 continue
 
             for rule, rule_config in comm_list_config['rule'].items():
-                tmp = f'bgp community-list {comm_list}'
+                tmp = f'bgp community-list {comm_list} seq {rule}'
                 if rule_config['action'] == 'permit':
                     tmp += ' permit'
                 else:
@@ -434,7 +434,7 @@ class TestPolicy(unittest.TestCase):
                 expanded = ''
                 if not comm_list.isnumeric():
                     expanded = ' expanded'
-                tmp = f'bgp extcommunity-list{expanded} {comm_list}'
+                tmp = f'bgp extcommunity-list{expanded} {comm_list} seq {rule}'
 
                 if rule_config['action'] == 'permit':
                     tmp += ' permit'
@@ -494,7 +494,7 @@ class TestPolicy(unittest.TestCase):
                 continue
 
             for rule, rule_config in comm_list_config['rule'].items():
-                tmp = f'bgp large-community-list expanded {comm_list}'
+                tmp = f'bgp large-community-list expanded {comm_list} seq {rule}'
 
                 if rule_config['action'] == 'permit':
                     tmp += ' permit'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add 'seq x' for smoketest policy
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3526

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
smoketest, policy
## Proposed changes
<!--- Describe your changes in detail -->
It tried to find 
```
bgp community-list 100 permit .*
```
In config
```
'bgp community-list 100 seq 5 permit .*\nbgp community-list 200 seq 5 deny ^1:201$\nbgp community-list 200 seq 10 deny 1:101$\nbgp community-list 200 seq 15 deny ^1:100$\n!'
```
And get fail.
```
07:19:12  DEBUG - test_community_list (__main__.TestPolicy) ... FAIL
07:19:19  DEBUG - test_extended_community_list (__main__.TestPolicy) ... FAIL
07:19:27  DEBUG - test_large_community_list (__main__.TestPolicy) ... FAIL
07:19:32  DEBUG - test_prefix_list (__main__.TestPolicy) ... ok
07:19:39  DEBUG - test_prefix_list6 (__main__.TestPolicy) ... ok
07:19:39  DEBUG - 
07:19:39  DEBUG - ======================================================================
07:19:39  DEBUG - FAIL: test_community_list (__main__.TestPolicy)
07:19:39  DEBUG - ----------------------------------------------------------------------
07:19:39  DEBUG - Traceback (most recent call last):
07:19:39  DEBUG -   File "/usr/libexec/vyos/tests/smoke/cli/test_policy.py", line 382, in test_community_list
07:19:39  DEBUG -     self.assertIn(tmp, config)
07:19:39  DEBUG - AssertionError: 'bgp community-list 100 permit .*' not found in 'bgp community-list 100 seq 5 permit .*\nbgp community-list 200 seq 5 deny ^1:201$\nbgp community-list 200 seq 10 deny 1:101$\nbgp community-list 200 seq 15 deny ^1:100$\n!'
```

Set  'seq x'
## How to test
```
vyos@r4-1.3:~$ /usr/libexec/vyos/tests/smoke/cli/test_policy.py
test_access_list (__main__.TestPolicy) ... ok
test_access_list6 (__main__.TestPolicy) ... ok
test_as_path_list (__main__.TestPolicy) ... ok
test_community_list (__main__.TestPolicy) ... ok
test_extended_community_list (__main__.TestPolicy) ... ok
test_large_community_list (__main__.TestPolicy) ... ok
test_prefix_list (__main__.TestPolicy) ... ok
test_prefix_list6 (__main__.TestPolicy) ... ok

----------------------------------------------------------------------
Ran 8 tests in 23.244s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
