### PR TITLE
ipsec: T4126: Ability to set priorities for installed policy

### DIFF
--- a/data/templates/ipsec/swanctl/peer.tmpl
+++ b/data/templates/ipsec/swanctl/peer.tmpl
@@ -101,6 +101,9 @@
 {%           set remote_prefix = tunnel_conf.remote.prefix if 'any' not in tunnel_conf.remote.prefix else ['0.0.0.0/0', '::/0'] %}
                 remote_ts = {{ remote_prefix | join(remote_suffix + ",") }}{{ remote_suffix }}
 {%         endif %}
+{%         if tunnel_conf.priority is defined and tunnel_conf.priority is not none %}
+                priority = {{ tunnel_conf.priority }}
+{%         endif %}
 {%       elif tunnel_esp.mode == 'transport' %}
                 local_ts = {{ peer_conf.local_address }}{{ local_suffix }}
                 remote_ts = {{ peer }}{{ remote_suffix }}

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -1047,6 +1047,18 @@
                       #include <include/ipsec/esp-group.xml.i>
                       #include <include/ipsec/local-traffic-selector.xml.i>
                       #include <include/ip-protocol.xml.i>
+                      <leafNode name="priority">
+                        <properties>
+                          <help>Priority for IPSec policy (lowest value more preferable)</help>
+                          <valueHelp>
+                            <format>u32:1-100</format>
+                            <description>Priority for IPSec policy (lowest value more preferable)</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-100"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
                       <node name="remote">
                         <properties>
                           <help>Match remote addresses</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add priority for policy-based IPSec VPN tunnels
If 2 tunnels have the same pair of local and remote traffic
selectors (prefixes) it allows setting more preferable install
policy from required peer
The lowest priority is more preferable

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4126

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Set the same pair "local and remote prefixes" 
Add the lowest `priority` for one peer
```
set vpn ipsec site-to-site peer 192.0.2.14 tunnel 0 local prefix '172.16.0.0/24'
set vpn ipsec site-to-site peer 192.0.2.14 tunnel 0 priority '100'
set vpn ipsec site-to-site peer 192.0.2.14 tunnel 0 remote prefix '10.0.0.0/24'

set vpn ipsec site-to-site peer 203.0.113.14 tunnel 0 local prefix '172.16.0.0/24'
set vpn ipsec site-to-site peer 203.0.113.14 tunnel 0 priority '1'
set vpn ipsec site-to-site peer 203.0.113.14 tunnel 0 remote prefix '10.0.0.0/24'
```
Expected route 10.0.0.0/24 from peer 203.0.113.14:
```
vyos@r11-roll# run show ip route table 220
Codes: K - kernel route, C - connected, S - static, R - RIP,

VRF default table 220:
K>* 10.0.0.0/24 [0/0] via 203.0.113.14, eth1, src 172.16.0.1, 00:19:39
```
Check IPSec policy, expected `priority 1`
```
vyos@r11-roll# run show vpn ipsec policy 
src 172.16.0.0/24 dst 10.0.0.0/24 
        dir out priority 1 ptype main 
        tmpl src 203.0.113.1 dst 203.0.113.14
                proto esp spi 0xcc6a38dc reqid 1 mode tunnel
src 10.0.0.0/24 dst 172.16.0.0/24 
        dir fwd priority 1 ptype main 
        tmpl src 203.0.113.14 dst 203.0.113.1
                proto esp reqid 1 mode tunnel
src 10.0.0.0/24 dst 172.16.0.0/24 
        dir in priority 1 ptype main 
        tmpl src 203.0.113.14 dst 203.0.113.1
                proto esp reqid 1 mode tunnel
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
