### PR TITLE
ipsec: T3828: Use IKE dh-group when ESP dh-group is set to `enable`

### DIFF
--- a/data/templates/ipsec/swanctl/l2tp.tmpl
+++ b/data/templates/ipsec/swanctl/l2tp.tmpl
@@ -20,7 +20,7 @@
         children {
             l2tp_remote_access_esp {
                 mode = transport
-                esp_proposals = {{ l2tp_esp | get_esp_ike_cipher | join(',') if l2tp_esp else l2tp_esp_default }}
+                esp_proposals = {{ l2tp_esp | get_esp_ike_cipher(l2tp_ike) | join(',') if l2tp_esp else l2tp_esp_default }}
                 life_time = {{ l2tp_esp.lifetime if l2tp_esp else l2tp.lifetime }}s
                 local_ts = dynamic[/1701]
                 remote_ts = dynamic

--- a/data/templates/ipsec/swanctl/peer.tmpl
+++ b/data/templates/ipsec/swanctl/peer.tmpl
@@ -56,7 +56,7 @@
 {%   if peer_conf.vti is defined and peer_conf.vti.bind is defined and peer_conf.tunnel is not defined %}
 {%     set vti_esp = esp_group[ peer_conf.vti.esp_group ] if peer_conf.vti.esp_group is defined else esp_group[ peer_conf.default_esp_group ] %}
             peer_{{ name }}_vti {
-                esp_proposals = {{ vti_esp | get_esp_ike_cipher | join(',') }}
+                esp_proposals = {{ vti_esp | get_esp_ike_cipher(ike) | join(',') }}
                 life_time = {{ vti_esp.lifetime }}s
                 local_ts = 0.0.0.0/0,::/0
                 remote_ts = 0.0.0.0/0,::/0
@@ -87,7 +87,7 @@
 {%       set remote_port = tunnel_conf.remote.port if tunnel_conf.remote is defined and tunnel_conf.remote.port is defined else '' %}
 {%       set remote_suffix = '[{0}/{1}]'.format(proto, remote_port) if proto or remote_port else '' %}
             peer_{{ name }}_tunnel_{{ tunnel_id }} {
-                esp_proposals = {{ tunnel_esp | get_esp_ike_cipher | join(',') }}
+                esp_proposals = {{ tunnel_esp | get_esp_ike_cipher(ike) | join(',') }}
                 life_time = {{ tunnel_esp.lifetime }}s
 {%       if tunnel_esp.mode is not defined or tunnel_esp.mode == 'tunnel' %}
 {%         if tunnel_conf.local is defined and tunnel_conf.local.prefix is defined %}

--- a/data/templates/ipsec/swanctl/profile.tmpl
+++ b/data/templates/ipsec/swanctl/profile.tmpl
@@ -19,7 +19,7 @@
 {%       endif %}
         children {
             dmvpn {
-                esp_proposals = {{ esp | get_esp_ike_cipher | join(',')  }}
+                esp_proposals = {{ esp | get_esp_ike_cipher(ike) | join(',')  }}
                 rekey_time = {{ esp.lifetime }}s
                 rand_time = 540s
                 local_ts = dynamic[gre]

--- a/data/templates/ipsec/swanctl/remote_access.tmpl
+++ b/data/templates/ipsec/swanctl/remote_access.tmpl
@@ -35,7 +35,7 @@
         }
         children {
             ikev2-vpn  {
-                esp_proposals = {{ esp | get_esp_ike_cipher | join(',') }}
+                esp_proposals = {{ esp | get_esp_ike_cipher(ike) | join(',') }}
                 rekey_time = {{ esp.lifetime }}s
                 rand_time = 540s
                 dpd_action = clear

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -393,8 +393,15 @@ def get_ip(interface):
     from vyos.ifconfig import Interface
     return Interface(interface).get_addr()
 
+def get_first_ike_dh_group(ike_group):
+    if ike_group and 'proposal' in ike_group:
+        for priority, proposal in ike_group['proposal'].items():
+            if 'dh_group' in proposal:
+                return 'dh-group' + proposal['dh_group']
+    return 'dh-group2' # Fallback on dh-group2
+
 @register_filter('get_esp_ike_cipher')
-def get_esp_ike_cipher(group_config):
+def get_esp_ike_cipher(group_config, ike_group=None):
     pfs_lut = {
         'dh-group1'  : 'modp768',
         'dh-group2'  : 'modp1024',
@@ -433,7 +440,7 @@ def get_esp_ike_cipher(group_config):
             elif 'pfs' in group_config and group_config['pfs'] != 'disable':
                 group = group_config['pfs']
                 if group_config['pfs'] == 'enable':
-                    group = 'dh-group2'
+                    group = get_first_ike_dh_group(ike_group)
                 tmp += '-' + pfs_lut[group]
 
             ciphers.append(tmp)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Use IKE dh-group when ESP dh-group is set to `enable` instead of `dh-group2`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3828

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec

## Proposed changes
<!--- Describe your changes in detail -->
Fixes expected behaviour to match old perl code, ESP `dh-group enable` should inherit dh-group from first IKE proposal.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
