### PR TITLE
PING: T3634: Adding do not fragment to Ping

### DIFF
--- a/src/op_mode/ping.py
+++ b/src/op_mode/ping.py
@@ -50,6 +50,11 @@ options = {
         'type': '<seconds>',
         'help': 'Number of seconds before ping exits'
     },
+    'do-not-fragment': {
+        'ping': '{command} -M dont',
+        'type': 'noarg',
+        'help': 'Set DF-bit flag to 1 for no fragmentation'
+    },
     'flood': {
         'ping': 'sudo {command} -f',
         'type': 'noarg',
@@ -227,4 +232,4 @@ if __name__ == '__main__':
 
     # print(f'{command} {host}')
     os.system(f'{command} {host}')
-
+    


### PR DESCRIPTION
In this commit we add the do not fragment capability
for ping commands.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

We just add a few lines to allow the option to use no fragmentation to ping commands.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3634

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ping

## Proposed changes
<!--- Describe your changes in detail -->

We just add a few lines to allow the option to use no fragmentation to ping commands.
It's unfortunately not very complicated. We just leverage the "ping -M dont" functionality.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
vyos@vyos:~$ ping 10.0.0.65 do-not-fragment size 1472     <---- 1500 ping works
PING 10.0.0.65 (10.0.0.65) 1472(1500) bytes of data.
1480 bytes from 10.0.0.65: icmp_seq=1 ttl=64 time=0.143 ms
1480 bytes from 10.0.0.65: icmp_seq=2 ttl=64 time=0.233 ms
1480 bytes from 10.0.0.65: icmp_seq=3 ttl=64 time=0.205 ms
^C
--- 10.0.0.65 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 51ms
rtt min/avg/max/mdev = 0.143/0.193/0.233/0.040 ms


vyos@vyos:~$ ping 10.0.0.65 do-not-fragment size 1473     <---- 1501 ping does not due to MTU limit
PING 10.0.0.65 (10.0.0.65) 1473(1501) bytes of data.
^C
--- 10.0.0.65 ping statistics ---
2 packets transmitted, 0 received, 100% packet loss, time 34ms

```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly, https://github.com/vyos/vyos-documentation/pull/551
