### PR TITLE
monitoring: T4418: Add output plugin azure-data-explorer

### DIFF
--- a/data/templates/monitoring/telegraf.j2
+++ b/data/templates/monitoring/telegraf.j2
@@ -14,6 +14,23 @@
   logfile = ""
   hostname = ""
   omit_hostname = false
+{% if azure_data_explorer is vyos_defined %}
+### Azure Data Explorer ###
+[[outputs.azure_data_explorer]]
+  ## The URI property of the Azure Data Explorer resource on Azure
+  endpoint_url = "{{ azure_data_explorer.url }}"
+
+  ## The Azure Data Explorer database that the metrics will be ingested into.
+  ## The plugin will NOT generate this database automatically, it's expected that this database already exists before ingestion.
+  database = "{{ azure_data_explorer.database }}"
+  metrics_grouping_type = "{{ azure_data_explorer.group_metrics }}"
+
+  ## Name of the single table to store all the metrics (Only needed if metrics_grouping_type is "SingleTable").
+{%     if azure_data_explorer.table is vyos_defined and azure_data_explorer.group_metrics == 'SingleTable' %}
+  table_name = "{{ azure_data_explorer.table }}"
+{%     endif %}
+### End Azure Data Explorer ###
+{% endif %}
 {% if influxdb_configured is vyos_defined %}
 ### InfluxDB2 ###
 [[outputs.influxdb_v2]]

--- a/interface-definitions/include/monitoring/url.xml.i
+++ b/interface-definitions/include/monitoring/url.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from monitoring/url.xml.i -->
+<leafNode name="url">
+  <properties>
+    <help>Remote URL [REQUIRED]</help>
+    <valueHelp>
+      <format>url</format>
+      <description>Remote URL</description>
+    </valueHelp>
+    <constraint>
+      <regex>(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}?(\/.*)?</regex>
+    </constraint>
+    <constraintErrorMessage>Incorrect URL format</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/service_monitoring_telegraf.xml.in
+++ b/interface-definitions/service_monitoring_telegraf.xml.in
@@ -42,6 +42,94 @@
                   </leafNode>
                 </children>
               </node>
+              <node name="azure-data-explorer">
+                <properties>
+                  <help>Output plugin Azure Data Explorer</help>
+                </properties>
+                <children>
+                  <node name="authentication">
+                    <properties>
+                      <help>Authentication parameters</help>
+                    </properties>
+                    <children>
+                      <leafNode name="client-id">
+                        <properties>
+                          <help>Application client id</help>
+                          <constraint>
+                            <regex>[-_a-zA-Z0-9]+</regex>
+                          </constraint>
+                          <constraintErrorMessage>Client-id is limited to alphanumerical characters and can contain hyphen and underscores</constraintErrorMessage>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="client-secret">
+                        <properties>
+                          <help>Application client secret</help>
+                          <constraint>
+                            <regex>[-_a-zA-Z0-9]+</regex>
+                          </constraint>
+                          <constraintErrorMessage>Client-secret is limited to alphanumerical characters and can contain hyphen and underscores</constraintErrorMessage>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="tenant-id">
+                        <properties>
+                          <help>Set tenant id</help>
+                          <constraint>
+                            <regex>[-_a-zA-Z0-9]+</regex>
+                          </constraint>
+                          <constraintErrorMessage>Tenant-id is limited to alphanumerical characters and can contain hyphen and underscores</constraintErrorMessage>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </node>
+                  <leafNode name="database">
+                    <properties>
+                      <help>Remote database name [REQUIRED]</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Remote database name</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>[-_a-zA-Z0-9]+</regex>
+                      </constraint>
+                      <constraintErrorMessage>Database is limited to alphanumerical characters and can contain hyphen and underscores</constraintErrorMessage>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="group-metrics">
+                    <properties>
+                      <help>Type of metrics grouping when push to Azure Data Explorer</help>
+                      <completionHelp>
+                        <list>single-table table-per-metric</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>single-table</format>
+                        <description>Metrics stores in one table</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>table-per-metric</format>
+                        <description>One table per gorups of metric by the metric name</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>(single-table|table-per-metric)</regex>
+                      </constraint>
+                    </properties>
+                    <defaultValue>table-per-metric</defaultValue>
+                  </leafNode>
+                  <leafNode name="table">
+                    <properties>
+                      <help>Name of the single table [Only if set group-metrics single-table]</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Table name</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>[-_a-zA-Z0-9]+</regex>
+                      </constraint>
+                      <constraintErrorMessage>Table is limited to alphanumerical characters and can contain hyphen and underscores</constraintErrorMessage>
+                    </properties>
+                  </leafNode>
+                  #include <include/monitoring/url.xml.i>
+                </children>
+              </node>
               <leafNode name="bucket">
                 <properties>
                   <help>Remote bucket</help>
@@ -206,19 +294,7 @@
                   </leafNode>
                 </children>
               </node>
-              <leafNode name="url">
-                <properties>
-                  <help>Remote URL [REQUIRED]</help>
-                  <valueHelp>
-                    <format>url</format>
-                    <description>Remote URL to InfluxDB v2</description>
-                  </valueHelp>
-                  <constraint>
-                    <regex>(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}?(\/.*)?</regex>
-                  </constraint>
-                  <constraintErrorMessage>Incorrect URL format.</constraintErrorMessage>
-                </properties>
-              </leafNode>
+              #include <include/monitoring/url.xml.i>
               #include <include/port-number.xml.i>
               <leafNode name="port">
                 <defaultValue>8086</defaultValue>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add output telegraf Plugin Azure Data Explorer

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4418

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
monitoring, telegraf
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service monitoring telegraf azure-data-explorer authentication client-id 'some-clientID'
set service monitoring telegraf azure-data-explorer authentication client-secret 'SecRtetsdf'
set service monitoring telegraf azure-data-explorer authentication tenant-id 'some-tanantID'
set service monitoring telegraf azure-data-explorer database 'foo_data'
set service monitoring telegraf azure-data-explorer group-metrics 'table-per-metric'
set service monitoring telegraf azure-data-explorer url 'http://localhost.loc'
```
telegraf config:
```
vyos@tstrtr2# cat /run/telegraf/vyos-telegraf.conf | grep Azure -A 10
### Azure Data Explorer ###
[[outputs.azure_data_explorer]]
  ## The URI property of the Azure Data Explorer resource on Azure
  endpoint_url = "http://localhost.loc"

  ## The Azure Data Explorer database that the metrics will be ingested into.
  ## The plugin will NOT generate this database automatically, it's expected that this database already exists before ingestion.
  database = "foo_data"
  metrics_grouping_type = "TablePerMetric"
### End Azure Data Explorer ###
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
