### PR TITLE
dhcp: T3600: Fix DHCP static table dhcp-interface route

### DIFF
--- a/data/templates/frr/static_routes_macro.j2
+++ b/data/templates/frr/static_routes_macro.j2
@@ -5,7 +5,7 @@
 {%   if prefix_config.dhcp_interface is defined and prefix_config.dhcp_interface is not none %}
 {%     set next_hop = prefix_config.dhcp_interface | get_dhcp_router %}
 {%     if next_hop is defined and next_hop is not none %}
-{{ ip_ipv6 }} route {{ prefix }} {{ next_hop }} {{ prefix_config.dhcp_interface }}
+{{ ip_ipv6 }} route {{ prefix }} {{ next_hop }} {{ prefix_config.dhcp_interface }} {{ 'table ' + table if table is defined and table is not none }}
 {%     endif %}
 {%   endif %}
 {%   if prefix_config.interface is defined and prefix_config.interface is not none %}


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Static table dhcp-interface route required table in template
Without table, this route will be placed to table 'main' by default
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3600

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
static route
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure interface with DHCP address and set dhcp-interface route with table X
```
set interfaces ethernet eth0 address 'dhcp'
set interfaces ethernet eth2 address 'dhcp'
set protocols static table 10 route 0.0.0.0/0 dhcp-interface 'eth0'
set protocols static table 11 route 0.0.0.0/0 dhcp-interface 'eth2'
```
Expected dhcp-interface routes in the proper table:
```
ip route 0.0.0.0/0 192.168.100.1 eth2 tag 210 210
ip route 0.0.0.0/0 192.168.122.1 eth0 tag 210 210
ip route 0.0.0.0/0 192.168.122.1 eth0 table 10
ip route 0.0.0.0/0 192.168.100.1 eth2 table 11

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
