### PR TITLE
T3803: add source-address option to the op mode ping CLI.

### DIFF
--- a/src/op_mode/ping.py
+++ b/src/op_mode/ping.py
@@ -62,8 +62,8 @@ options = {
     },
     'interface': {
         'ping': '{command} -I {value}',
-        'type': '<interface> <X.X.X.X> <h:h:h:h:h:h:h:h>',
-        'help': 'Interface to use as source for ping'
+        'type': '<interface>',
+        'help': 'Source interface'
     },
     'interval': {
         'ping': '{command} -i {value}',
@@ -114,6 +114,10 @@ options = {
         'ping': '{command} -s {value}',
         'type': '<bytes>',
         'help': 'Number of bytes to send'
+    },
+    'source-address': {
+        'ping': '{command} -I {value}',
+        'type': '<x.x.x.x> <h:h:h:h:h:h:h:h>',
     },
     'ttl': {
         'ping': '{command} -t {value}',
@@ -234,4 +238,4 @@ if __name__ == '__main__':
 
     # print(f'{command} {host}')
     os.system(f'{command} {host}')
-    
+


### PR DESCRIPTION
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add `ping x.x.x.x source-address y.y.y.y`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3803

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Op mode.

