### PR TITLE
op-mode: T4236: Split to new lines openvpn client certs

### DIFF
--- a/src/op_mode/generate_ovpn_client_file.py
+++ b/src/op_mode/generate_ovpn_client_file.py
@@ -18,6 +18,7 @@ import argparse
 import os
 
 from jinja2 import Template
+from textwrap import fill
 
 from vyos.configquery import ConfigTreeQuery
 from vyos.ifconfig import Section
@@ -117,8 +118,11 @@ if __name__ == '__main__':
         exit(f'OpenVPN certificate key "{key}" does not exist!')
 
     ca = config.value(['pki', 'ca', ca, 'certificate'])
+    ca = fill(ca, width=64)
     cert = config.value(['pki', 'certificate', cert, 'certificate'])
+    cert = fill(cert, width=64)
     key = config.value(['pki', 'certificate', key, 'private', 'key'])
+    key = fill(key, width=64)
     remote_host = config.value(base + [interface, 'local-host'])
 
     ovpn_conf = config.get_config_dict(base + [interface], key_mangling=('-', '_'), get_first_key=True)


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The command "generate openvpn client-config" generates client.ovpn
file and CA and client certificate are displayed in one line
To fix it
Add function that set new line after every x characters
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4236

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openvpn
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Op-mode
```
generate openvpn client-config interface vtun10 ca ca certificate client
```
Before fix:
```
# Encryption options

keysize 256
comp-lzo no

<ca>
-----BEGIN CERTIFICATE-----
MIIDnTCCAoWgAwIBAgIUF3Iy6UWnONbg3fjLGM+pA47xSNQwDQYJKoZIhvcNAQELBQAwVzELMAkGA1UEBhMCR0IxEzARBgNVBAgMClNvbWUtU3RhdGUxEjAQBgNVBAcMCVNvbWUtQ2l0eTENMAsGA1UECgwEVnlPUzEQMA4GA1UEAwwHdnlvcy5pbzAeFw0yMjA0MjUxMjA2NDdaFw0yNzA0MjQxMjA2NDdaMFcxCzAJBgNVBAYTAkdCMRMwEQYDVQQIDApTb21lLVN0YXRlMRIwEAYDVQQHDAlTb21lLUNpdHkxDTALBgNVBAoMBFZ5T1MxEDAOBgNVBAMMB3Z5b3MuaW8wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDJWD40+sjc1Q7N7w86SknnN9BrLKWx00z6KPyLphb1YrNGhA+MEuJMAPkfkde10cxxdooYdvuD1fdwAI3SOHWUx18MeWdYwrK4QwFHChAsrcsapmkHzJn8TrPlabFDORIRMkSo50kZh+3YQ/n8DU3gy2Dl4jdUiPdCdyVf9fEzH03V66ive7CygE/HMR4s+Eje6VoWrfr4khhpsh5Q3QgXA3RRHsW7siEVAwDl7P2U5bBYmhosQaRMgAA2pvE/BXvCdfVnOLC4NLgpZeZv7oc6ed45SFZpKjdwwu7l+YpxF82lMDjz7YdPsPF0QZ4fw5WrpCKyhCVnjr4kfFd18+EJAgMBAAGjYTBfMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgGGMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAdBgNVHQ4EFgQU+uc9G+YdcPpfQHzmatcctIn3eFYwDQYJKoZIhvcNAQELBQADggEBACSXYKrsLFqP42Adcilus2Iju/+Y6+7sPTosrtaj5yucGxT7UOKa8Lk2efiaytU+St1BEgX3thq26bLhbNWqlAkhZ/CTgH0xhlouVtKcElUy8Yv8hSNMLm8ilFX6YDa37ATD1G73HRwBKtZZvvDp3FrzsCHVmqgJOKS+RegSpc90W16SFSxUQse4vuxgHY852ai5CRTe7rRa/Dw46QKbLJnbaStgXVODQoW/q31Ubbgy8YmvTqAvTZg/yjyX4ge8FmqOSwLO2GPQwhwRkqyPi1Z6VRUI6AftdihBGO0ViZXawte8wCLF+Pd1fLOXCyOft16sGQQECyO9DXSQ8Pc1HL0=
-----END CERTIFICATE-----

</ca>
```

After fix
```
# Encryption options

keysize 256
comp-lzo no

<ca>
-----BEGIN CERTIFICATE-----
MIIDnTCCAoWgAwIBAgIUF3Iy6UWnONbg3fjLGM+pA47xSNQwDQYJKoZIhvcNAQEL
BQAwVzELMAkGA1UEBhMCR0IxEzARBgNVBAgMClNvbWUtU3RhdGUxEjAQBgNVBAcM
CVNvbWUtQ2l0eTENMAsGA1UECgwEVnlPUzEQMA4GA1UEAwwHdnlvcy5pbzAeFw0y
MjA0MjUxMjA2NDdaFw0yNzA0MjQxMjA2NDdaMFcxCzAJBgNVBAYTAkdCMRMwEQYD
VQQIDApTb21lLVN0YXRlMRIwEAYDVQQHDAlTb21lLUNpdHkxDTALBgNVBAoMBFZ5
T1MxEDAOBgNVBAMMB3Z5b3MuaW8wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
AoIBAQDJWD40+sjc1Q7N7w86SknnN9BrLKWx00z6KPyLphb1YrNGhA+MEuJMAPkf
kde10cxxdooYdvuD1fdwAI3SOHWUx18MeWdYwrK4QwFHChAsrcsapmkHzJn8TrPl
abFDORIRMkSo50kZh+3YQ/n8DU3gy2Dl4jdUiPdCdyVf9fEzH03V66ive7CygE/H
MR4s+Eje6VoWrfr4khhpsh5Q3QgXA3RRHsW7siEVAwDl7P2U5bBYmhosQaRMgAA2
pvE/BXvCdfVnOLC4NLgpZeZv7oc6ed45SFZpKjdwwu7l+YpxF82lMDjz7YdPsPF0
QZ4fw5WrpCKyhCVnjr4kfFd18+EJAgMBAAGjYTBfMA8GA1UdEwEB/wQFMAMBAf8w
DgYDVR0PAQH/BAQDAgGGMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAd
BgNVHQ4EFgQU+uc9G+YdcPpfQHzmatcctIn3eFYwDQYJKoZIhvcNAQELBQADggEB
ACSXYKrsLFqP42Adcilus2Iju/+Y6+7sPTosrtaj5yucGxT7UOKa8Lk2efiaytU+
St1BEgX3thq26bLhbNWqlAkhZ/CTgH0xhlouVtKcElUy8Yv8hSNMLm8ilFX6YDa3
7ATD1G73HRwBKtZZvvDp3FrzsCHVmqgJOKS+RegSpc90W16SFSxUQse4vuxgHY85
2ai5CRTe7rRa/Dw46QKbLJnbaStgXVODQoW/q31Ubbgy8YmvTqAvTZg/yjyX4ge8
FmqOSwLO2GPQwhwRkqyPi1Z6VRUI6AftdihBGO0ViZXawte8wCLF+Pd1fLOXCyOf
t16sGQQECyO9DXSQ8Pc1HL0=
-----END CERTIFICATE-----

</ca>
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
