### PR TITLE
logs: T3774: Added CLI options to control atop logs rotation

### DIFF
--- a/data/templates/logs/logrotate/vyos-atop.tmpl
+++ b/data/templates/logs/logrotate/vyos-atop.tmpl
@@ -2,12 +2,12 @@
     daily
     dateext
     dateformat _%Y-%m-%d_%H-%M-%S
-    maxsize {{ max_size|default('10') }}M
+    maxsize {{ max_size }}M
     missingok
     nocompress
     nocreate
     nomail
-    rotate {{ rotate|default('10') }}
+    rotate {{ rotate }}
     prerotate
         # stop the service
         systemctl stop atop.service

--- a/data/templates/logs/logrotate/vyos-atop.tmpl
+++ b/data/templates/logs/logrotate/vyos-atop.tmpl
@@ -2,7 +2,7 @@
     daily
     dateext
     dateformat _%Y-%m-%d_%H-%M-%S
-    maxsize {{ maxsize|default('10') }}M
+    maxsize {{ max_size|default('10') }}M
     missingok
     nocompress
     nocreate

--- a/data/templates/logs/logrotate/vyos-atop.tmpl
+++ b/data/templates/logs/logrotate/vyos-atop.tmpl
@@ -1,0 +1,20 @@
+/var/log/atop/atop.log {
+    daily
+    dateext
+    dateformat _%Y-%m-%d_%H-%M-%S
+    maxsize {{ maxsize|default('10') }}M
+    missingok
+    nocompress
+    nocreate
+    nomail
+    rotate {{ rotate|default('10') }}
+    prerotate
+        # stop the service
+        systemctl stop atop.service
+    endscript
+    postrotate
+        # start atop service again
+        systemctl start atop.service
+    endscript
+}
+

--- a/data/templates/logs/logrotate/vyos-rsyslog.tmpl
+++ b/data/templates/logs/logrotate/vyos-rsyslog.tmpl
@@ -1,0 +1,13 @@
+/var/log/messages {
+    create
+    missingok
+    nomail
+    notifempty
+    rotate {{ rotate|default('10') }}
+    size {{ max_size|default('1') }}M
+    postrotate
+        # restart rsyslog service
+        systemctl restart rsyslog.service
+    endscript
+}
+

--- a/data/templates/logs/logrotate/vyos-rsyslog.tmpl
+++ b/data/templates/logs/logrotate/vyos-rsyslog.tmpl
@@ -3,11 +3,11 @@
     missingok
     nomail
     notifempty
-    rotate {{ rotate|default('10') }}
-    size {{ max_size|default('1') }}M
+    rotate {{ rotate }}
+    size {{ max_size }}M
     postrotate
-        # restart rsyslog service
-        systemctl restart rsyslog.service
+        # inform rsyslog service about rotation
+        /usr/lib/rsyslog/rsyslog-rotate
     endscript
 }
 

--- a/interface-definitions/system-logs.xml.in
+++ b/interface-definitions/system-logs.xml.in
@@ -18,12 +18,47 @@
                   <help>Atop logs options (system resources usage)</help>
                 </properties>
                 <children>
-                  <leafNode name="maxsize">
+                  <leafNode name="max-size">
                     <properties>
                       <help>Size of a single log file that triggers rotation</help>
                       <valueHelp>
                         <format>u32:1-1024</format>
                         <description>Size in MB (default: 10)</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-1024" />
+                      </constraint>
+                      <constraintErrorMessage>The size must be between 1 and 1024 MB</constraintErrorMessage>
+                    </properties>
+                    <defaultValue>10</defaultValue>
+                  </leafNode>
+                  <leafNode name="rotate">
+                    <properties>
+                      <help>Count of rotations before old logs will be deleted</help>
+                      <valueHelp>
+                        <format>u32:1-100</format>
+                        <description>Rotations (default: 10)</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-100" />
+                      </constraint>
+                      <constraintErrorMessage>The count must be between 1 and 100</constraintErrorMessage>
+                    </properties>
+                    <defaultValue>10</defaultValue>
+                  </leafNode>
+                </children>
+              </node>
+              <node name="messages">
+                <properties>
+                  <help>The /var/log/messages file rotation</help>
+                </properties>
+                <children>
+                  <leafNode name="max-size">
+                    <properties>
+                      <help>Size of a single log file that triggers rotation</help>
+                      <valueHelp>
+                        <format>u32:1-1024</format>
+                        <description>Size in MB (default: 1)</description>
                       </valueHelp>
                       <constraint>
                         <validator name="numeric" argument="--range 1-1024" />

