### PR TITLE
pki: wireguard: T3642: Migrate Wireguard private key directly into CLI

### DIFF
--- a/interface-definitions/interfaces-wireguard.xml.in
+++ b/interface-definitions/interfaces-wireguard.xml.in
@@ -42,12 +42,12 @@
           </leafNode>
           <leafNode name="private-key">
             <properties>
-              <help>Private key to use on that interface</help>
-              <completionHelp>
-                <script>${vyos_op_scripts_dir}/wireguard.py --listkdir</script>
-              </completionHelp>
+              <help>Base64 encoded private key</help>
+              <constraint>
+                <regex>[0-9a-zA-Z\+/]{43}=$</regex>
+              </constraint>
+              <constraintErrorMessage>Key is not valid 44-character (32-bytes) base64</constraintErrorMessage>
             </properties>
-            <defaultValue>default</defaultValue>
           </leafNode>
           <tagNode name="peer">
             <properties>
@@ -59,7 +59,7 @@
             </properties>
             <children>
               #include <include/generic-disable-node.xml.i>
-              <leafNode name="pubkey">
+              <leafNode name="public-key">
                 <properties>
                   <help>base64 encoded public key</help>
                   <constraint>

--- a/op-mode-definitions/wireguard.xml.in
+++ b/op-mode-definitions/wireguard.xml.in
@@ -8,24 +8,6 @@
           <help>Generate Wireguard keys</help>
         </properties>
         <children>
-          <leafNode name="default-keypair">
-            <properties>
-              <help>Generate the default Wireguard keypair</help>
-            </properties>
-            <command>sudo ${vyos_op_scripts_dir}/wireguard.py --genkey</command>
-          </leafNode>
-          <leafNode name="preshared-key">
-            <properties>
-              <help>Generate a Wireguard preshared key</help>
-            </properties>
-            <command>${vyos_op_scripts_dir}/wireguard.py --genpsk</command>
-          </leafNode>
-          <tagNode name="named-keypairs">
-            <properties>
-              <help>Generate specified Wireguard keypairs</help>
-            </properties>
-            <command>sudo ${vyos_op_scripts_dir}/wireguard.py --genkey --location "$4"</command>
-          </tagNode>
           <tagNode name="client-config">
             <properties>
               <help>Generate Client config QR code</help>
@@ -94,25 +76,20 @@
               <help>Show Wireguard keys</help>
             </properties>
             <children>
-              <tagNode name="pubkey">
+              <leafNode name="pubkey">
                 <properties>
-                  <help>Show specified Wireguard public key</help>
-                  <completionHelp>
-                    <script>${vyos_op_scripts_dir}/wireguard.py --listkdir</script>
-                  </completionHelp>
+                  <help>Show Wireguard public keys</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/wireguard.py --showpub --location "$5"</command>
-              </tagNode>
-              <tagNode name="privkey">
+                <command>${vyos_op_scripts_dir}/wireguard.py --showpub</command>
+              </leafNode>
+              <leafNode name="privkey">
                 <properties>
-                  <help>Show specified Wireguard private key</help>
-                  <completionHelp>
-                    <script>${vyos_op_scripts_dir}/wireguard.py --listkdir</script>
-                  </completionHelp>
+                  <help>Show Wireguard private keys</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/wireguard.py --showpriv --location "$5"</command>
-              </tagNode>
+                <command>${vyos_op_scripts_dir}/wireguard.py --showpriv</command>
+              </leafNode>
             </children>
+            <command>${vyos_op_scripts_dir}/wireguard.py --showpub --showpriv</command>
           </node>
         </children>
       </node>

