### PR TITLE
vyos-1x-vmware: T3681: don't bytecompile ether-resume.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ clean:
 
 .PHONY: test
 test:
-	set -e; python3 -m compileall -q .
+	set -e; python3 -m compileall -q -x '/vmware-tools/scripts/' .
 	PYTHONPATH=python/ python3 -m "nose" --with-xunit src --with-coverage --cover-erase --cover-xml --cover-package src/conf_mode,src/op_mode,src/completion,src/helpers,src/validators,src/tests --verbose
 
 .PHONY: sonar


### PR DESCRIPTION
Exclude /vmware-tools/scripts/ from bytecompilation to avoid the `__pycache__` directory being created.
Note this is a backport to equuleus, the change was already committed to the current branch.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Fixes suspend and resume warning of VMware due to open-vm-tools script not able to handle the `__pycache__` directory.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3681

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

vyos-1x-vmware

## Proposed changes
<!--- Describe your changes in detail -->

The `__pycache__` directory in `/etc/vmware-tools/scripts/resume-vm-default.d/__pycache__` causes errors by the vmware resume script. This change avoids the creation of the `__pycache__` directory.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Suspend and resume VyOS with VMware Fusion or Workstation, and check for error popup.
Alternative way to check using the vmware shell scripts is described in https://phabricator.vyos.net/T3681

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
