### PR TITLE
T3639: xml: Make GCC preprocessor ignore C(++)-style comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ op_xml_obj = $(op_xml_src:.xml.in=.xml)
 	# -P         Inhibit generation of linemarkers in the output from the
 	#            preprocessor
 	mkdir -p $(BUILD_DIR)/$(dir $@)
-	@$(CC) -x c-header -E -undef -nostdinc -P -I$(CURDIR)/$(dir $<) -o $(BUILD_DIR)/$@ -c $<
+	@$(CC) -x c-header -C -E -undef -nostdinc -P -I$(CURDIR)/$(dir $<) -o $(BUILD_DIR)/$@ -c $<
 
 .PHONY: interface_definitions
 .ONESHELL:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
GCC preprocessor clobbers lines that contain (what it assumes to be) C comments. `/* ... */` is rare enough that it practically never happens, but C++ comments like `// ...` break things like unquoted strings. It can be worked around by using character entity references, but it would be much cleaner to simply ask GCC to leave the comments untouched.

## Related Task(s)
* https://phabricator.vyos.net/T3639

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
