### PR TITLE
dhcpdv6: T3658: add support for dhcpdv6 fixed-prefix6

### DIFF
--- a/data/templates/dhcp-server/dhcpdv6.conf.tmpl
+++ b/data/templates/dhcp-server/dhcpdv6.conf.tmpl
@@ -107,6 +107,9 @@ shared-network {{ network | replace('_','-') }} {
 {%             if host_config.ipv6_address is defined and host_config.ipv6_address is not none %}
             fixed-address6 {{ host_config.ipv6_address }};
 {%             endif %}
+{%             if host_config.ipv6_prefix is defined and host_config.ipv6_prefix is not none %}
+            fixed-prefix6 {{ host_config.ipv6_prefix }};
+{%             endif %}
         }
 {%           endfor %}
 {%         endif %}

--- a/interface-definitions/dhcpv6-server.xml.in
+++ b/interface-definitions/dhcpv6-server.xml.in
@@ -360,6 +360,18 @@
                           </constraint>
                         </properties>
                       </leafNode>
+                      <leafNode name="ipv6-prefix">
+                        <properties>
+                          <help>Client IPv6 prefix for this static mapping</help>
+                          <valueHelp>
+                            <format>ipv6net</format>
+                            <description>IPv6 prefix for this static mapping</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="ipv6-prefix"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
                     </children>
                   </tagNode>
                 </children>

--- a/smoketest/scripts/cli/test_service_dhcpv6-server.py
+++ b/smoketest/scripts/cli/test_service_dhcpv6-server.py
@@ -86,6 +86,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
             cid = '00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:{}'.format(client_base)
             self.cli_set(pool + ['static-mapping', client, 'identifier', cid])
             self.cli_set(pool + ['static-mapping', client, 'ipv6-address', inc_ip(subnet, client_base)])
+            self.cli_set(pool + ['static-mapping', client, 'ipv6-prefix', inc_ip(subnet, client_base << 64) + '/64'])
             client_base += 1
 
         # commit changes
@@ -114,8 +115,10 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         for client in ['client1', 'client2', 'client3']:
             cid = '00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:{}'.format(client_base)
             ip = inc_ip(subnet, client_base)
+            prefix = inc_ip(subnet, client_base << 64) + '/64'
             self.assertIn(f'host {shared_net_name}_{client}' + ' {', config)
             self.assertIn(f'fixed-address6 {ip};', config)
+            self.assertIn(f'fixed-prefix6 {prefix};', config)
             self.assertIn(f'host-identifier option dhcp6.client-id {cid};', config)
             client_base += 1
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
Add support for dhcpdv6 fixed-prefix6.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3658

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* dhcpdv6

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
configure
set service dhcpv6-server shared-network-name LAN subnet 2001:db8::/64 static-mapping CLIENT ipv6-prefix 2001:db8:0:1::/64
commit
exit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly