### PR TITLE
vpn-ipsec: T4398: Fix unexpected passthrough policy for peer

### DIFF
--- a/data/templates/ipsec/swanctl/peer.tmpl
+++ b/data/templates/ipsec/swanctl/peer.tmpl
@@ -152,7 +152,7 @@
 {%       endif %}
             }
 {%       if tunnel_conf.passthrough is vyos_defined %}
-            peer_{{ name }}_tunnel_{{ tunnel_id }}_passthough {
+            peer_{{ name }}_tunnel_{{ tunnel_id }}_passthrough {
                 local_ts = {{ tunnel_conf.passthrough | join(",") }}
                 remote_ts = {{ tunnel_conf.passthrough | join(",") }}
                 start_action = trap

--- a/src/conf_mode/vpn_ipsec.py
+++ b/src/conf_mode/vpn_ipsec.py
@@ -553,13 +553,15 @@ def generate(ipsec):
                     if not local_prefixes or not remote_prefixes:
                         continue
 
-                    passthrough = []
+                    passthrough = None
 
                     for local_prefix in local_prefixes:
                         for remote_prefix in remote_prefixes:
                             local_net = ipaddress.ip_network(local_prefix)
                             remote_net = ipaddress.ip_network(remote_prefix)
                             if local_net.overlaps(remote_net):
+                                if passthrough is None:
+                                    passthrough = []
                                 passthrough.append(local_prefix)
 
                     ipsec['site_to_site']['peer'][peer]['tunnel'][tunnel]['passthrough'] = passthrough


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Set default passtrough list to None to prevent unexpected policy
for peers with not overplapped local and remote prefixes
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4398

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vpn, ipsec
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS config
```
set vpn ipsec esp-group ESP-GRP compression 'disable'
set vpn ipsec esp-group ESP-GRP lifetime '3600'
set vpn ipsec esp-group ESP-GRP mode 'tunnel'
set vpn ipsec esp-group ESP-GRP pfs 'dh-group14'
set vpn ipsec esp-group ESP-GRP proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-GRP proposal 1 hash 'sha256'
set vpn ipsec ike-group IKE-GRP close-action 'none'
set vpn ipsec ike-group IKE-GRP dead-peer-detection action 'restart'
set vpn ipsec ike-group IKE-GRP dead-peer-detection interval '30'
set vpn ipsec ike-group IKE-GRP dead-peer-detection timeout '120'
set vpn ipsec ike-group IKE-GRP ikev2-reauth 'no'
set vpn ipsec ike-group IKE-GRP key-exchange 'ikev2'
set vpn ipsec ike-group IKE-GRP lifetime '28800'
set vpn ipsec ike-group IKE-GRP proposal 1 dh-group '14'
set vpn ipsec ike-group IKE-GRP proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE-GRP proposal 1 hash 'sha256'
set vpn ipsec interface 'eth2'
set vpn ipsec site-to-site peer 192.0.2.1 authentication id '192.0.2.2'
set vpn ipsec site-to-site peer 192.0.2.1 authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer 192.0.2.1 authentication pre-shared-secret 'Secret'
set vpn ipsec site-to-site peer 192.0.2.1 connection-type 'initiate'
set vpn ipsec site-to-site peer 192.0.2.1 ike-group 'IKE-GRP'
set vpn ipsec site-to-site peer 192.0.2.1 ikev2-reauth 'inherit'
set vpn ipsec site-to-site peer 192.0.2.1 local-address '192.0.2.2'
set vpn ipsec site-to-site peer 192.0.2.1 tunnel 1 esp-group 'ESP-GRP'
set vpn ipsec site-to-site peer 192.0.2.1 tunnel 1 local prefix '10.10.0.2/32'
set vpn ipsec site-to-site peer 192.0.2.1 tunnel 1 remote prefix '10.10.0.1/32'
set vpn ipsec site-to-site peer 203.0.113.24 authentication id '203.0.113.1'
set vpn ipsec site-to-site peer 203.0.113.24 authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer 203.0.113.24 authentication pre-shared-secret 'secret'
set vpn ipsec site-to-site peer 203.0.113.24 ike-group 'IKE-GRP'
set vpn ipsec site-to-site peer 203.0.113.24 local-address '192.0.2.2'
set vpn ipsec site-to-site peer 203.0.113.24 tunnel 0 esp-group 'ESP-GRP'
set vpn ipsec site-to-site peer 203.0.113.24 tunnel 0 local prefix '100.64.0.0/24'
set vpn ipsec site-to-site peer 203.0.113.24 tunnel 0 remote prefix '100.64.22.0/24'
set vpn ipsec site-to-site peer 203.0.113.24 tunnel 0 remote prefix '100.64.0.0/22'
```
Expected not option `passthrough` for peer 192.0.2.1
Expected option `passthrough` for peer 203.0.113.24
```
vyos@tstrtr2# cat /etc/swanctl/swanctl.conf | grep child -A 20
        children {
            peer_192-0-2-1_tunnel_1 {
                esp_proposals = aes256-sha256-modp2048
                life_time = 3600s
                local_ts = 10.10.0.2/32
                remote_ts = 10.10.0.1/32
                ipcomp = no
                mode = tunnel
                start_action = start
                dpd_action = restart
                close_action = none
            }
        }
    }

    peer_203-0-113-24 {
        proposals = aes256-sha256-modp2048
        version = 2
        local_addrs = 192.0.2.2 # dhcp:no
        remote_addrs = 203.0.113.24
        dpd_timeout = 120
--
        children {
            peer_203-0-113-24_tunnel_0 {
                esp_proposals = aes256-sha256-modp2048
                life_time = 3600s
                local_ts = 100.64.0.0/24
                remote_ts = 100.64.22.0/24,100.64.0.0/22
                ipcomp = no
                mode = tunnel
                start_action = start
                dpd_action = restart
                close_action = none
            }
            peer_203-0-113-24_tunnel_0_passthrough {
                local_ts = 100.64.0.0/24
                remote_ts = 100.64.0.0/24
                start_action = trap
                mode = pass
            }
        }
    }
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
