### PR TITLE
firewall: T4209: Fix support for rule `recent` matches

### DIFF
--- a/data/templates/firewall/nftables.tmpl
+++ b/data/templates/firewall/nftables.tmpl
@@ -31,14 +31,25 @@ table ip filter {
     }
 {% endif %}
 {% if name is defined %}
+{%   set ns = namespace(sets=[]) %}
 {%   for name_text, conf in name.items() %}
     chain NAME_{{ name_text }} {
 {%     if conf.rule is defined %}
 {%       for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not defined %}
         {{ rule_conf | nft_rule(name_text, rule_id) }}
+{%         if rule_conf.recent is defined %}
+{%           set ns.sets = ns.sets + [name_text + '_' + rule_id] %}
+{%         endif %}
 {%       endfor %}
 {%     endif %}
         {{ conf | nft_default_rule(name_text) }}
+    }
+{%   endfor %}
+{%   for set_name in ns.sets %}
+    set RECENT_{{ set_name }} {
+        type ipv4_addr
+        size 65535
+        flags dynamic
     }
 {%   endfor %}
 {% endif %}
@@ -81,14 +92,25 @@ table ip6 filter {
     }
 {% endif %}
 {% if ipv6_name is defined %}
+{%   set ns = namespace(sets=[]) %}
 {%   for name_text, conf in ipv6_name.items() %}
     chain NAME6_{{ name_text }} {
 {%     if conf.rule is defined %}
 {%       for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not defined %}
         {{ rule_conf | nft_rule(name_text, rule_id, 'ip6') }}
+{%         if rule_conf.recent is defined %}
+{%           set ns.sets = ns.sets + [name_text + '_' + rule_id] %}
+{%         endif %}
 {%       endfor %}
 {%     endif %}
         {{ conf | nft_default_rule(name_text) }}
+    }
+{%   endfor %}
+{%   for set_name in ns.sets %}
+    set RECENT6_{{ set_name }} {
+        type ipv6_addr
+        size 65535
+        flags dynamic
     }
 {%   endfor %}
 {% endif %}

--- a/interface-definitions/include/firewall/common-rule.xml.i
+++ b/interface-definitions/include/firewall/common-rule.xml.i
@@ -146,13 +146,24 @@
     </leafNode>
     <leafNode name="time">
       <properties>
-        <help>Source addresses seen in the last N seconds</help>
+        <help>Source addresses seen in the last second/minute/hour</help>
+        <completionHelp>
+          <list>second minute hour</list>
+        </completionHelp>
         <valueHelp>
-          <format>u32:0-4294967295</format>
-          <description>Source addresses seen in the last N seconds</description>
+          <format>second</format>
+          <description>Source addresses seen COUNT times in the last second</description>
+        </valueHelp>
+        <valueHelp>
+          <format>minute</format>
+          <description>Source addresses seen COUNT times in the last minute</description>
+        </valueHelp>
+        <valueHelp>
+          <format>hour</format>
+          <description>Source addresses seen COUNT times in the last hour</description>
         </valueHelp>
         <constraint>
-          <validator name="numeric" argument="--range 0-4294967295"/>
+          <regex>^(second|minute|hour)$</regex>
         </constraint>
       </properties>
     </leafNode>

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -181,9 +181,7 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
     if 'recent' in rule_conf:
         count = rule_conf['recent']['count']
         time = rule_conf['recent']['time']
-        # output.append(f'meter {fw_name}_{rule_id} {{ ip saddr and 255.255.255.255 limit rate over {count}/{time} burst {count} packets }}')
-        # Waiting on input from nftables developers due to
-        # bug with above line and atomic chain flushing.
+        output.append(f'add @RECENT{def_suffix}_{fw_name}_{rule_id} {{ {ip_name} saddr limit rate over {count}/{time} burst {count} packets }}')
 
     if 'time' in rule_conf:
         output.append(parse_time(rule_conf['time']))

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -278,6 +278,7 @@ def cleanup_rule(table, jump_chain):
 
 def cleanup_commands(firewall):
     commands = []
+    commands_end = []
     for table in ['ip filter', 'ip6 filter']:
         state_chain = 'VYOS_STATE_POLICY' if table == 'ip filter' else 'VYOS_STATE_POLICY6'
         json_str = cmd(f'nft -j list table {table}')
