### PR TITLE
policy: T2493: add ip-next-hop unchanged and peer-address

### DIFF
--- a/data/templates/frr/policy.frr.tmpl
+++ b/data/templates/frr/policy.frr.tmpl
@@ -276,6 +276,9 @@ route-map {{ route_map }} {{ rule_config.action }} {{ rule }}
 {%           if rule_config.set.ipv6_next_hop is defined and rule_config.set.ipv6_next_hop.local is defined and rule_config.set.ipv6_next_hop.local is not none %}
  set ipv6 next-hop local {{ rule_config.set.ipv6_next_hop.local }}
 {%           endif %}
+{%           if rule_config.set.ipv6_next_hop is defined and rule_config.set.ipv6_next_hop.peer_address is defined %}
+ set ipv6 next-hop peer-address
+{%           endif %}
 {%           if rule_config.set.ipv6_next_hop is defined and rule_config.set.ipv6_next_hop.prefer_global is defined %}
  set ipv6 next-hop prefer-global
 {%           endif %}

--- a/interface-definitions/policy.xml.in
+++ b/interface-definitions/policy.xml.in
@@ -1115,13 +1115,23 @@
                       <help>Nexthop IP address</help>
                       <completionHelp>
                         <script>${vyos_completion_dir}/list_local_ips.sh --ipv4</script>
+                        <list>unchanged peer-address</list>
                       </completionHelp>
                       <valueHelp>
                         <format>ipv4</format>
                         <description>IP address</description>
                       </valueHelp>
+                      <valueHelp>
+                        <format>unchanged</format>
+                        <description>Set the BGP nexthop address as unchanged</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>peer-address</format>
+                        <description>Set the BGP nexthop address to the address of the peer</description>
+                      </valueHelp>
                       <constraint>
                         <validator name="ipv4-address"/>
+                        <regex>^(unchanged|peer-address)$</regex>
                       </constraint>
                     </properties>
                   </leafNode>
@@ -1158,6 +1168,12 @@
                           <constraint>
                             <validator name="ipv6-address"/>
                           </constraint>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="peer-address">
+                        <properties>
+                          <help>Use peer address (for BGP only)</help>
+                          <valueless/>
                         </properties>
                       </leafNode>
                       <leafNode name="prefer-global">


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This PR adds the ability to set BGP next-hop to self or to leave it unchanged in a route-map.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4293

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
policy

## Proposed changes
<!--- Describe your changes in detail -->
FRR can use a route-map to either force the BGP next-hop address to be self, or to override setting it to be self and leave it unchanged. http://docs.frrouting.org/en/stable-8.2/routemap.html#clicmd-set-ip-next-hop-unchanged . This PR lets VyOS set those options.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
These lines in a config:
```
set policy route-map testing rule 1 action 'permit'
set policy route-map testing rule 1 set ip-next-hop 'unchanged'
set policy route-map testing rule 2 action 'permit'
set policy route-map testing rule 2 set ip-next-hop 'peer-address'
```
lead to these lines in frr.conf:
```
route-map testing permit 1
 set ip next-hop unchanged
exit
!
route-map testing permit 2
 set ip next-hop peer-address
exit
```

Completion works too:
```
vyos@vyos# set policy route-map testing rule 2 set ip-next-hop
Possible completions:
   <x.x.x.x>    IP address
   unchanged    Set the BGP nexthop address as unchanged
   peer-address Set the BGP nexthop address to the address of the peer
   127.0.0.1
   172.16.18.182


```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

