### PR TITLE
T3732: merge leafNodes containing a defaultValue with default-less leafNodes of same path

### DIFF
--- a/scripts/override-default
+++ b/scripts/override-default
@@ -27,6 +27,7 @@
 import sys
 import glob
 import logging
+from copy import deepcopy
 from lxml import etree
 
 debug = False
@@ -60,6 +61,28 @@ def override_element(l: list):
     for el in parents:
         el.getparent().remove(el)
 
+def merge_remaining(l: list, elementtree):
+    """
+    Merge (now) single leaf node containing 'defaultValue' with leaf nodes
+    of same path and no 'defaultValue'.
+    """
+    for p in l:
+        p = p.split()
+        path_str = f'/interfaceDefinition/*'
+        path_list = []
+        for i in range(len(p)):
+            path_list.append(f'[@name="{p[i]}"]')
+        path_str += '/children/*'.join(path_list)
+        rp = elementtree.xpath(path_str)
+        if len(rp) > 1:
+            for el in rp[1:]:
+                # in practice there will only be one child of the path,
+                # either defaultValue or Properties, since
+                # override_element() has already run
+                for child in el:
+                    rp[0].append(deepcopy(child))
+                el.getparent().remove(el)
+
 def collect_and_override(dir_name):
     """
     Collect elements with defaultValue tag into dictionary indexed by name
@@ -83,6 +106,9 @@ def collect_and_override(dir_name):
             if len(v) > 1:
                 logger.info(f"overridding default in path '{k}'")
                 override_element(v)
+
+        to_merge = list(defv)
+        merge_remaining(to_merge, tree)
 
         revised_str = etree.tostring(root, encoding='unicode', pretty_print=True)
 

--- a/scripts/override-default
+++ b/scripts/override-default
@@ -62,26 +62,26 @@ def override_element(l: list):
 
 def collect_and_override(dir_name):
     """
-    Collect elements with defaultValue tag into dictionary indexed by tuple
-    of (name: str, ancestor path: str).
+    Collect elements with defaultValue tag into dictionary indexed by name
+    attributes of ancestor path.
     """
     for fname in glob.glob(f'{dir_name}/*.xml'):
         tree = etree.parse(fname)
         root = tree.getroot()
         defv = {}
 
-        xpath_str = f'//defaultValue'
+        xpath_str = '//defaultValue'
         xp = tree.xpath(xpath_str)
 
         for element in xp:
             ap = element.xpath('ancestor::*[@name]')
             ap_name = [el.get("name") for el in ap]
-            ap_path_str = ' '.join(ap_name[:-1])
-            defv.setdefault((ap_name[-1], ap_path_str), []).append(element)
+            ap_path_str = ' '.join(ap_name)
+            defv.setdefault(ap_path_str, []).append(element)
 
         for k, v in defv.items():
             if len(v) > 1:
-                logger.info(f"overridding default in {k[0]}, path '{k[1]}'")
+                logger.info(f"overridding default in path '{k}'")
                 override_element(v)
 
         revised_str = etree.tostring(root, encoding='unicode', pretty_print=True)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The XML preprocessing script 'override-default' was provided to support adding modified defaultValues in a separate *.xml.in include file, thus overriding resident values; the override-script will replace all entries with the final (in document order) defaultValue, resulting in a single leafNode at that path. As described in the task, this works fine in overriding and consolidating those leaf nodes, all of which contain an instance of defaultValue, but will fail if there are two leaf nodes at the same path, one with a single child of defaultValue, one with no defaultValue. The root cause is that the schema requires a leafNode to contain a 'properties' element, as a sanity check, hence stand-alone defaultValues that are not merged with sibling leafNodes at the same path, will fail validation. The modification provided here will merge those remaining cases.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3732

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->
Described in summary.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

As described in the task, make the following change; fails in current; fine with script modification provided here:

```
diff --git a/interface-definitions/interfaces-vxlan.xml.in b/interface-definitions/interfaces-vxlan.xml.in
index 56d01dfb..1714f197 100644
--- a/interface-definitions/interfaces-vxlan.xml.in
+++ b/interface-definitions/interfaces-vxlan.xml.in
@@ -76,17 +76,8 @@
               </leafNode>
             </children>
           </node>
+          #include <include/port-number.xml.i>
           <leafNode name="port">
-            <properties>
-              <help>Destination port of VXLAN tunnel (default: 8472)</help>
-              <valueHelp>
-                <format>u32:1-65535</format>
-                <description>Numeric IP port</description>
-              </valueHelp>
-              <constraint>
-                <validator name="numeric" argument="--range 1-65535"/>
-              </constraint>
-            </properties>
             <defaultValue>8472</defaultValue>
           </leafNode>
           #include <include/source-address-ipv4-ipv6.xml.i>
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
