### PR TITLE
flow-accounting: T3132: fix egress iptables chain

### DIFF
--- a/src/conf_mode/flow_accounting_conf.py
+++ b/src/conf_mode/flow_accounting_conf.py
@@ -43,7 +43,7 @@ uacctd_conf_path = '/etc/pmacct/uacctd.conf'
 iptables_nflog_table = 'raw'
 iptables_nflog_chain = 'VYATTA_CT_PREROUTING_HOOK'
 egress_iptables_nflog_table = 'mangle'
-egress_iptables_nflog_chain = 'POSTROUTING'
+egress_iptables_nflog_chain = 'FORWARD'
 
 # helper functions
 # check if node exists and return True if this is true


### PR DESCRIPTION
## Change Summary
Use the right iptables chain for egress flow sampling.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T3132

## Component(s) name
flow-accounting

## Proposed changes
Use the right iptables chain for egress flow sampling. Used POSTROUTING, which indeed includes packets created by local processes. Those packets shouldn't be sampled as also done by ingress flow sampling. 

This fix also should be cherry-picked in to the current branch.

Please see the comments on the linked task for the problem.

## How to test
I've tested it on my lab router. After i applied the proposed change, the samples with macaddress  00:00:00:00:00:00 displayed by `show flow-accounting` disappeared. Same i can confirm with my sFlow collector.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
