### PR TITLE
vyos-1x-vmware: T3682: remove dhclient from ether-resume.py

### DIFF
--- a/src/etc/vmware-tools/scripts/resume-vm-default.d/ether-resume.py
+++ b/src/etc/vmware-tools/scripts/resume-vm-default.d/ether-resume.py
@@ -25,9 +25,8 @@ def get_config():
     c = Config()
     interfaces = dict()
     for intf in c.list_effective_nodes('interfaces ethernet'):
-        # skip interfaces that are disabled or is configured for dhcp
+        # skip interfaces that are disabled
         check_disable = f'interfaces ethernet {intf} disable'
-        check_dhcp = f'interfaces ethernet {intf} address dhcp'
         if c.exists_effective(check_disable):
             continue
 
@@ -49,10 +48,10 @@ def apply(config):
 
         # add configured addresses to interface
         for addr in addresses:
-            if addr == 'dhcp':
-                cmd = ['dhclient', intf]
-            else:
-                cmd = f'ip address add {addr} dev {intf}'
+            # dhcp is handled by netplug
+            if addr in ['dhcp', 'dhcpv6']:
+                continue
+            cmd = f'ip address add {addr} dev {intf}'
             syslog.syslog(cmd)
             run(cmd)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

Note this is a backport to equuleus, the original change was already commited to the current branch.

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

dhclient is already handled by netplug so it's removed to avoid double renewing of dhcp leases.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3682

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

vyos-1x-vmware

## Proposed changes
<!--- Describe your changes in detail -->

Removed the dhclient code part, which was already broken due to it being a list instead of a string. (breaks the  `syslog.syslog()` function). Refactored that when an address is `dhcp` or `dhcpv6` it is skipped and also documented that this is handled by netplug in a comment.

Also removed some dead/unused code.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Example:

1. configure eth0 interface with static address
2. configure eth1 interface with dhcp or dhcpv6 address
3. pause and resume vm using VMware
4. check if static address is assigned on eth0 again
    *  grep ether-resume /var/log/messages
5. check if dhcp address is assigned on eth1 again
   *  journalctl -u netplug

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
