### PR TITLE
ddclient: T3897: Add option for IPv6 Dynamic DNS

### DIFF
--- a/data/templates/dynamic-dns/ddclient.conf.tmpl
+++ b/data/templates/dynamic-dns/ddclient.conf.tmpl
@@ -9,7 +9,7 @@ ssl=yes
 {%     set web_skip = ", web-skip='" + interface[iface].use_web.skip + "'" if interface[iface].use_web.skip is defined else '' %}
 use=web, web='{{ interface[iface].use_web.url }}'{{ web_skip }}
 {%   else %}
-use=if, if={{ iface }}
+{{ 'usev6=if' if interface[iface].ipv6_enable is defined else 'use=if' }}, if={{ iface }}
 {%   endif %}
 
 {%   if interface[iface].rfc2136 is defined and interface[iface].rfc2136 is not none %}

--- a/interface-definitions/dns-dynamic.xml.in
+++ b/interface-definitions/dns-dynamic.xml.in
@@ -274,6 +274,12 @@
                       </leafNode>
                     </children>
                   </node>
+                  <leafNode name="ipv6-enable">
+                    <properties>
+                      <help>Allow explicit IPv6 addresses for Dynamic DNS for this interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
                 </children>
               </tagNode>
             </children>

--- a/src/conf_mode/dynamic_dns.py
+++ b/src/conf_mode/dynamic_dns.py
@@ -132,7 +132,7 @@ def generate(dyndns):
         return None
 
     render(config_file, 'dynamic-dns/ddclient.conf.tmpl', dyndns,
-           permission=0o600)
+           permission=0o644)
 
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow to use IPv6 for service Dynamic DNS

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3897

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ddclient, ddns
## Proposed changes
Allow using IPv6 option. By default, it expected an IPv4 address.
Add option "v6-only"

## How to test
WIthout this option I get IPv6 address on interface eth2
```
set service dns dynamic interface eth2 service dynv6 host-name 'xxx.dynv6.net'
set service dns dynamic interface eth2 service dynv6 login 'none'
set service dns dynamic interface eth2 service dynv6 password 'xxx'
set service dns dynamic interface eth2 service dynv6 protocol 'dyndns2'
set service dns dynamic interface eth2 service dynv6 server 'dynv6.com'
```
In logs it compare IPv4 address
```
Oct 11 09:09:34 r1-roll ddclient[2246]: WARNING:  malformed IPv4 address (xxxx:xxx:xx:458::126)
Oct 11 09:10:34 r1-roll ddclient[2526]: WARNING:  malformed IPv4 address (xxxx:xxx:xx:458::126)
Oct 11 09:11:34 r1-roll ddclient[2529]: WARNING:  malformed IPv4 address (xxxx:xxx:xx:458::126)
Oct 11 09:12:34 r1-roll ddclient[2532]: WARNING:  malformed IPv4 address ( xxxx:xxx:xx:458::126)

```
With this option, all works as expected:
```
set service dns dynamic interface eth2 service dynv6 host-name 'xxx.dynv6.net'
set service dns dynamic interface eth2 service dynv6 login 'none'
set service dns dynamic interface eth2 service dynv6 password 'xxx'
set service dns dynamic interface eth2 service dynv6 protocol 'dyndns2'
set service dns dynamic interface eth2 service dynv6 server 'dynv6.com'
set service dns dynamic interface eth2 v6-only

```
Logs:
```
Oct 11 09:28:38 r1-roll systemd[1]: ddclient.service: Succeeded.
Oct 11 09:28:39 r1-roll ddclient[4005]: SUCCESS:  updating xxx.dynv6.net: good: IP address set to xxxx:xxx:xx:458::126
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
