### PR TITLE
Firewall: T4186: Correct icmp type-name options for firewall rules

### DIFF
--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -308,182 +308,31 @@
                   <help>ICMPv6 type and code information</help>
                 </properties>
                 <children>
-                  <leafNode name="type">
+                  <leafNode name="code">
                     <properties>
-                      <help>ICMP type-name</help>
-                      <completionHelp>
-                        <list>any echo-reply pong destination-unreachable network-unreachable host-unreachable protocol-unreachable port-unreachable fragmentation-needed source-route-failed network-unknown host-unknown network-prohibited host-prohibited TOS-network-unreachable TOS-host-unreachable communication-prohibited host-precedence-violation precedence-cutoff source-quench redirect network-redirect host-redirect TOS-network-redirect TOS host-redirect echo-request ping router-advertisement router-solicitation time-exceeded ttl-exceeded ttl-zero-during-transit ttl-zero-during-reassembly parameter-problem ip-header-bad required-option-missing timestamp-request timestamp-reply address-mask-request address-mask-reply packet-too-big</list>
-                      </completionHelp>
+                      <help>ICMPv6 code (0-255)</help>
                       <valueHelp>
-                        <format>any</format>
-                        <description>Any ICMP type/code</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>echo-reply</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>pong</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>destination-unreachable</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>network-unreachable</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>host-unreachable</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>protocol-unreachable</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>port-unreachable</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>fragmentation-needed</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>source-route-failed</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>network-unknown</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>host-unknown</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>network-prohibited</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>host-prohibited</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>TOS-network-unreachable</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>TOS-host-unreachable</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>communication-prohibited</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>host-precedence-violation</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>precedence-cutoff</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>source-quench</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>redirect</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>network-redirect</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>host-redirect</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>TOS-network-redirect</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>TOS host-redirect</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>echo-request</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>ping</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>router-advertisement</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>router-solicitation</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>time-exceeded</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>ttl-exceeded</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>ttl-zero-during-transit</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>ttl-zero-during-reassembly</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>parameter-problem</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>ip-header-bad</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>required-option-missing</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>timestamp-request</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>timestamp-reply</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>address-mask-request</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>address-mask-reply</format>
-                        <description>ICMP type/code name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>packet-too-big</format>
-                        <description>ICMP type/code name</description>
+                        <format>u32:0-255</format>
+                        <description>ICMPv6 code (0-255)</description>
                       </valueHelp>
                       <constraint>
-                        <regex>^(any|echo-reply|pong|destination-unreachable|network-unreachable|host-unreachable|protocol-unreachable|port-unreachable|fragmentation-needed|source-route-failed|network-unknown|host-unknown|network-prohibited|host-prohibited|TOS-network-unreachable|TOS-host-unreachable|communication-prohibited|host-precedence-violation|precedence-cutoff|source-quench|redirect|network-redirect|host-redirect|TOS-network-redirect|TOS host-redirect|echo-request|ping|router-advertisement|router-solicitation|time-exceeded|ttl-exceeded|ttl-zero-during-transit|ttl-zero-during-reassembly|parameter-problem|ip-header-bad|required-option-missing|timestamp-request|timestamp-reply|address-mask-request|address-mask-reply|packet-too-big)$</regex>
                         <validator name="numeric" argument="--range 0-255"/>
                       </constraint>
                     </properties>
                   </leafNode>
+                  <leafNode name="type">
+                    <properties>
+                      <help>ICMPv6 type (0-255)</help>
+                      <valueHelp>
+                        <format>u32:0-255</format>
+                        <description>ICMPv6 type (0-255)</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-255"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  #include <include/firewall/icmpv6-type-name.xml.i>
                 </children>
               </node>
             </children>

--- a/interface-definitions/include/firewall/icmp-type-name.xml.i
+++ b/interface-definitions/include/firewall/icmp-type-name.xml.i
@@ -63,7 +63,7 @@
     </valueHelp>
     <valueHelp>
       <format>address-mask-reply</format>
-      <description>ICMP type 18: address-mask-replye</description>
+      <description>ICMP type 18: address-mask-reply</description>
     </valueHelp>
     <constraint>
       <regex>^(echo-reply|destination-unreachable|source-quench|redirect|echo-request|router-advertisement|router-solicitation|time-exceeded|parameter-problem|timestamp-request|timestamp-reply|info-request|info-reply|address-mask-request|address-mask-reply)$</regex>

