### PR TITLE
ntp: T4184: Fix allow-clients address 1.3

### DIFF
--- a/data/templates/ntp/ntpd.conf.tmpl
+++ b/data/templates/ntp/ntpd.conf.tmpl
@@ -27,6 +27,7 @@ restrict -6 ::1
 
 {% if allow_clients is defined and allow_clients.address is defined %}
 # Allowed clients configuration
+restrict default ignore
 {%   for address in allow_clients.address %}
 restrict {{ address|address_from_cidr }} mask {{ address|netmask_from_cidr }} nomodify notrap nopeer
 {%   endfor %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
NTP-server with option "allow-clients address x.x.x.x" should
accept requests only from clients addresses which declared in
configuration if this option exists
Add "restrict default ignore" to fix it, in another case it
response to any address

(cherry picked from commit 40f0e78dd94691d54ffd4d2e270ed071e2d2513a)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4184

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ntp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
NTP configuration on server site:
```
set system ntp allow-clients address '192.168.122.0/24'
set system ntp allow-clients address '203.0.113.0/24'
set system ntp server time1.vyos.net
set system ntp server time2.vyos.net
set system ntp server time3.vyos.net
```
Expect to respond only for clients from networks `192.168.122.0/24` and `203.0.113.0/24`

Before fix request (from a client 192.0.2.14) NTP from the network which not included in `allow-clients`:
```
vyos@r4# sudo ntpdate 192.0.2.11
15 Jan 17:26:43 ntpdate[5445]: adjust time server 192.0.2.11 offset -0.000588 sec
[edit]
vyos@r4# 
```
After the fix, do not expect a response from `192.0.2.0/24` :
```
vyos@r4# sudo ntpdate 192.0.2.11
15 Jan 17:30:17 ntpdate[5451]: no server suitable for synchronization found
[edit]
vyos@r4# 
vyos@r4# sudo ntpdate 192.168.122.11
15 Jan 17:30:31 ntpdate[5453]: adjust time server 192.168.122.11 offset -0.005514 sec
[edit]
vyos@r4#
```

NTP expected configuration:
```
...

# Allowed clients configuration
restrict default ignore
restrict 192.168.122.0 mask 255.255.255.0 nomodify notrap nopeer
restrict 203.0.113.0 mask 255.255.255.0 nomodify notrap nopeer

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
