### PR TITLE
vrrp: T3467: Add ipv4 and ipv6 validators for /31 addresses

### DIFF
--- a/interface-definitions/vrrp.xml
+++ b/interface-definitions/vrrp.xml
@@ -218,8 +218,8 @@
                   <multi/>
                   <help>Virtual address (IPv4 or IPv6, but they must not be mixed in one group)</help>
                   <constraint>
-                    <validator name="ipv4-host"/>
-                    <validator name="ipv6-host"/>
+                    <validator name="ipv4"/>
+                    <validator name="ipv6"/>
                   </constraint>
                   <constraintErrorMessage>Virtual address must be a valid IPv4 or IPv6 address with prefix length (e.g. 192.0.2.3/24 or 2001:db8:ff::10/64)</constraintErrorMessage>
                   <valueHelp>

--- a/src/validators/ipv4
+++ b/src/validators/ipv4
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+ipaddrcheck --is-ipv4 $1

--- a/src/validators/ipv6
+++ b/src/validators/ipv6
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+ipaddrcheck --is-ipv6 $1


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
In some cases, we can't use ipv4-host to correct validate
ip addresses
For example ip address with prefix /31, 192.168.99.2/31
it is network and host at the same time and the validator thinks
that its network.
Additional ipv4 and ipv6 validators fix this issue

It also fixes for adding /31 prefixes as vrrp virtual-address
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3467

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
validators, vrrp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set high-availability vrrp group GRP02 hello-source-address '203.0.113.1'
set high-availability vrrp group GRP02 interface 'eth1.50'
set high-availability vrrp group GRP02 no-preempt
set high-availability vrrp group GRP02 priority '150'
set high-availability vrrp group GRP02 rfc3768-compatibility
set high-availability vrrp group GRP02 virtual-address '192.168.99.2/31'
set high-availability vrrp group GRP02 vrid '10'

```
Show interfaces vrrp:
```
vyos@r12-lts:~$ show int vrrp 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
eth1.50v10       192.168.99.2/31                   u/u  
vyos@r12-lts:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