--- a/interface-definitions/include/firewall/icmp-type-name.xml.i
+++ b/interface-definitions/include/firewall/icmp-type-name.xml.i
@@ -3,170 +3,70 @@
   <properties>
     <help>ICMP type-name</help>
     <completionHelp>
-      <list>any echo-reply pong destination-unreachable network-unreachable host-unreachable protocol-unreachable port-unreachable fragmentation-needed source-route-failed network-unknown host-unknown network-prohibited host-prohibited TOS-network-unreachable TOS-host-unreachable communication-prohibited host-precedence-violation precedence-cutoff source-quench redirect network-redirect host-redirect TOS-network-redirect TOS host-redirect echo-request ping router-advertisement router-solicitation time-exceeded ttl-exceeded ttl-zero-during-transit ttl-zero-during-reassembly parameter-problem ip-header-bad required-option-missing timestamp-request timestamp-reply address-mask-request address-mask-reply</list>
+      <list>echo-reply destination-unreachable source-quench redirect echo-request router-advertisement router-solicitation time-exceeded parameter-problem timestamp-request timestamp-reply info-request info-reply address-mask-request address-mask-reply</list>
     </completionHelp>
     <valueHelp>
-      <format>any</format>
-      <description>Any ICMP type/code</description>
-    </valueHelp>
-    <valueHelp>
       <format>echo-reply</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>pong</format>
-      <description>ICMP type/code name</description>
+      <description>ICMP type 0: echo-reply</description>
     </valueHelp>
     <valueHelp>
       <format>destination-unreachable</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>network-unreachable</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>host-unreachable</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>protocol-unreachable</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>port-unreachable</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>fragmentation-needed</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>source-route-failed</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>network-unknown</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>host-unknown</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>network-prohibited</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>host-prohibited</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>TOS-network-unreachable</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>TOS-host-unreachable</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>communication-prohibited</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>host-precedence-violation</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>precedence-cutoff</format>
-      <description>ICMP type/code name</description>
+      <description>ICMP type 3: destination-unreachable</description>
     </valueHelp>
     <valueHelp>
       <format>source-quench</format>
-      <description>ICMP type/code name</description>
+      <description>ICMP type 4: source-quench</description>
     </valueHelp>
     <valueHelp>
       <format>redirect</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>network-redirect</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>host-redirect</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>TOS-network-redirect</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>TOS host-redirect</format>
-      <description>ICMP type/code name</description>
+      <description>ICMP type 5: redirect</description>
     </valueHelp>
     <valueHelp>
       <format>echo-request</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>ping</format>
-      <description>ICMP type/code name</description>
+      <description>ICMP type 8: echo-request</description>
     </valueHelp>
     <valueHelp>
       <format>router-advertisement</format>
-      <description>ICMP type/code name</description>
+      <description>ICMP type 9: router-advertisement</description>
     </valueHelp>
     <valueHelp>
       <format>router-solicitation</format>
-      <description>ICMP type/code name</description>
+      <description>ICMP type 10: router-solicitation</description>
     </valueHelp>
     <valueHelp>
       <format>time-exceeded</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>ttl-exceeded</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>ttl-zero-during-transit</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>ttl-zero-during-reassembly</format>
-      <description>ICMP type/code name</description>
+      <description>ICMP type 11: time-exceeded</description>
     </valueHelp>
     <valueHelp>
       <format>parameter-problem</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>ip-header-bad</format>
-      <description>ICMP type/code name</description>
-    </valueHelp>
-    <valueHelp>
-      <format>required-option-missing</format>
-      <description>ICMP type/code name</description>
+      <description>ICMP type 12: parameter-problem</description>
     </valueHelp>
     <valueHelp>
       <format>timestamp-request</format>
-      <description>ICMP type/code name</description>
+      <description>ICMP type 13: timestamp-request</description>
     </valueHelp>
     <valueHelp>
       <format>timestamp-reply</format>
