### PR TITLE
vxlan: T3683: Fix MTU for ipv6 addresses

### DIFF
--- a/src/conf_mode/interfaces-vxlan.py
+++ b/src/conf_mode/interfaces-vxlan.py
@@ -25,6 +25,7 @@ from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_mtu_ipv6
 from vyos.configverify import verify_source_interface
+from vyos.template import is_ipv6
 from vyos.ifconfig import VXLANIf, Interface
 from vyos import ConfigError
 from vyos import airbag
@@ -78,6 +79,9 @@ def verify(vxlan):
 
 
 def generate(vxlan):
+    # For ipv6 VXLAN we need sub 20 bytes from default MTU 1450 XML value. T3683
+    if 'source_address' in vxlan and is_ipv6(vxlan['source_address']) and vxlan['mtu'] == '1450':
+        vxlan['mtu'] = (int(vxlan['mtu']) - 20)
     return None
 
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix MTU bug with VXLAN if it is used source ipv6address. Current.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3683

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vxlan
## Proposed changes
<!--- Describe your changes in detail -->
Check default MTU parameter, if it is 1450 for vxlan we need to "sub" 20 bytes for ipv6.
## How to test
VyOS configuration
```
set interface vxlan vxlan0 vni 0
set interface vxlan vxlan0 source-address fe80::3
set interface vxlan vxlan0 remote fe80::2
set interface vxlan vxlan0 source-interface eth0
````
Expected MTU 1430
```
vyos@r1-roll# sudo ip -d link show dev vxlan0
6: vxlan0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1430 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether ce:ae:84:df:8a:0a brd ff:ff:ff:ff:ff:ff promiscuity 0 minmtu 68 maxmtu 65535 
    vxlan id 0 remote fe80::2 local fe80::3 dev eth0 srcport 0 0 dstport 8472 tos inherit ttl 16 ageing 300 udpcsum noudp6zerocsumtx noudp6zerocsumrx addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
