### PR TITLE
pdns_recursor: T3840: Allow larger DNS forwarding cache sizes

### DIFF
--- a/interface-definitions/dns-forwarding.xml.in
+++ b/interface-definitions/dns-forwarding.xml.in
@@ -18,11 +18,11 @@
                 <properties>
                   <help>DNS forwarding cache size (default: 10000)</help>
                   <valueHelp>
-                    <format>u32:0-10000</format>
+                    <format>u32:0-2147483647</format>
                     <description>DNS forwarding cache size</description>
                   </valueHelp>
                   <constraint>
-                    <validator name="numeric" argument="--range 0-10000"/>
+                    <validator name="numeric" argument="--range 0-2147483647"/>
                   </constraint>
                 </properties>
                 <defaultValue>10000</defaultValue>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The dns forwarding cache-size configuration mode property currently only accepts a range of values 0-10000. The high end of this range is actually lower than what PowerDNS recommends as their default cache size (100k entries).

This change increases the acceptable value range up to UINT_MAX, allowing users to configure any cache size their system memory can handle.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3840

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

- dns forwarding

## Proposed changes
<!--- Describe your changes in detail -->

This change increases the acceptable value range up to INT_MAX (`2147483647`), allowing users to configure any cache size their system memory can handle. Note that technically a read of pdns source seems to suggest this could accept up to UINT32_MAX, but there's probably little need to accept values right up to that limit.

Both the format string under `valueHelp` and the constraint were updated to use this new value.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
configure
set service dns forwarding cache-size 100000
commit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
