### PR TITLE
VXLAN: T4120: add ability to set multiple remotes

### DIFF
--- a/interface-definitions/include/interface/tunnel-remote.xml.i
+++ b/interface-definitions/include/interface/tunnel-remote.xml.i
@@ -1,4 +1,4 @@
-<!-- include start from rip/tunnel-remote.xml.i -->
+<!-- include start from interface/tunnel-remote.xml.i -->
 <leafNode name="remote">
   <properties>
     <help>Tunnel remote address</help>

--- a/interface-definitions/include/interface/tunnel-remotes.xml.i
+++ b/interface-definitions/include/interface/tunnel-remotes.xml.i
@@ -1,0 +1,19 @@
+<!-- include start from rip/tunnel-remote.xml.i -->
+<leafNode name="remote">
+  <properties>
+    <help>Tunnel remote address</help>
+    <valueHelp>
+      <format>ipv4</format>
+      <description>Tunnel remote IPv4 address</description>
+    </valueHelp>
+    <valueHelp>
+      <format>ipv6</format>
+      <description>Tunnel remote IPv6 address</description>
+    </valueHelp>
+    <constraint>
+      <validator name="ip-address"/>
+    </constraint>
+    <multi/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/interface/tunnel-remotes.xml.i
+++ b/interface-definitions/include/interface/tunnel-remotes.xml.i
@@ -1,4 +1,4 @@
-<!-- include start from rip/tunnel-remote.xml.i -->
+<!-- include start from rip/tunnel-remotes.xml.i -->
 <leafNode name="remote">
   <properties>
     <help>Tunnel remote address</help>

--- a/interface-definitions/include/interface/tunnel-remotes.xml.i
+++ b/interface-definitions/include/interface/tunnel-remotes.xml.i
@@ -1,4 +1,4 @@
-<!-- include start from rip/tunnel-remotes.xml.i -->
+<!-- include start from interface/tunnel-remotes.xml.i -->
 <leafNode name="remote">
   <properties>
     <help>Tunnel remote address</help>

--- a/interface-definitions/interfaces-vxlan.xml.in
+++ b/interface-definitions/interfaces-vxlan.xml.in
@@ -96,7 +96,7 @@
           </leafNode>
           #include <include/source-address-ipv4-ipv6.xml.i>
           #include <include/source-interface.xml.i>
-          #include <include/interface/tunnel-remote.xml.i>
+          #include <include/interface/tunnel-remotes.xml.i>
           #include <include/interface/vrf.xml.i>
           #include <include/vni.xml.i>
         </children>

--- a/python/vyos/ifconfig/vxlan.py
+++ b/python/vyos/ifconfig/vxlan.py
@@ -62,7 +62,6 @@ class VXLANIf(Interface):
             'parameters.ip.ttl'          : 'ttl',
             'parameters.ipv6.flowlabel'  : 'flowlabel',
             'parameters.nolearning'      : 'nolearning',
-            'remote'                     : 'remote',
             'source_address'             : 'local',
             'source_interface'           : 'dev',
             'vni'                        : 'id',
@@ -82,3 +81,8 @@ class VXLANIf(Interface):
         self._cmd(cmd.format(**self.config))
         # interface is always A/D down. It needs to be enabled explicitly
         self.set_admin_state('down')
+        remote = dict_search('remote', self.config)
+        for rem in remote:
+            self.config["rem"] = rem
+            cmd2 = 'bridge fdb append to 00:00:00:00:00:00 dst {rem} port {port} dev {ifname}'
+            self._cmd(cmd2.format(**self.config))

--- a/python/vyos/ifconfig/vxlan.py
+++ b/python/vyos/ifconfig/vxlan.py
@@ -62,6 +62,7 @@ class VXLANIf(Interface):
             'parameters.ip.ttl'          : 'ttl',
             'parameters.ipv6.flowlabel'  : 'flowlabel',
             'parameters.nolearning'      : 'nolearning',
+            'remote'                     : 'remote',
             'source_address'             : 'local',
             'source_interface'           : 'dev',
             'vni'                        : 'id',
@@ -81,8 +82,10 @@ class VXLANIf(Interface):
         self._cmd(cmd.format(**self.config))
         # interface is always A/D down. It needs to be enabled explicitly
         self.set_admin_state('down')
-        remote = dict_search('remote', self.config)
-        for rem in remote:
-            self.config["rem"] = rem
-            cmd2 = 'bridge fdb append to 00:00:00:00:00:00 dst {rem} port {port} dev {ifname}'
-            self._cmd(cmd2.format(**self.config))
+
+        other_remotes = self.config.get('other_remotes')
+        if other_remotes:
+            for rem in other_remotes:
+                self.config['rem'] = rem
+                cmd2 = 'bridge fdb append to 00:00:00:00:00:00 dst {rem} port {port} dev {ifname}'
+                self._cmd(cmd2.format(**self.config))

