### PR TITLE
pki: openconnect: sstp: T3642: Migrate OpenConnect and SSTP to PKI configuration

### DIFF
--- a/data/templates/accel-ppp/sstp.config.tmpl
+++ b/data/templates/accel-ppp/sstp.config.tmpl
@@ -29,9 +29,9 @@ disable
 verbose=1
 ifname=sstp%d
 accept=ssl
-ssl-ca-file={{ ssl.ca_cert_file }}
-ssl-pemfile={{ ssl.cert_file }}
-ssl-keyfile={{ ssl.key_file }}
+ssl-ca-file=/run/accel-pppd/sstp-ca.pem
+ssl-pemfile=/run/accel-pppd/sstp-cert.pem
+ssl-keyfile=/run/accel-pppd/sstp-cert.key
 
 {# Common IP pool definitions #}
 {% include 'accel-ppp/config_ip_pool.j2' %}

--- a/data/templates/ocserv/ocserv_config.tmpl
+++ b/data/templates/ocserv/ocserv_config.tmpl
@@ -12,16 +12,16 @@ auth = "radius [config=/run/ocserv/radiusclient.conf]"
 auth = "plain[/run/ocserv/ocpasswd]"
 {% endif %}
 
-{% if ssl.cert_file %}
-server-cert = {{  ssl.cert_file }}
+{% if ssl.certificate is defined %}
+server-cert = /run/ocserv/cert.pem
+server-key = /run/ocserv/cert.key
+{% if ssl.passphrase is defined %}
+key-pin = {{ ssl.passphrase }}
+{% endif %}
 {% endif %}
 
-{% if ssl.key_file %}
-server-key = {{  ssl.key_file }}
-{% endif %}
-
-{% if ssl.ca_cert_file %}
-ca-cert = {{  ssl.ca_cert_file }}
+{% if ssl.ca_certificate is defined %}
+ca-cert = /run/ocserv/ca.pem
 {% endif %}
 
 socket-file = /run/ocserv/ocserv.socket

--- a/interface-definitions/vpn_openconnect.xml.in
+++ b/interface-definitions/vpn_openconnect.xml.in
@@ -75,7 +75,7 @@
           </node>
           <node name="listen-ports">
             <properties>
-              <help>SSL Certificate, SSL Key and CA (/config/auth)</help>
+              <help>Specify custom ports to use for client connections</help>
             </properties>
             <children>
               <leafNode name="tcp">
@@ -108,12 +108,11 @@
           </node>
           <node name="ssl">
             <properties>
-              <help>SSL Certificate, SSL Key and CA (/config/auth)</help>
+              <help>SSL Certificate, SSL Key and CA</help>
             </properties>
             <children>
-              #include <include/certificate.xml.i>
-              #include <include/certificate-ca.xml.i>
-              #include <include/certificate-key.xml.i>
+              #include <include/pki/ca-certificate.xml.i>
+              #include <include/pki/certificate-key.xml.i>
             </children>
           </node>
           <node name="network-settings">

--- a/interface-definitions/vpn_sstp.xml.in
+++ b/interface-definitions/vpn_sstp.xml.in
@@ -50,12 +50,11 @@
           </node>
           <node name="ssl">
             <properties>
-              <help>SSL Certificate, SSL Key and CA (/config/user-data/sstp)</help>
+              <help>SSL Certificate, SSL Key and CA</help>
             </properties>
             <children>
-              #include <include/certificate.xml.i>
-              #include <include/certificate-ca.xml.i>
-              #include <include/certificate-key.xml.i>
+              #include <include/pki/ca-certificate.xml.i>
+              #include <include/pki/certificate.xml.i>
             </children>
           </node>
         </children>

--- a/smoketest/configs/pki-misc
+++ b/smoketest/configs/pki-misc
@@ -1,0 +1,69 @@
+interfaces {
+    ethernet eth0 {
+        address 192.168.150.1/24
+    }
+}
+system {
+    config-management {
+        commit-revisions 100
+    }
+    console {
+        device ttyS0 {
+            speed 115200
+        }
+    }
+    host-name vyos
+    login {
+        user vyos {
+            authentication {
+                encrypted-password $6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/
+                plaintext-password ""
+            }
+        }
+    }
+    ntp {
+        server time1.vyos.net {
+        }
+        server time2.vyos.net {
+        }
+        server time3.vyos.net {
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level info
+            }
+            facility protocols {
+                level debug
+            }
+        }
+    }
+}
+vpn {
+    openconnect {
+        authentication {
+            local-users {
+                username test {
+                    password test
+                }
+            }
+            mode local
+        }
+        network-settings {
+            client-ip-settings {
+                subnet 192.168.160.0/24
+            }
+        }
+        ssl {
+            ca-cert-file /config/auth/ovpn_test_ca.pem
+            cert-file /config/auth/ovpn_test_server.pem
+            key-file /config/auth/ovpn_test_server.key
+        }
+    }
+}
+
+
+// Warning: Do not remove the following line.
+// vyos-config-version: "bgp@1:broadcast-relay@1:cluster@1:config-management@1:conntrack@2:conntrack-sync@2:dhcp-relay@2:dhcp-server@5:dhcpv6-server@1:dns-forwarding@3:firewall@5:https@2:interfaces@22:ipoe-server@1:ipsec@6:isis@1:l2tp@3:lldp@1:mdns@1:nat@5:nat66@1:ntp@1:policy@1:pppoe-server@5:pptp@2:qos@1:quagga@9:rpki@1:salt@1:snmp@2:ssh@2:sstp@3:system@21:vrf@2:vrrp@2:vyos-accel-ppp@2:wanloadbalance@3:webproxy@2:zone-policy@1"
+// Release version: 1.4-rolling-202106290839

