### PR TITLE
Updated uacctd.conf.tmpl to replace ":" with "." in the netflow secti…

### DIFF
--- a/data/templates/pmacct/uacctd.conf.tmpl
+++ b/data/templates/pmacct/uacctd.conf.tmpl
@@ -21,7 +21,7 @@ imt_mem_pools_number: 169
 {% set plugin = [] %}
 {% if netflow.server is vyos_defined %}
 {%   for server in netflow.server %}
-{%     set _ = plugin.append('nfprobe[nf_' ~ server ~ ']') %}
+{%     set _ = plugin.append('nfprobe[nf_' ~ server.replace(':', '.') ~ ']') %}
 {%   endfor %}
 {% endif %}
 {% if sflow.server is vyos_defined %}
@@ -37,22 +37,22 @@ plugins: {{ plugin | join(',') }}
 {% if netflow.server is vyos_defined %}
 # NetFlow servers
 {%   for server, server_config in netflow.server.items() %}
-nfprobe_receiver[nf_{{ server }}]: {{ server }}:{{ server_config.port }}
-nfprobe_version[nf_{{ server }}]: {{ netflow.version }}
+nfprobe_receiver[nf_{{ server.replace(':', '.')  }}]: {{ server }}:{{ server_config.port }}
+nfprobe_version[nf_{{ server.replace(':', '.') }}]: {{ netflow.version }}
 {%     if netflow.engine_id is vyos_defined %}
-nfprobe_engine[nf_{{ server }}]: {{ netflow.engine_id }}
+nfprobe_engine[nf_{{ server.replace(':', '.') }}]: {{ netflow.engine_id }}
 {%     endif %}
 {%     if netflow.max_flows is vyos_defined %}
-nfprobe_maxflows[nf_{{ server }}]: {{ netflow.max_flows }}
+nfprobe_maxflows[nf_{{ server.replace(':', '.') }}]: {{ netflow.max_flows }}
 {%     endif %}
 {%     if netflow.sampling_rate is vyos_defined %}
-sampling_rate[nf_{{ server }}]: {{ netflow.sampling_rate }}
+sampling_rate[nf_{{ server.replace(':', '.') }}]: {{ netflow.sampling_rate }}
 {%     endif %}
 {%     if netflow.source_address is vyos_defined %}
-nfprobe_source_ip[nf_{{ server }}]: {{ netflow.source_address }}
+nfprobe_source_ip[nf_{{ server.replace(':', '.') }}]: {{ netflow.source_address }}
 {%     endif %}
 {%     if netflow.timeout is vyos_defined %}
-nfprobe_timeouts[nf_{{ server }}]: expint={{ netflow.timeout.expiry_interval }}:general={{ netflow.timeout.flow_generic }}:icmp={{ netflow.timeout.icmp }}:maxlife={{ netflow.timeout.max_active_life }}:tcp.fin={{ netflow.timeout.tcp_fin }}:tcp={{ netflow.timeout.tcp_generic }}:tcp.rst={{ netflow.timeout.tcp_rst }}:udp={{ netflow.timeout.udp }}
+nfprobe_timeouts[nf_{{ server.replace(':', '.') }}]: expint={{ netflow.timeout.expiry_interval }}:general={{ netflow.timeout.flow_generic }}:icmp={{ netflow.timeout.icmp }}:maxlife={{ netflow.timeout.max_active_life }}:tcp.fin={{ netflow.timeout.tcp_fin }}:tcp={{ netflow.timeout.tcp_generic }}:tcp.rst={{ netflow.timeout.tcp_rst }}:udp={{ netflow.timeout.udp }}
 {%     endif %}
 
 {%   endfor %}
@@ -72,3 +72,4 @@ sfprobe_source_ip[sf_{{ server }}]: {{ sflow.source_address }}
 
 {%   endfor %}
 {% endif %}
+


### PR DESCRIPTION
…on of the configuration.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Updated the template for uacctd.conf to replace ":" with "." to prevent sentax errors when using IPv6 Addresses.  

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
uacctd
## Proposed changes
<!--- Describe your changes in detail -->
When configuring netflow with an IPv6 address for the server you will get a configuration similar to what is below. having ":" between the brackets in the lines i have commented "problem line below" causes a sentax error in the uacctd.conf file. I have  added a replace to the server string to replace any ":" with a "." to prevent this from causing an issue when using an IPv6 address.

Error from /var/log/messages.
`Apr 16 21:53:35 vyos uacctd[3461]: ERROR: [/run/pmacct/uacctd.conf:15] Syntax error: illegal brackets. Exiting.`

```
# Genereated from VyOS configuration
daemonize: true
promisc: false
pidfile: /run/pmacct/uacctd.pid
uacctd_group: 2
uacctd_nl_size: 2097152
snaplen: 128
aggregate: in_iface,out_iface,src_mac,dst_mac,vlan,src_host,dst_host,src_port,dst_port,proto,tos,flows
plugin_pipe_size: 2147483648
plugin_buffer_size: 2147483

plugins: nfprobe[nf_2a0e:b100:112::1]

# NetFlow servers
nfprobe_receiver[nf_2a0e:b100:112::1]: 2a0e:b100:112::1:2055 #problem line
nfprobe_version[nf_2a0e:b100:112::1]: 9 #problem line
nfprobe_engine[nf_2a0e:b100:112::1]: 155 #problem line
nfprobe_timeouts[nf_2a0e:b100:112::1]: expint=60:general=3600:icmp=300:maxlife=604800:tcp.fin=300:tcp=3600:tcp.rst=120:udp=300 #problem line
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Setup a fresh instance of VyOS 1.4

Added the following config.
```
set system flow-accounting buffer-size '2048'
set system flow-accounting disable-imt
set system flow-accounting enable-egress
set system flow-accounting interface 'eth0'
set system flow-accounting netflow engine-id '155'
set system flow-accounting netflow server 2a0e:b100:112::1
```

check the status of uacctd and you will see that the service has failed and you will see an error message in the logs similar to what i included in the initial description.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
