### PR TITLE
dhcpv6-server: T3918: Fix subnets verify raise ConfigError

### DIFF
--- a/src/conf_mode/dhcpv6_server.py
+++ b/src/conf_mode/dhcpv6_server.py
@@ -128,7 +128,7 @@ def verify(dhcpv6):
 
             # Subnets must be unique
             if subnet in subnets:
-                raise ConfigError('DHCPv6 subnets must be unique! Subnet {0} defined multiple times!'.format(subnet['network']))
+                raise ConfigError(f'DHCPv6 subnets must be unique! Subnet {subnet} defined multiple times!')
             subnets.append(subnet)
 
         # DHCPv6 requires at least one configured address range or one static mapping


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix for subnets verify ConfigError
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3918

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add the same subnet for different shared network names.
Tested configuration:
```
set service dhcpv6-server shared-network-name DHCPv6 subnet 2001:cafe:fefe::/48 address-range start 2001:cafe:fefe::100 stop '2001:cafe:fefe::1000'
set service dhcpv6-server shared-network-name PREFIX subnet 2001:cafe:fefe::/48 prefix-delegation start 2001:cafe:fefe:1111:: prefix-length '64'
set service dhcpv6-server shared-network-name PREFIX subnet 2001:cafe:fefe::/48 prefix-delegation start 2001:cafe:fefe:1111:: stop '2001:cafe:fefe:ffff::'

vyos@r1-roll# commit
[ service dhcpv6-server ]
DHCPv6 subnets must be unique! Subnet 2001:cafe:fefe::/48 defined multiple times!

[[service dhcpv6-server]] failed
Commit failed
[edit]
vyos@r1-roll# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
