### PR TITLE
interfaces: T2281: Ability to set static and DHCP addr on same interface

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1056,14 +1056,6 @@ class Interface(Control):
 
         addr_is_v4 = is_ipv4(addr)
 
-        # we can't have both DHCP and static IPv4 addresses assigned
-        for a in self._addr:
-            if ( ( addr == 'dhcp' and a != 'dhcpv6' and is_ipv4(a) ) or
-                    ( a == 'dhcp' and addr != 'dhcpv6' and addr_is_v4 ) ):
-                raise ConfigError((
-                    "Can't configure both static IPv4 and DHCP address "
-                    "on the same interface"))
-
         # add to interface
         if addr == 'dhcp':
             self.set_dhcp(True)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
There is not any reason to enable only DHCP or only static address
on the interface at the same time
It is possible to have both.

So I delete this check to figure out what can be wrong with it.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T2281

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
interfaces, address, dhcp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Set DHCP + static ip address on the same interface
```
set interfaces ethernet eth2 address '192.0.2.4/24'
set interfaces ethernet eth2 address 'dhcp'
```
Check that system gets both addresses:
```
vyos@r1-roll# run show interfaces ethernet 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
eth0             192.168.122.11/24                 u/u  
eth1             100.64.0.1/30                     u/u  
eth2             192.0.2.4/24                      u/u  
                 192.168.100.177/24                     
[edit]
vyos@r1-roll# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
