### PR TITLE
Firewall: T990: Add snat and dnat connection status on firewall

### DIFF
--- a/interface-definitions/include/firewall/common-rule.xml.i
+++ b/interface-definitions/include/firewall/common-rule.xml.i
@@ -95,51 +95,25 @@
     </constraint>
   </properties>
 </leafNode>
-<node name="ct-status">
+<leafNode name="connection-status">
   <properties>
-    <help>Connection status in conntrack</help>
+    <help>Connection status</help>
+    <completionHelp>
+      <list>dnat snat</list>
+    </completionHelp>
+    <valueHelp>
+      <format>dnat</format>
+      <description>Match connections that are subject to destination NAT</description>
+    </valueHelp>
+    <valueHelp>
+      <format>snat</format>
+      <description>Match connections that are subject to source NAT</description>
+    </valueHelp>
+    <constraint>
+      <regex>^(dnat|snat)$</regex>
+    </constraint>
   </properties>
-  <children>
-    <leafNode name="dnat">
-      <properties>
-        <help>Set when connection needs DNAT in original direction</help>
-        <completionHelp>
-          <list>enable disable</list>
-        </completionHelp>
-        <valueHelp>
-          <format>enable</format>
-          <description>Enable</description>
-        </valueHelp>
-        <valueHelp>
-          <format>disable</format>
-          <description>Disable</description>
-        </valueHelp>
-        <constraint>
-          <regex>^(enable|disable)$</regex>
-        </constraint>
-      </properties>
-    </leafNode>
-    <leafNode name="snat">
-      <properties>
-        <help>Set when connection needs SNAT in original direction</help>
-        <completionHelp>
-          <list>enable disable</list>
-        </completionHelp>
-        <valueHelp>
-          <format>enable</format>
-          <description>Enable</description>
-        </valueHelp>
-        <valueHelp>
-          <format>disable</format>
-          <description>Disable</description>
-        </valueHelp>
-        <constraint>
-          <regex>^(enable|disable)$</regex>
-        </constraint>
-      </properties>
-    </leafNode>
-  </children>
-</node>
+</leafNode>
 <leafNode name="protocol">
   <properties>
     <help>Protocol to match (protocol name, number, or "all")</help>

--- a/interface-definitions/include/firewall/common-rule.xml.i
+++ b/interface-definitions/include/firewall/common-rule.xml.i
@@ -95,6 +95,51 @@
     </constraint>
   </properties>
 </leafNode>
+<node name="ct-status">
+  <properties>
+    <help>Connection status in conntrack</help>
+  </properties>
+  <children>
+    <leafNode name="dnat">
+      <properties>
+        <help>Set when connection needs DNAT in original direction</help>
+        <completionHelp>
+          <list>enable disable</list>
+        </completionHelp>
+        <valueHelp>
+          <format>enable</format>
+          <description>Enable</description>
+        </valueHelp>
+        <valueHelp>
+          <format>disable</format>
+          <description>Disable</description>
+        </valueHelp>
+        <constraint>
+          <regex>^(enable|disable)$</regex>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="snat">
+      <properties>
+        <help>Set when connection needs SNAT in original direction</help>
+        <completionHelp>
+          <list>enable disable</list>
+        </completionHelp>
+        <valueHelp>
+          <format>enable</format>
+          <description>Enable</description>
+        </valueHelp>
+        <valueHelp>
+          <format>disable</format>
+          <description>Disable</description>
+        </valueHelp>
+        <constraint>
+          <regex>^(enable|disable)$</regex>
+        </constraint>
+      </properties>
+    </leafNode>
+  </children>
+</node>
 <leafNode name="protocol">
   <properties>
     <help>Protocol to match (protocol name, number, or "all")</help>

--- a/interface-definitions/include/firewall/common-rule.xml.i
+++ b/interface-definitions/include/firewall/common-rule.xml.i
@@ -95,25 +95,32 @@
     </constraint>
   </properties>
 </leafNode>
-<leafNode name="connection-status">
+<node name="connection-status">
   <properties>
     <help>Connection status</help>
-    <completionHelp>
-      <list>dnat snat</list>
-    </completionHelp>
-    <valueHelp>
-      <format>dnat</format>
-      <description>Match connections that are subject to destination NAT</description>
-    </valueHelp>
-    <valueHelp>
-      <format>snat</format>
-      <description>Match connections that are subject to source NAT</description>
-    </valueHelp>
-    <constraint>
-      <regex>^(dnat|snat)$</regex>
-    </constraint>
   </properties>
