### PR TITLE
interfaces: T3777: Does not delete empty eui64 address

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -38,6 +38,7 @@ from vyos.util import dict_search
 from vyos.util import read_file
 from vyos.util import get_interface_config
 from vyos.template import is_ipv4
+from vyos.template import is_ipv6
 from vyos.validate import is_intf_addr_assigned
 from vyos.validate import is_ipv6_link_local
 from vyos.validate import assert_boolean
@@ -588,9 +589,10 @@ class Interface(Control):
         Delete the address based on the interface's MAC-based EUI64
         combined with the prefix address.
         """
-        eui64 = mac2eui64(self.get_mac(), prefix)
-        prefixlen = prefix.split('/')[1]
-        self.del_addr(f'{eui64}/{prefixlen}')
+        if is_ipv6(prefix):
+            eui64 = mac2eui64(self.get_mac(), prefix)
+            prefixlen = prefix.split('/')[1]
+            self.del_addr(f'{eui64}/{prefixlen}')
 
     def set_ipv6_forwarding(self, forwarding):
         """


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
If we get an empty value for ipv6 eui64_old address, don't try to delete it.

```
{'address': ['192.168.122.14/24'],
 'description': 'FOO-BAR',
 'duplex': 'auto',
 'hw_id': '52:54:00:5d:46:09',
 'ifname': 'eth0',
 'ip': {'arp_cache_timeout': '30'},
 'ipv6': {'address': {'eui64': ['2001:db8::/64'], 'eui64_old': ['']}},
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3777

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipv6
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Set eui64 ipv6 address
```
set interfaces ethernet eth0 ipv6 address eui64 2001:db8::/64
```
Before fix:
```
File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 1259, in update
  self.del_ipv6_eui64_address(addr)
File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 592, in del_ipv6_eui64_address
  prefixlen = prefix.split('/')[1]
```
After fix:
```
vyos@r4-1.3# set interfaces ethernet eth0 ipv6 address eui64 2001:db8::/64
[edit]
vyos@r4-1.3# commit
[edit]
vyos@r4-1.3# run sho int
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
eth0             192.168.122.14/24                 u/u  FOO-BAR
                 2001:db8::5054:ff:fe5d:4609/64         

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
