### PR TITLE
T3749: Moving some counters into the proper loop

### DIFF
--- a/src/conf_mode/containers.py
+++ b/src/conf_mode/containers.py
@@ -142,9 +142,9 @@ def verify(container):
 
     # Add new network
     if 'network' in container:
-        v4_prefix = 0
-        v6_prefix = 0
         for network, network_config in container['network'].items():
+            v4_prefix = 0
+            v6_prefix = 0
             # If ipv4-prefix not defined for user-defined network
             if 'prefix' not in network_config:
                 raise ConfigError(f'prefix for network "{net}" must be defined!')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

A loop of validation code that counted up prefixes wasn't being reset.  Moving them into a lower loop fixed it.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3749

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

containers

## Proposed changes
<!--- Describe your changes in detail -->

Moving two lines of code

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Try to add two container networks.  Creating the second one will fail with a cryptic and inappropriate error message. 

```
admin@edge# set container network dnsnet2 prefix 10.0.73.0/24
[edit]
admin@edge# commit
[ container ]
Only one IPv4 prefix can be defined for network "dnsnet2"!

[[container]] failed
Commit failed
[edit]
admin@edge# show container network
 network dnsnet {
     prefix 10.0.72.0/24
 }
+network dnsnet2 {
+    prefix 10.0.73.0/24
+}
````

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X ] I have linked this PR to one or more Phabricator Task(s)
- [ N/A ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ X ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
