### PR TITLE
ipsec prefix: T4275: Fix for prefix val_help of remote-access and s2s vpn

### DIFF
--- a/interface-definitions/include/ipsec/local-traffic-selector.xml.i
+++ b/interface-definitions/include/ipsec/local-traffic-selector.xml.i
@@ -9,11 +9,11 @@
       <properties>
         <help>Local IPv4 or IPv6 prefix</help>
         <valueHelp>
-          <format>ipv4</format>
+          <format>ipv4net</format>
           <description>Local IPv4 prefix</description>
         </valueHelp>
         <valueHelp>
-          <format>ipv6</format>
+          <format>ipv6net</format>
           <description>Local IPv6 prefix</description>
         </valueHelp>
         <constraint>

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -897,11 +897,11 @@
                     <properties>
                       <help>Local IPv4 or IPv6 pool prefix</help>
                       <valueHelp>
-                        <format>ipv4</format>
+                        <format>ipv4net</format>
                         <description>Local IPv4 pool prefix</description>
                       </valueHelp>
                       <valueHelp>
-                        <format>ipv6</format>
+                        <format>ipv6net</format>
                         <description>Local IPv6 pool prefix</description>
                       </valueHelp>
                       <constraint>
@@ -1114,11 +1114,11 @@
                             <properties>
                               <help>Remote IPv4 or IPv6 prefix</help>
                               <valueHelp>
-                                <format>ipv4</format>
+                                <format>ipv4net</format>
                                 <description>Remote IPv4 prefix</description>
                               </valueHelp>
                               <valueHelp>
-                                <format>ipv6</format>
+                                <format>ipv6net</format>
                                 <description>Remote IPv6 prefix</description>
                               </valueHelp>
                               <constraint>


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
It accepts network as the input value but the completion help is showing
ip address in other section also(part of the previous commit)
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4275

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec vpn
## Proposed changes
<!--- Describe your changes in detail -->

Existing:

```
vyos@vyos# set vpn ipsec remote-access pool test prefix
Possible completions:
   <x.x.x.x>    Local IPv4 pool prefix
   <h:h:h:h:h:h:h:h>
                Local IPv6 pool prefix

vyos@vyos# set vpn ipsec remote-access pool test exclude
Possible completions:
   <x.x.x.x>    Local IPv4 pool prefix exclusion
   <h:h:h:h:h:h:h:h>
                Local IPv6 pool prefix exclusion
Remote prefix:

vyos@vyos# set vpn ipsec site-to-site peer 172.21.0.2 tunnel 0 remote prefix
Possible completions:
   <x.x.x.x>    Remote IPv4 prefix
   <h:h:h:h:h:h:h:h>
                Remote IPv6 prefix

```
Proposed:

```
vyos@vyos# set vpn ipsec site-to-site peer 172.21.0.2 tunnel 0 remote prefix
Possible completions:
   <x.x.x.x/x>    Remote IPv4 prefix
   <h:h:h:h:h:h:h:h/h>
                Remote IPv6 prefix
```
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
