### PR TITLE
IPV6 : T3976: add prefix-list and access-list option from ipv6 route-map

### DIFF
--- a/data/templates/frr/policy.frr.j2
+++ b/data/templates/frr/policy.frr.j2
@@ -218,8 +218,14 @@ route-map {{ route_map }} {{ rule_config.action }} {{ rule }}
 {%                     if rule_config.match.ipv6.address.prefix_len is vyos_defined %}
  match ipv6 address prefix-len {{ rule_config.match.ipv6.address.prefix_len }}
 {%                     endif %}
-{%                     if rule_config.match.ipv6.nexthop is vyos_defined %}
- match ipv6 next-hop address {{ rule_config.match.ipv6.nexthop }}
+{%                     if rule_config.match.ipv6.nexthop.address is vyos_defined %}
+ match ipv6 next-hop address {{ rule_config.match.ipv6.nexthop.address }}
+{%                     endif %}
+{%                     if rule_config.match.ipv6.nexthop.access_list is vyos_defined %}
+ match ipv6 next-hop {{ rule_config.match.ipv6.nexthop.access_list }}
+{%                     endif %}
+{%                     if rule_config.match.ipv6.nexthop.prefix_list is vyos_defined %}
+ match ipv6 next-hop prefix-list {{ rule_config.match.ipv6.nexthop.prefix_list }}
 {%                     endif %}
 {%                     if rule_config.match.large_community.large_community_list is vyos_defined %}
  match large-community {{ rule_config.match.large_community.large_community_list }}

--- a/interface-definitions/policy.xml.in
+++ b/interface-definitions/policy.xml.in
@@ -821,6 +821,7 @@
                           </leafNode>
                         </children>
                       </node>
+                <!--  T3976 but it overwrite node nexthop
                       <leafNode name="nexthop">
                         <properties>
                           <help>IPv6 next-hop of route to match</help>
@@ -833,6 +834,47 @@
                           </constraint>
                         </properties>
                       </leafNode>
+                    </children>
+                  </node> -->
+                      <node name="nexthop">
+                        <properties>
+                          <help>IPv6 next-hop of route to match</help>
+                        </properties>
+                        <children>
+                          <leafNode name="address">
+                            <properties>
+                              <help>IPv6 address of next-hop</help>
+                              <valueHelp>
+                                <format>ipv6</format>
+                                <description>Nexthop IPv6 address</description>
+                              </valueHelp>
+                              <constraint>
+                                <validator name="ipv6-address"/>
+                              </constraint>
+                            </properties>
+                          </leafNode>                           
+                          <leafNode name="access-list">
+                            <properties>
+                              <help>IPv6 access-list to match</help>
+                              <valueHelp>
+                                <format>txt</format>
+                                <description>IPV6 access list name</description>
+                              </valueHelp>
+                              <completionHelp>
+                                <path>policy access-list6</path>
+                              </completionHelp>
+                            </properties>
+                          </leafNode>
+                          <leafNode name="prefix-list">
+                            <properties>
+                              <help>IPv6 prefix-list to match</help>
+                              <completionHelp>
+                                <path>policy prefix-list6</path>
+                              </completionHelp>
+                            </properties>
+                          </leafNode>
+                        </children>
+                      </node>
                     </children>
                   </node>
                   <node name="large-community">

--- a/smoketest/scripts/cli/test_policy.py
+++ b/smoketest/scripts/cli/test_policy.py
@@ -711,7 +711,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         large_community_list = 'bgp-large-community-123456'
         prefix_list = 'foo-pfx-list'
-        ipv6_nexthop = 'fe80::1'
+        ipv6_nexthop_address = 'fe80::1'
         local_pref = '300'
         metric = '50'
         peer = '2.3.4.5'
@@ -791,7 +791,9 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                     '30' : {
                         'action' : 'permit',
                         'match' : {
-                            'ipv6-nexthop' : ipv6_nexthop,
+                            'ipv6-nexthop-address' : ipv6_nexthop_address,
+                            'ipv6-nexthop-access-list' : access_list,
+                            'ipv6-nexthop-prefix-list' : prefix_list,
                             'ipv6-address-pfx-len' : ipv6_prefix_len,
                             'large-community' : large_community_list,
                             'local-pref' : local_pref,
@@ -965,8 +967,12 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                         self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'address', 'prefix-list', rule_config['match']['ipv6-address-pfx']])
                     if 'ipv6-address-pfx-len' in rule_config['match']:
                         self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'address', 'prefix-len', rule_config['match']['ipv6-address-pfx-len']])
-                    if 'ipv6-nexthop' in rule_config['match']:
-                        self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'nexthop', rule_config['match']['ipv6-nexthop']])
+                    if 'ipv6-nexthop-address' in rule_config['match']:
+                        self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'nexthop', 'address', rule_config['match']['ipv6-nexthop-address']])
+                    if 'ipv6-nexthop-access-list' in rule_config['match']:
+                        self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'nexthop', 'access-list' rule_config['match']['ipv6-nexthop-access-list']])
+                    if 'ipv6-nexthop-prefix-list' in rule_config['match']:
+                        self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'nexthop', 'prefix-list', rule_config['match']['ipv6-nexthop-prefix-list']])
                     if 'large-community' in rule_config['match']:
                         self.cli_set(path + ['rule', rule, 'match', 'large-community', 'large-community-list', rule_config['match']['large-community']])
                     if 'local-pref' in rule_config['match']:
