### PR TITLE
interface: T3782: Fix unexpected delete qdisc rule

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1079,12 +1079,14 @@ class Interface(Control):
             source_if = next(iter(self._config['is_mirror_intf']))
             config = self._config['is_mirror_intf'][source_if].get('mirror', None)
 
-        # Please do not clear the 'set $? = 0 '. It's meant to force a return of 0
-        # Remove existing mirroring rules
-        delete_tc_cmd  = f'tc qdisc del dev {source_if} handle ffff: ingress 2> /dev/null;'
-        delete_tc_cmd += f'tc qdisc del dev {source_if} handle 1: root prio 2> /dev/null;'
-        delete_tc_cmd += 'set $?=0'
-        self._popen(delete_tc_cmd)
+        # Check configuration stored by old perl code before delete T3782
+        if not 'redirect' in self._config:
+            # Please do not clear the 'set $? = 0 '. It's meant to force a return of 0
+            # Remove existing mirroring rules
+            delete_tc_cmd  = f'tc qdisc del dev {source_if} handle ffff: ingress 2> /dev/null;'
+            delete_tc_cmd += f'tc qdisc del dev {source_if} handle 1: root prio 2> /dev/null;'
+            delete_tc_cmd += 'set $?=0'
+            self._popen(delete_tc_cmd)
 
         # Bail out early if nothing needs to be configured
         if not config:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Check if we have tc qdisc configuration from old perl code and if it exists prevent deleting dqisc by default.
VyOS 1.3

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3782

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
interface. qdisc, tc
## Proposed changes
<!--- Describe your changes in detail -->
Check some tc qdisc commands generated by old perl code and if it exists, prevent deleting tc qdisc from the interface by new code 
https://github.com/vyos/vyos-1x/blob/11fdcb7cdd078e67b460b6863f8fd9785c33dc2d/python/vyos/ifconfig/interface.py#L1084-L1085
From debug, we can see per each commit it's deleted qdisc when it shouldn't
```
DEBUG/IFCONFIG cmd 'tc qdisc del dev eth0 handle ffff: ingress 2> /dev/null;tc qdisc del dev eth0 handle 1: root prio 2> /dev/null;set $?=0'
DEBUG/IFCONFIG cmd 'ip link set dev eth0 up'

[edit]
vyos@r4-1.3#
```

## How to test
We should get ~20 mbit in such configuration:
```
set traffic-policy shaper spectrum-downstream bandwidth '20mbit'
set traffic-policy shaper spectrum-downstream default bandwidth '100%'
set traffic-policy shaper spectrum-downstream default burst '15k'
set traffic-policy shaper spectrum-downstream default queue-type 'fq-codel'
set interfaces ethernet eth0 redirect 'ifb0'
set interfaces input ifb0 traffic-policy out 'spectrum-downstream'
commit

```
Iperf
```
vyos@r4-1.3# sudo iperf3 -c 192.168.122.12 -R
Connecting to host 192.168.122.12, port 5201
Reverse mode, remote host 192.168.122.12 is sending
[  5] local 192.168.122.14 port 53452 connected to 192.168.122.12 port 5201
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec  2.28 MBytes  19.1 Mbits/sec                  
[  5]   1.00-2.00   sec  2.26 MBytes  18.9 Mbits/sec                  
[  5]   2.00-3.00   sec  2.26 MBytes  18.9 Mbits/sec   
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
