### PR TITLE
vyos-1x-vmware: T3681: don't bytecompile ether-resume.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ clean:
 
 .PHONY: test
 test:
-	set -e; python3 -m compileall -q .
+	set -e; python3 -m compileall -q -x '/vmware-tools/scripts/' .
 	PYTHONPATH=python/ python3 -m "nose" --with-xunit src --with-coverage --cover-erase --cover-xml --cover-package src/conf_mode,src/op_mode,src/completion,src/helpers,src/validators,src/tests --verbose
 
 .PHONY: sonar


### PR DESCRIPTION
Exclude `/vmware-tools/scripts/` from bytecompilation to avoid the `__pycache__` directory being created.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This change avoids the bytecompilation of `ether-resume.py` by excluding the `/vmware-tools/scripts/` path (regex).
This effectively avoids creating the `/etc/vmware-tools/scripts/resume-vm-default.d/__pycache__` directory which causes errors/warnings when resuming a suspended VyOS in VMware.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3681

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

vyos-1x-vmware

## Proposed changes
<!--- Describe your changes in detail -->

This change avoids the byte compilation of the python scripts matching the path `/vmware-tools/scripts/`. This in turn prevents the `__pycache__` directory creation. This directory conflicts with the `open-vm-tools` resume script as it does not handle directories.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

On VyOS-1.3.0-rc5, check the vyos-1x-vmware package (note the` __pycache__` directory):
```
$ dpkg -L vyos-1x-vmware
/.
/etc
/etc/vmware-tools
/etc/vmware-tools/scripts
/etc/vmware-tools/scripts/resume-vm-default.d
/etc/vmware-tools/scripts/resume-vm-default.d/__pycache__
/etc/vmware-tools/scripts/resume-vm-default.d/__pycache__/ether-resume.cpython-37.pyc
/etc/vmware-tools/scripts/resume-vm-default.d/ether-resume.py
/usr
/usr/share
/usr/share/doc/vyos-1x-vmware
/usr/share/doc/vyos-1x-vmware/changelog.Debian.gz
/usr/share/doc/vyos-1x-vmware/copyright
```

Then performed a build with the new Makefile to ensure the `vyos-1x-vmware` package doesn't have `__pycache__`:
```
# dpkg --contents /vyos-1x-vmware_1.4dev0-1096-g5c352043+dirty_amd64.deb
drwxr-xr-x root/root         0 2021-01-11 18:02 ./
drwxr-xr-x root/root         0 2021-01-11 18:02 ./etc/
drwxr-xr-x root/root         0 2021-01-11 18:02 ./etc/vmware-tools/
drwxr-xr-x root/root         0 2021-01-11 18:02 ./etc/vmware-tools/scripts/
drwxr-xr-x root/root         0 2021-01-11 18:02 ./etc/vmware-tools/scripts/resume-vm-default.d/
-rwxr-xr-x root/root      2145 2021-01-11 18:02 ./etc/vmware-tools/scripts/resume-vm-default.d/ether-resume.py
-rw-r--r-- root/root        33 2021-01-11 18:02 ./etc/vmware-tools/tools.conf
drwxr-xr-x root/root         0 2021-01-11 18:02 ./usr/
drwxr-xr-x root/root         0 2021-01-11 18:02 ./usr/share/
drwxr-xr-x root/root         0 2021-01-11 18:02 ./usr/share/doc/
drwxr-xr-x root/root         0 2021-01-11 18:02 ./usr/share/doc/vyos-1x-vmware/
-rw-r--r-- root/root       324 2021-01-11 18:02 ./usr/share/doc/vyos-1x-vmware/changelog.gz
-rw-r--r-- root/root      1261 2021-01-11 18:02 ./usr/share/doc/vyos-1x-vmware/copyright
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
