### PR TITLE
conf-mode:T3998:bgp route-target completion incorrect description

### DIFF
--- a/interface-definitions/include/bgp/afi-route-target-vpn.xml.i
+++ b/interface-definitions/include/bgp/afi-route-target-vpn.xml.i
@@ -1,7 +1,7 @@
 <!-- include start from bgp/route-target-both.xml.i -->
 <node name="route-target">
   <properties>
-    <help>Specify route distinguisher</help>
+    <help>Specify route target list</help>
   </properties>
   <children>
     <node name="vpn">


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Corrected the help description for route target from "Specify route distinguisher" to "Specify route target list"

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Corrected the typo of completion help

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/Txxxx

https://phabricator.vyos.net/T3998
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp
## Proposed changes
<!--- Describe your changes in detail -->

From:

vyos@vyos# set proto bgp address-family ipv4-unicast
Possible completions:
.
.
> route-target Specify route distinguisher

To:

vyos@vyos# set proto bgp address-family ipv4-unicast
Possible completions:
.
.
> route-target Specify route target list
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
