### PR TITLE
ipsec prefix: T4275: Incorrect val_help for local/remote prefix in site-to-site ipsec vpn

### DIFF
--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -879,11 +879,11 @@
                     <properties>
                       <help>Local IPv4 or IPv6 pool prefix exclusions</help>
                       <valueHelp>
-                        <format>ipv4</format>
+                        <format>ipv4net</format>
                         <description>Local IPv4 pool prefix exclusion</description>
                       </valueHelp>
                       <valueHelp>
-                        <format>ipv6</format>
+                        <format>ipv6net</format>
                         <description>Local IPv6 pool prefix exclusion</description>
                       </valueHelp>
                       <constraint>


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
It accepts network as the input value but the completion help is showing ip address
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4275

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec
## Proposed changes
<!--- Describe your changes in detail -->
Previousconfig:

```
vyos@vyos# set vpn ipsec site-to-site peer x.x.x.x tunnel x local prefix
Possible completions:
   <x.x.x.x>    Local IPv4 prefix
   <h:h:h:h:h:h:h:h>
                Local IPv6 prefix
```

New config:

```
vyos@vyos# set vpn ipsec site-to-site peer x.x.x.x tunnel 1 local prefix
Possible completions:
   <x.x.x.x/x>  Local IPv4 prefix
   <h:h:h:h:h:h:h:h/x>
                Local IPv6 prefix
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
