### PR TITLE
T3796:op-mode: wireguard interface not shown

### DIFF
--- a/op-mode-definitions/wireguard.xml
+++ b/op-mode-definitions/wireguard.xml
@@ -19,7 +19,7 @@
               <help>generate a wireguard preshared key</help>
             </properties>
             <command>${vyos_op_scripts_dir}/wireguard.py --genpsk</command>
-          </leafNode> 
+          </leafNode>
         </children>
       </node>
     </children>
@@ -51,10 +51,10 @@
             <properties>
               <help>show wireguard interface information</help>
               <completionHelp>
-                <script>${vyos_completion_dir}/list_interfaces.py -t wireguard</script>
+                <script>${vyos_completion_dir}/list_interfaces.py --type wireguard</script>
               </completionHelp>
             </properties>
-            <command>sudo wg show "$4"</command>
+            <command>${vyatta_bindir}/vyatta-show-interfaces.pl --intf="$4"</command>
             <children>
               <leafNode name="allowed-ips">
                 <properties>
@@ -74,12 +74,17 @@
                 </properties>
                 <command>sudo wg show "$4" peers</command>
               </leafNode>
-             <!-- more commands upon request --> 
+             <!-- more commands upon request -->
             </children>
           </tagNode>
+          <node name="wireguard">
+            <properties>
+              <help>Show WireGuard interface information</help>
+            </properties>
+            <command> ${vyatta_bindir}/vyatta-show-interfaces.pl --intf-type=wireguard --action=show-brief</command>
+          </node>
         </children>
       </node>
     </children>
   </node>
 </interfaceDefinition>
-


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

When executed the command 'show interfaces wireguard' command, it is not
showing the configured interface in the output. Modified the script to show
the interface results.
Also modified the script to show in detail information when the specific interface is mentioned.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/Txxxx
https://phabricator.vyos.net/T3796

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireguard,
## Proposed changes
<!--- Describe your changes in detail -->

proper syntax is added to show the configured interfaces
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
--> Add the wireguard configuration:
set interfaces wireguard wg01 address 'x.x.x.x/x'
set interfaces wireguard wg01 peer wg01 allowed-ips 'x.x.x.x/x'
set interfaces wireguard wg01 peer wg01 endpoint 'x.x.x.x:51820'
set interfaces wireguard wg01 peer wg01 pubkey 'xO4cT2OkoqjQfY7DG/4Tu55e7koXZFS7mk9VSLoRH04='
set interfaces wireguard wg01 port '51820'

Then run this command:

$ show interfaces wireguard
$ show interface wireguard wg01

Desired O/P:

vyos@labR1:~$ show interfaces wireguard
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
wg01             x0.x00.0.x0/xx                    u/u  wg01

vyos@labR1:~$ show interfaces wireguard wg01
wg01: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1420 qdisc noqueue state UNKNOWN group default qlen 1000
    link/none
    inet 10.100.0.10/24 scope global wg01
       valid_lft forever preferred_lft forever
    Description: wg01

    RX:  bytes    packets     errors    dropped    overrun      mcast
             0          0          0          0          0          0
    TX:  bytes    packets     errors    dropped    carrier collisions
             0          0          0          0          0          0


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
