### PR TITLE
VRF: T3655: proper connection tracking for VRFs

### DIFF
--- a/data/templates/firewall/nftables-vrf-zones.tmpl
+++ b/data/templates/firewall/nftables-vrf-zones.tmpl
@@ -1,0 +1,17 @@
+table inet vrf_zones {
+  # Map of interfaces and connections tracking zones
+  map ct_iface_map {
+    typeof iifname : ct zone
+  }
+  # Assign unique zones for each VRF
+  # Chain for inbound traffic
+  chain vrf_zones_ct_in {
+    type filter hook prerouting priority raw; policy accept;
+    counter ct zone set iifname map @ct_iface_map
+  }
+  # Chain for locally-generated traffic
+  chain vrf_zones_ct_out {
+    type filter hook output priority raw; policy accept;
+    counter ct zone set oifname map @ct_iface_map
+  }
+}

--- a/interface-definitions/vrf.xml.in
+++ b/interface-definitions/vrf.xml.in
@@ -19,7 +19,7 @@
           <constraint>
             <validator name="vrf-name"/>
           </constraint>
-          <constraintErrorMessage>VRF instance name must be 15 characters or less and can not\nbe named as regular network interfaces.\n</constraintErrorMessage>
+          <constraintErrorMessage>VRF instance name must be 15 characters or less and can not\nbe named as regular network interfaces.\nA name must starts from a letter.\n</constraintErrorMessage>
           <valueHelp>
             <format>txt</format>
             <description>VRF instance name</description>
@@ -76,13 +76,13 @@
             <properties>
               <help>Routing table associated with this instance</help>
               <valueHelp>
-                <format>100-2147483647</format>
+                <format>100-65535</format>
                 <description>Routing table ID</description>
               </valueHelp>
               <constraint>
-                <validator name="numeric" argument="--range 100-2147483647"/>
+                <validator name="numeric" argument="--range 100-65535"/>
               </constraint>
-              <constraintErrorMessage>VRF routing table must be in range from 100 to 2147483647</constraintErrorMessage>
+              <constraintErrorMessage>VRF routing table must be in range from 100 to 65535</constraintErrorMessage>
             </properties>
           </leafNode>
           #include <include/vni.xml.i>

--- a/src/migration-scripts/vrf/2-to-3
+++ b/src/migration-scripts/vrf/2-to-3
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Since connection tracking zones are int16, VRFs tables maximum value must
+# be limited to 65535
+# Also, interface names in nftables cannot start from numbers,
+# so VRF name should not start from a number
+
+from sys import argv
+from sys import exit
+from random import randrange
+from random import choice
+from string import ascii_lowercase
+from vyos.configtree import ConfigTree
+import re
+
+
+# Helper function to find all config items with a VRF name
+def _search_vrfs(config_commands, vrf_name):
+    vrf_values = []
+    # Regex to find path of config command with old VRF
+    regex_filter = re.compile(rf'^set (?P<cmd_path>[^\']+vrf) \'{vrf_name}\'$')
+    # Check each command for VRF value
+    for config_command in config_commands:
+        search_result = regex_filter.search(config_command)
+        if search_result:
+            # Append VRF command to a list
+            vrf_values.append(search_result.group('cmd_path').split())
+    if vrf_values:
+        return vrf_values
+    else:
+        return None
+
+
+# Helper function to find all config items with a table number
+def _search_tables(config_commands, table_num):
+    table_items = {'table_tags': [], 'table_values': []}
+    # Regex to find values and nodes with a table number
+    regex_tags = re.compile(rf'^set (?P<cmd_path>[^\']+table {table_num}) ?.*$')
+    regex_values = re.compile(
+        rf'^set (?P<cmd_path>[^\']+table) \'{table_num}\'$')
+    for config_command in config_commands:
+        # Search for tag nodes
+        search_result = regex_tags.search(config_command)
+        if search_result:
+            # Append table node path to a tag nodes list
+            cmd_path = search_result.group('cmd_path').split()
+            if cmd_path not in table_items['table_tags']:
+                table_items['table_tags'].append(cmd_path)
+        # Search for value nodes
+        search_result = regex_values.search(config_command)
+        if search_result:
+            # Append table node path to a value nodes list
+            table_items['table_values'].append(
+                search_result.group('cmd_path').split())
+    return table_items
+
+
+if (len(argv) < 2):
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['vrf', 'name']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+
+# Get a list of all currently used VRFs and tables
+vrfs_current = {}
+for vrf in config.list_nodes(base):
+    vrfs_current[vrf] = int(config.return_value(base + [vrf, 'table']))
+
+# Check VRF names and table numbers
+name_regex = re.compile(r'^\d.*$')
+for vrf_name, vrf_table in vrfs_current.items():
+    # Check table number
+    if vrf_table > 65535:
+        # Find new unused table number
+        vrfs_current[vrf_name] = None
+        while not vrfs_current[vrf_name]:
+            table_random = randrange(100, 65535)
+            if table_random not in vrfs_current.values():
+                vrfs_current[vrf_name] = table_random
+        # Update number to a new one
+        config.set(['vrf', 'name', vrf_name, 'table'],
+                   vrfs_current[vrf_name],
+                   replace=True)
+        # Check config items with old table number and replace to new one
+        config_commands = config.to_commands().split('\n')
+        table_config_lines = _search_tables(config_commands, vrf_table)
+        # Rename table nodes
+        if table_config_lines.get('table_tags'):
+            for table_config_path in table_config_lines.get('table_tags'):
+                config.rename(table_config_path, f'{vrfs_current[vrf_name]}')
+        # Replace table values
+        if table_config_lines.get('table_values'):
+            for table_config_path in table_config_lines.get('table_values'):
+                config.set(table_config_path,
+                           f'{vrfs_current[vrf_name]}',
+                           replace=True)
+
+    # Check VRF name
+    if name_regex.match(vrf_name):
+        vrf_name_new = None
+        while not vrf_name_new:
+            vrf_name_rand = f'{choice(ascii_lowercase)}{vrf_name}'[:15]
+            if vrf_name_rand not in vrfs_current:
+                vrf_name_new = vrf_name_rand
+        # Update VRF name to a new one
+        config.rename(['vrf', 'name', vrf_name], vrf_name_new)
+        # Check config items with old VRF name and replace to new one
+        config_commands = config.to_commands().split('\n')
+        vrf_config_lines = _search_vrfs(config_commands, vrf_name)
+        # Rename VRF to a new name
+        if vrf_config_lines:
+            for vrf_value_path in vrf_config_lines:
+                config.set(vrf_value_path, vrf_name_new, replace=True)
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)

