### PR TITLE
dns: T4343: forwarding timeout should be a config

### DIFF
--- a/data/templates/dns-forwarding/recursor.conf.tmpl
+++ b/data/templates/dns-forwarding/recursor.conf.tmpl
@@ -19,6 +19,9 @@ max-cache-entries={{ cache_size }}
 # negative TTL for NXDOMAIN
 max-negative-ttl={{ negative_ttl }}
 
+# network-timeout
+network-timeout={{ network_timeout }}
+
 # ignore-hosts-file
 export-etc-hosts={{ 'no' if ignore_hosts_file is defined else 'yes' }}
 

--- a/data/templates/dns-forwarding/recursor.conf.tmpl
+++ b/data/templates/dns-forwarding/recursor.conf.tmpl
@@ -19,8 +19,8 @@ max-cache-entries={{ cache_size }}
 # negative TTL for NXDOMAIN
 max-negative-ttl={{ negative_ttl }}
 
-# network-timeout
-network-timeout={{ network_timeout }}
+# timeout
+network-timeout={{ timeout }}
 
 # ignore-hosts-file
 export-etc-hosts={{ 'no' if ignore_hosts_file is defined else 'yes' }}

--- a/interface-definitions/dns-forwarding.xml.in
+++ b/interface-definitions/dns-forwarding.xml.in
@@ -598,15 +598,15 @@
                 </properties>
                 <defaultValue>3600</defaultValue>
               </leafNode>
-              <leafNode name="network-timeout">
+              <leafNode name="timeout">
                 <properties>
                   <help>Number of milliseconds to wait for a remote authoritative server to respond</help>
                   <valueHelp>
-                    <format>u32:0-4294967295</format>
+                    <format>u32:10-60000</format>
                     <description>Network timeout in milliseconds</description>
                   </valueHelp>
                   <constraint>
-                    <validator name="numeric" argument="--range 0-4294967295"/>
+                    <validator name="numeric" argument="--range 10-60000"/>
                   </constraint>
                 </properties>
                 <defaultValue>1500</defaultValue>

--- a/interface-definitions/dns-forwarding.xml.in
+++ b/interface-definitions/dns-forwarding.xml.in
@@ -598,6 +598,19 @@
                 </properties>
                 <defaultValue>3600</defaultValue>
               </leafNode>
+              <leafNode name="network-timeout">
+                <properties>
+                  <help>Number of milliseconds to wait for a remote authoritative server to respond</help>
+                  <valueHelp>
+                    <format>u32:0-4294967295</format>
+                    <description>Network timeout in milliseconds</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967295"/>
+                  </constraint>
+                </properties>
+                <defaultValue>1500</defaultValue>
+              </leafNode>
               #include <include/name-server-ipv4-ipv6.xml.i>
               <leafNode name="source-address">
                 <properties>