@@ -1126,8 +1132,14 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                     if 'ipv6-address-pfx-len' in rule_config['match']:
                         tmp = f'match ipv6 address prefix-len {rule_config["match"]["ipv6-address-pfx-len"]}'
                         self.assertIn(tmp, config)
-                    if 'ipv6-nexthop' in rule_config['match']:
-                        tmp = f'match ipv6 next-hop address {rule_config["match"]["ipv6-nexthop"]}'
+                    if 'ipv6-nexthop-address' in rule_config['match']:
+                        tmp = f'match ipv6 next-hop address {rule_config["match"]["ipv6-nexthop-address"]}'
+                        self.assertIn(tmp, config)
+                    if 'ipv6-nexthop-access-list' in rule_config['match']:
+                        tmp = f'match ipv6 next-hop {rule_config["match"]["ipv6-nexthop-access-list"]}'
+                        self.assertIn(tmp, config)
+                    if 'ipv6-nexthop-prefix-list' in rule_config['match']:
+                        tmp = f'match ipv6 next-hop prefix-list {rule_config["match"]["ipv6-nexthop-prefix-list"]}'
                         self.assertIn(tmp, config)
                     if 'large-community' in rule_config['match']:
                         tmp = f'match large-community {rule_config["match"]["large-community"]}'

--- a/smoketest/scripts/cli/test_policy.py
+++ b/smoketest/scripts/cli/test_policy.py
@@ -970,7 +970,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                     if 'ipv6-nexthop-address' in rule_config['match']:
                         self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'nexthop', 'address', rule_config['match']['ipv6-nexthop-address']])
                     if 'ipv6-nexthop-access-list' in rule_config['match']:
-                        self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'nexthop', 'access-list' rule_config['match']['ipv6-nexthop-access-list']])
+                        self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'nexthop', 'access-list', rule_config['match']['ipv6-nexthop-access-list']])
                     if 'ipv6-nexthop-prefix-list' in rule_config['match']:
                         self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'nexthop', 'prefix-list', rule_config['match']['ipv6-nexthop-prefix-list']])
                     if 'large-community' in rule_config['match']:

--- a/src/conf_mode/policy.py
+++ b/src/conf_mode/policy.py
@@ -150,6 +150,16 @@ def verify(policy):
                 tmp = dict_search('match.ipv6.address.prefix_list', rule_config)
                 if tmp and tmp not in policy.get('prefix_list6', []):
                     raise ConfigError(f'prefix-list6 {tmp} does not exist!')
+                    
+                # Specified access_list6 in nexthop must exist
+                tmp = dict_search('match.ipv6.nexthop.access_list', rule_config)
+                if tmp and tmp not in policy.get('access_list6', []):
+                    raise ConfigError(f'access_list6 {tmp} does not exist!')
+
+                # Specified prefix-list6 in nexthop must exist
+                tmp = dict_search('match.ipv6.nexthop.prefix_list', rule_config)
+                if tmp and tmp not in policy.get('prefix_list6', []):
+                    raise ConfigError(f'prefix-list6 {tmp} does not exist!')
 
     # When routing protocols are active some use prefix-lists, route-maps etc.
     # to apply the systems routing policy to the learned or redistributed routes.

--- a/src/migration-scripts/policy/2-to-3
+++ b/src/migration-scripts/policy/2-to-3
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+​
+# T3976: change cli
+#     from: set policy route-map FOO rule 10 match ipv6 nexthop 'h:h:h:h:h:h:h:h'
+#       to: set policy route-map FOO rule 10 match ipv6 nexthop address 'h:h:h:h:h:h:h:h'
+​
+from sys import argv
+from sys import exit
+​
+from vyos.configtree import ConfigTree
+​
+if (len(argv) < 1):
+    print("Must specify file name!")
+    exit(1)
+​
+file_name = argv[1]
+​
+with open(file_name, 'r') as f:
+    config_file = f.read()
+​
+base = ['policy', 'route-map']
+config = ConfigTree(config_file)
+​
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+​
+​
+for route_map in config.list_nodes(base):
+    if not config.exists(base + [route_map, 'rule']):
+        continue
+    for rule in config.list_nodes(base + [route_map, 'rule']):
+        base_rule = base + [route_map, 'rule', rule]
+​
+        if config.exists(base_rule + ['match', 'ipv6', 'nexthop']):
+            tmp = config.return_value(base_rule + ['match', 'ipv6', 'nexthop'])
+            config.delete(base_rule + ['match', 'ipv6', 'nexthop'])
+            config.set(base_rule + ['match', 'ipv6', 'nexthop', 'address'], value=tmp)
+​
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print(f'Failed to save the modified config: {e}')
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

there are some missing options on the ipv6 route-map(nexthop) : 
-access-list
-prefix-list

and it also solved an issue with `ipv6 next-hop address` command frr.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3976

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
route-map ipv6

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos-cli : 
set policy access-list6 ipv6test rule 10 action 'permit'
set policy access-list6 ipv6test rule 10 description 'test'
set policy access-list6 ipv6test rule 10 source any
set policy route-map testv6 rule 10 action 'permit'
set policy route-map testv6 rule 10 match ipv6 nexthop access-list 'ipv6test'

frr: 
vyos@test-rm# sudo vtysh -c "show run"
Building configuration...

Current configuration:
!
frr version 8.2.2
frr defaults traditional
hostname test-rm
log syslog
log facility local7
service integrated-vtysh-config 
ipv6 access-list ipv6test seq 10 permit any
!
route-map testv6 permit 10
 match ipv6 next-hop ipv6test
exit
!

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
