### PR TITLE
tunnel: T2920: Add checks tun with same source addr and keys

### DIFF
--- a/src/conf_mode/interfaces-tunnel.py
+++ b/src/conf_mode/interfaces-tunnel.py
@@ -18,6 +18,7 @@ import os
 
 from sys import exit
 from netifaces import interfaces
+from ipaddress import IPv4Address
 
 from vyos.config import Config
 from vyos.configdict import dict_merge
@@ -31,6 +32,7 @@ from vyos.configverify import verify_mtu_ipv6
 from vyos.configverify import verify_vrf
 from vyos.configverify import verify_tunnel
 from vyos.ifconfig import Interface
+from vyos.ifconfig import Section
 from vyos.ifconfig import TunnelIf
 from vyos.template import is_ipv4
 from vyos.template import is_ipv6
@@ -99,6 +101,27 @@ def verify(tunnel):
        tunnel['source_address'] == '0.0.0.0' and \
        dict_search('parameters.ip.key', tunnel) == None:
         raise ConfigError('Tunnel parameters ip key must be set!')
+
+    if tunnel['encapsulation'] in ['gre', 'gretap']:
+        if dict_search('parameters.ip.key', tunnel) != None:
+            # Check pairs tunnel source-address/encapsulation/key with exists tunnels.
+            # Prevent the same key for 2 tunnels with same source-address/encap. T2920
+            for tunnel_if in Section.interfaces('tunnel'):
+                tunnel_cfg = get_interface_config(tunnel_if)
+                exist_encap = tunnel_cfg['linkinfo']['info_kind']
+                exist_source_address = tunnel_cfg['address']
+                exist_key = tunnel_cfg['linkinfo']['info_data']['ikey']
+                new_source_address = tunnel['source_address']
+                # Convert tunnel key to ip key, format "ip -j link show"
+                # 1 => 0.0.0.1, 999 => 0.0.3.231
+                orig_new_key = int(tunnel['parameters']['ip']['key'])
+                new_key = IPv4Address(orig_new_key)
+                new_key = str(new_key)
+                if tunnel['encapsulation'] == exist_encap and \
+                   new_source_address == exist_source_address and \
+                   new_key == exist_key:
+                    raise ConfigError(f'Key "{orig_new_key}" for source-address "{new_source_address}" ' \
+                                      f'is already used for tunnel "{tunnel_if}"!')
 
     verify_mtu_ipv6(tunnel)
     verify_address(tunnel)


### PR DESCRIPTION
2 tunnels with the same local-address should has different keys
Check existing tunnels (source-address key) with new tunnel.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T2920

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
tunnel, gre
## Proposed changes
<!--- Describe your changes in detail -->
Check each new tunnel "source-address/key" with exists in "ip -j tunnel show"
If the new source-address exists with the same key, get an error.

## How to test
Create 2 tunnels with the same source-address/key:
```
set interfaces tunnel tun1 encapsulation gre
set interfaces tunnel tun1 source-address '0.0.0.0'
set interfaces tunnel tun1 address 10.10.10.1/30
set interfaces tunnel tun1 parameters ip key '1'
set interfaces tunnel tun1 multicast 'enable'

set interfaces tunnel tun2 encapsulation gre
set interfaces tunnel tun2 source-address '0.0.0.0'
set interfaces tunnel tun2 address 10.255.10.1/30
set interfaces tunnel tun2 parameters ip key '1'
set interfaces tunnel tun2 multicast 'enable'
```
Commit:
```
vyos@r1-roll# commit
[ interfaces tunnel tun2 ]
Key "1" for source-address "0.0.0.0" is already used for tunnel "tun1"!

[[interfaces tunnel tun2]] failed
Commit failed
[edit]
vyos@r1-roll# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