@@ -308,7 +309,10 @@ def cleanup_commands(firewall):
                             chain = rule['chain']
                             handle = rule['handle']
                             commands.append(f'delete rule {table} {chain} handle {handle}')
-    return commands
+            elif 'set' in item:
+                set_name = item['set']['name']
+                commands_end.append(f'delete set {table} {set_name}')
+    return commands + commands_end
 
 def generate(firewall):
     if not os.path.exists(nftables_conf):

--- a/src/migration-scripts/firewall/6-to-7
+++ b/src/migration-scripts/firewall/6-to-7
@@ -104,6 +104,7 @@ if config.exists(base + ['name']):
             continue
 
         for rule in config.list_nodes(base + ['name', name, 'rule']):
+            rule_recent = base + ['name', name, 'rule', rule, 'recent']
             rule_time = base + ['name', name, 'rule', rule, 'time']
             rule_tcp_flags = base + ['name', name, 'rule', rule, 'tcp', 'flags']
             rule_icmp = base + ['name', name, 'rule', rule, 'icmp']
@@ -113,6 +114,15 @@ if config.exists(base + ['name']):
 
             if config.exists(rule_time + ['utc']):
                 config.delete(rule_time + ['utc'])
+
+            if config.exists(rule_recent + ['time']):
+                tmp = int(config.return_value(rule_recent + ['time']))
+                unit = 'minute'
+                if tmp > 600:
+                    unit = 'hour'
+                elif tmp < 10:
+                    unit = 'second'
+                config.set(rule_recent + ['time'], value=unit)
 
             if config.exists(rule_tcp_flags):
                 tmp = config.return_value(rule_tcp_flags)
@@ -148,6 +158,7 @@ if config.exists(base + ['ipv6-name']):
             continue
 
         for rule in config.list_nodes(base + ['ipv6-name', name, 'rule']):
+            rule_recent = base + ['ipv6-name', name, 'rule', rule, 'recent']
             rule_time = base + ['ipv6-name', name, 'rule', rule, 'time']
             rule_tcp_flags = base + ['ipv6-name', name, 'rule', rule, 'tcp', 'flags']
             rule_icmp = base + ['ipv6-name', name, 'rule', rule, 'icmpv6']
@@ -157,6 +168,15 @@ if config.exists(base + ['ipv6-name']):
 
             if config.exists(rule_time + ['utc']):
                 config.delete(rule_time + ['utc'])
+
+            if config.exists(rule_recent + ['time']):
+                tmp = int(config.return_value(rule_recent + ['time']))
+                unit = 'minute'
+                if tmp > 600:
+                    unit = 'hour'
+                elif tmp < 10:
+                    unit = 'second'
+                config.set(rule_recent + ['time'], value=unit)
 
             if config.exists(rule_tcp_flags):
                 tmp = config.return_value(rule_tcp_flags)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Adds support for `recent` matches on new firewall implementation.

Due to nftables not allowing for granular limits (e.g. 4 connections per 30 seconds) a migration is needed to calculate a "closest" match (previous example would migrate to 4/minute). Can't see a way around this unless anyone else has an idea.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4209

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->
Uses nftables [dynamic sets](https://wiki.nftables.org/wiki-nftables/index.php/Meters) to migrate the effect of the iptables recent module.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set firewall name FOO default-action 'reject'
set firewall name FOO rule 10 action 'accept'
set firewall name FOO rule 10 state established 'enable'
set firewall name FOO rule 10 state related 'enable'
set firewall name FOO rule 20 action 'accept'
set firewall name FOO rule 20 protocol 'icmp'
set firewall name FOO rule 20 state new 'enable'
set firewall name FOO rule 30 action 'reject'
set firewall name FOO rule 30 destination port '22'
set firewall name FOO rule 30 protocol 'tcp'
set firewall name FOO rule 30 recent count '4'
set firewall name FOO rule 30 recent time 'minute`
set firewall name FOO rule 40 action 'accept'
set firewall name FOO rule 40 destination port '22'
set firewall name FOO rule 40 protocol 'tcp'
set firewall name FOO rule 40 state new 'enable'
set interfaces ethernet eth0 firewall local name 'FOO'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
