### PR TITLE
bgp: T1176: Add solo option for neighbor

### DIFF
--- a/data/templates/frr/bgpd.frr.tmpl
+++ b/data/templates/frr/bgpd.frr.tmpl
@@ -65,6 +65,9 @@
 {%   if config.shutdown is defined %}
  neighbor {{ neighbor }} shutdown
 {%   endif %}
+{%   if config.solo is defined %}
+ neighbor {{ neighbor }} solo
+{%   endif %}
 {%   if config.strict_capability_match is defined %}
  neighbor {{ neighbor }} strict-capability-match
 {%   endif %}

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -1038,6 +1038,12 @@
     </leafNode>
     #include <include/bgp/remote-as.xml.i>
     #include <include/bgp/neighbor-shutdown.xml.i>
+    <leafNode name="solo">
+      <properties>
+        <help>Do not send back prefixes learned from the neighbor</help>
+        <valueless/>
+      </properties>
+    </leafNode>
     <leafNode name="strict-capability-match">
       <properties>
         <help>Enable strict capability negotiation</help>

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -694,5 +694,21 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'  neighbor {interface} activate', frrconfig)
         self.assertIn(f' exit-address-family', frrconfig)
 
+    def test_bgp_13_solo(self):
+        remote_asn = str(int(ASN) + 150)
+        neighbor = '192.0.2.55'
+
+        self.cli_set(base_path + ['local-as', ASN])
+        self.cli_set(base_path + ['neighbor', neighbor, 'remote-as', remote_asn])
+        self.cli_set(base_path + ['neighbor', neighbor, 'solo'])
+
+        # commit changes
+        self.cli_commit()
+
+        # Verify FRR bgpd configuration
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
+        self.assertIn(f'router bgp {ASN}', frrconfig)
+        self.assertIn(f' neighbor {neighbor} solo', frrconfig)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add bgp option "solo" for neighbor.
It prevents sending routes back to ebgp neighbor, from which this prefix was received.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T1176

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure 1 ebgp neighbor and receive some prefixes from him.
With option "solo" these prefixes shouldn't send back to this neighbor.

```
set protocols bgp local-as '65002'
set protocols bgp neighbor 203.0.113.1 remote-as '65001'
set protocols bgp neighbor 203.0.113.1 solo


vyos@r1-roll:~$ show ip bgp neighbors 203.0.113.1 routes | match 100
Default local pref 100, local AS 65002
*> 100.64.1.0/24    203.0.113.1              0             0 65001 i
*> 100.64.2.0/24    203.0.113.1              0             0 65001 i
vyos@r1-roll:~$ 
vyos@r1-roll:~$ show ip bgp neighbors 203.0.113.1 advertised-routes | match 100
vyos@r1-roll:~$ 

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
