### PR TITLE
filesystem: T3946: root partition auto resize as a service

### DIFF
--- a/interface-definitions/system-option.xml.in
+++ b/interface-definitions/system-option.xml.in
@@ -113,6 +113,12 @@
                <valueless/>
              </properties>
            </leafNode>
+           <leafNode name="root-partition-auto-resize">
+             <properties>
+               <help>Enable root partition auto-extention on system boot</help>
+               <valueless/>
+             </properties>
+           </leafNode>
         </children>
       </node>
     </children>

--- a/op-mode-definitions/force-root-partition-auto-resize.xml.in
+++ b/op-mode-definitions/force-root-partition-auto-resize.xml.in
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="force">
+    <children>
+      <node name="root-partition-auto-resize">
+        <properties>
+          <help>Resize the VyOS partition</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/force_root-partition-auto-resize.sh</command>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/src/conf_mode/system-option.py
+++ b/src/conf_mode/system-option.py
@@ -125,6 +125,12 @@ def apply(options):
     if 'keyboard_layout' in options:
         cmd('loadkeys {keyboard_layout}'.format(**options))
 
+    # Enable/diable root-partition-auto-resize SystemD service
+    if 'root_partition_auto_resize' in options:
+      cmd('systemctl enable root-partition-auto-resize.service')
+    else:
+      cmd('systemctl disable root-partition-auto-resize.service')
+
 if __name__ == '__main__':
     try:
         c = get_config()

--- a/src/op_mode/force_root-partition-auto-resize.sh
+++ b/src/op_mode/force_root-partition-auto-resize.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2021 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# ROOT_PART_DEV – root partition device path
+# ROOT_PART_NAME – root partition device name
+# ROOT_DEV_NAME – disk device name
+# ROOT_DEV – disk device path
+# ROOT_PART_NUM – number of root partition on disk
+# ROOT_DEV_SIZE – disk total size in 512 bytes sectors
+# ROOT_PART_SIZE – root partition total size in 512 bytes sectors
+# ROOT_PART_START – number of 512 bytes sector where root partition starts
+# AVAILABLE_EXTENSION_SIZE – calculation available disk space after root partition in 512 bytes sectors
+ROOT_PART_DEV=$(findmnt /usr/lib/live/mount/persistence -o source -n)
+ROOT_PART_NAME=$(echo "$ROOT_PART_DEV" | cut -d "/" -f 3)
+ROOT_DEV_NAME=$(echo /sys/block/*/"${ROOT_PART_NAME}" | cut -d "/" -f 4)
+ROOT_DEV="/dev/${ROOT_DEV_NAME}"
+ROOT_PART_NUM=$(cat "/sys/block/${ROOT_DEV_NAME}/${ROOT_PART_NAME}/partition")
+ROOT_DEV_SIZE=$(cat "/sys/block/${ROOT_DEV_NAME}/size")
+ROOT_PART_SIZE=$(cat "/sys/block/${ROOT_DEV_NAME}/${ROOT_PART_NAME}/size")
+ROOT_PART_START=$(cat "/sys/block/${ROOT_DEV_NAME}/${ROOT_PART_NAME}/start")
+AVAILABLE_EXTENSION_SIZE=$((ROOT_DEV_SIZE - ROOT_PART_START - ROOT_PART_SIZE - 8))
+
+#
+# Check if device have space for root partition growing up.
+#
+if [ $AVAILABLE_EXTENSION_SIZE -lt 1 ]; then
+    echo "There is no available space for root partition extension"
+    exit 0;
+fi
+
+#
+# Resize the partition and grow the filesystem.
+#
+parted -m ${ROOT_DEV} ---pretend-input-tty > /dev/null 2>&1 <<EOF 
+resizepart
+${ROOT_PART_NUM}
+Yes
+100%
+EOF
+partprobe > /dev/null 2>&1
+resize2fs ${ROOT_PART_DEV} > /dev/null 2>&1

--- a/src/op_mode/force_root-partition-auto-resize.sh
+++ b/src/op_mode/force_root-partition-auto-resize.sh
@@ -44,7 +44,13 @@ fi
 #
 # Resize the partition and grow the filesystem.
 #
+# "print" and "Fix" directives were added to fix GPT table if it corrupted after virtual drive extension.
+# If GPT table is corrupted we'll get Fix/Ignore dialogue after "print" command.
+# "Fix" will be the answer for this dialogue. 
+# If GPT table is fine and no auto-fix dialogue appeared the directive "Fix" simply will print parted utility help info.  
 parted -m ${ROOT_DEV} ---pretend-input-tty > /dev/null 2>&1 <<EOF 
+print
+Fix
 resizepart
 ${ROOT_PART_NUM}
 Yes

--- a/src/systemd/root-partition-auto-resize.service
+++ b/src/systemd/root-partition-auto-resize.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=VyOS root partition auto resizing
+After=multi-user.target
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+ExecStart=/usr/libexec/vyos/op_mode/force_root-partition-auto-resize.sh 
+
+[Install]
+WantedBy=vyos.target


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
* Added an optional root-partition-suto-resize service for SystemD
* Name of current resizing script and op command were changed to be consistent with the SystemD service.
* Resizing script was changed to work fine with SystemD

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3946

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
filesystem
## Proposed changes
<!--- Describe your changes in detail -->
This PR provides root-partition-auto-resize.service which can auto extend root partition and FS when there is enough free space. The service can be enabled via conf mode and is disabled by default.
Op command "force root-partition-auto-resize" allows to run root-partition-auto-resize once.
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

1. Check root partition free size:
```
lsblk
```
2. Enable the service:
```
configure
set system option root-partition-auto-resize
commit
save
exit
```
3. Restart OS
4. Check size of root partition and FS:
```
lsblk
df -h /dev/<your_disk>
```

Instead of steps 2 and 3 it's possible just to run once from op mode:
```
force root-partition-auto-resize
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
