### PR TITLE
ipsec: T3656: T3659: Fix passthrough with ipv6. Fix op-mode ipsec commands. Remove python3-crypto dependency.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -110,7 +110,7 @@ Depends:
   procps,
   python3,
   python3-certbot-nginx,
-  python3-crypt | python3-pycryptodome,
+  python3-pycryptodome,
   python3-cryptography,
   python3-flask,
   python3-hurry.filesize,

--- a/op-mode-definitions/vpn-ipsec.xml.in
+++ b/op-mode-definitions/vpn-ipsec.xml.in
@@ -101,7 +101,7 @@
         <properties>
           <help>Restart IPSec VPN</help>
         </properties>
-        <command>if pgrep charon >/dev/null ; then sudo /usr/sbin/ipsec restart ; else echo "IPSec process not running" ; fi</command>
+        <command>if pgrep charon >/dev/null ; then sudo ipsec restart ; sleep 3 ; sudo swanctl -q ; else echo "IPSec process not running" ; fi</command>
       </node>
     </children>
   </node>

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -705,38 +705,6 @@ def get_all_vrfs():
         data[name] = entry
     return data
 
-def cidr_fit(cidr_a, cidr_b, both_directions = False):
-    """
-    Does CIDR A fit inside of CIDR B?
-
-    Credit: https://gist.github.com/magnetikonline/686fde8ee0bce4d4930ce8738908a009
-    """
-    def split_cidr(cidr):
-        part_list = cidr.split("/")
-        if len(part_list) == 1:
-            # if just an IP address, assume /32
-            part_list.append("32")
-
-        # return address and prefix size
-        return part_list[0].strip(), int(part_list[1])
-    def address_to_bits(address):
-        # convert each octet of IP address to binary
-        bit_list = [bin(int(part)) for part in address.split(".")]
-
-        # join binary parts together
-        # note: part[2:] to slice off the leading "0b" from bin() results
-        return "".join([part[2:].zfill(8) for part in bit_list])
-    def binary_network_prefix(cidr):
-        # return CIDR as bits, to the length of the prefix size only (drop the rest)
-        address, prefix_size = split_cidr(cidr)
-        return address_to_bits(address)[:prefix_size]
-
-    prefix_a = binary_network_prefix(cidr_a)
-    prefix_b = binary_network_prefix(cidr_b)
-    if both_directions:
-        return prefix_a.startswith(prefix_b) or prefix_b.startswith(prefix_a)
-    return prefix_a.startswith(prefix_b)
-
 def print_error(str='', end='\n'):
     """
     Print `str` to stderr, terminated with `end`.

--- a/src/conf_mode/vpn_ipsec.py
+++ b/src/conf_mode/vpn_ipsec.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import ipaddress
 import os
 
 from sys import exit
@@ -34,7 +35,6 @@ from vyos.util import call
 from vyos.util import dict_search
 from vyos.util import process_named_running
 from vyos.util import run
-from vyos.util import cidr_fit
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -407,7 +407,9 @@ def generate(ipsec):
 
                         for local_prefix in local_prefixes:
                             for remote_prefix in remote_prefixes:
-                                if cidr_fit(local_prefix, remote_prefix):
+                                local_net = ipaddress.ip_network(local_prefix)
+                                remote_net = ipaddress.ip_network(remote_prefix)
+                                if local_net.overlaps(remote_net):
                                     passthrough.append(local_prefix)
 
                         data['site_to_site']['peer'][peer]['tunnel'][tunnel]['passthrough'] = passthrough

--- a/src/op_mode/show_ipsec_sa.py
+++ b/src/op_mode/show_ipsec_sa.py
@@ -26,7 +26,7 @@ import vyos.util
 def format_output(conns, sas):
     sa_data = []
 
-    for peer, parent_conn in conn.items():
+    for peer, parent_conn in conns.items():
         if peer not in sas:
             continue
 

--- a/src/op_mode/vpn_ipsec.py
+++ b/src/op_mode/vpn_ipsec.py
@@ -23,7 +23,7 @@ import argparse
 from subprocess import TimeoutExpired
 
 from vyos.util import ask_yes_no, call, cmd, process_named_running
-from Crypto.PublicKey.RSA import importKey
+from Cryptodome.PublicKey.RSA import importKey
 
 RSA_LOCAL_KEY_PATH = '/config/ipsec.d/rsa-keys/localhost.key'
 RSA_LOCAL_PUB_PATH = '/etc/ipsec.d/certs/localhost.pub'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Update pass-through check to support ipv6 prefixes
Fixes op-mode ipsec commands
Removes python3-crypto dependency

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3656
* https://phabricator.vyos.net/T3659

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec

## Proposed changes
<!--- Describe your changes in detail -->
Fixes passthrough test for IPv6 addresses, also changed to use builtin python module.
Fixes op-mode bugs and `restart vpn` properly restarts swanctl connections.
Removes python3-crypto now Bullseye is used

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