-      <description>ICMP type/code name</description>
+      <description>ICMP type 14: timestamp-reply</description>
+    </valueHelp>
+    <valueHelp>
+      <format>info-request</format>
+      <description>ICMP type 15: info-request</description>
+    </valueHelp>
+    <valueHelp>
+      <format>info-reply</format>
+      <description>ICMP type 16: info-reply</description>
     </valueHelp>
     <valueHelp>
       <format>address-mask-request</format>
-      <description>ICMP type/code name</description>
+      <description>ICMP type 17: address-mask-request</description>
     </valueHelp>
     <valueHelp>
       <format>address-mask-reply</format>
-      <description>ICMP type/code name</description>
+      <description>ICMP type 18: address-mask-replye</description>
     </valueHelp>
     <constraint>
-      <regex>^(any|echo-reply|pong|destination-unreachable|network-unreachable|host-unreachable|protocol-unreachable|port-unreachable|fragmentation-needed|source-route-failed|network-unknown|host-unknown|network-prohibited|host-prohibited|TOS-network-unreachable|TOS-host-unreachable|communication-prohibited|host-precedence-violation|precedence-cutoff|source-quench|redirect|network-redirect|host-redirect|TOS-network-redirect|TOS host-redirect|echo-request|ping|router-advertisement|router-solicitation|time-exceeded|ttl-exceeded|ttl-zero-during-transit|ttl-zero-during-reassembly|parameter-problem|ip-header-bad|required-option-missing|timestamp-request|timestamp-reply|address-mask-request|address-mask-reply)$</regex>
+      <regex>^(echo-reply|destination-unreachable|source-quench|redirect|echo-request|router-advertisement|router-solicitation|time-exceeded|parameter-problem|timestamp-request|timestamp-reply|info-request|info-reply|address-mask-request|address-mask-reply)$</regex>
     </constraint>
   </properties>
 </leafNode>

