### PR TITLE
powerctl: T3862: Fix for reboot at 00:00

### DIFF
--- a/src/op_mode/powerctrl.py
+++ b/src/op_mode/powerctrl.py
@@ -97,7 +97,7 @@ def execute_shutdown(time, reboot = True, ask=True):
   elif len(time) == 1:
     # Assume the argument is just time
     ts = parse_time(time[0])
-    if ts:
+    if ts is not None:
       cmd = check_output(["/sbin/shutdown", action, time[0]], stderr=STDOUT)
     else:
       sys.exit("Invalid time \"{0}\". The valid format is HH:MM".format(time[0]))
@@ -105,7 +105,7 @@ def execute_shutdown(time, reboot = True, ask=True):
     # Assume it's date and time
     ts = parse_time(time[0])
     ds = parse_date(time[1])
-    if ts and ds:
+    if ts is not None and ds:
       t = datetime.combine(ds, ts)
       td = t - datetime.now()
       t2 = 1 + int(td.total_seconds())//60 # Get total minutes


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
For some reason time, `00:00` was checked incorrectly in ts checks.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3862

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
reboot
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Before fix:
```
vyos@r12-lts:~$ reboot at 00:00
Invalid time "00:00". The valid format is HH:MM
vyos@r12-lts:~$ 
vyos@r12-lts:~$ reboot at 00:00 date 21.12.2021
Invalid time "00:00". The valid format is HH:MM
vyos@r12-lts:~$ 

```
After fix:
```
vyos@r12-lts:~$ reboot at 00:00
Shutting down at Sat 2021-10-30 00:00:00 EEST (reboot)...
vyos@r12-lts:~$ 

vyos@r12-lts:~$ reboot at 00:00 date 23.12.2021
Shutting down at Wed 2021-12-22 23:00:45 EET (reboot)...
vyos@r12-lts:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
