### PR TITLE
dhcp-server: T4344: Fix underscores for shared network name

### DIFF
--- a/data/templates/dhcp-server/dhcpd.conf.tmpl
+++ b/data/templates/dhcp-server/dhcpd.conf.tmpl
@@ -62,7 +62,7 @@ subnet {{ address | network_from_ipv4 }} netmask {{ address | netmask_from_ipv4 
 # Shared network configration(s)
 {% if shared_network_name is defined and shared_network_name is not none %}
 {%   for network, network_config in shared_network_name.items() if network_config.disable is not defined %}
-shared-network {{ network | replace('_','-') }} {
+shared-network {{ network }} {
 {%     if network_config.authoritative is defined %}
     authoritative;
 {%     endif %}
@@ -212,7 +212,7 @@ shared-network {{ network | replace('_','-') }} {
 {%       endfor %}
 {%     endif %}
     on commit {
-        set shared-networkname = "{{ network | replace('_','-') }}";
+        set shared-networkname = "{{ network }}";
 {%     if hostfile_update is defined %}
         set ClientIp = binary-to-ascii(10, 8, ".", leased-address);
         set ClientMac = binary-to-ascii(16, 8, ":", substring(hardware, 1, 6));

--- a/data/templates/dhcp-server/dhcpdv6.conf.tmpl
+++ b/data/templates/dhcp-server/dhcpdv6.conf.tmpl
@@ -15,7 +15,7 @@ option dhcp6.name-servers {{ global_parameters.name_server | join(', ') }};
 # Shared network configration(s)
 {% if shared_network_name is defined and shared_network_name is not none %}
 {%   for network, network_config in shared_network_name.items() if network_config.disable is not defined %}
-shared-network {{ network | replace('_','-') }} {
+shared-network {{ network }} {
 {%     if network_config.common_options is defined and network_config.common_options is not none %}
 {%       if network_config.common_options.info_refresh_time is defined and network_config.common_options.info_refresh_time is not none %}
     option dhcp6.info-refresh-time {{ network_config.common_options.info_refresh_time }};
@@ -117,7 +117,7 @@ shared-network {{ network | replace('_','-') }} {
 {%       endfor %}
 {%     endif %}
     on commit {
-        set shared-networkname = "{{ network | replace('_','-') }}";
+        set shared-networkname = "{{ network }}";
     }
 }
 {%   endfor %}

--- a/src/conf_mode/dhcp_server.py
+++ b/src/conf_mode/dhcp_server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2021 VyOS maintainers and contributors
+# Copyright (C) 2018-2022 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -109,7 +109,7 @@ def get_config(config=None):
     if not conf.exists(base):
         return None
 
-    dhcp = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
+    dhcp = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True, no_tag_node_value_mangle=True)
     # T2665: defaults include lease time per TAG node which need to be added to
     # individual subnet definitions
     default_values = defaults(base + ['shared-network-name', 'subnet'])

--- a/src/conf_mode/dhcpv6_server.py
+++ b/src/conf_mode/dhcpv6_server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2020 VyOS maintainers and contributors
+# Copyright (C) 2018-2022 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -41,7 +41,7 @@ def get_config(config=None):
     if not conf.exists(base):
         return None
 
-    dhcpv6 = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
+    dhcpv6 = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True, no_tag_node_value_mangle=True)
     return dhcpv6
 
 def verify(dhcpv6):


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Shared network name should not be handled by tag node mangling
I.e. should not replace underscores with dashed

(cherry picked from commit b75b351b7dd2ec87407f98668468b1fc146428bf)
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4344

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp, dhcpv6
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add dhcp_pool with underscores
```
set service dhcp-server shared-network-name NET_01 authoritative
set service dhcp-server shared-network-name NET_01 name-server '1.1.1.1'
set service dhcp-server shared-network-name NET_01 subnet 192.0.2.0/24 range R1 start '192.0.2.21'
set service dhcp-server shared-network-name NET_01 subnet 192.0.2.0/24 range R1 stop '192.0.2.254'
```

Before fix
dhcp.conf
```
...
    on commit {
        set shared-networkname = "NET-01";
    }
```
After fix
Expected the same name in dhcp configuration:
```
# Shared network configration(s)
shared-network NET_01 {
    authoritative;
    option domain-name-servers 1.1.1.1;
    subnet 192.0.2.0 netmask 255.255.255.0 {
        default-lease-time 86400;
        max-lease-time 86400;
        pool {
            range 192.0.2.21 192.0.2.254;
        }
    }
    on commit {
        set shared-networkname = "NET_01";
    }
}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
