### PR TITLE
bridge: T3715: Standby port supporting

### DIFF
--- a/interface-definitions/interfaces-bridge.xml.in
+++ b/interface-definitions/interfaces-bridge.xml.in
@@ -184,6 +184,14 @@
                       <valueless/>
                     </properties>
                   </leafNode>
+                  <leafNode name="backup-port">
+                    <properties>
+                      <help>If the port loses carrier all traffic will be redirected to the configured backup port</help>
+                      <completionHelp>
+                        <script>${vyos_completion_dir}/list_interfaces.py --bridgeable</script>
+                      </completionHelp>
+                    </properties>
+                  </leafNode>
                 </children>
               </tagNode>
             </children>

--- a/interface-definitions/interfaces-bridge.xml.in
+++ b/interface-definitions/interfaces-bridge.xml.in
@@ -190,6 +190,10 @@
                       <completionHelp>
                         <script>${vyos_completion_dir}/list_interfaces.py --bridgeable</script>
                       </completionHelp>
+                      <constraint>
+                        <validator name="interface-name-eth"/>
+                      </constraint>
+                      <constraintErrorMessage>Device is not a ethernet interface and cannot be used as an alternate port!</constraintErrorMessage>
                     </properties>
                   </leafNode>
                 </children>

--- a/src/conf_mode/interfaces-bridge.py
+++ b/src/conf_mode/interfaces-bridge.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import re
 
 from sys import exit
 from netifaces import interfaces
@@ -134,10 +133,6 @@ def verify(bridge):
             if 'backup_port' in interface_config and 'backup_port_exist' not in interface_config:
                 tmp = interface_config['backup_port']
                 raise ConfigError(error_msg + f'Device {tmp} is not a bridge member and cannot be used as an alternate port!')
-            
-            if 'backup_port' in interface_config and 'backup_port_exist' in interface_config:
-                if not re.search('^((eth|lan)[0-9]+|(eno|ens|enp|enx).+)$', interface):
-                    raise ConfigError(error_msg + f'Device {tmp} is not a ethernet interface and cannot be used as an alternate port!')
 
             if 'is_source_interface' in interface_config:
                 tmp = interface_config['is_source_interface']

--- a/src/validators/interface-name-eth
+++ b/src/validators/interface-name-eth
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import re
+
+from sys import argv
+from sys import exit
+
+pattern = '^(eth|lan)[0-9]+?|lo$'
+
+if __name__ == '__main__':
+    if len(argv) != 2:
+        exit(1)
+    interface = argv[1]
+
+    if re.match(pattern, interface):
+        exit(0)
+    if os.path.exists(f'/sys/class/net/{interface}'):
+        exit(0)
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Standby port supporting

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3715

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bridge

## Proposed changes
<!--- Describe your changes in detail -->
Standby port supporting

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
