### PR TITLE
dhclient: T4121: Fixed resolv.conf generation at early boot stage

### DIFF
--- a/src/etc/dhcp/dhclient-enter-hooks.d/04-vyos-resolvconf
+++ b/src/etc/dhcp/dhclient-enter-hooks.d/04-vyos-resolvconf
@@ -1,44 +1,48 @@
-# modified make_resolv_conf () for VyOS
-make_resolv_conf() {
-    hostsd_client="/usr/bin/vyos-hostsd-client"
-    hostsd_changes=
+# modified make_resolv_conf() for VyOS
+# should be used only if vyos-hostsd is running
 
-    if [ -n "$new_domain_name" ]; then
-        logmsg info "Deleting search domains with tag \"dhcp-$interface\" via vyos-hostsd-client"
-        $hostsd_client --delete-search-domains --tag "dhcp-$interface"
-        logmsg info "Adding domain name \"$new_domain_name\" as search domain with tag \"dhcp-$interface\" via vyos-hostsd-client"
-        $hostsd_client --add-search-domains "$new_domain_name" --tag "dhcp-$interface"
-        hostsd_changes=y
-    fi
+if /usr/bin/systemctl -q is-active vyos-hostsd; then
+    make_resolv_conf() {
+        hostsd_client="/usr/bin/vyos-hostsd-client"
+        hostsd_changes=
 
-    if [ -n "$new_dhcp6_domain_search" ]; then
-        logmsg info "Deleting search domains with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
-        $hostsd_client --delete-search-domains --tag "dhcpv6-$interface"
-        logmsg info "Adding search domain \"$new_dhcp6_domain_search\" with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
-        $hostsd_client --add-search-domains "$new_dhcp6_domain_search" --tag "dhcpv6-$interface"
-        hostsd_changes=y
-    fi
+        if [ -n "$new_domain_name" ]; then
+            logmsg info "Deleting search domains with tag \"dhcp-$interface\" via vyos-hostsd-client"
+            $hostsd_client --delete-search-domains --tag "dhcp-$interface"
+            logmsg info "Adding domain name \"$new_domain_name\" as search domain with tag \"dhcp-$interface\" via vyos-hostsd-client"
+            $hostsd_client --add-search-domains "$new_domain_name" --tag "dhcp-$interface"
+            hostsd_changes=y
+        fi
 
-    if [ -n "$new_domain_name_servers" ]; then
-        logmsg info "Deleting nameservers with tag \"dhcp-$interface\" via vyos-hostsd-client"
-        $hostsd_client --delete-name-servers --tag "dhcp-$interface"
-        logmsg info "Adding nameservers \"$new_domain_name_servers\" with tag \"dhcp-$interface\" via vyos-hostsd-client"
-        $hostsd_client --add-name-servers $new_domain_name_servers --tag "dhcp-$interface"
-        hostsd_changes=y
-    fi
+        if [ -n "$new_dhcp6_domain_search" ]; then
+            logmsg info "Deleting search domains with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
+            $hostsd_client --delete-search-domains --tag "dhcpv6-$interface"
+            logmsg info "Adding search domain \"$new_dhcp6_domain_search\" with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
+            $hostsd_client --add-search-domains "$new_dhcp6_domain_search" --tag "dhcpv6-$interface"
+            hostsd_changes=y
+        fi
 
-    if [ -n "$new_dhcp6_name_servers" ]; then
-        logmsg info "Deleting nameservers with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
-        $hostsd_client --delete-name-servers --tag "dhcpv6-$interface"
-        logmsg info "Adding nameservers \"$new_dhcpv6_name_servers\" with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
-        $hostsd_client --add-name-servers $new_dhcpv6_name_servers --tag "dhcpv6-$interface"
-        hostsd_changes=y
-    fi
+        if [ -n "$new_domain_name_servers" ]; then
+            logmsg info "Deleting nameservers with tag \"dhcp-$interface\" via vyos-hostsd-client"
+            $hostsd_client --delete-name-servers --tag "dhcp-$interface"
+            logmsg info "Adding nameservers \"$new_domain_name_servers\" with tag \"dhcp-$interface\" via vyos-hostsd-client"
+            $hostsd_client --add-name-servers $new_domain_name_servers --tag "dhcp-$interface"
+            hostsd_changes=y
+        fi
 
-    if [ $hostsd_changes ]; then
-        logmsg info "Applying changes via vyos-hostsd-client"
-        $hostsd_client --apply
-    else
-        logmsg info "No changes to apply via vyos-hostsd-client"
-    fi
-}
+        if [ -n "$new_dhcp6_name_servers" ]; then
+            logmsg info "Deleting nameservers with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
+            $hostsd_client --delete-name-servers --tag "dhcpv6-$interface"
+            logmsg info "Adding nameservers \"$new_dhcpv6_name_servers\" with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
+            $hostsd_client --add-name-servers $new_dhcpv6_name_servers --tag "dhcpv6-$interface"
+            hostsd_changes=y
+        fi
+
+        if [ $hostsd_changes ]; then
+            logmsg info "Applying changes via vyos-hostsd-client"
+            $hostsd_client --apply
+        else
+            logmsg info "No changes to apply via vyos-hostsd-client"
+        fi
+    }
+fi