-</leafNode>
+  <children>
+    <leafNode name="nat">
+      <properties>
+        <help>NAT connection status</help>
+        <completionHelp>
+          <list>destination source</list>
+        </completionHelp>
+        <valueHelp>
+          <format>destination</format>
+          <description>Match connections that are subject to destination NAT</description>
+        </valueHelp>
+        <valueHelp>
+          <format>source</format>
+          <description>Match connections that are subject to source NAT</description>
+        </valueHelp>
+        <constraint>
+          <regex>^(destination|source)$</regex>
+        </constraint>
+      </properties>
+    </leafNode>
+  </children>
+</node>
 <leafNode name="protocol">
   <properties>
     <help>Protocol to match (protocol name, number, or "all")</help>

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -49,11 +49,9 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
         if states:
             output.append(f'ct state {{{states}}}')
 
-    if 'ct_status' in rule_conf and rule_conf['ct_status']:
-        status = ",".join([s for s, v in rule_conf['ct_status'].items() if v == 'enable'])
-
-        if status:
-            output.append(f'ct status {{{status}}}')
+    if 'connection_status' in rule_conf and rule_conf['connection_status']:
+        status = rule_conf['connection_status']
+        output.append(f'ct status {{{status}}}')
 
     if 'protocol' in rule_conf and rule_conf['protocol'] != 'all':
         proto = rule_conf['protocol']

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -49,6 +49,12 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
         if states:
             output.append(f'ct state {{{states}}}')
 
+    if 'ct_status' in rule_conf and rule_conf['ct_status']:
+        status = ",".join([s for s, v in rule_conf['ct_status'].items() if v == 'enable'])
+
+        if status:
+            output.append(f'ct status {{{status}}}')
+
     if 'protocol' in rule_conf and rule_conf['protocol'] != 'all':
         proto = rule_conf['protocol']
         operator = ''

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -51,7 +51,12 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
 
     if 'connection_status' in rule_conf and rule_conf['connection_status']:
         status = rule_conf['connection_status']
-        output.append(f'ct status {{{status}}}')
+        if status['nat'] == 'destination':
+            nat_status = '{dnat}'
+            output.append(f'ct status {nat_status}')
+        if status['nat'] == 'source':
+            nat_status = '{snat}'
+            output.append(f'ct status {nat_status}')
 
     if 'protocol' in rule_conf and rule_conf['protocol'] != 'all':
         proto = rule_conf['protocol']

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -162,6 +162,45 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
                 nftables_output = cmd(f'sudo nft list chain {table} {chain}')
                 self.assertTrue('jump VYOS_STATE_POLICY' in nftables_output)
 
+    def test_state_and_status_rules(self):
+        self.cli_set(['firewall', 'name', 'smoketest', 'default-action', 'drop'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '1', 'action', 'accept'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '1', 'state', 'established', 'enable'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '1', 'state', 'related', 'enable'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '2', 'action', 'reject'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '2', 'state', 'invalid', 'enable'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '3', 'action', 'accept'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '3', 'state', 'new', 'enable'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '3', 'ct-status', 'dnat', 'enable'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '4', 'action', 'accept'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '4', 'state', 'new', 'enable'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '4', 'state', 'established', 'enable'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '4', 'ct-status', 'snat', 'enable'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '4', 'ct-status', 'dnat', 'enable'])
+
+        self.cli_set(['interfaces', 'ethernet', 'eth0', 'firewall', 'in', 'name', 'smoketest'])
+
+        self.cli_commit()
+
+        nftables_search = [
+            ['iifname "eth0"', 'jump NAME_smoketest'],
+            ['ct state { established, related }', 'return'],
+            ['ct state { invalid }', 'reject'],
+            ['ct state { new }', 'ct status { dnat }', 'return'],
+            ['ct state { established, new }', 'ct status { snat, dnat }', 'return'],
+            ['smoketest default-action', 'drop']
+        ]
+
+        nftables_output = cmd('sudo nft list table ip filter')
+
+        for search in nftables_search:
+            matched = False
+            for line in nftables_output.split("\n"):
+                if all(item in line for item in search):
+                    matched = True
+                    break
+            self.assertTrue(matched, msg=search)
+
     def test_sysfs(self):
         for name, conf in sysfs_config.items():
             paths = glob(conf['sysfs'])

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -171,11 +171,12 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '2', 'state', 'invalid', 'enable'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '3', 'action', 'accept'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '3', 'state', 'new', 'enable'])
-        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '3', 'connection-status', 'dnat'])
+
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '3', 'connection-status', 'nat', 'destination'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '4', 'action', 'accept'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '4', 'state', 'new', 'enable'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '4', 'state', 'established', 'enable'])
-        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '4', 'connection-status', 'snat'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '4', 'connection-status', 'nat', 'source'])
 
         self.cli_set(['interfaces', 'ethernet', 'eth0', 'firewall', 'in', 'name', 'smoketest'])
 

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -171,12 +171,11 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '2', 'state', 'invalid', 'enable'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '3', 'action', 'accept'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '3', 'state', 'new', 'enable'])
-        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '3', 'ct-status', 'dnat', 'enable'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '3', 'connection-status', 'dnat'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '4', 'action', 'accept'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '4', 'state', 'new', 'enable'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '4', 'state', 'established', 'enable'])
-        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '4', 'ct-status', 'snat', 'enable'])
-        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '4', 'ct-status', 'dnat', 'enable'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '4', 'connection-status', 'snat'])
 
         self.cli_set(['interfaces', 'ethernet', 'eth0', 'firewall', 'in', 'name', 'smoketest'])
 
