### PR TITLE
validators: T4052: Fix for warn message in the validator script

### DIFF
--- a/src/validators/script
+++ b/src/validators/script
@@ -36,7 +36,7 @@ if __name__ == '__main__':
 
     # File outside the config dir is just a warning
     if not vyos.util.file_is_persistent(script):
-        sys.exit(
+        sys.exit(0)(
             f'Warning: file {script} is outside the "/config" directory\n'
             'It will not be automatically migrated to a new image on system update'
         )

--- a/src/validators/script
+++ b/src/validators/script
@@ -37,6 +37,6 @@ if __name__ == '__main__':
     # File outside the config dir is just a warning
     if not vyos.util.file_is_persistent(script):
         sys.exit(
-            f'Warning: file {path} is outside the / config directory\n'
+            f'Warning: file {script} is outside the "/config" directory\n'
             'It will not be automatically migrated to a new image on system update'
         )


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Validator expects variable "script" for the Warning message
But it gets undeclared "path"

Exit code should be `0` as it should be only a warning message if a script not in `/config` directory
for example script:
```
set high-availability vrrp group FOO transition-script backup '/usr/bin/true'
```
In the original it was just a warning:
https://github.com/vyos/vyos-1x/commit/3639a5610b590a64d6d56bee81dddd252994cfe5#diff-87ee33ff4bebeec3921219895213b6db1fb2a732c9aaa4715f5484c21007bfc8L46

Can be cherry-picked to 1.3

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4052
* https://phabricator.vyos.net/T4053

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
validators
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Touch scripts, use it in CLI for example vrrp
```
sudo touch /home/vyos/script.sh
sudo chmod +x /home/vyos/script.sh
set high-availability vrrp group GR1 health-check script '/home/vyos/script.sh'
```
Before fix:
```
vyos@r11-roll# set high-availability vrrp group GR1 health-check script '/home/vyos/script.sh'

  Traceback (most recent call last):
    File "/usr/libexec/vyos/validators/script", line 40, in <module>
      f'Warning: file {path} is outside the / config directory
'
  NameError: name 'path' is not defined
  
  
  
  Invalid value
  Value validation failed
  Set failed

```
After fix:
```
vyos@r11-roll# set high-availability vrrp group GR1 health-check script '/home/vyos/script.sh'

  Warning: file /home/vyos/script.sh is outside the "/config" directory
  It will not be automatically migrated to a new image on system update
  
  
  
  Invalid value
  Value validation failed
  Set failed

[edit]
vyos@r11-roll#
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
