### PR TITLE
pki: eapol: T4244: Fix KeyError when CA cert name differs from client cert name

### DIFF
--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -173,7 +173,7 @@ def verify_eapol(config):
             if ca_cert_name not in config['pki']['ca']:
                 raise ConfigError('Invalid CA certificate specified for EAPoL')
 
-            ca_cert = config['pki']['ca'][cert_name]
+            ca_cert = config['pki']['ca'][ca_cert_name]
 
             if 'certificate' not in ca_cert:
                 raise ConfigError('Invalid CA certificate specified for EAPoL')

--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -165,7 +165,7 @@ def generate(ethernet):
         if 'ca_certificate' in ethernet['eapol']:
             ca_cert_file_path = os.path.join(cfg_dir, f'{ifname}_ca.pem')
             ca_cert_name = ethernet['eapol']['ca_certificate']
-            pki_ca_cert = ethernet['pki']['ca'][cert_name]
+            pki_ca_cert = ethernet['pki']['ca'][ca_cert_name]
 
             write_file(ca_cert_file_path,
                        wrap_certificate(pki_ca_cert['certificate']))


### PR DESCRIPTION
## Change Summary

This commit fixes a small typo where the client cert name was being used to index the CA configuration dict, leading to a `KeyError` during `commit`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://phabricator.vyos.net/T4244

## Component(s) name

pki, eapol

## Proposed changes

Simple typo fix

## How to test

Set up eapol where the CA cert name is different from the client cert name. Eg:

```
interfaces {
    ethernet eth0 {
        ca-certificate foo
        certificate bar
    }
}
```

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
