### PR TITLE
dhclient: T3832: Add hexadecimal format for client-id

### DIFF
--- a/data/templates/dhcp-client/ipv4.tmpl
+++ b/data/templates/dhcp-client/ipv4.tmpl
@@ -7,7 +7,12 @@ retry 300;
 interface "{{ ifname }}" {
     send host-name "{{ dhcp_options.host_name }}";
 {% if dhcp_options.client_id is defined and dhcp_options.client_id is not none %}
-    send dhcp-client-identifier "{{ dhcp_options.client_id }}";
+{%   set client_id = dhcp_options.client_id %}
+{#   Use HEX representation of client-id as it is send in MAC-address style using hex characters. If not HEX, use double quotes ASCII format #}
+{%   if not dhcp_options.client_id.split(':') | length >= 5 %}
+{%     set client_id = '"' + dhcp_options.client_id + '"' %}
+{%   endif %}
+    send dhcp-client-identifier {{ client_id  }};
 {% endif %}
 {% if dhcp_options.vendor_class_id is defined and dhcp_options.vendor_class_id is not none %}
     send vendor-class-identifier "{{ dhcp_options.vendor_class_id }}";


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to use hexadecimal format for DHCP client option client-id.
The value of this option should be without double quotes.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3832

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces ethernet eth2 address 'dhcp'
set interfaces ethernet eth2 dhcp-options client-id '23:33:bb:aa:dd:2d:33:2f:ff'
```
Expected to see client-id without quotes:
```
vyos@r1-roll# cat /var/lib/dhcp/dhclient_eth2.conf
### Autogenerated by interface.py ###

option rfc3442-classless-static-routes code 121 = array of unsigned integer 8;
timeout 60;
retry 300;

interface "eth2" {
    send host-name "r1-roll";
    send dhcp-client-identifier 23:33:bb:aa:dd:2d:33:2f:ff

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
