### PR TITLE
VXLAN: T3683: Fix for ipv6 source-interface option

### DIFF
--- a/python/vyos/ifconfig/vxlan.py
+++ b/python/vyos/ifconfig/vxlan.py
@@ -79,8 +79,9 @@ class VXLANIf(Interface):
             cmdline.append('remote')
 
         if self.config['group'] or self.config['source_interface']:
-            if self.config['group'] and self.config['source_interface']:
+            if self.config['group']:
                 cmdline.append('group')
+            if self.config['source_interface']:
                 cmdline.append('source_interface')
             else:
                 ifname = self.config['ifname']


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
For ipv6 VXLAN, source interface it's a required option.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3683

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vxlan
## Proposed changes
<!--- Describe your changes in detail -->
Ipv6 requires a source interface option and may not contain a multicast group option.
## How to test
Before fix:
```
set interfaces vxlan vxlan0 mtu '1430'
set interfaces vxlan vxlan0 remote 'fe80::2'
set interfaces vxlan vxlan0 source-address 'fe80::3'
set interfaces vxlan vxlan0 source-interface 'eth0'
set interfaces vxlan vxlan0 vni '0'

vyos@r4-1.3# commit
[ interfaces vxlan vxlan0 ]
WARNING: RFC7348 recommends VXLAN tunnels preserve a 1500 byte MTU
VXLAN "vxlan0" is missing mandatory underlay multicastgroup or source interface for a multicast network.

[[interfaces vxlan vxlan0]] failed
Commit failed
[edit]
vyos@r4-1.3# 
```
With fix:
```
set interfaces vxlan vxlan0 mtu '1430'
set interfaces vxlan vxlan0 remote 'fe80::2'
set interfaces vxlan vxlan0 source-address 'fe80::3'
set interfaces vxlan vxlan0 source-interface 'eth0'
set interfaces vxlan vxlan0 vni '0'

vyos@r4-1.3# commit
[ interfaces vxlan vxlan0 ]
WARNING: RFC7348 recommends VXLAN tunnels preserve a 1500 byte MTU

[edit]
vyos@r4-1.3# sudo ip -d link show dev vxlan0
5: vxlan0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1430 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 6e:a4:2b:c2:ee:1c brd ff:ff:ff:ff:ff:ff promiscuity 0 minmtu 68 maxmtu 65535 
    vxlan id 0 remote fe80::2 local fe80::3 dev eth0 srcport 0 0 dstport 8472 ttl 16 ageing 300 udpcsum noudp6zerocsumtx noudp6zerocsumrx addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 
[edit]
vyos@r4-1.3# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
