### PR TITLE
FRR: op-mode: T3776: rename "restart frr <daemon>" to "restart <daemon>"

### DIFF
--- a/op-mode-definitions/restart-frr.xml.in
+++ b/op-mode-definitions/restart-frr.xml.in
@@ -2,62 +2,60 @@
 <interfaceDefinition>
   <node name="restart">
     <children>
-      <node name="frr">
+      <leafNode name="all">
         <properties>
-          <help>Restart FRRouting daemons</help>
+          <help>Restart all routing daemons</help>
         </properties>
         <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart</command>
-        <children>
-          <leafNode name="bfdd">
-            <properties>
-              <help>Restart Bidirectional Forwarding Detection daemon</help>
-            </properties>
-            <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon bfdd</command>
-          </leafNode>
-          <leafNode name="bgpd">
-            <properties>
-              <help>Restart Border Gateway Protocol daemon</help>
-            </properties>
-            <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon bgpd</command>
-          </leafNode>
-          <leafNode name="ospfd">
-            <properties>
-              <help>Restart OSPFv2 daemon</help>
-            </properties>
-            <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon ospfd</command>
-          </leafNode>
-          <leafNode name="ospf6d">
-            <properties>
-              <help>Restart OSPFv3 daemon</help>
-            </properties>
-            <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon ospf6d</command>
-          </leafNode>
-          <leafNode name="ripd">
-            <properties>
-              <help>Restart Routing Information Protocol daemon</help>
-            </properties>
-            <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon ripd</command>
-          </leafNode>
-          <leafNode name="ripngd">
-            <properties>
-              <help>Restart RIPng daemon</help>
-            </properties>
-            <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon ripngd</command>
-          </leafNode>
-          <leafNode name="staticd">
-            <properties>
-              <help>Restart Static Route daemon</help>
-            </properties>
-            <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon staticd</command>
-          </leafNode>
-          <leafNode name="zebra">
-            <properties>
-              <help>Restart IP routing manager daemon</help>
-            </properties>
-            <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon zebra</command>
-          </leafNode>
-        </children>
-      </node>
+      </leafNode>
+      <leafNode name="bfd">
+        <properties>
+          <help>Restart Bidirectional Forwarding Detection (BFD) daemon</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon bfdd</command>
+      </leafNode>
+      <leafNode name="bgp">
+        <properties>
+          <help>Restart Border Gateway Protocol (BGP) routing daemon</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon bgpd</command>
+      </leafNode>
+      <leafNode name="ospf">
+        <properties>
+          <help>Restart Open Shortest Path First (OSPF) routing daemon</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon ospfd</command>
+      </leafNode>
+      <leafNode name="ospfv3">
+        <properties>
+          <help>Restart IPv6 Open Shortest Path First (OSPFv3) routing daemon</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon ospf6d</command>
+      </leafNode>
+      <leafNode name="rip">
+        <properties>
+          <help>Restart Routing Information Protocol (RIP) routing daemon</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon ripd</command>
+      </leafNode>
+      <leafNode name="ripng">
+        <properties>
+          <help>Restart Routing Information Protocol NG (RIPng) routing daemon</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon ripngd</command>
+      </leafNode>
+      <leafNode name="static">
+        <properties>
+          <help>Restart static routing daemon</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon staticd</command>
+      </leafNode>
+      <leafNode name="zebra">
+        <properties>
+          <help>Restart Routing Information Base (RIB) manager daemon</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon zebra</command>
+      </leafNode>
     </children>
   </node>
 </interfaceDefinition>

--- a/op-mode-definitions/restart-frr.xml.in
+++ b/op-mode-definitions/restart-frr.xml.in
@@ -20,6 +20,12 @@
         </properties>
         <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon bgpd</command>
       </leafNode>
+      <leafNode name="isis">
+        <properties>
+          <help>Restart Intermediate System to Intermediate System (IS-IS) routing daemon</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon isisd</command>
+      </leafNode>
       <leafNode name="ospf">
         <properties>
           <help>Restart Open Shortest Path First (OSPF) routing daemon</help>

--- a/src/op_mode/restart_frr.py
+++ b/src/op_mode/restart_frr.py
@@ -155,7 +155,7 @@ def _check_args_daemon(daemons):
 # define program arguments
 cmd_args_parser = argparse.ArgumentParser(description='restart frr daemons')
 cmd_args_parser.add_argument('--action', choices=['restart'], required=True, help='action to frr daemons')