--- a/smoketest/configs/pki-misc
+++ b/smoketest/configs/pki-misc
@@ -61,6 +61,26 @@ vpn {
             key-file /config/auth/ovpn_test_server.key
         }
     }
+    sstp {
+        authentication {
+            local-users {
+                username test {
+                    password test
+                }
+            }
+            mode local
+            protocols mschap-v2
+        }
+        client-ip-pool {
+            subnet 192.168.170.0/24
+        }
+        gateway-address 192.168.150.1
+        ssl {
+            ca-cert-file /config/auth/ovpn_test_ca.pem
+            cert-file /config/auth/ovpn_test_server.pem
+            key-file /config/auth/ovpn_test_server.key
+        }
+    }
 }
 
 

--- a/smoketest/scripts/cli/test_vpn_openconnect.py
+++ b/smoketest/scripts/cli/test_vpn_openconnect.py
@@ -23,25 +23,33 @@ from vyos.util import process_named_running
 
 OCSERV_CONF = '/run/ocserv/ocserv.conf'
 base_path = ['vpn', 'openconnect']
-cert = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
-cert_key = '/etc/ssl/private/ssl-cert-snakeoil.key'
+
+pki_path = ['pki']
+cert_data = 'MIICFDCCAbugAwIBAgIUfMbIsB/ozMXijYgUYG80T1ry+mcwCgYIKoZIzj0EAwIwWTELMAkGA1UEBhMCR0IxEzARBgNVBAgMClNvbWUtU3RhdGUxEjAQBgNVBAcMCVNvbWUtQ2l0eTENMAsGA1UECgwEVnlPUzESMBAGA1UEAwwJVnlPUyBUZXN0MB4XDTIxMDcyMDEyNDUxMloXDTI2MDcxOTEyNDUxMlowWTELMAkGA1UEBhMCR0IxEzARBgNVBAgMClNvbWUtU3RhdGUxEjAQBgNVBAcMCVNvbWUtQ2l0eTENMAsGA1UECgwEVnlPUzESMBAGA1UEAwwJVnlPUyBUZXN0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE01HrLcNttqq4/PtoMua8rMWEkOdBu7vP94xzDO7A8C92ls1v86eePy4QllKCzIw3QxBIoCuH2peGRfWgPRdFsKNhMF8wDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAYYwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMBMB0GA1UdDgQWBBSu+JnU5ZC4mkuEpqg2+Mk4K79oeDAKBggqhkjOPQQDAgNHADBEAiBEFdzQ/Bc3LftzngrY605UhA6UprHhAogKgROv7iR4QgIgEFUxTtW3xXJcnUPWhhUFhyZoqfn8dE93+dm/LDnp7C0='
+key_data = 'MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgPLpD0Ohhoq0g4nhx2KMIuze7ucKUt/lBEB2wc03IxXyhRANCAATTUestw222qrj8+2gy5rysxYSQ50G7u8/3jHMM7sDwL3aWzW/zp54/LhCWUoLMjDdDEEigK4fal4ZF9aA9F0Ww'
 
 class TestVpnOpenconnect(VyOSUnitTestSHIM.TestCase):
     def tearDown(self):
         # Delete vpn openconnect configuration
+        self.cli_delete(pki_path)
         self.cli_delete(base_path)
         self.cli_commit()
 
     def test_vpn(self):
         user = 'vyos_user'
         password = 'vyos_pass'
+        self.cli_delete(pki_path)
         self.cli_delete(base_path)
