### PR TITLE
T3766: container expansion

### DIFF
--- a/interface-definitions/containers.xml.in
+++ b/interface-definitions/containers.xml.in
@@ -48,6 +48,11 @@
               <help>Image name in the hub-registry</help>
             </properties>
           </leafNode>
+          <leafNode name="containerfile">
+            <properties>
+              <help>Dockerfile/Containerfile to use to build this container</help>
+             </properties>
+          </leafNode>
           <leafNode name="memory">
             <properties>
               <help>Constrain the memory available to a container (default: 512MB)</help>

--- a/src/conf_mode/containers.py
+++ b/src/conf_mode/containers.py
@@ -245,7 +245,16 @@ def apply(container):
             # polling process to the user to display progress. If the image exists
             # locally, a user can update it running `update container image <name>`
             tmp = run(f'podman image exists {image}')
-            if tmp != 0: print(os.system(f'podman pull {image}'))
+            if tmp != 0:
+                if "containerfile" in container_config:
+                    # do a build from a Containerfile/Dockerfile
+                    path = container_config['containerfile']
+                    # image name becomes the container name here
+                    print(os.system(f'podman build -f {path} -t {image}'))
+                else:
+                    # Currently the best way to run a command and immediately print stdout
+                    print(os.system(f'podman pull {image}'))
+
 
             # Check/set environment options "-e foo=bar"
             env_opt = ''


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

The goal here was to gain a few more options around configurability for containers.

The two pieces of this goal are:

* Better build configurability, without the need for a full blown custom repository. To this end, I've introduced the option to be able build a container based on a Dockerfile/Containerfile. This would allow near infinite configurability.
* Better network management. I'm one that hates NAT/masquerading and the lack of concise control over the network. So this allows one to create a traditional bridge, minus the NAT, which can then be dropped into something like a zone firewall.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3766

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Containers

## Proposed changes
<!--- Describe your changes in detail -->

* Allow a user to build from a Dockerfile/containerfile instead of strictly a registry
* Allow a user to treat the podman bridge as a normal interface without podman controlled NAT/masq

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
admin@edge# show container 
 name ubuntubuild {
     containerfile /config/containers/kroytest.Containerfile
     image kroy/test
     network service01 {
         address 10.72.1.202
     }
 }
 name ubuntutest {
     image ubuntu:focal
     network service01 {
     }
 }
 network service01 {
     enable-bridging
     prefix 10.72.1.0/24
 }

```
Containerfile

```
admin@edge# cat /config/containers/kroytest.Containerfile 
FROM ubuntu:20.04

RUN apt-get update -y
RUN apt-get install ssh-import-id -y 
RUN apt-get install openssh-server -y
RUN apt-get install iproute2 -y


CMD ssh-import-id-gh kroy-the-rabbit && service ssh start && bash

```
Firewalling:

```
set zone-policy zone LAN interface cni-podman0

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable.  Not really sure what to do here
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly - will update once vetted