--- a/src/validators/vrf-name
+++ b/src/validators/vrf-name
@@ -33,8 +33,8 @@ if __name__ == '__main__':
     if vrf == "lo":
         exit(1)
 
-    pattern = "^(?!(bond|br|dum|eth|lan|eno|ens|enp|enx|gnv|ipoe|l2tp|l2tpeth|" \
-              "vtun|ppp|pppoe|peth|tun|vti|vxlan|wg|wlan|wwan)\d+(\.\d+(v.+)?)?$).*$"
+    pattern = r'^(?!(bond|br|dum|eth|lan|eno|ens|enp|enx|gnv|ipoe|l2tp|l2tpeth|\
+       vtun|ppp|pppoe|peth|tun|vti|vxlan|wg|wlan|wwan|\d)\d*(\.\d+)?(v.+)?).*$'
     if not re.match(pattern, vrf):
         exit(1)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Proper connection tracking for VRFs

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe): 

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3655

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
VRF, nftables, conntrack

## Proposed changes
<!--- Describe your changes in detail -->
Currently, all VRFs share the same connection tracking table, which can
lead to problems:

- traffic leaks to a wrong VRF
- improper NAT rules handling when multiple VRFs contain the same IP
networks
- stateful firewall rules issues

The commit implements connection tracking zones support. Each VRF
utilizes its own zone, so connections will never mix up.

It also adds some restrictions to VRF names and assigned table numbers,
because of nftables and conntrack requirements:

- VRF name should always start from a letter (interfaces that start from
numbers are not supported in nftables rules)
- table number must be in the 100-65535 range because conntrack supports
only 65535 zones

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Topology for test:

- eth0 and eth1 are connected to the same L2 domain;
- eth2 is connected to Internet via gateway with IP `192.168.122.1`

Minimum config to reproduce the original problem:
```
set interfaces ethernet eth0 address '192.168.0.101/24'
set interfaces ethernet eth0 vrf 'VRF1'
set interfaces ethernet eth1 address '192.168.0.102/24'
set interfaces ethernet eth1 vrf 'VRF2'
set interfaces ethernet eth2 address '192.168.122.103/24'
set interfaces ethernet eth2 vrf 'VRF2'
set nat source rule 100 outbound-interface 'eth2'
set nat source rule 100 translation address 'masquerade'
set vrf name VRF1 protocols static route 0.0.0.0/0 next-hop 192.168.0.102 interface 'eth0'
set vrf name VRF1 table '101'
set vrf name VRF2 protocols static route 0.0.0.0/0 next-hop 192.168.122.1
set vrf name VRF2 table '102'
```
After trying to ping something from VRF1 (`ping 8.8.8.8 vrf VRF1 count 1`), we may see the next conntrack table:
```
icmp     1 26 src=192.168.0.101 dst=8.8.8.8 type=8 code=0 id=3446 [UNREPLIED] src=8.8.8.8 dst=192.168.0.101 type=0 code=0 id=3446 mark=0 use=1
```
There is only single entry for this ICMP exchange and NAT actually does not performs, because of already existing conntrack entry.

After this PR situation will be different:
```
icmp     1 28 src=192.168.0.101 dst=8.8.8.8 type=8 code=0 id=51761 src=8.8.8.8 dst=192.168.122.103 type=0 code=0 id=51761 mark=0 zone=26112 use=1
icmp     1 28 src=192.168.0.101 dst=8.8.8.8 type=8 code=0 id=51761 src=8.8.8.8 dst=192.168.0.101 type=0 code=0 id=51761 mark=0 zone=25856 use=1
```
There will be two entries - for each VRF.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