-cmd_args_parser.add_argument('--daemon', choices=['bfdd', 'bgpd', 'ospfd', 'ospf6d', 'ripd', 'ripngd', 'staticd', 'zebra'], required=False,  nargs='*', help='select single or multiple daemons')
+cmd_args_parser.add_argument('--daemon', choices=['bfdd', 'bgpd', 'ospfd', 'ospf6d', 'isisd', 'ripd', 'ripngd', 'staticd', 'zebra'], required=False,  nargs='*', help='select single or multiple daemons')
 # parse arguments
 cmd_args = cmd_args_parser.parse_args()
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The current command to restart any of the FRR processes is:

```
    vyos@vyos:~$ restart frr
    Possible completions:
      <Enter>       Execute the current command
      bfdd          Restart Bidirectional Forwarding Detection daemon
      bgpd          Restart Border Gateway Protocol daemon
      ospf6d        Restart OSPFv3 daemon
      ospfd         Restart OSPFv2 daemon
      ripd          Restart Routing Information Protocol daemon
      ripngd        Restart RIPng daemon
      staticd       Restart Static Route daemon
      zebra         Restart IP routing manager daemon
```

From a real-life example: Two engineers needed 5 minutes to figure its under `restart frr` -  that is why this commit drops the artificial `frr` level on the op-mode commands to restart routing protocol daemons.

It's less intuitive to have `restart frr ospfd` or `restart frr bgpd` compared to `restart ospf` and `restart bgp` - we have the same for `restart ssh` or `restart snmp` and not `restart openssh sshd`.

This commit also drops the **d** (daemon) suffix of the op-mode commands so the command aligns with the VyOS CLI, else there would be a miss-understanding from ospf6d to ospfv3.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Command rename

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3776
* https://phabricator.vyos.net/T1514

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
frr

## Proposed changes
<!--- Describe your changes in detail -->
* `restart ospf` vs `restart frr ospfd`
* `restart bgp` vs `restart frr bgpd`

The new completion help looks like this:

```
vyos@vyos:~$ restart
Possible completions:
  all                 Restart all routing daemons
  bfd                 Restart Bidirectional Forwarding Detection (BFD) daemon
  bgp                 Restart Border Gateway Protocol (BGP) routing daemon
  cluster             Restart cluster node
  conntrack-sync      Restart connection tracking synchronization service
  dhcp                Restart DHCP server processes
  dhcpv6              Restart DHCPv6 server processes
  dns                 Restart specific DNS service
  flow-accounting     Restart (net)flow accounting process
  igmp-proxy          Restart the IGMP proxy process
  ipoe-server         Restart IPoE server process
  isis                Restart Intermediate System to Intermediate System (IS-IS) routing daemon
  openconnect-server  Restart openconnect server process
  ospf                Restart Open Shortest Path First (OSPF) routing daemon
  ospfv3              Restart IPv6 Open Shortest Path First (OSPFv3) routing daemon
  pppoe-server        Restart PPPoE server process
  rip                 Restart Routing Information Protocol (RIP) routing daemon
  ripng               Restart Routing Information Protocol NG (RIPng) routing daemon
  snmp                Restart SNMP service
  ssh                 Restart SSH service
  static              Restart static routing daemon
  vpn                 Restart IPsec VPN
  vrrp                Restart VRRP (Virtual Router Redundancy Protocol) process
  wan-load-balance    Restart WAN load balancing
  webproxy            Restart WebProxy service
  zebra               Restart Routing Information Base (RIB) manager daemon
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Just setup the routing protocol and restart it.

```
cpo@CR1.wueI:~$ restart frr ospfd
WARNING: This is a potentially unsafe function! You may lose the connection to the router or active configuration after running this command. Use it at your own risk! Continue? [y/N]: y
cpo@CR1.wueI:~$ show ip ospf neighbor

Neighbor ID     Pri State           Dead Time Address         Interface                        RXmtL RqstL DBsmL
194.145.151.254   1 ExStart/DROther   38.503s 194.145.151.214 tun1337:194.145.151.215              0     0     0

cpo@CR1.wueI:~$ show ip ospf neighbor

Neighbor ID     Pri State           Dead Time Address         Interface                        RXmtL RqstL DBsmL
194.145.151.254   1 Full/DROther      39.234s 194.145.151.214 tun1337:194.145.151.215              0     0     0
```
The `/usr/lib/frr/ospfd` now has a new process ID

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

