### PR TITLE
ipoe: T2580: Add pools and gateway options

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.tmpl
+++ b/data/templates/accel-ppp/ipoe.config.tmpl
@@ -25,11 +25,21 @@ level=5
 verbose=1
 {% for interface in interfaces %}
 {% if interface.vlan_mon %}
-interface=re:{{ interface.name }}\.\d+,{% else %}interface={{ interface.name }},{% endif %}shared={{ interface.shared }},mode={{ interface.mode }},ifcfg={{ interface.ifcfg }},range={{ interface.range }},start={{ interface.sess_start }},ipv6=1
+interface=re:{{ interface.name }}\.\d+,{% else %}interface={{ interface.name }},{% endif %}shared={{ interface.shared }},mode={{ interface.mode }},ifcfg={{ interface.ifcfg }}{{ ',range=' + interface.range if interface.range is defined and interface.range is not none }},start={{ interface.sess_start }},ipv6=1
 {% endfor %}
-{% if auth_mode == 'noauth' %}
+{%   if auth_mode == 'noauth' %}
 noauth=1
-{% elif auth_mode == 'local' %}
+{%     if client_named_ip_pool %}
+{%       for pool in client_named_ip_pool %}
+{%         if pool.subnet is defined  %}
+ip-pool={{ pool.name }}
+{%         endif %}
+{%         if pool.gateway_address is defined %}
+gw-ip-address={{ pool.gateway_address }}/{{ pool.subnet.split('/')[1] }}
+{%         endif %}
+{%       endfor%}
+{%     endif %}
+{%   elif auth_mode == 'local' %}
 username=ifname
 password=csid
 {% endif %}
@@ -60,6 +70,18 @@ verbose=1
 
 [ipv6-dhcp]
 verbose=1
+
+{% if client_named_ip_pool %}
+[ip-pool]
+{%   for pool in client_named_ip_pool %}
+{%     if pool.subnet is defined  %}
+{{ pool.subnet }},name={{ pool.name }}
+{%     endif %}
+{%     if pool.gateway_address is defined %}
+gw-ip-address={{ pool.gateway_address }}/{{ pool.subnet.split('/')[1] }}
+{%     endif %}
+{%   endfor%}
+{% endif %}
 
 {% if client_ipv6_pool %}
 [ipv6-pool]

--- a/interface-definitions/include/accel-ppp/client-ip-pool-subnet-single.xml.i
+++ b/interface-definitions/include/accel-ppp/client-ip-pool-subnet-single.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from accel-ppp/client-ip-pool-subnet-single.xml.i -->
+<leafNode name="subnet">
+  <properties>
+    <help>Client IP subnet (CIDR notation)</help>
+    <valueHelp>
+      <format>ipv4net</format>
+      <description>IPv4 address and prefix length</description>
+    </valueHelp>
+    <constraint>
+      <validator name="ipv4-prefix"/>
+    </constraint>
+    <constraintErrorMessage>Not a valid CIDR formatted prefix</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/service_ipoe-server.xml.in
+++ b/interface-definitions/service_ipoe-server.xml.in
@@ -112,6 +112,22 @@
             </children>
           </tagNode>
           #include <include/name-server-ipv4-ipv6.xml.i>
+          <node name="client-ip-pool">
+            <properties>
+              <help>Client IP pools and gateway setting</help>
+            </properties>
+            <children>
+              <tagNode name="name">
+                <properties>
+                  <help>Pool name</help>
+                </properties>
+                <children>
+                  #include <include/accel-ppp/gateway-address.xml.i>
+                  #include <include/accel-ppp/client-ip-pool-subnet-single.xml.i>
+                </children>
+              </tagNode>
+            </children>
+          </node>
           #include <include/accel-ppp/client-ipv6-pool.xml.i>
           <node name="authentication">
             <properties>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add new feature to allow to use named pools
Can be used also with Radius attribute 'Framed-Pool'
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T2580

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipoe
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add named pool for server and get ip address on the client:
```
set service ipoe-server authentication mode 'noauth'
set service ipoe-server client-ip-pool name POOL1 gateway-address '192.0.2.2'
set service ipoe-server client-ip-pool name POOL1 subnet '192.0.2.0/24'
set service ipoe-server interface eth2
```
Show sessions:
```
vyos@testrouter:~$ show ipoe-server sessions 
ifname | username |    calling-sid    |    ip     | rate-limit | type | comp | state  |  uptime  
--------+----------+-------------------+-----------+------------+------+------+--------+----------
 ipoe0  |          | 00:50:79:66:68:14 | 192.0.2.0 |            | ipoe |      | active | 00:00:09
```

ipoe.conf:
```
[ipoe]
verbose=1
interface=eth2,shared=1,mode=L2,ifcfg=1,start=dhcpv4,ipv6=1
noauth=1
ip-pool=POOL1
gw-ip-address=192.0.2.2/24
proxy-arp=1

[ip-pool]
192.0.2.0/24,name=POOL1
gw-ip-address=192.0.2.2/24


```

Client:
```
VPCS> show ip

NAME        : VPCS[1]
IP/MASK     : 192.0.2.0/24
GATEWAY     : 192.0.2.2
DNS         :
DHCP SERVER : 192.0.2.2
DHCP LEASE  : 597, 600/300/525
MAC         : 00:50:79:66:68:14
LPORT       : 20000
RHOST:PORT  : 127.0.0.1:30000
MTU         : 1500
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
