### PR TITLE
ppppoe-server: T4373: Add option multiplier for correct shaping

### DIFF
--- a/data/templates/accel-ppp/config_shaper_radius.j2
+++ b/data/templates/accel-ppp/config_shaper_radius.j2
@@ -6,5 +6,8 @@ attr={{ authentication.radius.rate_limit.attribute }}
 {%         if authentication.radius.rate_limit.vendor is vyos_defined %}
 vendor={{ authentication.radius.rate_limit.vendor }}
 {%         endif %}
+{%         if authentication.radius.rate_limit.multiplier is vyos_defined %}
+rate-multiplier={{ authentication.radius.rate_limit.multiplier }}
+{%         endif %}
 {%     endif %}
 {% endif %}

--- a/interface-definitions/include/accel-ppp/radius-additions-rate-limit.xml.i
+++ b/interface-definitions/include/accel-ppp/radius-additions-rate-limit.xml.i
@@ -21,6 +21,20 @@
         <valueless />
       </properties>
     </leafNode>
+    <leafNode name="multiplier">
+      <properties>
+        <help>Shaper multiplier</help>
+        <valueHelp>
+          <format>&lt;0.001-1000&gt;</format>
+          <description>Shaper multiplier</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 0.001-1000 --float"/>
+        </constraint>
+        <constraintErrorMessage>Multiplier needs to be between 0.001 and 1000</constraintErrorMessage>
+      </properties>
+      <defaultValue>1</defaultValue>
+    </leafNode>
   </children>
 </node>
 <!-- include end -->


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Multiplier option is required by some vendors for correct shaping
For RADIUS based rate-limits

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4373

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure pppoe-server with multiplier option:
```
set service pppoe-server authentication mode 'radius'
set service pppoe-server authentication radius rate-limit attribute 'Mikrotik-Rate-Limit'
set service pppoe-server authentication radius rate-limit enable
set service pppoe-server authentication radius rate-limit multiplier '0.001'
set service pppoe-server authentication radius rate-limit vendor 'Mikrotik'
set service pppoe-server authentication radius server 192.0.2.1 key 'foo'
set service pppoe-server client-ip-pool start '192.0.2.5'
set service pppoe-server client-ip-pool stop '192.0.2.254'
set service pppoe-server gateway-address '192.0.2.1'
set service pppoe-server interface eth3
```
Expected `rate-multiplier` in the `[shaper]` section:
```
[shaper]
verbose=1
attr=Mikrotik-Rate-Limit
vendor=Mikrotik
rate-multiplier=0.001
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
