### PR TITLE
netns: T3829: Ability to configure network namespaces

### DIFF
--- a/interface-definitions/include/interface/netns.xml.i
+++ b/interface-definitions/include/interface/netns.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from interface/netns.xml.i -->
+<leafNode name="netns">
+  <properties>
+    <help>Network namespace name</help>
+    <valueHelp>
+      <format>text</format>
+      <description>Network namespace name</description>
+    </valueHelp>
+    <completionHelp>
+      <path>netns name</path>
+    </completionHelp>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/interfaces-dummy.xml.in
+++ b/interface-definitions/interfaces-dummy.xml.in
@@ -27,6 +27,7 @@
               #include <include/interface/source-validation.xml.i>
             </children>
           </node>
+          #include <include/interface/netns.xml.i>
           #include <include/interface/vrf.xml.i>
         </children>
       </tagNode>

--- a/interface-definitions/netns.xml.in
+++ b/interface-definitions/netns.xml.in
@@ -9,13 +9,13 @@
       <tagNode name="name">
         <properties>
           <help>Network namespace name</help>
+          <constraint>
+            <regex>^[a-zA-Z0-9-_]{1,100}</regex>
+          </constraint>
+          <constraintErrorMessage>Netns name must be alphanumeric and can contain hyphens and underscores.</constraintErrorMessage>
         </properties>
         <children>
-          <leafNode name="descriprion">
-            <properties>
-              <help>Network namespace description</help>
-            </properties>
-          </leafNode>
+          #include <include/interface/description.xml.i>
         </children>
       </tagNode>
     </children>

--- a/interface-definitions/netns.xml.in
+++ b/interface-definitions/netns.xml.in
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="netns" owner="${vyos_conf_scripts_dir}/netns.py">
+    <properties>
+      <help>Network namespace</help>
+      <priority>299</priority>
+    </properties>
+    <children>
+      <tagNode name="name">
+        <properties>
+          <help>Network namespace name</help>
+        </properties>
+        <children>
+          <leafNode name="descriprion">
+            <properties>
+              <help>Network namespace description</help>
+            </properties>
+          </leafNode>
+        </children>
+      </tagNode>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/op-mode-definitions/show-netns.xml.in
+++ b/op-mode-definitions/show-netns.xml.in
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="show">
+    <children>
+      <node name="netns">
+        <properties>
+          <help>Show network namespace information</help>
+        </properties>
+        <command>ip netns ls</command>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -794,6 +794,24 @@ def get_interface_address(interface):
     tmp = loads(cmd(f'ip -d -j addr show {interface}'))[0]
     return tmp
 
+def get_interface_namespace(iface):
+    """
+       Returns wich netns the interface belongs to
+    """
+    from json import loads
+    # Check if netns exist
+    tmp = loads(cmd(f'ip --json netns ls'))
+    if len(tmp) == 0:
+        return None
+
+    for ns in tmp:
+        namespace = f'{ns["name"]}'
+        # Search interface in each netns
+        data = loads(cmd(f'ip netns exec {namespace} ip -j link show'))
+        for compare in data:
+            if iface == compare["ifname"]:
+                return namespace
+
 def get_all_vrfs():
     """ Return a dictionary of all system wide known VRF instances """
     from json import loads

