### PR TITLE
T4235: Add support for config tree diff algorithm

### DIFF
--- a/python/vyos/configdiff.py
+++ b/python/vyos/configdiff.py
@@ -16,6 +16,7 @@
 from enum import IntFlag, auto
 
 from vyos.config import Config
+from vyos.configtree import DiffTree
 from vyos.configdict import dict_merge
 from vyos.util import get_sub_dict, mangle_dict_keys
 from vyos.xml import defaults
@@ -35,6 +36,8 @@ class Diff(IntFlag):
     DELETE = auto()
     ADD = auto()
     STABLE = auto()
+
+ALL = Diff.MERGE | Diff.DELETE | Diff.ADD | Diff.STABLE
 
 requires_effective = [enum_to_key(Diff.DELETE)]
 target_defaults = [enum_to_key(Diff.MERGE)]
@@ -73,18 +76,23 @@ def get_config_diff(config, key_mangling=None):
             isinstance(key_mangling[1], str)):
         raise ValueError("key_mangling must be a tuple of two strings")
 
-    return ConfigDiff(config, key_mangling)
+    diff_t = DiffTree(config._running_config, config._session_config)
+
+    return ConfigDiff(config, key_mangling, diff_tree=diff_t)
 
 class ConfigDiff(object):
     """
     The class of config changes as represented by comparison between the
     session config dict and the effective config dict.
     """
-    def __init__(self, config, key_mangling=None):
+    def __init__(self, config, key_mangling=None, diff_tree=None):
         self._level = config.get_level()
         self._session_config_dict = config.get_cached_root_dict(effective=False)
         self._effective_config_dict = config.get_cached_root_dict(effective=True)
         self._key_mangling = key_mangling
+
+        self._diff_tree = diff_tree
+        self._diff_dict = diff_tree.dict if diff_tree else {}
 
     # mirrored from Config; allow path arguments relative to level
     def _make_path(self, path):
@@ -134,7 +142,17 @@ class ConfigDiff(object):
                                                     self._key_mangling[1])
         return config_dict
 
-    def get_child_nodes_diff(self, path=[], expand_nodes=Diff(0), no_defaults=False):
+    def is_node_changed(self, path=[]):
+        if self._diff_tree is None:
+            raise NotImplementedError("diff_tree class not available")
+
+        if (self._diff_tree.add.exists(self._make_path(path)) or
+            self._diff_tree.sub.exists(self._make_path(path))):
+            return True
+        return False
+
+    def get_child_nodes_diff(self, path=[], expand_nodes=Diff(0), no_defaults=False,
+                             recursive=False):
         """
         Args:
             path (str|list): config path
@@ -144,6 +162,8 @@ class ConfigDiff(object):
                                   value
             no_detaults=False: if expand_nodes & Diff.MERGE, do not merge default
                                values to ret['merge']
+            recursive: if true, use config_tree diff algorithm provided by
+                       diff_tree class
 
         Returns: dict of lists, representing differences between session
                                 and effective config, under path
@@ -154,6 +174,34 @@ class ConfigDiff(object):
         """
         session_dict = get_sub_dict(self._session_config_dict,
                                     self._make_path(path), get_first_key=True)
+
+        if recursive:
+            if self._diff_tree is None:
+                raise NotImplementedError("diff_tree class not available")
+            else:
+                add = get_sub_dict(self._diff_tree.dict, ['add'], get_first_key=True)
+                sub = get_sub_dict(self._diff_tree.dict, ['sub'], get_first_key=True)
+                inter = get_sub_dict(self._diff_tree.dict, ['inter'], get_first_key=True)
+                ret = {}
+                ret[enum_to_key(Diff.MERGE)] = session_dict
+                ret[enum_to_key(Diff.DELETE)] = get_sub_dict(sub, self._make_path(path),
+                                                             get_first_key=True)
+                ret[enum_to_key(Diff.ADD)] = get_sub_dict(add, self._make_path(path),
+                                                          get_first_key=True)
+                ret[enum_to_key(Diff.STABLE)] = get_sub_dict(inter, self._make_path(path),
+                                                             get_first_key=True)
+                for e in Diff:
+                    k = enum_to_key(e)
+                    if not (e & expand_nodes):
+                        ret[k] = list(ret[k])
+                    else:
+                        if self._key_mangling:
+                            ret[k] = self._mangle_dict_keys(ret[k])
+                        if k in target_defaults and not no_defaults:
+                            default_values = defaults(self._make_path(path))
+                            ret[k] = dict_merge(default_values, ret[k])
+                return ret
+
         effective_dict = get_sub_dict(self._effective_config_dict,
                                       self._make_path(path), get_first_key=True)
 
