### PR TITLE
firewall: T4178: Use lowercase for TCP flags and add an validator

### DIFF
--- a/interface-definitions/include/firewall/common-rule.xml.i
+++ b/interface-definitions/include/firewall/common-rule.xml.i
@@ -274,12 +274,42 @@
         <help>TCP flags to match</help>
         <valueHelp>
           <format>txt</format>
-          <description>TCP flags to match</description>
+          <description>Multiple comma-separated flags</description>
+        </valueHelp>
+        <valueHelp>
+          <format>syn</format>
+          <description>Syncronise flag</description>
+        </valueHelp>
+        <valueHelp>
+          <format>ack</format>
+          <description>Acknowledge flag</description>
+        </valueHelp>
+        <valueHelp>
+          <format>fin</format>
+          <description>Finish flag</description>
+        </valueHelp>
+        <valueHelp>
+          <format>rst</format>
+          <description>Reset flag</description>
+        </valueHelp>
+        <valueHelp>
+          <format>urg</format>
+          <description>Urgent flag</description>
+        </valueHelp>
+        <valueHelp>
+          <format>psh</format>
+          <description>Push flag</description>
         </valueHelp>
         <valueHelp>
           <format> </format>
-          <description>\n\n  Allowed values for TCP flags : SYN ACK FIN RST URG PSH ALL\n  When specifying more than one flag, flags should be comma-separated.\n For example : value of 'SYN,!ACK,!FIN,!RST' will only match packets with\n  the SYN flag set, and the ACK, FIN and RST flags unset</description>
+          <description>\n When specifying more than one flag, flags should be comma-separated.\n For example: value of 'SYN,!ACK,!FIN,!RST' will only match packets with\n the SYN flag set, and the ACK, FIN and RST flags unset</description>
         </valueHelp>
+        <completionHelp>
+          <list>syn ack fin rst urg psh</list>
+        </completionHelp>
+        <constraint>
+          <validator name="tcp-flag"/>
+        </constraint>
       </properties>
     </leafNode>
   </children>

--- a/interface-definitions/include/policy/route-common-rule-ipv6.xml.i
+++ b/interface-definitions/include/policy/route-common-rule-ipv6.xml.i
@@ -330,12 +330,42 @@
         <help>TCP flags to match</help>
         <valueHelp>
           <format>txt</format>
-          <description>TCP flags to match</description>
+          <description>Multiple comma-separated flags</description>
+        </valueHelp>
+        <valueHelp>
+          <format>syn</format>
+          <description>Syncronise flag</description>
+        </valueHelp>
+        <valueHelp>
+          <format>ack</format>
+          <description>Acknowledge flag</description>
+        </valueHelp>
+        <valueHelp>
+          <format>fin</format>
+          <description>Finish flag</description>
+        </valueHelp>
+        <valueHelp>
+          <format>rst</format>
+          <description>Reset flag</description>
+        </valueHelp>
+        <valueHelp>
+          <format>urg</format>
+          <description>Urgent flag</description>
+        </valueHelp>
+        <valueHelp>
+          <format>psh</format>
+          <description>Push flag</description>
         </valueHelp>
         <valueHelp>
           <format> </format>
-          <description>\n\n  Allowed values for TCP flags : SYN ACK FIN RST URG PSH ALL\n  When specifying more than one flag, flags should be comma-separated.\n For example : value of 'SYN,!ACK,!FIN,!RST' will only match packets with\n  the SYN flag set, and the ACK, FIN and RST flags unset</description>
+          <description>\n When specifying more than one flag, flags should be comma-separated.\n For example: value of 'SYN,!ACK,!FIN,!RST' will only match packets with\n the SYN flag set, and the ACK, FIN and RST flags unset</description>
         </valueHelp>
+        <completionHelp>
+          <list>syn ack fin rst urg psh</list>
+        </completionHelp>
+        <constraint>
+          <validator name="tcp-flag"/>
+        </constraint>
       </properties>
     </leafNode>
   </children>

