### PR TITLE
isis: T3693: Adding IPv6 redistribution to ISIS

### DIFF
--- a/data/templates/frr/isis.frr.tmpl
+++ b/data/templates/frr/isis.frr.tmpl
@@ -116,18 +116,33 @@ router isis VyOS {{ 'vrf ' + vrf if vrf is defined and vrf is not none }}
 {%     endfor %}
 {%   endfor %}
 {% endif %}
-{% if redistribute is defined and redistribute.ipv4 is defined and redistribute.ipv4 is not none %}
-{%   for protocol in redistribute.ipv4 %}
-{%     for level, level_config in redistribute.ipv4[protocol].items() %}
-{%       if level_config.metric is defined and level_config.metric is not none %}
+{% if redistribute is defined %} 
+{%   if redistribute.ipv4 is defined and redistribute.ipv4 is not none %}
+{%     for protocol, protocol_options in redistribute.ipv4.items() %}
+{%       for level, level_config in redistribute.ipv4.protocol.items() %}
+{%         if level_config.metric is defined and level_config.metric is not none %}
  redistribute ipv4 {{ protocol }} {{ level | replace('_', '-') }} metric {{ level_config.metric }}
-{%       elif level_config.route_map is defined and level_config.route_map is not none %}
+{%         elif level_config.route_map is defined and level_config.route_map is not none %}
  redistribute ipv4 {{ protocol }} {{ level | replace('_', '-') }} route-map {{ level_config.route_map }}
-{%       else %}
+{%         else %}
  redistribute ipv4 {{ protocol }} {{ level | replace('_', '-') }}
-{%       endif %}
+{%         endif %}
+{%       endfor %}
 {%     endfor %}
-{%   endfor %}
+{%   endif %}
+{%   if redistribute.ipv6 is defined and redistribute.ipv6 is not none %}
+{%     for protocol, protocol_options in redistribute.ipv6.items() %}
+{%       for level, level_config in redistribute.ipv6.protocol.items() %}
+{%         if level_config.metric is defined and level_config.metric is not none %}
+ redistribute ipv6 {{ protocol }} {{ level | replace('_', '-') }} metric {{ level_config.metric }}
+{%         elif level_config.route_map is defined and level_config.route_map is not none %}
+ redistribute ipv6 {{ protocol }} {{ level | replace('_', '-') }} route-map {{ level_config.route_map }}
+{%         else %}
+ redistribute ipv6 {{ protocol }} {{ level | replace('_', '-') }}
+{%         endif %}
+{%       endfor %}
+{%     endfor %}
+{%   endif %}
 {% endif %}
 {% if level is defined and level is not none %}
 {%   if level == 'level-2'  %}

--- a/interface-definitions/include/isis/protocol-common-config.xml.i
+++ b/interface-definitions/include/isis/protocol-common-config.xml.i
@@ -492,6 +492,61 @@
         </node>
       </children>
     </node>
+    <node name="ipv6">
+      <properties>
+        <help>Redistribute IPv6 routes</help>
+      </properties>
+      <children>
+        <node name="bgp">
+          <properties>
+            <help>Redistribute BGP routes into IS-IS</help>
+          </properties>
+          <children>
+            #include <include/isis/redistribute-ipv6.xml.i>
+          </children>
+        </node>
+        <node name="connected">
+          <properties>
+            <help>Redistribute connected routes into IS-IS</help>
+          </properties>
+          <children>
+            #include <include/isis/redistribute-ipv6.xml.i>
+          </children>
+        </node>
+        <node name="kernel">
+          <properties>
+            <help>Redistribute kernel routes into IS-IS</help>
+          </properties>
+          <children>
+            #include <include/isis/redistribute-ipv6.xml.i>
+          </children>
+        </node>
+        <node name="ospf6">
+          <properties>
+            <help>Redistribute OSPFv3 routes into IS-IS</help>
+          </properties>
+          <children>
+            #include <include/isis/redistribute-ipv6.xml.i>
+          </children>
+        </node>
+        <node name="ripng">
+          <properties>
+            <help>Redistribute RIPng routes into IS-IS</help>
+          </properties>
+          <children>
+            #include <include/isis/redistribute-ipv6.xml.i>
+          </children>
+        </node>
+        <node name="static">
+          <properties>
+            <help>Redistribute static routes into IS-IS</help>
+          </properties>
+          <children>
+            #include <include/isis/redistribute-ipv6.xml.i>
+          </children>
+        </node>
+      </children>
+    </node>
   </children>
 </node>
 <leafNode name="set-attached-bit">

