### PR TITLE
firewall: T4134: Fix completion help for protocols

### DIFF
--- a/interface-definitions/include/firewall/common-rule.xml.i
+++ b/interface-definitions/include/firewall/common-rule.xml.i
@@ -99,7 +99,7 @@
   <properties>
     <help>Protocol to match (protocol name, number, or "all")</help>
     <completionHelp>
-      <script>cat /etc/protocols | sed -e '/^#.*/d' | awk '{ print $1 }'</script>
+      <script>${vyos_completion_dir}/list_protocols.sh</script>
     </completionHelp>
     <valueHelp>
       <format>all</format>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix completion help for firewall node protocols
Completion was wrong because nodes add their own quotes in generated nodes, like `sh -c "my command "`
Use completion script
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4134

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Expected correct completion help for protocols (no DUP, lowercase):
```
vyos@r11-roll# set firewall name FOO rule 10 protocol 
Possible completions:
   all          All IP protocols
   tcp_udp      Both TCP and UDP
   <0-255>      IP protocol number
   !<protocol>  IP protocol number
   ah           
   ax.25        
   dccp         
   ddp          
   egp          
   eigrp        
   encap        
   esp          
   etherip      
   fc           
   ggp          
   gre          
   hip          
   hmp          
   hopopt       
   icmp         
   idpr-cmtp    
   idrp         
   igmp         
   igp          
   ip           
   ipcomp       
   ipencap      
   ipip         
   ipv6         
   ipv6-frag    
   ipv6-icmp    
   ipv6-nonxt   
   ipv6-opts    
   ipv6-route   
   isis         
   iso-tp4      
   l2tp         
   manet        
   mobility-header
                
   mpls-in-ip   
   ospf         
   pim          
   pup          
   rdp          
   rohc         
   rspf         
   rsvp         
   sctp         
   shim6        
   skip         
   st           
   tcp          
   udp          
   udplite      
   vmtp         
   vrrp         
   wesp         
   xns-idp      
   xtp          

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
