### PR TITLE
atop: T3774: Atop log file rotation fix

### DIFF
--- a/debian/vyos-1x.install
+++ b/debian/vyos-1x.install
@@ -1,6 +1,7 @@
 etc/cron.hourly
 etc/dhcp
 etc/ipsec.d
+etc/logrotate.d
 etc/netplug
 etc/opennhrp
 etc/ppp

--- a/src/etc/logrotate.d/vyos-atop
+++ b/src/etc/logrotate.d/vyos-atop
@@ -1,0 +1,20 @@
+/var/log/atop/atop.log {
+    daily
+    dateext
+    dateformat _%Y-%m-%d_%H-%M-%S
+    maxsize 10M
+    missingok
+    nocompress
+    nocreate
+    nomail
+    rotate 10
+    prerotate
+        # stop the service
+        systemctl stop atop.service
+    endscript
+    postrotate
+        # start atop service again
+        systemctl start atop.service
+    endscript
+}
+

--- a/src/etc/systemd/system/atop.service.d/10-override.conf
+++ b/src/etc/systemd/system/atop.service.d/10-override.conf
@@ -1,0 +1,6 @@
+[Service]
+ExecStartPre=
+ExecStart=
+ExecStart=/bin/sh -c 'exec /usr/bin/atop ${LOGOPTS} -w "${LOGPATH}/atop.log" ${LOGINTERVAL}'
+ExecStartPost=
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Atop service by default rotate files only daily and keeps the latest 28 files. The rotation logic is too complex. This commit changes service in a way that allows us to control rotation strategy.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3774

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
atop, logrotate

## Proposed changes
<!--- Describe your changes in detail -->
The systemd unit for atop service is changed, so the log file name and location will be always the same. It also adds the logrotate configuration to conditionally rotate a log file.
Hardcoded values:
- maximum log file size: 10 MB
- maximum count of files: 10
These values can be easily changed within the `/etc/logrotate.d/vyos-atop`, no additional configuration is required.
Rotation will be done hourly, if necessary, according to `/etc/cron.hourly/vyos-logrotate-hourly`.

This change has two benefits:
- rotation strategy control can be done via logrotate, and can be exposed to CLI now;
- the total size of all logs is now controlled more aggressively, so the chance to get a situation when atop logs took all the space on a drive is significantly lower. Also, if this will be necessary, rotation may be done even each minute what reduces risks related to logs size even more.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
