### PR TITLE
pbr: T3702: Fix incorrect splits for fwmark

### DIFF
--- a/src/conf_mode/policy-local-route.py
+++ b/src/conf_mode/policy-local-route.py
@@ -114,15 +114,15 @@ def apply(pbr):
             # Only fwmark in the rule
             # set policy local-route rule 101 fwmark '23'
             if 'fwmark' in pbr['rule'][rule] and not 'source' in pbr['rule'][rule]:
-                for fwmk in pbr['rule'][rule]['fwmark']:
-                    call(f'ip rule add prio {rule} from all fwmark {fwmk} lookup {table}')
+                fwmk = pbr['rule'][rule]['fwmark']
+                call(f'ip rule add prio {rule} from all fwmark {fwmk} lookup {table}')
             # Source and fwmark in the rule
             # set policy local-route rule 100 source '203.0.113.1'
             # set policy local-route rule 100 fwmark '23'
             if 'source' in pbr['rule'][rule] and 'fwmark' in pbr['rule'][rule]:
+                fwmk = pbr['rule'][rule]['fwmark']
                 for src in pbr['rule'][rule]['source']:
-                    for fwmk in pbr['rule'][rule]['fwmark']:
-                        call(f'ip rule add prio {rule} from {src} fwmark {fwmk} lookup {table}')
+                    call(f'ip rule add prio {rule} from {src} fwmark {fwmk} lookup {table}')
 
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix incorrect split for pbr fwmark. So it can't pass smoketest.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3702

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pbr
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Config:
```
set policy local-route rule 10 fwmark '25'
set policy local-route rule 10 set table '25'
set policy local-route rule 15 fwmark '115'
set policy local-route rule 15 source 203.0.113.1
set policy local-route rule 15 set table '115'
commit
```
Fwmark shouldn't split into '2' and '5'
```
vyos@r1-roll# sudo ip rule show
0:	from all lookup local
10:	from all fwmark 0x19 lookup 25
15:	from 203.0.113.1 fwmark 0x73 lookup 115

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
