### PR TITLE
OSPF : T4304: Set import/export filter inter-area prefix

### DIFF
--- a/data/templates/frr/ospfd.frr.tmpl
+++ b/data/templates/frr/ospfd.frr.tmpl
@@ -97,6 +97,12 @@ router ospf {{ 'vrf ' + vrf if vrf is defined and vrf is not none }}
 {%         endif %}
 {%       endfor %}
 {%     endif %}
+{%     if area_config.export_list is defined and area_config.export_list is not none %}
+ area {{ area_id }} export-list {{ area_config.export_list }}
+{%     endif %}
+{%     if area_config.import_list is defined and area_config.import_list is not none %}
+ area {{ area_id }} import-list {{ area_config.import_list }}
+{%     endif %}
 {%     if area_config.shortcut is defined and area_config.shortcut is not none %}
  area {{ area_id }} shortcut {{ area_config.shortcut }}
 {%     endif %}

--- a/interface-definitions/include/ospf/protocol-common-config.xml.i
+++ b/interface-definitions/include/ospf/protocol-common-config.xml.i
@@ -256,6 +256,36 @@
         </constraint>
       </properties>
     </leafNode>
+    <leafNode name="export-list">
+      <properties>
+        <help>Set the filter for networks announced to other areas</help>
+        <completionHelp>
+          <path>policy access-list</path>
+        </completionHelp>
+        <valueHelp>
+          <format>u32</format>
+          <description>Access-list number</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 0-4294967295"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="import-list">
+      <properties>
+        <help>Set the filter for networks from other areas announced</help>
+        <completionHelp>
+          <path>policy access-list</path>
+        </completionHelp>
+        <valueHelp>
+          <format>u32</format>
+          <description>Access-list number</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 0-4294967295"/>
+        </constraint>
+      </properties>
+    </leafNode>
     <tagNode name="virtual-link">
       <properties>
         <help>Virtual link</help>

--- a/src/conf_mode/protocols_ospf.py
+++ b/src/conf_mode/protocols_ospf.py
@@ -25,6 +25,7 @@ from vyos.configdict import node_changed
 from vyos.configverify import verify_common_route_maps
 from vyos.configverify import verify_route_map
 from vyos.configverify import verify_interface_exists
+from vyos.configverify import verify_access_list
 from vyos.template import render_to_string
 from vyos.util import dict_search
 from vyos.util import get_interface_config
@@ -158,6 +159,16 @@ def verify(ospf):
     # As we can have a default-information route-map, we need to validate it!
     route_map_name = dict_search('default_information.originate.route_map', ospf)
     if route_map_name: verify_route_map(route_map_name, ospf)
+
+    # Validate if configured Access-list exists 
+    if 'area' in ospf:
+          for area, area_config in ospf['area'].items():
+              if 'import_list' in area_config:
+                  acl_import = area_config['import_list']
+                  if acl_import: verify_access_list(acl_import, ospf)
+              if 'export_list' in area_config:
+                  acl_export = area_config['export_list']
+                  if acl_export: verify_access_list(acl_export, ospf)
 
     if 'interface' in ospf:
         for interface, interface_config in ospf['interface'].items():


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
set  import/export filter for ospf inter-area prefix
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4304

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ospf

## Proposed changes
<!--- Describe your changes in detail -->
Ospf have the ability to filter on ABR , the Type-3 summary-LSAs announced to other areas originated

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
# set policy access-list 

vyos@vyos# run show configuration commands | match "ospf|policy"
set policy access-list 100 rule 10 action 'permit'
set policy access-list 100 rule 10 description 'test-acl'
set policy access-list 100 rule 10 destination any
set policy access-list 100 rule 10 source inverse-mask '0.0.255.255'
set policy access-list 100 rule 10 source network '10.10.0.0'
set policy access-list 100 rule 100 action 'deny'
set policy access-list 100 rule 100 destination any
set policy access-list 100 rule 100 source any

# applied filter on area-ospf

set protocols ospf area 10.10.0.0 export-list '100'
set protocols ospf area 10.10.0.0 network '172.16.80.0/24'
set protocols ospf area 10.10.0.0 network '30.30.30.30/32'
set protocols ospf area 10.10.0.0 network '50.50.50.50/32'
set protocols ospf area 10.10.0.0 network '10.0.0.0/8'
set protocols ospf parameters abr-type 'cisco'
set protocols ospf parameters router-id '50.50.50.50'

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
