### PR TITLE
NHRP : T4399: fix restart nhrp when adding or delete a tunnel

### DIFF
--- a/src/conf_mode/protocols_nhrp.py
+++ b/src/conf_mode/protocols_nhrp.py
@@ -104,7 +104,7 @@ def apply(nhrp):
         if rule_handle:
             remove_nftables_rule('ip filter', 'VYOS_FW_OUTPUT', rule_handle)
 
-    action = 'restart' if nhrp and 'tunnel' in nhrp else 'stop'
+    action = 'reload-or-restart' if nhrp and 'tunnel' in nhrp else 'stop'
     run(f'systemctl {action} opennhrp')
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
when you add or delete a nhrp tunnel , it restarts the opennhrp process of all tunnels which trigger any connection to be lost , this code solved it. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4399

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nhrp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@hub-dmvpn# set protocols nhrp tunnel tun104 holding-time '400'
[edit]
vyos@hub-dmvpn# compare
[edit protocols nhrp]
+tunnel tun104 {
+    cisco-authentication pass123
+    holding-time 400
+}
[edit]
vyos@hub-dmvpn# commit

# it should reload the opennhrp services 

**Apr 27 20:01:34 hub-dmvpn systemd[1]: Reloading OpenNHRP.
Apr 27 20:01:34 hub-dmvpn opennhrp[25022]: Removing dynamic 100.64.10.2/32 nbma 100.0.0.3 dev tun100 up expires_in 0:04
Apr 27 20:01:34 hub-dmvpn opennhrp[25022]: NL-ARP(tun100) 100.64.10.2 not-reachable
Apr 27 20:01:34 hub-dmvpn systemd[1]: Reloaded OpenNHRP.******
Apr 27 20:01:34 hub-dmvpn sudo[25996]: pam_unix(sudo:session): session closed for user root
Apr 27 20:01:34 hub-dmvpn vyos-configd[24217]: Sending response 1
Apr 27 20:01:34 hub-dmvpn sudo[26016]:     root : PWD=/ ; USER=root ; COMMAND=/usr/sbin/ip route del 100.0.0.3 src 100.0.0.1 proto 42
Apr 27 20:01:34 hub-dmvpn sudo[26016]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
Apr 27 20:01:34 hub-dmvpn sudo[26016]: pam_unix(sudo:session): session closed for user root
Apr 27 20:01:34 hub-dmvpn systemd[1]: opt-vyatta-config-tmp-new_config_25157.mount: Succeeded.

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
