### PR TITLE
logrotate: T4250: Fixed logrotate config generation

### DIFF
--- a/data/templates/syslog/logrotate.tmpl
+++ b/data/templates/syslog/logrotate.tmpl
@@ -1,12 +1,11 @@
-{% for file in files %}
-{{files[file]['log-file']}} {
+{{ config_render['log-file'] }} {
   missingok
   notifempty
   create
-  rotate {{files[file]['max-files']}}
-  size={{files[file]['max-size']//1024}}k
+  rotate {{ config_render['max-files'] }}
+  size={{ config_render['max-size'] // 1024 }}k
   postrotate
     invoke-rc.d rsyslog rotate > /dev/null
   endscript
 }
-{% endfor %}
+

--- a/debian/vyos-1x.postinst
+++ b/debian/vyos-1x.postinst
@@ -93,3 +93,7 @@ for file in $DELETE; do
         rm -f ${file}
     fi
 done
+
+# Remove logrotate items controlled via CLI and VyOS defaults
+sed -i '/^\/var\/log\/messages$/d' /etc/logrotate.d/rsyslog
+sed -i '/^\/var\/log\/auth.log$/d' /etc/logrotate.d/rsyslog

--- a/src/etc/logrotate.d/vyos-rsyslog
+++ b/src/etc/logrotate.d/vyos-rsyslog
@@ -1,0 +1,12 @@
+/var/log/messages {
+    create
+    missingok
+    nomail
+    notifempty
+    rotate 10
+    size 1M
+    postrotate
+        # inform rsyslog service about rotation
+        /usr/lib/rsyslog/rsyslog-rotate
+    endscript
+}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed logrotate config generation

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4250

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
logrotate

## Proposed changes
<!--- Describe your changes in detail -->
* Removed `/var/log/auth.log` and `/var/log/messages` from `/etc/logrotate.d/rsyslog`, because they conflict with VyOS-controlled items what leads to service error.
* Removed generation config file for `/var/log/messages` from `system-syslog.py` - this should be done from `syslom logs` now.
* Generate each logfile from `system syslog file` to a dedicated logrotate config file.
* Fixed logrotate config file names in `/etc/rsyslog.d/vyos-rsyslog.conf`.
* Added default logrotate settins for `/var/log/messages`

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Start logrotate service via systemd, and you should see the error:
```
vyos@vyos:~$ sudo systemctl start logrotate.service
Job for logrotate.service failed because the control process exited with error code.
See "systemctl status logrotate.service" and "journalctl -xe" for details.
vyos@vyos:~$ systemctl status logrotate.service | tee
● logrotate.service - Rotate log files
     Loaded: loaded (/lib/systemd/system/logrotate.service; static)
     Active: failed (Result: exit-code) since Mon 2022-03-07 17:57:01 UTC; 1s ago
TriggeredBy: ● logrotate.timer
       Docs: man:logrotate(8)
             man:logrotate.conf(5)
    Process: 2100 ExecStart=/usr/sbin/logrotate /etc/logrotate.conf (code=exited, status=1/FAILURE)
   Main PID: 2100 (code=exited, status=1/FAILURE)
        CPU: 29ms

Mar 07 17:57:01 vyos systemd[1]: Starting Rotate log files...
Mar 07 17:57:01 vyos logrotate[2100]: error: rsyslog:1 duplicate log entry for /var/log/auth.log
Mar 07 17:57:01 vyos logrotate[2100]: error: found error in file rsyslog, skipping
Mar 07 17:57:01 vyos logrotate[2100]: error: vyos-rsyslog:1 duplicate log entry for /var/log/messages
Mar 07 17:57:01 vyos logrotate[2100]: error: found error in file vyos-rsyslog, skipping
Mar 07 17:57:01 vyos systemd[1]: logrotate.service: Main process exited, code=exited, status=1/FAILURE
Mar 07 17:57:01 vyos systemd[1]: logrotate.service: Failed with result 'exit-code'.
Mar 07 17:57:01 vyos systemd[1]: Failed to start Rotate log files.
```
After suggested changes, everything works:
```
vyos@vyos:~$ sudo systemctl start logrotate.service
vyos@vyos:~$ sudo systemctl status logrotate.service | tee
● logrotate.service - Rotate log files
     Loaded: loaded (/lib/systemd/system/logrotate.service; static)
     Active: inactive (dead) since Mon 2022-03-07 17:58:27 UTC; 9s ago
TriggeredBy: ● logrotate.timer
       Docs: man:logrotate(8)
             man:logrotate.conf(5)
    Process: 2390 ExecStart=/usr/sbin/logrotate /etc/logrotate.conf (code=exited, status=0/SUCCESS)
   Main PID: 2390 (code=exited, status=0/SUCCESS)
        CPU: 34ms

Mar 07 17:58:27 vyos systemd[1]: Starting Rotate log files...
Mar 07 17:58:27 vyos systemd[1]: logrotate.service: Succeeded.
Mar 07 17:58:27 vyos systemd[1]: Finished Rotate log files.
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
