### PR TITLE
T3946: Automatically resize the root partition if the drive has extra…

### DIFF
--- a/op-mode-definitions/force-part-resize.xml.in
+++ b/op-mode-definitions/force-part-resize.xml.in
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="force">
+    <children>
+      <node name="resize-partition">
+        <properties>
+          <help>Resize the VyOS partition</help>
+        </properties>
+        <command>${vyos_op_scripts_dir}/force_part_resize.sh</command>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/src/op_mode/force_part_resize.sh
+++ b/src/op_mode/force_part_resize.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2021 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#
+# Function to get the vyos version from the commandline.
+#
+get_version () {
+for item in `cat /proc/cmdline`; do
+  if [  "vyos-union" == "${item%=*}" ]; then
+    echo ${item#*=}
+  fi
+done
+}
+
+#
+# VERSION is the output of the get_version output.
+# DEVICEPART is the device partition where VyOS is mounted on.
+# DEVICEPATH is the path to the device where VyOS is mounted on.
+# DEVICE is the device of the device partition.
+# PARTNR is the device partition number used for parted.
+#
+VERSION=$(get_version)
+DEVICEPART=$(mount | grep $VERSION/grub | cut -d' ' -f1 | rev | cut -d'/' -f1 | rev)
+DEVICEPATH=$(mount | grep $VERSION/grub | cut -d' ' -f1 | rev | cut -d'/' -f2- | rev)
+DEVICE=$(lsblk -no pkname $DEVICEPATH/$DEVICEPART)
+PARTNR=$(grep -c $DEVICEPART /proc/partitions)
+
+#
+# Check if the device really exits.
+#
+fdisk -l $DEVICEPATH/$DEVICE >> /dev/null 2>&1 || (echo "could not find device $DEVICE" && exit 1)
+
+#
+# START is the partition starting sector.
+# CURSIZE is the partition start sector + the partition end sector.
+# MAXSIZE is the device end sector.
+#
+START=$(cat /sys/block/$DEVICE/$DEVICEPART/start)
+CURSIZE=$(($START+$(cat /sys/block/$DEVICE/$DEVICEPART/size)))
+MAXSIZE=$(($(cat /sys/block/$DEVICE/size)-8))
+
+#
+# Check if the device size is larger then the partition size
+# and if that is the case, resize the partition and grow the filesystem.
+#
+if [ $MAXSIZE -gt $CURSIZE ]; then
+parted "${DEVICEPATH}/${DEVICE}" ---pretend-input-tty > /dev/null 2>&1 <<EOF
+unit
+s
+resizepart
+${PARTNR}
+Yes
+"$MAXSIZE"
+quit
+EOF
+  partprobe > /dev/null 2>&1
+  resize2fs ${DEVICEPATH}/$DEVICEPART > /dev/null 2>&1
+fi
+


### PR DESCRIPTION
… space

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3946

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
filesystem

## Proposed changes
<!--- Describe your changes in detail -->
A force op mode command to resize the partition and underlying filesystem.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
force resize-partition
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
