### PR TITLE
wireguard: T4183: Allow to set peer IPv6 link-local address

### DIFF
--- a/interface-definitions/interfaces-wireguard.xml.in
+++ b/interface-definitions/interfaces-wireguard.xml.in
@@ -101,6 +101,7 @@
                   </valueHelp>
                   <constraint>
                     <validator name="ip-address"/>
+                    <validator name="ipv6-link-local"/>
                   </constraint>
                 </properties>
               </leafNode>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow setting IPv6 address as remote peer
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4183

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireguard
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure IPv6 link-local address as the peer address
```
set interfaces wireguard wg0 address '10.2.4.1/30'
set interfaces wireguard wg0 peer FOO address 'fe80::5054:ff:fe49:ce7f%eth0'
set interfaces wireguard wg0 peer FOO allowed-ips '0.0.0.0/0'
set interfaces wireguard wg0 peer FOO port '12521'
set interfaces wireguard wg0 peer FOO public-key 'vUH9='
set interfaces wireguard wg0 port '12345'
set interfaces wireguard wg0 private-key 'uEC='

```
Expected packet to port 12345 on eth0 and real addresses on wg0 interface:
```
vyos@r11-roll:~$ sudo tcpdump -ni eth0 port 12345
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), snapshot length 262144 bytes
22:59:28.517319 IP6 fe80::5054:ff:fe49:ce7f.12521 > fe80::5054:ff:fe48:a0c6.12345: UDP, length 128
22:59:28.517648 IP6 fe80::5054:ff:fe48:a0c6.12345 > fe80::5054:ff:fe49:ce7f.12521: UDP, length 128
22:59:29.541301 IP6 fe80::5054:ff:fe49:ce7f.12521 > fe80::5054:ff:fe48:a0c6.12345: UDP, length 128
22:59:29.541673 IP6 fe80::5054:ff:fe48:a0c6.12345 > fe80::5054:ff:fe49:ce7f.12521: UDP, length 128
^C
4 packets captured
4 packets received by filter
0 packets dropped by kernel
vyos@r11-roll:~$ 
vyos@r11-roll:~$ sudo tcpdump -ni wg0
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on wg0, link-type RAW (Raw IP), snapshot length 262144 bytes
22:59:37.733544 IP 10.2.4.2 > 10.2.4.1: ICMP echo request, id 10978, seq 38, length 64
22:59:37.733589 IP 10.2.4.1 > 10.2.4.2: ICMP echo reply, id 10978, seq 38, length 64
22:59:38.757473 IP 10.2.4.2 > 10.2.4.1: ICMP echo request, id 10978, seq 39, length 64
22:59:38.757503 IP 10.2.4.1 > 10.2.4.2: ICMP echo reply, id 10978, seq 39, length 64
^C
4 packets captured
4 packets received by filter
0 packets dropped by kernel
vyos@r11-roll:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
