### PR TITLE
github: Add .gitattributes to correct language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+data/templates/**/*.conf linguist-language=Jinja
+*.tmpl linguist-language=Jinja
+*.xml.i linguist-language=XML
+*.xml.in linguist-language=XML

--- a/interface-definitions/include/routing-passive-interface.xml.i
+++ b/interface-definitions/include/routing-passive-interface.xml.i
@@ -1,4 +1,4 @@
-<!-- include start from routing-passive-interface-xml.i -->
+<!-- include start from routing-passive-interface.xml.i -->
 <leafNode name="passive-interface">
   <properties>
     <help>Suppress routing updates on an interface</help>

--- a/interface-definitions/protocols-rip.xml.in
+++ b/interface-definitions/protocols-rip.xml.in
@@ -155,7 +155,7 @@
               #include <include/static/static-route-distance.xml.i>
             </children>
           </tagNode>
-          #include <include/routing-passive-interface-xml.i>
+          #include <include/routing-passive-interface.xml.i>
           <node name="redistribute">
             <properties>
               <help>Redistribute information from another routing protocol</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Adds .gitattributes to correctly process xml includes and jinja templates. Also renames a template to use the correct extension.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Github visual/search improvement

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/Txxxx

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
github

## Proposed changes
<!--- Describe your changes in detail -->
Added .gitattributes that corrects the language breakdown on the repo sidebar. Currently incorrectly assumes some XML includes to be "SWIG" or Assembly, and doesn't recognise JInja templates with .tmpl suffix at all.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

See how new breakdown looks on my fork: https://github.com/sarthurdev/vyos-1x

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
