### PR TITLE
T4341 SSH and system login fixes + smoketests

### DIFF
--- a/smoketest/scripts/cli/test_service_ssh.py
+++ b/smoketest/scripts/cli/test_service_ssh.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2020 VyOS maintainers and contributors
+# Copyright (C) 2019-2022 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -26,6 +26,7 @@ from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.configsession import ConfigSessionError
 from vyos.util import cmd
+from vyos.util import is_systemd_service_running
 from vyos.util import process_named_running
 from vyos.util import read_file
 
@@ -46,9 +47,17 @@ class TestServiceSSH(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(base_path)
 
     def tearDown(self):
+        # Check for running process
+        self.assertTrue(process_named_running(PROCESS_NAME))
+
         # delete testing SSH config
         self.cli_delete(base_path)
         self.cli_commit()
+
+        # Established SSH connections remains running after service is stopped.
+        # We can not use process_named_running here - we rather need to check
+        # that the systemd service is no longer running
+        self.assertFalse(is_systemd_service_running(PROCESS_NAME))
 
     def test_ssh_default(self):
         # Check if SSH service runs with default settings - used for checking
@@ -61,9 +70,6 @@ class TestServiceSSH(VyOSUnitTestSHIM.TestCase):
         # Check configured port
         port = get_config_value('Port')[0]
         self.assertEqual('22', port)
-
-        # Check for running process
-        self.assertTrue(process_named_running(PROCESS_NAME))
 
     def test_ssh_single_listen_address(self):
         # Check if SSH service can be configured and runs
@@ -101,9 +107,6 @@ class TestServiceSSH(VyOSUnitTestSHIM.TestCase):
         keepalive = get_config_value('ClientAliveInterval')[0]
         self.assertTrue("100" in keepalive)
 
-        # Check for running process
-        self.assertTrue(process_named_running(PROCESS_NAME))
-
     def test_ssh_multiple_listen_addresses(self):
         # Check if SSH service can be configured and runs with multiple
         # listen ports and listen-addresses
@@ -128,9 +131,6 @@ class TestServiceSSH(VyOSUnitTestSHIM.TestCase):
         for address in addresses:
             self.assertIn(address, tmp)
 
-        # Check for running process
-        self.assertTrue(process_named_running(PROCESS_NAME))
-
     def test_ssh_vrf(self):
         # Check if SSH service can be bound to given VRF
         port = '22'
@@ -149,9 +149,6 @@ class TestServiceSSH(VyOSUnitTestSHIM.TestCase):
         # Check configured port
         tmp = get_config_value('Port')
         self.assertIn(port, tmp)
-
-        # Check for running process
-        self.assertTrue(process_named_running(PROCESS_NAME))
 
         # Check for process in VRF
         tmp = cmd(f'ip vrf pids {vrf}')

--- a/smoketest/scripts/cli/test_system_login.py
+++ b/smoketest/scripts/cli/test_system_login.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2020 VyOS maintainers and contributors
+# Copyright (C) 2019-2022 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -23,6 +23,7 @@ from base_vyostest_shim import VyOSUnitTestSHIM
 from distutils.version import LooseVersion
 from platform import release as kernel_version
 from subprocess import Popen, PIPE
+from pwd import getpwall
 
 from vyos.configsession import ConfigSessionError
 from vyos.util import cmd
@@ -51,6 +52,11 @@ class TestSystemLogin(VyOSUnitTestSHIM.TestCase):
             self.cli_delete(base_path + ['user', user])
 
         self.cli_commit()
+
+        # After deletion, a user is not allowed to remain in /etc/passwd
+        usernames = [x[0] for x in getpwall()]
+        for user in users:
+            self.assertNotIn(user, usernames)
 
     def test_add_linux_system_user(self):
         # We are not allowed to re-use a username already taken by the Linux

--- a/src/conf_mode/system-login.py
+++ b/src/conf_mode/system-login.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020-2021 VyOS maintainers and contributors
+# Copyright (C) 2020-2022 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -23,6 +23,7 @@ from pwd import getpwall
 from pwd import getpwnam
 from spwd import getspnam
 from sys import exit
+from time import sleep
 
 from vyos.config import Config
 from vyos.configdict import dict_merge
@@ -31,6 +32,7 @@ from vyos.template import render
 from vyos.template import is_ipv4
 from vyos.util import cmd
 from vyos.util import call
+from vyos.util import run
 from vyos.util import DEVNULL
 from vyos.util import dict_search
 from vyos.xml import defaults
@@ -262,10 +264,16 @@ def apply(login):
                 # Logout user if he is still logged in
                 if user in list(set([tmp[0] for tmp in users()])):
                     print(f'{user} is logged in, forcing logout!')
-                    call(f'pkill -HUP -u {user}')
+                    # re-run command until user is logged out
+                    while run(f'pkill -HUP -u {user}'):
+                        sleep(0.250)
 
-                # Remove user account but leave home directory to be safe
-                call(f'userdel -r {user}', stderr=DEVNULL)
+                # Remove user account but leave home directory in place. Re-run
+                # command until user is removed - userdel might return 8 as
+                # SSH sessions are not all yet properly cleaned away, thus we
+                # simply re-run the command until the account wen't away
+                while run(f'userdel --remove {user}', stderr=DEVNULL):
+                    sleep(0.250)
 
             except Exception as e:
                 raise ConfigError(f'Deleting user "{user}" raised exception: {e}')

--- a/src/conf_mode/system-login.py
+++ b/src/conf_mode/system-login.py
@@ -256,6 +256,9 @@ def apply(login):
     if 'rm_users' in login:
         for user in login['rm_users']:
             try:
+                # Disable user to prevent re-login
+                call(f'usermod -s /sbin/nologin {user}')
+
                 # Logout user if he is still logged in
                 if user in list(set([tmp[0] for tmp in users()])):
                     print(f'{user} is logged in, forcing logout!')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Some extensions when we delete system users.

Before we delete a user account - we kill it's session and force a log-out. In theory the user could log back in in a very tiny window and prevent the deletion of the account.
To prevent this loophole the account should be disabled before we force a logout.

Source code: https://github.com/vyos/vyos-1x/blob/175b0a082808955adba811f18424a126e798dd32/src/conf_mode/system-login.py#L253-L259

In addition we only try to delete the user account once - if this fails - the account persists. `userdel(8)` should be called in a loop which only exists once the account deletion was completed successfully.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): New Smoketests

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4341

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* `system login`
* `service ssh`

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests inside

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
