### PR TITLE
op-mode: T4395: Extend show vpn debug for IPSec add vpn_ipsec.py

### DIFF
--- a/src/op_mode/vpn_ipsec.py
+++ b/src/op_mode/vpn_ipsec.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+
+from vyos.util import call
+
+
+def debug_peer(peer, tunnel):
+    if not peer or peer == "all":
+        debug_commands = [
+            "sudo ipsec statusall",
+            "sudo swanctl -L",
+            "sudo swanctl -l",
+            "sudo swanctl -P",
+            "sudo ip x sa show",
+            "sudo ip x policy show",
+            "sudo ip tunnel show",
+            "sudo ip address",
+            "sudo ip rule show",
+            "sudo ip route | head -100",
+            "sudo ip route show table 220"
+        ]
+        for debug_cmd in debug_commands:
+            print(f'\n### {debug_cmd} ###')
+            call(debug_cmd)
+        return
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--action', help='Control action', required=True)
+    parser.add_argument('--name', help='Name for peer reset', required=False)
+    parser.add_argument('--tunnel', help='Specific tunnel of peer', required=False)
+
+    args = parser.parse_args()
+
+    if args.action == "vpn-debug":
+        debug_peer(args.name, args.tunnel)


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add python script for op-mode 'show vpn debug'
Extend `show vpn debug`

## Related PR
https://github.com/vyos/vyatta-op-vpn/pull/33

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4395

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vpn
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
show vpn debug
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
