### PR TITLE
T3561: router-advert: add support for specific routes

### DIFF
--- a/data/templates/router-advert/radvd.conf.tmpl
+++ b/data/templates/router-advert/radvd.conf.tmpl
@@ -30,17 +30,19 @@ interface {{ iface }} {
     AdvOtherConfigFlag {{ 'on' if interface[iface].other_config_flag is defined else 'off' }};
     AdvRetransTimer {{ interface[iface].retrans_timer }};
     AdvCurHopLimit {{ interface[iface].hop_limit }};
-{%     for route in interface[iface].route %}
+{%     if interface[iface].route is defined %}
+{%       for route in interface[iface].route %}
     route {{ route }} {
-{%     if interface[iface].route[route].valid_lifetime is defined %}
+{%         if interface[iface].route[route].valid_lifetime is defined %}
         AdvRouteLifetime {{ interface[iface].route[route].valid_lifetime }};
-{%     endif %}
-{%     if interface[iface].route[route].route_preference is defined %}
+{%         endif %}
+{%         if interface[iface].route[route].route_preference is defined %}
         AdvRoutePreference {{ interface[iface].route[route].route_preference }};
-{%     endif %}
+{%         endif %}
         RemoveRoute {{ 'off' if interface[iface].route[route].no_remove_route is defined else 'on' }};
     };
-{%     endfor %}
+{%       endfor %}
+{%     endif %}
 {%     for prefix in interface[iface].prefix %}
     prefix {{ prefix }} {
         AdvAutonomous {{ 'off' if interface[iface].prefix[prefix].no_autonomous_flag is defined else 'on' }};

--- a/data/templates/router-advert/radvd.conf.tmpl
+++ b/data/templates/router-advert/radvd.conf.tmpl
@@ -30,6 +30,17 @@ interface {{ iface }} {
     AdvOtherConfigFlag {{ 'on' if interface[iface].other_config_flag is defined else 'off' }};
     AdvRetransTimer {{ interface[iface].retrans_timer }};
     AdvCurHopLimit {{ interface[iface].hop_limit }};
+{%     for route in interface[iface].route %}
+    route {{ route }} {
+{%     if interface[iface].route[route].valid_lifetime is defined %}
+        AdvRouteLifetime {{ interface[iface].route[route].valid_lifetime }};
+{%     endif %}
+{%     if interface[iface].route[route].route_preference is defined %}
+        AdvRoutePreference {{ interface[iface].route[route].route_preference }};
+{%     endif %}
+        RemoveRoute {{ 'off' if interface[iface].route[route].no_remove_route is defined else 'on' }};
+    };
+{%     endfor %}
 {%     for prefix in interface[iface].prefix %}
     prefix {{ prefix }} {
         AdvAutonomous {{ 'off' if interface[iface].prefix[prefix].no_autonomous_flag is defined else 'on' }};

--- a/interface-definitions/service_router-advert.xml.in
+++ b/interface-definitions/service_router-advert.xml.in
@@ -154,6 +154,72 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <tagNode name="route">
+                <properties>
+                  <help>IPv6 route to be advertised in Router Advertisements (RAs)</help>
+                  <valueHelp>
+                    <format>ipv6net</format>
+                    <description>IPv6 route to be advertized</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="ipv6-prefix"/>
+                  </constraint>
+                </properties>
+                <children>
+                  <leafNode name="valid-lifetime">
+                    <properties>
+                      <help>Time in seconds that the route will remain valid (default: 1800 seconds)</help>
+                      <completionHelp>
+                        <list>infinity</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>1-4294967295</format>
+                        <description>Time in seconds that the route will remain valid</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>infinity</format>
+                        <description>Route will remain preferred forever</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-4294967295"/>
+                        <regex>^(infinity)$</regex>
+                      </constraint>
+                    </properties>
+                    <defaultValue>1800</defaultValue>
+                  </leafNode>
+                  <leafNode name="route-preference">
+                    <properties>
+                      <help>Preference associated with the route,</help>
+                      <completionHelp>
+                        <list>low medium high</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>low</format>
+                        <description>Route has low preference</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>medium</format>
+                        <description>Route has medium preference (default)</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>high</format>
+                        <description>Route has high preference</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>^(low|medium|high)$</regex>
+                      </constraint>
+                      <constraintErrorMessage>Route preference must be low, medium or high</constraintErrorMessage>
+                    </properties>
+                    <defaultValue>medium</defaultValue>
+                  </leafNode>
+                  <leafNode name="no-remove-route">
+                    <properties>
+                      <help>Do not announce this route with a zero second lifetime upon shutdown</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </tagNode>
               <tagNode name="prefix">
                 <properties>
                   <help>IPv6 prefix to be advertised in Router Advertisements (RAs)</help>

--- a/src/conf_mode/service_router-advert.py
+++ b/src/conf_mode/service_router-advert.py
@@ -64,7 +64,6 @@ def get_config(config=None):
                     rtradv['interface'][interface]['route'][route] = dict_merge(
                         default_route_values, rtradv['interface'][interface]['route'][route])
 
-
             if 'name_server' in rtradv['interface'][interface]:
                 # always use a list when dealing with nameservers - eases the template generation
                 if isinstance(rtradv['interface'][interface]['name_server'], str):
@@ -95,7 +94,7 @@ def verify(rtradv):
 
                 if not (int(valid_lifetime) > int(preferred_lifetime)):
                     raise ConfigError('Prefix valid-lifetime must be greater then preferred-lifetime')
-                    
+
     return None
 
 def generate(rtradv):

--- a/src/conf_mode/service_router-advert.py
+++ b/src/conf_mode/service_router-advert.py
@@ -40,11 +40,14 @@ def get_config(config=None):
     # We have gathered the dict representation of the CLI, but there are default
     # options which we need to update into the dictionary retrived.
     default_interface_values = defaults(base + ['interface'])
-    # we deal with prefix defaults later on
+    # we deal with prefix, route defaults later on
     if 'prefix' in default_interface_values:
         del default_interface_values['prefix']
-
+    if 'route' in default_interface_values:
+        del default_interface_values['route']
+        
     default_prefix_values = defaults(base + ['interface', 'prefix'])
+    default_route_values = defaults(base + ['interface', 'route'])
 
     if 'interface' in rtradv:
         for interface in rtradv['interface']:
@@ -55,6 +58,12 @@ def get_config(config=None):
                 for prefix in rtradv['interface'][interface]['prefix']:
                     rtradv['interface'][interface]['prefix'][prefix] = dict_merge(
                         default_prefix_values, rtradv['interface'][interface]['prefix'][prefix])
+                        
+            if 'route' in rtradv['interface'][interface]:
+                for route in rtradv['interface'][interface]['route']:
+                    rtradv['interface'][interface]['route'][route] = dict_merge(
+                        default_route_values, rtradv['interface'][interface]['route'][route])
+
 
             if 'name_server' in rtradv['interface'][interface]:
                 # always use a list when dealing with nameservers - eases the template generation
@@ -86,7 +95,7 @@ def verify(rtradv):
 
                 if not (int(valid_lifetime) > int(preferred_lifetime)):
                     raise ConfigError('Prefix valid-lifetime must be greater then preferred-lifetime')
-
+                    
     return None
 
 def generate(rtradv):

--- a/src/migration-scripts/interfaces/5-to-6
+++ b/src/migration-scripts/interfaces/5-to-6
@@ -55,6 +55,16 @@ def copy_rtradv(c, old_base, interface):
                 min_max = interval.split('-')[0]
                 c.set(new_base + ['interval', min_max], value=tmp)
 
+		# cleanup boolean nodes in individual route
+		route_base = new_base + ['route']
+		if c.exists(route_base):
+		    for route in config.list_nodes(route_base):
+			    if c.exists(route_base + [route, 'remove-route']):
+				    tmp = c.return_value(route_base + [route, 'remove-route'])
+					c.delete(route_base + [route, 'remove-route'])
+					if tmp == 'false':
+					   c.set(route_base + [route, 'no-remove-route'])
+					   
         # cleanup boolean nodes in individual prefix
         prefix_base = new_base + ['prefix']
         if c.exists(prefix_base):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add vyos support for radvd `route` statement

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3561

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
service router-advert

## Proposed changes
<!--- Describe your changes in detail -->
add support for the `route` directive 
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
