### PR TITLE
T4405: Fix administrative distance of DHCP routes

### DIFF
--- a/src/etc/dhcp/dhclient-enter-hooks.d/03-vyos-ipwrapper
+++ b/src/etc/dhcp/dhclient-enter-hooks.d/03-vyos-ipwrapper
@@ -23,7 +23,7 @@ function iptovtysh () {
     local VTYSH_GATEWAY=""
     local VTYSH_DEV=""
     local VTYSH_TAG="210"
-    local VTYSH_DISTANCE=""
+    local VTYSH_DISTANCE=$IF_METRIC
     # convert default route to 0.0.0.0/0
     if [ "$4" == "default" ] ; then
         VTYSH_NETADDR="0.0.0.0/0"


### PR DESCRIPTION
## Change Summary
- Default dhclient script only uses value of `$IF_MERIC` envvar for default route recived via `router` option.
- This variable has no effect on rotes received via `rfc3442-classless-static-routes` option
- Considering that Vyos overrrides `ip` command originating from `dhclient` this can be easily fixed in `iptovtysh()` function by using the `$IF_METRIC` envvar directly in the dhclient hook.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T4405

## Component(s) name
dhcp-client

## Proposed changes
Extend application of default route distance to routes revceived via `rfc3442-classless-static-routes`

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
- Set up a DHCP server that serves routes via `rfc3442-classless-static-routes` option (Starlink router in bypass mode was used in this particular case)...
- Configure an interface to receive address via DHCP from the router.
- Check routes with `sow ip route` command and make sure they are listed with administrative distance of 210

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
