### PR TITLE
conntrack-sync: T4237: Fix checks for listen-address list to str

### DIFF
--- a/src/conf_mode/conntrack_sync.py
+++ b/src/conf_mode/conntrack_sync.py
@@ -93,9 +93,9 @@ def verify(conntrack):
             raise ConfigError('Can not configure expect-sync "all" with other protocols!')
 
     if 'listen_address' in conntrack:
-        address = conntrack['listen_address']
-        if not is_addr_assigned(address):
-            raise ConfigError(f'Specified listen-address {address} not assigned to any interface!')
+        for address in conntrack['listen_address']:
+            if not is_addr_assigned(address):
+                raise ConfigError(f'Specified listen-address {address} not assigned to any interface!')
 
     vrrp_group = dict_search('failover_mechanism.vrrp.sync_group', conntrack)
     if vrrp_group == None:


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Verify section conntrack_sync.py function 'is_addr_assigned'
should checks address as a string, not as a list

(cherry picked from commit c41c51e4ed7ceb293161014a73bdd350162c3300)


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):
cherry-pick

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4237

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
conntrack-sync
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
This config should  be without any config:
```
set high-availability vrrp group FOO address 192.168.0.254/24
set high-availability vrrp group FOO interface 'eth0'
set high-availability vrrp group FOO vrid '10'
set high-availability vrrp sync-group SG member 'FOO'
set interfaces ethernet eth0 address '192.168.0.50/24'
set service conntrack-sync failover-mechanism vrrp sync-group 'SG'
set service conntrack-sync interface eth0
set service conntrack-sync listen-address '192.168.0.50'

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
