### PR TITLE
strip-private: T4177: Fix for hiding private data token/url/bucket

### DIFF
--- a/src/helpers/strip-private.py
+++ b/src/helpers/strip-private.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Copyright 2021 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2021-2022 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -111,6 +111,10 @@ if __name__ == "__main__":
         (True, re.compile(r'public-keys \S+'), 'public-keys xxxx@xxx.xxx'),
         (True, re.compile(r'type \'ssh-(rsa|dss)\''), 'type ssh-xxx'),
         (True, re.compile(r' key \S+'), ' key xxxxxx'),
+        # Strip bucket
+        (True, re.compile(r' bucket \S+'), ' bucket xxxxxx'),
+        # Strip tokens
+        (True, re.compile(r' token \S+'), ' token xxxxxx'),
         # Strip OpenVPN secrets
         (True, re.compile(r'(shared-secret-key-file|ca-cert-file|cert-file|dh-file|key-file|client) (\S+)'), r'\1 xxxxxx'),
         # Strip IPSEC secrets
@@ -123,8 +127,8 @@ if __name__ == "__main__":
         # Strip MAC addresses
         (args.mac, re.compile(r'([0-9a-fA-F]{2}\:){5}([0-9a-fA-F]{2}((\:{0,1})){3})'), r'xx:xx:xx:xx:xx:\2'),
 
-        # Strip host-name, domain-name, and domain-search
-        (args.hostname, re.compile(r'(host-name|domain-name|domain-search) \S+'), r'\1 xxxxxx'),
+        # Strip host-name, domain-name, domain-search and url
+        (args.hostname, re.compile(r'(host-name|domain-name|domain-search|url) \S+'), r'\1 xxxxxx'),
 
         # Strip user-names
         (args.username, re.compile(r'(user|username|user-id) \S+'), r'\1 xxxxxx'),


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add URL, token, and bucket hiding data when is used function "strip-private"
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4177

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
helper
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add monitoring configuration
```
vyos@r11-roll# run show configuration comm | match monitor | strip-private
set service monitoring telegraf authentication organization 'vyos'
set service monitoring telegraf authentication token '167NIYAmDDO_COdHjMVnYVEFthf5YSkYkMLMQoj-bH_wh3BKPbWDj3XKoM029y-wdxseiXBI8GXoOt47OPaE_A=='
set service monitoring telegraf bucket 'bucket_vyos'
set service monitoring telegraf port '8086'
set service monitoring telegraf source 'all'
set service monitoring telegraf url 'http://foo.local'
```
Expected hidden private data:
```
vyos@r11-roll:~$ show conf com | match monitor | strip-private 
set service monitoring telegraf authentication organization 'vyos'
set service monitoring telegraf authentication token xxxxxx
set service monitoring telegraf bucket xxxxxx
set service monitoring telegraf port '8086'
set service monitoring telegraf source 'all'
set service monitoring telegraf url xxxxxx
vyos@r11-roll:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