@@ -179,7 +227,8 @@ class ConfigDiff(object):
 
         return ret
 
-    def get_node_diff(self, path=[], expand_nodes=Diff(0), no_defaults=False):
+    def get_node_diff(self, path=[], expand_nodes=Diff(0), no_defaults=False,
+                      recursive=False):
         """
         Args:
             path (str|list): config path
@@ -189,6 +238,8 @@ class ConfigDiff(object):
                                   value
             no_detaults=False: if expand_nodes & Diff.MERGE, do not merge default
                                values to ret['merge']
+            recursive: if true, use config_tree diff algorithm provided by
+                       diff_tree class
 
         Returns: dict of lists, representing differences between session
                                 and effective config, at path
@@ -198,6 +249,31 @@ class ConfigDiff(object):
                  dict['stable'] = config values in both session and effective
         """
         session_dict = get_sub_dict(self._session_config_dict, self._make_path(path))
+
+        if recursive:
+            if self._diff_tree is None:
+                raise NotImplementedError("diff_tree class not available")
+            else:
+                add = get_sub_dict(self._diff_tree.dict, ['add'], get_first_key=True)
+                sub = get_sub_dict(self._diff_tree.dict, ['sub'], get_first_key=True)
+                inter = get_sub_dict(self._diff_tree.dict, ['inter'], get_first_key=True)
+                ret = {}
+                ret[enum_to_key(Diff.MERGE)] = session_dict
+                ret[enum_to_key(Diff.DELETE)] = get_sub_dict(sub, self._make_path(path))
+                ret[enum_to_key(Diff.ADD)] = get_sub_dict(add, self._make_path(path))
+                ret[enum_to_key(Diff.STABLE)] = get_sub_dict(inter, self._make_path(path))
+                for e in Diff:
+                    k = enum_to_key(e)
+                    if not (e & expand_nodes):
+                        ret[k] = list(ret[k])
+                    else:
+                        if self._key_mangling:
+                            ret[k] = self._mangle_dict_keys(ret[k])
+                        if k in target_defaults and not no_defaults:
+                            default_values = defaults(self._make_path(path))
+                            ret[k] = dict_merge(default_values, ret[k])
+                return ret
+
         effective_dict = get_sub_dict(self._effective_config_dict, self._make_path(path))
 
         ret = _key_sets_from_dicts(session_dict, effective_dict)

--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -126,6 +126,10 @@ class ConfigTree(object):
         self.__set_tag.argtypes = [c_void_p, c_char_p]
         self.__set_tag.restype = c_int
 
+        self.__get_subtree = self.__lib.get_subtree
+        self.__get_subtree.argtypes = [c_void_p, c_char_p]
+        self.__get_subtree.restype = c_void_p
+
         self.__destroy = self.__lib.destroy
         self.__destroy.argtypes = [c_void_p]
 
@@ -290,6 +294,14 @@ class ConfigTree(object):
             return True
         else:
             raise ConfigTreeError("Path [{}] doesn't exist".format(path_str))
+
+    def get_subtree(self, path, with_node=False):
+        check_path(path)
+        path_str = " ".join(map(str, path)).encode()
+
+        res = self.__get_subtree(self.__config, path_str, with_node)
+        subt = ConfigTree(address=res)
+        return subt
 
 class Diff:
     def __init__(self, left, right, path=[], libpath=LIBPATH):

--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -305,6 +305,10 @@ class ConfigTree(object):
 
 class DiffTree:
     def __init__(self, left, right, path=[], libpath=LIBPATH):
+        if left is None:
+            left = ConfigTree(config_string='\n')
+        if right is None:
+            right = ConfigTree(config_string='\n')
         if not (isinstance(left, ConfigTree) and isinstance(right, ConfigTree)):
             raise TypeError("Arguments must be instances of ConfigTree")
         if path:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Backport of vyos-1x support of config_tree diff algorithm. This is a DRAFT PR, until the corresponding PRs for vyos1x-config ( https://github.com/vyos/vyos1x-config/pull/7) and libvyosconfig (https://github.com/vyos/libvyosconfig/pull/5) are merged, and the vyos-build Dockerfile commit hashes are updated.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4235

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