--- a/interface-definitions/system-logs.xml.in
+++ b/interface-definitions/system-logs.xml.in
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interfaceDefinition>
+  <node name="system">
+    <children>
+      <node name="logs" owner="${vyos_conf_scripts_dir}/system-logs.py">
+        <properties>
+          <help>Logging options</help>
+          <priority>9999</priority>
+        </properties>
+        <children>
+          <node name="logrotate">
+            <properties>
+              <help>Logrotate options</help>
+            </properties>
+            <children>
+              <node name="atop">
+                <properties>
+                  <help>Atop logs options</help>
+                </properties>
+                <children>
+                  <leafNode name="maxsize">
+                    <properties>
+                      <help>Size of a single log file that triggers rotation</help>
+                      <valueHelp>
+                        <format>u32:1-1024</format>
+                        <description>Size in MB</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-1024" />
+                      </constraint>
+                      <constraintErrorMessage>The size must be between 1 and 1024 MB</constraintErrorMessage>
+                    </properties>
+                    <defaultValue>10</defaultValue>
+                  </leafNode>
+                  <leafNode name="rotate">
+                    <properties>
+                      <help>Count of rotations before old logs will be deleted</help>
+                      <valueHelp>
+                        <format>u32:1-100</format>
+                        <description>Rotations</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-100" />
+                      </constraint>
+                      <constraintErrorMessage>The count must be between 1 and 100</constraintErrorMessage>
+                    </properties>
+                    <defaultValue>10</defaultValue>
+                  </leafNode>
+                </children>
+              </node>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/interface-definitions/system-logs.xml.in
+++ b/interface-definitions/system-logs.xml.in
@@ -65,7 +65,7 @@
                       </constraint>
                       <constraintErrorMessage>The size must be between 1 and 1024 MB</constraintErrorMessage>
                     </properties>
-                    <defaultValue>10</defaultValue>
+                    <defaultValue>1</defaultValue>
                   </leafNode>
                   <leafNode name="rotate">
                     <properties>

--- a/interface-definitions/system-logs.xml.in
+++ b/interface-definitions/system-logs.xml.in
@@ -15,7 +15,7 @@
             <children>
               <node name="atop">
                 <properties>
-                  <help>Atop logs options</help>
+                  <help>Atop logs options (system resources usage)</help>
                 </properties>
                 <children>
                   <leafNode name="maxsize">
@@ -23,7 +23,7 @@
                       <help>Size of a single log file that triggers rotation</help>
                       <valueHelp>
                         <format>u32:1-1024</format>
-                        <description>Size in MB</description>
+                        <description>Size in MB (default: 10)</description>
                       </valueHelp>
                       <constraint>
                         <validator name="numeric" argument="--range 1-1024" />
@@ -37,7 +37,7 @@
                       <help>Count of rotations before old logs will be deleted</help>
                       <valueHelp>
                         <format>u32:1-100</format>
-                        <description>Rotations</description>
+                        <description>Rotations (default: 10)</description>
                       </valueHelp>
                       <constraint>
                         <validator name="numeric" argument="--range 1-100" />

--- a/smoketest/scripts/cli/test_system_logs.py
+++ b/smoketest/scripts/cli/test_system_logs.py
@@ -19,11 +19,14 @@ import unittest
 from base_vyostest_shim import VyOSUnitTestSHIM
 from vyos.util import read_file
 
-# path to logrotate config for atop
+# path to logrotate configs
 logrotate_atop_file = '/etc/logrotate.d/vyos-atop'
+logrotate_rsyslog_file = '/etc/logrotate.d/vyos-rsyslog'
 # default values
 default_atop_maxsize = '10M'
 default_atop_rotate = '10'
+default_rsyslog_size = '1M'
+default_rsyslog_rotate = '10'
 
 base_path = ['system', 'logs']
 
