### PR TITLE
op-mode:T3521: Allowing permission for the operator use to execute "show version"

### DIFF
--- a/op-mode-definitions/version.xml
+++ b/op-mode-definitions/version.xml
@@ -6,13 +6,13 @@
         <properties>
           <help>Show system version information</help>
         </properties>
-        <command>sudo ${vyos_op_scripts_dir}/version.py</command>
+        <command>${vyos_op_scripts_dir}/version.py</command>
         <children>
           <leafNode name="funny">
             <properties>
               <help>Show system version and some fun stuff</help>
             </properties>
-            <command>sudo ${vyos_op_scripts_dir}/version.py --funny</command>
+            <command>${vyos_op_scripts_dir}/version.py --funny</command>
           </leafNode>
           <leafNode name="all">
              <properties>


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary:
The command "show version" throws an error when a user with operator level executed the command.

```
user1@vyos> show version

We trust you have received the usual lecture from the local System
Administrator. It usually boils down to these three things:

    #1) Respect the privacy of others.
    #2) Think before you type.
    #3) With great power comes great responsibility.

[sudo] password for user1:
Sorry, user user1 is not allowed to execute '/usr/libexec/vyos/op_mode/version.py' as root on vyos.
```
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
 https://phabricator.vyos.net/T3521

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->
The operator user should atleast be able to see the software version of the
    server till a proper role-based access control is implemented in the future.
    Removed "sudo" from the scripts so that "show version" command could be
    run by non-root user.
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics -->

```
Create a user "user1" with operator privilege

set system login user user1 level operator

Login as user1 and execute the command show version
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
