### PR TITLE
T4337: isis: IETF SPF delay algorithm cannot be configured - results in vyos.frr.CommitError (equuleus)

### DIFF
--- a/data/templates/frr/isisd.frr.tmpl
+++ b/data/templates/frr/isisd.frr.tmpl
@@ -99,8 +99,8 @@ router isis VyOS {{ 'vrf ' + vrf if vrf is defined and vrf is not none }}
 {%     endfor %}
 {%   endif %}
 {% endif %}
-{% if spf_delay_ietf is defined and spf_delay_ietf.init_delay is defined and spf_delay_ietf.init_delay is not none %}
- spf-delay-ietf init-delay {{ spf_delay_ietf.init_delay }}
+{% if spf_delay_ietf is defined and spf_delay_ietf.init_delay is defined and spf_delay_ietf.short_delay is defined and spf_delay_ietf.long_delay is defined and spf_delay_ietf.holddown is defined and spf_delay_ietf.time_to_learn is defined %}
+ spf-delay-ietf init-delay {{ spf_delay_ietf.init_delay }} short-delay {{ spf_delay_ietf.short_delay }} long-delay {{ spf_delay_ietf.long_delay }} holddown {{ spf_delay_ietf.holddown }} time-to-learn {{ spf_delay_ietf.time_to_learn }}
 {% endif %}
 {% if area_password is defined and area_password is not none %}
 {%   if area_password.md5 is defined and area_password.md5 is not none %}

--- a/smoketest/scripts/cli/test_protocols_isis.py
+++ b/smoketest/scripts/cli/test_protocols_isis.py
@@ -165,5 +165,52 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f' domain-password clear {password}', tmp)
         self.assertIn(f' area-password clear {password}', tmp)
 
+    def test_isis_06_spf_delay(self):
+        network = 'point-to-point'
+        holddown = '10'
+        init_delay = '50'
+        long_delay = '200'
+        short_delay = '100'
+        time_to_learn = '75'
+
+        self.cli_set(base_path + ['net', net])
+        for interface in self._interfaces:
+            self.cli_set(base_path + ['interface', interface, 'network', network])
+
+        self.cli_set(base_path + ['spf-delay-ietf', 'holddown', holddown])
+        # verify() - All types of spf-delay must be configured
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_set(base_path + ['spf-delay-ietf', 'init-delay', init_delay])
+        # verify() - All types of spf-delay must be configured
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_set(base_path + ['spf-delay-ietf', 'long-delay', long_delay])
+        # verify() - All types of spf-delay must be configured
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_set(base_path + ['spf-delay-ietf', 'short-delay', short_delay])
+        # verify() - All types of spf-delay must be configured
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(base_path + ['spf-delay-ietf', 'time-to-learn', time_to_learn])
+
+        # Commit all changes
+        self.cli_commit()
+
+        # Verify all changes
+        tmp = self.getFRRconfig(f'router isis {domain}', daemon='isisd')
+        self.assertIn(f' net {net}', tmp)
+        self.assertIn(f' spf-delay-ietf init-delay {init_delay} short-delay {short_delay} long-delay {long_delay} holddown {holddown} time-to-learn {time_to_learn}', tmp)
+
+        for interface in self._interfaces:
+            tmp = self.getFRRconfig(f'interface {interface}', daemon='isisd')
+            self.assertIn(f' ip router isis {domain}', tmp)
+            self.assertIn(f' ipv6 router isis {domain}', tmp)
+            self.assertIn(f' isis network {network}', tmp)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

isis: IETF SPF delay algorithm can not be configured - results in vyos.frr.CommitError

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/Txxxx

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

To reproduce:

```
set protocols isis interface eth1
set protocols isis net '49.0001.1921.6800.1002.00'
```

now enable SPF

```
set protocols isis spf-delay-ietf holddown '20'
set protocols isis spf-delay-ietf init-delay '31'
set protocols isis spf-delay-ietf long-delay '30'
set protocols isis spf-delay-ietf short-delay '32'
set protocols isis spf-delay-ietf time-to-learn '44'
```
This will only render the FRR config line: `spf-delay-ietf init-delay 31` which is incomplete:

```
frr-reload output:   2 2022-04-03 12:35:24,764   ERROR: vtysh failed to process new configuration: vtysh (mark file) exited with status 4:
frr-reload output:   3 b'line 15: % Command incomplete:  spf-delay-ietf init-delay 31\n\n'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
