### PR TITLE
openvpn: T65: Fix auth-user-pass authentication only

### DIFF
--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -332,7 +332,7 @@ def verify(openvpn):
         if 'ca_cert_file' not in openvpn['tls']:
             raise ConfigError('Must specify "tls ca-cert-file"')
 
-        if not (openvpn['mode'] == 'client' and 'auth_file' in openvpn['tls']):
+        if not (openvpn['mode'] == 'client' and 'authentication' in openvpn):
             if 'cert_file' not in openvpn['tls']:
                 raise ConfigError('Missing "tls cert-file"')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Username and password authentication only (without any tls client certs) is broken since the test_interfaces_openvpn script was ported from Perl to Python. This patch fixes it again.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->

* https://phabricator.vyos.net/T56
* https://phabricator.vyos.net/T65

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

openvpn

## Proposed changes
<!--- Describe your changes in detail -->

'auh_file' should be 'authentication'

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

The following minimal configuration with username+password auth only should work now:
```
set interfaces openvpn vtun0 mode client
set interfaces openvpn vtun0 remote-host 127.0.0.1
set interfaces openvpn vtun0 tls ca-cert-file /config/auth/vpn/ca.crt
set interfaces openvpn vtun0 authentication username user
set interfaces openvpn vtun0 authentication username pass
commit
```

Without this patch, the check will complain about:  Missing "tls cert-file"
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
