### PR TITLE
bridge: T3700: Support VLAN tunnel mapping of VLAN aware bridges

### DIFF
--- a/interface-definitions/include/interface/tunnel-external.xml.i
+++ b/interface-definitions/include/interface/tunnel-external.xml.i
@@ -1,0 +1,8 @@
+<!-- include start from interface/tunnel-external.xml.i -->
+<leafNode name="external">
+  <properties>
+    <help>make this tunnel externally controlled</help>
+    <valueless/>
+  </properties>
+</leafNode>
+<!-- include end from interface/tunnel-external.xml.i -->

--- a/interface-definitions/include/interface/vxlan-endpoint.xml.i
+++ b/interface-definitions/include/interface/vxlan-endpoint.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from interface/vxlan-endpoint.xml.i -->
+<leafNode name="port">
+  <properties>
+    <help>Destination port of VXLAN tunnel (default: 8472)</help>
+    <valueHelp>
+    <format>u32:1-65535</format>
+      <description>Numeric IP port</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-65535"/>
+    </constraint>
+  </properties>
+</leafNode>
+#include <include/interface/tunnel-remote.xml.i>
+<!-- include end from interface/vxlan-endpoint.xml.i -->

--- a/interface-definitions/interfaces-bridge.xml.in
+++ b/interface-definitions/interfaces-bridge.xml.in
@@ -119,6 +119,35 @@
                   </completionHelp>
                 </properties>
                 <children>
+                  <tagNode name="vlan-tunnel">
+                    <properties>
+                      <help>Set the VLAN tunnel ID of the interface</help>
+                      <valueHelp>
+                        <format>1-429496729</format>
+                        <description>Set the VLAN tunnel ID of the interface</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-429496729"/>
+                      </constraint>
+                      <constraintErrorMessage>TUNNEL ID must be between 1 and 429496729</constraintErrorMessage>
+                    </properties>
+                    <children>
+                      <leafNode name="vlan">
+                        <properties>
+                          <help>Set VLAN ID of tunnel ID mapping</help>
+                          <valueHelp>
+                            <format>&lt;id&gt;</format>
+                            <description>VLAN id allowed to pass this interface</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-4094"/>
+                          </constraint>
+                          <constraintErrorMessage>VLAN ID must be between 1 and 4094</constraintErrorMessage>
+                        </properties>
+                      </leafNode>
+                      #include <include/interface/vxlan-endpoint.xml.i>
+                    </children>
+                  </tagNode>
                   <leafNode name="native-vlan">
                     <properties>
                       <help>Specify VLAN id which should natively be present on the link</help>

--- a/interface-definitions/interfaces-vxlan.xml.in
+++ b/interface-definitions/interfaces-vxlan.xml.in
@@ -82,8 +82,9 @@
           </leafNode>
           #include <include/source-address-ipv4-ipv6.xml.i>
           #include <include/source-interface.xml.i>
-          #include <include/interface/tunnel-remote.xml.i>
+          #include <include/interface/vxlan-endpoint.xml.i>
           #include <include/interface/vrf.xml.i>
+          #include <include/interface/tunnel-external.xml.i>
           #include <include/vni.xml.i>
         </children>
       </tagNode>

--- a/op-mode-definitions/show-bridge.xml.in
+++ b/op-mode-definitions/show-bridge.xml.in
@@ -13,13 +13,19 @@
             </properties>
             <command>bridge -c vlan show</command>
           </leafNode>
+          <leafNode name="vlan-tunnel">
+            <properties>
+              <help>View the VLAN Tunnel Info settings of the bridge</help>
+            </properties>
+            <command>bridge -c vlan tunnelshow</command>
+          </leafNode>
         </children>
       </node>
       <leafNode name="bridge">
         <properties>
           <help>Show bridging information</help>
         </properties>
-        <command>bridge -c link show</command>
+        <command>bridge -c -d link show</command>
       </leafNode>
       <tagNode name="bridge">
         <properties>

--- a/python/vyos/ifconfig/vxlan.py
+++ b/python/vyos/ifconfig/vxlan.py
@@ -63,9 +63,10 @@ class VXLANIf(Interface):
             'parameters.ip.ttl'          : 'ttl',
             'parameters.ipv6.flowlabel'  : 'flowlabel',
             'parameters.nolearning'      : 'nolearning',
+            'vni'                        : 'id'
         }
 