--- a/src/etc/dhcp/dhclient-exit-hooks.d/01-vyos-cleanup
+++ b/src/etc/dhcp/dhclient-exit-hooks.d/01-vyos-cleanup
@@ -4,14 +4,19 @@
 # NOTE: here we use 'ip' wrapper, therefore a route will be actually deleted via /usr/sbin/ip or vtysh, according to the system state
 hostsd_client="/usr/bin/vyos-hostsd-client"
 hostsd_changes=
+# check vyos-hostsd status
+/usr/bin/systemctl -q is-active vyos-hostsd
+hostsd_status=$?
 
 if [[ $reason =~ (EXPIRE|FAIL|RELEASE|STOP) ]]; then
-    # delete search domains and nameservers via vyos-hostsd
-    logmsg info "Deleting search domains with tag \"dhcp-$interface\" via vyos-hostsd-client"
-    $hostsd_client --delete-search-domains --tag "dhcp-$interface"
-    logmsg info "Deleting nameservers with tag \"dhcp-${interface}\" via vyos-hostsd-client"
-    $hostsd_client --delete-name-servers --tag "dhcp-${interface}"
-    hostsd_changes=y
+    if [[ $hostsd_status -eq 0 ]]; then
+        # delete search domains and nameservers via vyos-hostsd
+        logmsg info "Deleting search domains with tag \"dhcp-$interface\" via vyos-hostsd-client"
+        $hostsd_client --delete-search-domains --tag "dhcp-$interface"
+        logmsg info "Deleting nameservers with tag \"dhcp-${interface}\" via vyos-hostsd-client"
+        $hostsd_client --delete-name-servers --tag "dhcp-${interface}"
+        hostsd_changes=y
+    fi
 
     if_metric="$IF_METRIC"
 
@@ -92,12 +97,14 @@ if [[ $reason =~ (EXPIRE|FAIL|RELEASE|STOP) ]]; then
 fi
 
 if [[ $reason =~ (EXPIRE6|RELEASE6|STOP6) ]]; then
-    # delete search domains and nameservers via vyos-hostsd
-    logmsg info "Deleting search domains with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
-    $hostsd_client --delete-search-domains --tag "dhcpv6-$interface"
-    logmsg info "Deleting nameservers with tag \"dhcpv6-${interface}\" via vyos-hostsd-client"
-    $hostsd_client --delete-name-servers --tag "dhcpv6-${interface}"
-    hostsd_changes=y
+    if [[ $hostsd_status -eq 0 ]]; then
+        # delete search domains and nameservers via vyos-hostsd
+        logmsg info "Deleting search domains with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
+        $hostsd_client --delete-search-domains --tag "dhcpv6-$interface"
+        logmsg info "Deleting nameservers with tag \"dhcpv6-${interface}\" via vyos-hostsd-client"
+        $hostsd_client --delete-name-servers --tag "dhcpv6-${interface}"
+        hostsd_changes=y
+    fi
 fi
 
 if [ $hostsd_changes ]; then

--- a/src/systemd/vyos-hostsd.service
+++ b/src/systemd/vyos-hostsd.service
@@ -7,7 +7,7 @@ DefaultDependencies=no
 
 # Seemingly sensible way to say "as early as the system is ready"
 # All vyos-hostsd needs is read/write mounted root
-After=systemd-remount-fs.service
+After=systemd-remount-fs.service cloud-init.service
 
 [Service]
 WorkingDirectory=/run/vyos-hostsd


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed resolv.conf generation at early boot stage

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4121

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhclient, vyos-hostsd

## Proposed changes
<!--- Describe your changes in detail -->
In case if a CLI configuration is not available, dhclient cannot add nameservers to a `resolv.conf` file, because `vyos-hostsd` requires that an interface be listed in the `set system name-server` option.
This commit introduces two changes:
- `vyos-hostsd` service will not be started before Cloud-Init fetch all remote data. This is required because all meta-data should be available for Cloud-Init before any of VyOS-related services start since it is used for configuration generation.
- the `vyos-hostsd-client` in the `dhclient-script` will be used only if the `vyos-hostsd` is running. In other words - if VyOS services already started, dhclient changes `resolv.conf` using `vyos-hostsd`; in other cases - does this directly.

These changes should protect us from problems with DHCP during system boot if DHCP is required by third-party utils.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
To test this change, you need to deploy VyOS in an environment that uses Cloud-Init with a DNS-based URL for meta-data service. Without the fix, Cloud-Init will not be able to resolve the service and meta-data will not be fetched.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
