### PR TITLE
T3474: move component version info to XML

### DIFF
--- a/interface-definitions/include/version/bgp-version.xml.i
+++ b/interface-definitions/include/version/bgp-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/bgp-version.xml.i -->
+<syntaxVersion component='bgp' version='2'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/broadcast-relay-version.xml.i
+++ b/interface-definitions/include/version/broadcast-relay-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/broadcast-relay-version.xml.i -->
+<syntaxVersion component='broadcast-relay' version='1'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/cluster-version.xml.i
+++ b/interface-definitions/include/version/cluster-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/cluster-version.xml.i -->
+<syntaxVersion component='cluster' version='1'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/config-management-version.xml.i
+++ b/interface-definitions/include/version/config-management-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/config-management-version.xml.i -->
+<syntaxVersion component='config-management' version='1'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/conntrack-sync-version.xml.i
+++ b/interface-definitions/include/version/conntrack-sync-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/conntrack-sync-version.xml.i -->
+<syntaxVersion component='conntrack-sync' version='2'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/conntrack-version.xml.i
+++ b/interface-definitions/include/version/conntrack-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/conntrack-version.xml.i -->
+<syntaxVersion component='conntrack' version='3'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/dhcp-relay-version.xml.i
+++ b/interface-definitions/include/version/dhcp-relay-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/dhcp-relay-version.xml.i -->
+<syntaxVersion component='dhcp-relay' version='2'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/dhcp-server-version.xml.i
+++ b/interface-definitions/include/version/dhcp-server-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/dhcp-server-version.xml.i -->
+<syntaxVersion component='dhcp-server' version='6'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/dhcpv6-server-version.xml.i
+++ b/interface-definitions/include/version/dhcpv6-server-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/dhcpv6-server-version.xml.i -->
+<syntaxVersion component='dhcpv6-server' version='1'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/dns-forwarding-version.xml.i
+++ b/interface-definitions/include/version/dns-forwarding-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/dns-forwarding-version.xml.i -->
+<syntaxVersion component='dns-forwarding' version='3'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/firewall-version.xml.i
+++ b/interface-definitions/include/version/firewall-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/firewall-version.xml.i -->
+<syntaxVersion component='firewall' version='7'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/flow-accounting-version.xml.i
+++ b/interface-definitions/include/version/flow-accounting-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/flow-accounting-version.xml.i -->
+<syntaxVersion component='flow-accounting' version='1'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/https-version.xml.i
+++ b/interface-definitions/include/version/https-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/https-version.xml.i -->
+<syntaxVersion component='https' version='3'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/interfaces-version.xml.i
+++ b/interface-definitions/include/version/interfaces-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/interfaces-version.xml.i -->
+<syntaxVersion component='interfaces' version='25'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/ipoe-server-version.xml.i
+++ b/interface-definitions/include/version/ipoe-server-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/ipoe-server-version.xml.i -->
+<syntaxVersion component='ipoe-server' version='1'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/ipsec-version.xml.i
+++ b/interface-definitions/include/version/ipsec-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/ipsec-version.xml.i -->
+<syntaxVersion component='ipsec' version='8'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/isis-version.xml.i
+++ b/interface-definitions/include/version/isis-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/isis-version.xml.i -->
+<syntaxVersion component='isis' version='1'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/l2tp-version.xml.i
+++ b/interface-definitions/include/version/l2tp-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/l2tp-version.xml.i -->
+<syntaxVersion component='l2tp' version='4'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/lldp-version.xml.i
+++ b/interface-definitions/include/version/lldp-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/lldp-version.xml.i -->
+<syntaxVersion component='lldp' version='1'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/mdns-version.xml.i
+++ b/interface-definitions/include/version/mdns-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/mdns-version.xml.i -->
+<syntaxVersion component='mdns' version='1'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/nat-version.xml.i
+++ b/interface-definitions/include/version/nat-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/nat-version.xml.i -->
+<syntaxVersion component='nat' version='5'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/nat66-version.xml.i
+++ b/interface-definitions/include/version/nat66-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/nat66-version.xml.i -->
+<syntaxVersion component='nat66' version='1'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/ntp-version.xml.i
+++ b/interface-definitions/include/version/ntp-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/ntp-version.xml.i -->
+<syntaxVersion component='ntp' version='1'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/openconnect-version.xml.i
+++ b/interface-definitions/include/version/openconnect-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/openconnect-version.xml.i -->
+<syntaxVersion component='openconnect' version='1'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/ospf-version.xml.i
+++ b/interface-definitions/include/version/ospf-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/ospf-version.xml.i -->
+<syntaxVersion component='ospf' version='1'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/policy-version.xml.i
+++ b/interface-definitions/include/version/policy-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/policy-version.xml.i -->
+<syntaxVersion component='policy' version='2'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/pppoe-server-version.xml.i
+++ b/interface-definitions/include/version/pppoe-server-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/pppoe-server-version.xml.i -->
+<syntaxVersion component='pppoe-server' version='5'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/pptp-version.xml.i
+++ b/interface-definitions/include/version/pptp-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/pptp-version.xml.i -->
+<syntaxVersion component='pptp' version='2'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/qos-version.xml.i
+++ b/interface-definitions/include/version/qos-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/qos-version.xml.i -->
+<syntaxVersion component='qos' version='1'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/quagga-version.xml.i
+++ b/interface-definitions/include/version/quagga-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/quagga-version.xml.i -->
+<syntaxVersion component='quagga' version='9'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/rpki-version.xml.i
+++ b/interface-definitions/include/version/rpki-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/rpki-version.xml.i -->
+<syntaxVersion component='rpki' version='1'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/salt-version.xml.i
+++ b/interface-definitions/include/version/salt-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/salt-version.xml.i -->
+<syntaxVersion component='salt' version='1'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/snmp-version.xml.i
+++ b/interface-definitions/include/version/snmp-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/snmp-version.xml.i -->
+<syntaxVersion component='snmp' version='2'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/ssh-version.xml.i
+++ b/interface-definitions/include/version/ssh-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/ssh-version.xml.i -->
+<syntaxVersion component='ssh' version='2'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/sstp-version.xml.i
+++ b/interface-definitions/include/version/sstp-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/sstp-version.xml.i -->
+<syntaxVersion component='sstp' version='4'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/system-version.xml.i
+++ b/interface-definitions/include/version/system-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/system-version.xml.i -->
+<syntaxVersion component='system' version='22'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/vrf-version.xml.i
+++ b/interface-definitions/include/version/vrf-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/vrf-version.xml.i -->
+<syntaxVersion component='vrf' version='3'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/vrrp-version.xml.i
+++ b/interface-definitions/include/version/vrrp-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/vrrp-version.xml.i -->
+<syntaxVersion component='vrrp' version='3'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/vyos-accel-ppp-version.xml.i
+++ b/interface-definitions/include/version/vyos-accel-ppp-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/vyos-accel-ppp-version.xml.i -->
+<syntaxVersion component='vyos-accel-ppp' version='2'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/wanloadbalance-version.xml.i
+++ b/interface-definitions/include/version/wanloadbalance-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/wanloadbalance-version.xml.i -->
+<syntaxVersion component='wanloadbalance' version='3'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/include/version/webproxy-version.xml.i
+++ b/interface-definitions/include/version/webproxy-version.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from include/version/webproxy-version.xml.i -->
+<syntaxVersion component='webproxy' version='2'></syntaxVersion>
+<!-- include end -->

