### PR TITLE
T4088: login banner: Typo in completion help of banner types

### DIFF
--- a/interface-definitions/system-login-banner.xml.in
+++ b/interface-definitions/system-login-banner.xml.in
@@ -15,12 +15,12 @@
             <children>
               <leafNode name="post-login">
                 <properties>
-                  <help>System loging banner post-login</help>
+                  <help>A system banner after the user logs in </help>
                 </properties>
               </leafNode>
               <leafNode name="pre-login">
                 <properties>
-                  <help>System loging banner pre-login</help>
+                  <help>A system banner before the user logs in</help>
                 </properties>
               </leafNode>
             </children>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

There is typo in the completion help when this command "set sys login banner"
executed, Changed the completion help to a proper one.

```
vyos@vyos# set sys login banner
Possible completions:
   post-login   A system banner after the user logs in
   pre-login    A system banner before the user logs in
```


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):
cosmetic issue
## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/Txxxx
https://phabricator.vyos.net/T4088
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
login banner
## Proposed changes
<!--- Describe your changes in detail -->
Previous:
```
vyos@vyos# set system login banner
Possible completions:
   post-login   System loging banner post-login
   pre-login    System loging banner pre-login
```
New:

```
vyos@vyos# set sys login banner
Possible completions:
   post-login   A system banner after the user logs in
   pre-login    A system banner before the user logs in
```
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
