### PR TITLE
policy: T4151: bugfix multiple commits and smoketest

### DIFF
--- a/smoketest/scripts/cli/test_policy.py
+++ b/smoketest/scripts/cli/test_policy.py
@@ -1135,9 +1135,6 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        # Check generated configuration
-
-        # Expected values
         original = """
         50:	from 203.0.113.1 lookup 23
         50:	from 203.0.113.2 lookup 23
@@ -1159,9 +1156,6 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        # Check generated configuration
-
-        # Expected values
         original = """
         101:    from all fwmark 0x18 lookup 154
         """
@@ -1182,9 +1176,6 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        # Check generated configuration
-
-        # Expected values
         original = """
         102:    from all to 203.0.113.1 lookup 154
         """
@@ -1207,9 +1198,6 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        # Check generated configuration
-
-        # Expected values
         original = """
         100:	from 203.0.113.11 fwmark 0x17 lookup 150
         100:	from 203.0.113.12 fwmark 0x17 lookup 150
@@ -1236,9 +1224,6 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        # Check generated configuration
-
-        # Expected values
         original = """
         103:	from 203.0.113.11 to 203.0.113.13 fwmark 0x17 lookup 150
         103:	from 203.0.113.11 to 203.0.113.15 fwmark 0x17 lookup 150
@@ -1262,9 +1247,6 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        # Check generated configuration
-
-        # Expected values
         original = """
         50:	from 2001:db8:123::/48 lookup 23
         50:	from 2001:db8:126::/48 lookup 23
@@ -1286,9 +1268,6 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        # Check generated configuration
-
-        # Expected values
         original = """
         100:    from all fwmark 0x18 lookup 154
         """
@@ -1309,9 +1288,6 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        # Check generated configuration
-
-        # Expected values
         original = """
         101:    from all to 2001:db8:1337::/126 lookup 154
         """
@@ -1334,9 +1310,6 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        # Check generated configuration
-
-        # Expected values
         original = """
         102:	from 2001:db8:1338::/126 fwmark 0x17 lookup 150
         102:	from 2001:db8:1339::/126 fwmark 0x17 lookup 150
@@ -1363,9 +1336,6 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        # Check generated configuration
-
-        # Expected values
         original = """
         103:	from 2001:db8:1338::/126 to 2001:db8:13::/48 fwmark 0x17 lookup 150
         103:	from 2001:db8:1338::/126 to 2001:db8:16::/48 fwmark 0x17 lookup 150
@@ -1404,20 +1374,17 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        # Check generated configuration
-
-        # Expected values
         original = """
-        103:	from 203.0.113.1/24 to 203.0.112.1/24 fwmark 0x17 lookup 150
-        103:	from 203.0.113.1/24 to 203.0.116.5 fwmark 0x17 lookup 150
-        103:	from 203.0.114.5 to 203.0.112.1/24 fwmark 0x17 lookup 150
+        103:	from 203.0.113.0/24 to 203.0.116.5 fwmark 0x17 lookup 150
+        103:	from 203.0.114.5 to 203.0.112.0/24 fwmark 0x17 lookup 150
         103:	from 203.0.114.5 to 203.0.116.5 fwmark 0x17 lookup 150
+        103:	from 203.0.113.0/24 to 203.0.112.0/24 fwmark 0x17 lookup 150
         """
         original_v6 = """
-        103:	from 20016 to 2001:db8:13::/48 fwmark 0x17 lookup 150
         103:	from 2001:db8:1338::/126 to 2001:db8:16::/48 fwmark 0x17 lookup 150
         103:	from 2001:db8:1339::/56 to 2001:db8:13::/48 fwmark 0x17 lookup 150
         103:	from 2001:db8:1339::/56 to 2001:db8:16::/48 fwmark 0x17 lookup 150
+        103:    from 2001:db8:1338::/126 to 2001:db8:13::/48 fwmark 0x17 lookup 150
         """
         tmp = cmd('ip rule show prio 103')
         tmp_v6 = cmd('ip -6 rule show prio 103')
@@ -1432,11 +1399,8 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
         tmp = cmd('ip rule show prio 103')
         tmp_v6 = cmd('ip -6 rule show prio 103')
 
-        original = None
-        original_v6 = None
-
-        self.assertEqual(sort_ip(tmp), original)
-        self.assertEqual(sort_ip(tmp_v6), original_v6)
+        self.assertEqual(sort_ip(tmp), [])
+        self.assertEqual(sort_ip(tmp_v6), [])
 
     # Test multiple commits ipv4
     def test_multiple_commit_ipv4_table_id(self):
