### PR TITLE
T4346 Deprecate "system ipv6 disable" option to disable address family within OS kernel (equuleus)

### DIFF
--- a/python/vyos/base.py
+++ b/python/vyos/base.py
@@ -15,6 +15,12 @@
 
 from textwrap import fill
 
+class DeprecationWarning():
+    def __init__(self, message):
+        # Reformat the message and trim it to 72 characters in length
+        message = fill(message, width=72)
+        print(f'\nDEPRECATION WARNING: {message}\n')
+
 class ConfigError(Exception):
     def __init__(self, message):
         # Reformat the message and trim it to 72 characters in length

--- a/src/conf_mode/system-ipv6.py
+++ b/src/conf_mode/system-ipv6.py
@@ -17,6 +17,7 @@
 import os
 
 from sys import exit
+from vyos.base import DeprecationWarning
 from vyos.config import Config
 from vyos.configdict import dict_merge
 from vyos.configdict import leaf_node_changed
@@ -49,6 +50,9 @@ def get_config(config=None):
     return opt
 
 def verify(opt):
+    if 'disable' in opt:
+        DeprecationWarning('VyOS 1.4 (sagitta) will remove the CLI command to '\
+                           'disable IPv6 address family in the Linux Kernel!')
     pass
 
 def generate(opt):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Disabling an entire address family in an IPv6 enabled operating system/world actually adds more harm then good to VyOS.

VyOS does not send out any RA if not configured explicitly thus VyOS behaves like any other Linux/Windows/Mac when it comes to networking.
It only does what it's instructed to do.

Reasons why this option is marked deprecated in 1.3 and removed in 1.4:

- IPv6 is more then 20 years old
- No RAs sent by VyOS if not told so
- Disabling IPv6 but have services listen on an IPv6 address could cause all kind of config errors on reboots

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): deprecation

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4346

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
IPv6

## Proposed changes
<!--- Describe your changes in detail -->

```
cpo@LR1.wue3# set system ipv6 disable
[edit]
cpo@LR1.wue3# commit
[ system ipv6 ]

DEPRECATION WARNING: VyOS 1.4 (sagitta) will remove the CLI command to disable IPv6 address
family in the Linux Kernel!

Changing IPv6 disable parameter will only take affect
when the system is rebooted.
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

`set system ipv6 disable`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
