### PR TITLE
ipsec: T3948: Add CLI site-to-site peer connection-type none

### DIFF
--- a/data/templates/ipsec/swanctl/peer.tmpl
+++ b/data/templates/ipsec/swanctl/peer.tmpl
@@ -77,6 +77,8 @@
                 start_action = start
 {%     elif peer_conf.connection_type == 'respond' %}
                 start_action = trap
+{%     elif peer_conf.connection_type == 'none' %}
+                start_action = none
 {%     endif %}
 {%     if ike.dead_peer_detection is defined %}
 {%       set dpd_translate = {'clear': 'clear', 'hold': 'trap', 'restart': 'start'} %}
@@ -119,6 +121,8 @@
                 start_action = start
 {%       elif peer_conf.connection_type == 'respond' %}
                 start_action = trap
+{%       elif peer_conf.connection_type == 'none' %}
+                start_action = none
 {%       endif %}
 {%       if ike.dead_peer_detection is defined %}
 {%         set dpd_translate = {'clear': 'clear', 'hold': 'trap', 'restart': 'start'} %}

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -978,7 +978,7 @@
                     <properties>
                       <help>Connection type</help>
                       <completionHelp>
-                        <list>initiate respond</list>
+                        <list>initiate respond none</list>
                       </completionHelp>
                       <valueHelp>
                         <format>initiate</format>
@@ -988,8 +988,12 @@
                         <format>respond</format>
                         <description>Bring the connection up only if traffic is detected</description>
                       </valueHelp>
+                      <valueHelp>
+                        <format>none</format>
+                        <description>Load the connection only</description>
+                      </valueHelp>
                       <constraint>
-                        <regex>^(initiate|respond)$</regex>
+                        <regex>^(initiate|respond|none)$</regex>
                       </constraint>
                     </properties>
                   </leafNode>

--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -238,6 +238,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         peer_base_path = base_path + ['site-to-site', 'peer', peer_ip]
         self.cli_set(peer_base_path + ['authentication', 'mode', 'pre-shared-secret'])
         self.cli_set(peer_base_path + ['authentication', 'pre-shared-secret', secret])
+        self.cli_set(peer_base_path + ['connection-type', 'none'])
         self.cli_set(peer_base_path + ['ike-group', ike_group])
         self.cli_set(peer_base_path + ['default-esp-group', esp_group])
         self.cli_set(peer_base_path + ['local-address', local_address])
@@ -266,6 +267,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             f'mode = tunnel',
             f'local_ts = 172.16.10.0/24,172.16.11.0/24',
             f'remote_ts = 172.17.10.0/24,172.17.11.0/24',
+            f'start_action = none',
             f'if_id_in = {if_id}', # will be 11 for vti10 - shifted by one
             f'if_id_out = {if_id}',
             f'updown = "/etc/ipsec.d/vti-up-down {vti}"'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add VPN ipsec peer connection-type 'none'

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3948

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vpn, ipsec
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add peer connection-type 'none'
```
set vpn ipsec site-to-site peer 192.168.122.14 connection-type none
```
Swanctl configuration:
```
vyos@r11-roll:~$ sudo cat /etc/swanctl/swanctl.conf | grep start
                start_action = none

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
