### PR TITLE
containers: T3662: Repair system damage during upgrade

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -134,6 +134,7 @@ Depends:
   python3-zmq,
   qrencode,
   radvd,
+  runc,
   salt-minion,
   sed,
   smartmontools,

--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import unittest
 import json
 
@@ -75,6 +76,10 @@ class TesContainer(VyOSUnitTestSHIM.TestCase):
 
         self.assertEqual(json_subnet, prefix)
         self.assertEqual(json_ip, cont_ip)
+    
+    def test_oci_runtime_exists(self):
+        self.assertTrue(os.path.exists('/usr/bin/runc'))
+            
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/containers.py
+++ b/src/conf_mode/containers.py
@@ -36,6 +36,8 @@ airbag.enable()
 config_containers_registry = '/etc/containers/registries.conf'
 config_containers_storage = '/etc/containers/storage.conf'
 
+runtime = '/usr/bin/runc'
+
 def _cmd(command):
     if os.path.exists('/tmp/vyos.container.debug'):
         print(command)
@@ -244,18 +246,18 @@ def apply(container):
                         volume += f' -v {svol}:{dvol}'
 
                 if 'allow_host_networks' in container_config:
-                    _cmd(f'podman run -dit --name {name} --net host {port} {volume} {env_opt} {image}')
+                    _cmd(f'podman --runtime {runtime} run -dit --name {name} --net host {port} {volume} {env_opt} {image}')
                 else:
                     for network in container_config['network']:
                         ipparam = ''
                         if 'address' in container_config['network'][network]:
                             ipparam = '--ip ' + container_config['network'][network]['address']
-                        _cmd(f'podman run --name {name} -dit --net {network} {ipparam} {port} {volume} {env_opt} {image}')
+                        _cmd(f'podman --runtime {runtime} run --name {name} -dit --net {network} {ipparam} {port} {volume} {env_opt} {image}')
 
             # Else container is already created. Just start it.
             # It's needed after reboot.
             elif container_status(name) != 'running':
-                _cmd(f'podman start {name}')
+                _cmd(f'podman --runtime {runtime} start {name}')
 
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Repair system damage during upgrade

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3662

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
containers

## Proposed changes
<!--- Describe your changes in detail -->
Because the new vyos system may not have the OCI runtime `runc` used by podman by default, but there is a crun, resulting in the container configuration can not be used normally. We need to point to the `crun` through the soft link when the system can not find the `runc`.

This patch will fix the above problem.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

When upgrading a vyos system containing container configuration, the configuration will be destroyed, such as the following configuration:

```
set interfaces ethernet eth0 address dhcp
set interfaces ethernet eth0 ipv6 address autoconf
set system name-service 114.114.114.114
set container name nginx image nginx
set container name nginx allow-host-networks
commit
save
exit
```

After upgrading to vyos compiled by this branch, Restart after the first upgrade:
![图片](https://user-images.githubusercontent.com/9047180/124386710-3ac1eb80-dd0e-11eb-8008-3bc70c5231eb.png)



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