+
+        self.cli_set(pki_path + ['ca', 'openconnect', 'certificate', cert_data])
+        self.cli_set(pki_path + ['certificate', 'openconnect', 'certificate', cert_data])
+        self.cli_set(pki_path + ['certificate', 'openconnect', 'private', 'key', key_data])
+
         self.cli_set(base_path + ["authentication", "local-users", "username", user, "password", password])
         self.cli_set(base_path + ["authentication", "mode", "local"])
         self.cli_set(base_path + ["network-settings", "client-ip-settings", "subnet", "192.0.2.0/24"])
-        self.cli_set(base_path + ["ssl", "ca-cert-file", cert])
-        self.cli_set(base_path + ["ssl", "cert-file", cert])
-        self.cli_set(base_path + ["ssl", "key-file", cert_key])
+        self.cli_set(base_path + ["ssl", "ca-certificate", 'openconnect'])
+        self.cli_set(base_path + ["ssl", "certificate", 'openconnect'])
 
         self.cli_commit()
 

--- a/src/migration-scripts/openconnect/0-to-1
+++ b/src/migration-scripts/openconnect/0-to-1
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# - Update SSL to use PKI configuration
+
+import os
+
+from sys import argv
+from sys import exit
+from vyos.configtree import ConfigTree
+from vyos.pki import load_certificate
+from vyos.pki import load_crl
+from vyos.pki import load_private_key
+from vyos.pki import encode_certificate
+from vyos.pki import encode_private_key
+from vyos.util import run
+
+if (len(argv) < 1):
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+base = ['vpn', 'openconnect']
+pki_base = ['pki']
+
+if not config.exists(base):
+    exit(0)
+
+AUTH_DIR = '/config/auth'
+
+def wrapped_pem_to_config_value(pem):
+    return "".join(pem.strip().split("\n")[1:-1])
+
+if not config.exists(base + ['ssl']):
+    exit(0)
+
+x509_base = base + ['ssl']
+pki_name = 'openconnect'
+
+if not config.exists(pki_base + ['ca']):
+    config.set(pki_base + ['ca'])
+    config.set_tag(pki_base + ['ca'])
+
+if not config.exists(pki_base + ['certificate']):
+    config.set(pki_base + ['certificate'])
+    config.set_tag(pki_base + ['certificate'])
+
+if config.exists(x509_base + ['ca-cert-file']):
+    cert_file = config.return_value(x509_base + ['ca-cert-file'])
+    cert_path = os.path.join(AUTH_DIR, cert_file)
+    cert = None
+
+    if os.path.isfile(cert_path):
+        if not os.access(cert_path, os.R_OK):
+            run(f'sudo chmod 644 {cert_path}')
+
+        with open(cert_path, 'r') as f:
+            cert_data = f.read()
+            cert = load_certificate(cert_data, wrap_tags=False)
+
+    if cert:
+        cert_pem = encode_certificate(cert)
+        config.set(pki_base + ['ca', pki_name, 'certificate'], value=wrapped_pem_to_config_value(cert_pem))
+        config.set(x509_base + ['ca-certificate'], value=pki_name)
+    else:
+        print(f'Failed to migrate CA certificate on openconnect config')
+
+    config.delete(x509_base + ['ca-cert-file'])
+
+if config.exists(x509_base + ['cert-file']):
+    cert_file = config.return_value(x509_base + ['cert-file'])
+    cert_path = os.path.join(AUTH_DIR, cert_file)
+    cert = None
+
+    if os.path.isfile(cert_path):
+        if not os.access(cert_path, os.R_OK):
+            run(f'sudo chmod 644 {cert_path}')
+
+        with open(cert_path, 'r') as f:
+            cert_data = f.read()
+            cert = load_certificate(cert_data, wrap_tags=False)
+
+    if cert:
+        cert_pem = encode_certificate(cert)
+        config.set(pki_base + ['certificate', pki_name, 'certificate'], value=wrapped_pem_to_config_value(cert_pem))
+        config.set(x509_base + ['certificate'], value=pki_name)
+    else:
+        print(f'Failed to migrate certificate on openconnect config')
+
+    config.delete(x509_base + ['cert-file'])
+
+if config.exists(x509_base + ['key-file']):
+    key_file = config.return_value(x509_base + ['key-file'])
+    key_path = os.path.join(AUTH_DIR, key_file)
+    key = None
+
+    if os.path.isfile(key_path):
+        if not os.access(key_path, os.R_OK):
+            run(f'sudo chmod 644 {key_path}')
+
+        with open(key_path, 'r') as f:
+            key_data = f.read()
+            key = load_private_key(key_data, passphrase=None, wrap_tags=False)
+
+    if key:
+        key_pem = encode_private_key(key, passphrase=None)
+        config.set(pki_base + ['certificate', pki_name, 'private', 'key'], value=wrapped_pem_to_config_value(key_pem))
+    else:
+        print(f'Failed to migrate private key on openconnect config')
+        
+    config.delete(x509_base + ['key-file'])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)

