### PR TITLE
DHCP: T4196: fix client-prefix-length parameter

### DIFF
--- a/data/templates/dhcp-server/dhcpd.conf.tmpl
+++ b/data/templates/dhcp-server/dhcpd.conf.tmpl
@@ -165,7 +165,7 @@ shared-network {{ network | replace('_','-') }} {
         option wpad-url "{{ subnet_config.wpad_url }}";
 {%         endif %}
 {%         if subnet_config.client_prefix_length is defined and subnet_config.client_prefix_length is not none %}
-        option subnet-mask {{ subnet_config.client_prefix_length }};
+        option subnet-mask {{ ('0.0.0.0/' ~ subnet_config.client_prefix_length) | netmask_from_cidr }};
 {%         endif %}
 {%         if subnet_config.lease is defined and subnet_config.lease is not none %}
         default-lease-time {{ subnet_config.lease }};


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
fix client-prefix-length parameter
Subnet mask should be in the form A.B.C.D, not prefix-length

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4196

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp

## Proposed changes
<!--- Describe your changes in detail -->
Before "option subnet-mask 24"
After "option subnet-mask 255.255.255.0" 

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configure DHCP server:
```
set interfaces ethernet eth0 address '10.1.1.1/24'
set service dhcp-server shared-network-name DHCP_SCOPE subnet 10.1.1.0/24 client-prefix-length '24'
set service dhcp-server shared-network-name DHCP_SCOPE subnet 10.1.1.0/24 default-router '10.1.1.1'
set service dhcp-server shared-network-name DHCP_SCOPE subnet 10.1.1.0/24 range CLIENT_RANGE start '10.1.1.50'
set service dhcp-server shared-network-name DHCP_SCOPE subnet 10.1.1.0/24 range CLIENT_RANGE stop '10.1.1.250'
```
Check generated DHCP server config:
```
cat /run/dhcp-server/dhcpd.conf
...
        option subnet-mask 255.255.255.0;
...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
