### PR TITLE
dns: forwarding: T3804: bugfix DHCP name-servers used for recursion

### DIFF
--- a/src/conf_mode/dns_forwarding.py
+++ b/src/conf_mode/dns_forwarding.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2020 VyOS maintainers and contributors
+# Copyright (C) 2018-2022 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -16,6 +16,7 @@
 
 import os
 
+from netifaces import interfaces
 from sys import exit
 
 from vyos.config import Config
@@ -62,10 +63,6 @@ def get_config(config=None):
         if conf.exists(base_nameservers):
             dns.update({'system_name_server': conf.return_values(base_nameservers)})
 
-        base_nameservers_dhcp = ['system', 'name-servers-dhcp']
-        if conf.exists(base_nameservers_dhcp):
-            dns.update({'system_name_server_dhcp': conf.return_values(base_nameservers_dhcp)})
-
     return dns
 
 def verify(dns):
@@ -87,9 +84,8 @@ def verify(dns):
                 raise ConfigError(f'No server configured for domain {domain}!')
 
     if 'system' in dns:
-        if not ('system_name_server' in dns or 'system_name_server_dhcp' in dns):
-            print("Warning: No 'system name-server' or 'system " \
-                  "name-servers-dhcp' configured")
+        if not 'system_name_server' in dns:
+            print('Warning: No "system name-server" configured')
 
     return None
 
@@ -142,10 +138,15 @@ def apply(dns):
             hc.delete_name_server_tags_recursor(['system'])
 
         # add dhcp nameserver tags for configured interfaces
-        if 'system_name_server_dhcp' in dns:
-            for interface in dns['system_name_server_dhcp']:
-                hc.add_name_server_tags_recursor(['dhcp-' + interface,
-                                                  'dhcpv6-' + interface ])
+        if 'system_name_server' in dns:
+            for interface in dns['system_name_server']:
+                # system_name_server key contains both IP addresses and interface
+                # names (DHCP) to use DNS servers. We need to check if the
+                # value is an interface name - only if this is the case, add the
+                # interface based DNS forwarder.
+                if interface in interfaces():
+                    hc.add_name_server_tags_recursor(['dhcp-' + interface,
+                                                      'dhcpv6-' + interface ])
 
         # hostsd will generate the forward-zones file
         # the list and keys() are required as get returns a dict, not list


### PR DESCRIPTION
Commit 2ecf7a9f9c ('name-server: T3804: merge "system name-servers-dhcp" into
"system name-server"') missed out an old dictionary key "system_name_server_dhcp"
and thus system nameservers configured via DHCP did not get used for the DNS
forwar recursor.

(cherry picked from commit 806ff50bf1a970d731c2227f9d2cd2342b8a1b4e)

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3804

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
DNS forwarding

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set interfaces ethernet eth1 address dhcp
set system name-server eth1
set service dns forwarding allow-from 0.0.0.0/0
set service dns forwarding listen-address 172.18.254.201
set service dns forwarding system
```

The file `/run/powerdns/recursor.forward-zones.conf` needs to have an entry like:

```
# dhcp-eth1: 172.16.254.30
# dhcpv6-eth1:

+.=172.16.254.30
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
