### PR TITLE
op-mode: T3536: Fix for show ip route longer-prefixes

### DIFF
--- a/op-mode-definitions/show-ip-route.xml.in
+++ b/op-mode-definitions/show-ip-route.xml.in
@@ -153,9 +153,9 @@
             <children>
               <leafNode name="longer-prefixes">
                 <properties>
-                  <help>Show longer prefixes of routes for specified IP address or prefix</help>
+                  <help>Show longer prefixes of routes for specified prefix</help>
                 </properties>
-                <command>vtysh -c "show ip route $4 longer-prefixes"</command>
+                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
               </leafNode>
             </children>
           </tagNode>

--- a/op-mode-definitions/show-ipv6-route.xml.in
+++ b/op-mode-definitions/show-ipv6-route.xml.in
@@ -133,9 +133,9 @@
             <children>
               <node name="longer-prefixes">
                 <properties>
-                  <help>Show longer prefixes of routes for given address or prefix</help>
+                  <help>Show longer prefixes of routes for given prefix</help>
                 </properties>
-                <command>vtysh -c "show ipv6 route $4 longer-prefixes"</command>
+                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
               </node>
             </children>
             <command>vtysh -c "show ipv6 route $4"</command>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add checks for pattern "/" in routes for longer-prefixes. Op-mode.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3536

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
static route
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Expect no errors for values without prefix
```
vyos@r6-roll:~$ show ip route 192.168.122.0 longer-prefixes 
vyos@r6-roll:~$ 
```
Expect longer-prefixes with "/x"
```
vyos@r6-roll:~$ show ip route 192.168.122.0/8 longer-prefixes 
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup

S>* 192.168.0.0/16 [1/0] unreachable (blackhole), weight 1, 00:47:07
C>* 192.168.122.0/24 is directly connected, eth0, 01:08:26
vyos@r6-roll:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
