### PR TITLE
tunnels: T3592: Set default TTL to 64

### DIFF
--- a/interface-definitions/interfaces-tunnel.xml.in
+++ b/interface-definitions/interfaces-tunnel.xml.in
@@ -240,6 +240,9 @@
                   #include <include/interface/interface-parameters-key.xml.i>
                   #include <include/interface/interface-parameters-tos.xml.i>
                   #include <include/interface/interface-parameters-ttl.xml.i>
+                  <leafNode name="ttl">
+                    <defaultValue>64</defaultValue>
+                  </leafNode>
                 </children>
               </node>
               <node name="ipv6">

--- a/smoketest/scripts/cli/test_interfaces_tunnel.py
+++ b/smoketest/scripts/cli/test_interfaces_tunnel.py
@@ -189,6 +189,7 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
         self.cli_set(self._base_path + [interface, 'parameters', 'ip', 'no-pmtu-discovery'])
         self.cli_set(self._base_path + [interface, 'parameters', 'ip', 'key', gre_key])
         self.cli_set(self._base_path + [interface, 'parameters', 'ip', 'tos', tos])
+        self.cli_set(self._base_path + [interface, 'parameters', 'ip', 'ttl', '0'])
 
         # Check if commit is ok
         self.cli_commit()
@@ -221,7 +222,7 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
         self.assertEqual(encapsulation, conf['linkinfo']['info_kind'])
         self.assertEqual(self.local_v4, conf['linkinfo']['info_data']['local'])
         self.assertEqual(remote_ip4,    conf['linkinfo']['info_data']['remote'])
-        self.assertEqual(0,             conf['linkinfo']['info_data']['ttl'])
+        self.assertEqual(64,           conf['linkinfo']['info_data']['ttl'])
 
         # Change remote ip address (inc host by 2
         new_remote = inc_ip(remote_ip4, 2)
@@ -258,7 +259,7 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
         self.assertEqual(encapsulation,     conf['linkinfo']['info_kind'])
         self.assertEqual(self.local_v4,     conf['linkinfo']['info_data']['local'])
         self.assertEqual(remote_ip4,        conf['linkinfo']['info_data']['remote'])
-        self.assertEqual(0,                 conf['linkinfo']['info_data']['ttl'])
+        self.assertEqual(64,               conf['linkinfo']['info_data']['ttl'])
         self.assertEqual(f'0.0.0.{ip_key}', conf['linkinfo']['info_data']['ikey'])
         self.assertEqual(f'0.0.0.{ip_key}', conf['linkinfo']['info_data']['okey'])
         self.assertEqual(int(idx),          conf['linkinfo']['info_data']['erspan_index'])
@@ -314,7 +315,7 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
         self.assertEqual(encapsulation,     conf['linkinfo']['info_kind'])
         self.assertEqual(self.local_v6,     conf['linkinfo']['info_data']['local'])
         self.assertEqual(remote_ip6,        conf['linkinfo']['info_data']['remote'])
-        self.assertEqual(0,                 conf['linkinfo']['info_data']['ttl'])
+        self.assertEqual(64,               conf['linkinfo']['info_data']['ttl'])
         self.assertEqual(f'0.0.0.{ip_key}', conf['linkinfo']['info_data']['ikey'])
         self.assertEqual(f'0.0.0.{ip_key}', conf['linkinfo']['info_data']['okey'])
         self.assertEqual(erspan_ver,        conf['linkinfo']['info_data']['erspan_ver'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Set default TTL value for tunnels from 0 to 64
There are a lot of situation when the default value 0 (inherit)
not work properly when you have routing configuration for OSPF
or BGP over the tunnels. To fix it you need an explicit set TTL
value other than 0. Or hardcode another value as default.

Also, in some situations with "inherit" value the BGP session can't be established when you upgrade from 1.2 to 1.3/1.4
In 1.2 the TTL value is hardcoded to 255.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3592

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
tunnel, ttl
## Proposed changes
<!--- Describe your changes in detail -->
The change default TTL value for tunnels from 0 (inherit) to 64

## How to test
```
set interfaces tunnel tun0 address '10.0.0.1/30'
set interfaces tunnel tun0 encapsulation 'gre'
set interfaces tunnel tun0 remote '192.0.2.2'
set interfaces tunnel tun0 source-address '192.0.2.1'
```
Expected ttl 255
```
vyos@r1-roll# sudo ip -d tunnel show
tun0: gre/ip remote 192.0.2.2 local 192.0.2.1 ttl 64 tos inherit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
