### PR TITLE
ntp: T2809: Fix migration script if server not exist

### DIFF
--- a/src/migration-scripts/ntp/0-to-1
+++ b/src/migration-scripts/ntp/0-to-1
@@ -17,7 +17,7 @@ with open(file_name, 'r') as f:
 
 config = ConfigTree(config_file)
 
-if not config.exists(['system', 'ntp']):
+if not config.exists(['system', 'ntp', 'server']):
     # Nothing to do
     sys.exit(0)
 else:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix for 1.4, 1.3, 1.2
Check if node "server" exist in ntp migration script
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T2809

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ntp, migration
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Delete "system ntp server" on 1.1.8 and copy the config to 1.2 or 1.4
```
     ntp {
     }

```
Load config without fix
```
vyos@r6-roll# load ntp.conf
Loading configuration from 'ntp.conf'
Traceback (most recent call last):
  File "/opt/vyatta/etc/config-migrate/migrate/ntp/0-to-1", line 27, in <module>
    for server in config.list_nodes(base):
  File "/usr/lib/python3/dist-packages/vyos/configtree.py", line 236, in list_nodes
    raise ConfigTreeError("Path [{}] doesn't exist".format(path_str))
vyos.configtree.ConfigTreeError: Path [b'system ntp server'] doesn't exist

Migration script error: /opt/vyatta/etc/config-migrate/migrate/ntp/0-to-1: Command '['/opt/vyatta/etc/config-migrate/migrate/ntp/0-to-1', '/tmp/tmplr7bmtjf']' returned non-zero exit status 1..
[edit]
vyos@r6-roll#
```
After fix
```
vyos@r6-roll# load ntp.conf
Loading configuration from 'ntp.conf'
Load complete. Use 'commit' to make changes effective.
[edit]
vyos@r6-roll#
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
