### PR TITLE
snmp: T3709: Allow enable oid ipCidrRouteTable

### DIFF
--- a/data/templates/snmp/override.conf.tmpl
+++ b/data/templates/snmp/override.conf.tmpl
@@ -1,4 +1,5 @@
 {% set vrf_command = 'ip vrf exec ' + vrf + ' ' if vrf is defined else '' %}
+{% set oid_route_table = ' ' if route_table is sameas true else '-I -ipCidrRouteTable,inetCidrRouteTable' %}
 [Unit]
 StartLimitIntervalSec=0
 After=vyos-router.service
@@ -7,7 +8,7 @@ After=vyos-router.service
 Environment=
 Environment="MIBDIRS=/usr/share/snmp/mibs:/usr/share/snmp/mibs/iana:/usr/share/snmp/mibs/ietf:/usr/share/vyos/mibs"
 ExecStart=
-ExecStart={{vrf_command}}/usr/sbin/snmpd -LS0-5d -Lf /dev/null -u Debian-snmp -g Debian-snmp -I -ipCidrRouteTable,inetCidrRouteTable -f -p /run/snmpd.pid
+ExecStart={{vrf_command}}/usr/sbin/snmpd -LS0-5d -Lf /dev/null -u Debian-snmp -g Debian-snmp {{oid_route_table}} -f -p /run/snmpd.pid
 Restart=always
 RestartSec=10
 

--- a/interface-definitions/snmp.xml.in
+++ b/interface-definitions/snmp.xml.in
@@ -129,6 +129,26 @@
               <constraintErrorMessage>Location is limited to 255 characters or less</constraintErrorMessage>
             </properties>
           </leafNode>
+          <leafNode name="oid-enable">
+            <properties>
+              <help>Enable specific oids</help>
+              <valueHelp>
+                <format>txt</format>
+                <description>Enable specific oids</description>
+              </valueHelp>
+              <valueHelp>
+                <format>route-table</format>
+                <description>Enable route table oids (ipCidrRouteTable inetCidrRouteTable)</description>
+              </valueHelp>
+              <completionHelp>
+                <list>route-table</list>
+              </completionHelp>
+              <constraint>
+                <regex>^(route-table)$</regex>
+              </constraint>
+              <constraintErrorMessage>Oid must be 'route-table'</constraintErrorMessage>
+            </properties>
+          </leafNode>
           <leafNode name="smux-peer">
             <properties>
               <help>Register a subtree for SMUX-based processing</help>

--- a/src/conf_mode/snmp.py
+++ b/src/conf_mode/snmp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2020 VyOS maintainers and contributors
+# Copyright (C) 2018-2021 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -54,6 +54,7 @@ default_config_data = {
     'location' : '',
     'description' : '',
     'contact' : '',
+    'route_table': 'False',
     'trap_source': '',
     'trap_targets': [],
     'vyos_user': '',
@@ -185,6 +186,9 @@ def get_config():
             }
 
             snmp['script_ext'].append(extension)
+
+    if conf.exists('oid-enable route-table'):
+        snmp['route_table'] = True
 
     if conf.exists('vrf'):
         # Append key to dict but don't place it in the default dictionary.


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
We are disabled by default oids "ipCidrRouteTable,inetCidrRouteTable" as it was an issue with high CPU utilization (+ full view) in https://phabricator.vyos.net/T1705
So it hardcoded "off those mibs" and there are not options to enable it
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3709

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
snmp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Enable option to enable "ipCidrRouteTable,inetCidrRouteTable" in snmp
General configuration (default behaviour):
```
set service snmp community public client '127.0.0.1'

vyos@r1-roll# ps ax | grep snmpd
   4958 ?        Ss     0:00 /usr/sbin/snmpd -LS0-5d -Lf /dev/null -u Debian-snmp -g Debian-snmp -I -ipCidrRouteTable inetCidrRouteTable -f -p /run/snmpd.pid

```
Enable oids
```
vyos@r1-roll# set service snmp oid-enable 'route-table'
[edit]
vyos@r1-roll# commit
[edit]
vyos@r1-roll# ps ax | grep snmpd
   5114 ?        Ss     0:00 /usr/sbin/snmpd -LS0-5d -Lf /dev/null -u Debian-snmp -g Debian-snmp -f -p /run/snmpd.pid

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
