### PR TITLE
T4115:Reboot:Options "in" and "at" are not working as expected

### DIFF
--- a/op-mode-definitions/reboot.xml.in
+++ b/op-mode-definitions/reboot.xml.in
@@ -25,7 +25,7 @@
             <list>&lt;Minutes&gt;</list>
           </completionHelp>
         </properties>
-        <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --reboot $3 $4</command>
+        <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --reboot_in $3 $4</command>
       </tagNode>
       <tagNode name="at">
         <properties>
@@ -40,7 +40,7 @@
             <properties>
               <help>Reboot at a specific date</help>
               <completionHelp>
-                <list>&lt;DDMMYYYY&gt; &lt;DD/MM/YYYY&gt; &lt;DD.MM.YYYY&gt; &lt;DD:MM:YYYY&gt;</list>
+                <list>&lt;DD/MM/YYYY&gt; &lt;DD.MM.YYYY&gt; &lt;DD:MM:YYYY&gt;</list>
               </completionHelp>
             </properties>
             <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --reboot $3 $5</command>

--- a/src/op_mode/powerctrl.py
+++ b/src/op_mode/powerctrl.py
@@ -33,10 +33,12 @@ def utc2local(datetime):
 
 def parse_time(s):
     try:
-        if re.match(r'^\d{1,2}$', s):
-            if (int(s) > 59):
+        if re.match(r'^\d{1,9999}$', s):
+            if (int(s) > 59) and (int(s) < 1440):
                 s = str(int(s)//60) + ":" + str(int(s)%60)
                 return datetime.strptime(s, "%H:%M").time()
+            if (int(s) >= 1440):
+                return s.split()
             else:
                 return datetime.strptime(s, "%M").time()
         else:
@@ -141,7 +143,7 @@ def execute_shutdown(time, reboot=True, ask=True):
             cmd(f'/usr/bin/wall "{wall_msg}"')
         else:
             if not ts:
-                exit(f'Invalid time "{time[0]}". The valid format is HH:MM')
+                exit(f'Invalid time "{time[0]}". Uses 24 Hour Clock format')
             else:
                 exit(f'Invalid date "{time[1]}". A valid format is YYYY-MM-DD [HH:MM]')
     else:
@@ -172,7 +174,12 @@ def main():
     action.add_argument("--reboot", "-r",
                         help="Reboot the system",
                         nargs="*",
-                        metavar="Minutes|HH:MM")
+                        metavar="HH:MM")
+
+    action.add_argument("--reboot_in", "-i",
+                        help="Reboot the system",
+                        nargs="*",
+                        metavar="Minutes")
 
     action.add_argument("--poweroff", "-p",
                         help="Poweroff the system",
@@ -190,7 +197,17 @@ def main():
 
     try:
         if args.reboot is not None:
+            for r in args.reboot:
+                if ':' not in r and '/' not in r and '.' not in r:
+                    print("Incorrect  format! Use HH:MM")
+                    exit(1)
             execute_shutdown(args.reboot, reboot=True, ask=args.yes)
+        if args.reboot_in is not None:
+            for i in args.reboot_in:
+                if ':' in i:
+                    print("Incorrect format! Use Minutes")
+                    exit(1)
+            execute_shutdown(args.reboot_in, reboot=True, ask=args.yes)
         if args.poweroff is not None:
             execute_shutdown(args.poweroff, reboot=False, ask=args.yes)
         if args.cancel:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
When reboot is executed with "in" option it only accepts minutes till 99 value
and does not accept greater values and "at" is also working same like in option
where as it should work with exact timings.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T4115
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
reboot
## Proposed changes
<!--- Describe your changes in detail -->
```
vyos@vyos:~$ reboot in 99

Broadcast message from vyos@vyos (somewhere) (Wed Dec 29 19:30:13 2021):

System reboot is scheduled 99

Reboot is scheduled 2021-12-29 21:09:13
vyos@vyos:~$ reboot in 100
Invalid time "100". The valid format is HH:MM
```

Increased the value to accepts x number of minutes and to convert into date and time. Also modified the in option so that 
it will only accepts Minutes XX not this format HH:MM and at option only accepts HH:MM DD/MM/YYYY
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos:~$ reboot in 900

Broadcast message from vyos@vyos (somewhere) (Sun Feb 20 20:17:08 2022):

System reboot is scheduled 900

Reboot is scheduled 2022-02-21 11:17:08

vyos@vyos:~$ reboot at 33
Incorrect  format! Use HH:MM

vyos@vyos:~$ reboot at 09:00 date 21/02/2022

Broadcast message from vyos@vyos (somewhere) (Sun Feb 20 20:50:09 2022):

System reboot is scheduled 21/02/2022 09:00

Reboot is scheduled 2022-02-21 09:00:08


```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
