### PR TITLE
isis: T3708: Fix errors in MTU calculation

### DIFF
--- a/src/conf_mode/protocols_isis.py
+++ b/src/conf_mode/protocols_isis.py
@@ -113,9 +113,13 @@ def verify(isis):
         # Interface MTU must be >= configured lsp-mtu
         mtu = Interface(interface).get_mtu()
         area_mtu = isis['lsp_mtu']
-        if mtu < int(area_mtu):
-            raise ConfigError(f'Interface {interface} has MTU {mtu}, minimum ' \
-                              f'area MTU is {area_mtu}!')
+        # Recommended maximum PDU size = interface MTU - 3 bytes
+        recom_area_mtu = mtu - 3
+        if mtu < int(area_mtu) or int(area_mtu) > recom_area_mtu:
+            raise ConfigError(f'Interface {interface} has MTU {mtu}, ' \
+                              f'current area MTU is {area_mtu}! \n' \
+                              f'Recommended area lsp-mtu {recom_area_mtu} or less ' \
+                              '(calculated on MTU size).')
 
         if 'vrf' in isis:
             # If interface specific options are set, we must ensure that the


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Additional check for lsp-mtu
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3708

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
isis
## Proposed changes
<!--- Describe your changes in detail -->
Max lsp-mtu should be = interface MTU - 3 bytes
## How to test
With gre-tap interface max-lsp-mtu should be 1473
```
set interfaces tunnel tun0 address '100.64.0.1/30'
set interfaces tunnel tun0 encapsulation 'gretap'
set interfaces tunnel tun0 source-address  '203.0.113.1'
set interfaces tunnel tun0 remote '203.0.113.2'
set protocols isis interface tun0
set protocols isis net 49.0001.0000.0011.0001.00
set protocols isis lsp-mtu 1476

vyos@r1-roll# commit

Interface tun0 has MTU 1476, current area MTU is 1476! 
Recommended area lsp-mtu 1473 or less (calculated on MTU size).

[[protocols isis]] failed
Commit failed

```
Change lsp-mtu to 1473
```
vyos@r1-roll# set protocols isis lsp-mtu 1473
[edit]
vyos@r1-roll# commit
[edit]
vyos@r1-roll#
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
