### PR TITLE
T4324, T4338, T4339 WWAN interface bugfixes

### DIFF
--- a/debian/vyos-1x.install
+++ b/debian/vyos-1x.install
@@ -1,4 +1,3 @@
-etc/cron.d
 etc/dhcp
 etc/netplug
 etc/ppp

--- a/interface-definitions/interfaces-wireless.xml.in
+++ b/interface-definitions/interfaces-wireless.xml.in
@@ -6,6 +6,9 @@
         <properties>
           <help>Wireless (WiFi/WLAN) Network Interface</help>
           <priority>318</priority>
+          <completionHelp>
+            <script>cd /sys/class/net; if compgen -G "wlan*" > /dev/null; then ls -d wlan*; fi</script>
+          </completionHelp>
           <constraint>
             <regex>^wlan[0-9]+$</regex>
           </constraint>

--- a/interface-definitions/interfaces-wwan.xml.in
+++ b/interface-definitions/interfaces-wwan.xml.in
@@ -7,7 +7,7 @@
           <help>Wireless Modem (WWAN) Interface</help>
           <priority>350</priority>
           <completionHelp>
-            <script>cd /sys/class/net; ls -d wwan*</script>
+            <script>cd /sys/class/net; if compgen -G "wwan*" > /dev/null; then ls -d wwan*; fi</script>
           </completionHelp>
           <constraint>
             <regex>^wwan[0-9]+$</regex>

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -797,6 +797,11 @@ def is_wwan_connected(interface):
     if not interface.startswith('wwan'):
         raise ValueError(f'Specified interface "{interface}" is not a WWAN interface')
 
+    # ModemManager is required for connection(s) - if service is not running,
+    # there won't be any connection at all!
+    if not is_systemd_service_active('ModemManager.service'):
+        return False
+
     modem = interface.lstrip('wwan')
 
     tmp = cmd(f'mmcli --modem {modem} --output-json')

--- a/src/conf_mode/interfaces-wwan.py
+++ b/src/conf_mode/interfaces-wwan.py
@@ -36,7 +36,7 @@ from vyos import airbag
 airbag.enable()
 
 service_name = 'ModemManager.service'
-cron_script = '/etc/cron.d/wwan'
+cron_script = '/etc/cron.d/vyos-wwan'
 
 def get_config(config=None):
     """
@@ -57,8 +57,8 @@ def get_config(config=None):
                                                     get_first_key=True,
                                                     no_tag_node_value_mangle=True)
 
-    # This if-clause is just to be sure - it will always evaluate to true
     ifname = wwan['ifname']
+    # This if-clause is just to be sure - it will always evaluate to true
     if ifname in wwan['other_interfaces']:
         del wwan['other_interfaces'][ifname]
     if len(wwan['other_interfaces']) == 0:
@@ -82,13 +82,25 @@ def verify(wwan):
 
 def generate(wwan):
     if 'deleted' in wwan:
+        # We are the last WWAN interface - there are no other ones remaining
+        # thus the cronjob needs to go away, too
+        if 'other_interfaces' not in wwan:
+            if os.path.exists(cron_script):
+                os.unlink(cron_script)
         return None
 
+    # Install cron triggered helper script to re-dial WWAN interfaces on
+    # disconnect - e.g. happens during RF signal loss. The script watches every
+    # WWAN interface - so there is only one instance.
     if not os.path.exists(cron_script):
         write_file(cron_script, '*/5 * * * * root /usr/libexec/vyos/vyos-check-wwan.py')
+
     return None
 
 def apply(wwan):
+    # ModemManager is required to dial WWAN connections - one instance is
+    # required to serve all modems. Activate ModemManager on first invocation
+    # of any WWAN interface.
     if not is_systemd_service_active(service_name):
         cmd(f'systemctl start {service_name}')
 
@@ -111,7 +123,8 @@ def apply(wwan):
     if 'deleted' in wwan or 'disable' in wwan:
         w.remove()
 
-        # There are no other WWAN interfaces - stop the daemon
+        # We are the last WWAN interface - there are no other WWAN interfaces
+        # remaining, thus we can stop ModemManager and free resources.
         if 'other_interfaces' not in wwan:
             cmd(f'systemctl stop {service_name}')
             # Clean CRON helper script which is used for to re-connect when
@@ -138,9 +151,6 @@ def apply(wwan):
     command = f'{base_cmd} --simple-connect="{options}"'
     call(command, stdout=DEVNULL)
     w.update(wwan)
-
-    if 'other_interfaces' not in wwan and 'deleted' in wwan:
-        cmd(f'systemctl start {service_name}')
 
     return None
 

--- a/src/etc/cron.d/check-wwan
+++ b/src/etc/cron.d/check-wwan
@@ -1,1 +1,0 @@
-*/5 * * * * root /usr/libexec/vyos/vyos-check-wwan.py


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The WWAN interface check cronjob script is installed once a WWAN interface is added to the system.

```
Mar 27 10:50:01 LR1.wue3 CRON[2740]: (root) CMD (/usr/libexec/vyos/vyos-check-wwan.py)
```

If a WWAN interface is disabled, the script is called by cron but exits early due to the disabled state. Unfortunately if all WWAN interfaces are removed thw script is not vacuumed. Its not a bug, just eye candy and less spammed logs (once every 5 Minutes)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4324

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

WWAN

## Proposed changes
<!--- Describe your changes in detail -->

- `is_wwan_connected()` must verify if ModemManager is running
- wwan: T4324: cronjob is setup via interfaces-wwan.py - drop dedicated cron file 
- wwan: T4324: properly start/stop ModemManager and cron helper on interface add/removal

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests

```
set interfaces wwan wwan0 address 'dhcp'
set interfaces wwan wwan0 apn 'internet.telekom'
set interfaces wwan wwan0 dhcp-options default-route-distance '220'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