-        cmd = 'ip link add {ifname} type {type} id {vni} dstport {port}'
+        cmd = 'ip link add {ifname} type {type} dstport {port}'
         for vyos_key, iproute2_key in mapping.items():
             # dict_search will return an empty dict "{}" for valueless nodes like
             # "parameters.nolearning" - thus we need to test the nodes existence
@@ -75,6 +76,9 @@ class VXLANIf(Interface):
                 cmd += f' {iproute2_key}'
             elif tmp != None:
                 cmd += f' {iproute2_key} {tmp}'
+        
+        if 'external' in self.config:
+            cmd += ' external'
 
         self._cmd(cmd.format(**self.config))
         # interface is always A/D down. It needs to be enabled explicitly

--- a/smoketest/scripts/cli/test_interfaces_bridge.py
+++ b/smoketest/scripts/cli/test_interfaces_bridge.py
@@ -147,6 +147,99 @@ class BridgeInterfaceTest(BasicInterfaceTest.TestCase):
             base = self._base_path + [interface]
             self.cli_set(base + ['enable-vlan'])
         super().test_vif_8021q_mtu_limits()
+    
+    def test_bridge_vlan_tunnel_mapping(self):
+        vif_vlan = 2
+        # Add member interface to bridge and set VLAN filter
+        vxlan_interface = 'vxlan0'
+        for interface in self._interfaces:
+            base = self._base_path + [interface]
+            self.cli_set(['interfaces', 'ethernet', 'eth0', 'address', '192.168.2.1/24'])
+            self.cli_set(['interfaces', 'vxlan', vxlan_interface, 'external'])
+            self.cli_set(['interfaces', 'vxlan', vxlan_interface, 'mtu', '1500'])
+            self.cli_set(['interfaces', 'vxlan', vxlan_interface, 'source-address', '192.168.2.1'])
+            self.cli_set(base + ['enable-vlan'])
+            self.cli_set(base + ['vif', str(vif_vlan), 'address', '192.0.3.1/24'])
+            self.cli_set(base + ['vif', str(vif_vlan), 'mtu', self._mtu])
+
+            vlan_id = 101
+            allowed_vlan = 2
+            allowed_vlan_range = '4-9'
+            # assign members to bridge interface
+            base_member = base + ['member', 'interface', vxlan_interface]
+            self.cli_set(base_member + ['allowed-vlan', str(allowed_vlan)])
+            self.cli_set(base_member + ['allowed-vlan', allowed_vlan_range])
+            self.cli_set(base_member + ['vlan-tunnel', str(vlan_id), 'vlan', str(vlan_id)])
+            self.cli_set(base_member + ['vlan-tunnel', str(vlan_id), 'remote', '192.0.2.2'])
+
+        # commit config
+        self.cli_commit()
+
+        # Detect the vlan filter function
+        for interface in self._interfaces:
+            tmp = read_file(f'/sys/class/net/{interface}/bridge/vlan_filtering')
+            self.assertEqual(tmp, '1')
+
+        # Execute the program to obtain status information
+        json_data = cmd('bridge -j vlan show', shell=True)
+        vlan_filter_status = None
+        vlan_filter_status = json.loads(json_data)
+
+        if vlan_filter_status is not None:
+            for interface_status in vlan_filter_status:
+                ifname = interface_status['ifname']
+                for interface in self._members:
+                    vlan_success = 0;
+                    if interface == ifname:
+                        vlans_status = interface_status['vlans']
+                        for vlan_status in vlans_status:
+                            vlan_id = vlan_status['vlan']
+                            flag_num = 0
+                            if 'flags' in vlan_status:
+                                flags = vlan_status['flags']
+                                for flag in flags:
+                                    flag_num = flag_num +1
+                            if vlan_id == 2:
+                                if flag_num == 0:
+                                    vlan_success = vlan_success + 1
+                            else:
+                                for id in range(4,10):
+                                    if vlan_id == id:
+                                        if flag_num == 0:
+                                            vlan_success = vlan_success + 1
+                                if vlan_id >= 101:
+                                    if flag_num == 2:
+                                        vlan_success = vlan_success + 1
+                        if vlan_success >= 7:
+                            self.assertTrue(True)
+                        else:
+                            self.assertTrue(False)
+
+        else:
+            self.assertTrue(False)
+            
+        json_data = cmd('bridge -j vlan tunnelshow', shell=True)
+        vlan_tunnel_status = None
+        vlan_tunnel_status = json.loads(json_data)
+        
+        if vlan_tunnel_status is not None:
+            vlan_success = 0;
+            for tunnel_status in vlan_tunnel_status:
+                ifname = tunnel_status['ifname']
+                vlan_tunnel_status = tunnel_status['tunnels']
+                for tunnel_status in vlan_tunnel_status:
+                    vlan_id = tunnel_status['vlan']
+                    tunnel_id = tunnel_status['tunid']
+                    self.assertEqual(vlan_id, tunnel_id)
+                    vlan_success += 1
+            self.assertEqual(vlan_success, 1)
+
+        # delete all members
+        for interface in self._interfaces:
+            self.cli_delete(self._base_path + [interface, 'member'])
+        
+        self.cli_delete(['interfaces', 'ethernet', 'eth0'])
+        self.cli_delete(['interfaces', 'vxlan', 'vxlan0'])
 
     def test_bridge_vlan_filter(self):
         vif_vlan = 2

