### PR TITLE
T3822: set the OpenVPN key file owner to openvpn:openvpn

### DIFF
--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -477,6 +477,7 @@ def generate(openvpn):
     # Fixup file permissions
     for file in fix_permissions:
         chmod_600(file)
+        chown(file, 'openvpn', 'openvpn')
 
     return None
 


### PR DESCRIPTION
## Change Summary

The `interfaces-openvpn.py` script changes the permissions of key files to `600`. Unfortunately, it doesn't account for the fact that OpenVPN now runs as `openvpn:openvpn`, while keys generated with `run generate openvpn key` are owned by `root:vyattacfg`, so the permission fix makes them unreadable for OpenVPN processes.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://phabricator.vyos.net/T3822

## Component(s) name

OpenVPN

## How to test

Run `generate openvpn key`, try to set up a tunnel.