### PR TITLE
T4441: wwan: connection not possible after a change added after 1.3.1-S1 release - equuleus

### DIFF
--- a/src/conf_mode/interfaces-wwan.py
+++ b/src/conf_mode/interfaces-wwan.py
@@ -21,7 +21,7 @@ from time import sleep
 
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
-from vyos.configdict import leaf_node_changed
+from vyos.configdict import is_node_changed
 from vyos.configverify import verify_authentication
 from vyos.configverify import verify_interface_exists
 from vyos.configverify import verify_vrf
@@ -54,27 +54,25 @@ def get_config(config=None):
     # We should only terminate the WWAN session if critical parameters change.
     # All parameters that can be changed on-the-fly (like interface description)
     # should not lead to a reconnect!
-    tmp = leaf_node_changed(conf, ['address'])
+    tmp = is_node_changed(conf, ['address'])
     if tmp: wwan.update({'shutdown_required': {}})
 
-    tmp = leaf_node_changed(conf, ['apn'])
+    tmp = is_node_changed(conf, ['apn'])
     if tmp: wwan.update({'shutdown_required': {}})
 
-    tmp = leaf_node_changed(conf, ['disable'])
+    tmp = is_node_changed(conf, ['disable'])
     if tmp: wwan.update({'shutdown_required': {}})
 
-    tmp = leaf_node_changed(conf, ['vrf'])
-    # leaf_node_changed() returns a list, as VRF is a non-multi node, there
-    # will be only one list element
-    if tmp: wwan.update({'vrf_old': tmp[0]})
+    tmp = is_node_changed(conf, ['vrf'])
+    if tmp: wwan.update({'vrf_old': {}})
 
-    tmp = leaf_node_changed(conf, ['authentication', 'user'])
+    tmp = is_node_changed(conf, ['authentication', 'user'])
     if tmp: wwan.update({'shutdown_required': {}})
 
-    tmp = leaf_node_changed(conf, ['authentication', 'password'])
+    tmp = is_node_changed(conf, ['authentication', 'password'])
     if tmp: wwan.update({'shutdown_required': {}})
 
-    tmp = leaf_node_changed(conf, ['ipv6', 'address', 'autoconf'])
+    tmp = is_node_changed(conf, ['ipv6', 'address', 'autoconf'])
     if tmp: wwan.update({'shutdown_required': {}})
 
     # We need to know the amount of other WWAN interfaces as ModemManager needs


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Use `is_node_changed()` over `leaf_node_changed()`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4441

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wwan

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketest or

```
set interfaces wwan wwan0 address 'dhcp'
set interfaces wwan wwan0 apn 'internet.t-d1.de'
set interfaces wwan wwan0 dhcp-options default-route-distance '220'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
