### PR TITLE
ipoe: T2580: Add pools and gateway options

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.tmpl
+++ b/data/templates/accel-ppp/ipoe.config.tmpl
@@ -24,11 +24,24 @@ level=5
 [ipoe]
 verbose=1
 {% for interface in interfaces %}
-{% if interface.vlan_mon %}
-interface=re:{{ interface.name }}\.\d+,{% else %}interface={{ interface.name }},{% endif %}shared={{ interface.shared }},mode={{ interface.mode }},ifcfg={{ interface.ifcfg }},range={{ interface.range }},start={{ interface.sess_start }},ipv6=1
+{%   set ifname = interface.name %}
+{%   if interface.vlan_mon %}
+{%     set ifname = 're:' ~ interface.name ~ '\.\d+' %}
+{%   endif %}
+interface={{ ifname }},shared={{ interface.shared }},mode={{ interface.mode }},ifcfg={{ interface.ifcfg }}{{ ',range=' ~ interface.range if interface.range is defined and interface.range is not none }},start={{ interface.sess_start }},ipv6=1
 {% endfor %}
 {% if auth_mode == 'noauth' %}
 noauth=1
+{%   if client_named_ip_pool %}
+{%     for pool in client_named_ip_pool %}
+{%       if pool.subnet is defined  %}
+ip-pool={{ pool.name }}
+{%       endif %}
+{%       if pool.gateway_address is defined %}
+gw-ip-address={{ pool.gateway_address }}/{{ pool.subnet.split('/')[1] }}
+{%       endif %}
+{%     endfor%}
+{%   endif %}
 {% elif auth_mode == 'local' %}
 username=ifname
 password=csid
@@ -60,6 +73,18 @@ verbose=1
 
 [ipv6-dhcp]
 verbose=1
+
+{% if client_named_ip_pool %}
+[ip-pool]
+{%   for pool in client_named_ip_pool %}
+{%     if pool.subnet is defined  %}
+{{ pool.subnet }},name={{ pool.name }}
+{%     endif %}
+{%     if pool.gateway_address is defined %}
+gw-ip-address={{ pool.gateway_address }}/{{ pool.subnet.split('/')[1] }}
+{%     endif %}
+{%   endfor%}
+{% endif %}
 
 {% if client_ipv6_pool %}
 [ipv6-pool]

--- a/interface-definitions/include/accel-ppp/client-ip-pool-subnet-single.xml.i
+++ b/interface-definitions/include/accel-ppp/client-ip-pool-subnet-single.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from accel-ppp/client-ip-pool-subnet-single.xml.i -->
+<leafNode name="subnet">
+  <properties>
+    <help>Client IP subnet (CIDR notation)</help>
+    <valueHelp>
+      <format>ipv4net</format>
+      <description>IPv4 address and prefix length</description>
+    </valueHelp>
+    <constraint>
+      <validator name="ipv4-prefix"/>
+    </constraint>
+    <constraintErrorMessage>Not a valid CIDR formatted prefix</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/service_ipoe-server.xml.in
+++ b/interface-definitions/service_ipoe-server.xml.in
@@ -112,6 +112,26 @@
             </children>
           </tagNode>
           #include <include/name-server-ipv4-ipv6.xml.i>
+          <node name="client-ip-pool">
+            <properties>
+              <help>Client IP pools and gateway setting</help>
+            </properties>
+            <children>
+              <tagNode name="name">
+                <properties>
+                  <help>Pool name</help>
+                  <constraint>
+                    <regex>[-_a-zA-Z0-9]+</regex>
+                  </constraint>
+                  <constraintErrorMessage>Client IP pool is limited to alphanumerical characters and can contain hyphen and underscores</constraintErrorMessage>
+                </properties>
+                <children>
+                  #include <include/accel-ppp/gateway-address.xml.i>
+                  #include <include/accel-ppp/client-ip-pool-subnet-single.xml.i>
+                </children>
+              </tagNode>
+            </children>
+          </node>
           #include <include/accel-ppp/client-ipv6-pool.xml.i>
           <node name="authentication">
             <properties>


### PR DESCRIPTION
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add new feature to allow to use named pools
Can be used also with Radius attribute 'Framed-Pool'

```
set service ipoe-server client-ip-pool name POOL1 gateway-address '192.0.2.1'
set service ipoe-server client-ip-pool name POOL1 subnet '192.0.2.0/24'

```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T2580

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipoe
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service ipoe-server authentication mode 'noauth'
set service ipoe-server client-ip-pool name POOL1 gateway-address '192.0.2.2'
set service ipoe-server client-ip-pool name POOL1 subnet '192.0.2.0/24'
set service ipoe-server interface eth2
```

check ipoe session:
```
vyos@testrouter# run show ipoe-server sessions 
ifname | username |    calling-sid    |    ip     | rate-limit | type | comp | state  |  uptime  
--------+----------+-------------------+-----------+------------+------+------+--------+----------
 ipoe0  |          | 00:50:79:66:68:14 | 192.0.2.0 |            | ipoe |      | active | 00:00:11
[edit]
vyos@testrouter# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
