### PR TITLE
template: T3730: Add bracketize_ipv6 filter

### DIFF
--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -139,6 +139,13 @@ def address_from_cidr(prefix):
     from ipaddress import ip_network
     return str(ip_network(prefix).network_address)
 
+@register_filter('bracketize_ipv6')
+def bracketize_ipv6(address):
+    """ Place a passed IPv6 address into [] brackets, do nothing for IPv4 """
+    if is_ipv6(address):
+        return f'[{address}]'
+    return address
+
 @register_filter('netmask_from_cidr')
 def netmask_from_cidr(prefix):
     """ Take CIDR prefix and convert the prefix length to a "subnet mask".


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add bracketize_ipv6 filter.
It is required for some components. It was missed after migration contrack-sync to XML/Python for 1.3

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3730

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Show conntrack:
without filter:
```
  File "/usr/lib/python3/dist-packages/jinja2/compiler.py", line 70, in new_func
    return f(self, node, frame, **kwargs)
  File "/usr/lib/python3/dist-packages/jinja2/compiler.py", line 1578, in visit_Filter
    self.fail('no filter named %r' % node.name, node.lineno)
  File "/usr/lib/python3/dist-packages/jinja2/compiler.py", line 315, in fail
    raise TemplateAssertionError(msg, lineno, self.name, self.filename)
jinja2.exceptions.TemplateAssertionError: no filter named 'bracketize_ipv6'
vyos@r4-1.3:~$
```
With filter:
```
vyos@r4-1.3:~$ show conntrack-sync cache internal 
Main Table Entries:
Source                                           Destination                                      Protocol

Expect Table Entries:
Source                                           Destination                                      Protocol

vyos@r4-1.3:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
