### PR TITLE
ospv3: T3554: Add area-type stub

### DIFF
--- a/data/templates/frr/ospfv3.frr.tmpl
+++ b/data/templates/frr/ospfv3.frr.tmpl
@@ -50,6 +50,11 @@ router ospf6
  interface {{ interface }} area {{ area_id }}
 {%       endfor %}
 {%     endif %}
+{%     if area_config.area_type is defined and area_config.area_type is not none %}
+{%       for type, type_config in area_config.area_type.items() %}
+ area {{ area_id }} {{ type }} {{ 'no-summary' if type_config.no_summary is defined }}
+{%       endfor %}
+{%     endif %}
 {%     if area_config.range is defined and area_config.range is not none %}
 {%       for prefix, prefix_config in area_config.range.items() %}
  area {{ area_id }} range {{ prefix }} {{ 'advertise' if prefix_config.advertise is defined }} {{ 'not-advertise' if prefix_config.not_advertise is defined }}

--- a/interface-definitions/protocols-ospfv3.xml.in
+++ b/interface-definitions/protocols-ospfv3.xml.in
@@ -25,6 +25,26 @@
               </constraint>
             </properties>
             <children>
+              <node name="area-type">
+                <properties>
+                  <help>OSPFv3 Area type</help>
+                </properties>
+                <children>
+                  <node name="stub">
+                    <properties>
+                      <help>Stub OSPFv3 area</help>
+                    </properties>
+                    <children>
+                      <leafNode name="no-summary">
+                        <properties>
+                          <help>Do not inject inter-area routes into the stub</help>
+                          <valueless/>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </node>
+                </children>
+              </node>
               <leafNode name="export-list">
                 <properties>
                   <help>Name of export-list</help>

--- a/smoketest/scripts/cli/test_protocols_ospfv3.py
+++ b/smoketest/scripts/cli/test_protocols_ospfv3.py
@@ -150,5 +150,22 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
             cost = str(int(cost) + 10)
             priority = str(int(priority) + 5)
 
+
+    def test_ospfv3_05_area_stub(self):
+        area_stub = '23'
+        area_stub_nosum = '26'
+
+        self.cli_set(base_path + ['area', area_stub, 'area-type', 'stub'])
+        self.cli_set(base_path + ['area', area_stub_nosum, 'area-type', 'stub', 'no-summary'])
+
+        # commit changes
+        self.cli_commit()
+
+        # Verify FRR ospfd configuration
+        frrconfig = self.getFRRconfig('router ospf6')
+        self.assertIn(f'router ospf6', frrconfig)
+        self.assertIn(f' area {area_stub} stub', frrconfig)
+        self.assertIn(f' area {area_stub_nosum} stub no-summary', frrconfig)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add area-type stub for ospfv3, configuration mode.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3554

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ospfv3
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS config.
```
set protocols ospfv3 area 24 area-type stub
commit
```
Frr config
```
!
router ospf6
 area 24 stub
!
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