--- a/interface-definitions/include/isis/redistribute-ipv6.xml.i
+++ b/interface-definitions/include/isis/redistribute-ipv6.xml.i
@@ -1,0 +1,42 @@
+<!-- include start from isis/redistribute-ipv6.xml.i -->
+<node name="level-1">
+  <properties>
+    <help>Redistribute into level-1</help>
+  </properties>
+  <children>
+    <leafNode name="metric">
+      <properties>
+        <help>Metric for redistributed routes</help>
+        <valueHelp>
+          <format>u32:0-16777215</format>
+          <description>ISIS default metric</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 0-16777215"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    #include <include/route-map.xml.i>
+  </children>
+</node>
+<node name="level-2">
+  <properties>
+    <help>Redistribute into level-2</help>
+  </properties>
+  <children>
+    <leafNode name="metric">
+      <properties>
+        <help>Metric for redistributed routes</help>
+        <valueHelp>
+          <format>u32:0-16777215</format>
+          <description>ISIS default metric</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 0-16777215"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    #include <include/route-map.xml.i>
+  </children>
+</node>
+<!-- include end -->

--- a/src/conf_mode/protocols_isis.py
+++ b/src/conf_mode/protocols_isis.py
@@ -149,7 +149,7 @@ def verify(isis):
     # If Redistribute set, but level don't set
     if 'redistribute' in isis:
         proc_level = isis.get('level','').replace('-','_')
-        for afi in ['ipv4']:
+        for afi in ['ipv4', 'ipv6']:
             if afi not in isis['redistribute']:
                 continue
 


### PR DESCRIPTION
In this commit we add the ability to redistribute into
ISIS for IPv6 address family.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

In this change, we are just adding IPv6 redistribution for ISIS. We also make a check in the protocols_isis.py as well. But specifically this will allow for IPv6 to be redistributed for all protocols supported configured within VyOS so far.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3693

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
isis

## Proposed changes
<!--- Describe your changes in detail -->
The additions are mostly just expansion from the existing IPv4 ISIS redistribution configurations. This unfortunately doesn't get too much deeper or too much complicated than that.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

I tested using the following config:

```
set protocols isis interface lo
set protocols isis net '49.0001.1921.6800.1002.00'
set protocols isis redistribute ipv4 bgp level-1 route-map 'EXPORT-ISIS'
set protocols isis redistribute ipv4 bgp level-2 route-map 'EXPORT-ISIS'
set protocols isis redistribute ipv4 connected level-1 route-map 'EXPORT-ISIS'
set protocols isis redistribute ipv4 connected level-2 route-map 'EXPORT-ISIS'
set protocols isis redistribute ipv4 kernel level-1 route-map 'EXPORT-ISIS'
set protocols isis redistribute ipv4 kernel level-2 route-map 'EXPORT-ISIS'
set protocols isis redistribute ipv4 ospf level-1 route-map 'EXPORT-ISIS'
set protocols isis redistribute ipv4 ospf level-2 route-map 'EXPORT-ISIS'
set protocols isis redistribute ipv4 rip level-1 route-map 'EXPORT-ISIS'
set protocols isis redistribute ipv4 rip level-2 route-map 'EXPORT-ISIS'
set protocols isis redistribute ipv4 static level-1 route-map 'EXPORT-ISIS'
set protocols isis redistribute ipv4 static level-2 route-map 'EXPORT-ISIS'
set protocols isis redistribute ipv6 bgp level-1 route-map 'EXPORT-ISIS-6'
set protocols isis redistribute ipv6 bgp level-2 route-map 'EXPORT-ISIS-6'
set protocols isis redistribute ipv6 connected level-1 route-map 'EXPORT-ISIS-6'
set protocols isis redistribute ipv6 connected level-2 route-map 'EXPORT-ISIS-6'
set protocols isis redistribute ipv6 kernel level-1 route-map 'EXPORT-ISIS-6'
set protocols isis redistribute ipv6 kernel level-2 route-map 'EXPORT-ISIS-6'
set protocols isis redistribute ipv6 ospf6 level-1 route-map 'EXPORT-ISIS-6'
set protocols isis redistribute ipv6 ospf6 level-2 route-map 'EXPORT-ISIS-6'
set protocols isis redistribute ipv6 ripng level-1 route-map 'EXPORT-ISIS-6'
set protocols isis redistribute ipv6 ripng level-2 route-map 'EXPORT-ISIS-6'
set protocols isis redistribute ipv6 static level-1 route-map 'EXPORT-ISIS-6'
set protocols isis redistribute ipv6 static level-2 route-map 'EXPORT-ISIS-6'
```