@@ -64,13 +67,18 @@ class TestSystemLogs(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # read the config file and check content
-        logrotate_config = logrotate_config_parse(logrotate_atop_file)
-        self.assertEqual(logrotate_config['maxsize'], default_atop_maxsize)
-        self.assertEqual(logrotate_config['rotate'], default_atop_rotate)
+        logrotate_config_atop = logrotate_config_parse(logrotate_atop_file)
+        logrotate_config_rsyslog = logrotate_config_parse(
+            logrotate_rsyslog_file)
+        self.assertEqual(logrotate_config_atop['maxsize'], default_atop_maxsize)
+        self.assertEqual(logrotate_config_atop['rotate'], default_atop_rotate)
+        self.assertEqual(logrotate_config_rsyslog['size'], default_rsyslog_size)
+        self.assertEqual(logrotate_config_rsyslog['rotate'],
+                         default_rsyslog_rotate)
 
     def test_logs_atop_maxsize(self):
         # test for maxsize option
-        self.cli_set(base_path + ['logrotate', 'atop', 'maxsize', '50'])
+        self.cli_set(base_path + ['logrotate', 'atop', 'max-size', '50'])
         self.cli_commit()
 
         # read the config file and check content
@@ -84,6 +92,24 @@ class TestSystemLogs(VyOSUnitTestSHIM.TestCase):
 
         # read the config file and check content
         logrotate_config = logrotate_config_parse(logrotate_atop_file)
+        self.assertEqual(logrotate_config['rotate'], '50')
+
+    def test_logs_rsyslog_size(self):
+        # test for size option
+        self.cli_set(base_path + ['logrotate', 'messages', 'max-size', '50'])
+        self.cli_commit()
+
+        # read the config file and check content
+        logrotate_config = logrotate_config_parse(logrotate_rsyslog_file)
+        self.assertEqual(logrotate_config['size'], '50M')
+
+    def test_logs_rsyslog_rotate(self):
+        # test for rotate option
+        self.cli_set(base_path + ['logrotate', 'messages', 'rotate', '50'])
+        self.cli_commit()
+
+        # read the config file and check content
+        logrotate_config = logrotate_config_parse(logrotate_rsyslog_file)
         self.assertEqual(logrotate_config['rotate'], '50')
 
 

--- a/smoketest/scripts/cli/test_system_logs.py
+++ b/smoketest/scripts/cli/test_system_logs.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import unittest
+from base_vyostest_shim import VyOSUnitTestSHIM
+from vyos.util import read_file
+
+# path to logrotate config for atop
+logrotate_atop_file = '/etc/logrotate.d/vyos-atop'
+# default values
+default_atop_maxsize = '10M'
+default_atop_rotate = '10'
+
+base_path = ['system', 'logs']
+
+
+def logrotate_config_parse(file_path):
+    # read the file
+    logrotate_config = read_file(file_path)
+    # create regex for parsing options
+    regex_options = re.compile(
+        r'(^\s+(?P<option_name_script>postrotate|prerotate|firstaction|lastaction|preremove)\n(?P<option_value_script>((?!endscript).)*)\n\s+endscript\n)|(^\s+(?P<option_name>[\S]+)([ \t]+(?P<option_value>\S+))*$)',
+        re.M | re.S)
+    # create empty dict for config
+    logrotate_config_dict = {}
+    # fill dictionary with actual config
+    for option in regex_options.finditer(logrotate_config):
+        option_name = option.group('option_name')
+        option_value = option.group('option_value')
+        option_name_script = option.group('option_name_script')
+        option_value_script = option.group('option_value_script')
+        if option_name:
+            logrotate_config_dict[option_name] = option_value
+        if option_name_script:
+            logrotate_config_dict[option_name_script] = option_value_script
+
+    # return config dictionary
+    return (logrotate_config_dict)
+
+
+class TestSystemLogs(VyOSUnitTestSHIM.TestCase):
+
+    def tearDown(self):
+        self.cli_delete(base_path)
+        self.cli_commit()
+
+    def test_logs_defaults(self):
+        # test with empty section for default values
+        self.cli_set(base_path)
+        self.cli_commit()
+
+        # read the config file and check content
+        logrotate_config = logrotate_config_parse(logrotate_atop_file)
+        self.assertEqual(logrotate_config['maxsize'], default_atop_maxsize)
+        self.assertEqual(logrotate_config['rotate'], default_atop_rotate)
+
+    def test_logs_atop_maxsize(self):
+        # test for maxsize option
+        self.cli_set(base_path + ['logrotate', 'atop', 'maxsize', '50'])
+        self.cli_commit()
+
+        # read the config file and check content
+        logrotate_config = logrotate_config_parse(logrotate_atop_file)
+        self.assertEqual(logrotate_config['maxsize'], '50M')
+
+    def test_logs_atop_rotate(self):
+        # test for rotate option
+        self.cli_set(base_path + ['logrotate', 'atop', 'rotate', '50'])
+        self.cli_commit()
+
+        # read the config file and check content
+        logrotate_config = logrotate_config_parse(logrotate_atop_file)
+        self.assertEqual(logrotate_config['rotate'], '50')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2, failfast=True)

