### PR TITLE
keepalived: T4081: Fix health-checking when syn-group is used

### DIFF
--- a/data/templates/vrrp/keepalived.conf.tmpl
+++ b/data/templates/vrrp/keepalived.conf.tmpl
@@ -83,15 +83,24 @@ vrrp_instance {{ name }} {
 {% endif %}
 
 {% if sync_group is defined and sync_group is not none %}
-{%   for name, group_config in sync_group.items() if group_config.disable is not defined %}
+{%   for name, sync_group_config in sync_group.items() if sync_group_config.disable is not defined %}
 vrrp_sync_group {{ name }} {
     group {
-{%     if group_config.member is defined and group_config.member is not none %}
-{%       for member in group_config.member %}
+{%     if sync_group_config.member is defined and sync_group_config.member is not none %}
+{%       for member in sync_group_config.member %}
         {{ member }}
 {%       endfor %}
 {%     endif %}
     }
+
+{# Health-check scripts should be in section sync-group if member is part of the sync-group T4081 #}
+{%   for name, group_config in group.items() if group_config.disable is not defined %}
+{%     if group_config.health_check is defined and group_config.health_check.script is defined and group_config.health_check.script is not none and name in sync_group_config.member %}
+    track_script {
+        healthcheck_{{ name }}
+    }
+{%     endif %}
+{%   endfor %}
 {%     if conntrack_sync_group is defined and conntrack_sync_group == name %}
 {%     set vyos_helper = "/usr/libexec/vyos/vyos-vrrp-conntracksync.sh" %}
     notify_master "{{ vyos_helper }} master {{ name }}"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->
For 1.3
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
If health-check scripts are used in vrrp group and vrrp group
is member of sync-group, then health-check scripts should be
part of the section "vrrp_sync_group". In another case the
health-scripts won't work anymore.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4081

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrrp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set high-availability vrrp group GRP01 health-check script '/config/scripts/vrrp-health.sh'
set high-availability vrrp group GRP01 interface 'eth1'
set high-availability vrrp group GRP01 no-preempt
set high-availability vrrp group GRP01 peer-address '203.0.113.2'
set high-availability vrrp group GRP01 priority '150'
set high-availability vrrp group GRP01 virtual-address '203.0.113.254/24'
set high-availability vrrp group GRP01 vrid '10'
set high-availability vrrp group GRP02 health-check script '/config/scripts/vrrp-health-sec.sh'
set high-availability vrrp group GRP02 hello-source-address '192.0.2.1'
set high-availability vrrp group GRP02 interface 'eth0'
set high-availability vrrp group GRP02 no-preempt
set high-availability vrrp group GRP02 priority '150'
set high-availability vrrp group GRP02 virtual-address '192.0.2.254/24'
set high-availability vrrp group GRP02 vrid '20'
set high-availability vrrp sync-group SGR member 'GRP01'
set high-availability vrrp sync-group SGR member 'GRP02'
set interfaces ethernet eth0 address '192.0.2.1/24'
set interfaces ethernet eth1 address '203.0.113.1/24'
```
Expected success executed of the health-check scripts.
```
Dec 27 15:58:37 r4 Keepalived_vrrp[10782]: VRRP_Script(healthcheck_GRP02) succeeded
Dec 27 15:58:37 r4 Keepalived_vrrp[10782]: VRRP_Script(healthcheck_GRP01) succeeded
```
Sync-group section of keepalived.conf:
```
vrrp_sync_group SGR {
    group {
        GRP01
        GRP02
    }

    track_script {
        healthcheck_GRP01
    }
    track_script {
        healthcheck_GRP02
    }

```
Additional checks:
```
vyos@r4# cat /config/scripts/vrrp-health.sh  /config/scripts/vrrp-health-sec.sh 
#!/usr/bin/env bash

true
echo "Healh-check is executed $(date)" >> /tmp/vrrp-health.txt
exit 0

#!/usr/bin/env bash

true
echo "Healh-check is executed $(date)" >> /tmp/vrrp-health-sec.txt
exit 0

[edit]
vyos@r4#
```
So both scripts are executed:
```
vyos@r4# sudo cat /tmp/vrrp-health.txt | tail -n 3
Healh-check is executed Mon 27 Dec 2021 04:03:37 PM EET
Healh-check is executed Mon 27 Dec 2021 04:04:37 PM EET
Healh-check is executed Mon 27 Dec 2021 04:05:37 PM EET
[edit]
vyos@r4# sudo cat /tmp/vrrp-health-sec.txt | tail -n 3
Healh-check is executed Mon 27 Dec 2021 04:04:37 PM EET
Healh-check is executed Mon 27 Dec 2021 04:05:37 PM EET
Healh-check is executed Mon 27 Dec 2021 04:06:37 PM EET
[edit]
vyos@r4# 
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