This is the config of FRR before we add the above config:

```
Every 0.2s: vtysh -c '''show run'''                                                                                                                                                                                                                                                          vyos: Sun Jul 25 20:26:43 2021

Building configuration...

Current configuration:
!
frr version 7.5.1-20201222-185-gb3f4ff1d9
frr defaults traditional
hostname vyos
log syslog
log facility local7
service integrated-vtysh-config
!
ip route 0.0.0.0/0 10.0.0.65
!
interface eth0
 ip router isis VyOS
 ipv6 router isis VyOS
!
router isis VyOS
!
ip prefix-list EXPORT-ISIS seq 10 permit 203.0.113.0/24
!
ipv6 prefix-list EXPORT-ISIS-6 seq 10 permit 2001::/64
!
route-map EXPORT-ISIS permit 10
 match ip address prefix-list EXPORT-ISIS
!
route-map EXPORT-ISIS-6 permit 10
 match ipv6 address prefix-list EXPORT-ISIS-6
!
route-map foo-isis-in permit 10
!
line vty
!
end
```

After we add the config, the FRR portion looks like this:

```
Every 0.2s: vtysh -c '''show run'''                                                                                                                                                                                                                                                          vyos: Sun Jul 25 20:27:33 2021

Building configuration...

Current configuration:
!
frr version 7.5.1-20201222-185-gb3f4ff1d9
frr defaults traditional
hostname vyos
log syslog
log facility local7
service integrated-vtysh-config
!
ip route 0.0.0.0/0 10.0.0.65
!
interface eth0
 ip router isis VyOS
 ipv6 router isis VyOS
!
interface lo
 ip router isis VyOS
 ipv6 router isis VyOS
 isis passive
!
router isis VyOS
 net 49.0001.1921.6800.1002.00
 redistribute ipv4 bgp level-1 route-map EXPORT-ISIS
 redistribute ipv4 bgp level-2 route-map EXPORT-ISIS
 redistribute ipv4 connected level-1 route-map EXPORT-ISIS
 redistribute ipv4 connected level-2 route-map EXPORT-ISIS
 redistribute ipv4 kernel level-1 route-map EXPORT-ISIS
 redistribute ipv4 kernel level-2 route-map EXPORT-ISIS
 redistribute ipv4 ospf level-1 route-map EXPORT-ISIS
 redistribute ipv4 ospf level-2 route-map EXPORT-ISIS
 redistribute ipv4 rip level-1 route-map EXPORT-ISIS
 redistribute ipv4 rip level-2 route-map EXPORT-ISIS
 redistribute ipv4 static level-1 route-map EXPORT-ISIS
 redistribute ipv4 static level-2 route-map EXPORT-ISIS
 redistribute ipv6 bgp level-1 route-map EXPORT-ISIS-6
 redistribute ipv6 bgp level-2 route-map EXPORT-ISIS-6
 redistribute ipv6 connected level-1 route-map EXPORT-ISIS-6
 redistribute ipv6 connected level-2 route-map EXPORT-ISIS-6
 redistribute ipv6 kernel level-1 route-map EXPORT-ISIS-6
 redistribute ipv6 kernel level-2 route-map EXPORT-ISIS-6
 redistribute ipv6 ospf6 level-1 route-map EXPORT-ISIS-6
 redistribute ipv6 ospf6 level-2 route-map EXPORT-ISIS-6
 redistribute ipv6 ripng level-1 route-map EXPORT-ISIS-6
 redistribute ipv6 ripng level-2 route-map EXPORT-ISIS-6
 redistribute ipv6 static level-1 route-map EXPORT-ISIS-6
 redistribute ipv6 static level-2 route-map EXPORT-ISIS-6
!
ip prefix-list EXPORT-ISIS seq 10 permit 203.0.113.0/24
!
ipv6 prefix-list EXPORT-ISIS-6 seq 10 permit 2001::/64
!
route-map EXPORT-ISIS permit 10
 match ip address prefix-list EXPORT-ISIS
!
route-map EXPORT-ISIS-6 permit 10
 match ipv6 address prefix-list EXPORT-ISIS-6
!
route-map foo-isis-in permit 10
!
line vty
!
end
```



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly


I am unsure if we need documentation addition but we absolutely can. Another thing is the smoketest. I will be needing help on this as well. But I have verified the configs here do work properly.