### PR TITLE
vrrp: T4182: Check if VRRP configured in op mode

### DIFF
--- a/src/op_mode/vrrp.py
+++ b/src/op_mode/vrrp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018 VyOS maintainers and contributors
+# Copyright (C) 2018-2022 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -23,6 +23,7 @@ import tabulate
 
 import vyos.util
 
+from vyos.configquery import ConfigTreeQuery
 from vyos.ifconfig.vrrp import VRRP
 from vyos.ifconfig.vrrp import VRRPError, VRRPNoData
 
@@ -35,7 +36,17 @@ group.add_argument("-d", "--data", action="store_true", help="Print detailed VRR
 
 args = parser.parse_args()
 
+def is_configured():
+    """ Check if VRRP is configured """
+    config = ConfigTreeQuery()
+    if not config.exists(['high-availability', 'vrrp', 'group']):
+        return False
+    return True
+
 # Exit early if VRRP is dead or not configured
+if  is_configured() == False:
+    print('VRRP not configured!')
+    exit(0)
 if not VRRP.is_running():
     print('VRRP is not running')
     sys.exit(0)


### PR DESCRIPTION
There is a situation when service keepalived is active but
there a no any "vrrp" configuration. In that case "show vrrp"
hangs up because it expect data from keepalived daemon which
can't get
Check if "vrrp" exists in configuration and only then check if pid
is active

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4182

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrrp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
From op-mode `show vrrp` when vrrp is not configured

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
