### PR TITLE
T4351: Generate the 20-override.conf with a newline at the end

### DIFF
--- a/data/templates/openvpn/service-override.conf.tmpl
+++ b/data/templates/openvpn/service-override.conf.tmpl
@@ -18,3 +18,4 @@ ExecStart=/usr/sbin/openvpn --daemon openvpn-%i --config %i.conf --status %i.sta
 {%-   endfor %}
 {% endif %}
 
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add another newline at the end of the `service-override.conf.tmpl` so that the resulting file also have a newline at the end.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4351

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
- openvpn

## Proposed changes
<!--- Describe your changes in detail -->
Add another newline at the end of the `service-override.conf.tmpl` so that the resulting file also have a newline at the end.
If the file does not end with a newline character the last line will be ignored by systemd.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
interfaces {
    bridge br0 {
        address 10.0.0.1/16
        member {
            interface eth1 {
            }
            interface vtun10 {
            }
        }
    }
    openvpn vtun10 {
        device-type tap
        local-port 1194
        mode server
        openvpn-option "server-bridge 10.0.0.1 255.255.0.0 10.0.0.100 10.0.0.250"
        persistent-tunnel
        protocol tcp-passive
        tls {
            ca-certificate CA
            certificate SERVER_CERT
        }
    }
}
```
Use the config above and verify that the `openvpn` process will be executed with the `server-bridge 10.0.0.1 255.255.0.0 10.0.0.100 10.0.0.250` argument

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
