### PR TITLE
interfaces: T4331: Fix assign link-local static IPv6 addr to vrf

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1434,9 +1434,6 @@ class Interface(Control):
                 else:
                     self.del_addr(addr)
 
-        for addr in new_addr:
-            self.add_addr(addr)
-
         # start DHCPv6 client when only PD was configured
         if dhcpv6pd:
             self.set_dhcpv6(True)
@@ -1450,6 +1447,10 @@ class Interface(Control):
             # also drop the interface out of a bridge or bond - thus this is
             # checked before
             self.set_vrf(config.get('vrf', ''))
+
+        # Add this section after vrf T4331
+        for addr in new_addr:
+            self.add_addr(addr)
 
         # Configure MSS value for IPv4 TCP connections
         tmp = dict_search('ip.adjust_mss', config)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Set address after vrf
Fix assign link-local static address to vrf

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4331

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
interfaces
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
If we have link-local static address `fe80::5200:ff:fe55:222/64` and vrf, for example:
```
set interfaces ethernet eth2 address 'fe80::5200:ff:fe55:222/64'
set interfaces ethernet eth2 vrf 'foo'
```

This IPv6 address was assign before vrf, as result after
attaching the interface to vrf we lose this static linklocal
address

```
DEBUG/IFCONFIG cmd 'ip addr add fe80::5200:ff:fe55:222/64 dev eth2'
DEBUG/IFCONFIG cmd 'ip link set dev eth2 master foo'
DEBUG/IFCONFIG cmd 'ip addr add fe80::5208:ff:fe13:2/64 dev eth2'
```

Before fix IPv6 address `fe80::5200:ff:fe55:222/64` not in the routing table:
```
set interfaces ethernet eth2 address 'fe80::5200:ff:fe55:222/64'
set interfaces ethernet eth2 address '192.0.2.5/32'
set interfaces ethernet eth2 address '2002:2::2/120'
et interfaces ethernet eth2 vrf 'foo'
set vrf name foo table '120'

4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast master foo state UP group default qlen 1000
    link/ether 50:08:00:13:00:02 brd ff:ff:ff:ff:ff:ff
    inet 192.0.2.5/32 scope global eth2
       valid_lft forever preferred_lft forever
    inet6 2002:2::2/120 scope global 
       valid_lft forever preferred_lft forever
    inet6 fe80::5208:ff:fe13:2/64 scope link 
       valid_lft forever preferred_lft forever
```

After fix IPv6 address `fe80::5200:ff:fe55:222/64` in the routing table
```
4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast master foo state UP group default qlen 1000
    link/ether 50:08:00:13:00:02 brd ff:ff:ff:ff:ff:ff
    inet 192.0.2.5/32 scope global eth2
       valid_lft forever preferred_lft forever
    inet6 2002:2::2/120 scope global 
       valid_lft forever preferred_lft forever
    inet6 fe80::5208:ff:fe13:2/64 scope link 
       valid_lft forever preferred_lft forever
    inet6 fe80::5200:ff:fe55:222/64 scope link 
       valid_lft forever preferred_lft forever
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