--- a/src/conf_mode/interfaces-bridge.py
+++ b/src/conf_mode/interfaces-bridge.py
@@ -138,9 +138,18 @@ def verify(bridge):
                 if 'wlan' in interface:
                     raise ConfigError(error_msg + 'VLAN aware cannot be set!')
             else:
-                for option in ['allowed_vlan', 'native_vlan']:
+                for option in ['allowed_vlan', 'native_vlan', 'vlan_tunnel']:
                     if option in interface_config:
                         raise ConfigError('Can not use VLAN options on non VLAN aware bridge')
+            
+            if 'vlan_tunnel' in interface_config:
+                for tunnel_id, tunnel_mapping_config in interface_config['vlan_tunnel'].items():
+                    for option in ['vlan', 'remote']:
+                        if option not in tunnel_mapping_config:
+                            raise ConfigError(f'vlan-tunnel mapping configuration is incomplete. {option} options must be set')
+                # VLAN tunnel mapping can only be applied to vxlan tunnels
+                if 'vxlan' not in interface:
+                    raise ConfigError(error_msg + 'VLAN Tunnel Mapping cannot be set!')
 
     if 'enable_vlan' in bridge:
         if dict_search('vif.1', bridge):

--- a/src/conf_mode/interfaces-vxlan.py
+++ b/src/conf_mode/interfaces-vxlan.py
@@ -43,6 +43,9 @@ def get_config(config=None):
         conf = Config()
     base = ['interfaces', 'vxlan']
     vxlan = get_interface_dict(conf, base)
+    
+    if 'port' not in vxlan:
+        vxlan['port'] = '8472'
 
     return vxlan
 
@@ -63,8 +66,11 @@ def verify(vxlan):
     if not any(tmp in ['group', 'remote', 'source_address'] for tmp in vxlan):
         raise ConfigError('Group, remote or source-address must be configured')
 
-    if 'vni' not in vxlan:
-        raise ConfigError('Must configure VNI for VXLAN')
+    if 'external' not in vxlan and 'vni' not in vxlan:
+        raise ConfigError('VNI must be configured for vxlan or the external flag must be turned on')
+    
+    if 'external' in vxlan and 'vni' in vxlan:
+        raise ConfigError('You can only turn on the external flag or configure VNI for vxlan. The two options cannot exist at the same time')
 
     if 'source_interface' in vxlan:
         # VXLAN adds at least an overhead of 50 byte - we need to check the


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Support VLAN tunnel mapping of VLAN aware bridges

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3700

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bridge

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

![图片](https://user-images.githubusercontent.com/9047180/126909721-dceb7597-31a5-4833-a033-cce4aa06f2b1.png)


example for vyos a:

```
set interfaces ethernet eth0 address 192.168.122.2/24
set interfaces vxlan vxlan0 external
set interfaces vxlan vxlan0 source-address 192.168.122.2
set interfaces vxlan vxlan0 mtu 1500
set interfaces bridge br0 enable-vlan
set interfaces bridge br0 vif 2 address 192.168.111.1/24
set interfaces bridge br0 member interface vxlan0 vlan-tunnel 10 vlan 2
set interfaces bridge br0 member interface vxlan0 vlan-tunnel 10 remote 192.168.122.3
commit
```

example for vyos b:

```
set interfaces ethernet eth0 address 192.168.122.3/24
set interfaces vxlan vxlan0 external
set interfaces vxlan vxlan0 source-address 192.168.122.3
set interfaces vxlan vxlan0 mtu 1500
set interfaces bridge br0 enable-vlan
set interfaces bridge br0 vif 2 address 192.168.111.2/24
set interfaces bridge br0 member interface vxlan0 vlan-tunnel 10 vlan 2
set interfaces bridge br0 member interface vxlan0 vlan-tunnel 10 remote 192.168.122.2
commit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