--- a/interface-definitions/include/firewall/icmpv6-type-name.xml.i
+++ b/interface-definitions/include/firewall/icmpv6-type-name.xml.i
@@ -1,0 +1,73 @@
+<!-- include start from firewall/icmpv6-type-name.xml.i -->
+<leafNode name="type-name">
+  <properties>
+    <help>ICMPv6 type-name</help>
+    <completionHelp>
+      <list>destination-unreachable packet-too-big time-exceeded echo-request echo-reply mld-listener-query mld-listener-report mld-listener-reduction nd-router-solicit nd-router-advert nd-neighbor-solicit nd-neighbor-advert nd-redirect parameter-problem router-renumbering</list>
+    </completionHelp>
+    <valueHelp>
+      <format>destination-unreachable</format>
+      <description>ICMPv6 type 1: destination-unreachable</description>
+    </valueHelp>
+    <valueHelp>
+      <format>packet-too-big</format>
+      <description>ICMPv6 type 2: packet-too-big</description>
+    </valueHelp>
+    <valueHelp>
+      <format>time-exceeded</format>
+      <description>ICMPv6 type 3: time-exceeded</description>
+    </valueHelp>
+    <valueHelp>
+      <format>echo-request</format>
+      <description>ICMPv6 type 128: echo-request</description>
+    </valueHelp>
+    <valueHelp>
+      <format>echo-reply</format>
+      <description>ICMPv6 type 129: echo-reply</description>
+    </valueHelp>
+    <valueHelp>
+      <format>mld-listener-query</format>
+      <description>ICMPv6 type 130: mld-listener-query</description>
+    </valueHelp>
+    <valueHelp>
+      <format>mld-listener-report</format>
+      <description>ICMPv6 type 131: mld-listener-report</description>
+    </valueHelp>
+    <valueHelp>
+      <format>mld-listener-reduction</format>
+      <description>ICMPv6 type 132: mld-listener-reduction</description>
+    </valueHelp>
+    <valueHelp>
+      <format>nd-router-solicit</format>
+      <description>ICMPv6 type 133: nd-router-solicit</description>
+    </valueHelp>
+    <valueHelp>
+      <format>nd-router-advert</format>
+      <description>ICMPv6 type 134: nd-router-advert</description>
+    </valueHelp>
+    <valueHelp>
+      <format>nd-neighbor-solicit</format>
+      <description>ICMPv6 type 135: nd-neighbor-solicit</description>
+    </valueHelp>
+    <valueHelp>
+      <format>nd-neighbor-advert</format>
+      <description>ICMPv6 type 136: nd-neighbor-advert</description>
+    </valueHelp>
+    <valueHelp>
+      <format>nd-redirect</format>
+      <description>ICMPv6 type 137: nd-redirect</description>
+    </valueHelp>
+    <valueHelp>
+      <format>parameter-problem</format>
+      <description>ICMPv6 type 4: parameter-problem</description>
+    </valueHelp>
+    <valueHelp>
+      <format>router-renumbering</format>
+      <description>ICMPv6 type 138: router-renumbering</description>
+    </valueHelp>
+    <constraint>
+      <regex>^(destination-unreachable|packet-too-big|time-exceeded|echo-request|echo-reply|mld-listener-query|mld-listener-report|mld-listener-reduction|nd-router-solicit|nd-router-advert|nd-neighbor-solicit|nd-neighbor-advert|nd-redirect|parameter-problem|router-renumbering)$</regex>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
In firewall, there were options for icmp type-name that are not supported in nft. Those options were removed, and helpers for options that remains were also changed.
In corcondancy, same corrections are applied for icmpv6

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4186
* https://phabricator.vyos.net/T4199

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
Firewall
## Proposed changes
<!--- Describe your changes in detail -->
Reduce options for icmp type-name to the ones that are supported in nft. this options are available [here](https://wiki.nftables.org/wiki-nftables/index.php/Matching_packet_headers#Matching_ICMP_traffic)
Also description for this options where modified, giving a clearer information of what type of icmp message is being matched.

Same applies to icmpv6 options and helpers. [Wifi reference icmpv6](https://wiki.nftables.org/wiki-nftables/index.php/Quick_reference-nftables_in_10_minutes#Icmpv6)

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos# set firewall name FOO rule 10 icmp type-name 
Possible completions:
   echo-reply   ICMP type 0: echo-reply
   destination-unreachable
                ICMP type 3: destination-unreachable
   source-quench
                ICMP type 4: source-quench
   redirect     ICMP type 5: redirect
   echo-request ICMP type 8: echo-request
   router-advertisement
                ICMP type 9: router-advertisement
   router-solicitation
                ICMP type 10: router-solicitation
   time-exceeded
                ICMP type 11: time-exceeded
   parameter-problem
                ICMP type 12: parameter-problem
   timestamp-request
                ICMP type 13: timestamp-request
   timestamp-reply
                ICMP type 14: timestamp-reply
   info-request ICMP type 15: info-request
   info-reply   ICMP type 16: info-reply
   address-mask-request
                ICMP type 17: address-mask-request
   address-mask-reply
                ICMP type 18: address-mask-reply
                
[edit]

vyos@vyos# set firewall ipv6-name FOO-v6 rule 10 icmpv6 
Possible completions:
   code         ICMPv6 code (0-255)
   type         ICMPv6 type (0-255)
   type-name    ICMPv6 type-name

vyos@vyos# set firewall ipv6-name FOO-v6 rule 10 icmpv6 type-name 
Possible completions:
   destination-unreachable
                ICMPv6 type 1: destination-unreachable
   packet-too-big
                ICMPv6 type 2: packet-too-big
   time-exceeded
                ICMPv6 type 3: time-exceeded
   echo-request ICMPv6 type 128: echo-request
   echo-reply   ICMPv6 type 129: echo-reply
   mld-listener-query
                ICMPv6 type 130: mld-listener-query
   mld-listener-report
                ICMPv6 type 131: mld-listener-report
   mld-listener-reduction
                ICMPv6 type 132: mld-listener-reduction
   nd-router-solicit
                ICMPv6 type 133: nd-router-solicit
   nd-router-advert
                ICMPv6 type 134: nd-router-advert
   nd-neighbor-solicit
                ICMPv6 type 135: nd-neighbor-solicit
   nd-neighbor-advert
                ICMPv6 type 136: nd-neighbor-advert
   nd-redirect  ICMPv6 type 137: nd-redirect
   parameter-problem
                ICMPv6 type 4: parameter-problem
   router-renumbering
                ICMPv6 type 138: router-renumbering

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