@@ -1452,8 +1416,6 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        # Check generated configuration
-        # Expected values
         original_first = """
         105:	from 192.0.2.1 lookup 151
         105:	from 192.0.2.2 lookup 151
@@ -1476,7 +1438,10 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
 
 def sort_ip(output):
-    return output.splitlines().sort()
+    o = '\n'.join([' '.join(line.strip().split()) for line in output.strip().splitlines()])
+    o = o.splitlines()
+    o.sort()
+    return o
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/smoketest/scripts/cli/test_policy.py
+++ b/smoketest/scripts/cli/test_policy.py
@@ -1438,6 +1438,43 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
         self.assertEqual(sort_ip(tmp), original)
         self.assertEqual(sort_ip(tmp_v6), original_v6)
 
+    # Test multiple commits ipv4
+    def test_multiple_commit_ipv4_table_id(self):
+        path = base_path + ['local-route']
+
+        sources = ['192.0.2.1', '192.0.2.2']
+        destination = '203.0.113.25'
+        rule = '105'
+        table = '151'
+        self.cli_set(path + ['rule', rule, 'set', 'table', table])
+        for src in sources:
+            self.cli_set(path + ['rule', rule, 'source', src])
+
+        self.cli_commit()
+
+        # Check generated configuration
+        # Expected values
+        original_first = """
+        105:	from 192.0.2.1 lookup 151
+        105:	from 192.0.2.2 lookup 151
+        """
+        tmp = cmd('ip rule show prio 105')
+
+        self.assertEqual(sort_ip(tmp), sort_ip(original_first))
+
+        # Create second commit with added destination
+        self.cli_set(path + ['rule', rule, 'destination', destination])
+        self.cli_commit()
+
+        original_second = """
+        105:	from 192.0.2.1 to 203.0.113.25 lookup 151
+        105:	from 192.0.2.2 to 203.0.113.25 lookup 151
+        """
+        tmp = cmd('ip rule show prio 105')
+
+        self.assertEqual(sort_ip(tmp), sort_ip(original_second))
+
+
 def sort_ip(output):
     return output.splitlines().sort()
 

--- a/src/conf_mode/policy-local-route.py
+++ b/src/conf_mode/policy-local-route.py
@@ -69,20 +69,47 @@ def get_config(config=None):
         # delete policy local-route rule x fwmark x
         # delete policy local-route rule x destination x.x.x.x
         if 'rule' in pbr[route]:
-            for rule in pbr[route]['rule']:
+            for rule, rule_config in pbr[route]['rule'].items():
                 src = leaf_node_changed(conf, base_rule + [rule, 'source'])
                 fwmk = leaf_node_changed(conf, base_rule + [rule, 'fwmark'])
                 dst = leaf_node_changed(conf, base_rule + [rule, 'destination'])
+                # keep track of changes in configuration
+                # otherwise we might remove an existing node although nothing else has changed
+                changed = False
 
                 rule_def = {}
-                if src:
-                    rule_def = dict_merge({'source' : src}, rule_def)
-                if fwmk:
-                    rule_def = dict_merge({'fwmark' : fwmk}, rule_def)
-                if dst:
-                    rule_def = dict_merge({'destination' : dst}, rule_def)
-                dict = dict_merge({dict_id : {rule : rule_def}}, dict)
-                pbr.update(dict)
+                # src is None if there are no changes to src
+                if src is None:
+                    # if src hasn't changed, include it in the removal selector
+                    # if a new selector is added, we have to remove all previous rules without this selector
+                    # to make sure we remove all previous rules with this source(s), it will be included
+                    if 'source' in rule_config:
+                        rule_def = dict_merge({'source': rule_config['source']}, rule_def)
+                else:
+                    # if src is not None, it's previous content will be returned
+                    # this can be an empty array if it's just being set, or the previous value
+                    # either way, something has to be changed and we only want to remove previous values
+                    changed = True
+                    # set the old value for removal if it's not empty
+                    if len(src) > 0:
+                        rule_def = dict_merge({'source' : src}, rule_def)
+                if fwmk is None:
+                    if 'fwmark' in rule_config:
+                        rule_def = dict_merge({'fwmark': rule_config['fwmark']}, rule_def)
+                else:
+                    changed = True
+                    if len(fwmk) > 0:
+                        rule_def = dict_merge({'fwmark' : fwmk}, rule_def)
+                if dst is None:
+                    if 'destination' in rule_config:
+                        rule_def = dict_merge({'destination': rule_config['destination']}, rule_def)
+                else:
+                    changed = True
+                    if len(dst) > 0:
+                        rule_def = dict_merge({'destination' : dst}, rule_def)
+                if changed:
+                    dict = dict_merge({dict_id : {rule : rule_def}}, dict)
+                    pbr.update(dict)
 
     return pbr
 
@@ -115,6 +142,8 @@ def generate(pbr):
 def apply(pbr):
     if not pbr:
         return None
+
+    print(pbr)
 
     # Delete old rule if needed
     for rule_rm in ['rule_remove', 'rule6_remove']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This change bugfixes an issue found by @sever-sever.
Also, the smoketest now properly compares the ip output again.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4151

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
policy

## Proposed changes
<!--- Describe your changes in detail -->
The policy route implementation would previously issue one `ip rule del prio xxx` command on a rule edit. However, if the rule had multiple source/destination directives, this would only delete the first old rule and create multiple new rules.
This seems to be a limitation of the ip command.
I fixed it by adding a selector for each existing field to the rule_remove dict.
This way, the removal logic will iterate over each field that has to be removed and produce the same set of commands that were used for the rule creation.

Another solution would be to remove rules for a given priority until there are no rules left. However, I think this should be the cleaner solution, as vyos keeps track of each rule that has been created by it and only removes those.

The logic to do this has gotten pretty ugly, as I only want to set a existing selector for removal, if it itself has not been modified, otherwise the old value has to be removed.
To decide whether a selector has been modified or not depends on the output of `leaf_node_changed`. Which can be `None` (no changes) or an empty array (new value, has changes) or a filled array with old values. I'm not sure if there is a better way to decide what to do. Or if we should just remove all rules for a given priority.

Also, the smoketest was half broken. .sort() is an inplace operation and would always return None...

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set policy local-route rule 10 set table '101'
set policy local-route rule 10 source '192.0.2.1'
set policy local-route rule 10 source '192.0.2.2'
commit
ip rule show
set policy local-route rule 10 destination '203.0.113.25'
commit
ip rule show
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
