### PR TITLE
T4319: bugfixes for disabled IPv6 (equuleus)

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -38,7 +38,7 @@ from vyos.util import dict_search
 from vyos.util import read_file
 from vyos.util import get_interface_config
 from vyos.util import is_systemd_service_active
-from vyos.util import sysctl_read
+from vyos.util import is_ipv6_enabled
 from vyos.template import is_ipv4
 from vyos.template import is_ipv6
 from vyos.validate import is_intf_addr_assigned
@@ -1359,7 +1359,7 @@ class Interface(Control):
         self.set_ipv4_source_validation(value)
 
         # Only change IPv6 parameters if IPv6 was not explicitly disabled
-        if sysctl_read('net.ipv6.conf.all.disable_ipv6') == '0':
+        if is_ipv6_enabled():
             # IPv6 forwarding
             tmp = dict_search('ipv6.disable_forwarding', config)
             value = '0' if (tmp != None) else '1'

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1386,10 +1386,6 @@ class Interface(Control):
             value = tmp if (tmp != None) else '1'
             self.set_ipv6_dad_messages(value)
 
-            # MTU - Maximum Transfer Unit
-            if 'mtu' in config:
-                self.set_mtu(config.get('mtu'))
-
             # Delete old IPv6 EUI64 addresses before changing MAC
             for addr in (dict_search('ipv6.address.eui64_old', config) or []):
                 self.del_ipv6_eui64_address(addr)
@@ -1405,6 +1401,10 @@ class Interface(Control):
             if tmp:
                 for addr in tmp:
                     self.add_ipv6_eui64_address(addr)
+
+        # MTU - Maximum Transfer Unit
+        if 'mtu' in config:
+            self.set_mtu(config.get('mtu'))
 
         # re-add ourselves to any bridge we might have fallen out of
         if 'is_bridge_member' in config:

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -990,6 +990,10 @@ class Interface(Control):
                     "Can't configure both static IPv4 and DHCP address "
                     "on the same interface"))
 
+        # Failsave - do not add IPv6 address if IPv6 is disabled
+        if is_ipv6(addr) and not is_ipv6_enabled():
+            return False
+
         # add to interface
         if addr == 'dhcp':
             self.set_dhcp(True)

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1362,6 +1362,13 @@ class Interface(Control):
         value = tmp if (tmp != None) else '0'
         self.set_ipv4_source_validation(value)
 
+        # MTU - Maximum Transfer Unit has a default value. It must ALWAYS be set
+        # before mangling any IPv6 option. If MTU is less then 1280 IPv6 will be
+        # automatically disabled by the kernel. Also MTU must be increased before
+        # configuring any IPv6 address on the interface.
+        if 'mtu' in config:
+            self.set_mtu(config.get('mtu'))
+
         # Only change IPv6 parameters if IPv6 was not explicitly disabled
         if is_ipv6_enabled():
             # IPv6 forwarding
@@ -1401,10 +1408,6 @@ class Interface(Control):
             if tmp:
                 for addr in tmp:
                     self.add_ipv6_eui64_address(addr)
-
-        # MTU - Maximum Transfer Unit
-        if 'mtu' in config:
-            self.set_mtu(config.get('mtu'))
 
         # re-add ourselves to any bridge we might have fallen out of
         if 'is_bridge_member' in config:

--- a/python/vyos/ifconfig/loopback.py
+++ b/python/vyos/ifconfig/loopback.py
@@ -13,9 +13,8 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-import vyos.util
-
 from vyos.ifconfig.interface import Interface
+from vyos.util import is_ipv6_enabled
 
 @Interface.register
 class LoopbackIf(Interface):
@@ -33,8 +32,6 @@ class LoopbackIf(Interface):
             'bridgeable': True,
         }
     }
-
-    name = 'loopback'
 
     def remove(self):
         """
@@ -62,11 +59,11 @@ class LoopbackIf(Interface):
         on any interface. """
 
         addr = config.get('address', [])
-        # We must ensure that the loopback addresses are never deleted from the system
-        addr += ['127.0.0.1/8']
 
-        if (vyos.util.sysctl_read('net.ipv6.conf.all.disable_ipv6') == '0'):
-            addr += ['::1/128']
+        # We must ensure that the loopback addresses are never deleted from the system
+        addr.append('127.0.0.1/8')
+        if is_ipv6_enabled():
+            addr.append('::1/128')
 
         # Update IP address entry in our dictionary
         config.update({'address' : addr})

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -827,3 +827,7 @@ def sysctl_write(name, value):
         call(f'sysctl -wq {name}={value}')
         return True
     return False
