### PR TITLE
containers: T4006: Add capabilities net-bind-service

### DIFF
--- a/interface-definitions/containers.xml.in
+++ b/interface-definitions/containers.xml.in
@@ -25,11 +25,15 @@
             <properties>
               <help>Container capabilities/permissions</help>
               <completionHelp>
-                <list>net-admin net-raw setpcap sys-admin sys-time</list>
+                <list>net-admin net-bind-service net-raw setpcap sys-admin sys-time</list>
               </completionHelp>
               <valueHelp>
                 <format>net-admin</format>
                 <description>Network operations (interface, firewall, routing tables)</description>
+              </valueHelp>
+              <valueHelp>
+                <format>net-bind-service</format>
+                <description>Bind a socket to privileged ports (port numbers less than 1024)</description>
               </valueHelp>
               <valueHelp>
                 <format>net-raw</format>
@@ -48,7 +52,7 @@
                 <description>Permission to set system clock</description>
               </valueHelp>
               <constraint>
-                <regex>^(net-admin|net-raw|setpcap|sys-admin|sys-time)$</regex>
+                <regex>^(net-admin|net-bind-service|net-raw|setpcap|sys-admin|sys-time)$</regex>
               </constraint>
               <multi/>
             </properties>


### PR DESCRIPTION
## Change Summary
Add/extend container capabilities "net_bind_service"

## Types of changes
* [ ]  Bug fix (non-breaking change which fixes an issue)
* [x]  New feature (non-breaking change which adds functionality)
* [ ]  Code style update (formatting, renaming)
* [ ]  Refactoring (no functional changes)
* [ ]  Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
* [ ]  Other (please describe):

Proposed changes
Add container with capabilities:

```
set container name busybox allow-host-networks
set container name busybox cap-add 'net-bind-service'
set container name busybox image 'alpine'
```

Inspect container:

```
vyos@r1-roll# sudo podman inspect busybox | grep -i "\-add="
                "--cap-add=NET_BIND_SERVICE",
[edit]
vyos@r1-roll# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

Signed-off-by: Anthony Rabbito <hello@anthonyrabbito.com>

https://phabricator.vyos.net/T4006