### PR TITLE
ike-group: T4288 : close-action is missing in swanctl.conf

### DIFF
--- a/data/templates/ipsec/swanctl/peer.tmpl
+++ b/data/templates/ipsec/swanctl/peer.tmpl
@@ -87,9 +87,10 @@
                 start_action = none
 {%     endif %}
 {%     if ike.dead_peer_detection is defined %}
-{%       set dpd_translate = {'clear': 'clear', 'hold': 'trap', 'restart': 'start'} %}
+{%       set dpd_translate = {'clear': 'clear', 'hold': 'trap', 'restart': 'restart'} %}
                 dpd_action = {{ dpd_translate[ike.dead_peer_detection.action] }}
 {%     endif %}
+                close_action = {{ {'none': 'none', 'hold': 'trap', 'restart': 'start'}[ike.close_action] }}
             }
 {%   elif peer_conf.tunnel is defined %}
 {%     for tunnel_id, tunnel_conf in peer_conf.tunnel.items() if tunnel_conf.disable is not defined %}
@@ -137,9 +138,10 @@
                 start_action = none
 {%       endif %}
 {%       if ike.dead_peer_detection is defined %}
-{%         set dpd_translate = {'clear': 'clear', 'hold': 'trap', 'restart': 'start'} %}
+{%         set dpd_translate = {'clear': 'clear', 'hold': 'trap', 'restart': 'restart'} %}
                 dpd_action = {{ dpd_translate[ike.dead_peer_detection.action] }}
 {%       endif %}
+                close_action = {{ {'none': 'none', 'hold': 'trap', 'restart': 'start'}[ike.close_action] }}
 {%       if peer_conf.vti is defined and peer_conf.vti.bind is defined %}
                 updown = "/etc/ipsec.d/vti-up-down {{ peer_conf.vti.bind }}"
                 {# The key defaults to 0 and will match any policies which similarly do not have a lookup key configuration. #}

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -231,7 +231,7 @@
                 <properties>
                   <help>Action to take if a child SA is unexpectedly closed</help>
                   <completionHelp>
-                    <list>none hold clear restart</list>
+                    <list>none hold restart</list>
                   </completionHelp>
                   <valueHelp>
                     <format>none</format>
@@ -242,15 +242,11 @@
                     <description>Attempt to re-negotiate when matching traffic is seen</description>
                   </valueHelp>
                   <valueHelp>
-                    <format>clear</format>
-                    <description>Remove the connection immediately</description>
-                  </valueHelp>
-                  <valueHelp>
                     <format>restart</format>
                     <description>Attempt to re-negotiate the connection immediately</description>
                   </valueHelp>
                   <constraint>
-                    <regex>^(none|hold|clear|restart)$</regex>
+                    <regex>^(none|hold|restart)$</regex>
                   </constraint>
                 </properties>
               </leafNode>

--- a/src/migration-scripts/ipsec/8-to-9
+++ b/src/migration-scripts/ipsec/8-to-9
@@ -1,0 +1,49 @@
+
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+
+if (len(argv) < 1):
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['vpn', 'ipsec', 'ike-group']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+else:
+    for ike_group in config.list_nodes(base):
+        base_closeaction = base + [ike_group, 'close-action']
+        if config.exists(base_closeaction) and config.return_value(base_closeaction) == 'clear':
+            config.set(base_closeaction, 'none', replace=True)
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print(f'Failed to save the modified config: {e}')
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
close-action parameter is missing in the swanctl.conf file so added the parameter as per Strongswan guide.
Also changed the dead-peer-detection action from start to restart as per the following guide:

https://docs.strongswan.org/strongswan-docs/5.9/swanctl/swanctlConf.html 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4288

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vpn ipsec ike-group
## Proposed changes
<!--- Describe your changes in detail -->

Existing template;

```
        children {
            peer_172-21-0-2_tunnel_0 {
                esp_proposals = aes128-sha1
                life_time = 120s
                local_ts = 192.168.0.0/22
                remote_ts = 192.168.254.0/24
                ipcomp = no
                mode = tunnel
                start_action = start
                dpd_action = start
            }
        }
    }
```

New template:
```
children {
            peer_172-21-0-2_tunnel_0 {
                esp_proposals = aes128-sha1
                life_time = 120s
                local_ts = 192.168.0.0/22
                remote_ts = 192.168.254.0/24
                ipcomp = no
                mode = tunnel
                start_action = start
                dpd_action = restart
                close_action = trap
```
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
vyos@vyos# set vpn ipsec ike-group ike1 close-action
Possible completions:
   none         Do nothing
   hold         Attempt to re-negotiate when matching traffic is seen
   restart      Attempt to re-negotiate the connection immediately

vyos@vyos# set vpn ipsec ike-group ike1 dead-peer-detection action
Possible completions:
   hold         Attempt to re-negotiate the connection when matching traffic isn
   clear        Remove the connection immediately
   restart      Attempt to re-negotiate the connection immediately

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
