### PR TITLE
T3823: Stop strip-private regexp from swallowing quotes

### DIFF
--- a/src/helpers/strip-private.py
+++ b/src/helpers/strip-private.py
@@ -47,7 +47,7 @@ ipv4_re = re.compile(r'(\d{1,3}\.){2}(\d{1,3}\.\d{1,3})')
 ipv4_subst = r'xxx.xxx.\2'
 
 # Censor all but the first two fields.
-ipv6_re = re.compile(r'([0-9a-fA-F]{1,4}\:){2}(\S+)')
+ipv6_re = re.compile(r'([0-9a-fA-F]{1,4}\:){2}([0-9a-fA-F:]+)')
 ipv6_subst = r'xxxx:xxxx:\2'
 
 def ip_match(match: re.Match, subst: str) -> str:
@@ -96,12 +96,12 @@ if __name__ == "__main__":
     args = parser.parse_args()
     # Strict mode is the default and the absence of loose mode implies presence of strict mode.
     if not args.loose:
-        for arg in [args.mac, args.domain, args.hostname, args.username, args.dhcp, args.asn, args.snmp, args.lldp]:
-            arg = True
+        args.mac = args.domain = args.hostname = args.username = args.dhcp = args.asn = args.snmp = args.lldp = True
         if not args.public_address and not args.keep_address:
             args.address = True
     elif not args.address and not args.public_address:
         args.keep_address = True
+
     # (condition, precompiled regexp, substitution string)
     stripping_rules = [
         # Strip passwords
@@ -120,7 +120,7 @@ if __name__ == "__main__":
         (True, re.compile(r'private-key \S+'), 'private-key xxxxxx'),
 
         # Strip MAC addresses
-        (args.mac, re.compile(r'([0-9a-fA-F]{2}\:){5}([0-9a-fA-F]{2}((\:{0,1})){3})'), r'XX:XX:XX:XX:XX:\2'),
+        (args.mac, re.compile(r'([0-9a-fA-F]{2}\:){5}([0-9a-fA-F]{2}((\:{0,1})){3})'), r'xx:xx:xx:xx:xx:\2'),
 
         # Strip host-name, domain-name, and domain-search
         (args.hostname, re.compile(r'(host-name|domain-name|domain-search) \S+'), r'\1 xxxxxx'),


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
`\S+` instead of `[0-9a-fA-F:]+` in IPv6 regexp swallows the rest of the line and breaks the substitution when called with `commands` helper.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3823

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
helper

## Proposed changes
<!--- Describe your changes in detail -->
Also fixes an issue with `--strict` parameters not kicking in by default.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```-->

```
$ strip-private.py <<< "'2001:1578:2fe:fffd::/64'"
'xxxx:xxxx:2fe:fffd::/64'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
