### PR TITLE
bandwidth-test: T4153: Fixed bandwidth-test initiate

### DIFF
--- a/src/op_mode/monitor_bandwidth_test.sh
+++ b/src/op_mode/monitor_bandwidth_test.sh
@@ -24,6 +24,9 @@ elif [[ $(dig $1 AAAA +short | grep -v '\.$' | wc -l) -gt 0 ]]; then
 
     # Set address family to IPv6 when FQDN has at least one AAAA record
     OPT="-V"
+else
+    # It's not IPv6, no option needed
+    OPT=""
 fi
 
 /usr/bin/iperf $OPT -c $1 $2


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix for making bandwidth-test initiate work with ipv4 addresses.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4153

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bandwidth-test
## Proposed changes
<!--- Describe your changes in detail -->
Script monitor_bandwidth_test.sh has ipv6 and AAAA check, and adds option "-V" to iperf. But for ipv4, that option is not required.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Ipv4 tests:
```
vyos@vyos:~$ monitor bandwidth-test initiate tcp 203.0.113.1
------------------------------------------------------------
Client connecting to 203.0.113.1, TCP port 5001
TCP window size:  162 KByte (default)
------------------------------------------------------------
[  3] local 203.0.113.2 port 34878 connected with 203.0.113.1 port 5001
[ ID] Interval       Transfer     Bandwidth
[  3] 0.0000-10.0027 sec  1.62 GBytes  1.39 Gbits/sec
vyos@vyos:~$ 
vyos@vyos:~$ monitor bandwidth-test initiate tcp vyos-server
------------------------------------------------------------
Client connecting to vyos-server, TCP port 5001
TCP window size:  162 KByte (default)
------------------------------------------------------------
[  3] local 203.0.113.2 port 34880 connected with 203.0.113.1 port 5001
[ ID] Interval       Transfer     Bandwidth
[  3] 0.0000-10.0011 sec  1.55 GBytes  1.33 Gbits/sec
```

IPv6 tests:
```
vyos@vyos:~$ monitor bandwidth-test initiate tcp 2001:db8::1
------------------------------------------------------------
Client connecting to 2001:db8::1, TCP port 5001
TCP window size:  162 KByte (default)
------------------------------------------------------------
[  3] local 2001:db8::3 port 57182 connected with 2001:db8::1 port 5001
[ ID] Interval       Transfer     Bandwidth
[  3] 0.0000-10.0018 sec  1.53 GBytes  1.32 Gbits/sec
vyos@vyos:~$ 
vyos@vyos:~$ 
vyos@vyos:~$ monitor bandwidth-test initiate tcp vyos-server6
------------------------------------------------------------
Client connecting to vyos-server6, TCP port 5001
TCP window size:  162 KByte (default)
------------------------------------------------------------
[  3] local 2001:db8::3 port 57184 connected with 2001:db8::1 port 5001
[ ID] Interval       Transfer     Bandwidth
[  3] 0.0000-10.0002 sec  1.47 GBytes  1.27 Gbits/sec
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
