### PR TITLE
openvpn: T3686: Fix for check local-address in script and tmpl

### DIFF
--- a/data/templates/openvpn/server.conf.tmpl
+++ b/data/templates/openvpn/server.conf.tmpl
@@ -141,11 +141,13 @@ ping {{ keep_alive.interval }}
 ping-restart {{ keep_alive.failure_count }}
 
 {%   if device_type == 'tap' %}
-{%     for laddr, laddr_conf in local_address.items() if laddr | is_ipv4 %}
-{%       if laddr_conf is defined and laddr_conf.subnet_mask is defined and laddr_conf.subnet_mask is not none %}
+{%     if local_address is defined and local_address is not none  %}
+{%       for laddr, laddr_conf in local_address.items() if laddr | is_ipv4 %}
+{%         if laddr_conf is defined and laddr_conf.subnet_mask is defined and laddr_conf.subnet_mask is not none %}
 ifconfig {{ laddr }} {{ laddr_conf.subnet_mask }}
-{%       endif %}
-{%     endfor %}
+{%         endif %}
+{%       endfor %}
+{%     endif %}
 {%   else %}
 {%     for laddr in local_address if laddr | is_ipv4 %}
 {%       for raddr in remote_address if raddr | is_ipv4 %}

--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2021 VyOS maintainers and contributors
+# Copyright (C) 2019-2022 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -225,11 +225,12 @@ def verify(openvpn):
         if 'local_address' not in openvpn and 'is_bridge_member' not in openvpn:
             raise ConfigError('Must specify "local-address" or add interface to bridge')
 
-        if len([addr for addr in openvpn['local_address'] if is_ipv4(addr)]) > 1:
-            raise ConfigError('Only one IPv4 local-address can be specified')
+        if 'local_address' in openvpn:
+            if len([addr for addr in openvpn['local_address'] if is_ipv4(addr)]) > 1:
+                raise ConfigError('Only one IPv4 local-address can be specified')
 
-        if len([addr for addr in openvpn['local_address'] if is_ipv6(addr)]) > 1:
-            raise ConfigError('Only one IPv6 local-address can be specified')
+            if len([addr for addr in openvpn['local_address'] if is_ipv6(addr)]) > 1:
+                raise ConfigError('Only one IPv6 local-address can be specified')
 
         if openvpn['device_type'] == 'tun':
             if 'remote_address' not in openvpn:
@@ -268,7 +269,7 @@ def verify(openvpn):
             if dict_search('remote_host', openvpn) in dict_search('remote_address', openvpn):
                 raise ConfigError('"remote-address" and "remote-host" can not be the same')
 
-        if openvpn['device_type'] == 'tap':
+        if openvpn['device_type'] == 'tap' and 'local_address' in openvpn:
             # we can only have one local_address, this is ensured above
             v4addr = None
             for laddr in openvpn['local_address']:


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Local-address should be checked/executed only if it exists in the
openvpn configuration, dictionary, jinja2 template
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3686

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openvpn
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
This configuration should not cause an error:
```
set interfaces bridge br3 member interface vtun2
set interfaces openvpn vtun2 device-type 'tap'
set interfaces openvpn vtun2 mode 'site-to-site'
set interfaces openvpn vtun2 persistent-tunnel
set interfaces openvpn vtun2 shared-secret-key 'foo'
set pki openvpn shared-secret foo key '190696ff2244ca9ce8d5bef8718c58881fe8df8e3519c8bf6ede49108c97a5d9456db648d8c5ca953bb19d21978527a742497426313e614640d037ffffa4980be315e193727ebfb28f3725b779e2d3309ad6f8c939363f7fc14a0080c81e3faf4b053661c81c3003ddabeb87ac8611b81718956b7325f03978c74f502b39965f0d788b21b4370f6a625e3098f8d71ff3e653f50c54b424c511cba78871b38337237830a34266aa9558cd69c68ded89f7f0a82f94b5b87200c7ea05edb14a806e9e4998b00dc2895d976c0e506a6a06056745bca6ce1d2a5c95a51a1460e3080c7743eecbcee9d2c4f89d9e1b59f44484e43591f43bf713255b5de13ae8500620'
set pki openvpn shared-secret foo version '1'
```

Before changes:
```
Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/interfaces-openvpn.py", line 663, in <module>
    verify(c)
  File "/usr/libexec/vyos/conf_mode/interfaces-openvpn.py", line 228, in verify
    if len([addr for addr in openvpn['local_address'] if is_ipv4(addr)]) > 1:
KeyError: 'local_address'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
