### PR TITLE
T3574: add constraintGroup to schema and build-command-templates

### DIFF
--- a/python/vyos/xml/load.py
+++ b/python/vyos/xml/load.py
@@ -225,6 +225,9 @@ def _format_node(inside, conf, xml):
                         else:
                             _fatal(constraint)
 
+                elif 'constraintGroup' in properties:
+                    properties.pop('constraintGroup')
+
                 elif 'constraintErrorMessage' in properties:
                     r[kw.error] = properties.pop('constraintErrorMessage')
 

--- a/schema/interface_definition.rnc
+++ b/schema/interface_definition.rnc
@@ -93,6 +93,7 @@ properties = element properties
 {
     help? &
     constraint? &
+    constraintGroup* &
     valueHelp* &
     (element constraintErrorMessage { text })? &
     completionHelp* &
@@ -135,6 +136,16 @@ ownerAttr = attribute owner
 # (respectively).
 # When multiple constraints are listed, they work as logical OR
 constraint = element constraint
+{
+    ( (element regex { text }) |
+      validator )+
+}
+
+# Tag and leaf nodes may have constraintGroups on their names and
+# values (respectively).
+# When multiple constraints are listed within a group, they work as
+# logical AND
+constraintGroup = element constraintGroup
 {
     ( (element regex { text }) |
       validator )+

--- a/schema/interface_definition.rng
+++ b/schema/interface_definition.rng
@@ -161,6 +161,9 @@
           <ref name="constraint"/>
         </optional>
         <zeroOrMore>
+          <ref name="constraintGroup"/>
+        </zeroOrMore>
+        <zeroOrMore>
           <ref name="valueHelp"/>
         </zeroOrMore>
         <optional>
@@ -234,6 +237,24 @@
   -->
   <define name="constraint">
     <element name="constraint">
+      <oneOrMore>
+        <choice>
+          <element name="regex">
+            <text/>
+          </element>
+          <ref name="validator"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <!--
+    Tag and leaf nodes may have constraintGroups on their names and
+    values (respectively).
+    When multiple constraints are listed within a group, they work as
+    logical AND
+  -->
+  <define name="constraintGroup">
+    <element name="constraintGroup">
       <oneOrMore>
         <choice>
           <element name="regex">

--- a/scripts/build-command-templates
+++ b/scripts/build-command-templates
@@ -86,6 +86,37 @@ def make_path(l):
         print(path)
     return path
 
+def collect_validators(ve):
+    regexes = []
+    regex_elements = ve.findall("regex")
+    if regex_elements is not None:
+        regexes = list(map(lambda e: e.text.strip().replace('\\','\\\\'), regex_elements))
+    if "" in regexes:
+        print("Warning: empty regex, node will be accepting any value")
+
+    validator_elements = ve.findall("validator")
+    validators = []
+    if validator_elements is not None:
+        for v in validator_elements:
+            v_name = os.path.join(validator_dir, v.get("name"))
+
+            # XXX: lxml returns None for empty arguments
+            v_argument = None
+            try:
+                v_argument = v.get("argument")
+            except:
+                pass
+            if v_argument is None:
+                v_argument = ""
+
+            validators.append("{0} {1}".format(v_name, v_argument))
+
+
+    regex_args = " ".join(map(lambda s: "--regex \\\'{0}\\\'".format(s), regexes))
+    validator_args = " ".join(map(lambda s: "--exec \\\"{0}\\\"".format(s), validators))
+
+    return regex_args + " " + validator_args
+
 def get_properties(p):
     props = {}
 
@@ -108,7 +139,8 @@ def get_properties(p):
     except:
         props["val_help"] = []
 
-    # Get the constraint statements
+    # Get the constraint and constraintGroup statements
+
     error_msg = default_constraint_err_msg
     # Get the error message if it's there
     try:
@@ -117,40 +149,24 @@ def get_properties(p):
         pass
 
     vce = p.find("constraint")
-    vc = []
+
+    distinct_validator_string = ""
     if vce is not None:
         # The old backend doesn't support multiple validators in OR mode
         # so we emulate it
 
-        regexes = []
-        regex_elements = vce.findall("regex")
-        if regex_elements is not None:
-            regexes = list(map(lambda e: e.text.strip().replace('\\','\\\\'), regex_elements))
-        if "" in regexes:
-            print("Warning: empty regex, node will be accepting any value")
+        distinct_validator_string = collect_validators(vce)
 
-        validator_elements = vce.findall("validator")
-        validators = []
-        if validator_elements is not None:
-            for v in validator_elements:
-                v_name = os.path.join(validator_dir, v.get("name"))
+    vcge = p.findall("constraintGroup")
 
-                # XXX: lxml returns None for empty arguments
-                v_argument = None
-                try:
-                    v_argument = v.get("argument")
-                except:
-                    pass
-                if v_argument is None:
-                    v_argument = ""
+    group_validator_string = ""
+    if len(vcge):
+        for vcg in vcge:
+            group_validator_string = group_validator_string + " --grp " + collect_validators(vcg)
 
-                validators.append("{0} {1}".format(v_name, v_argument))
-
-
-        regex_args = " ".join(map(lambda s: "--regex \\\'{0}\\\'".format(s), regexes))
-        validator_args = " ".join(map(lambda s: "--exec \\\"{0}\\\"".format(s), validators))
+    if vce is not None or len(vcge):
         validator_script = '${vyos_libexec_dir}/validate-value'
-        validator_string = "exec \"{0} {1} {2} --value \\\'$VAR(@)\\\'\"; \"{3}\"".format(validator_script, regex_args, validator_args, error_msg)
+        validator_string = "exec \"{0} {1} {2} --value \\\'$VAR(@)\\\'\"; \"{3}\"".format(validator_script, distinct_validator_string, group_validator_string, error_msg)
 
         props["constraint"] = validator_string
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

N.B. this PR depends on https://github.com/vyos/vyos-utils/pull/1

This (draft) PR adds support for elements `<constraintGroup>` in interface definition XML; when processed by build-command-templates, all child element constraints within a `<constraintGroup>` are joined with logical AND. Processing `<constraint>` and `<constraintGroup>` will combine with logical OR.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3574

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
```
-->
A quick sanity check of the logic can be done with a mock interface-definition and an entry such as below, noting that logical OR is union, and logical AND is intersection; similarly for validators and tag nodes. A real world example will be added.
```
             <leafNode name="single-value">
                <properties>
                  <help>single value</help>
                  <constraint>
                    <regex>^(foo)[0-9]+$</regex>
                    <regex>^(foo)[0-3]+$</regex>
                  </constraint>
                  <constraintGroup>
                    <regex>^(bar)[0-9]+$</regex>
                    <regex>^(bar)[0-3]+$</regex>
                  </constraintGroup>
                  <constraintGroup>
                    <regex>^(baz)[0-9]+$</regex>
                    <regex>^(baz)[0-3]+$</regex>
                  </constraintGroup>
                </properties>
              </leafNode>
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
