### PR TITLE
login: T971 allow quoting in public-keys options

### DIFF
--- a/src/conf_mode/system-login.py
+++ b/src/conf_mode/system-login.py
@@ -240,7 +240,9 @@ def apply(login):
                 # XXX: Should we deny using root at all?
                 home_dir = getpwnam(user).pw_dir
                 render(f'{home_dir}/.ssh/authorized_keys', 'login/authorized_keys.tmpl',
-                       user_config, permission=0o600, user=user, group='users')
+                       user_config, permission=0o600,
+                       formater=lambda _: _.replace("&quot;", '"'),
+                       user=user, group='users')
 
             except Exception as e:
                 raise ConfigError(f'Adding user "{user}" raised exception: "{e}"')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Fixes T971 to allow you to specify where a user is allowed to connect from when using an ssh key

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T971

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
login

## Proposed changes
<!--- Describe your changes in detail -->
This uses the `&quot;` method already used by dhcp_server.py and interfaces-openvpn.py to allow putting `"` in the options field in `authorized_keys`.

This is my first PR against VyOS, so please forgive any mistakes I'm making. Thanks to @c-po for guidance via Slack.

This change requires a change to the documentation (actually, `options` isn't mentioned at all in the login docs). I am happy to add that, but want to make sure this patch is acceptable before doing so.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics

```
like this
```
-->
```
vyos@vyos# set system login user paul authentication public-keys paul@thinkpad options from=&quot;10.0.0.0/24&quot;
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# sudo cat /home/paul/.ssh/authorized_keys
### Automatically generated by system-login.py ###

from="10.0.0.0/24" ssh-rsa <removed public key> paul@thinkpad
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
