### PR TITLE
T4331: IPv6 link local addresses are not configured when an interface is in a VRF (equuleus)

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1296,9 +1296,6 @@ class Interface(Control):
                 else:
                     self.del_addr(addr)
 
-        for addr in new_addr:
-            self.add_addr(addr)
-
         # start DHCPv6 client when only PD was configured
         if dhcpv6pd:
             self.set_dhcpv6(True)
@@ -1312,6 +1309,10 @@ class Interface(Control):
             # also drop the interface out of a bridge or bond - thus this is
             # checked before
             self.set_vrf(config.get('vrf', ''))
+
+        # Add this section after vrf T4331
+        for addr in new_addr:
+            self.add_addr(addr)
 
         # Configure ARP cache timeout in milliseconds - has default value
         tmp = dict_search('ip.arp_cache_timeout', config)

--- a/smoketest/scripts/cli/test_vrf.py
+++ b/smoketest/scripts/cli/test_vrf.py
@@ -29,6 +29,7 @@ from vyos.ifconfig import Section
 from vyos.template import is_ipv6
 from vyos.util import cmd
 from vyos.util import read_file
+from vyos.util import get_interface_config
 from vyos.validate import is_intf_addr_assigned
 
 base_path = ['vrf']
@@ -176,11 +177,11 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
         # commit changes
         self.cli_commit()
 
-        # Verify & cleanup
+        # Verify VRF assignmant
         for interface in self._interfaces:
-            # os.readlink resolves to: '../../../../../virtual/net/foovrf'
-            tmp = os.readlink(f'/sys/class/net/{interface}/master').split('/')[-1]
-            self.assertEqual(tmp, vrf)
+            tmp = get_interface_config(interface)
+            self.assertEqual(vrf, tmp['master'])
+
             # cleanup
             section = Section.section(interface)
             self.cli_delete(['interfaces', section, interface, 'vrf'])
@@ -255,6 +256,46 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
             self.cli_delete(['interfaces', 'ethernet', 'eth0', 'address', '192.0.2.1/24'])
 
             table = str(int(table) + 1)
+
+    def test_vrf_link_local_ip_addresses(self):
+        # Testcase for issue T4331
+        table = '100'
+        vrf = 'orange'
+        interface = 'dum9998'
+        addresses = ['192.0.2.1/26', '2001:db8:9998::1/64', 'fe80::1/64']
+
+        for address in addresses:
+            self.cli_set(['interfaces', 'dummy', interface, 'address', address])
+
+        # Create dummy interfaces
+        self.cli_commit()
+
+        # ... and verify IP addresses got assigned
+        for address in addresses:
+            self.assertTrue(is_intf_addr_assigned(interface, address))
+
+        # Move interface to VRF
+        self.cli_set(base_path + ['name', vrf, 'table', table])
+        self.cli_set(['interfaces', 'dummy', interface, 'vrf', vrf])
+
+        # Apply VRF config
+        self.cli_commit()
+        # Ensure VRF got created
+        self.assertIn(vrf, interfaces())
+        # ... and IP addresses are still assigned
+        for address in addresses:
+            self.assertTrue(is_intf_addr_assigned(interface, address))
+        # Verify VRF table ID
+        tmp = get_interface_config(vrf)
+        self.assertEqual(int(table), tmp['linkinfo']['info_data']['table'])
+
+        # Verify interface is assigned to VRF
+        tmp = get_interface_config(interface)
+        self.assertEqual(vrf, tmp['master'])
+
+        # Delete Interface
+        self.cli_delete(['interfaces', 'dummy', interface])
+        self.cli_commit()
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

When an interface is configured with a VRF and link local address, the link local address is not configured (ip a show eth0). This happens right after configuring the VRF on the interface (the previously configured link local address is removed) and on boot.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4331

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

VRF

## Proposed changes
<!--- Describe your changes in detail -->

re-order IP address assignment

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketest

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