+
+def is_ipv6_enabled() -> bool:
+    """ Check if IPv6 support on the system is enabled or not """
+    return (sysctl_read('net.ipv6.conf.all.disable_ipv6') == '0')

--- a/smoketest/scripts/cli/test_system_ipv6.py
+++ b/smoketest/scripts/cli/test_system_ipv6.py
@@ -21,6 +21,7 @@ from base_vyostest_shim import VyOSUnitTestSHIM
 from vyos.template import is_ipv4
 from vyos.util import read_file
 from vyos.util import is_ipv6_enabled
+from vyos.util import get_interface_config
 from vyos.validate import is_intf_addr_assigned
 
 base_path = ['system', 'ipv6']
@@ -68,6 +69,17 @@ class TestSystemIPv6(VyOSUnitTestSHIM.TestCase):
                 self.assertTrue(is_intf_addr_assigned('lo', addr))
             else:
                 self.assertFalse(is_intf_addr_assigned('lo', addr))
+
+        # T4330: Verify MTU can be changed with IPv6 disabled
+        mtu = '1600'
+        eth_if = 'eth0'
+        self.cli_set(['interfaces', 'ethernet', eth_if, 'mtu', mtu])
+        self.cli_commit()
+
+        tmp = get_interface_config(eth_if)
+        self.assertEqual(tmp['mtu'], int(mtu))
+
+        self.cli_delete(['interfaces', 'ethernet', eth_if, 'mtu'])
 
     def test_system_ipv6_strict_dad(self):
         # This defaults to 1

--- a/src/conf_mode/vrf.py
+++ b/src/conf_mode/vrf.py
@@ -27,6 +27,7 @@ from vyos.util import call
 from vyos.util import cmd
 from vyos.util import dict_search
 from vyos.util import sysctl_write
+from vyos.util import is_ipv6_enabled
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -194,10 +195,11 @@ def apply(vrf):
 
             # set VRF description for e.g. SNMP monitoring
             vrf_if = Interface(name)
-            # We also should add proper loopback IP addresses to the newly
-            # created VRFs for services bound to the loopback address (SNMP, NTP)
+            # We also should add proper loopback IP addresses to the newly added
+            # VRF for services bound to the loopback address (SNMP, NTP)
             vrf_if.add_addr('127.0.0.1/8')
-            vrf_if.add_addr('::1/128')
+            if is_ipv6_enabled():
+                vrf_if.add_addr('::1/128')
             # add VRF description if available
             vrf_if.set_alias(config.get('description', ''))
 

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from unittest import TestCase
-from vyos.util import mangle_dict_keys
+from vyos.util import *
 
 class TestVyOSUtil(TestCase):
     def test_key_mangline(self):

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020 VyOS maintainers and contributors
+# Copyright (C) 2020-2022 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -24,3 +24,15 @@ class TestVyOSUtil(TestCase):
         new_data = mangle_dict_keys(data, '-', '_')
         self.assertEqual(new_data, expected_data)
 
+    def test_sysctl_read(self):
+        self.assertEqual(sysctl_read('net.ipv4.conf.lo.forwarding'), '1')
+
+    def test_ipv6_enabled(self):
+        tmp = sysctl_read('net.ipv6.conf.all.disable_ipv6')
+        # We need to test for both variants as this depends on how the
+        # Docker container is started (with or without IPv6 support) - so we
+        # will simply check both cases to not make the users life miserable.
+        if tmp == '0':
+            self.assertTrue(is_ipv6_enabled())
+        else:
+            self.assertFalse(is_ipv6_enabled())


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Commit c82db71f started this discussion as disabling an entire address family in the Kernel has huge side effects.

This PR extends the implementation with a new helper `is_ipv6_disabled()` to detect the current state. Also IPv6 addresses should not be added (and can not be added) to an interface if IPv6 is disabled on the kernel - we simply ignore the addresses when configuring the Kernel.

VRF instances also should no longer receive a ::/128 localhost IPv6 address once IPv6 is disabled on the system.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4319

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* VRF
* IPv6
* Interfaces

## Proposed changes
<!--- Describe your changes in detail -->



## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

VyOS smoketests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
