### PR TITLE
openvpn: T4236: Add generator for ovpn configurations in op-mode

### DIFF
--- a/op-mode-definitions/generate-openvpn-config-client.xml.in
+++ b/op-mode-definitions/generate-openvpn-config-client.xml.in
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="generate">
+    <children>
+      <node name="openvpn">
+        <properties>
+          <help>Generate OpenVPN client configuration ovpn file</help>
+        </properties>
+        <children>
+          <node name="client-config">
+            <properties>
+              <help>Generate Client config</help>
+            </properties>
+            <children>
+              <tagNode name="interface">
+                <properties>
+                  <help>Local interface used for connection</help>
+                  <completionHelp>
+                    <script>${vyos_completion_dir}/list_interfaces.py --type openvpn</script>
+                  </completionHelp>
+                </properties>
+                <children>
+                  <tagNode name="ca">
+                    <properties>
+                      <help>CA certificate</help>
+                      <completionHelp>
+                        <path>pki ca</path>
+                      </completionHelp>
+                    </properties>
+                    <children>
+                      <tagNode name="certificate">
+                        <properties>
+                          <help>Cerificate used by client</help>
+                          <completionHelp>
+                            <path>pki certificate</path>
+                          </completionHelp>
+                        </properties>
+                        <children>
+                          <tagNode name="key">
+                            <properties>
+                              <help>Certificate key used by client</help>
+                            </properties>
+                            <command>sudo ${vyos_op_scripts_dir}/generate_ovpn_client_file.py --interface "$5" --ca "$7" --cert "$9" --key "${11}"</command>
+                          </tagNode>
+                        </children>
+                        <command>sudo ${vyos_op_scripts_dir}/generate_ovpn_client_file.py --interface "$5" --ca "$7" --cert "$9"</command>
+                      </tagNode>
+                    </children>
+                  </tagNode>
+                </children>
+              </tagNode>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/src/op_mode/generate_ovpn_client_file.py
+++ b/src/op_mode/generate_ovpn_client_file.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import os
+
+from jinja2 import Template
+
+from vyos.configquery import ConfigTreeQuery
+from vyos.ifconfig import Section
+from vyos.util import cmd
+
+
+client_config = """
+
+client
+nobind
+remote {{ remote_host }} {{ port }}
+remote-cert-tls server
+proto {{ 'tcp-client' if protocol == 'tcp-active' else 'udp' }}
+dev {{ device }}
+dev-type {{ device }}
+persist-key
+persist-tun
+verb 3
+
+# Encryption options
+{% if encryption is defined and encryption is not none %}
+{%   if encryption.cipher is defined and encryption.cipher is not none %}
+cipher {{ encryption.cipher }}
+{%     if encryption.cipher == 'bf128' %}
+keysize 128
+{%     elif encryption.cipher == 'bf256' %}
+keysize 256
+{%     endif %}
+{%   endif %}
+{%   if encryption.ncp_ciphers is defined and encryption.ncp_ciphers is not none %}
+data-ciphers {{ encryption.ncp_ciphers }}
+{%   endif %}
+{% endif %}
+
+{% if hash is defined and hash is not none %}
+auth {{ hash }}
+{% endif %}
+keysize 256
+comp-lzo {{ '' if use_lzo_compression is defined else 'no' }}
+
+<ca>
+-----BEGIN CERTIFICATE-----
+{{ ca }}
+-----END CERTIFICATE-----
+
+</ca>
+
+<cert>
+-----BEGIN CERTIFICATE-----
+{{ cert }}
+-----END CERTIFICATE-----
+
+</cert>
+
+<key>
+-----BEGIN PRIVATE KEY-----
+{{ key }}
+-----END PRIVATE KEY-----
+
+</key>
+
+"""
+
+config = ConfigTreeQuery()
+base = ['interfaces', 'openvpn']
+
+if not config.exists(base):
+    print('OpenVPN not configured')
+    exit(0)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--interface", type=str, help='OpenVPN interface the client is connecting to', required=True)
+    parser.add_argument("-a", "--ca", type=str, help='OpenVPN CA cerificate', required=True)
+    parser.add_argument("-c", "--cert", type=str, help='OpenVPN client cerificate', required=True)
+    parser.add_argument("-k", "--key", type=str, help='OpenVPN client cerificate key', action="store")
+    args = parser.parse_args()
+
+    interface = args.interface
+    ca = args.ca
+    cert = args.cert
+    key = args.key
+    if not key:
+        key = args.cert
+
+    if interface not in Section.interfaces('openvpn'):
+        exit(f'OpenVPN interface "{interface}" does not exist!')
+
+    if not config.exists(['pki', 'ca', ca, 'certificate']):
+        exit(f'OpenVPN CA certificate "{ca}" does not exist!')
+
+    if not config.exists(['pki', 'certificate', cert, 'certificate']):
+        exit(f'OpenVPN certificate "{cert}" does not exist!')
+
+    if not config.exists(['pki', 'certificate', cert, 'private', 'key']):
+        exit(f'OpenVPN certificate key "{key}" does not exist!')
+
+    ca = config.value(['pki', 'ca', ca, 'certificate'])
+    cert = config.value(['pki', 'certificate', cert, 'certificate'])
+    key = config.value(['pki', 'certificate', key, 'private', 'key'])
+    remote_host = config.value(base + [interface, 'local-host'])
+
+    ovpn_conf = config.get_config_dict(base + [interface], key_mangling=('-', '_'), get_first_key=True)
+
+    port = '1194' if 'local_port' not in ovpn_conf else ovpn_conf['local_port']
+    proto = 'udp' if 'protocol' not in ovpn_conf else ovpn_conf['protocol']
+    device = 'tun' if 'device_type' not in ovpn_conf else ovpn_conf['device_type']
+
+    config = {
+        'interface'   : interface,
+        'ca'          : ca,
+        'cert'        : cert,
+        'key'         : key,
+        'device'      : device,
+        'port'        : port,
+        'proto'       : proto,
+        'remote_host' : remote_host,
+        'address'     : [],
+    }
+
+# Clear out terminal first
+print('\x1b[2J\x1b[H')
+client = Template(client_config, trim_blocks=True).render(config)
+print(client)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This generator generates client .ovpn files with the required initial configuration
It gets information from interface vtun, pki ca and certificates

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4236

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openvpn
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
It requires pki ca/certs/keys in the configuration

