### PR TITLE
ospfv3: T3581: Fix op-mode for linkstate

### DIFF
--- a/op-mode-definitions/include/ospfv3-detail.xml.i
+++ b/op-mode-definitions/include/ospfv3-detail.xml.i
@@ -4,6 +4,6 @@
     <help>Show detailed information</help>
   </properties>
   <!-- FRR uses ospf6 where we use ospfv3, thus alter the command -->
-  <command>vtysh -c "show ipv6 ospf6 ${@:4}"</command>
+  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
 </node>
 <!-- included end -->

--- a/op-mode-definitions/show-ipv6-ospfv3.xml.in
+++ b/op-mode-definitions/show-ipv6-ospfv3.xml.in
@@ -381,18 +381,34 @@
                 </properties>
                 <children>
                   #include <include/ospfv3-detail.xml.i>
-                  <node name="network">
+                  <tagNode name="network">
                     <properties>
-                      <help>Show linkstate Network information</help>
+                      <help>Show linkstate Network information (Router ID)</help>
+                      <completionHelp>
+                        <list>&lt;x.x.x.x&gt;</list>
+                      </completionHelp>
                     </properties>
-                    <command>vtysh -c "show ipv6 ospf6 linkstate network"</command>
-                  </node>
-                  <node name="router">
+                    <children>
+                      <tagNode name="link-state-id">
+                        <properties>
+                          <help>Specify Link state ID as IPv4 address notation</help>
+                          <completionHelp>
+                            <list>&lt;x.x.x.x&gt;</list>
+                          </completionHelp>
+                        </properties>
+                        <command>vtysh -c "show ipv6 ospf6 linkstate network $6 $8"</command>
+                      </tagNode>
+                    </children>
+                  </tagNode>
+                  <tagNode name="router">
                     <properties>
                       <help>Show linkstate Router information</help>
+                      <completionHelp>
+                        <list>&lt;x.x.x.x&gt;</list>
+                      </completionHelp>
                     </properties>
-                    <command>vtysh -c "show ipv6 ospf6 linkstate router"</command>
-                  </node>
+                    <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                  </tagNode>
                 </children>
               </node>
               <node name="neighbor">

--- a/src/op_mode/vtysh_wrapper.sh
+++ b/src/op_mode/vtysh_wrapper.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 declare -a tmp
-tmp=$@
+# FRR uses ospf6 where we use ospfv3, thus alter the command
+tmp=$(echo $@ | sed -e "s/ospfv3/ospf6/")
 vtysh -c "$tmp"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix for ospfv3 linkstate. The nodes "network" and "router" required value.
```
vyos@r4-1.3:~$ show ipv6 ospfv3 linkstate network 
% Command incomplete: show ipv6 ospf6 linkstate network
vyos@r4-1.3:~$
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3581

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
osfpv3
## Proposed changes
<!--- Describe your changes in detail -->
Replace node => tagNode  for "router" and network
```
show ipv6 ospfv3 linkstate router
```
In the FRR it required values
```
r4-1.3# show ipv6 ospf6 linkstate network 
  A.B.C.D  Specify Router ID as IPv4 address notation

r4-1.3# show ipv6 ospf6 linkstate router 
  A.B.C.D  Specify Router ID as IPv4 address notation
```

Also for some reason, The word "detail" is cut off.
 https://github.com/vyos/vyos-1x/blob/32bc1e5babd1bd31909a93ca1818998bf46db003/op-mode-definitions/include/ospfv3-detail.xml.i#L7

We can check it with debug
```run: echo "DEBUG: vtysh -c 'show ipv6 ospf6 ${@:4}'" && vtysh -c "show ipv6 ospf6 ${@:4}"```

 In echo, it contains **detail** but not in vtysh cmd

```
vyos@r4-1.3:~$ show ipv6 ospfv3 linkstate detail 
DEBUG: vtysh -c 'show ipv6 ospf6 linkstate detail'
% Command incomplete: show ipv6 ospf6 linkstate
vyos@r4-1.3:~$
```


## How to test
Expected output without errors
```
show ipv6 ospfv3 linkstate detail
show ipv6 ospfv3 linkstate router 1.2.3.4
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