--- a/smoketest/scripts/cli/test_interfaces_vxlan.py
+++ b/smoketest/scripts/cli/test_interfaces_vxlan.py
@@ -33,6 +33,8 @@ class VXLANInterfaceTest(BasicInterfaceTest.TestCase):
             'vxlan10': ['vni 10', 'remote 127.0.0.2'],
             'vxlan20': ['vni 20', 'group 239.1.1.1', 'source-interface eth0'],
             'vxlan30': ['vni 30', 'remote 2001:db8:2000::1', 'source-address 2001:db8:1000::1', 'parameters ipv6 flowlabel 0x1000'],
+            'vxlan40': ['vni 40', 'remote 127.0.0.2', 'remote 127.0.0.3'],
+            'vxlan50': ['vni 50', 'remote 2001:db8:2000::1', 'remote 2001:db8:2000::2', 'parameters ipv6 flowlabel 0x1000'],
         }
         cls._interfaces = list(cls._options)
         # call base-classes classmethod

--- a/src/conf_mode/interfaces-vxlan.py
+++ b/src/conf_mode/interfaces-vxlan.py
@@ -115,6 +115,33 @@ def verify(vxlan):
             raise ConfigError(f'Underlaying device MTU is to small ({lower_mtu} '\
                               f'bytes) for VXLAN overhead ({vxlan_overhead} bytes!)')
 
+    # Check for mixed IPv4 and IPv6 addresses
+    protocol = None
+    if 'source_address' in vxlan:
+        if is_ipv6(vxlan['source_address']):
+            protocol = 'ipv6'
+        else:
+            protocol = 'ipv4'
+    if 'remote' in vxlan:
+        if is_ipv6(vxlan['remote']):
+            if protocol == 'ipv4':
+                raise ConfigError('IPv4 and IPV6 cannot be mixed')
+            protocol = 'ipv6'
+        else:
+            if protocol == 'ipv6':
+                raise ConfigError('IPv4 and IPV6 cannot be mixed')
+            protocol = 'ipv4'
+    if 'other_remotes' in vxlan:
+        for rem in vxlan['other_remotes']:
+            if is_ipv6(rem):
+                if protocol == 'ipv4':
+                    raise ConfigError('IPv4 and IPV6 cannot be mixed')
+                protocol = 'ipv6'
+            else:
+                if protocol == 'ipv6':
+                    raise ConfigError('IPv4 and IPV6 cannot be mixed')
+                protocol = 'ipv4'
+
     verify_mtu_ipv6(vxlan)
     verify_address(vxlan)
     return None

--- a/src/conf_mode/interfaces-vxlan.py
+++ b/src/conf_mode/interfaces-vxlan.py
@@ -58,6 +58,13 @@ def get_config(config=None):
     if len(vxlan['other_tunnels']) == 0:
         del vxlan['other_tunnels']
 
+    # leave first remote in dict and put the other ones (if they exists) to "other_remotes"
+    remotes = vxlan.get('remote')
+    if remotes:
+        vxlan['remote'] = remotes[0]
+        if len(remotes) > 1:
+            del remotes[0]
+            vxlan['other_remotes'] = remotes
     return vxlan
 
 def verify(vxlan):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
VXLAN does support using multiple remotes but VyOS does not.
Add the ability to set multiple remotes and add them using "bridge"
commands

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4120

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vxlan

## Proposed changes
<!--- Describe your changes in detail -->
Instead adding vxlan interface like 
```
ip link add vxlan10 type vxlan id 10 remote 10.0.0.1 dstport 0
```

Insert them without remote and then add the remotes with "bridge" command:
```
ip link add vxlan10 type vxlan id 10 dstport 0
bridge fdb append to 00:00:00:00:00:00 dst 10.0.0.1 dev vxlan10
bridge fdb append to 00:00:00:00:00:00 dst 10.0.0.2 dev vxlan10
```
This allows using multiple remotes.
Broadcast traffic (like arp) got pushed to all remotes then. After a mac address is learned vxlan only sends to that remote.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
-->
```
set interfaces vxlan vxlan10 remote '10.0.0.1'
set interfaces vxlan vxlan10 remote '10.0.0.2'
set interfaces vxlan vxlan10 vni '10'
commit

vyos@vyos# bridge fdb show dev vxlan10
00:00:00:00:00:00 dst 10.0.0.1 self permanent
00:00:00:00:00:00 dst 10.0.0.2 self permanent
```
If another port is used then it also works. You do not see the changed port with "bridge dfb show" but tcpdump prove that the other port is used.

Removing remotes is also possible:
```
delete interfaces vxlan vxlan10 remote '10.0.0.2'
commit

vyos@vyos# bridge fdb show dev vxlan10
00:00:00:00:00:00 dst 10.0.0.1 self permanent
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
