### PR TITLE
vrrp: T1972: Ability to set IP address on not vrrp interface

### DIFF
--- a/data/templates/high-availability/keepalived.conf.tmpl
+++ b/data/templates/high-availability/keepalived.conf.tmpl
@@ -28,6 +28,9 @@ vrrp_instance {{ name }} {
     virtual_router_id {{ group_config.vrid }}
     priority {{ group_config.priority }}
     advert_int {{ group_config.advertise_interval }}
+{%     if group_config.track is defined and group_config.track.exclude_vrrp_interface is defined %}
+    dont_track_primary
+{%     endif %}
 {%     if group_config.no_preempt is not defined and group_config.preempt_delay is defined and group_config.preempt_delay is not none %}
     preempt_delay {{ group_config.preempt_delay }}
 {%     elif group_config.no_preempt is defined %}
@@ -61,8 +64,8 @@ vrrp_instance {{ name }} {
 {%     endif %}
 {%     if group_config.address is defined and group_config.address is not none %}
     virtual_ipaddress {
-{%       for addr in group_config.address %}
-        {{ addr }}
+{%       for addr, addr_config in group_config.address.items() %}
+        {{ addr }}{{ ' dev ' + addr_config.interface if addr_config.interface is defined }}
 {%       endfor %}
     }
 {%     endif %}
@@ -70,6 +73,13 @@ vrrp_instance {{ name }} {
     virtual_ipaddress_excluded {
 {%       for addr in group_config.excluded_address %}
         {{ addr }}
+{%       endfor %}
+    }
+{%     endif %}
+{%     if group_config.track is defined and group_config.track.interface is defined and group_config.track.interface is not none %}
+    track_interface {
+{%       for interface in group_config.track.interface %}
+        {{ interface }}
 {%       endfor %}
     }
 {%     endif %}
@@ -113,8 +123,8 @@ vrrp_sync_group {{ name }} {
 {%   endfor %}
 {% endif %}
 
-# Virtual-server configuration
 {% if virtual_server is defined and virtual_server is not none %}
+# Virtual-server configuration
 {%   for vserver, vserver_config in virtual_server.items() %}
 virtual_server {{ vserver }} {{ vserver_config.port }} {
     delay_loop {{ vserver_config.delay_loop }}

--- a/interface-definitions/high-availability.xml.in
+++ b/interface-definitions/high-availability.xml.in
@@ -177,8 +177,37 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <node name="track">
+                <properties>
+                  <help>Track settings</help>
+                </properties>
+                <children>
+                  <leafNode name="exclude-vrrp-interface">
+                    <properties>
+                      <valueless/>
+                      <help>Disable track state of main interface</help>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="interface">
+                    <properties>
+                      <help>Interface name state check</help>
+                      <completionHelp>
+                        <script>${vyos_completion_dir}/list_interfaces.py --broadcast</script>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Interface name</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="interface-name"/>
+                      </constraint>
+                      <multi/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
               #include <include/vrrp-transition-script.xml.i>
-              <leafNode name="address">
+              <tagNode name="address">
                 <properties>
                   <help>Virtual IP address</help>
                   <valueHelp>
@@ -193,9 +222,11 @@
                     <validator name="ipv4-host"/>
                     <validator name="ipv6-host"/>
                   </constraint>
-                  <multi/>
                 </properties>
-              </leafNode>
+                <children>
+                  #include <include/generic-interface-broadcast.xml.i>
+                </children>
+              </tagNode>
               <leafNode name="excluded-address">
                 <properties>
                   <help>Virtual address (If you need additional IPv4 and IPv6 in same group)</help>

--- a/smoketest/scripts/cli/test_ha_vrrp.py
+++ b/smoketest/scripts/cli/test_ha_vrrp.py
@@ -166,5 +166,35 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
         for group in groups:
             self.assertIn(f'{group}', config)
 
+    def test_04_exclude_vrrp_interface(self):
+        group = 'VyOS-WAN'
+        none_vrrp_interface = 'eth2'
+        vlan_id = '24'
+        vip = '100.64.24.1/24'
+        vip_dev = '192.0.2.2/24'
+        vrid = '150'
+        group_base = base_path + ['vrrp', 'group', group]
+
+        self.cli_set(['interfaces', 'ethernet', vrrp_interface, 'vif', vlan_id, 'address', '100.64.24.11/24'])
+        self.cli_set(group_base + ['interface', f'{vrrp_interface}.{vlan_id}'])
+        self.cli_set(group_base + ['address', vip])
+        self.cli_set(group_base + ['address', vip_dev, 'interface', none_vrrp_interface])
+        self.cli_set(group_base + ['track', 'exclude-vrrp-interface'])
+        self.cli_set(group_base + ['track', 'interface', none_vrrp_interface])
+        self.cli_set(group_base + ['vrid', vrid])
+
+        # commit changes
+        self.cli_commit()
+
+        config = getConfig(f'vrrp_instance {group}')
+
+        self.assertIn(f'interface {vrrp_interface}.{vlan_id}', config)
+        self.assertIn(f'virtual_router_id {vrid}', config)
+        self.assertIn(f'dont_track_primary', config)
+        self.assertIn(f'    {vip}', config)
+        self.assertIn(f'    {vip_dev} dev {none_vrrp_interface}', config)
+        self.assertIn(f'track_interface', config)
+        self.assertIn(f'    {none_vrrp_interface}', config)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to set virtual_address on not vrrp-listen interface `192.168.222.222/24 dev eth2`
Add ability don't track primary vrrp interface - `dont_track_primary` option
Add ability to set tracking (state UP/Down) on desired interfaces
For example, eth0 is used for vrrp and we want to track another eth1
interface that does not belong to any vrrp-group
Add `track-options`,

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T1972

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrrp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set high-availability vrrp group WAN address 192.0.2.55/24
set high-availability vrrp group WAN address 192.168.222.222/24 interface 'eth2'
set high-availability vrrp group WAN address 198.51.100.111/24
set high-availability vrrp group WAN interface 'eth0'
set high-availability vrrp group WAN no-preempt
set high-availability vrrp group WAN priority '200'
set high-availability vrrp group WAN track exclude-vrrp-interface
set high-availability vrrp group WAN track interface 'eth2'
set high-availability vrrp group WAN track interface 'eth1'
set high-availability vrrp group WAN vrid '100'

```
Keepalived conf, expected `dont_track_primary` and `192.168.222.222/24 dev eth2` and `track_interface`:
```
vrrp_instance WAN {
    state BACKUP
    interface eth0
    virtual_router_id 100
    priority 200
    advert_int 1
    dont_track_primary
    nopreempt
    virtual_ipaddress {
        192.0.2.55/24
        192.168.222.222/24 dev eth2
        198.51.100.111/24
    }
    track_interface {
        eth2
        eth1
    }
}

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
