### PR TITLE
IPSec: T3941: Fix uptime for tunnels sa op-mode

### DIFF
--- a/src/op_mode/show_ipsec_sa.py
+++ b/src/op_mode/show_ipsec_sa.py
@@ -57,10 +57,7 @@ for sa in sas:
         else:
             state = "down"
 
-        if state == "up":
-            uptime = vyos.util.seconds_to_human(parent_sa["established"].decode())
-        else:
-            uptime = "N/A"
+        uptime = "N/A"
 
         remote_host = parent_sa["remote-host"].decode()
         remote_id = parent_sa["remote-id"].decode()
@@ -87,6 +84,8 @@ for sa in sas:
                 pkts_str = "{0}/{1}".format(pkts_in, pkts_out)
                 # Remove B from <1K values
                 pkts_str = re.sub(r'B', r'', pkts_str)
+
+                uptime = vyos.util.seconds_to_human(isa['install-time'].decode())
 
                 enc = isa["encr-alg"].decode()
                 if "encr-keysize" in isa:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
VyOS 1.3
The current uptime for tunnels is getting from parent SA
That is incorrect as we should get value from child SA

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3941

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Compare uptime from op-mode and the real time from child SA 
Expected time 25s  and not 1103s
```
vyos@r4-epa2:~$ show vpn ipsec sa && sudo swanctl -l
Connection                  State    Uptime    Bytes In/Out    Packets In/Out    Remote address    Remote ID    Proposal
--------------------------  -------  --------  --------------  ----------------  ----------------  -----------  ----------------------
peer-100.64.0.1-tunnel-vti  up       25s       0B/0B           0/0               100.64.0.1        N/A          AES_GCM_16_256/ECP_256
peer-100.64.0.1-tunnel-vti: #2, ESTABLISHED, IKEv2, 358b3d494d31570b_i* d76bd2b4488eba0e_r
  local  '100.64.0.2' @ 100.64.0.2[500]
  remote '100.64.0.1' @ 100.64.0.1[500]
  AES_GCM_16-256/PRF_HMAC_SHA2_256/ECP_256
  established 1103s ago, rekeying in 26182s
  peer-100.64.0.1-tunnel-vti: #36, reqid 2, INSTALLED, TUNNEL, ESP:AES_GCM_16-256/ECP_256
    installed 25s ago, rekeying in 2756s, expires in 3575s
    in  cd025bb3 (0x00900001),      0 bytes,     0 packets
    out c5fb3611 (0x00900001),      0 bytes,     0 packets
    local  0.0.0.0/0
    remote 0.0.0.0/0
vyos@r4-epa2:~$ 


```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
