### PR TITLE
vpn: T4254: Add cisco_flexvpn and install_virtual_ip_on options

### DIFF
--- a/data/templates/ipsec/charon.tmpl
+++ b/data/templates/ipsec/charon.tmpl
@@ -20,6 +20,17 @@ charon {
     # Send Cisco Unity vendor ID payload (IKEv1 only).
     # cisco_unity = no
 
+    # Cisco FlexVPN
+{% if options is defined %}
+    cisco_flexvpn = {{ 'yes' if options.flexvpn is defined else 'no' }}
+{%   if options.virtual_ip is defined %}
+    install_virtual_ip = yes
+{%   endif %}
+{%   if options.interface is defined and options.interface is not none %}
+    install_virtual_ip_on = {{ options.interface }}
+{%   endif %}
+{%  endif %}
+
     # Close the IKE_SA if setup of the CHILD_SA along with IKE_AUTH failed.
     # close_ike_on_child_failure = no
 

--- a/data/templates/ipsec/swanctl/peer.tmpl
+++ b/data/templates/ipsec/swanctl/peer.tmpl
@@ -5,6 +5,9 @@
     peer_{{ name }} {
         proposals = {{ ike | get_esp_ike_cipher | join(',') }}
         version = {{ ike.key_exchange[4:] if ike is defined and ike.key_exchange is defined else "0" }}
+{%   if peer_conf.virtual_address is defined and peer_conf.virtual_address is not none %}
+        vips = {{ peer_conf.virtual_address | join(', ') }}
+{%   endif %}
         local_addrs = {{ peer_conf.local_address if peer_conf.local_address != 'any' else '0.0.0.0/0' }} # dhcp:{{ peer_conf.dhcp_interface if 'dhcp_interface' in peer_conf else 'no' }}
         remote_addrs = {{ peer if peer not in ['any', '0.0.0.0'] and peer[0:1] != '@' else '0.0.0.0/0' }}
 {%   if peer_conf.authentication is defined and peer_conf.authentication.mode is defined and peer_conf.authentication.mode == 'x509' %}

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -622,6 +622,19 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <leafNode name="flexvpn">
+                <properties>
+                  <help>Allow FlexVPN vendor ID payload (IKEv2 only)</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              #include <include/generic-interface.xml.i>
+              <leafNode name="virtual-ip">
+                <properties>
+                  <help>Allow install virtual-ip addresses</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
             </children>
           </node>
           <tagNode name="profile">
@@ -1087,6 +1100,20 @@
                       </node>
                     </children>
                   </tagNode>
+                  <leafNode name="virtual-address">
+                    <properties>
+                      <help>Initiator request virtual-address from peer</help>
+                      <valueHelp>
+                        <format>ipv4</format>
+                        <description>Request IPv4 address from peer</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>ipv6</format>
+                        <description>Request IPv6 address from peer</description>
+                      </valueHelp>
+                      <multi/>
+                    </properties>
+                  </leafNode>
                   <node name="vti">
                     <properties>
                       <help>Virtual tunnel interface [REQUIRED]</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to set Cisco FlexVPN vendor ID payload:
charon.`cisco_flexvpn = yes`
charon.`install_virtual_ip_on = tunX`
swanctl.`connections.<conn>.vips = x.x.x.x, z.z.z.z`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4254

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vpn
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
New configuration commands:
```
set vpn ipsec options flexvpn
set vpn ipsec options virtual-ip
set vpn ipsec options interface tunX
set vpn ipsec site-to-site peer 192.168.122.14 virtual-address '192.0.2.5'
set vpn ipsec site-to-site peer 192.168.122.14 virtual-address '192.0.2.6'
```
Charon options:
```
vyos@r11-roll# sudo cat /etc/strongswan.d/charon.conf | grep -i flex -A 4
    # Cisco FlexVPN
    cisco_flexvpn = yes 
    install_virtual_ip = yes
    install_virtual_ip_on = tun1
```
Swanctl:
```
vyos@r11-roll# sudo cat /etc/swanctl/swanctl.conf 
### Autogenerated by vpn_ipsec.py ###

connections {
    peer_192-168-122-14 {
        proposals = aes256-sha256-modp1536
        version = 2
        vips = 192.0.2.5, 192.0.2.6
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