--- a/smoketest/configs/dialup-router-complex
+++ b/smoketest/configs/dialup-router-complex
@@ -1361,6 +1361,7 @@ service {
             listen-address 172.16.254.30
             listen-address 172.31.0.254
             negative-ttl 60
+            network-timeout 5000
         }
     }
     lldp {

--- a/smoketest/configs/dialup-router-complex
+++ b/smoketest/configs/dialup-router-complex
@@ -1361,7 +1361,7 @@ service {
             listen-address 172.16.254.30
             listen-address 172.31.0.254
             negative-ttl 60
-            network-timeout 5000
+            timeout 5000
         }
     }
     lldp {

--- a/smoketest/configs/dialup-router-complex
+++ b/smoketest/configs/dialup-router-complex
@@ -1361,7 +1361,6 @@ service {
             listen-address 172.16.254.30
             listen-address 172.31.0.254
             negative-ttl 60
-            timeout 5000
         }
     }
     lldp {


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Make the dns forwarder network-timeout for remote authoritative dns servers configurable.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4343

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* dns

## Proposed changes
<!--- Describe your changes in detail -->
Makes the powerdns `network-timeout` setting configurable via: `service dns forwarding network-timeout`.
The powerdns default is 1500ms, VyOS now explicitly sets the same default value or the configured value so that the setting can have a readily apparent default in the help, rather than the user having to know it's powerdns.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
I ran the tests (Are these the smoke tests?):
```
# make test 
set -e; python3 -m compileall -q -x '/vmware-tools/scripts/, /ppp/' .
PYTHONPATH=python/ python3 -m "nose" --with-xunit src --with-coverage --cover-erase --cover-xml --cover-package src/conf_mode,src/op_mode,src/completion,src/helpers,src/validators,src/tests --verbose
test_copy (test_config_parser.TestConfigParser) ... ok
test_copy_duplicate (test_config_parser.TestConfigParser) ... ok
test_rename (test_config_parser.TestConfigParser) ... ok
test_rename_duplicate (test_config_parser.TestConfigParser) ... ok
test_top_level_leaf (test_config_parser.TestConfigParser) ... ok
test_top_level_tag (test_config_parser.TestConfigParser) ... ok
test_top_level_valueless (test_config_parser.TestConfigParser) ... ok
test_dh_key_256 (test_configverify.TestDictSearch) ... ok
test_dh_key_512 (test_configverify.TestDictSearch) ... ok
test_dh_key_none (test_configverify.TestDictSearch) ... ok
test_dict_key_value (test_dict_search.TestDictSearch) ... ok
test_dict_search_recursive (test_dict_search.TestDictSearch) ... ok
test_invalid_input (test_dict_search.TestDictSearch) ... ok
test_list (test_dict_search.TestDictSearch) ... ok
test_nested_dict_key_empty (test_dict_search.TestDictSearch) ... ok
test_nested_dict_key_value (test_dict_search.TestDictSearch) ... ok
test_nested_list (test_dict_search.TestDictSearch) ... ok
test_non_existing_keys (test_dict_search.TestDictSearch) ... ok
test_string (test_dict_search.TestDictSearch) ... ok
test_create_user (test_initial_setup.TestInitialSetup) ... ok
test_disable_user_password (test_initial_setup.TestInitialSetup) ... ok
test_set_gateway (test_initial_setup.TestInitialSetup) ... ok
test_set_hostname (test_initial_setup.TestInitialSetup) ... ok
test_set_name_servers (test_initial_setup.TestInitialSetup) ... ok
test_set_ssh_key_with_name (test_initial_setup.TestInitialSetup) ... ok
test_set_ssh_key_without_name (test_initial_setup.TestInitialSetup) ... ok
test_set_user_password (test_initial_setup.TestInitialSetup) ... ok
test_helpers_first_host_address (test_jinja_filters.TestTeamplteHelpers) ... ok
test_helpers_from_cidr (test_jinja_filters.TestTeamplteHelpers) ... ok
test_helpers_ipv4 (test_jinja_filters.TestTeamplteHelpers) ... ok
test_helpers_ipv6 (test_jinja_filters.TestTeamplteHelpers) ... ok
test_generate (test_task_scheduler.TestUpdateCrontab) ... ok
test_verify (test_task_scheduler.TestUpdateCrontab) ... ok
test_address_from_cidr (test_template.TestVyOSTemplate) ... ok
test_cipher_to_string (test_template.TestVyOSTemplate) ... ok
test_decrement_ip (test_template.TestVyOSTemplate) ... ok
test_first_host_address (test_template.TestVyOSTemplate) ... ok
test_increment_ip (test_template.TestVyOSTemplate) ... ok
test_is_interface (test_template.TestVyOSTemplate) ... ok
test_is_ip (test_template.TestVyOSTemplate) ... ok
test_is_ipv4 (test_template.TestVyOSTemplate) ... ok
test_is_ipv6 (test_template.TestVyOSTemplate) ... ok
test_is_network (test_template.TestVyOSTemplate) ... ok
test_last_host_address (test_template.TestVyOSTemplate) ... ok
test_netmask_from_cidr (test_template.TestVyOSTemplate) ... ok
test_ipv6_enabled (test_util.TestVyOSUtil) ... ok
test_key_mangline (test_util.TestVyOSUtil) ... ok
test_sysctl_read (test_util.TestVyOSUtil) ... ok
test_is_addr_assigned (test_validate.TestVyOSValidate) ... ok
test_is_ipv6_link_local (test_validate.TestVyOSValidate) ... ok

----------------------------------------------------------------------
XML: /vyos/vyos-1x/nosetests.xml
Name                                           Stmts   Miss  Cover   Missing
----------------------------------------------------------------------------
src/completion/list_disks.py                      20     20     0%   19-45
src/completion/list_dumpable_interfaces.py         6      6     0%   5-12
src/completion/list_interfaces.py                 28     28     0%   17-54
src/completion/list_ipoe.py                       11     11     0%   3-16
src/completion/list_openvpn_clients.py            33     33     0%   17-59
src/completion/list_openvpn_users.py              23     23     0%   17-47
src/conf_mode/arp.py                              56     56     0%   19-104
src/conf_mode/bcast_relay.py                      63     63     0%   17-111
src/conf_mode/conntrack.py                        92     92     0%   17-171
src/conf_mode/conntrack_sync.py                   91     91     0%   17-146
src/conf_mode/containers.py                      224    224     0%   17-356
src/conf_mode/dhcp_relay.py                       53     53     0%   17-92
src/conf_mode/dhcp_server.py                     180    180     0%   17-327
src/conf_mode/dhcpv6_relay.py                     65     65     0%   17-109
src/conf_mode/dhcpv6_server.py                   108    108     0%   17-188
src/conf_mode/dns_forwarding.py                  217    217     0%   17-375
src/conf_mode/dynamic_dns.py                      83     83     0%   17-155
src/conf_mode/firewall-interface.py              109    109     0%   17-175
src/conf_mode/firewall.py                        286    286     0%   17-428
src/conf_mode/flow_accounting_conf.py            168    168     0%   17-281
src/conf_mode/high-availability.py               117    117     0%   17-180
src/conf_mode/host_name.py                       105    105     0%   17-187
src/conf_mode/http-api.py                         90     90     0%   17-146
src/conf_mode/https.py                           143    143     0%   17-237
src/conf_mode/igmp_proxy.py                       70     70     0%   17-121
src/conf_mode/intel_qat.py                        52     52     0%   17-105
src/conf_mode/interfaces-bonding.py              140    140     0%   17-219
src/conf_mode/interfaces-bridge.py               110    110     0%   17-178
src/conf_mode/interfaces-dummy.py                 43     43     0%   17-76
src/conf_mode/interfaces-ethernet.py             134    134     0%   17-217
src/conf_mode/interfaces-geneve.py                51     51     0%   17-92
src/conf_mode/interfaces-l2tpv3.py                64     64     0%   17-110
src/conf_mode/interfaces-loopback.py              36     36     0%   17-66
src/conf_mode/interfaces-macsec.py                73     73     0%   17-139
src/conf_mode/interfaces-openvpn.py              437    437     0%   17-684
src/conf_mode/interfaces-pppoe.py                 87     87     0%   17-148
src/conf_mode/interfaces-pseudo-ethernet.py       57     57     0%   17-99
src/conf_mode/interfaces-tunnel.py               134    134     0%   17-218
src/conf_mode/interfaces-vti.py                   38     38     0%   17-68
src/conf_mode/interfaces-vxlan.py                101    101     0%   17-174
src/conf_mode/interfaces-wireguard.py             74     74     0%   17-120
src/conf_mode/interfaces-wireless.py             179    179     0%   17-286
src/conf_mode/interfaces-wwan.py                 118    118     0%   17-196
src/conf_mode/le_cert.py                          64     64     0%   17-114
src/conf_mode/lldp.py                             83     83     0%   17-137
src/conf_mode/nat.py                             124    124     0%   17-210
src/conf_mode/nat66.py                           115    115     0%   17-176
src/conf_mode/netns.py                            71     71     0%   17-118
src/conf_mode/ntp.py                              53     53     0%   17-88
src/conf_mode/pki.py                             133    133     0%   17-203
src/conf_mode/policy-local-route.py              154    154     0%   17-222
src/conf_mode/policy-route-interface.py           73     73     0%   17-120
src/conf_mode/policy-route.py                    190    190     0%   17-261
src/conf_mode/policy.py                          137    137     0%   17-223
src/conf_mode/protocols_bfd.py                    75     75     0%   17-124
src/conf_mode/protocols_bgp.py                   203    203     0%   17-342
src/conf_mode/protocols_igmp.py                   74     74     0%   17-139
src/conf_mode/protocols_isis.py                  147    147     0%   17-262
src/conf_mode/protocols_mpls.py                   86     86     0%   17-143
src/conf_mode/protocols_nhrp.py                   79     79     0%   17-119
src/conf_mode/protocols_ospf.py                  143    143     0%   17-255
src/conf_mode/protocols_ospfv3.py                 98     98     0%   17-184
src/conf_mode/protocols_pim.py                    88     88     0%   17-166
src/conf_mode/protocols_rip.py                    85     85     0%   17-144
src/conf_mode/protocols_ripng.py                  77     77     0%   17-129
src/conf_mode/protocols_rpki.py                   69     69     0%   17-108
src/conf_mode/protocols_static.py                 73     73     0%   17-131
src/conf_mode/protocols_static_multicast.py       66     66     0%   17-120
src/conf_mode/qos.py                              49     49     0%   17-90
src/conf_mode/salt-minion.py                      70     70     0%   17-126
src/conf_mode/service_console-server.py           72     72     0%   17-127
src/conf_mode/service_ids_fastnetmon.py           55     55     0%   17-92
src/conf_mode/service_ipoe-server.py             170    170     0%   17-331
src/conf_mode/service_mdns-repeater.py            83     83     0%   17-130
src/conf_mode/service_monitoring_telegraf.py      99     99     0%   17-175
src/conf_mode/service_pppoe-server.py             72     72     0%   17-122
src/conf_mode/service_router-advert.py            78     78     0%   17-128
src/conf_mode/service_upnp.py                    108    108     0%   17-157
src/conf_mode/service_webproxy.py                117    117     0%   17-209
src/conf_mode/snmp.py                            193    193     0%   17-311
src/conf_mode/ssh.py                              70     70     0%   17-111
src/conf_mode/system-ip.py                        47     47     0%   17-84
src/conf_mode/system-ipv6.py                      59     59     0%   17-103
src/conf_mode/system-login-banner.py              60     60     0%   17-107
src/conf_mode/system-login.py                    179    179     0%   17-319
src/conf_mode/system-logs.py                      41     41     0%   17-83
src/conf_mode/system-option.py                    89     89     0%   17-143
src/conf_mode/system-proxy.py                     51     51     0%   19-95
src/conf_mode/system-syslog.py                   135    135     0%   17-276
src/conf_mode/system-timezone.py                  33     33     0%   17-61
src/conf_mode/system_console.py                   99     99     0%   17-173
src/conf_mode/system_lcd.py                       51     51     0%   17-91
src/conf_mode/system_sysctl.py                    41     41     0%   17-73
src/conf_mode/task_scheduler.py                   95     24    75%   54, 57-79, 142, 146-153
src/conf_mode/tftp_server.py                      88     88     0%   17-145
src/conf_mode/vpn_ipsec.py                       441    441     0%   17-616
src/conf_mode/vpn_l2tp.py                        208    208     0%   17-393
src/conf_mode/vpn_openconnect.py                 125    125     0%   17-197
src/conf_mode/vpn_pptp.py                        159    159     0%   17-296
src/conf_mode/vpn_sstp.py                         94     94     0%   17-158
src/conf_mode/vrf.py                             144    144     0%   17-258
src/conf_mode/vrf_vni.py                          38     38     0%   17-65
src/conf_mode/zone_policy.py                     149    149     0%   17-213
src/helpers/commit-confirm-notify.py              20     20     0%   2-30
src/helpers/run-config-migration.py               39     39     0%   18-86
src/helpers/strip-private.py                      56     56     0%   18-153
src/helpers/system-versions-foot.py               14     14     0%   18-38
src/helpers/vyos-boot-config-loader.py           110    110     0%   19-178
src/helpers/vyos-check-wwan.py                    12     12     0%   17-35
src/helpers/vyos-interface-rescan.py             124    124     0%   19-206
src/helpers/vyos-load-config.py                   60     60     0%   19-104
src/helpers/vyos-merge-config.py                  70     70     0%   18-111
src/helpers/vyos-sudo.py                          11     11     0%   18-33
src/op_mode/clear_conntrack.py                     7      7     0%   17-26
src/op_mode/connect_disconnect.py                 57     57     0%   17-99
src/op_mode/conntrack_sync.py                    121    121     0%   17-181
src/op_mode/containers_op.py                      48     48     0%   17-78
src/op_mode/cpu_summary.py                        19     19     0%   17-47
src/op_mode/dns_forwarding_reset.py               22     22     0%   23-54
src/op_mode/dns_forwarding_statistics.py          16     16     0%   3-32
src/op_mode/dynamic_dns.py                        56     56     0%   17-107
src/op_mode/firewall.py                          269    269     0%   17-361
src/op_mode/flow_accounting_op.py                131    131     0%   18-252
src/op_mode/format_disk.py                        80     80     0%   17-133
src/op_mode/generate_ovpn_client_file.py          45     45     0%   17-145
src/op_mode/generate_public_key_command.py        24     24     0%   17-45
src/op_mode/generate_ssh_server_key.py             8      8     0%   17-26
src/op_mode/ikev2_profile_generator.py           100    100     0%   17-230
src/op_mode/ipoe-control.py                       28     28     0%   17-65
src/op_mode/lldp_op.py                            76     76     0%   17-127
src/op_mode/maya_date.py                          51     51     0%   17-208
src/op_mode/openconnect-control.py                38     38     0%   17-67
src/op_mode/ping.py                               77     77     0%   17-240
src/op_mode/pki.py                               614    614     0%   17-867
src/op_mode/policy_route.py                      132    132     0%   17-189
src/op_mode/powerctrl.py                         137    137     0%   17-221
src/op_mode/ppp-server-ctrl.py                    30     30     0%   17-74
src/op_mode/reset_openvpn.py                      12     12     0%   17-31
src/op_mode/reset_vpn.py                          31     31     0%   17-72
src/op_mode/restart_dhcp_relay.py                 23     23     0%   21-55
src/op_mode/restart_frr.py                       103    103     0%   17-180
src/op_mode/show-bond.py                          51     51     0%   17-92
src/op_mode/show_acceleration.py                  76     76     0%   18-116
src/op_mode/show_configuration_json.py            12     12     0%   17-36
src/op_mode/show_cpu.py                           33     33     0%   17-71
src/op_mode/show_dhcp.py                         156    156     0%   19-259
src/op_mode/show_dhcpv6.py                       134    134     0%   19-219
src/op_mode/show_igmpproxy.py                     90     90     0%   22-240
src/op_mode/show_interfaces.py                   176    176     0%   18-305
src/op_mode/show_ipsec_sa.py                      80     80     0%   17-130
src/op_mode/show_nat66_rules.py                   64     64     0%   17-101
src/op_mode/show_nat66_statistics.py              23     23     0%   17-62
src/op_mode/show_nat66_translations.py           136    136     0%   17-204
src/op_mode/show_nat_rules.py                     85     85     0%   17-122
src/op_mode/show_nat_statistics.py                23     23     0%   17-62
src/op_mode/show_nat_translations.py             136    136     0%   17-204
src/op_mode/show_neigh.py                         28     28     0%   61-96
src/op_mode/show_openvpn.py                       82     82     0%   18-177
src/op_mode/show_openvpn_mfa.py                   36     36     0%   18-63
src/op_mode/show_ram.py                           31     31     0%   18-71
src/op_mode/show_sensors.py                       20     20     0%   3-25
src/op_mode/show_uptime.py                        34     34     0%   17-63
src/op_mode/show_usb_serial.py                    21     21     0%   17-57
src/op_mode/show_users.py                         63     63     0%   16-111
src/op_mode/show_version.py                       27     27     0%   21-76
src/op_mode/show_virtual_server.py                12     12     0%   17-33
src/op_mode/show_vpn_ra.py                        25     25     0%   17-56
src/op_mode/show_vrf.py                           31     31     0%   17-66
src/op_mode/show_wireless.py                      83     83     0%   17-149
src/op_mode/show_wwan.py                          55     55     0%   17-82
src/op_mode/snmp.py                               40     40     0%   22-78
src/op_mode/snmp_ifmib.py                         70     70     0%   22-121
src/op_mode/snmp_v3.py                            75     75     0%   22-180
src/op_mode/vpn_ike_sa.py                         47     47     0%   17-77
src/op_mode/vpn_ipsec.py                          79     79     0%   17-119
src/op_mode/vrrp.py                               38     38     0%   18-66
src/op_mode/wireguard_client.py                   52     52     0%   17-119
src/op_mode/zone_policy.py                        47     47     0%   17-81
src/tests/helper.py                                7      7     0%   17-24
src/tests/test_config_parser.py                   30      0   100%
src/tests/test_configverify.py                    17      0   100%
src/tests/test_dict_search.py                     31      0   100%
src/tests/test_find_device_file.py                13     13     0%   17-35
src/tests/test_initial_setup.py                   59      1    98%   101
src/tests/test_jinja_filters.py                   46      0   100%
src/tests/test_task_scheduler.py                  34      5    85%   25-28, 129
src/tests/test_template.py                        91      8    91%   31, 107-114
src/tests/test_util.py                            15      1    93%   36
src/tests/test_validate.py                        26      9    65%   30-38
----------------------------------------------------------------------------
TOTAL                                          16102  15706     2%
----------------------------------------------------------------------
Ran 50 tests in 2.100s

OK
```

I ran this on my own router with several timeouts from very short which always produces SERVFAIL to more reasonable values.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
