### PR TITLE
containers: T2216: bugfix host networking on image upgrade

### DIFF
--- a/src/conf_mode/containers.py
+++ b/src/conf_mode/containers.py
@@ -298,7 +298,7 @@ def apply(container):
                                  f'--memory {memory}m --memory-swap 0 --restart {restart} ' \
                                  f'--name {name} {port} {volume} {env_opt}'
             if 'allow_host_networks' in container_config:
-                _cmd(f'{container_base_cmd} --net host {image}')
+                run(f'{container_base_cmd} --net host {image}')
             else:
                 for network in container_config['network']:
                     ipparam = ''
@@ -306,18 +306,24 @@ def apply(container):
                         address = container_config['network'][network]['address']
                         ipparam = f'--ip {address}'
 
-                    counter = 0
-                    while True:
-                        if counter >= 10:
-                            break
-                        try:
-                            _cmd(f'{container_base_cmd} --net {network} {ipparam} {image}')
-                            break
-                        except:
-                            counter = counter +1
-                            sleep(0.5)
+                    run(f'{container_base_cmd} --net {network} {ipparam} {image}')
 
     return None
+
+def run(container_cmd):
+    counter = 0
+    while True:
+        if counter >= 10:
+            break
+        try:
+            _cmd(container_cmd)
+            break
+        except:
+            counter = counter +1
+            sleep(0.5)
+
+    return None
+
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T2216

## Component(s) name
containers

## Proposed changes
The bug was partially fixed with this commit: https://github.com/vyos/vyos-1x/commit/358f0b481d8620cad4954e3fe418054b9a8c3ecd

The earlier commit introduced a startup retry (up to 10 times) to allow
the OS to settle before the container is started. However, it only applies if
host networking is NOT used. This change applies the same for containers
where host networking is employed.

Since the retry portion of the code (written in the earlier commit) is now
referenced twice, it has been moved to its own function.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

I followed this documentation: https://docs.vyos.io/en/latest/contributing/build-vyos.html

I used the vyos-build docker image/container to build vyos-1x into a deb file, then added it into
the packages folder before configuring/making the vyos iso.

I then added that iso as a system image in my existing home environment and rebooted
the system. All of my containers (which use host networking) had started successfully.
With previous images I would manually restart the system a second time to get them going.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
