### PR TITLE
smoketest: http: add decorator to suppress warnings locally

### DIFF
--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -16,6 +16,7 @@ import os
 import unittest
 
 from time import sleep
+from typing import Type
 
 from vyos.configsession import ConfigSession
 from vyos.configsession import ConfigSessionError
@@ -85,3 +86,17 @@ class VyOSUnitTestSHIM:
                 print(f'\n\ncommand "{command}" returned:\n')
                 pprint.pprint(out)
             return out
+
+# standard construction; typing suggestion: https://stackoverflow.com/a/70292317
+def ignore_warning(warning: Type[Warning]):
+    import warnings
+    from functools import wraps
+
+    def inner(f):
+        @wraps(f)
+        def wrapped(*args, **kwargs):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=warning)
+                return f(*args, **kwargs)
+        return wrapped
+    return inner

--- a/smoketest/scripts/cli/test_service_https.py
+++ b/smoketest/scripts/cli/test_service_https.py
@@ -15,15 +15,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-import urllib3
 
 from requests import request
+from urllib3.exceptions import InsecureRequestWarning
 
 from base_vyostest_shim import VyOSUnitTestSHIM
+from base_vyostest_shim import ignore_warning
 from vyos.util import read_file
 from vyos.util import run
-
-urllib3.disable_warnings()
 
 base_path = ['service', 'https']
 pki_base = ['pki']
@@ -100,6 +99,7 @@ class TestHTTPSService(VyOSUnitTestSHIM.TestCase):
         ret = run('sudo /usr/sbin/nginx -t')
         self.assertEqual(ret, 0)
 
+    @ignore_warning(InsecureRequestWarning)
     def test_api_auth(self):
         vhost_id = 'example'
         address = '127.0.0.1'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The smoketest 'test_service_https.py' initially used a script-global call to
`urllib3.disable_warnings()`
in order to suppress the expected InsecureRequestWarning. However, the unittest module resets warnings filters on init, which would require that the above disable function be called within the class or test function. Since warnings filters are a global setting, it is preferable to use a method decorator, so as not to affect future added tests.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

https, http-api

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
