### PR TITLE
Root partition auto-extension

### DIFF
--- a/debian/vyos-1x.install
+++ b/debian/vyos-1x.install
@@ -17,6 +17,7 @@ lib/
 opt/
 usr/sbin
 usr/bin/initial-setup
+usr/bin/root-part-auto-extention.sh
 usr/bin/vyos-config-file-query
 usr/bin/vyos-config-to-commands
 usr/bin/vyos-config-to-json

--- a/src/systemd/root-part-auto-extention.service
+++ b/src/systemd/root-part-auto-extention.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=VyOS root partition auto extention
+After=multi-user.target
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+ExecStart=/usr/bin/root-part-auto-extention.sh 
+
+[Install]
+WantedBy=vyos.target

--- a/src/utils/root-part-auto-extention.sh
+++ b/src/utils/root-part-auto-extention.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+ROOT_PART_DEV=$(findmnt /usr/lib/live/mount/persistence -o source -n)
+ROOT_PART_NAME=$(echo "$ROOT_PART_DEV" | cut -d "/" -f 3)
+ROOT_DEV_NAME=$(echo /sys/block/*/"${ROOT_PART_NAME}" | cut -d "/" -f 4)
+ROOT_DEV="/dev/${ROOT_DEV_NAME}"
+ROOT_PART_NUM=$(cat "/sys/block/${ROOT_DEV_NAME}/${ROOT_PART_NAME}/partition")
+NEXT_PART_NUM=$((ROOT_PART_NUM + 1))
+ROOT_DEV_SIZE=$(cat "/sys/block/${ROOT_DEV_NAME}/size")
+ROOT_PART_SIZE=$(cat "/sys/block/${ROOT_DEV_NAME}/${ROOT_PART_NAME}/size")
+ROOT_PART_START=$(cat "/sys/block/${ROOT_DEV_NAME}/${ROOT_PART_NAME}/start")
+AVAILABLE_EXTENSION_SIZE=$((ROOT_DEV_SIZE - ROOT_PART_START - ROOT_PART_SIZE - 1))
+TARGET_END=$((ROOT_DEV_SIZE - 1))
+
+if [ -d "/sys/block/${ROOT_DEV_NAME}/${ROOT_DEV_NAME}${NEXT_PART_NUM}/" ]; then
+    echo "The root partition is not the last"
+    exit 0;
+fi
+
+if [ $AVAILABLE_EXTENSION_SIZE -lt 1 ]; then
+    echo "There is no available space for root partition extension"
+    exit 0;
+fi
+
+parted -m ${ROOT_DEV} ---pretend-input-tty "u s resizepart ${ROOT_PART_NUM} Yes ${TARGET_END}s"
+resize2fs "$ROOT_PART_DEV"
+
+

--- a/src/utils/root-part-auto-extention.sh
+++ b/src/utils/root-part-auto-extention.sh
@@ -21,7 +21,14 @@ if [ $AVAILABLE_EXTENSION_SIZE -lt 1 ]; then
     exit 0;
 fi
 
-parted -m ${ROOT_DEV} ---pretend-input-tty "u s resizepart ${ROOT_PART_NUM} Yes ${TARGET_END}s"
+parted -m ${ROOT_DEV} ---pretend-input-tty <<EOF 
+u
+s
+resizepart
+${ROOT_PART_NUM}
+Yes
+${TARGET_END}s 
+EOF
 resize2fs "$ROOT_PART_DEV"
 
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This PR provides an initial feature for auto-growing root partition and file system.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3946

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
root-part-auto-extention

## Proposed changes
<!--- Describe your changes in detail -->
This feature provides a SystemD service called "root-part-auto-extention" that does root partition and FS growing up while system booting.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
1. Check root partition free size:
```
lsblk
```
2. Enable the service:
```
systemctl enable root-part-auto-extention.service
```
3. Restart OS
4. Check size of root partition and FS:
```
lsblk
df -h /dev/<your_disk>
```

Also it's possible to do it once without rebooting simply by:
```
systemctl start root-part-auto-extention.service
``` 

Requirements for current solution:
* root FS should be ext4
* no LVM
* root partition should be last (higher number)
* free space should be AFTER root partition

All necessary assumptions and exceptions can be implemented. Which additional workarounds are needed?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