--- a/interface-definitions/xml-component-version.xml.in
+++ b/interface-definitions/xml-component-version.xml.in
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  #include <include/version/bgp-version.xml.i>
+  #include <include/version/broadcast-relay-version.xml.i>
+  #include <include/version/cluster-version.xml.i>
+  #include <include/version/config-management-version.xml.i>
+  #include <include/version/conntrack-sync-version.xml.i>
+  #include <include/version/conntrack-version.xml.i>
+  #include <include/version/dhcp-relay-version.xml.i>
+  #include <include/version/dhcp-server-version.xml.i>
+  #include <include/version/dhcpv6-server-version.xml.i>
+  #include <include/version/dns-forwarding-version.xml.i>
+  #include <include/version/firewall-version.xml.i>
+  #include <include/version/flow-accounting-version.xml.i>
+  #include <include/version/https-version.xml.i>
+  #include <include/version/interfaces-version.xml.i>
+  #include <include/version/ipoe-server-version.xml.i>
+  #include <include/version/ipsec-version.xml.i>
+  #include <include/version/isis-version.xml.i>
+  #include <include/version/l2tp-version.xml.i>
+  #include <include/version/lldp-version.xml.i>
+  #include <include/version/mdns-version.xml.i>
+  #include <include/version/nat66-version.xml.i>
+  #include <include/version/nat-version.xml.i>
+  #include <include/version/ntp-version.xml.i>
+  #include <include/version/openconnect-version.xml.i>
+  #include <include/version/ospf-version.xml.i>
+  #include <include/version/policy-version.xml.i>
+  #include <include/version/pppoe-server-version.xml.i>
+  #include <include/version/pptp-version.xml.i>
+  #include <include/version/qos-version.xml.i>
+  #include <include/version/quagga-version.xml.i>
+  #include <include/version/rpki-version.xml.i>
+  #include <include/version/salt-version.xml.i>
+  #include <include/version/snmp-version.xml.i>
+  #include <include/version/ssh-version.xml.i>
+  #include <include/version/sstp-version.xml.i>
+  #include <include/version/system-version.xml.i>
+  #include <include/version/vrf-version.xml.i>
+  #include <include/version/vrrp-version.xml.i>
+  #include <include/version/vyos-accel-ppp-version.xml.i>
+  #include <include/version/wanloadbalance-version.xml.i>
+  #include <include/version/webproxy-version.xml.i>
+</interfaceDefinition>

