### PR TITLE
VRRP: T4081: health-check script on sync-group

### DIFF
--- a/data/templates/vrrp/keepalived.conf.tmpl
+++ b/data/templates/vrrp/keepalived.conf.tmpl
@@ -98,6 +98,13 @@ vrrp_sync_group {{ name }} {
     notify_backup "{{ vyos_helper }} backup {{ name }}"
     notify_fault "{{ vyos_helper }} fault {{ name }}"
 {%     endif %}
+{%     for name, group_config in group.items() if group_config.disable is not defined %}
+{%     if group_config.health_check is defined and group_config.health_check.script is defined and group_config.health_check.script is not none %}
+    track_script {
+        healthcheck_{{ name }}
+    }
+{%     endif %}
+{%     endfor %}
 }
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
VRRP health-check scripts are copied to the VRRP sync-group. As a workaround of bug T4081.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4081

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrrp

## Proposed changes

There is a bug T4081. VRRP health-check script stops working when setting up a sync group
In keepalived with VRRP sync group, health-check scripts must be set to groups. There is no 
corresponding command in VyOS. As a workaround the group scripts are copied to sync-group. 
This allows to maintain compatibility with previous versions and to keep the health-check 
mechanism during migration.

## How to test

Create VRRP groups with health-check script. Create VRRP sync-group. 
Verify that the health check script has run.

'''
set interfaces ethernet eth0 address '172.16.1.37/24'
set interfaces ethernet eth0 description 'outside'

set interfaces ethernet eth1 address '10.1.1.2/24'
set interfaces ethernet eth1 description 'inside'

set high-availability vrrp group TST virtual-address '172.16.1.36/24'
set high-availability vrrp group TST health-check failure-count '3'
set high-availability vrrp group TST health-check interval '2'
set high-availability vrrp group TST health-check script '/config/scripts/vrrp-health.sh'
set high-availability vrrp group TST interface 'eth0'
set high-availability vrrp group TST priority '100'
set high-availability vrrp group TST vrid '1'

set high-availability vrrp group TST_LAN virtual-address '10.45.1.1/24'
set high-availability vrrp group TST_LAN interface 'eth1'
set high-availability vrrp group TST_LAN priority '100'
set high-availability vrrp group TST_LAN vrid '2'

set high-availability vrrp sync-group SYNCgrp member 'TST'
set high-availability vrrp sync-group SYNCgrp member TST_LAN
'''

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
