### PR TITLE
monitoring: T3872: Delete iptables input plugin as we use nft

### DIFF
--- a/data/templates/monitoring/telegraf.tmpl
+++ b/data/templates/monitoring/telegraf.tmpl
@@ -42,11 +42,6 @@
   dirs = ["/proc/sys/net/ipv4/netfilter","/proc/sys/net/netfilter"]
 [[inputs.ethtool]]
   interface_include = {{ interfaces_ethernet }}
-[[inputs.iptables]]
-  use_sudo = false
-  table = "filter"
-  chains = {{ nft_chains }}
-  use_lock = true
 [[inputs.ntpq]]
   dns_lookup = true
 [[inputs.internal]]


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Telegraf inputs iptables plugin incompatible with nftables
As it tries to get statistics from `iptables -L -n -v`
which doesn't display required data in 1.4 as we don't use iptables anymore

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3872

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
monitoring
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure monitoring and check in the logs:
```
r11-roll telegraf[7703]: 2022-01-12T17:37:30Z E! [inputs.iptables] Error in plugin: exit status 1
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
