### PR TITLE
keepalived: T4150: Fix template option conntrack_sync_group

### DIFF
--- a/data/templates/high-availability/keepalived.conf.tmpl
+++ b/data/templates/high-availability/keepalived.conf.tmpl
@@ -103,7 +103,7 @@ vrrp_sync_group {{ name }} {
 {%         endif %}
 {%       endfor %}
 {%     endif %}
-{%     if vrrp.conntrack_sync_group is defined and vrrp.conntrack_sync_group == name %}
+{%     if conntrack_sync_group is defined and conntrack_sync_group == name %}
 {%     set vyos_helper = "/usr/libexec/vyos/vyos-vrrp-conntracksync.sh" %}
     notify_master "{{ vyos_helper }} master {{ name }}"
     notify_backup "{{ vyos_helper }} backup {{ name }}"


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
conntrack_sync_group option not under 'vrrp' section but part of
high-availability dictionary
Fix keepalived template.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4150

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrrp, conntrack-sync
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Tested configuration:
```
set high-availability vrrp group LAN address '10.0.0.5/24'
set high-availability vrrp group LAN interface 'eth1'
set high-availability vrrp group LAN no-preempt
set high-availability vrrp group LAN priority '200'
set high-availability vrrp group LAN vrid '101'
set high-availability vrrp group WAN address '192.168.0.5/27'
set high-availability vrrp group WAN interface 'eth0'
set high-availability vrrp group WAN no-preempt
set high-availability vrrp group WAN priority '200'
set high-availability vrrp group WAN vrid '100'
set high-availability vrrp sync-group SYNCgrp member 'LAN'
set high-availability vrrp sync-group SYNCgrp member 'WAN'

set service conntrack-sync accept-protocol 'tcp'
set service conntrack-sync accept-protocol 'udp'
set service conntrack-sync accept-protocol 'icmp'
set service conntrack-sync disable-external-cache
set service conntrack-sync failover-mechanism vrrp sync-group 'SYNCgrp'
set service conntrack-sync interface eth2

```
As we can see **conntrack_sync_group** not a part of **vrrp**
```
vyos@r11-roll# set high-availability vrrp group LAN priority 202
vyos@r11-roll# commit
[ high-availability ]
{'conntrack_sync_group': 'SYNCgrp',
 'vrrp': {'group': {'LAN': {'address': ['10.0.0.5/24'],
                            'advertise_interval': '1',
                            'health_check': {'failure_count': '3',
                                             'interval': '60'},
                            'interface': 'eth1',
                            'no_preempt': {},
                            'preempt_delay': '0',
                            'priority': '202',
                            'vrid': '101'},
                    'WAN': {'address': ['192.168.0.5/27'],
                            'advertise_interval': '1',
                            'health_check': {'failure_count': '3',
                                             'interval': '60'},
                            'interface': 'eth0',
                            'no_preempt': {},
                            'preempt_delay': '0',
                            'priority': '200',
                            'vrid': '100'}},
          'sync_group': {'SYNCgrp': {'member': ['LAN', 'WAN']}}}}
```

Keepalived conf before fix, section sync_group:
```
vrrp_sync_group SYNCgrp {
    group {
        LAN
        WAN
    }

}
```
Keepalived conf after fix:
```
vrrp_sync_group SYNCgrp {
    group {
        LAN
        WAN
    }

    notify_master "/usr/libexec/vyos/vyos-vrrp-conntracksync.sh master SYNCgrp"
    notify_backup "/usr/libexec/vyos/vyos-vrrp-conntracksync.sh backup SYNCgrp"
    notify_fault "/usr/libexec/vyos/vyos-vrrp-conntracksync.sh fault SYNCgrp"
}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
