### PR TITLE
logging: T4308: log options for routing protocol

### DIFF
--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -212,6 +212,79 @@
               </tagNode>
             </children>
           </node>
+          <node name="protocol">
+            <properties>
+              <help>Show log for Routing Protocols</help>
+            </properties>
+            <children>
+              <leafNode name="ospf">
+                <properties>
+                  <help>Show log for OSPF</help>
+                </properties>
+                <command>journalctl -b /usr/lib/frr/ospfd</command>
+              </leafNode>
+              <leafNode name="ospfv3">
+                <properties>
+                  <help>Show log for OSPF for IPv6</help>
+                </properties>
+                <command>journalctl -b /usr/lib/frr/ospf6d</command>
+              </leafNode>
+              <leafNode name="bgp">
+                <properties>
+                  <help>Show log for BGP</help>
+                </properties>
+                <command>journalctl -b /usr/lib/frr/bgpd</command>
+              </leafNode>
+              <leafNode name="rip">
+                <properties>
+                  <help>Show log for RIP</help>
+                </properties>
+                <command>journalctl -b /usr/lib/frr/ripd</command>
+              </leafNode>
+              <leafNode name="ripng">
+                <properties>
+                  <help>Show log for RIPng</help>
+                </properties>
+                <command>journalctl -b /usr/lib/frr/ripngd</command>
+              </leafNode>
+              <leafNode name="static">
+                <properties>
+                  <help>Show log for static route</help>
+                </properties>
+                <command>journalctl -b /usr/lib/frr/staticd</command>
+              </leafNode>
+              <leafNode name="multicast">
+                <properties>
+                  <help>Show log for Multicast protocol</help>
+                </properties>
+                <command>journalctl -b /usr/lib/frr/pimd</command>
+              </leafNode>
+              <leafNode name="isis">
+                <properties>
+                  <help>Show log for ISIS</help>
+                </properties>
+                <command>journalctl -b /usr/lib/frr/isisd</command>
+              </leafNode>
+              <leafNode name="nhrp">
+                <properties>
+                  <help>Show log for NHRP</help>
+                </properties>
+                <command>journalctl -b /usr/lib/frr/nhrpd</command>
+              </leafNode>
+              <leafNode name="bfd">
+                <properties>
+                  <help>Show log for BFD</help>
+                </properties>
+                <command>journalctl -b /usr/lib/frr/bfdd</command>
+              </leafNode>
+              <leafNode name="mpls">
+                <properties>
+                  <help>Show log for MPLS</help>
+                </properties>
+                <command>journalctl -b /usr/lib/frr/ldpd</command>
+              </leafNode>
+            </children>
+          </node>
           <leafNode name="snmp">
             <properties>
               <help>Show log for Simple Network Monitoring Protocol (SNMP)</help>


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
It will be more convenient or comfortable  if there is a separate option to view the logs related to most used routing protocols i.e OSPF, OSPF6 and BGP.
Added the logs under a new "protocol" hierarchy as these protocols are configured under the same tree. 
Also used the command journalctl to view the logs instead of /var/log/messages as this file does not show entire messages.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4308

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
logging

## Proposed changes
<!--- Describe your changes in detail -->

op-mode command:

$ show log protocol ospf
$ show log protocol ospfv6
$ show log protocol bgp

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
First configure any protocol, for example ospf 

set protocols ospf area 0 network '172.16.1.0/24'
set protocols ospf area 0 network '10.20.0.0/24'
set protocols ospf log-adjacency-changes detail
set protocols ospf parameters router-id '22.22.22.22'

and once configured, then you can check the  logs using the command "show log protocol ospf"

vyos@vyos# run sh log protocol ospf
-- Journal begins at Sun 2022-03-27 18:49:00 UTC, ends at Mon 2022-03-28 18:25:56 UTC. --
Mar 28 16:23:11 vyos ospfd[937]: [H0QH3-2B67G] AdjChg: Nbr 33.33.33.33(default) on eth1:172.16.1.2: Full -> Deleted (InactivityTimer)
Mar 28 16:23:11 vyos ospfd[937]: [P4PQ9-K4XFD] DR-Election[1st]: Backup 172.16.1.2
Mar 28 16:23:11 vyos ospfd[937]: [HBZ7F-65Y86] DR-Election[1st]: DR     172.16.1.2
Mar 28 16:23:11 vyos ospfd[937]: [H01MF-RN00N] DR-Election[2nd]: Backup 0.0.0.0
Mar 28 16:23:11 vyos ospfd[937]: [R7BJ4-KP8JT] DR-Election[2nd]: DR     172.16.1.2
Mar 28 16:23:11 vyos ospfd[937]: [S3578-FNEB0] nsm_change_state:[33.33.33.33:default], Full -> Deleted): scheduling new router-LSA origination

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
