### PR TITLE
openvpn: T4230: Delete checks if local-host address assigned

### DIFF
--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -39,6 +39,7 @@ from vyos.template import is_ipv6
 from vyos.util import call
 from vyos.util import chown
 from vyos.util import chmod_600
+from vyos.util import cmd
 from vyos.util import dict_search
 from vyos.util import makedir
 from vyos.validate import is_addr_assigned
@@ -297,8 +298,8 @@ def verify(openvpn):
     # verify specified IP address is present on any interface on this system
     if 'local_host' in openvpn:
         if not is_addr_assigned(openvpn['local_host']):
-            raise ConfigError('local-host IP address "{local_host}" not assigned' \
-                              ' to any interface'.format(**openvpn))
+            print('local-host IP address "{local_host}" not assigned' \
+                  ' to any interface'.format(**openvpn))
 
     # TCP active
     if openvpn['protocol'] == 'tcp-active':
@@ -505,6 +506,13 @@ def apply(openvpn):
             VTunIf(interface).remove()
 
         return None
+
+    # verify specified IP address is present on any interface on this system
+    # Allow to bind service to nonlocal address, if it virtaual-vrrp address
+    # or if address will be assign later
+    if 'local_host' in openvpn:
+        if not is_addr_assigned(openvpn['local_host']):
+            cmd('sysctl -w net.ipv4.ip_nonlocal_bind=1')
 
     # No matching OpenVPN process running - maybe it got killed or none
     # existed - nevertheless, spawn new OpenVPN process


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
VyOS 1.3 OpenVPN can't start if it depends on VRRP virtual-address as
virtual-address is not yet assigned by HA (openvpn and ha
in one commit) as we have checks "if address assigned"
It depends on commit priorities:
```
 460 interfaces/openvpn
 800 high-availability
```
Delete check if local-host address assigned

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4230
* https://phabricator.vyos.net/T1317

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openvpn
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure HA + OpenVPN in one commit
```
set interfaces ethernet eth0 address '10.1.12.1/24'
set high-availability vrrp group FOO interface 'eth0'
set high-availability vrrp group FOO no-preempt
set high-availability vrrp group FOO priority '150'
set high-availability vrrp group FOO rfc3768-compatibility
set high-availability vrrp group FOO virtual-address '203.0.113.1/24'
set high-availability vrrp group FOO vrid '10'

set interfaces openvpn vtun10 encryption cipher 'aes256'
set interfaces openvpn vtun10 hash 'sha512'
set interfaces openvpn vtun10 local-host '203.0.113.1'
set interfaces openvpn vtun10 local-port '1194'
set interfaces openvpn vtun10 mode 'server'
set interfaces openvpn vtun10 persistent-tunnel
set interfaces openvpn vtun10 protocol 'udp'
set interfaces openvpn vtun10 server client client1 ip '10.10.0.10'
set interfaces openvpn vtun10 server domain-name 'vyos.net'
set interfaces openvpn vtun10 server max-connections '250'
set interfaces openvpn vtun10 server name-server '172.16.254.30'
set interfaces openvpn vtun10 server subnet '10.10.0.0/24'
set interfaces openvpn vtun10 server topology 'subnet'
set interfaces openvpn vtun10 tls ca-cert-file '/config/auth/ca.crt'
set interfaces openvpn vtun10 tls cert-file '/config/auth/central.crt'
set interfaces openvpn vtun10 tls dh-file '/config/auth/dh.pem'
set interfaces openvpn vtun10 tls key-file '/config/auth/central.key'
set interfaces openvpn vtun10 tls tls-version-min '1.0'
set interfaces openvpn vtun10 use-lzo-compression
```
Service OpenVPN should start without errors:
```
vyos@r4:~$ show openvpn server 

OpenVPN status on vtun10

Client CN       Remote Host           Local Host            TX bytes    RX bytes   Connected Since
---------       -----------           ----------            --------    --------   ---------------

branch1         192.168.122.1:44790   203.0.113.1:1194      3.2 KB      3.5 KB     2022-02-08 12:38:31

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