--- a/src/conf_mode/system-logs.py
+++ b/src/conf_mode/system-logs.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from sys import exit
+
+from vyos import ConfigError
+from vyos import airbag
+from vyos.config import Config
+from vyos.logger import syslog
+from vyos.template import render_to_string
+from vyos.util import read_file, write_file
+airbag.enable()
+
+# path to logrotate config for atop
+logrotate_atop_file = '/etc/logrotate.d/vyos-atop'
+
+
+def get_config(config=None):
+    if config:
+        conf = config
+    else:
+        conf = Config()
+
+    base = ['system', 'logs']
+    logs_config = conf.get_config_dict(base)
+
+    return logs_config
+
+
+def verify(logs_config):
+    # Nothing to verify here
+    pass
+
+
+def generate(logs_config):
+    # get configuration for logrotate atop
+    logrotate_atop = logs_config.get('logs', {}).get('logrotate',
+                                                     {}).get('atop', {})
+    # read current config file for atop
+    logrotate_atop_current = read_file(logrotate_atop_file)
+    # generate new config file for atop
+    logrotate_atop_new = render_to_string('logs/logrotate/vyos-atop.tmpl',
+                                          logrotate_atop)
+    # update configuration files if this is necessary
+    if logrotate_atop_new != logrotate_atop_current:
+        syslog.debug('Adding logrotate config for atop')
+        write_file(logrotate_atop_file, logrotate_atop_new)
+
+
+def apply(logs_config):
+    # No further actions needed
+    pass
+
+
+if __name__ == '__main__':
+    try:
+        c = get_config()
+        verify(c)
+        generate(c)
+        apply(c)
+    except ConfigError as e:
+        print(e)
+        exit(1)

--- a/src/conf_mode/system-logs.py
+++ b/src/conf_mode/system-logs.py
@@ -24,8 +24,9 @@ from vyos.template import render
 from vyos.util import dict_search
 airbag.enable()
 
-# path to logrotate config for atop
+# path to logrotate configs
 logrotate_atop_file = '/etc/logrotate.d/vyos-atop'
+logrotate_rsyslog_file = '/etc/logrotate.d/vyos-rsyslog'
 
 
 def get_config(config=None):
@@ -35,7 +36,7 @@ def get_config(config=None):
         conf = Config()
 
     base = ['system', 'logs']
-    logs_config = conf.get_config_dict(base)
+    logs_config = conf.get_config_dict(base, key_mangling=('-', '_'))
 
     return logs_config
 
@@ -54,6 +55,16 @@ def generate(logs_config):
     # generate new config file for atop
     syslog.debug('Adding logrotate config for atop')
     render(logrotate_atop_file, 'logs/logrotate/vyos-atop.tmpl', logrotate_atop)
+
+    # get configuration for logrotate rsyslog
+    logrotate_rsyslog = dict_search('logs.logrotate.messages', logs_config)
+    # provide an empty dictionary if there is no config
+    if not logrotate_rsyslog:
+        logrotate_rsyslog = {}
+    # generate new config file for rsyslog
+    syslog.debug('Adding logrotate config for rsyslog')
+    render(logrotate_rsyslog_file, 'logs/logrotate/vyos-rsyslog.tmpl',
+           logrotate_rsyslog)
 
 
 def apply(logs_config):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added CLI options to generate logrotate configuration file for atop logs

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3774

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
logs, logrotate, atop

## Proposed changes
<!--- Describe your changes in detail -->
To give users control over logs we should provide a CLI section for this. The commit adds the section with the first option that can be controlled - atop log file rotation strategy. In the same way, we can add more (`/var/log/messages` is the first and obvious candidate).

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
To test:
```
set system logs logrotate atop maxsize 15
set system logs logrotate atop rotate 25
commit
```
Then check values:
```
vyos@vyos# grep -E 'maxsize|rotate' /etc/logrotate.d/vyos-atop 
    maxsize 15M
    rotate 25
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
