### PR TITLE
T4353: alternative Jinja2 style guide

### DIFF
--- a/README.jinja2
+++ b/README.jinja2
@@ -1,0 +1,84 @@
+# Jinja2 style guide
+
+Our templates are large. We must keep them easy to read and modify
+if we want to be able to maintain and grow VyOS in the future.
+
+Consistent style that ensures readability and editability is crucial
+to ensure it.
+
+## General guidelines
+
+### Statements per line
+
+One line should have only one template tag.
+
+No:
+
+```
+{% if foo %} {% if bar %}
+{% endif %} {% endif %}
+```
+
+Yes:
+
+```
+{% if foo %}
+    {% if bar %}
+    {% endif %}
+{% endif %}
+```
+
+## Indentation
+
+### Example
+
+```
+{% for item in items %}
+    {% if item %}
+        There is {{ item }}  
+    {% endif %}
+{% endfor}
+
+{% if foo is defined %}
+    Foo is defined!
+{% endif %}
+```
+
+### Indent width
+
+Indent width is four spaces, for consistency with our Python code.
+
+### Indent position
+
+Indentation goes before the opening template tag, not inside the template tag.
+
+No:
+
+```
+{% if foo %}
+{%    if bar %}
+    baz
+{%    endif %}
+{% endif %}
+```
+
+Yes:
+
+```      
+{% if foo %}
+    {% if bar %}
+        baz
+    {% endif %}
+{% endif %}
+```
+
+Rationale:
+
+* Templates are easy to re-indent with built-in tools of any editor.
+* The opening tag is a part of the template syntax.
+
+### Content inside template logic blocks must be indented
+
+Content inside block is essentially a statement to emit that content.
+A level of indentation is a visual aid for separating logic for emitting that content
+from the content itself.