@@ -187,7 +186,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['ct state { established, related }', 'return'],
             ['ct state { invalid }', 'reject'],
             ['ct state { new }', 'ct status { dnat }', 'return'],
-            ['ct state { established, new }', 'ct status { snat, dnat }', 'return'],
+            ['ct state { established, new }', 'ct status { snat }', 'return'],
             ['smoketest default-action', 'drop']
         ]
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
source nat and destination nat connection status available in firewall rules configuration.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T990

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->
On this first approach, we are adding only snat and dnat options for ct status.
In future PR, all options should be covered.

Netfilter references: 

- https://wiki.nftables.org/wiki-nftables/index.php/Matching_connection_tracking_stateful_metainformation#ct_status_-_conntrack_status
- https://wiki.nftables.org/wiki-nftables/index.php/Quick_reference-nftables_in_10_minutes#Ct

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
cli options
```
vyos@vyos# set firewall name FOO rule 10 
Possible completions:
   action       Rule action [REQUIRED]
 > connection-status
                Connection status
   description  Description
 > destination  Destination parameters
   disable      Option to disable firewall rule
 > fragment     IP fragment match
 > icmp         ICMP type and code information
 > ipsec        Inbound IPsec packets
 > limit        Rate limit using a token bucket filter
   log          Option to log packets matching rule
   protocol     Protocol to match (protocol name, number, or "all")
 > recent       Parameters for matching recently seen sources
 > source       Source parameters
 > state        Session state
 > tcp          TCP flags to match
 > time         Time to match rule

      
[edit]
vyos@vyos# set firewall name FOO rule 10 connection-status 
Possible completions:
   nat          NAT connection status

      
[edit]
vyos@vyos# set firewall name FOO rule 10 connection-status nat 
Possible completions:
   destination  Match connections that are subject to destination NAT
   source       Match connections that are subject to source NAT
                

```

Configurations and validations
```
set firewall ipv6-name FOO rule 10 action 'accept'
set firewall ipv6-name FOO rule 10 connection-status nat destination
set firewall ipv6-name FOO rule 10 state new 'enable'
set firewall name FOO rule 10 action 'drop'
set firewall name FOO rule 10 connection-status nat source
set firewall name FOO rule 10 state invalid 'enable'

vyos@vyos# sudo nft list chain ip filter NAME_FOO
table ip filter {
        chain NAME_FOO {
                ct state { invalid } ct status { snat } counter packets 0 bytes 0 drop comment "FOO-10"
                counter packets 0 bytes 0 return comment "FOO default-action accept"
        }
}
[edit]
vyos@vyos# sudo nft list chain ip6 filter NAME6_FOO
table ip6 filter {
        chain NAME6_FOO {
                ct state { new } ct status { dnat } counter packets 0 bytes 0 return comment "FOO-10"
                counter packets 0 bytes 0 return comment "FOO default-action accept"
        }
}
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
