### PR TITLE
dhcp-server: T3610: Allow configuration for non-primary ip address

### DIFF
--- a/src/conf_mode/dhcp_server.py
+++ b/src/conf_mode/dhcp_server.py
@@ -226,7 +226,7 @@ def verify(dhcp):
             # There must be one subnet connected to a listen interface.
             # This only counts if the network itself is not disabled!
             if 'disable' not in network_config:
-                if is_subnet_connected(subnet, primary=True):
+                if is_subnet_connected(subnet, primary=False):
                     listen_ok = True
 
             # Subnets must be non overlapping


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
For some reason, we have a limit that only primary ip address should be configured for DHCP-server.
Allow secondary ip address for DHCP-server.
I can't find any reason why it was implemented. A user can deploy primary address "X" secondary address "Y" and then configure DHCP-server for address X, then remove and add address X from/to interface. In that case the address "X" will be secondary.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3610

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add 2 ip addresses to interface and set DHCP-server config for secondary network:
```
set interfaces ethernet eth1 address '10.100.100.1/24'
set interfaces ethernet eth1 address '192.168.50.1/24'
set service dhcp-server shared-network-name LAN-eth2 subnet 192.168.50.0/24 default-router '192.168.50.1'
set service dhcp-server shared-network-name LAN-eth2 subnet 192.168.50.0/24 name-server '8.8.8.8'
set service dhcp-server shared-network-name LAN-eth2 subnet 192.168.50.0/24 range 0 start '192.168.50.100'
set service dhcp-server shared-network-name LAN-eth2 subnet 192.168.50.0/24 range 0 stop '192.168.50.150'
```
Check service dhcp-server and generated configuration:
```
vyos@r1-roll# sudo systemctl status isc-dhcp-server
● isc-dhcp-server.service - ISC DHCP IPv4 server
     Loaded: loaded (/lib/systemd/system/isc-dhcp-server.service; disabled; vendor preset: enabled)
     Active: active (running) since Thu 2021-10-21 20:18:52 EEST; 14min ago
       Docs: man:dhcpd(8)

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
