### PR TITLE
openvpn: T690: Add metric for pushed routes

### DIFF
--- a/data/templates/openvpn/server.conf.tmpl
+++ b/data/templates/openvpn/server.conf.tmpl
@@ -74,6 +74,16 @@ topology {{ server.topology }}
 {%       for subnet in server.subnet %}
 {%         if subnet | is_ipv4 %}
 server {{ subnet | address_from_cidr }} {{ subnet | netmask_from_cidr }} nopool
+{# First ip address is used as gateway. It's allows to use metrics #}
+{%     if server.push_route is defined and server.push_route is not none %}
+{%       for route, route_config in server.push_route.items() %}
+{%         if route | is_ipv4 %}
+push "route {{ route | address_from_cidr }} {{ route | netmask_from_cidr }} {{ subnet | first_host_address }} {{ route_config.metric if route_config.metric is defined else "0" }}"
+{%         elif route | is_ipv6 %}
+push "route-ipv6 {{ route }}"
+{%         endif %}
+{%       endfor %}
+{%     endif %}
 {# OpenVPN assigns the first IP address to its local interface so the pool used #}
 {# in net30 topology - where each client receives a /30 must start from the second subnet #}
 {%           if server.topology is defined and server.topology == 'net30' %}
@@ -106,15 +116,6 @@ management /run/openvpn/openvpn-mgmt-intf unix
 ccd-exclusive
 {%     endif %}
 
-{%     if server.push_route is defined and server.push_route is not none %}
-{%       for route in server.push_route %}
-{%         if route | is_ipv4 %}
-push "route {{ route | address_from_cidr }} {{ route | netmask_from_cidr }}"
-{%         elif route | is_ipv6 %}
-push "route-ipv6 {{ route }}"
-{%         endif %}
-{%       endfor %}
-{%     endif %}
 {%     if server.name_server is defined and server.name_server is not none %}
 {%       for nameserver in server.name_server %}
 {%         if nameserver | is_ipv4 %}

--- a/interface-definitions/interfaces-openvpn.xml.in
+++ b/interface-definitions/interfaces-openvpn.xml.in
@@ -571,7 +571,7 @@
                   <multi/>
                 </properties>
               </leafNode>
-              <leafNode name="push-route">
+              <tagNode name="push-route">
                 <properties>
                   <help>Route to be pushed to all clients</help>
                   <valueHelp>
@@ -585,9 +585,23 @@
                   <constraint>
                     <validator name="ip-prefix"/>
                   </constraint>
-                  <multi/>
                 </properties>
-              </leafNode>
+                <children>
+                  <leafNode name="metric">
+                    <properties>
+                      <help>Set metric for this route</help>
+                      <valueHelp>
+                        <format>u32:0-4294967295</format>
+                        <description>Metric for this route</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-4294967295"/>
+                      </constraint>
+                    </properties>
+                    <defaultValue>0</defaultValue>
+                  </leafNode>
+                </children>
+              </tagNode>
               <leafNode name="reject-unconfigured-clients">
                 <properties>
                   <help>Reject connections from clients that are not explicitly configured</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add a new feature "metric" for pushed routes for server-mode configuration.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T690


## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openvpn
## Proposed changes
<!--- Describe your changes in detail -->
Add metric for pushed routes.
## How to test
Add metrics for pushed routes, a route without metric has metric "0" by default
```
set interfaces openvpn vtun10 encryption cipher 'aes256'
set interfaces openvpn vtun10 hash 'sha512'
set interfaces openvpn vtun10 local-host '192.168.122.14'
set interfaces openvpn vtun10 local-port '1194'
set interfaces openvpn vtun10 mode 'server'
set interfaces openvpn vtun10 persistent-tunnel
set interfaces openvpn vtun10 protocol 'udp'
set interfaces openvpn vtun10 server client client1 ip '10.10.0.10'
set interfaces openvpn vtun10 server domain-name 'vyos.net'
set interfaces openvpn vtun10 server max-connections '250'
set interfaces openvpn vtun10 server name-server '172.16.254.30'
set interfaces openvpn vtun10 server push-route 100.64.10.0/24
set interfaces openvpn vtun10 server push-route 100.64.20.0/24 metric '20'
set interfaces openvpn vtun10 server push-route 100.64.30.0/24 metric '30'
set interfaces openvpn vtun10 server subnet '10.10.0.0/24'
set interfaces openvpn vtun10 server topology 'subnet'
set interfaces openvpn vtun10 tls ca-cert-file '/config/auth/ca.crt'
set interfaces openvpn vtun10 tls cert-file '/config/auth/central.crt'
set interfaces openvpn vtun10 tls dh-file '/config/auth/dh.pem'
set interfaces openvpn vtun10 tls key-file '/config/auth/central.key'
set interfaces openvpn vtun10 tls tls-version-min '1.0'
set interfaces openvpn vtun10 use-lzo-compression

```
Chek routes on the client site:
Metric 0
```
vyos@r12-lts:~$ show ip route 100.64.10.0/24
Routing entry for 100.64.10.0/24
  Known via "kernel", distance 0, metric 0, best
  Last update 00:23:38 ago
  * 10.10.0.1, via vtun10

```
Metric 20, 30
```
vyos@r12-lts:~$ show ip route 100.64.20.0/24
Routing entry for 100.64.20.0/24
  Known via "kernel", distance 0, metric 20, best
  Last update 00:24:21 ago
  * 10.10.0.1, via vtun10

vyos@r12-lts:~$ show ip route 100.64.30.0/24
Routing entry for 100.64.30.0/24
  Known via "kernel", distance 0, metric 30, best
  Last update 00:24:24 ago
  * 10.10.0.1, via vtun10

vyos@r12-lts:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
