### PR TITLE
dhclient hooks: T3920: avoid 'too many args' error when no vrf

### DIFF
--- a/src/etc/dhcp/dhclient-exit-hooks.d/01-vyos-cleanup
+++ b/src/etc/dhcp/dhclient-exit-hooks.d/01-vyos-cleanup
@@ -19,7 +19,7 @@ if [[ $reason =~ (EXPIRE|FAIL|RELEASE|STOP) ]]; then
     for router in $old_routers; do
         # check if we are bound to a VRF
         local vrf_name=$(basename /sys/class/net/${interface}/upper_* | sed -e 's/upper_//')
-        if [ -n $vrf_name ]; then
+        if [ "$vrf_name" != "*" ]; then
             vrf="vrf $vrf_name"
         fi
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Stop 01-vyos-cleanup producing an error when there is no VRF/upper interface.
```
Oct 20 11:59:49 vyos dhclient[2057]: /etc/dhcp/dhclient-exit-hooks.d/01-vyos-cleanup: line 25: [: too many arguments
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3920

## Component(s) name
dhclient exit hook script

## Proposed changes
When upper_* has no match $vrf_name will be set to *. This combined with the lack of quoting around the $vrf_name variable in the next line (`[ -n $vrf_name ]`) causes * to expand to whatever files/directories are in the scripts working directory triggering the 'too many arguments' error. I have changed the if so it will only set $vrf when $vrf_name is not *.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
