### PR TITLE
configd: T3694: always set script.argv

### DIFF
--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -133,8 +133,7 @@ def explicit_print(path, mode, msg):
         logger.critical("error explicit_print")
 
 def run_script(script, config, args) -> int:
-    if args:
-        script.argv = args
+    script.argv = args
     config.set_level([])
     try:
         c = script.get_config(config)
@@ -208,7 +207,7 @@ def process_node_data(config, data) -> int:
         return R_ERROR_DAEMON
 
     script_name = None
-    args = None
+    args = []
 
     res = re.match(r'^(VYOS_TAGNODE_VALUE=[^/]+)?.*\/([^/]+).py(.*)', data)
     if res.group(1):
@@ -221,7 +220,7 @@ def process_node_data(config, data) -> int:
         return R_ERROR_DAEMON
     if res.group(3):
         args = res.group(3).split()
-        args.insert(0, f'{script_name}.py')
+    args.insert(0, f'{script_name}.py')
 
     if script_name not in include_set:
         return R_PASS


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Always set `script.argv` in vyos-configd.

Several scripts imported by vyos-configd (including `src/conf_mode/protocols_static.py`) rely on `argv` for operating on VRFs.  Always setting `script.argv` in `src/services/vyos-configd` ensures those scripts will operate on the default VRF when called with no arguments.  Otherwise, a stale `argv` might cause those scripts to operate on the last modified VRF instead of the default VRF.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3694

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* configd

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
configure
set vrf name MGMT table 100
set interfaces ethernet eth0 vrf MGMT
set interfaces ethernet eth0 address 10.0.0.2/24
set interfaces ethernet eth1 address 192.168.251.2/24
set vrf name MGMT protocols static route 0.0.0.0/0 next-hop 10.0.0.1
commit
set protocols static route 0.0.0.0/0 next-hop 192.168.251.1
commit
exit
show ip route
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly