### PR TITLE
ipsec: T3643: Fix for show tunnels with state down

### DIFF
--- a/src/op_mode/show_ipsec_sa.py
+++ b/src/op_mode/show_ipsec_sa.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019 VyOS maintainers and contributors
+# Copyright (C) 2019-2021 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -29,35 +29,22 @@ def convert(text):
 def alphanum_key(key):
     return [convert(c) for c in re.split('([0-9]+)', str(key))]
 
-try:
-    session = vici.Session()
-    sas = session.list_sas()
-except PermissionError:
-    print("You do not have a permission to connect to the IPsec daemon")
-    sys.exit(1)
-except ConnectionRefusedError:
-    print("IPsec is not runing")
-    sys.exit(1)
-except Exception as e:
-    print("An error occured: {0}".format(e))
-    sys.exit(1)
+def format_output(conns, sas):
+    sa_data = []
 
-sa_data = []
+    for peer, parent_conn in conns.items():
+        if peer not in sas:
+            continue
 
-for sa in sas:
-    # list_sas() returns a list of single-item dicts
-    for peer in sa:
-        parent_sa = sa[peer]
-        child_sas = parent_sa["child-sas"]
-        installed_sas = {k: v for k, v in child_sas.items() if v["state"] == b"INSTALLED"}
+        parent_sa = sas[peer]
+        child_sas = parent_sa['child-sas']
+        installed_sas = {v['name'].decode(): v for k, v in child_sas.items() if v["state"] == b"INSTALLED"}
 
-        # parent_sa["state"] = IKE state, child_sas["state"] = ESP state
+        state = 'down'
+        uptime = 'N/A'
+
         if parent_sa["state"] == b"ESTABLISHED" and installed_sas:
             state = "up"
-        else:
-            state = "down"
-
-        uptime = "N/A"
 
         remote_host = parent_sa["remote-host"].decode()
         remote_id = parent_sa["remote-id"].decode()
@@ -66,53 +53,79 @@ for sa in sas:
             remote_id = "N/A"
 
         # The counters can only be obtained from the child SAs
-        if not installed_sas:
-            data = [peer, state, "N/A", "N/A", "N/A", "N/A", "N/A", "N/A"]
-            sa_data.append(data)
-        else:
-            for csa in installed_sas:
-                isa = installed_sas[csa]
-                csa_name = isa['name']
-                csa_name = csa_name.decode()
-
-                bytes_in = hurry.filesize.size(int(isa["bytes-in"].decode()))
-                bytes_out = hurry.filesize.size(int(isa["bytes-out"].decode()))
-                bytes_str = "{0}/{1}".format(bytes_in, bytes_out)
-
-                pkts_in = hurry.filesize.size(int(isa["packets-in"].decode()), system=hurry.filesize.si)
-                pkts_out = hurry.filesize.size(int(isa["packets-out"].decode()), system=hurry.filesize.si)
-                pkts_str = "{0}/{1}".format(pkts_in, pkts_out)
-                # Remove B from <1K values
-                pkts_str = re.sub(r'B', r'', pkts_str)
-
-                uptime = vyos.util.seconds_to_human(isa['install-time'].decode())
-
-                enc = isa["encr-alg"].decode()
-                if "encr-keysize" in isa:
-                    key_size = isa["encr-keysize"].decode()
-                else:
-                    key_size = ""
-                if "integ-alg" in isa:
-                    hash = isa["integ-alg"].decode()
-                else:
-                    hash = ""
-                if "dh-group" in isa:
-                    dh_group = isa["dh-group"].decode()
-                else:
-                    dh_group = ""
-
-                proposal = enc
-                if key_size:
-                    proposal = "{0}_{1}".format(proposal, key_size)
-                if hash:
-                    proposal = "{0}/{1}".format(proposal, hash)
-                if dh_group:
-                    proposal = "{0}/{1}".format(proposal, dh_group)
-
-                data = [csa_name, state, uptime, bytes_str, pkts_str, remote_host, remote_id, proposal]
+        for child_conn in parent_conn['children']:
+            if child_conn not in installed_sas:
+                data = [child_conn, "down", "N/A", "N/A", "N/A", "N/A", "N/A", "N/A"]
                 sa_data.append(data)
+                continue
 
-headers = ["Connection", "State", "Uptime", "Bytes In/Out", "Packets In/Out", "Remote address", "Remote ID", "Proposal"]
-sa_data = sorted(sa_data, key=alphanum_key)
-output = tabulate.tabulate(sa_data, headers)
-print(output)
+            isa = installed_sas[child_conn]
+            csa_name = isa['name']
+            csa_name = csa_name.decode()
+
+            bytes_in = hurry.filesize.size(int(isa["bytes-in"].decode()))
+            bytes_out = hurry.filesize.size(int(isa["bytes-out"].decode()))
+            bytes_str = "{0}/{1}".format(bytes_in, bytes_out)
+
+            pkts_in = hurry.filesize.size(int(isa["packets-in"].decode()), system=hurry.filesize.si)
+            pkts_out = hurry.filesize.size(int(isa["packets-out"].decode()), system=hurry.filesize.si)
+            pkts_str = "{0}/{1}".format(pkts_in, pkts_out)
+            # Remove B from <1K values
+            pkts_str = re.sub(r'B', r'', pkts_str)
+
+            uptime = vyos.util.seconds_to_human(isa['install-time'].decode())
+
+            enc = isa["encr-alg"].decode()
+            if "encr-keysize" in isa:
+                key_size = isa["encr-keysize"].decode()
+            else:
+                key_size = ""
+            if "integ-alg" in isa:
+                hash = isa["integ-alg"].decode()
+            else:
+                hash = ""
+            if "dh-group" in isa:
+                dh_group = isa["dh-group"].decode()
+            else:
+                dh_group = ""
+
+            proposal = enc
+            if key_size:
+                proposal = "{0}_{1}".format(proposal, key_size)
+            if hash:
+                proposal = "{0}/{1}".format(proposal, hash)
+            if dh_group:
+                proposal = "{0}/{1}".format(proposal, dh_group)
+
+            data = [csa_name, state, uptime, bytes_str, pkts_str, remote_host, remote_id, proposal]
+            sa_data.append(data)
+    return sa_data
+
+if __name__ == '__main__':
+    try:
+        session = vici.Session()
+        conns = {}
+        sas = {}
+
+        for conn in session.list_conns():
+            for key in conn:
+                conns[key] = conn[key]
+
+        for sa in session.list_sas():
+            for key in sa:
+                sas[key] = sa[key]
+
+        headers = ["Connection", "State", "Uptime", "Bytes In/Out", "Packets In/Out", "Remote address", "Remote ID", "Proposal"]
+        sa_data = format_output(conns, sas)
+        sa_data = sorted(sa_data, key=alphanum_key)
+        output = tabulate.tabulate(sa_data, headers)
+        print(output)
+    except PermissionError:
+        print("You do not have a permission to connect to the IPsec daemon")
+        sys.exit(1)
+    except ConnectionRefusedError:
+        print("IPsec is not runing")
+        sys.exit(1)
+    except Exception as e:
+        print("An error occured: {0}".format(e))
+        sys.exit(1)


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The current op-mode for "show vpn ipsec sa" shows only tunnels
which established (parent SA) and installed (child SA)
If the tunnel is not installed it can't show correct information about
this tunnel, in that case, it can show only parent sa state
Get codebase for "show_ipsec_sa.py" (op-mode) from 1.4 branch
where it was fixed.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3643

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Op-mode before fix
Configure 3 tunnels for one peer 192.0.2.2
It shows only  state from parent SA and can't show states of child SA if they not "INSTALLED"
```
root@r4-epa2:/home/vyos# show vpn ipsec sa
Connection                  State    Uptime    Bytes In/Out    Packets In/Out    Remote address    Remote ID    Proposal
--------------------------  -------  --------  --------------  ----------------  ----------------  -----------  --------------
peer-100.64.0.1-tunnel-vti  up       4m32s     0B/0B           0/0               100.64.0.1        N/A          AES_GCM_16_256
peer-192.0.2.2-tunnel-1     down     N/A       N/A             N/A               N/A               N/A          N/A
root@r4-epa2:/home/vyos# 
```
Op-mode after fix:
```
vyos@r4-epa2:~$ show vpn ipsec sa
Connection                  State    Uptime    Bytes In/Out    Packets In/Out    Remote address    Remote ID    Proposal
--------------------------  -------  --------  --------------  ----------------  ----------------  -----------  --------------
peer-100.64.0.1-tunnel-vti  up       26m18s    0B/0B           0/0               100.64.0.1        N/A          AES_GCM_16_256
peer-192.0.2.2-tunnel-1     down     N/A       N/A             N/A               N/A               N/A          N/A
peer-192.0.2.2-tunnel-2     down     N/A       N/A             N/A               N/A               N/A          N/A
peer-192.0.2.2-tunnel-3     down     N/A       N/A             N/A               N/A               N/A          N/A
vyos@r4-epa2:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
