### PR TITLE
NAT: T4365: Fix for nat tables manipulation on netfilter

### DIFF
--- a/data/templates/firewall/nftables-nat.tmpl
+++ b/data/templates/firewall/nftables-nat.tmpl
@@ -138,8 +138,9 @@
 {%   endif %}
 {% endmacro %}
 
-# Start with clean NAT table
-flush table ip nat
+# Start with clean SNAT and DNAT chains
+flush chain ip nat PREROUTING
+flush chain ip nat POSTROUTING
 {% if helper_functions is vyos_defined('remove') %}
 {# NAT if going to be disabled - remove rules and targets from nftables #}
 {%   set base_command = 'delete rule ip raw' %}
@@ -164,6 +165,7 @@ add rule ip raw NAT_CONNTRACK counter accept
 #
 # Destination NAT rules build up here
 #
+add rule ip nat PREROUTING counter jump VYOS_PRE_DNAT_HOOK
 {% if destination.rule is vyos_defined %}
 {%   for rule, config in destination.rule.items() if config.disable is not vyos_defined %}
 {{ nat_rule(rule, config, 'PREROUTING') }}
@@ -172,6 +174,7 @@ add rule ip raw NAT_CONNTRACK counter accept
 #
 # Source NAT rules build up here
 #
+add rule ip nat POSTROUTING counter jump VYOS_PRE_SNAT_HOOK
 {% if source.rule is vyos_defined %}
 {%   for rule, config in source.rule.items() if config.disable is not vyos_defined %}
 {{ nat_rule(rule, config, 'POSTROUTING') }}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Change current behavior for loading nat configuration. 
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4365

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat
## Proposed changes
<!--- Describe your changes in detail -->
Before this PR, when adding/deleting nat configuration through vyos cli, table ip nat was completely flushed, and it did not create the very first rule in PREROUTING and POSTROUTING chains, which stands for jump action to VYOS_PRE_XNAT_HOOK, necessary for features like wan load balancing.
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Create, modify and/or delete nat rules. It should always contain these main rules:
```
# Prerouting chain should always contain this first rule:
chain PREROUTING {
    type nat hook prerouting priority dstnat; policy accept;
    counter packets 671 bytes 139082 jump VYOS_PRE_DNAT_HOOK
    .... #other rules
}

# Postrouting chain should always contain this first rule:

chain POSTROUTING {
    type nat hook postrouting priority srcnat; policy accept;
    counter packets 289 bytes 17364 jump VYOS_PRE_SNAT_HOOK
    .... #other rules
}

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
