### PR TITLE
containers: T3614: Fix for network names with hyphen

### DIFF
--- a/src/conf_mode/containers.py
+++ b/src/conf_mode/containers.py
@@ -75,7 +75,7 @@ def get_config(config=None):
 
     base = ['container']
     container = conf.get_config_dict(base, key_mangling=('-', '_'),
-                                     get_first_key=True)
+                                     get_first_key=True, no_tag_node_value_mangle=True)
     # We have gathered the dict representation of the CLI, but there are default
     # options which we need to update into the dictionary retrived.
     default_values = defaults(base)


### PR DESCRIPTION
Fix for containers and newtorks names with hyphen in names.
We shouldn't mangle tagNode values.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Not mangle tag node values for network/containers names.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3614

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
containers
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Set container network name with hyphen
We should to get the same name in op-mode
```
set container network foo-bar prefix 192.168.99.0/24
commit

vyos@r1-roll# run show container network 
NAME     VERSION  PLUGINS
foo-bar  0.4.0    bridge,portmap,firewall,tuning
[edit]
vyos@r1-roll# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
