### PR TITLE
T4363: salt-minion: default mine_interval option is not set

### DIFF
--- a/smoketest/scripts/cli/test_service_salt.py
+++ b/smoketest/scripts/cli/test_service_salt.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from socket import gethostname
+from base_vyostest_shim import VyOSUnitTestSHIM
+
+from vyos.util import process_named_running
+from vyos.util import read_file
+from vyos.util import cmd
+
+PROCESS_NAME = 'salt-minion'
+SALT_CONF = '/etc/salt/minion'
+base_path = ['service', 'salt-minion']
+
+class TestServiceSALT(VyOSUnitTestSHIM.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestServiceSALT, cls).setUpClass()
+
+        # ensure we can also run this test on a live system - so lets clean
+        # out the current configuration :)
+        cls.cli_delete(cls, base_path)
+
+    def tearDown(self):
+        # Check for running process
+        self.assertTrue(process_named_running(PROCESS_NAME))
+
+        # delete testing SALT config
+        self.cli_delete(base_path)
+        self.cli_commit()
+
+        # For an unknown reason on QEMU systems (e.g. where smoketests are executed
+        # from the CI) salt-minion process is not killed by systemd. Apparently
+        # no issue on VMWare.
+        if cmd('systemd-detect-virt') != 'kvm':
+            self.assertFalse(process_named_running(PROCESS_NAME))
+
+    def test_default(self):
+        servers = ['192.0.2.1', '192.0.2.2']
+
+        for server in servers:
+            self.cli_set(base_path + ['master', server])
+
+        self.cli_commit()
+
+        # commiconf = read_file() Check configured port
+        conf = read_file(SALT_CONF)
+        self.assertIn(f'- {server}', conf)
+
+        # defaults
+        hostname = gethostname()
+        self.assertIn(f'hash_type: sha256', conf)
+        self.assertIn(f'id: {hostname}', conf)
+        self.assertIn(f'mine_interval: 60', conf)
+
+    def test_options(self):
+        server = '192.0.2.3'
+        hash = 'sha1'
+        id = 'foo'
+        interval = '120'
+
+        self.cli_set(base_path + ['master', server])
+        self.cli_set(base_path + ['hash', hash])
+        self.cli_set(base_path + ['id', id])
+        self.cli_set(base_path + ['interval', interval])
+
+        self.cli_commit()
+
+        # commiconf = read_file() Check configured port
+        conf = read_file(SALT_CONF)
+        self.assertIn(f'- {server}', conf)
+
+        # defaults
+        self.assertIn(f'hash_type: {hash}', conf)
+        self.assertIn(f'id: {id}', conf)
+        self.assertIn(f'mine_interval: {interval}', conf)
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/src/conf_mode/salt-minion.py
+++ b/src/conf_mode/salt-minion.py
@@ -39,7 +39,7 @@ default_config_data = {
     'user': 'minion',
     'group': 'vyattacfg',
     'salt_id': gethostname(),
-    'mine_interval': '60',
+    'interval': '60',
     'verify_master_pubkey_sign': 'false',
     'master_key': ''
 }


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

salt-minion default mine_interval option is not set. Error in Jinja2 variable reference prevents configuration of mine update interval value.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4363

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
salt

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

smoketests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
