### PR TITLE
pppoe-server: sstp-server: T3731: Define vpn type for ConfigError mes…

### DIFF
--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -307,7 +307,7 @@ def verify_vlan_config(config):
             verify_mtu_parent(c_vlan, config)
             verify_mtu_parent(c_vlan, s_vlan)
 
-def verify_accel_ppp_base_service(config):
+def verify_accel_ppp_base_service(config, vpn_type):
     """
     Common helper function which must be used by all Accel-PPP services based
     on get_config_dict()
@@ -315,7 +315,7 @@ def verify_accel_ppp_base_service(config):
     # vertify auth settings
     if dict_search('authentication.mode', config) == 'local':
         if not dict_search('authentication.local_users', config):
-            raise ConfigError('PPPoE local auth mode requires local users to be configured!')
+            raise ConfigError(vpn_type + ' local auth mode requires local users to be configured!')
 
         for user in dict_search('authentication.local_users.username', config):
             user_config = config['authentication']['local_users']['username'][user]
@@ -339,7 +339,7 @@ def verify_accel_ppp_base_service(config):
                 raise ConfigError(f'Missing RADIUS secret key for server "{server}"')
 
     if 'gateway_address' not in config:
-        raise ConfigError('PPPoE server requires gateway-address to be configured!')
+        raise ConfigError(vpn_type + ' server requires gateway-address to be configured!')
 
     if 'name_server_ipv4' in config:
         if len(config['name_server_ipv4']) > 2:

--- a/src/conf_mode/service_pppoe-server.py
+++ b/src/conf_mode/service_pppoe-server.py
@@ -48,7 +48,7 @@ def verify(pppoe):
     if not pppoe:
         return None
 
-    verify_accel_ppp_base_service(pppoe)
+    verify_accel_ppp_base_service(pppoe, 'PPPoE')
 
     if 'wins_server' in pppoe and len(pppoe['wins_server']) > 2:
         raise ConfigError('Not more then two IPv4 WINS name-servers can be configured')

--- a/src/conf_mode/vpn_sstp.py
+++ b/src/conf_mode/vpn_sstp.py
@@ -48,7 +48,7 @@ def verify(sstp):
     if not sstp:
         return None
 
-    verify_accel_ppp_base_service(sstp)
+    verify_accel_ppp_base_service(sstp, 'SSTP')
 
     if not sstp['client_ip_pool']:
         raise ConfigError('Client IP subnet required')


### PR DESCRIPTION
…sage

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3731

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