--- a/python/vyos/migrator.py
+++ b/python/vyos/migrator.py
@@ -195,7 +195,7 @@ class Migrator(object):
             # This will force calling all migration scripts:
             cfg_versions = {}
 
-        sys_versions = systemversions.get_system_versions()
+        sys_versions = systemversions.get_system_component_version()
 
         # save system component versions in json file for easy reference
         self.save_json_record(sys_versions)

--- a/python/vyos/systemversions.py
+++ b/python/vyos/systemversions.py
@@ -17,7 +17,10 @@ import os
 import re
 import sys
 import vyos.defaults
+from vyos.xml import component_version
 
+# legacy version, reading from the file names in
+# /opt/vyatta/etc/config-migrate/current
 def get_system_versions():
     """
     Get component versions from running system; critical failure if
@@ -37,3 +40,7 @@ def get_system_versions():
             system_versions[pair[0]] = int(pair[1])
 
     return system_versions
+
+# read from xml cache
+def get_system_component_version():
+    return component_version()

--- a/python/vyos/xml/__init__.py
+++ b/python/vyos/xml/__init__.py
@@ -46,8 +46,8 @@ def is_tag(lpath):
 def is_leaf(lpath, flat=True):
     return load_configuration().is_leaf(lpath, flat)
 
-def component_versions():
-    return load_configuration().component_versions()
+def component_version():
+    return load_configuration().component_version()
 
 def defaults(lpath, flat=False):
     return load_configuration().defaults(lpath, flat)

--- a/python/vyos/xml/definition.py
+++ b/python/vyos/xml/definition.py
@@ -249,10 +249,11 @@ class XML(dict):
     # @lru_cache(maxsize=100)
     # XXX: need to use cachetool instead - for later
 
-    def component_versions(self) -> dict:
-        sort_component = sorted(self[kw.component_version].items(),
-                                key = lambda kv: kv[0])
-        return dict(sort_component)
+    def component_version(self) -> dict:
+        d = {}
+        for k in sorted(self[kw.component_version]):
+            d[k] = int(self[kw.component_version][k])
+        return d
 
     def defaults(self, lpath, flat):
         d = self[kw.default]

--- a/smoketest/scripts/cli/test_component_version.py
+++ b/smoketest/scripts/cli/test_component_version.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from vyos.systemversions import get_system_versions, get_system_component_version
+
+# After T3474, component versions should be updated in the files in
+# vyos-1x/interface-definitions/include/version/
+# This test verifies that the legacy version in curver_DATA does not exceed
+# that in the xml cache.
+class TestComponentVersion(unittest.TestCase):
+    def setUp(self):
+        self.legacy_d = get_system_versions()
+        self.xml_d = get_system_component_version()
+
+    def test_component_version(self):
+        self.assertTrue(set(self.legacy_d).issubset(set(self.xml_d)))
+        for k, v in self.legacy_d.items():
+            self.assertTrue(v <= self.xml_d[k])
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/src/helpers/system-versions-foot.py
+++ b/src/helpers/system-versions-foot.py
@@ -21,7 +21,7 @@ import vyos.systemversions as systemversions
 import vyos.defaults
 import vyos.version
 
-sys_versions = systemversions.get_system_versions()
+sys_versions = systemversions.get_system_component_version()
 
 component_string = formatversions.format_versions_string(sys_versions)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add component version data within interface-definitions XML, allowing it to be read from the python xml cache, instead of from the legacy file names in /opt/vyatta/etc/config-migrate/current. Consequently, component versions should be updated at one site, the associated file in

interface-definitions/include/version/

Add a smoketest to catch updates in curver_DATA that are not reflected in the above files.
Add use of the above in scripts and migrator.py instead of legacy read from vyatta directory.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe):
        Internal change for migration of components.

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3474

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