--- a/src/migration-scripts/sstp/3-to-4
+++ b/src/migration-scripts/sstp/3-to-4
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# - Update SSL to use PKI configuration
+
+import os
+
+from sys import argv
+from sys import exit
+from vyos.configtree import ConfigTree
+from vyos.pki import load_certificate
+from vyos.pki import load_crl
+from vyos.pki import load_private_key
+from vyos.pki import encode_certificate
+from vyos.pki import encode_private_key
+from vyos.util import run
+
+if (len(argv) < 1):
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+base = ['vpn', 'sstp']
+pki_base = ['pki']
+
+if not config.exists(base):
+    exit(0)
+
+AUTH_DIR = '/config/auth'
+
+def wrapped_pem_to_config_value(pem):
+    return "".join(pem.strip().split("\n")[1:-1])
+
+if not config.exists(base + ['ssl']):
+    exit(0)
+
+x509_base = base + ['ssl']
+pki_name = 'sstp'
+
+if not config.exists(pki_base + ['ca']):
+    config.set(pki_base + ['ca'])
+    config.set_tag(pki_base + ['ca'])
+
+if not config.exists(pki_base + ['certificate']):
+    config.set(pki_base + ['certificate'])
+    config.set_tag(pki_base + ['certificate'])
+
+if config.exists(x509_base + ['ca-cert-file']):
+    cert_file = config.return_value(x509_base + ['ca-cert-file'])
+    cert_path = os.path.join(AUTH_DIR, cert_file)
+    cert = None
+
+    if os.path.isfile(cert_path):
+        if not os.access(cert_path, os.R_OK):
+            run(f'sudo chmod 644 {cert_path}')
+
+        with open(cert_path, 'r') as f:
+            cert_data = f.read()
+            cert = load_certificate(cert_data, wrap_tags=False)
+
+    if cert:
+        cert_pem = encode_certificate(cert)
+        config.set(pki_base + ['ca', pki_name, 'certificate'], value=wrapped_pem_to_config_value(cert_pem))
+        config.set(x509_base + ['ca-certificate'], value=pki_name)
+    else:
+        print(f'Failed to migrate CA certificate on sstp config')
+
+    config.delete(x509_base + ['ca-cert-file'])
+
+if config.exists(x509_base + ['cert-file']):
+    cert_file = config.return_value(x509_base + ['cert-file'])
+    cert_path = os.path.join(AUTH_DIR, cert_file)
+    cert = None
+
+    if os.path.isfile(cert_path):
+        if not os.access(cert_path, os.R_OK):
+            run(f'sudo chmod 644 {cert_path}')
+
+        with open(cert_path, 'r') as f:
+            cert_data = f.read()
+            cert = load_certificate(cert_data, wrap_tags=False)
+
+    if cert:
+        cert_pem = encode_certificate(cert)
+        config.set(pki_base + ['certificate', pki_name, 'certificate'], value=wrapped_pem_to_config_value(cert_pem))
+        config.set(x509_base + ['certificate'], value=pki_name)
+    else:
+        print(f'Failed to migrate certificate on sstp config')
+
+    config.delete(x509_base + ['cert-file'])
+
+if config.exists(x509_base + ['key-file']):
+    key_file = config.return_value(x509_base + ['key-file'])
+    key_path = os.path.join(AUTH_DIR, key_file)
+    key = None
+
+    if os.path.isfile(key_path):
+        if not os.access(key_path, os.R_OK):
+            run(f'sudo chmod 644 {key_path}')
+
+        with open(key_path, 'r') as f:
+            key_data = f.read()
+            key = load_private_key(key_data, passphrase=None, wrap_tags=False)
+
+    if key:
+        key_pem = encode_private_key(key, passphrase=None)
+        config.set(pki_base + ['certificate', pki_name, 'private', 'key'], value=wrapped_pem_to_config_value(key_pem))
+    else:
+        print(f'Failed to migrate private key on sstp config')
+        
+    config.delete(x509_base + ['key-file'])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Migrates OpenConnect and SSTP to use new PKI configuration

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3642

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pki, openconnect, sstp

## Proposed changes
<!--- Describe your changes in detail -->
Changes OpenConnect and SSTP to use new PKI configuration
Added migrations for each and updated smoketests for new syntax

**Requires: https://github.com/vyos/vyatta-cfg-system/pull/157**

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Migrations properly updated the config for new syntax, adding PKI entries for existing certificates.
Smoketests were updated and ran successfully with new syntax.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
