### PR TITLE
T3904: Fix NTP pool associations

### DIFF
--- a/data/templates/ntp/ntpd.conf.tmpl
+++ b/data/templates/ntp/ntpd.conf.tmpl
@@ -6,6 +6,8 @@
 driftfile /var/lib/ntp/ntp.drift
 # By default, only allow ntpd to query time sources, ignore any incoming requests
 restrict default noquery nopeer notrap nomodify
+# Allow pool associations
+restrict source nomodify notrap noquery
 # Local users have unrestricted access, allowing reconfiguration via ntpdc
 restrict 127.0.0.1
 restrict -6 ::1


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Update `ntpd.conf.tmpl` to exclude servers specified in configuration file from `nopeer` restriction.
As of NTP 4.2.7, `nopeer` causes `pool` associations to silently fail.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3904

## Component(s) name
- ntp
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
Add `restrict source nomodify notrap noquery` to `ntpd.conf.tmpl`

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
# show system ntp
 server pool.ntp.org {
     pool
 }
```
Without this PR, this configuration results in ntpd continuously attempting to query servers from `pool.ntp.org` but doing nothing with the results.
```
# ntpq -c peers
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 pool.ntp.org    .POOL.          16 p    -   64    0    0.000    0.000   0.000
```
With this PR, the `peers` output above should, soon after NTP starts, contain a peer with `refid` other than `.POOL.`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
