### PR TITLE
sstp: T2566: Fix to allow IPv6 only pools

### DIFF
--- a/data/templates/accel-ppp/config_ipv6_pool.j2
+++ b/data/templates/accel-ppp/config_ipv6_pool.j2
@@ -5,7 +5,7 @@ AdvAutonomousFlag=1
 {%   if client_ipv6_pool.prefix is defined and client_ipv6_pool.prefix is not none %}
 [ipv6-pool]
 {%     for prefix, options in client_ipv6_pool.prefix.items() %}
-{{ prefix }},{{ options.mask }}
+{{ prefix }},{{ '64 ' if options.mask is not defined else options.mask }}
 {%     endfor %}
 {%     if client_ipv6_pool.delegate is defined and client_ipv6_pool.delegate is not none %}
 {%       for prefix, options in client_ipv6_pool.delegate.items() %}

--- a/data/templates/accel-ppp/sstp.config.tmpl
+++ b/data/templates/accel-ppp/sstp.config.tmpl
@@ -52,9 +52,9 @@ verbose=1
 check-ip=1
 {# MTU #}
 mtu={{ mtu }}
-{% if client_ipv6_pool is defined %}
-ipv6=allow
-{% endif %}
+ipv6={{ 'allow' if ppp_options.ipv6 == "deny" and client_ipv6_pool is defined else ppp_options.ipv6 }}
+ipv4={{ ppp_options.ipv4 }}
+
 mppe={{ ppp_options.mppe }}
 lcp-echo-interval={{ ppp_options.lcp_echo_interval }}
 lcp-echo-timeout={{ ppp_options.lcp_echo_timeout }}

--- a/interface-definitions/include/accel-ppp/ppp-options-ipv4.xml.i
+++ b/interface-definitions/include/accel-ppp/ppp-options-ipv4.xml.i
@@ -1,0 +1,23 @@
+<!-- include start from accel-ppp/ppp-options-ipv4.xml.i -->
+<leafNode name="ipv4">
+  <properties>
+    <help>IPv4 negotiation algorithm</help>
+    <constraint>
+      <regex>^(deny|allow)$</regex>
+    </constraint>
+    <constraintErrorMessage>invalid value</constraintErrorMessage>
+    <valueHelp>
+      <format>deny</format>
+      <description>Do not negotiate IPv4</description>
+    </valueHelp>
+    <valueHelp>
+      <format>allow</format>
+      <description>Negotiate IPv4 only if client requests</description>
+    </valueHelp>
+    <completionHelp>
+      <list>deny allow</list>
+    </completionHelp>
+  </properties>
+  <defaultValue>allow</defaultValue>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/accel-ppp/ppp-options-ipv6.xml.i
+++ b/interface-definitions/include/accel-ppp/ppp-options-ipv6.xml.i
@@ -1,0 +1,31 @@
+<!-- include start from accel-ppp/ppp-options-ipv6.xml.i -->
+<leafNode name="ipv6">
+  <properties>
+    <help>IPv6 (IPCP6) negotiation algorithm</help>
+    <constraint>
+      <regex>^(deny|allow|prefer|require)$</regex>
+    </constraint>
+    <constraintErrorMessage>invalid value</constraintErrorMessage>
+    <valueHelp>
+      <format>deny</format>
+      <description>Do not negotiate IPv6</description>
+    </valueHelp>
+    <valueHelp>
+      <format>allow</format>
+      <description>Negotiate IPv6 only if client requests</description>
+    </valueHelp>
+    <valueHelp>
+      <format>prefer</format>
+      <description>Ask client for IPv6 negotiation, do not fail if it rejects</description>
+    </valueHelp>
+    <valueHelp>
+      <format>require</format>
+      <description>Require IPv6 negotiation</description>
+    </valueHelp>
+    <completionHelp>
+      <list>deny allow prefer require</list>
+    </completionHelp>
+  </properties>
+  <defaultValue>deny</defaultValue>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/vpn_sstp.xml.in
+++ b/interface-definitions/vpn_sstp.xml.in
@@ -43,6 +43,8 @@
             </properties>
             <children>
               #include <include/accel-ppp/ppp-mppe.xml.i>
+              #include <include/accel-ppp/ppp-options-ipv4.xml.i>
+              #include <include/accel-ppp/ppp-options-ipv6.xml.i>
               #include <include/accel-ppp/lcp-echo-interval-failure.xml.i>
               #include <include/accel-ppp/lcp-echo-timeout.xml.i>
             </children>


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
To allow IPv6 only for vpn sstp sessions we have to add
'ppp-options' which can disable IPv4 allocation explicitly.
Additional IPv6 ppp-options and fix template for it.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T2566

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
sstp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS sstp configuration:
```
set vpn sstp authentication local-users username foo password 'bar'
set vpn sstp authentication local-users username foo2 password 'bar2'
set vpn sstp authentication mode 'local'
set vpn sstp client-ipv6-pool prefix 2001:db8::/48
set vpn sstp gateway-address '192.168.122.14'
set vpn sstp ppp-options ipv4 'deny'
set vpn sstp ppp-options ipv6 'allow'
set vpn sstp ssl ca-cert-file '/config/user-data/sstp/ca.crt'
set vpn sstp ssl cert-file '/config/user-data/sstp/server.crt'
set vpn sstp ssl key-file '/config/user-data/sstp/server.key'
```
Check sessions:
```
vyos@r4-epa2# run show sstp-server sessions 
ifname | username |          ip           |          ip6          | ip6-dp |   calling-sid   | rate-limit | state  |  uptime  | rx-bytes | tx-bytes 
--------+----------+-----------------------+-----------------------+--------+-----------------+------------+--------+----------+----------+----------
 sstp0  | foo2     | 2001:db8:0:0:200::/64 | 2001:db8:0:0:200::/64 |        | 192.168.122.222 |            | active | 00:12:45 | 2.9 KiB  | 946 B
[edit]
vyos@r4-epa2# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
