### PR TITLE
ipsec: T1441: Clean up vti-up-down script for XFRM interfaces

### DIFF
--- a/data/templates/ipsec/swanctl/peer.tmpl
+++ b/data/templates/ipsec/swanctl/peer.tmpl
@@ -60,7 +60,7 @@
                 life_time = {{ vti_esp.lifetime }}s
                 local_ts = 0.0.0.0/0,::/0
                 remote_ts = 0.0.0.0/0,::/0
-                updown = "/etc/ipsec.d/vti-up-down {{ peer_conf.vti.bind }} {{ peer_conf.dhcp_interface if peer_conf.dhcp_interface is defined else 'no' }}"
+                updown = "/etc/ipsec.d/vti-up-down {{ peer_conf.vti.bind }}"
                 {# The key defaults to 0 and will match any policies which similarly do not have a lookup key configuration. #}
                 {# Thus we simply shift the key by one to also support a vti0 interface #}
 {%              set if_id = peer_conf.vti.bind | replace('vti', '') | int +1 %}
@@ -119,7 +119,7 @@
                 dpd_action = {{ dpd_translate[ike.dead_peer_detection.action] }}
 {%       endif %}
 {%       if peer_conf.vti is defined and peer_conf.vti.bind is defined %}
-                updown = "/etc/ipsec.d/vti-up-down {{ peer_conf.vti.bind }} {{ peer_conf.dhcp_interface if peer_conf.dhcp_interface is defined else 'no' }}"
+                updown = "/etc/ipsec.d/vti-up-down {{ peer_conf.vti.bind }}"
                 {# The key defaults to 0 and will match any policies which similarly do not have a lookup key configuration. #}
                 {# Thus we simply shift the key by one to also support a vti0 interface #}
 {%              set if_id = peer_conf.vti.bind | replace('vti', '') | int +1 %}

--- a/src/etc/ipsec.d/vti-up-down
+++ b/src/etc/ipsec.d/vti-up-down
@@ -29,19 +29,10 @@ from vyos.util import call
 from vyos.util import get_interface_config
 from vyos.util import get_interface_address
 
-def get_dhcp_address(interface):
-    addr = get_interface_address(interface)
-    if not addr:
-        return None
-    if len(addr['addr_info']) == 0:
-        return None
-    return addr['addr_info'][0]['local']
-
 if __name__ == '__main__':
     verb = os.getenv('PLUTO_VERB')
     connection = os.getenv('PLUTO_CONNECTION')
     interface = sys.argv[1]
-    dhcp_interface = sys.argv[2]
 
     openlog(ident=f'vti-up-down', logoption=LOG_PID, facility=LOG_INFO)
     syslog(f'Interface {interface} {verb} {connection}')
@@ -63,9 +54,6 @@ if __name__ == '__main__':
 
     if verb in ['up-client', 'up-host']:
         if not vti_link_up:
-            if dhcp_interface != 'no':
-                local_ip = get_dhcp_address(dhcp_interface)
-                call(f'sudo ip tunnel change {interface} local {local_ip}')
             if 'disable' not in vti_dict:
                 call(f'sudo ip link set {interface} up')
             else:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
With the migration to XFRM interfaces, some of the `dhcp-interface` logic in the `vti-up-down` script needed to cajole legacy VTI tunnel interfaces to match traffic on changing addresses is no longer necessary. Some of the commands executed by the script fail on the new XFRM interfaces, but the failure is ignored and largely harmless. Nonetheless this PR removes the logic in the interest of code cleanup.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T1441 (piggybacking off the original XFRM ticket, lmk if a new ticket is required)

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
- ipsec/vti interfaces

## Proposed changes
<!--- Describe your changes in detail -->

This change removes all `dhcp-interface` logic from the `vti-up-down` script. It also updates the `swanctl.conf` template to no longer pass the DHCP interface name to the `vti-up-down` script.

The `sudo ip tunnel change {interface} local {local_ip}` called by the old script silently errors out on XFRM interfaces as they are not a tunnel. There is no need to modify the XFRM interface in any way when VPN IPs change. Net code deletion :)

Tested on `VyOS 1.4-rolling-202109191513` with no issues.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Configure a site-to-site ipsec tunnel with the `dhcp-interface` setting and bind it to a `vti` interface. Confirm the`vti` interface comes up when the connection comes up and will route traffic over the VPN.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
