### PR TITLE
T4183: T4110: Ability to set IPv6-link-local addresses for services and wg

### DIFF
--- a/interface-definitions/include/listen-address.xml.i
+++ b/interface-definitions/include/listen-address.xml.i
@@ -17,6 +17,7 @@
     <constraint>
       <validator name="ipv4-address"/>
       <validator name="ipv6-address"/>
+      <validator name="ipv6-link-local"/>
     </constraint>
   </properties>
 </leafNode>

--- a/interface-definitions/interfaces-wireguard.xml.in
+++ b/interface-definitions/interfaces-wireguard.xml.in
@@ -99,6 +99,7 @@
                   </valueHelp>
                   <constraint>
                     <validator name="ip-address"/>
+                    <validator name="ipv6-link-local"/>
                   </constraint>
                 </properties>
               </leafNode>

--- a/src/validators/ipv6-link-local
+++ b/src/validators/ipv6-link-local
@@ -1,0 +1,12 @@
+#!/usr/bin/python3
+
+import sys
+from vyos.validate import is_ipv6_link_local
+
+if __name__ == '__main__':
+    if len(sys.argv)>1:
+        addr = sys.argv[1]
+        if not is_ipv6_link_local(addr):
+            sys.exit(1)
+
+    sys.exit(0)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add ability to set ipv6-link-local addresses for services (ssh/ntp) and wiregurad peer interfaces

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4183
* https://phabricator.vyos.net/T4110

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireguard
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Set IPv6 link local addresses for service ssh/ntp and as wiregurad peer
```
vyos@r4# run show conf com | match "wireguard|listen"
set interfaces wireguard wg0 address '203.0.113.2/30'
set interfaces wireguard wg0 peer FOO address 'fe80::5054:ff:fe48:a0c6%eth0'
set interfaces wireguard wg0 peer FOO allowed-ips '0.0.0.0/0'
set interfaces wireguard wg0 peer FOO port '12345'
set interfaces wireguard wg0 peer FOO pubkey 'exgQ='
set service ssh listen-address '192.168.122.14'
set service ssh listen-address 'fe80::5054:ff:fe49:ce7f%eth0'
set system ntp listen-address 'fe80::5054:ff:fe49:ce7f%eth0'

```
Expected required listen addresses in ssh/ntp/wg configuration:
```
vyos@r4# cat /run/sshd/sshd_config | grep -i list
# Specifies the port number that sshd(8) listens on
# Specifies the local addresses sshd should listen on
ListenAddress 192.168.122.14
ListenAddress fe80::5054:ff:fe49:ce7f%eth0
[edit]
vyos@r4# 
vyos@r4# cat /run/ntpd/n | grep -i list
ntpd.conf  ntpd.pid   
[edit]
vyos@r4# cat /run/ntpd/ntpd.conf | grep -i list
# NTP should listen on configured addresses only
interface listen fe80::5054:ff:fe49:ce7f%eth0
[edit]
vyos@r4# 


vyos@r4# sudo wg
interface: wg0
  public key: vU...=
  private key: (hidden)
  listening port: 39617

peer: exgJQamM...=
  endpoint: [fe80::5054:ff:fe48:a0c6%eth0]:12345
  allowed ips: 0.0.0.0/0
  latest handshake: 18 minutes, 13 seconds ago
  transfer: 86.79 KiB received, 87.30 KiB sent
[edit]
vyos@r4#
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
