### PR TITLE
T3006: add a range validator

### DIFF
--- a/src/validators/range
+++ b/src/validators/range
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import sys
+import argparse
+
+class MalformedRange(Exception):
+    pass
+
+def validate_range(value, min=None, max=None):
+    try:
+        lower, upper = re.match(r'^(\d+)-(\d+)$', value).groups()
+
+        lower, upper = int(lower), int(upper)
+
+        if int(lower) > int(upper):
+            raise MalformedRange("the lower bound exceeds the upper bound".format(value))
+
+        if min is not None:
+            if lower < min:
+                raise MalformedRange("the lower bound must not be less than {}".format(min))
+
+        if max is not None:
+            if upper > max:
+                raise MalformedRange("the upper bound must not be greater than {}".format(max))
+
+    except (AttributeError, ValueError):
+        raise MalformedRange("range syntax error")
+
+parser = argparse.ArgumentParser(description='Range validator.')
+parser.add_argument('--min', type=int, action='store')
+parser.add_argument('--max', type=int, action='store')
+parser.add_argument('value', action='store')
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+
+    try:
+        validate_range(args.value, min=args.min, max=args.max)
+    except MalformedRange as e:
+        print("Incorrect range '{}': {}".format(args.value, e))
+        sys.exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

Adds a new `range` validator for checking ranges of numbers (e.g. ports, VLANs etc.).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3006

## Proposed changes

This is an alternative to the range regex generator proposed in #1100 

Why I believe it's better:

* Command definition files remain easily readable: `<validator name="range" argument="--min=1 --max=4096"/>` instead of a long regex that will take a human quite some time to comprehend and even more time to verify.
* It can replace special-purpose VLAN and port range validators, perhaps if we add custom error messages to commands.
* It can be easily extended to handle more features, e.g. commas and negation needed for ip/nftables port ranges.(`10,20-30,!40`), while the regex generator approach is limited to simple ranges.
* It's less code than the regex generator and if performance becomes a concern, can still be easily ported to a compiled language.


## How to test

```
/usr/libexec/vyos/validator/range --min=10 --max=20 1-200
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
