### PR TITLE
interface: T4056: Fix unexpected delete tc qdisc

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1304,8 +1304,8 @@ class Interface(Control):
             source_if = next(iter(self._config['is_mirror_intf']))
             config = self._config['is_mirror_intf'][source_if].get('mirror', None)
 
-        # Check configuration stored by old perl code before delete T3782
-        if not 'redirect' in self._config:
+        # Check configuration stored by old perl code before delete T3782/T4056
+        if not 'redirect' in self._config and not 'traffic_policy' in self._config:
             # Please do not clear the 'set $? = 0 '. It's meant to force a return of 0
             # Remove existing mirroring rules
             delete_tc_cmd  = f'tc qdisc del dev {source_if} handle ffff: ingress 2> /dev/null;'


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Traffic-policy rules are generated by old Perl code
This commit prevents to unexpected override of this code by python.
As we see in debugging it deletes `tc qdisc` per each interface commit:
```
DEBUG/IFCONFIG cmd 'tc qdisc del dev eth2 handle ffff: ingress 2> /dev/null;tc qdisc del dev eth2 handle 1: root prio 2> /dev/null;set $?=0'
DEBUG/IFCONFIG cmd 'ip link set dev eth2 up'
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4056

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
interface, qdisc
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces ethernet eth2 traffic-policy in '1G'
set traffic-policy limiter 1G default bandwidth '1gbit'
set traffic-policy limiter 1G default burst '188kb'
```
Expected tc values:
```
vyos@r11-roll# sudo tc filter show dev eth2 parent ffff:
filter protocol all pref 255 basic chain 0 
filter protocol all pref 255 basic chain 0 handle 0x1 flowid ffff:1 
	action order 1:  police 0x1 rate 1Gbit burst 192375b mtu 2Kb action drop overhead 0b 
	ref 1 bind 1

[edit]
vyos@r11-roll# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
