### PR TITLE
wireguard: T3763: Added check for listening port availability

### DIFF
--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -819,3 +819,42 @@ def is_systemd_service_running(service):
     Copied from: https://unix.stackexchange.com/a/435317 """
     tmp = cmd(f'systemctl show --value -p SubState {service}')
     return bool((tmp == 'running'))
+
+def check_port_availability(ipaddress, port, protocol):
+    """
+    Check if port is available and not used by any service
+    Return False if a port is busy or IP address does not exists
+    Should be used carefully for services that can start listening
+    dynamically, because IP address may be dynamic too
+    """
+    from socketserver import TCPServer, UDPServer
+    from ipaddress import ip_address
+
+    # verify arguments
+    try:
+        ipaddress = ip_address(ipaddress).compressed
+    except:
+        print(f'The {ipaddress} is not a valid IPv4 or IPv6 address')
+        return
+    if port not in range(1, 65536):
+        print(f'The port number {port} is not in the 1-65535 range')
+        return
+    if protocol not in ['tcp', 'udp']:
+        print(
+            f'The protocol {protocol} is not supported. Only tcp and udp are allowed'
+        )
+        return
+
+    # check port availability
+    try:
+        if protocol == 'tcp':
+            server = TCPServer((ipaddress, port), None, bind_and_activate=True)
+        if protocol == 'udp':
+            server = UDPServer((ipaddress, port), None, bind_and_activate=True)
+        server.server_close()
+        return True
+    except:
+        print(
+            f'The {protocol} port {port} on the {ipaddress} is busy or unavailable'
+        )
+        return False

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -834,16 +834,13 @@ def check_port_availability(ipaddress, port, protocol):
     try:
         ipaddress = ip_address(ipaddress).compressed
     except:
-        print(f'The {ipaddress} is not a valid IPv4 or IPv6 address')
-        return
+        raise ValueError(f'The {ipaddress} is not a valid IPv4 or IPv6 address')
     if port not in range(1, 65536):
-        print(f'The port number {port} is not in the 1-65535 range')
-        return
+        raise ValueError(f'The port number {port} is not in the 1-65535 range')
     if protocol not in ['tcp', 'udp']:
-        print(
+        raise ValueError(
             f'The protocol {protocol} is not supported. Only tcp and udp are allowed'
         )
-        return
 
     # check port availability
     try:
@@ -854,7 +851,4 @@ def check_port_availability(ipaddress, port, protocol):
         server.server_close()
         return True
     except:
-        print(
-            f'The {protocol} port {port} on the {ipaddress} is busy or unavailable'
-        )
         return False

--- a/src/conf_mode/interfaces-wireguard.py
+++ b/src/conf_mode/interfaces-wireguard.py
@@ -74,9 +74,12 @@ def verify(wireguard):
     if 'peer' not in wireguard:
         raise ConfigError('At least one Wireguard peer is required!')
 
-    if 'port' in wireguard and check_port_availability(
-            '0.0.0.0', int(wireguard['port']), 'udp') is not True:
-        raise ConfigError('The port cannot be used for the interface')
+    listen_port = int(wireguard['port'])
+    if 'port' in wireguard and check_port_availability('0.0.0.0', listen_port,
+                                                       'udp') is not True:
+        raise ConfigError(
+            f'The UDP port {listen_port} is busy or unavailable and cannot be used for the interface'
+        )
 
     # run checks on individual configured WireGuard peer
     for tmp in wireguard['peer']:

--- a/src/conf_mode/interfaces-wireguard.py
+++ b/src/conf_mode/interfaces-wireguard.py
@@ -30,6 +30,7 @@ from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_mtu_ipv6
 from vyos.ifconfig import WireGuardIf
 from vyos.util import check_kmod
+from vyos.util import check_port_availability
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -72,6 +73,10 @@ def verify(wireguard):
 
     if 'peer' not in wireguard:
         raise ConfigError('At least one Wireguard peer is required!')
+
+    if 'port' in wireguard and check_port_availability(
+            '0.0.0.0', int(wireguard['port']), 'udp') is not True:
+        raise ConfigError('The port cannot be used for the interface')
 
     # run checks on individual configured WireGuard peer
     for tmp in wireguard['peer']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added check for listening port availability

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3763

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireguard, `vyos.util`

## Proposed changes
<!--- Describe your changes in detail -->
Each wireguard interface requires a unique port for in and out connections. This commit adds the new `vyos.util` function -
`check_port_availability`, and uses it to be sure that a port that is planned to be used for wireguard interface is truly available and not used by any other services (not only other wireguard interfaces).

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configure two interfaces with the same port value:
```
set interfaces wireguard wg1 peer peer1 allowed-ips '192.0.2.2/32'
set interfaces wireguard wg1 peer peer1 public-key 'l+U1Rz38RW11ClMYYtXqEneRNu3oLn2yvI5B+jBESyY='
set interfaces wireguard wg1 port '4000'
set interfaces wireguard wg1 private-key 'IMAGzmcQOHDTN70fyJ04uiWx0+wc/BKPj4aNKYAZRXA='
set interfaces wireguard wg2 peer peer1 allowed-ips '192.0.2.2/32'
set interfaces wireguard wg2 peer peer1 public-key 'l+U1Rz38RW11ClMYYtXqEneRNu3oLn2yvI5B+jBESyY='
set interfaces wireguard wg2 port '4000'
set interfaces wireguard wg2 private-key 'IMAGzmcQOHDTN70fyJ04uiWx0+wc/BKPj4aNKYAZRXA=
```
The config will not be applied with an error:
```
The udp port 4000 on the 0.0.0.0 is busy or unavailable
The port cannot be used for the interface
```
The same with a port used by another service, for example the 123 port used by NTP:
```
set interfaces wireguard wg1 peer peer1 allowed-ips '192.0.2.2/32'
set interfaces wireguard wg1 peer peer1 public-key 'l+U1Rz38RW11ClMYYtXqEneRNu3oLn2yvI5B+jBESyY='
set interfaces wireguard wg1 port '123'
set interfaces wireguard wg1 private-key 'IMAGzmcQOHDTN70fyJ04uiWx0+wc/BKPj4aNKYAZRXA='
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
