### PR TITLE
vyos.configverify: T3570: Verify MTU is not larger than MTU on a parent interface

### DIFF
--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -45,6 +45,16 @@ def verify_mtu(config):
             raise ConfigError(f'Interface MTU too high, ' \
                               f'maximum supported MTU is {max_mtu}!')
 
+def verify_mtu_parent(config, parent):
+    if 'mtu' not in config or 'mtu' not in parent:
+        return
+    
+    mtu = int(config['mtu'])
+    parent_mtu = int(parent['mtu'])
+    if mtu > parent_mtu:
+        raise ConfigError(f'Interface MTU ({mtu}) too high, ' \
+                          f'parent interface MTU is {parent_mtu}!')
+
 def verify_mtu_ipv6(config):
     """
     Common helper function used by interface implementations to perform
@@ -266,6 +276,7 @@ def verify_vlan_config(config):
         verify_dhcpv6(vlan)
         verify_address(vlan)
         verify_vrf(vlan)
+        verify_mtu_parent(vlan, config)
 
     # 802.1ad (Q-in-Q) VLANs
     for s_vlan in config.get('vif_s', {}):
@@ -273,12 +284,15 @@ def verify_vlan_config(config):
         verify_dhcpv6(s_vlan)
         verify_address(s_vlan)
         verify_vrf(s_vlan)
+        verify_mtu_parent(s_vlan, config)
 
         for c_vlan in s_vlan.get('vif_c', {}):
             c_vlan = s_vlan['vif_c'][c_vlan]
             verify_dhcpv6(c_vlan)
             verify_address(c_vlan)
             verify_vrf(c_vlan)
+            verify_mtu_parent(c_vlan, config)
+            verify_mtu_parent(c_vlan, s_vlan)
 
 def verify_accel_ppp_base_service(config):
     """


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3570

## Component(s) name
vyos.configverify

## Proposed changes
Add check to ensure MTU is not set larger than parent interface

## How to test
```
set interfaces ethernet eth0 mtu 1500
set interfaces ethernet eth0 vif 1000 mtu 9000
```
The above currently throws a python error instead of failing gracefully

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
