### PR TITLE
openvpn: T56: remove strict checks for tls cert-file and key-file

### DIFF
--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -332,13 +332,6 @@ def verify(openvpn):
         if 'ca_cert_file' not in openvpn['tls']:
             raise ConfigError('Must specify "tls ca-cert-file"')
 
-        if not (openvpn['mode'] == 'client' and 'auth_file' in openvpn['tls']):
-            if 'cert_file' not in openvpn['tls']:
-                raise ConfigError('Missing "tls cert-file"')
-
-            if 'key_file' not in openvpn['tls']:
-                raise ConfigError('Missing "tls key-file"')
-
         if {'auth_file', 'crypt_file'} <= set(openvpn['tls']):
             raise ConfigError('TLS auth and crypt are mutually exclusive')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This makes the tls cert-file and key-file optional and allows for more
advanced configurations via "openvpn-option", such as pkcs11 or pkcs12
options.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

Removed some strict configuration checking of TLS options in OpenVPN. This should not impact any functionality or usability.

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T56

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openvpn

## Proposed changes
<!--- Describe your changes in detail -->
Remove the strict TLS configuration checks to allow for advanced configurations by users.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics

-->

I tested with following extra openvpn-options and my Aladdin eToken (drivers needed):
```
openvpn-option "--pkcs11-id-management"
openvpn-option "--management-query-passwords"
openvpn-option "--management 127.0.0.1 1001"
openvpn-option "--pkcs11-providers /usr/lib/libeToken.so"
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