--- a/README.jinja2
+++ b/README.jinja2
@@ -28,6 +28,20 @@ Yes:
 {% endif %}
 ```
 
+### Empty lines
+
+Unrelated statements and blocks must be separated by a newline.
+
+```
+{% if foo is defined %}
+    Foo is defined!
+{% endif %}
+
+{% if bar is defined %}
+    Bar is defined!
+{% endif %}
+```
+
 ## Indentation
 
 ### Example

--- a/data/templates/openvpn/server.conf.j2
+++ b/data/templates/openvpn/server.conf.j2
@@ -10,215 +10,245 @@ verb 3
 dev-type {{ device_type }}
 dev {{ ifname }}
 persist-key
+
 {% if protocol is vyos_defined('tcp-active') %}
-proto tcp-client
+  proto tcp-client
 {% elif protocol is vyos_defined('tcp-passive') %}
-proto tcp-server
+  proto tcp-server
 {% else %}
-proto udp
+  proto udp
 {% endif %}
+
 {% if local_host is vyos_defined %}
-local {{ local_host }}
+    local {{ local_host }}
 {% endif %}
+
 {% if mode is vyos_defined('server') and protocol is vyos_defined('udp') and local_host is not vyos_defined %}
-multihome
+    multihome
 {% endif %}
+
 {% if local_port is vyos_defined %}
-lport {{ local_port }}
+    lport {{ local_port }}
 {% endif %}
+
 {% if remote_port is vyos_defined %}
-rport {{ remote_port }}
+    rport {{ remote_port }}
 {% endif %}
+
 {% if remote_host is vyos_defined %}
-{%     for remote in remote_host %}
-remote {{ remote }}
-{%     endfor %}
+    {% for remote in remote_host %}
+        remote {{ remote }}
+    {% endfor %}
 {% endif %}
+
 {% if shared_secret_key is vyos_defined %}
-secret /run/openvpn/{{ ifname }}_shared.key
+    secret /run/openvpn/{{ ifname }}_shared.key
 {% endif %}
+
 {% if persistent_tunnel is vyos_defined %}
-persist-tun
+    persist-tun
 {% endif %}
+
 {% if replace_default_route.local is vyos_defined %}
-push "redirect-gateway local def1"
+    push "redirect-gateway local def1"
 {% elif replace_default_route is vyos_defined %}
-push "redirect-gateway def1"
+    push "redirect-gateway def1"
 {% endif %}
+
 {% if use_lzo_compression is vyos_defined %}
-compress lzo
+    compress lzo
 {% endif %}
 
 {% if mode is vyos_defined('client') %}
-#
-# OpenVPN Client mode
-#
-client
-nobind
-
+    #
+    # OpenVPN Client mode
+    #
+    client
+    nobind
 {% elif mode is vyos_defined('server') %}
-#
-# OpenVPN Server mode
-#
-mode server
-tls-server
-{%     if server is vyos_defined %}
-{%         if server.subnet is vyos_defined %}
-{%             if server.topology is vyos_defined('point-to-point') %}
-topology p2p
-{%             elif server.topology is vyos_defined %}
-topology {{ server.topology }}
-{%             endif %}
-{%             for subnet in server.subnet %}
-{%                 if subnet | is_ipv4 %}
-server {{ subnet | address_from_cidr }} {{ subnet | netmask_from_cidr }} nopool
-{# First ip address is used as gateway. It's allows to use metrics #}
-{%                     if server.push_route is vyos_defined %}
-{%                         for route, route_config in server.push_route.items() %}
-{%                             if route | is_ipv4 %}
-push "route {{ route | address_from_cidr }} {{ route | netmask_from_cidr }} {{ subnet | first_host_address ~ ' ' ~ route_config.metric if route_config.metric is vyos_defined }}"
-{%                             elif route | is_ipv6 %}
-push "route-ipv6 {{ route }}"
-{%                             endif %}
-{%                         endfor %}
-{%                     endif %}
-{# OpenVPN assigns the first IP address to its local interface so the pool used #}
-{# in net30 topology - where each client receives a /30 must start from the second subnet #}
-{%                     if server.topology is vyos_defined('net30') %}
-ifconfig-pool {{ subnet | inc_ip('4') }} {{ subnet | last_host_address | dec_ip('1') }} {{ subnet | netmask_from_cidr if device_type == 'tap' else '' }}
-{%                     else %}
-{# OpenVPN assigns the first IP address to its local interface so the pool must #}
-{# start from the second address and end on the last address #}
-ifconfig-pool {{ subnet | first_host_address | inc_ip('1') }} {{ subnet | last_host_address | dec_ip('1') }} {{ subnet | netmask_from_cidr if device_type == 'tun' else '' }}
-{%                     endif %}
-{%                 elif subnet | is_ipv6 %}
-server-ipv6 {{ subnet }}
-{%                 endif %}
-{%             endfor %}
-{%         endif %}
+    #
+    # OpenVPN Server mode
+    #
+    mode server
+    tls-server
 
-{%         if server.client_ip_pool is vyos_defined and server.client_ip_pool.disable is not vyos_defined %}
-ifconfig-pool {{ server.client_ip_pool.start }} {{ server.client_ip_pool.stop }}{{ server.client_ip_pool.subnet_mask if server.client_ip_pool.subnet_mask is vyos_defined }}
-{%         endif %}
-{%         if server.max_connections is vyos_defined %}
-max-clients {{ server.max_connections }}
-{%         endif %}
-{%         if server.client is vyos_defined %}
-client-config-dir /run/openvpn/ccd/{{ ifname }}
-{%         endif %}
-{%     endif %}
-keepalive {{ keep_alive.interval }} {{ keep_alive.interval | int * keep_alive.failure_count | int }}
-management /run/openvpn/openvpn-mgmt-intf unix
-{%     if server is vyos_defined %}
-{%         if server.reject_unconfigured_clients is vyos_defined %}
-ccd-exclusive
-{%         endif %}
+    {% if server is vyos_defined %}
+        {% if server.subnet is vyos_defined %}
+            {% if server.topology is vyos_defined('point-to-point') %}
+                topology p2p
+            {% elif server.topology is vyos_defined %}
+                topology {{ server.topology }}
+            {% endif %}
 
-{%         if server.name_server is vyos_defined %}
-{%             for nameserver in server.name_server %}
-{%                 if nameserver | is_ipv4 %}
-push "dhcp-option DNS {{ nameserver }}"
-{%                 elif nameserver | is_ipv6 %}
-push "dhcp-option DNS6 {{ nameserver }}"
-{%                 endif %}
-{%             endfor %}
-{%         endif %}
-{%         if server.domain_name is vyos_defined %}
-push "dhcp-option DOMAIN {{ server.domain_name }}"
-{%         endif %}
-{%         if server.mfa.totp is vyos_defined %}
-{%             set totp_config = server.mfa.totp %}
-plugin "{{ plugin_dir }}/openvpn-otp.so" "otp_secrets=/config/auth/openvpn/{{ ifname }}-otp-secrets otp_slop={{ totp_config.slop }} totp_t0={{ totp_config.drift }} totp_step={{ totp_config.step }} totp_digits={{ totp_config.digits }} password_is_cr={{ '1' if totp_config.challenge == 'enable' else '0' }}"
-{%         endif %}
-{%     endif %}
+            {% for subnet in server.subnet %}
+                {% if subnet | is_ipv4 %}
+                    server {{ subnet | address_from_cidr }} {{ subnet | netmask_from_cidr }} nopool
+
+                    {# First ip address is used as gateway. It's allows to use metrics #}
+                    {% if server.push_route is vyos_defined %}
+                        {% for route, route_config in server.push_route.items() %}
+                            {% if route | is_ipv4 %}
+                                push "route {{ route | address_from_cidr }} {{ route | netmask_from_cidr }} {{ subnet | first_host_address ~ ' ' ~ route_config.metric if route_config.metric is vyos_defined }}"
+                            {% elif route | is_ipv6 %}
+                                push "route-ipv6 {{ route }}"
+                            {% endif %}
+                        {% endfor %}
+                    {% endif %}
+
+                    {% if server.topology is vyos_defined('net30') %}
+                        {# OpenVPN assigns the first IP address to its local interface so the pool used in the net30 topology #}
+                        {# where each client receives a /30 must start from the second subnet #}
+                        ifconfig-pool {{ subnet | inc_ip('4') }} {{ subnet | last_host_address | dec_ip('1') }} {{ subnet | netmask_from_cidr if device_type == 'tap' else '' }}
+                    {% else %}
+                        {# OpenVPN assigns the first IP address to its local interface so the pool must #}
+                        {# start from the second address and end on the last address #}
+                        ifconfig-pool {{ subnet | first_host_address | inc_ip('1') }} {{ subnet | last_host_address | dec_ip('1') }} {{ subnet | netmask_from_cidr if device_type == 'tun' else '' }}
+                    {% endif %}
+                {% elif subnet | is_ipv6 %}
+                    server-ipv6 {{ subnet }}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+
+        {% if server.client_ip_pool is vyos_defined and server.client_ip_pool.disable is not vyos_defined %}
+            ifconfig-pool {{ server.client_ip_pool.start }} {{ server.client_ip_pool.stop }}{{ server.client_ip_pool.subnet_mask if server.client_ip_pool.subnet_mask is vyos_defined }}
+        {% endif %}
+
+        {% if server.max_connections is vyos_defined %}
+            max-clients {{ server.max_connections }}
+        {% endif %}
+
+        {% if server.client is vyos_defined %}
+            client-config-dir /run/openvpn/ccd/{{ ifname }}
+        {% endif %}
+    {% endif %}
+
+    keepalive {{ keep_alive.interval }} {{ keep_alive.interval | int * keep_alive.failure_count | int }}
+
+    management /run/openvpn/openvpn-mgmt-intf unix
+
+    {% if server is vyos_defined %}
+        {% if server.reject_unconfigured_clients is vyos_defined %}
+            ccd-exclusive
+        {% endif %}
+
+        {% if server.name_server is vyos_defined %}
+            {% for nameserver in server.name_server %}
+                {% if nameserver | is_ipv4 %}
+                    push "dhcp-option DNS {{ nameserver }}"
+                {% elif nameserver | is_ipv6 %}
+                    push "dhcp-option DNS6 {{ nameserver }}"
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+
+        {% if server.domain_name is vyos_defined %}
+            push "dhcp-option DOMAIN {{ server.domain_name }}"
+        {% endif %}
+
+        {% if server.mfa.totp is vyos_defined %}
+            {% set totp_config = server.mfa.totp %}
+                plugin "{{ plugin_dir }}/openvpn-otp.so" "otp_secrets=/config/auth/openvpn/{{ ifname }}-otp-secrets otp_slop={{ totp_config.slop }} totp_t0={{ totp_config.drift }} totp_step={{ totp_config.step }} totp_digits={{ totp_config.digits }} password_is_cr={{ '1' if totp_config.challenge == 'enable' else '0' }}"
+        {% endif %}
+    {% endif %}
 {% else %}
-#
-# OpenVPN site-2-site mode
-#
-ping {{ keep_alive.interval }}
-ping-restart {{ keep_alive.failure_count }}
+    #
+    # OpenVPN site-2-site mode
+    #
+    ping {{ keep_alive.interval }}
+    ping-restart {{ keep_alive.failure_count }}
 
-{%     if device_type == 'tap' %}
-{%         if local_address is vyos_defined %}
-{%             for laddr, laddr_conf in local_address.items() if laddr | is_ipv4 %}
-{%                 if laddr_conf.subnet_mask is vyos_defined %}
-ifconfig {{ laddr }} {{ laddr_conf.subnet_mask }}
-{%                 endif %}
-{%             endfor %}
-{%         endif %}
-{%     else %}
-{%         for laddr in local_address if laddr | is_ipv4 %}
-{%             for raddr in remote_address if raddr | is_ipv4 %}
-ifconfig {{ laddr }} {{ raddr }}
-{%             endfor %}
-{%         endfor %}
-{%         for laddr in local_address if laddr | is_ipv6 %}
-{%             for raddr in remote_address if raddr | is_ipv6 %}
-ifconfig-ipv6 {{ laddr }} {{ raddr }}
-{%             endfor %}
-{%         endfor %}
-{%     endif %}
+    {% if device_type == 'tap' %}
+        {% if local_address is vyos_defined %}
+            {% for laddr, laddr_conf in local_address.items() if laddr | is_ipv4 %}
+                {% if laddr_conf.subnet_mask is vyos_defined %}
+                    ifconfig {{ laddr }} {{ laddr_conf.subnet_mask }}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+    {% else %}
+        {% for laddr in local_address if laddr | is_ipv4 %}
+            {% for raddr in remote_address if raddr | is_ipv4 %}
+                ifconfig {{ laddr }} {{ raddr }}
+            {% endfor %}
+        {% endfor %}
+
+        {% for laddr in local_address if laddr | is_ipv6 %}
+            {% for raddr in remote_address if raddr | is_ipv6 %}
+                ifconfig-ipv6 {{ laddr }} {{ raddr }}
+            {% endfor %}
+        {% endfor %}
+    {% endif %}
 {% endif %}
 
 {% if tls is vyos_defined %}
-# TLS options
-{%     if tls.ca_certificate is vyos_defined %}
-ca /run/openvpn/{{ ifname }}_ca.pem
-{%     endif %}
-{%     if tls.certificate is vyos_defined %}
-cert /run/openvpn/{{ ifname }}_cert.pem
-{%     endif %}
-{%     if tls.private_key is vyos_defined %}
-key /run/openvpn/{{ ifname }}_cert.key
-{%     endif %}
-{%     if tls.crypt_key is vyos_defined %}
-tls-crypt /run/openvpn/{{ ifname }}_crypt.key
-{%     endif %}
-{%     if tls.crl is vyos_defined %}
-crl-verify /run/openvpn/{{ ifname }}_crl.pem
-{%     endif %}
-{%     if tls.tls_version_min is vyos_defined %}
-tls-version-min {{ tls.tls_version_min }}
-{%     endif %}
-{%     if tls.dh_params is vyos_defined %}
-dh /run/openvpn/{{ ifname }}_dh.pem
-{%     elif mode is vyos_defined('server') and tls.private_key is vyos_defined %}
-dh none
-{%     endif %}
-{%     if tls.auth_key is vyos_defined %}
-{%         if mode == 'client' %}
-tls-auth /run/openvpn/{{ ifname }}_auth.key 1
-{%         elif mode == 'server' %}
-tls-auth /run/openvpn/{{ ifname }}_auth.key 0
-{%         endif %}
-{%     endif %}
-{%     if tls.role is vyos_defined('active') %}
-tls-client
-{%     elif tls.role is vyos_defined('passive') %}
-tls-server
-{%     endif %}
+    # TLS options
+    {% if tls.ca_certificate is vyos_defined %}
+        ca /run/openvpn/{{ ifname }}_ca.pem
+    {% endif %}
+
+    {% if tls.certificate is vyos_defined %}
+        cert /run/openvpn/{{ ifname }}_cert.pem
+    {% endif %}
+
+    {% if tls.private_key is vyos_defined %}
+        key /run/openvpn/{{ ifname }}_cert.key
+    {% endif %}
+
+    {% if tls.crypt_key is vyos_defined %}
+        tls-crypt /run/openvpn/{{ ifname }}_crypt.key
+    {% endif %}
+
+    {% if tls.crl is vyos_defined %}
+        crl-verify /run/openvpn/{{ ifname }}_crl.pem
+    {% endif %}
+
+    {% if tls.tls_version_min is vyos_defined %}
+        tls-version-min {{ tls.tls_version_min }}
+    {% endif %}
+
+    {% if tls.dh_params is vyos_defined %}
+        dh /run/openvpn/{{ ifname }}_dh.pem
+    {% elif mode is vyos_defined('server') and tls.private_key is vyos_defined %}
+        dh none
+    {% endif %}
+
+    {% if tls.auth_key is vyos_defined %}
+        {% if mode == 'client' %}
+            tls-auth /run/openvpn/{{ ifname }}_auth.key 1
+        {% lif mode == 'server' %}
+            tls-auth /run/openvpn/{{ ifname }}_auth.key 0
+        {% endif %}
+    {% endif %}
+
+    {% if tls.role is vyos_defined('active') %}
+        tls-client
+    {% elif tls.role is vyos_defined('passive') %}
+        tls-server
+    {% endif %}
 {% endif %}
 
 # Encryption options
 {% if encryption is vyos_defined %}
-{%     if encryption.cipher is vyos_defined %}
-cipher {{ encryption.cipher | openvpn_cipher }}
-{%         if encryption.cipher is vyos_defined('bf128') %}
-keysize 128
-{%         elif encryption.cipher is vyos_defined('bf256') %}
-keysize 256
-{%         endif %}
-{%     endif %}
-{%     if encryption.ncp_ciphers is vyos_defined %}
-data-ciphers {{ encryption.ncp_ciphers | openvpn_ncp_ciphers }}
-{%     endif %}
+    {% if encryption.cipher is vyos_defined %}
+        cipher {{ encryption.cipher | openvpn_cipher }}
+        {% if encryption.cipher is vyos_defined('bf128') %}
+            keysize 128
+        {% elif encryption.cipher is vyos_defined('bf256') %}
+            keysize 256
+        {% endif %}
+    {% endif %}
+
+    {% if encryption.ncp_ciphers is vyos_defined %}
+        data-ciphers {{ encryption.ncp_ciphers | openvpn_ncp_ciphers }}
+    {% endif %}
 {% endif %}
 
 {% if hash is vyos_defined %}
-auth {{ hash }}
+    auth {{ hash }}
 {% endif %}
 
 {% if authentication is vyos_defined %}
-auth-user-pass {{ auth_user_pass_file }}
-auth-retry nointeract
+    auth-user-pass {{ auth_user_pass_file }}
+    auth-retry nointeract
 {% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

### Points

* Indentation should be outside of template tags, not inside them.
* Content inside template blocks should be indented.
* Unrelated blocks must be separated by newlines.

### Details

First of all, I'm sorry for not stepping in earlier when Christian first introduced the j2lint linter! If the alternative style guide is accepted, I'm ready to reformat templates that he already updated.

The main change I want to propose is indenting template tags rather than statements inside template tags. That is, it should look like this:

```
{% for foo in bar %}
    {% if foo is defined %}
    {% endif %}
{% endfor %}
```
rather than like this:

```
{% for foo in bar %}
{%     if foo is defined %}
{%     endif %}
{% endfor %}
```
The main reason is that when opening tags are indented, any editor can reindent those templates. With indentation inside tags, a template writer will need a special editor setup, if tools to make such a setup in any editor even exist now.

I also, somewhat subjectively, believe that "outside" indents also make code much easier to read, since `{%` at the line start draws attention to itself. Besides, the opening tag _is_ a part of the statement.

Also, the style that j2linter enforces appears to be unique to Arista. Official [Jinja2 docs](https://jinja.palletsprojects.com/en/3.1.x/templates/) use "outside" indentation.
 
### j2lint considerations

j2lint, unfortunately, cannot be configured to use outside indentation. It's, sadly, a very opinionated tool, and its opinions are clearly against those of Jinja2 authors. ;)

I also looked inside the code and it's not possible to easily modify to support both outside and inside indentation.

It also disallows whitespace control tags by default, even though they are normal and useful.

However! That code isn't sophisticated either. It only recognized basic Jinja2 keywords (`if/endif`, `for/endfor`) etc. and doesn't try to do abstract interpretation for correctness checks, so a similar or better linter can be recreated in a few days of undisturbed effort.

For now we may disable its indentation and whitespace control checks, but keep the rest to check basic template syntax correctness automatically at least.

### Handling existing templates

Since Christian indented existing templates _consistently_, we can convert the "inside" style to "outside" with a script. Here's a prototype:

```python
#!/usr/bin/env python3

import re
import sys

with open(sys.argv[1], 'r') as f:
    for l in f.readlines():
        res = re.search(r'^\{%(\s+)\S', l)
        if res:
            # Extract the original indent
            spaces = res.group(1)

            # Replace the indent within the tag with a single space
            l = re.sub(r'(\{%)(\s+)(\S)', '\\1 \\3', l)

            # Since indents inside tags include an extra space,
            # we need to subtract it
            sys.stdout.write(spaces[1:])

        sys.stdout.write(l)

```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4353

## Proposed changes
<!--- Describe your changes in detail -->
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
