### PR TITLE
policy: T4194: Add prefix-list duplication checks

### DIFF
--- a/src/conf_mode/policy.py
+++ b/src/conf_mode/policy.py
@@ -87,6 +87,7 @@ def verify(policy):
 
             # human readable instance name (hypen instead of underscore)
             policy_hr = policy_type.replace('_', '-')
+            entries = []
             for rule, rule_config in instance_config['rule'].items():
                 mandatory_error = f'must be specified for "{policy_hr} {instance} rule {rule}"!'
                 if 'action' not in rule_config:
@@ -112,6 +113,11 @@ def verify(policy):
                 if policy_type in ['prefix_list', 'prefix_list6']:
                     if 'prefix' not in rule_config:
                         raise ConfigError(f'A prefix {mandatory_error}')
+
+                    # Check prefix duplicates
+                    if rule_config['prefix'] in entries and ('ge' not in rule_config and 'le' not in rule_config):
+                        raise ConfigError(f'Prefix {rule_config["prefix"]} is duplicated!')
+                    entries.append(rule_config['prefix'])
 
 
     # route-maps tend to be a bit more complex so they get their own verify() section


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Prefix-list should not be duplicated as FRR doesn't accept it
One option when can be duplicated when it uses "le" or "ge"

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4194

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
prefix-list
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add checks for duplicate entries for the prefix list
It can contain le or get, but without such options it shouldn't accept  configuration:
Config with dup prefixes
```
set policy prefix-list TST_PRF_LST rule 10 action 'permit'
set policy prefix-list TST_PRF_LST rule 10 prefix '10.5.5.0/24'
set policy prefix-list TST_PRF_LST rule 20 action 'permit'
set policy prefix-list TST_PRF_LST rule 20 prefix '10.6.6.0/24'
set policy prefix-list TST_PRF_LST rule 30 action 'permit'
set policy prefix-list TST_PRF_LST rule 30 prefix '10.6.6.0/24'
vyos@r11-roll# commit
[ policy ]
Prefix 10.6.6.0/24 is duplicated!

[[policy]] failed
Commit failed
[edit]
vyos@r11-roll# 
```
Config with dup prefixes but with "ge" option:
```
set policy prefix-list TST_PRF_LST rule 10 action 'permit'
set policy prefix-list TST_PRF_LST rule 10 prefix '10.5.5.0/24'
set policy prefix-list TST_PRF_LST rule 20 action 'permit'
set policy prefix-list TST_PRF_LST rule 20 prefix '10.6.6.0/24'
set policy prefix-list TST_PRF_LST rule 30 action 'permit'
set policy prefix-list TST_PRF_LST rule 30 prefix '10.6.6.0/24'
set policy prefix-list TST_PRF_LST rule 30 ge 30
commit

vtysh:
!
ip prefix-list TST_PRF_LST seq 10 permit 10.5.5.0/24
ip prefix-list TST_PRF_LST seq 20 permit 10.6.6.0/24
ip prefix-list TST_PRF_LST seq 30 permit 10.6.6.0/24 ge 30
!

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