initial Server config:
```
set interfaces openvpn vtun94 device-type 'tun'
set interfaces openvpn vtun94 local-host '203.0.113.1'
set interfaces openvpn vtun94 local-port '1194'
set interfaces openvpn vtun94 mode 'server'
set interfaces openvpn vtun94 protocol 'udp'
set interfaces openvpn vtun94 server subnet '10.10.0.0/24'
set interfaces openvpn vtun94 server topology 'subnet'
set interfaces openvpn vtun94 tls ca-certificate 'openvpn_vtun94'
set interfaces openvpn vtun94 tls certificate 'openvpn_vtun94'
set interfaces openvpn vtun94 tls dh-params 'openvpn_vtun94'
```

Generate Client configuration:
```
vyos@r11-roll:~$ generate openvpn client-config interface vtun94 ca openvpn_vtun94 certificate client01

client
nobind
remote 203.0.113.1 1194
remote-cert-tls server
proto udp
dev tun
dev-type tun
persist-key
persist-tun
verb 3

# Encryption options

keysize 256
comp-lzo no

<ca>
-----BEGIN CERTIFICATE-----
MIIDSzCKc5TQ==
-----END CERTIFICATE-----

</ca>

<cert>
-----BEGIN CERTIFICATE-----
MIIDsTCxxxxxxxLMw==
-----END CERTIFICATE-----

</cert>

<key>
-----BEGIN PRIVATE KEY-----
MIIExxxxx...
-----END PRIVATE KEY-----

</key>


```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
