### PR TITLE
mdns: vrrp: T3635: Add ability to use mDNS repeater with VRRP

### DIFF
--- a/interface-definitions/service_mdns-repeater.xml.in
+++ b/interface-definitions/service_mdns-repeater.xml.in
@@ -23,6 +23,12 @@
                   <multi/>
                 </properties>
               </leafNode>
+              <leafNode name="vrrp-disable">
+                <properties>
+                  <help>Disables mDNS repeater on VRRP interfaces not in MASTER state</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
             </children>
           </node>
         </children>

--- a/src/system/keepalived-fifo.py
+++ b/src/system/keepalived-fifo.py
@@ -37,6 +37,8 @@ logs_handler_syslog.setFormatter(logs_format)
 logger.addHandler(logs_handler_syslog)
 logger.setLevel(logging.DEBUG)
 
+mdns_running_file = '/run/mdns_vrrp_active'
+mdns_update_command = 'sudo /usr/libexec/vyos/conf_mode/service_mdns-repeater.py'
 
 # class for all operations
 class KeepalivedFifo:
@@ -121,6 +123,9 @@ class KeepalivedFifo:
                         logger.info("{} {} changed state to {}".format(n_type, n_name, n_state))
                         # check and run commands for VRRP instances
                         if n_type == 'INSTANCE':
+                            if os.path.exists(mdns_running_file):
+                                cmd(mdns_update_command)
+
                             if n_name in self.vrrp_config['vrrp_groups'] and n_state in self.vrrp_config['vrrp_groups'][n_name]:
                                 n_script = self.vrrp_config['vrrp_groups'][n_name].get(n_state)
                                 if n_script:
@@ -128,6 +133,9 @@ class KeepalivedFifo:
                         # check and run commands for VRRP sync groups
                         # currently, this is not available in VyOS CLI
                         if n_type == 'GROUP':
+                            if os.path.exists(mdns_running_file):
+                                cmd(mdns_update_command)
+                            
                             if n_name in self.vrrp_config['sync_groups'] and n_state in self.vrrp_config['sync_groups'][n_name]:
                                 n_script = self.vrrp_config['sync_groups'][n_name].get(n_state)
                                 if n_script:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This allows the mDNS repeater to be enabled on VRRP-enabled routers as only the master router will repeat the packets.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3635

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
mdns, vrrp

## Proposed changes
<!--- Describe your changes in detail -->
When the new setting is active, mDNS repeater will disable mDNS on interfaces where VRRP is active and the state is not MASTER.
A hook is also added to keepalived_fifo to keep the mDNS repeater updated as VRRP states change.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set service mdns repeater interface eth0
set service mdns repeater interface eth1
set service mdns repeater disable-on-vrrp
```
Assuming VRRP is enabled on eth0 and eth1, if the router is not the master router mDNS will be disabled to prevent a packet storm. If the state changes to master, mDNS will then be enabled on each master interface.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
