### PR TITLE
nat: T4210: Fix template for negated ports

### DIFF
--- a/data/templates/firewall/nftables-nat.tmpl
+++ b/data/templates/firewall/nftables-nat.tmpl
@@ -6,14 +6,14 @@
 {%   set src_addr  = 'ip saddr ' ~ config.source.address.replace('!','!= ') if config.source.address is vyos_defined %}
 {%   set dst_addr  = 'ip daddr ' ~ config.destination.address.replace('!','!= ') if config.destination.address is vyos_defined %}
 {#   negated port groups need special treatment, move != in front of { } group #}
-{%   if config.source.port is vyos_defined and config.source.port.startswith('!=') %}
-{%     set src_port  = 'sport != { ' ~ config.source.port.replace('!=','') ~ ' }' %}
+{%   if config.source.port is vyos_defined and config.source.port.startswith('!') %}
+{%     set src_port  = 'sport != { ' ~ config.source.port.replace('!','') ~ ' }' %}
 {%   else %}
 {%     set src_port  = 'sport { ' ~ config.source.port ~ ' }' if config.source.port is vyos_defined %}
 {%   endif %}
 {#   negated port groups need special treatment, move != in front of { } group #}
-{%   if config.destination.port is vyos_defined and config.destination.port.startswith('!=') %}
-{%     set dst_port  = 'dport != { ' ~ config.destination.port.replace('!=','') ~ ' }' %}
+{%   if config.destination.port is vyos_defined and config.destination.port.startswith('!') %}
+{%     set dst_port  = 'dport != { ' ~ config.destination.port.replace('!','') ~ ' }' %}
 {%   else %}
 {%     set dst_port  = 'dport { ' ~ config.destination.port ~ ' }' if config.destination.port is vyos_defined %}
 {%   endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix template for negated ports
It replaces `!=`, but must replace `!`
as in dictionary we get ports like `!80` and not `!=80`
```
[ nat ]
{'helper_functions': 'add',
...
 'source': {'rule': {'10': {'destination': {'port': '!80'},
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4210

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set nat source rule 10 destination port '!80'
set nat source rule 10 outbound-interface 'eth4'
set nat source rule 10 protocol 'tcp'
set nat source rule 10 translation address 'masquerade'

set nat source rule 20 protocol tcp
set nat source rule 20 outbound-interface 'eth4'
set nat source rule 20 source port !99
set nat source rule 20 translation address masquerade 
```
Before fix:
```
Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/nat.py", line 210, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/nat.py", line 198, in apply
    cmd(f'nft -f {nftables_nat_config}')
  File "/usr/lib/python3/dist-packages/vyos/util.py", line 161, in cmd
    raise OSError(code, feedback)
PermissionError: [Errno 1] failed to run command: nft -f /tmp/vyos-nat-rules.nft
returned: 
exit code: 1

noteworthy:
cmd 'nft -c -f /tmp/vyos-nat-rules.nft'
returned (out):

returned (err):
/tmp/vyos-nat-rules.nft:23:72-72: Error: syntax error, unexpected !
add rule ip nat POSTROUTING oifname "eth4" ip protocol tcp tcp dport { !80 } counter masquerade comment "SRC-NAT-10"
                                                                       ^
cmd 'nft -f /tmp/vyos-nat-rules.nft'
returned (out):

returned (err):
/tmp/vyos-nat-rules.nft:23:72-72: Error: syntax error, unexpected !
add rule ip nat POSTROUTING oifname "eth4" ip protocol tcp tcp dport { !80 } counter masquerade comment "SRC-NAT-10"
                                                                       ^

[[nat]] failed
Commit failed
[edit]
vyos@tstrtr2#
```
After fix:
```
add rule ip nat POSTROUTING oifname "eth4" ip protocol tcp tcp dport != { 80 } counter masquerade comment "SRC-NAT-10"
add rule ip nat POSTROUTING oifname "eth4" ip protocol tcp tcp sport != { 99 } counter masquerade comment "SRC-NAT-20"

```
Generated table nat:
```
table ip nat {
	chain PREROUTING {
		type nat hook prerouting priority dstnat; policy accept;
		counter packets 0 bytes 0 jump VYOS_PRE_DNAT_HOOK
	}

	chain POSTROUTING {
		type nat hook postrouting priority srcnat; policy accept;
		counter packets 60 bytes 3600 jump VYOS_PRE_SNAT_HOOK
		oifname "eth4" tcp dport != { 80 } counter packets 0 bytes 0 masquerade comment "SRC-NAT-10"
		oifname "eth4" tcp sport != { 99 } counter packets 0 bytes 0 masquerade comment "SRC-NAT-20"
	}
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
