### PR TITLE
interface-names: T3871: use tempfile during virtual migration

### DIFF
--- a/src/helpers/vyos_net_name
+++ b/src/helpers/vyos_net_name
@@ -20,12 +20,14 @@ import os
 import re
 import time
 import logging
+import tempfile
 import threading
 from sys import argv
 
 from vyos.configtree import ConfigTree
 from vyos.defaults import directories
 from vyos.util import cmd, boot_configuration_complete
+from vyos.migrator import VirtualMigrator
 
 vyos_udev_dir = directories['vyos_udev_dir']
 vyos_log_dir = '/run/udev/log'
@@ -139,14 +141,20 @@ def get_configfile_interfaces() -> dict:
     try:
         config = ConfigTree(config_file)
     except Exception:
-        logging.debug(f"updating component version string syntax")
         try:
-            # this will update the component version string in place, for
-            # updates 1.2 --> 1.3/1.4
-            os.system(f'/usr/libexec/vyos/run-config-migration.py {config_path} --virtual --set-vintage=vyos')
-            with open(config_path) as f:
-                config_file = f.read()
+            logging.debug(f"updating component version string syntax")
+            # this will update the component version string syntax,
+            # required for updates 1.2 --> 1.3/1.4
+            with tempfile.NamedTemporaryFile() as fp:
+                with open(fp.name, 'w') as fd:
+                    fd.write(config_file)
+                virtual_migration = VirtualMigrator(fp.name)
+                virtual_migration.run()
+                with open(fp.name) as fd:
+                    config_file = fd.read()
+
             config = ConfigTree(config_file)
+
         except Exception as e:
             logging.critical(f"ConfigTree error: {e}")
 
@@ -246,4 +254,3 @@ if not boot_configuration_complete():
 else:
     logging.debug("boot configuration complete")
 lock.release()
-


### PR DESCRIPTION
Use tempfile to avoid race conditions during virtual migration.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3871

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
