### PR TITLE
dhclient: T3940: Added lease file argument to the `dhclient -x` call

### DIFF
--- a/src/etc/dhcp/dhclient-enter-hooks.d/02-vyos-stopdhclient
+++ b/src/etc/dhcp/dhclient-enter-hooks.d/02-vyos-stopdhclient
@@ -23,10 +23,12 @@ if [ -z ${CONTROLLED_STOP} ] ; then
         if ([ $dhclient -ne $current_dhclient ] && [ $dhclient -ne $master_dhclient ]); then
             # get path to PID-file of dhclient process
             local dhclient_pidfile=`ps --no-headers --format args --pid $dhclient | awk 'match(\$0, ".*-pf (/.*pid) .*", PF) { print PF[1] }'`
+            # get path to lease-file of dhclient process
+            local dhclient_leasefile=`ps --no-headers --format args --pid $dhclient | awk 'match(\$0, ".*-lf (/\\\S*leases) .*", LF) { print LF[1] }'`
             # stop dhclient with native command - this will run dhclient-script with correct reason unlike simple kill
-            logmsg info "Stopping dhclient with PID: ${dhclient}, PID file: $dhclient_pidfile"
+            logmsg info "Stopping dhclient with PID: ${dhclient}, PID file: ${dhclient_pidfile}, Leases file: ${dhclient_leasefile}"
             if [[ -e $dhclient_pidfile ]]; then
-                dhclient -e CONTROLLED_STOP=yes -x -pf $dhclient_pidfile
+                dhclient -e CONTROLLED_STOP=yes -x -pf $dhclient_pidfile -lf $dhclient_leasefile
             else
                 logmsg error "PID file $dhclient_pidfile does not exists, killing dhclient with SIGTERM signal"
                 kill -s 15 ${dhclient}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added lease file argument to the `dhclient -x` call

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3940

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhclient

## Proposed changes
<!--- Describe your changes in detail -->
When `dhclient` with the `-x` option is used to stop running DHCP client
with a lease file that is not the same as in the new `dhclient` process,
it requires a `-lf` argument with a path to the old lease file to find
information about old/active leases and process them according to
instructions and config.

This commit adds the option to the `02-vyos-stopdhclient` hook, which
allows to properly process `dhclient` instances started in different
ways.


## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
The next script may be used to check the behavior:
```
#!/bin/bash
# stop dhclient stared by VyOS config
systemctl stop dhclient@eth0.service
# stop dhclient started by any of the rest tools
killall dhclient
# wait while all the processes will stop
sleep 10
# flush IP addresses on the interface, in case if they was not cleaned up
ip a flush eth0
# start shclient in the manner of Cloud-init
/sbin/dhclient -4 -v -i -pf /run/dhclient.eth0.pid -lf /var/lib/dhcp/dhclient.eth0.leases -I -df /var/lib/dhcp/dhclient6.eth0.leases eth0
# wait for a lease and hooks execution
sleep 10
# start dhclient in the VyOS-way
/sbin/dhclient -4 -v -nw -pf /var/lib/dhcp/dhclient_eth0.pid -lf /var/lib/dhcp/dhclient_eth0.leases eth0
# wait for a lease and hooks
sleep 10
```

After running it on a clean VyOS in a network with a DHCP server that processes DUID in DHCP messages, there should be two IP addresses on the eth0 interface with only one active `dhclient` process.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
