### PR TITLE
vyos.util: T3532: Replace func get_interface_config

### DIFF
--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -651,7 +651,7 @@ def dict_search(path, dict):
         c = c.get(p, {})
     return c.get(parts[-1], None)
 
-def get_json_iface_options(interface):
+def get_interface_config(interface):
     """ Returns the used encapsulation protocol for given interface.
         If interface does not exist, None is returned.
     """

--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -29,7 +29,7 @@ from vyos.util import read_file
 from vyos.util import cmd
 from vyos.util import dict_search
 from vyos.util import process_named_running
-from vyos.util import get_json_iface_options
+from vyos.util import get_interface_config
 from vyos.validate import is_intf_addr_assigned
 from vyos.validate import is_ipv6_link_local
 
@@ -353,7 +353,7 @@ class BasicInterfaceTest:
 
             for interface in self._interfaces:
                 for vif_s in self._qinq_range:
-                    tmp = get_json_iface_options(f'{interface}.{vif_s}')
+                    tmp = get_interface_config(f'{interface}.{vif_s}')
                     self.assertEqual(dict_search('linkinfo.info_data.protocol', tmp), '802.1ad')
 
                     for vif_c in self._vlan_range:

--- a/smoketest/scripts/cli/test_interfaces_bonding.py
+++ b/smoketest/scripts/cli/test_interfaces_bonding.py
@@ -22,7 +22,7 @@ from base_interfaces_test import BasicInterfaceTest
 from vyos.ifconfig import Section
 from vyos.ifconfig.interface import Interface
 from vyos.configsession import ConfigSessionError
-from vyos.util import get_json_iface_options
+from vyos.util import get_interface_config
 from vyos.util import read_file
 
 class BondingInterfaceTest(BasicInterfaceTest.BaseTest):
@@ -105,7 +105,7 @@ class BondingInterfaceTest(BasicInterfaceTest.BaseTest):
 
         # verify config
         for interface in self._interfaces:
-            tmp = get_json_iface_options(interface)
+            tmp = get_interface_config(interface)
 
             self.assertEqual(min_links, tmp['linkinfo']['info_data']['min_links'])
             # check LACP default rate
@@ -124,7 +124,7 @@ class BondingInterfaceTest(BasicInterfaceTest.BaseTest):
 
         # verify config
         for interface in self._interfaces:
-            tmp = get_json_iface_options(interface)
+            tmp = get_interface_config(interface)
 
             # check LACP minimum links (default value)
             self.assertEqual(0,         tmp['linkinfo']['info_data']['min_links'])

--- a/smoketest/scripts/cli/test_interfaces_macsec.py
+++ b/smoketest/scripts/cli/test_interfaces_macsec.py
@@ -25,7 +25,7 @@ from vyos.configsession import ConfigSessionError
 from vyos.ifconfig import Section
 from vyos.util import cmd
 from vyos.util import read_file
-from vyos.util import get_json_iface_options
+from vyos.util import get_interface_config
 from vyos.util import process_named_running
 
 def get_config_value(interface, key):
@@ -34,7 +34,7 @@ def get_config_value(interface, key):
     return tmp[0]
 
 def get_cipher(interface):
-    tmp = get_json_iface_options(interface)
+    tmp = get_interface_config(interface)
     return tmp['linkinfo']['info_data']['cipher_suite'].lower()
 
 class MACsecInterfaceTest(BasicInterfaceTest.BaseTest):

--- a/smoketest/scripts/cli/test_interfaces_tunnel.py
+++ b/smoketest/scripts/cli/test_interfaces_tunnel.py
@@ -18,7 +18,7 @@ import unittest
 
 from vyos.configsession import ConfigSession
 from vyos.configsession import ConfigSessionError
-from vyos.util import get_json_iface_options
+from vyos.util import get_interface_config
 from vyos.template import inc_ip
 from vyos.util import cmd
 
