### PR TITLE
T3642: Fix smaller OpenVpn issues

### DIFF
--- a/data/templates/openvpn/server.conf.tmpl
+++ b/data/templates/openvpn/server.conf.tmpl
@@ -176,6 +176,8 @@ tls-version-min {{ tls.tls_version_min }}
 {%   endif %}
 {%   if tls.dh_params is defined and tls.dh_params is not none %}
 dh /run/openvpn/{{ ifname }}_dh.pem
+{%   elif mode == 'server' and tls.private_key is defined %}
+dh none
 {%   endif %}
 {%   if tls.auth_key is defined and tls.auth_key is not none %}
 {%     if mode == 'client' %}

--- a/interface-definitions/interfaces-openvpn.xml.in
+++ b/interface-definitions/interfaces-openvpn.xml.in
@@ -678,7 +678,7 @@
                 <properties>
                   <help>Specify the minimum required TLS version</help>
                   <completionHelp>
-                    <list>1.0 1.1 1.2</list>
+                    <list>1.0 1.1 1.2 1.3</list>
                   </completionHelp>
                   <valueHelp>
                     <format>1.0</format>
@@ -692,8 +692,12 @@
                     <format>1.2</format>
                     <description>TLS v1.2</description>
                   </valueHelp>
+                  <valueHelp>
+                    <format>1.3</format>
+                    <description>TLS v1.3</description>
+                  </valueHelp>
                   <constraint>
-                    <regex>^(1.0|1.1|1.2)$</regex>
+                    <regex>^(1.0|1.1|1.2|1.3)$</regex>
                   </constraint>
                 </properties>
               </leafNode>

--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -134,7 +134,7 @@ def verify_pki(openvpn):
             if tls['certificate'] not in pki['certificate']:
                 raise ConfigError(f'Invalid certificate on openvpn interface {interface}')
 
-            if dict_search_args(pki, 'certificate', tls['certificate'], 'private', 'password_protected'):
+            if dict_search_args(pki, 'certificate', tls['certificate'], 'private', 'password_protected') is not None:
                 raise ConfigError(f'Cannot use encrypted private key on openvpn interface {interface}')
 
             if mode == 'server' and 'dh_params' not in tls and not is_ec_private_key(pki, tls['certificate']):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This PR introduces three very small changes:

1. Enable the use of `tls-min-version 1.3` for openvpn config
2. Fix a bug introduced in the pki refactoring: `password_protected` was not checked correctly
3. OpenVpn always expects a `dh` parameter in server mode. VyOS warns that you should not provide any, if you choose EC certificates. But OpenVpn requires the use of `dh none` in that case. So VyOS now generates `dh none` in absence of `dh-file`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3642

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openvpn

## Proposed changes
<!--- Describe your changes in detail -->
The changes are really small, see summary.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
1. Check that configuring `interface openvpn XXX tls tls-min-version 1.3` works.
2. Generate EC private key and assign `password-protected` property and use that for a OpenVpn server. Make sure the an error occurs.
3. Generate EC private key and use that for a OpenVpn server with no `dh-file` entry. Make sure the OpenVpn server starts correctly and `dh none` is part of the config.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