--- a/interface-definitions/include/policy/route-common-rule.xml.i
+++ b/interface-definitions/include/policy/route-common-rule.xml.i
@@ -330,12 +330,42 @@
         <help>TCP flags to match</help>
         <valueHelp>
           <format>txt</format>
-          <description>TCP flags to match</description>
+          <description>Multiple comma-separated flags</description>
+        </valueHelp>
+        <valueHelp>
+          <format>syn</format>
+          <description>Syncronise flag</description>
+        </valueHelp>
+        <valueHelp>
+          <format>ack</format>
+          <description>Acknowledge flag</description>
+        </valueHelp>
+        <valueHelp>
+          <format>fin</format>
+          <description>Finish flag</description>
+        </valueHelp>
+        <valueHelp>
+          <format>rst</format>
+          <description>Reset flag</description>
+        </valueHelp>
+        <valueHelp>
+          <format>urg</format>
+          <description>Urgent flag</description>
+        </valueHelp>
+        <valueHelp>
+          <format>psh</format>
+          <description>Push flag</description>
         </valueHelp>
         <valueHelp>
           <format> </format>
-          <description>\n\n  Allowed values for TCP flags : SYN ACK FIN RST URG PSH ALL\n  When specifying more than one flag, flags should be comma-separated.\n For example : value of 'SYN,!ACK,!FIN,!RST' will only match packets with\n  the SYN flag set, and the ACK, FIN and RST flags unset</description>
+          <description>\n When specifying more than one flag, flags should be comma-separated.\n For example: value of 'SYN,!ACK,!FIN,!RST' will only match packets with\n the SYN flag set, and the ACK, FIN and RST flags unset</description>
         </valueHelp>
+        <completionHelp>
+          <list>syn ack fin rst urg psh</list>
+        </completionHelp>
+        <constraint>
+          <validator name="tcp-flag"/>
+        </constraint>
       </properties>
     </leafNode>
   </children>

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -171,7 +171,6 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
     if tcp_flags:
         output.append(parse_tcp_flags(tcp_flags))
 
-
     output.append('counter')
 
     if 'set' in rule_conf:
@@ -190,10 +189,10 @@ def parse_tcp_flags(flags):
     include = []
     for flag in flags.split(","):
         if flag[0] == '!':
-            flag = flag[1:]
+            flag = flag[1:].lower()
         else:
-            include.append(flag)
-        all_flags.append(flag)
+            include.append(flag.lower())
+        all_flags.append(flag.lower())
     return f'tcp flags & ({"|".join(all_flags)}) == {"|".join(include)}'
 
 def parse_time(time):

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -142,6 +142,9 @@ def verify_rule(firewall, rule_conf, ipv6):
         if not {'count', 'time'} <= set(rule_conf['recent']):
             raise ConfigError('Recent "count" and "time" values must be defined')
 
+    if dict_search_args(rule_conf, 'tcp', 'flags') and dict_search_args(rule_conf, 'protocol') != 'tcp':
+        raise ConfigError('Protocol must be tcp when specifying tcp flags')
+
     for side in ['destination', 'source']:
         if side in rule_conf:
             side_conf = rule_conf[side]

--- a/src/validators/tcp-flag
+++ b/src/validators/tcp-flag
@@ -1,0 +1,19 @@
+#!/usr/bin/python3
+
+import sys
+import re
+
+if __name__ == '__main__':
+    if len(sys.argv)>1:
+        flags = sys.argv[1].split(",")
+
+        for flag in flags:
+            if flag and flag[0] == '!':
+                flag = flag[1:]
+            if flag.lower() not in ['syn', 'ack', 'rst', 'fin', 'urg', 'psh']:
+                print(f'Error: {flag} is not a valid TCP flag')
+                sys.exit(1)
+    else:
+        sys.exit(2)
+
+    sys.exit(0)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
* Fix for case sensitivity in nftables config
* Add tcp flags validator

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4178

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall, policy

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
