### PR TITLE
ipsec: T1856: Ability to set SA life bytes and packets

### DIFF
--- a/data/templates/ipsec/swanctl/peer.tmpl
+++ b/data/templates/ipsec/swanctl/peer.tmpl
@@ -57,6 +57,12 @@
 {%     set vti_esp = esp_group[ peer_conf.vti.esp_group ] if peer_conf.vti.esp_group is defined else esp_group[ peer_conf.default_esp_group ] %}
             peer_{{ name }}_vti {
                 esp_proposals = {{ vti_esp | get_esp_ike_cipher(ike) | join(',') }}
+{%   if vti_esp.life_bytes is defined and vti_esp.life_bytes is not none %}
+                life_bytes = {{ vti_esp.life_bytes }}
+{%   endif %}
+{%   if vti_esp.life_packets is defined and vti_esp.life_packets is not none %}
+                life_packets = {{ vti_esp.life_packets }}
+{%   endif %}
                 life_time = {{ vti_esp.lifetime }}s
                 local_ts = 0.0.0.0/0,::/0
                 remote_ts = 0.0.0.0/0,::/0
@@ -91,6 +97,12 @@
 {%       set remote_suffix = '[{0}/{1}]'.format(proto, remote_port) if proto or remote_port else '' %}
             peer_{{ name }}_tunnel_{{ tunnel_id }} {
                 esp_proposals = {{ tunnel_esp | get_esp_ike_cipher(ike) | join(',') }}
+{%       if tunnel_esp.life_bytes is defined and tunnel_esp.life_bytes is not none %}
+                life_bytes = {{ tunnel_esp.life_bytes }}
+{%       endif %}
+{%       if tunnel_esp.life_packets is defined and tunnel_esp.life_packets is not none %}
+                life_packets = {{ tunnel_esp.life_packets }}
+{%       endif %}
                 life_time = {{ tunnel_esp.lifetime }}s
 {%       if tunnel_esp.mode is not defined or tunnel_esp.mode == 'tunnel' %}
 {%         if tunnel_conf.local is defined and tunnel_conf.local.prefix is defined %}

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -55,6 +55,30 @@
                 </properties>
                 <defaultValue>3600</defaultValue>
               </leafNode>
+              <leafNode name="life-bytes">
+                <properties>
+                  <help>ESP life in bytes</help>
+                  <valueHelp>
+                    <format>u32:1024-26843545600000</format>
+                    <description>ESP life in bytes</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 1024-26843545600000"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="life-packets">
+                <properties>
+                  <help>ESP life in packets</help>
+                  <valueHelp>
+                    <format>u32:1000-26843545600000</format>
+                    <description>ESP life in packets</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 1000-26843545600000"/>
+                  </constraint>
+                </properties>
+              </leafNode>
               <leafNode name="mode">
                 <properties>
                   <help>ESP mode</help>

--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -171,7 +171,12 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         # Site to site
         local_address = '192.0.2.10'
         priority = '20'
+        life_bytes = '100000'
+        life_packets = '2000000'
         peer_base_path = base_path + ['site-to-site', 'peer', peer_ip]
+
+        self.cli_set(base_path + ['esp-group', esp_group, 'life-bytes', life_bytes])
+        self.cli_set(base_path + ['esp-group', esp_group, 'life-packets', life_packets])
 
         self.cli_set(peer_base_path + ['authentication', 'mode', 'pre-shared-secret'])
         self.cli_set(peer_base_path + ['authentication', 'pre-shared-secret', secret])
@@ -197,6 +202,8 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         swanctl_conf_lines = [
             f'version = 2',
             f'auth = psk',
+            f'life_bytes = {life_bytes}',
+            f'life_packets = {life_packets}',
             f'rekey_time = 28800s', # default value
             f'proposals = aes128-sha1-modp1024',
             f'esp_proposals = aes128-sha1-modp1024',


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to configure SA's packets and bytes

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T1856

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
VPN, ipsec
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set vpn ipsec esp-group grp-ESP life-bytes '100000'
set vpn ipsec esp-group grp-ESP life-packets '2000000'
set vpn ipsec site-to-site peer 192.168.122.14 tunnel 0 esp-group 'grp-ESP'
```
Swanctl configuration:
```
        children {
            peer_192-168-122-14_tunnel_0 {
                esp_proposals = aes256gcm128-sha256-modp2048
                life_bytes = 100000
                life_packets = 2000000
                life_time = 28800s

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
