### PR TITLE
dhcpv6: T4357: Add dhcpv6-server options for cisco VoIP tftp

### DIFF
--- a/data/templates/dhcp-server/dhcpdv6.conf.j2
+++ b/data/templates/dhcp-server/dhcpdv6.conf.j2
@@ -11,6 +11,11 @@ option dhcp6.preference {{ preference }};
 {% if global_parameters.name_server is vyos_defined %}
 option dhcp6.name-servers {{ global_parameters.name_server | join(', ') }};
 {% endif %}
+{% if vsio_cisco_tftp %}
+option space cisco;
+option cisco.tftp-servers code 1 = array of ip6-address;
+option vsio.cisco code 9 = encapsulate cisco;
+{% endif %}
 
 # Shared network configration(s)
 {% if shared_network_name is vyos_defined %}
@@ -112,6 +117,9 @@ shared-network {{ network }} {
 {%                         endif %}
         }
 {%                     endfor %}
+{%                 endif %}
+{%                 if subnet_config.vsio.cisco.tftp_server is vyos_defined %}
+        option cisco.tftp-servers {{ subnet_config.vsio.cisco.tftp_server | join(', ') }};
 {%                 endif %}
     }
 {%             endfor %}

--- a/interface-definitions/dhcpv6-server.xml.in
+++ b/interface-definitions/dhcpv6-server.xml.in
@@ -338,6 +338,33 @@
                       </leafNode>
                     </children>
                   </tagNode>
+                  <node name="vsio">
+                    <properties>
+                      <help>Vendor-specific Information Option</help>
+                    </properties>
+                    <children>
+                      <node name="cisco">
+                        <properties>
+                          <help>Parameters for cisco</help>
+                        </properties>
+                        <children>
+                          <leafNode name="tftp-server">
+                            <properties>
+                              <help>Parameters for cisco VoIP</help>
+                              <valueHelp>
+                                <format>ipv6</format>
+                                <description>TFTP IPv6 address</description>
+                              </valueHelp>
+                              <constraint>
+                                <validator name="ipv6-address"/>
+                              </constraint>
+                              <multi/>
+                            </properties>
+                          </leafNode>
+                        </children>
+                      </node>
+                    </children>
+                  </node>
                 </children>
               </tagNode>
             </children>

--- a/src/conf_mode/dhcpv6_server.py
+++ b/src/conf_mode/dhcpv6_server.py
@@ -42,6 +42,14 @@ def get_config(config=None):
         return None
 
     dhcpv6 = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True, no_tag_node_value_mangle=True)
+
+    for network, network_config in dhcpv6['shared_network_name'].items():
+        # A shared-network requires a subnet definition
+        if 'subnet' in network_config:
+            for subnet, subnet_config in network_config['subnet'].items():
+                if dict_search('vsio.cisco.tftp_server', subnet_config):
+                    dhcpv6['vsio_cisco_tftp'] = True
+
     return dhcpv6
 
 def verify(dhcpv6):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add vendor specific options for DHCPv6-server  for working with
cisco VoIP phone provisioning over IPv6
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4357

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcpv6-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add option `vsio cisco tftp-server`
Set tftp-servers for IPv6 subnet
```
set service dhcpv6-server global-parameters name-server '2001:db8:23::8888'
set service dhcpv6-server global-parameters name-server '2001:db8:23::8008'
set service dhcpv6-server shared-network-name Lan-v6-02 subnet 2001:db8:23::/64 address-range start 2001:db8:23::199 stop '2001:db8:23::fffd'
set service dhcpv6-server shared-network-name Lan-v6-02 subnet 2001:db8:23::/64 vsio cisco tftp-server '2001:db8:23::1001'

```
Expected dhcp configuration:
```
log-facility local7;

option dhcp6.name-servers 2001:db8:23::8888, 2001:db8:23::8008;
option space cisco;
option cisco.tftp-servers code 1 = array of ip6-address;
option vsio.cisco code 9 = encapsulate cisco;

# Shared network configration(s)
shared-network Lan-v6-02 {
    subnet6 2001:db8:23::/64 {
        range6 2001:db8:23::199 2001:db8:23::fffd;
         option cisco.tftp-servers 2001:db8:23::1001;
    }
    on commit {
        set shared-networkname = "Lan-v6-02";
    }
}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