--- a/src/migration-scripts/interfaces/22-to-23
+++ b/src/migration-scripts/interfaces/22-to-23
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# A VTI interface also requires an IPSec configuration - VyOS 1.2 supported
+# having a VTI interface in the CLI but no IPSec configuration - drop VTI
+# configuration if this is the case for VyOS 1.4
+
+import os
+import sys
+from vyos.configtree import ConfigTree
+
+if __name__ == '__main__':
+    if (len(sys.argv) < 1):
+        print("Must specify file name!")
+        sys.exit(1)
+
+    file_name = sys.argv[1]
+
+    with open(file_name, 'r') as f:
+        config_file = f.read()
+
+    config = ConfigTree(config_file)
+    base = ['interfaces', 'wireguard']
+    if not config.exists(base):
+        # Nothing to do
+        sys.exit(0)
+
+    for interface in config.list_nodes(base):
+        private_key_path = base + [interface, 'private-key']
+        
+        key_file = 'default'
+        if config.exists(private_key_path):
+            key_file = config.return_value(private_key_path)
+
+        full_key_path = f'/config/auth/wireguard/{key_file}/private.key'
+
+        if not os.path.exists(full_key_path):
+            print(f'Could not find wireguard private key for migration on interface "{interface}"')
+            continue
+
+        with open(full_key_path, 'r') as f:
+            key_data = f.read().strip()
+            config.set(private_key_path, value=key_data)
+
+        for peer in config.list_nodes(base + [interface, 'peer']):
+            config.rename(base + [interface, 'peer', peer, 'pubkey'], 'public-key')
+
+    try:
+        with open(file_name, 'w') as f:
+            f.write(config.to_string())
+    except OSError as e:
+        print("Failed to save the modified config: {}".format(e))
+        sys.exit(1)

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -215,7 +215,7 @@ def install_wireguard_key(name, private_key, public_key):
         print("")
         print("Public key for use on peer configuration: " + public_key)
     else:
-        print("set interfaces wireguard [INTERFACE] peer %s pubkey '%s'" % (name, public_key))
+        print("set interfaces wireguard [INTERFACE] peer %s public-key '%s'" % (name, public_key))
         print("")
         print("Private key for use on peer configuration: " + private_key)
 

--- a/src/op_mode/wireguard.py
+++ b/src/op_mode/wireguard.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2020 VyOS maintainers and contributors
+# Copyright (C) 2018-2021 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -15,132 +15,65 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
-import os
 import sys
-import shutil
-import syslog as sl
-import re
+import tabulate
 
 from vyos.config import Config
 from vyos.ifconfig import WireGuardIf
 from vyos.util import cmd
-from vyos.util import run
-from vyos.util import check_kmod
 from vyos import ConfigError
 
-dir = r'/config/auth/wireguard'
-psk = dir + '/preshared.key'
+base = ['interfaces', 'wireguard']
 
-k_mod = 'wireguard'
+def get_public_keys():
+    config = Config()
+    headers = ['Interface', 'Peer', 'Public Key']
+    out = []
+    if config.exists(base):
+        wg_interfaces = config.get_config_dict(base, key_mangling=('-', '_'),
+                                             get_first_key=True,
+                                             no_tag_node_value_mangle=True)
 
-def generate_keypair(pk, pub):
-    """ generates a keypair which is stored in /config/auth/wireguard """
-    old_umask = os.umask(0o027)
-    if run(f'wg genkey | tee {pk} | wg pubkey > {pub}') != 0:
-        raise ConfigError("wireguard key-pair generation failed")
-    else:
-        sl.syslog(
-            sl.LOG_NOTICE, "new keypair wireguard key generated in " + dir)
-    os.umask(old_umask)
+        for wg, wg_conf in wg_interfaces.items():
+            if 'peer' in wg_conf:
+                for peer, peer_conf in wg_conf['peer'].items():
+                    out.append([wg, peer, peer_conf['public_key']])
 
+    print("Wireguard Public Keys:")
+    print(tabulate.tabulate(out, headers))
 
-def genkey(location):
-    """ helper function to check, regenerate the keypair """
-    pk = "{}/private.key".format(location)
-    pub = "{}/public.key".format(location)
-    old_umask = os.umask(0o027)
-    if os.path.exists(pk) and os.path.exists(pub):
-        try:
-            choice = input(
-                "You already have a wireguard key-pair, do you want to re-generate? [y/n] ")
-            if choice == 'y' or choice == 'Y':
-                generate_keypair(pk, pub)
-        except KeyboardInterrupt:
-            sys.exit(0)
-    else:
-        """ if keypair is bing executed from a running iso """
-        if not os.path.exists(location):
-            run(f'sudo mkdir -p {location}')
-            run(f'sudo chgrp vyattacfg {location}')
-            run(f'sudo chmod 750 {location}')
-        generate_keypair(pk, pub)
-    os.umask(old_umask)
+def get_private_keys():
+    config = Config()
+    headers = ['Interface', 'Private Key', 'Public Key']
+    out = []
+    if config.exists(base):
+        wg_interfaces = config.get_config_dict(base, key_mangling=('-', '_'),
+                                             get_first_key=True,
+                                             no_tag_node_value_mangle=True)
 
+        for wg, wg_conf in wg_interfaces.items():
+            private_key = wg_conf['private_key']
+            public_key = cmd('wg pubkey', input=private_key)
+            out.append([wg, private_key, public_key])
 
