### PR TITLE
Firewall: T4286: Correct ipv6-range validator

### DIFF
--- a/src/validators/ipv6-range
+++ b/src/validators/ipv6-range
@@ -1,17 +1,20 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
-import sys
-import re
-from vyos.template import is_ipv6
+from ipaddress import IPv6Address
+from sys import argv, exit
 
 if __name__ == '__main__':
-    if len(sys.argv)>1:
-        ipv6_range = sys.argv[1]
-        # Regex for ipv6-ipv6 https://regexr.com/
-        if re.search('([a-f0-9:]+:+)+[a-f0-9]+-([a-f0-9:]+:+)+[a-f0-9]+', ipv6_range):
-            for tmp in ipv6_range.split('-'):
-                if not is_ipv6(tmp):
-                    print(f'Error: {ipv6_range} is not a valid IPv6 range')
-                    sys.exit(1)
-
-    sys.exit(0)
+    if len(argv) > 1:
+        # try to pass validation and raise an error if failed
+        try:
+            ipv6_range = argv[1]
+            range_left = ipv6_range.split('-')[0]
+            range_right = ipv6_range.split('-')[1]
+            if not IPv6Address(range_left) < IPv6Address(range_right):
+                raise ValueError(f'left element {range_left} must be less than right element {range_right}')
+        except Exception as err:
+            print(f'Error: {ipv6_range} is not a valid IPv6 range: {err}')
+            exit(1)
+    else:
+        print('Error: an IPv6 range argument must be provided')
+        exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
ipv6-range validator was not working as expected, and invalid entries were allowed, such as described on phabricator task
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4286

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->
ipv6-range validator changed.
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
vyos@vyos# set firewall ipv6-name FOO rule 10 source address laskdas

  
  Error: laskdas is not a valid IPv6 range: list index out of range
  
  
  Error: laskdas is not IPv6
  
  
  
  Invalid value
  Value validation failed
  Set failed

[edit]
vyos@vyos# set firewall ipv6-name FOO rule 10 source address 2008:1234::1-

  
  Error: 2008:1234::1- is not a valid IPv6 range: Address cannot be empty
  
  
  Error: 2008:1234::1- is not IPv6
  
  
  
  Invalid value
  Value validation failed
  Set failed

[edit]
234:1vyos# set firewall ipv6-name FOO rule 10 source address 2008:1234::1-2008:1 

  
  Error: 2008:1234::1-2008:1234:1 is not a valid IPv6 range: Exactly 8 parts expected without '::' in '2008:1234:1'
  
  
  Error: 2008:1234::1-2008:1234:1 is not IPv6
  
  
  
  Invalid value
  Value validation failed
  Set failed
vyos@vyos# set firewall ipv6-name FOO rule 10 source address 2008:1234::1-2008:1234::6
[edit]
vyos@vyos#
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
