### PR TITLE
ipsec: T4111: Fix for swanctl configuration IPV6 peers

### DIFF
--- a/data/templates/ipsec/swanctl.conf.tmpl
+++ b/data/templates/ipsec/swanctl.conf.tmpl
@@ -57,7 +57,7 @@ secrets {
 {%  endif %}
 {%  if site_to_site is defined and site_to_site.peer is defined %}
 {%    for peer, peer_conf in site_to_site.peer.items() if peer not in dhcp_no_address and peer_conf.disable is not defined %}
-{%      set peer_name = peer.replace(".", "-").replace("@", "") %}
+{%      set peer_name = peer.replace("@", "") | dot_colon_to_dash %}
 {%      if peer_conf.authentication.mode == 'pre-shared-secret' %}
     ike_{{ peer_name }} {
 {%        if peer_conf.local_address is defined %}

--- a/data/templates/ipsec/swanctl/peer.tmpl
+++ b/data/templates/ipsec/swanctl/peer.tmpl
@@ -1,5 +1,5 @@
 {% macro conn(peer, peer_conf, ike_group, esp_group) %}
-{%   set name = peer.replace(".", "-").replace("@", "") %}
+{%   set name = peer.replace("@", "") | dot_colon_to_dash %}
 {#   peer needs to reference the global IKE configuration for certain values #}
 {%   set ike = ike_group[peer_conf.ike_group] %}
     peer_{{ name }} {

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -151,6 +151,16 @@ def bracketize_ipv6(address):
         return f'[{address}]'
     return address
 
+@register_filter('dot_colon_to_dash')
+def dot_colon_to_dash(text):
+    """ Replace dot and colon to dash for string
+    Example:
+    192.0.2.1 => 192-0-2-1, 2001:db8::1 => 2001-db8--1
+    """
+    text = text.replace(":", "-")
+    text = text.replace(".", "-")
+    return text
+
 @register_filter('netmask_from_cidr')
 def netmask_from_cidr(prefix):
     """ Take CIDR prefix and convert the prefix length to a "subnet mask".


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Connection name must not contain dots and colons, otherwise
swanctl can't generate a correct configuration for swanctl.conf
This is used in connection names and child SA names
Add filter 'dot_colon_to_dash' which replace dots and colons

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4111

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec, swanctl
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add ipsec ipv6 peer and load configuration:
```
set vpn ipsec site-to-site peer dead:beef::2 authentication id 'dead:beef::1'
set vpn ipsec site-to-site peer dead:beef::2 authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer dead:beef::2 authentication pre-shared-secret 'SSSeeccRetT'
set vpn ipsec site-to-site peer dead:beef::2 authentication remote-id 'dead:beef::2'
set vpn ipsec site-to-site peer dead:beef::2 connection-type 'initiate'
set vpn ipsec site-to-site peer dead:beef::2 ike-group 'grp-IKE'
set vpn ipsec site-to-site peer dead:beef::2 ikev2-reauth 'inherit'
set vpn ipsec site-to-site peer dead:beef::2 local-address 'dead:beef::1'
set vpn ipsec site-to-site peer dead:beef::2 tunnel 0 esp-group 'grp-ESP'
set vpn ipsec site-to-site peer dead:beef::2 tunnel 0 local prefix '172.16.0.0/24'
set vpn ipsec site-to-site peer dead:beef::2 tunnel 0 remote prefix '10.0.0.0/24'
```
before fix:
```
vyos@r11-roll:~$ sudo swanctl -q
/etc/swanctl/swanctl.conf:4: syntax error, unexpected :, expecting "," or '{' [:]
invalid config file '/etc/swanctl/swanctl.conf'
no authorities found, 0 unloaded
no pools found, 0 unloaded
no connections found, 0 unloaded

vyos@r11-roll:~$ cat /etc/swanctl/swanctl.conf 
### Autogenerated by vpn_ipsec.py ###

connections {
    peer_dead:beef::2 {
```
After fix:
```
vyos@r11-roll:~$ sudo swanctl -q
loaded ike secret 'ike_dead-beef--2'
no authorities found, 0 unloaded
no pools found, 0 unloaded
loaded connection 'peer_dead-beef--2'
successfully loaded 1 connections, 0 unloaded
vyos@r11-roll:~$ 
vyos@r11-roll:~$ sudo cat /etc/swanctl/swanctl.conf 
### Autogenerated by vpn_ipsec.py ###

connections {
    peer_dead-beef--2 {

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
