### PR TITLE
monitoring: T4315: Add telegraf output plugin prometheus-client

### DIFF
--- a/data/templates/monitoring/telegraf.j2
+++ b/data/templates/monitoring/telegraf.j2
@@ -14,12 +14,28 @@
   logfile = ""
   hostname = ""
   omit_hostname = false
+{% if influxdb_configured is vyos_defined %}
 [[outputs.influxdb_v2]]
   urls = ["{{ url }}:{{ port }}"]
   insecure_skip_verify = true
   token = "$INFLUX_TOKEN"
   organization = "{{ authentication.organization }}"
   bucket = "{{ bucket }}"
+{% endif %}
+{% if prometheus_client is vyos_defined %}
+[[outputs.prometheus_client]]
+  ## Address to listen on
+  listen = "{{ prometheus_client.listen_address if prometheus_client.listen_address is vyos_defined else '' }}:{{ prometheus_client.port }}"
+  metric_version = {{ prometheus_client.metric_version }}
+{%     if prometheus_client.authentication.username is vyos_defined and prometheus_client.authentication.password is vyos_defined  %}
+  ## Use HTTP Basic Authentication
+  basic_username = "{{ prometheus_client.authentication.username }}"
+  basic_password = "{{ prometheus_client.authentication.password }}"
+{%     endif %}
+{%     if prometheus_client.allow_from is vyos_defined %}
+  ip_range = {{ prometheus_client.allow_from }}
+{%     endif %}
+{% endif %}
 [[inputs.cpu]]
     percpu = true
     totalcpu = true
@@ -50,6 +66,7 @@
   server = "unixgram:///run/telegraf/telegraf_syslog.sock"
   best_effort = true
   syslog_standard = "RFC3164"
+{% if influxdb_configured is vyos_defined %}
 [[inputs.exec]]
   commands = [
     "{{ custom_scripts_dir }}/show_firewall_input_filter.py",
@@ -58,3 +75,4 @@
   ]
   timeout = "10s"
   data_format = "influx"
+{% endif %}

--- a/interface-definitions/service_monitoring_telegraf.xml.in
+++ b/interface-definitions/service_monitoring_telegraf.xml.in
@@ -85,6 +85,89 @@
                 </properties>
                 <defaultValue>all</defaultValue>
               </leafNode>
+              <node name="prometheus-client">
+                <properties>
+                  <help>Output plugin Prometheus client</help>
+                </properties>
+                <children>
+                  <node name="authentication">
+                    <properties>
+                      <help>HTTP basic authentication parameters</help>
+                    </properties>
+                    <children>
+                      <leafNode name="username">
+                        <properties>
+                          <help>Authentication username</help>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="password">
+                        <properties>
+                          <help>Authentication password</help>
+                          <valueHelp>
+                            <format>txt</format>
+                            <description>Authentication password</description>
+                          </valueHelp>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </node>
+                  <leafNode name="allow-from">
+                    <properties>
+                      <help>Networks allowed to query this server</help>
+                      <valueHelp>
+                        <format>ipv4net</format>
+                        <description>IP address and prefix length</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>ipv6net</format>
+                        <description>IPv6 address and prefix length</description>
+                      </valueHelp>
+                      <multi/>
+                      <constraint>
+                        <validator name="ip-prefix"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="listen-address">
+                    <properties>
+                      <help>Local IP addresses to listen on</help>
+                      <completionHelp>
+                        <script>${vyos_completion_dir}/list_local_ips.sh --both</script>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>ipv4</format>
+                        <description>IPv4 address to listen for incoming connections</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>ipv6</format>
+                        <description>IPv6 address to listen for incoming connections</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="ipv4-address"/>
+                        <validator name="ipv6-address"/>
+                        <validator name="ipv6-link-local"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="metric-version">
+                    <properties>
+                      <help>Metric version control mapping from Telegraf to Prometheus format</help>
+                      <valueHelp>
+                        <format>u32:1-2</format>
+                        <description>Metric version (default: 2)</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-2"/>
+                      </constraint>
+                    </properties>
+                    <defaultValue>2</defaultValue>
+                  </leafNode>
+                  #include <include/port-number.xml.i>
+                  <leafNode name="port">
+                    <defaultValue>9273</defaultValue>
+                  </leafNode>
+                </children>
+              </node>
               <leafNode name="url">
                 <properties>
                   <help>Remote URL [REQUIRED]</help>

--- a/src/conf_mode/service_monitoring_telegraf.py
+++ b/src/conf_mode/service_monitoring_telegraf.py
@@ -99,6 +99,15 @@ def get_config(config=None):
     monitoring['interfaces_ethernet'] = get_interfaces('ethernet', vlan=False)
     monitoring['nft_chains'] = get_nft_filter_chains()
 
+    if 'authentication' in monitoring or \
+       'url' in monitoring:
+        monitoring['influxdb_configured'] = True
+
+    # Ignore default XML values if config doesn't exists
+    # Delete key from dict
+    if not conf.exists(base + ['prometheus-client']):
+        del monitoring['prometheus_client']
+
     return monitoring
 
 def verify(monitoring):
@@ -106,13 +115,14 @@ def verify(monitoring):
     if not monitoring:
         return None
 
-    if 'authentication' not in monitoring or \
-       'organization' not in monitoring['authentication'] or \
-       'token' not in monitoring['authentication']:
-        raise ConfigError(f'Authentication "organization and token" are mandatory!')
+    if 'influxdb_configured' in monitoring:
+        if 'authentication' not in monitoring or \
+           'organization' not in monitoring['authentication'] or \
+           'token' not in monitoring['authentication']:
+            raise ConfigError(f'Authentication "organization and token" are mandatory!')
 
-    if 'url' not in monitoring:
-        raise ConfigError(f'Monitoring "url" is mandatory!')
+        if 'url' not in monitoring:
+            raise ConfigError(f'Monitoring "url" is mandatory!')
 
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add output Plugin "prometheus-client" for telegraf:

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4315

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
monitoring, telegraf
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Minimal configuration:
```
set service monitoring telegraf prometheus-client
```
Check data from browser or curl:
```
vyos@tstrtr2# sudo curl http://localhost:9273/metrics | egrep -v "#" | head -10
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0conntrack_ip_conntrack_count{host="tstrtr2"} 5
conntrack_ip_conntrack_max{host="tstrtr2"} 262144
cpu_usage_guest{cpu="cpu-total",host="tstrtr2"} 0
cpu_usage_guest{cpu="cpu0",host="tstrtr2"} 0
cpu_usage_guest_nice{cpu="cpu-total",host="tstrtr2"} 0
cpu_usage_guest_nice{cpu="cpu0",host="tstrtr2"} 0
cpu_usage_idle{cpu="cpu-total",host="tstrtr2"} 97.22543352601456
cpu_usage_idle{cpu="cpu0",host="tstrtr2"} 97.22543352601456
cpu_usage_iowait{cpu="cpu-total",host="tstrtr2"} 0.3468208092485097
cpu_usage_iowait{cpu="cpu0",host="tstrtr2"} 0.3468208092485097
100 16190    0 16190    0     0   585k      0 --:--:-- --:--:-- --:--:--  585k
curl: (23) Failure writing output to destination
[edit]
vyos@tstrtr2# 
```

Possible options:
```
set service monitoring telegraf prometheus-client allow-from '192.0.2.0/24'
set service monitoring telegraf prometheus-client authentication username 'vyos'
set service monitoring telegraf prometheus-client authentication password 'vyospass'
set service monitoring telegraf prometheus-client listen-address '192.0.2.1'
set service monitoring telegraf prometheus-client metric-version '2'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
