### PR TITLE
typo: remove unnecessary 'i' from help

### DIFF
--- a/interface-definitions/include/source-address-ipv4.xml.i
+++ b/interface-definitions/include/source-address-ipv4.xml.i
@@ -1,7 +1,7 @@
 <!-- include start from source-address-ipv4.xml.i -->
 <leafNode name="source-address">
   <properties>
-    <help>IPv4 source address used to initiiate connection</help>
+    <help>IPv4 source address used to initiate connection</help>
     <completionHelp>
       <script>${vyos_completion_dir}/list_local_ips.sh --ipv4</script>
     </completionHelp>


### PR DESCRIPTION
Just a simple typo fix - no tests needed or extra information (IMHO)