### PR TITLE
T4235: changes to interface of diff_tree class

### DIFF
--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -126,6 +126,10 @@ class ConfigTree(object):
         self.__set_tag.argtypes = [c_void_p, c_char_p]
         self.__set_tag.restype = c_int
 
+        self.__get_subtree = self.__lib.get_subtree
+        self.__get_subtree.argtypes = [c_void_p, c_char_p]
+        self.__get_subtree.restype = c_void_p
+
         self.__destroy = self.__lib.destroy
         self.__destroy.argtypes = [c_void_p]
 
@@ -290,6 +294,14 @@ class ConfigTree(object):
             return True
         else:
             raise ConfigTreeError("Path [{}] doesn't exist".format(path_str))
+
+    def get_subtree(self, path, with_node=False):
+        check_path(path)
+        path_str = " ".join(map(str, path)).encode()
+
+        res = self.__get_subtree(self.__config, path_str, with_node)
+        subt = ConfigTree(address=res)
+        return subt
 
 class Diff:
     def __init__(self, left, right, path=[], libpath=LIBPATH):

--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -305,6 +305,10 @@ class ConfigTree(object):
 
 class DiffTree:
     def __init__(self, left, right, path=[], libpath=LIBPATH):
+        if left is None:
+            left = ConfigTree(config_string='\n')
+        if right is None:
+            right = ConfigTree(config_string='\n')
         if not (isinstance(left, ConfigTree) and isinstance(right, ConfigTree)):
             raise TypeError("Arguments must be instances of ConfigTree")
         if path:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

N.B. Draft PR pending merge of
https://github.com/vyos/libvyosconfig/pull/4

PR for two changes to the binding to the configtree diff algorithm:
(1) simplification of the return value of the configtree diff algorithm
(2) distinction between 'subtract' and 'delete' trees: subtract tree contains full paths that are in the left-hand side, but not the right-hand side, of the diff comparison; delete tree trims the paths to produce delete commands for CLI.

It is clear the delete tree is needed in practice; the subtract tree should maintain the information necessary for recursive identification of node changes.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4235

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
