### PR TITLE
conntrack-sync: T3854: Add missed statistics for op-mode

### DIFF
--- a/op-mode-definitions/conntrack-sync.xml.in
+++ b/op-mode-definitions/conntrack-sync.xml.in
@@ -87,6 +87,18 @@
               </node>
             </children>
           </node>
+          <leafNode name="statistics">
+            <properties>
+              <help>Show connection syncing statistics</help>
+            </properties>
+            <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py --show-statistics</command>
+          </leafNode>
+          <leafNode name="status">
+            <properties>
+              <help>Show conntrack-sync status</help>
+            </properties>
+            <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py --show-status</command>
+          </leafNode>
         </children>
       </node>
     </children>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->
For 1.3
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
After rewriting conntrack-sync to XML/python, part of op-mode
parameters were missed
Add "status" and "statistics" for conntrack-sync


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3854

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
conntrack-sync
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set service conntrack-sync accept-protocol 'tcp'
set service conntrack-sync accept-protocol 'udp'
set service conntrack-sync accept-protocol 'icmp'
set service conntrack-sync event-listen-queue-size '8'
set service conntrack-sync failover-mechanism vrrp sync-group 'SGR'
set service conntrack-sync interface eth0 peer '192.0.2.1'
```
Show status:
```
vyos@r4:~$ show conntrack-sync status

sync-interface        : eth0
failover-mechanism    : vrrp [sync-group SGR]
last state transition : MASTER at Fri 24 Dec 2021 10:34:36 AM EET
ExpectationSync       : disabled
vyos@r4:~$ 
```
Show statistics:
```
vyos@r4:~$ show conntrack-sync statistics 

Main Table Statistics:

cache internal:
current active connections:                0
connections created:                       0    failed:            0
connections updated:                       0    failed:            0
connections destroyed:                     0    failed:            0

cache external:
current active connections:                0
connections created:                       0    failed:            0
connections updated:                       0    failed:            0
connections destroyed:                     0    failed:            0

traffic processed:
                   0 Bytes                         0 Pckts

UDP traffic (active device=eth0):
                4272 Bytes sent                    0 Bytes recv
                 534 Pckts sent                    0 Pckts recv
                   0 Error send                    0 Error recv

message tracking:
                   0 Malformed msgs                    0 Lost msgs


```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