--- a/smoketest/scripts/cli/test_interfaces_netns.py
+++ b/smoketest/scripts/cli/test_interfaces_netns.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import os
+import json
+import unittest
+
+from netifaces import interfaces
+from base_vyostest_shim import VyOSUnitTestSHIM
+
+from vyos.configsession import ConfigSession
+from vyos.configsession import ConfigSessionError
+from vyos.ifconfig import Interface
+from vyos.ifconfig import Section
+from vyos.util import cmd
+
+base_path = ['netns']
+namespaces = ['mgmt', 'front', 'back', 'ams-ix']
+
+class NETNSTest(VyOSUnitTestSHIM.TestCase):
+
+    def setUp(self):
+        self._interfaces = ['dum10', 'dum12', 'dum50']
+
+    def test_create_netns(self):
+        for netns in namespaces:
+            base = base_path + ['name', netns]
+            self.cli_set(base)
+
+        # commit changes
+        self.cli_commit()
+
+        netns_list = cmd('ip netns ls')
+
+        # Verify NETNS configuration
+        for netns in namespaces:
+            self.assertTrue(netns in netns_list)
+
+
+    def test_netns_assign_interface(self):
+        netns = 'foo'
+        self.cli_set(['netns', 'name', netns])
+
+        # Set
+        for iface in self._interfaces:
+            self.cli_set(['interfaces', 'dummy', iface, 'netns', netns])
+
+        # commit changes
+        self.cli_commit()
+
+        netns_iface_list = cmd(f'sudo ip netns exec {netns} ip link show')
+
+        for iface in self._interfaces:
+            self.assertTrue(iface in netns_iface_list)
+
+        # Delete
+        for iface in self._interfaces:
+            self.cli_delete(['interfaces', 'dummy', iface, 'netns', netns])
+
+        # commit changes
+        self.cli_commit()
+
+        netns_iface_list = cmd(f'sudo ip netns exec {netns} ip link show')
+
+        for iface in self._interfaces:
+            self.assertNotIn(iface, netns_iface_list)
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/src/conf_mode/netns.py
+++ b/src/conf_mode/netns.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from sys import exit
+from tempfile import NamedTemporaryFile
+
+from vyos.config import Config
+from vyos.configdict import node_changed
+from vyos.ifconfig import Interface
+from vyos.util import call
+from vyos.util import dict_search
+from vyos.util import get_interface_config
+from vyos import ConfigError
+from vyos import airbag
+airbag.enable()
+
+
+def netns_interfaces(c, match):
+    """
+    get NETNS bound interfaces
+    """
+    matched = []
+    old_level = c.get_level()
+    c.set_level(['interfaces'])
+    section = c.get_config_dict([], get_first_key=True)
+    for type in section:
+        interfaces = section[type]
+        for name in interfaces:
+            interface = interfaces[name]
+            if 'netns' in interface:
+                v = interface.get('netns', '')
+                if v == match:
+                    matched.append(name)
+
+    c.set_level(old_level)
+    return matched
+
+def get_config(config=None):
+    if config:
+        conf = config
+    else:
+        conf = Config()
+
+    base = ['netns']
+    netns = conf.get_config_dict(base, get_first_key=True,
+                                       no_tag_node_value_mangle=True)
+
+    # determine which NETNS has been removed
+    for name in node_changed(conf, base + ['name']):
+        if 'netns_remove' not in netns:
+            netns.update({'netns_remove' : {}})
+
+        netns['netns_remove'][name] = {}
+        # get NETNS bound interfaces
+        interfaces = netns_interfaces(conf, name)
+        if interfaces: netns['netns_remove'][name]['interface'] = interfaces
+
+    return netns
+
+def verify(netns):
+    # ensure NETNS is not assigned to any interface
+    if 'netns_remove' in netns:
+        for name, config in netns['netns_remove'].items():
+            if 'interface' in config:
+                raise ConfigError(f'Can not remove NETNS "{name}", it still has '\
+                                  f'member interfaces!')
+
+    if 'name' in netns:
+        for name, config in netns['name'].items():
+            print(name)
+
+    return None
+
+
+def generate(netns):
+    if not netns:
+        return None
+
+    return None
+
+
+def apply(netns):
+
+    for tmp in (dict_search('netns_remove', netns) or []):
+        if os.path.isfile(f'/run/netns/{tmp}'):
+            call(f'ip netns del {tmp}')
+
+    if 'name' in netns:
+        for name, config in netns['name'].items():
+            if not os.path.isfile(f'/run/netns/{name}'):
+                call(f'ip netns add {name}')
+
+    return None
+
+if __name__ == '__main__':
+    try:
+        c = get_config()
+        verify(c)
+        generate(c)
+        apply(c)
+    except ConfigError as e:
+        print(e)
+        exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add a new feature, a configuration of network namespaces NETNS.
As a PoC it allows playing with only "dummy" interfaces
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3829

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
netns
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configuration:
```
set netns name foo
set interfaces dummy dum55 netns 'foo'
```
Expected the interface `dum55` will be in netns `foo`
```
vyos@r11-roll# sudo ip netns exec foo  ip link show
1: lo: <LOOPBACK> mtu 65536 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
43: dum55: <BROADCAST,NOARP> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ether 7a:60:bf:b1:55:16 brd ff:ff:ff:ff:ff:ff

```
Delete:
```
vyos@r11-roll# delete interfaces dummy dum55 netns 
[edit]
vyos@r11-roll# commit
[edit]
vyos@r11-roll# sudo ip netns exec foo ip link show
1: lo: <LOOPBACK> mtu 65536 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
[edit]
vyos@r11-roll# 

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
