### PR TITLE
wireguard: T3763: Fixed uninitialized port issue

### DIFF
--- a/src/conf_mode/interfaces-wireguard.py
+++ b/src/conf_mode/interfaces-wireguard.py
@@ -47,6 +47,9 @@ def get_config(config=None):
     base = ['interfaces', 'wireguard']
     wireguard = get_interface_dict(conf, base)
 
+    # Check if a port was changed
+    wireguard['port_changed'] = leaf_node_changed(conf, ['port'])
+
     # Determine which Wireguard peer has been removed.
     # Peers can only be removed with their public key!
     dict = {}
@@ -74,7 +77,7 @@ def verify(wireguard):
     if 'peer' not in wireguard:
         raise ConfigError('At least one Wireguard peer is required!')
 
-    if 'port' in wireguard:
+    if 'port' in wireguard and wireguard['port_changed']:
         listen_port = int(wireguard['port'])
         if check_port_availability('0.0.0.0', listen_port, 'udp') is not True:
             raise ConfigError(

--- a/src/conf_mode/interfaces-wireguard.py
+++ b/src/conf_mode/interfaces-wireguard.py
@@ -74,12 +74,12 @@ def verify(wireguard):
     if 'peer' not in wireguard:
         raise ConfigError('At least one Wireguard peer is required!')
 
-    listen_port = int(wireguard['port'])
-    if 'port' in wireguard and check_port_availability('0.0.0.0', listen_port,
-                                                       'udp') is not True:
-        raise ConfigError(
-            f'The UDP port {listen_port} is busy or unavailable and cannot be used for the interface'
-        )
+    if 'port' in wireguard:
+        listen_port = int(wireguard['port'])
+        if check_port_availability('0.0.0.0', listen_port, 'udp') is not True:
+            raise ConfigError(
+                f'The UDP port {listen_port} is busy or unavailable and cannot be used for the interface'
+            )
 
     # run checks on individual configured WireGuard peer
     for tmp in wireguard['peer']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The commit fixes the problem, when port availability check is triggered even if a port for WireGuard interface is not defined (randomized port, default behavior) or a port was not changed.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3763

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireguard

## Proposed changes
<!--- Describe your changes in detail -->
A port availability check will be triggered only if the port option is configured on the interface and it was changed in current commit.


## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Run the `/usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireguard.py` smoketest.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
