### PR TITLE
PING: T3634: Fixing do not fragment to Ping

### DIFF
--- a/src/op_mode/ping.py
+++ b/src/op_mode/ping.py
@@ -51,7 +51,7 @@ options = {
         'help': 'Number of seconds before ping exits'
     },
     'do-not-fragment': {
-        'ping': '{command} -M dont',
+        'ping': '{command} -M do',
         'type': 'noarg',
         'help': 'Set DF-bit flag to 1 for no fragmentation'
     },


### PR DESCRIPTION
In this commit we fix the do not fragment capability
for ping commands. Sorry for messing it up earlier :(

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Just a small bugfix on the do not fragment command. I misread the man
page for ping on it. I fixed it now.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3634

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ping

## Proposed changes
<!--- Describe your changes in detail -->

Not much to describe here. Just fixed the command in linux ping.

## How to test
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
Normal:
sudo ip vrf exec default /bin/ping 10.0.0.65
PING 10.0.0.65 (10.0.0.65) 56(84) bytes of data.
64 bytes from 10.0.0.65: icmp_seq=1 ttl=64 time=0.109 ms
64 bytes from 10.0.0.65: icmp_seq=2 ttl=64 time=0.531 ms
64 bytes from 10.0.0.65: icmp_seq=3 ttl=64 time=0.173 ms
64 bytes from 10.0.0.65: icmp_seq=4 ttl=64 time=0.184 ms
64 bytes from 10.0.0.65: icmp_seq=5 ttl=64 time=0.207 ms
64 bytes from 10.0.0.65: icmp_seq=6 ttl=64 time=0.177 ms
64 bytes from 10.0.0.65: icmp_seq=7 ttl=64 time=0.192 ms
^C
--- 10.0.0.65 ping statistics ---
7 packets transmitted, 7 received, 0% packet loss, time 6173ms



Do not fragment:
vyos@vyos:~$ ping 10.0.0.65 do-not-fragment
sudo ip vrf exec default /bin/ping -M do 10.0.0.65
PING 10.0.0.65 (10.0.0.65) 56(84) bytes of data.
64 bytes from 10.0.0.65: icmp_seq=1 ttl=64 time=0.091 ms
64 bytes from 10.0.0.65: icmp_seq=2 ttl=64 time=0.171 ms
64 bytes from 10.0.0.65: icmp_seq=3 ttl=64 time=0.151 ms
64 bytes from 10.0.0.65: icmp_seq=4 ttl=64 time=0.194 ms
64 bytes from 10.0.0.65: icmp_seq=5 ttl=64 time=0.166 ms
64 bytes from 10.0.0.65: icmp_seq=6 ttl=64 time=0.181 ms
^C
--- 10.0.0.65 ping statistics ---
6 packets transmitted, 6 received, 0% packet loss, time 5128ms
rtt min/avg/max/mdev = 0.091/0.159/0.194/0.033 ms



Normal, large payload, but it still seems to just fail out:
vyos@vyos:~$ ping 10.0.0.65 size 1473
sudo ip vrf exec default /bin/ping -s 1473 10.0.0.65
PING 10.0.0.65 (10.0.0.65) 1473(1501) bytes of data.
^C
--- 10.0.0.65 ping statistics ---
4 packets transmitted, 0 received, 100% packet loss, time 3073ms



Do not fragment, actually shows the message too long for the MTU:
vyos@vyos:~$ ping 10.0.0.65 size 1473 do-not-fragment
sudo ip vrf exec default /bin/ping -s 1473 -M do 10.0.0.65
PING 10.0.0.65 (10.0.0.65) 1473(1501) bytes of data.
/bin/ping: local error: message too long, mtu=1500
/bin/ping: local error: message too long, mtu=1500
/bin/ping: local error: message too long, mtu=1500
/bin/ping: local error: message too long, mtu=1500
^C
--- 10.0.0.65 ping statistics ---
4 packets transmitted, 0 received, +4 errors, 100% packet loss, time 3072ms
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
