### PR TITLE
vlan-aware: T3534: VLAN cannot be both `allowd-vlan` and `native-vlan`

### DIFF
--- a/src/conf_mode/interfaces-bridge.py
+++ b/src/conf_mode/interfaces-bridge.py
@@ -137,6 +137,13 @@ def verify(bridge):
 
                 if 'wlan' in interface:
                     raise ConfigError(error_msg + 'VLAN aware cannot be set!')
+                
+                # T3534: VLAN cannot be both "allow-vlan" and "native-vlan"
+                if 'allowed_vlan' in interface_config:
+                    for vlan in interface_config['allowed_vlan']:
+                        if 'native_vlan' in interface_config and interface_config['native_vlan'] == vlan:
+                            print(f'Warning: VLAN {vlan} cannot be both "allowed-vlan" and "native-vlan", The VLAN will be set to "native-vlan"!')
+                
             else:
                 for option in ['allowed_vlan', 'native_vlan']:
                     if option in interface_config:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
VLAN cannot be both `allowed-vlan` and `native-vlan`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3534

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vlan-aware bridge 

## Proposed changes
<!--- Describe your changes in detail -->
I just checked the current implementation. It seems that the current configuration is replacing `allowed-vlan` with `native-VLAN`, but there is no warning. I add a warning!

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Execution configuration:

```
set interfaces ethernet eth0
set interfaces bridge br0 enable-vlan
set interfaces bridge br0 member interface eth0 allow-vlan 1
set interfaces bridge br0 member interface eth0 native-vlan 1
commit
```

See the following output:
![图片](https://user-images.githubusercontent.com/9047180/117834910-2206fd80-b2aa-11eb-8a80-57a99e1b6e5c.png)



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
