### PR TITLE
T4327: ignore PermissionError caused by ethtool spee/duplex/autoneg setting

### DIFF
--- a/python/vyos/ifconfig/ethernet.py
+++ b/python/vyos/ifconfig/ethernet.py
@@ -170,11 +170,18 @@ class EthernetIf(Interface):
                 return
 
         cmd = f'ethtool --change {ifname}'
-        if speed == 'auto' or duplex == 'auto':
-            cmd += ' autoneg on'
-        else:
-            cmd += f' speed {speed} duplex {duplex} autoneg off'
-        return self._cmd(cmd)
+        try:
+            if speed == 'auto' or duplex == 'auto':
+                cmd += ' autoneg on'
+            else:
+                cmd += f' speed {speed} duplex {duplex} autoneg off'
+            return self._cmd(cmd)
+        except PermissionError:
+            # Some NICs do not tell that they don't suppport settings speed/duplex,
+            # but they do not actually support it either.
+            # In that case it's probably better to ignore the error
+            # than end up with a broken config.
+            print('Warning: could not set speed/duplex settings: operation not permitted!')
 
     def set_gro(self, state):
         """


### PR DESCRIPTION
Certain NICs seem to fail to report that they don't support speed/duplex setting,
so they look as if it's supported, but the command fails in practice.

The Hyper-V NIC is one example.

It's probably better to preserve a working config in that case, since the script will try to set autoneg by default (arguably, should, unless the NIC says it can't). If a NIC says it can set it but actually can't, there's nothing we can do to keep its config functional, other than ignore the error.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4327

## Component(s) name

* ethernet

## How to test


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
