### PR TITLE
T4035: correct the interface basename extraction logic to avoid confusing 'v' in GENEVE interface prefix ('gnv') with a "vXXX" part of a VRRP interface

### DIFF
--- a/python/vyos/ifconfig/section.py
+++ b/python/vyos/ifconfig/section.py
@@ -52,12 +52,12 @@ class Section:
         name: name of the interface
         vlan: if vlan is True, do not stop at the vlan number
         """
-        name = name.rstrip('0123456789')
-        name = name.rstrip('.')
-        if vlan:
-            name = name.rstrip('0123456789.')
         if vrrp:
-            name = name.rstrip('0123456789v')
+            name = re.sub(r'\d(\d|v|\.)*$', '', name)
+        elif vlan:
+            name = re.sub(r'\d(\d|\.)*$', '', name)
+        else:
+            name = re.sub(r'\d+$', '', name)
         return name
 
     @classmethod


### PR DESCRIPTION

## Change Summary

The original interface basename extraction logic would right strip all characters from the `[0-9v\.]` set so that if the user has something like `eth0.100v200` (a VRRP interface on a VLAN over ethernet), then only the `eth` part remains.

That logic worked until we introduced the `gnv` prefix for GENEVE interfaces. Since the prefix itself ends with 'v', the basename function would incorrectly return `gn`.

```
>>> vyos.ifconfig.GeneveIf._basename('gnv0', True, True)
'gn'
```

That caused interface filtering functions to assume that GENEVE interfaces aren't in the section and always return an empty list.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4035

## Component(s) name

Interaces.

## Proposed changes

Use regexes rather than a blind rstrip.

## How to test

Run `show interfaces` with various interface types configured on the system.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
