### PR TITLE
webproxy: T4116: Ability to listen on IPv6 addresses

### DIFF
--- a/data/templates/squid/squid.conf.tmpl
+++ b/data/templates/squid/squid.conf.tmpl
@@ -88,7 +88,7 @@ tcp_outgoing_address {{ outgoing_address }}
 
 {% if listen_address is defined and listen_address is not none %}
 {%   for address, config in listen_address.items() %}
-http_port {{ address }}:{{ config.port if config.port is defined else default_port }} {{ 'intercept' if config.disable_transparent is not defined }}
+http_port {{ address | bracketize_ipv6 }}:{{ config.port if config.port is defined else default_port }} {{ 'intercept' if config.disable_transparent is not defined }}
 {%   endfor %}
 {% endif %}
 http_port 127.0.0.1:{{ default_port }}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
IPv6 addresses on webproxy/SQUID are not added correctly.
They need to be added in brackets.
Modified squid.conf.tmpl to bracketize the address

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4116

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
webproxy

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Add a IPv6 address to webproxy listen-address
```
set interfaces ethernet eth0 address fd42:1983:1::1/64
set service webproxy listen-address fd42:1983:1::1 disable-transparent
```

Check  /etc/squid/squid.conf and listen ports:
```
vyos@vyos# grep "http_port" /etc/squid/squid.conf
http_port [fd42:1983:1::1]:3128
http_port 127.0.0.1:3128

vyos@vyos# sudo netstat -lnp |grep 3128
tcp        0      0 127.0.0.1:3128          0.0.0.0:*               LISTEN      13556/(squid-1)
tcp6       0      0 fd42:1983:1::1:3128     :::*                    LISTEN      13556/(squid-1)

```



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
