### PR TITLE
nhrp: T4152: Fix template holding-time for nhrp

### DIFF
--- a/data/templates/nhrp/opennhrp.conf.tmpl
+++ b/data/templates/nhrp/opennhrp.conf.tmpl
@@ -33,7 +33,7 @@ interface {{ name }} #{{ type }} {{ profile_name }}
 {%     endfor %}
 {%     if tunnel_conf.shortcut_target is defined and tunnel_conf.shortcut_target is not none %}
 {%       for target, shortcut_conf in tunnel_conf.shortcut_target.items() %}
-    shortcut-target {{ target }} {{ shortcut_conf.holding_time if shortcut_conf.holding_time is defined else '' }}
+    shortcut-target {{ target }}{{ ' holding-time ' + shortcut_conf.holding_time if shortcut_conf.holding_time is defined }}
 {%       endfor %}
 {%     endif %}
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add missed 'holding-time' option for shortcut-target address, nhrp template

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4152

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nhrp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Tested configuration:
```
set protocols nhrp tunnel tun0 cisco-authentication foo
set protocols nhrp tunnel tun0 holding-time '300'
set protocols nhrp tunnel tun0 map 10.0.0.1/20 nbma-address '10.0.112.72'
set protocols nhrp tunnel tun0 map 10.0.0.1/20 register
set protocols nhrp tunnel tun0 multicast 'nhs'
set protocols nhrp tunnel tun0 redirect
set protocols nhrp tunnel tun0 shortcut
set protocols nhrp tunnel tun0 shortcut-target 10.0.0.1/20 holding-time '15'
```
Opennhrp.conf and service before fix:
```
Jan 09 14:16:08 r11-roll opennhrp[25570]: opennhrp[25570]: Configuration file syntax error in /run/opennhrp/opennhrp.conf:11, near word '15'
Jan 09 14:16:08 r11-roll opennhrp[25570]: Adding local 10.0.0.1/20 dev tun0
Jan 09 14:16:08 r11-roll opennhrp[25570]: Configuration file syntax error in /run/opennhrp/opennhrp.conf:11, near word '15
   ...
    shortcut-target 10.0.0.1/20 15
```
Opennhrp.conf after the fix:
```
vyos@r11-roll# sudo systemctl status opennhrp
● opennhrp.service - OpenNHRP
     Loaded: loaded (/lib/systemd/system/opennhrp.service; static)
     Active: active (running) since Sun 2022-01-09 14:30:05 EET; 10min ago

    ...
    shortcut-target 10.0.0.1/20 holding-time 15
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