-def showkey(key):
-    """ helper function to show privkey or pubkey """
-    if os.path.exists(key):
-        print (open(key).read().strip())
-    else:
-        print ("{} not found".format(key))
-
-
-def genpsk():
-    """
-        generates a preshared key and shows it on stdout,
-        it's stored only in the cli config
-    """
-
-    psk = cmd('wg genpsk')
-    print(psk)
-
-def list_key_dirs():
-    """ lists all dirs under /config/auth/wireguard """
-    if os.path.exists(dir):
-        nks = next(os.walk(dir))[1]
-        for nk in nks:
-            print (nk)
-
-def del_key_dir(kname):
-    """ deletes /config/auth/wireguard/<kname> """
-    kdir = "{0}/{1}".format(dir,kname)
-    if not os.path.isdir(kdir):
-        print ("named keypair {} not found".format(kname))
-        return 1
-    shutil.rmtree(kdir)
-
+    print("Wireguard Private Keys:")
+    print(tabulate.tabulate(out, headers))
 
 if __name__ == '__main__':
-    check_kmod(k_mod)
     parser = argparse.ArgumentParser(description='wireguard key management')
     parser.add_argument(
-        '--genkey', action="store_true", help='generate key-pair')
+        '--showpub', action="store_true", help='shows public keys')
     parser.add_argument(
-        '--showpub', action="store_true", help='shows public key')
-    parser.add_argument(
-        '--showpriv', action="store_true", help='shows private key')
-    parser.add_argument(
-        '--genpsk', action="store_true", help='generates preshared-key')
-    parser.add_argument(
-        '--location', action="store", help='key location within {}'.format(dir))
-    parser.add_argument(
-        '--listkdir', action="store_true", help='lists named keydirectories')
-    parser.add_argument(
-        '--delkdir', action="store_true", help='removes named keydirectories')
+        '--showpriv', action="store_true", help='shows private keys')
     parser.add_argument(
         '--showinterface', action="store", help='shows interface details')
     args = parser.parse_args()
 
     try:
-        if args.genkey:
-            if args.location:
-                genkey("{0}/{1}".format(dir, args.location))
-            else:
-                genkey("{}/default".format(dir))
         if args.showpub:
-            if args.location:
-                showkey("{0}/{1}/public.key".format(dir, args.location))
-            else:
-                showkey("{}/default/public.key".format(dir))
+            get_public_keys()
         if args.showpriv:
-            if args.location:
-                showkey("{0}/{1}/private.key".format(dir, args.location))
-            else:
-                showkey("{}/default/private.key".format(dir))
-        if args.genpsk:
-            genpsk()
-        if args.listkdir:
-            list_key_dirs()
+            get_private_keys()
         if args.showinterface:
             try:
                 intf = WireGuardIf(args.showinterface, create=False, debug=False)
@@ -148,11 +81,6 @@ if __name__ == '__main__':
             # the interface does not exists
             except Exception:
                 pass
-        if args.delkdir:
-            if args.location:
-                del_key_dir(args.location)
-            else:
-                del_key_dir("default")
 
     except ConfigError as e:
         print(e)

--- a/src/op_mode/wireguard_client.py
+++ b/src/op_mode/wireguard_client.py
@@ -38,7 +38,7 @@ To enable this configuration on a VyOS router you can use the following commands
 {% for addr in address if address is defined %}
 set interfaces wireguard {{ interface }} peer {{ name }} allowed-ips '{{ addr }}'
 {% endfor %}
-set interfaces wireguard {{ interface }} peer {{ name }} pubkey '{{ pubkey }}'
+set interfaces wireguard {{ interface }} peer {{ name }} public-key '{{ pubkey }}'
 """
 
 client_config = """


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Migrates Wireguard private-key from /config/auth into CLI, and makes updates for PKI

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3642

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pki, wireguard

## Proposed changes
<!--- Describe your changes in detail -->
- Migrate wireguard `private-key` directly into CLI instead of linking to file
- Rename peer `pubkey` to `public-key` for naming consistency
- Removes `generate wireguard` op-mode commands in favour of `generate pki wireguard` equivalents
- Wireguard op-mode `show wireguard key-pairs ...` commands are updated

**Requires:
https://github.com/vyos/vyos-build/pull/177
https://github.com/vyos/vyatta-cfg-system/pull/156**

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
- Migrations have been tested for both private-key and peer public-key changes.
- Smoketests are updated to reflect new syntax and pass.
- Successfully tested wireguard connections with new syntax, and with migrated syntax.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