@@ -87,7 +87,7 @@ class TunnelInterfaceTest(BasicInterfaceTest.BaseTest):
             # Check if commit is ok
             self.session.commit()
 
-            conf = get_json_iface_options(interface)
+            conf = get_interface_config(interface)
             if encapsulation not in ['sit', 'gre-bridge']:
                 self.assertEqual(source_if, conf['link'])
 
@@ -128,7 +128,7 @@ class TunnelInterfaceTest(BasicInterfaceTest.BaseTest):
             # Check if commit is ok
             self.session.commit()
 
-            conf = get_json_iface_options(interface)
+            conf = get_interface_config(interface)
             self.assertEqual(interface, conf['ifname'])
             self.assertEqual(mtu, conf['mtu'])
             self.assertEqual(source_if, conf['link'])
@@ -185,7 +185,7 @@ class TunnelInterfaceTest(BasicInterfaceTest.BaseTest):
         # Check if commit is ok
         self.session.commit()
 
-        conf = get_json_iface_options(interface)
+        conf = get_interface_config(interface)
         self.assertEqual(mtu,           conf['mtu'])
         self.assertEqual(interface,     conf['ifname'])
         self.assertEqual(encapsulation, conf['linkinfo']['info_kind'])
@@ -206,7 +206,7 @@ class TunnelInterfaceTest(BasicInterfaceTest.BaseTest):
         # Check if commit is ok
         self.session.commit()
 
-        conf = get_json_iface_options(interface)
+        conf = get_interface_config(interface)
         self.assertEqual(mtu,           conf['mtu'])
         self.assertEqual(interface,     conf['ifname'])
         self.assertEqual('gretap',      conf['linkinfo']['info_kind'])
@@ -220,7 +220,7 @@ class TunnelInterfaceTest(BasicInterfaceTest.BaseTest):
         # Check if commit is ok
         self.session.commit()
 
-        conf = get_json_iface_options(interface)
+        conf = get_interface_config(interface)
         self.assertEqual(new_remote,    conf['linkinfo']['info_data']['remote'])
 
 if __name__ == '__main__':

--- a/src/conf_mode/interfaces-tunnel.py
+++ b/src/conf_mode/interfaces-tunnel.py
@@ -40,7 +40,7 @@ from vyos.ifconfig import SitIf
 from vyos.ifconfig import Sit6RDIf
 from vyos.template import is_ipv4
 from vyos.template import is_ipv6
-from vyos.util import get_json_iface_options
+from vyos.util import get_interface_config
 from vyos.util import dict_search
 from vyos import ConfigError
 from vyos import airbag
@@ -131,7 +131,7 @@ def apply(tunnel):
     # There is no other solution to destroy and recreate the tunnel.
     encap = ''
     remote = ''
-    tmp = get_json_iface_options(interface)
+    tmp = get_interface_config(interface)
     if tmp:
         encap = dict_search('linkinfo.info_kind', tmp)
         remote = dict_search('linkinfo.info_data.remote', tmp)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Replace function "**func get_interface_config**" (1.3) to function "**get_interface_config**"  which used that commit https://github.com/vyos/vyos-1x/commit/edcdea890b2eeb03d24b06fdd8ac38133e631c05
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3532

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vyos.util
## Proposed changes
Before fix
```
vyos@r4-1.3:~$ show int
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/show_interfaces.py", line 26, in <module>
    from vyos.ifconfig import Section
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/__init__.py", line 18, in <module>
    from vyos.ifconfig.interface import Interface
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 39, in <module>
    from vyos.util import get_interface_config
ImportError: cannot import name 'get_interface_config' from 'vyos.util' (/usr/lib/python3/dist-packages/vyos/util.py)
vyos@r4-1.3:~$ 
```
After
```
vyos@r4-1.3:~$ show int
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
eth0             192.168.122.14/24                 u/u  
eth1             -                                 u/u  foo
lo               127.0.0.1/8                       u/u  
                 ::1/128                                

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
