### PR TITLE
Policy: T4449: Extend matching options for route-map ip nexthop

### DIFF
--- a/data/templates/frr/policy.frr.j2
+++ b/data/templates/frr/policy.frr.j2
@@ -188,8 +188,17 @@ route-map {{ route_map }} {{ rule_config.action }} {{ rule }}
 {%                     if rule_config.match.ip.nexthop.access_list is vyos_defined %}
  match ip next-hop {{ rule_config.match.ip.nexthop.access_list }}
 {%                     endif %}
+{%                     if rule_config.match.ip.nexthop.address is vyos_defined %}
+ match ip next-hop address {{ rule_config.match.ip.nexthop.address }}
+{%                     endif %}
+{%                     if rule_config.match.ip.nexthop.prefix_len is vyos_defined %}
+ match ip next-hop prefix-len {{ rule_config.match.ip.nexthop.prefix_len }}
+{%                     endif %}
 {%                     if rule_config.match.ip.nexthop.prefix_list is vyos_defined %}
  match ip next-hop prefix-list {{ rule_config.match.ip.nexthop.prefix_list }}
+{%                     endif %}
+{%                     if rule_config.match.ip.nexthop.type is vyos_defined %}
+ match ip next-hop type {{ rule_config.match.ip.nexthop.type }}
 {%                     endif %}
 {%                     if rule_config.match.ip.route_source.access_list is vyos_defined %}
  match ip route-source {{ rule_config.match.ip.route_source.access_list }}

--- a/interface-definitions/policy.xml.in
+++ b/interface-definitions/policy.xml.in
@@ -655,12 +655,20 @@
                       <node name="nexthop">
                         <properties>
                           <help>IP next-hop of route to match</help>
-                          <valueHelp>
-                            <format>ipv4</format>
-                            <description>Next-hop IPv4 router address</description>
-                          </valueHelp>
                         </properties>
                         <children>
+                          <leafNode name="address">
+                            <properties>
+                              <help>IP address to match</help>
+                              <valueHelp>
+                                <format>ipv4</format>
+                                <description>Nexthop IP address</description>
+                              </valueHelp>
+                              <constraint>
+                                <validator name="ipv4-address"/>
+                              </constraint>
+                            </properties>
+                          </leafNode>
                           <leafNode name="access-list">
                             <properties>
                               <help>IP access-list to match</help>
@@ -682,12 +690,39 @@
                               </valueHelp>
                             </properties>
                           </leafNode>
+                          <leafNode name="prefix-len">
+                            <properties>
+                              <help>IP prefix-lenght to match</help>
+                              <valueHelp>
+                                <format>u32:0-32</format>
+                                <description>Prefix length</description>
+                              </valueHelp>
+                              <constraint>
+                                <validator name="numeric" argument="--range 0-32"/>
+                              </constraint>
+                            </properties>
+                          </leafNode>
                           <leafNode name="prefix-list">
                             <properties>
                               <help>IP prefix-list to match</help>
                               <completionHelp>
                                 <path>policy prefix-list</path>
                               </completionHelp>
+                            </properties>
+                          </leafNode>
+                          <leafNode name="type">
+                            <properties>
+                              <help>Match type</help>
+                              <completionHelp>
+                                <list>blackhole</list>
+                              </completionHelp>
+                              <valueHelp>
+                                <format>blackhole</format>
+                                <description>Blackhole</description>
+                              </valueHelp>
+                              <constraint>
+                                <regex>(blackhole)</regex>
+                              </constraint>
                             </properties>
                           </leafNode>
                         </children>

--- a/smoketest/scripts/cli/test_policy.py
+++ b/smoketest/scripts/cli/test_policy.py
@@ -718,6 +718,11 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
         tag = '6542'
         goto = '25'
 
+        ipv4_nexthop_address= '192.0.2.2'
+        ipv4_nexthop_plen= '18'
+        ipv4_nexthop_type= 'blackhole'
+        
+
         test_data = {
             'foo-map-bar' : {
                 'rule' : {
@@ -791,6 +796,24 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                             'metric': metric,
                             'origin-egp': '',
                             'peer' : peer,
+                        },
+                    },
+                    '40' : {
+                        'action' : 'permit',
+                        'match' : {
+                            'ip-nexthop-addr' : ipv4_nexthop_address,
+                        },
+                    },
+                    '42' : {
+                        'action' : 'deny',
+                        'match' : {
+                            'ip-nexthop-plen' : ipv4_nexthop_plen,
+                        },
+                    },
+                    '44' : {
+                        'action' : 'permit',
+                        'match' : {
+                            'ip-nexthop-type' : ipv4_nexthop_type,
                         },
                     },
                 },
@@ -921,6 +944,12 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                         self.cli_set(path + ['rule', rule, 'match', 'ip', 'nexthop', 'access-list', rule_config['match']['ip-nexthop-acl']])
                     if 'ip-nexthop-pfx' in rule_config['match']:
                         self.cli_set(path + ['rule', rule, 'match', 'ip', 'nexthop', 'prefix-list', rule_config['match']['ip-nexthop-pfx']])
+                    if 'ip-nexthop-addr' in rule_config['match']:
+                        self.cli_set(path + ['rule', rule, 'match', 'ip', 'nexthop', 'address', rule_config['match']['ip-nexthop-addr']])
+                    if 'ip-nexthop-plen' in rule_config['match']:
+                        self.cli_set(path + ['rule', rule, 'match', 'ip', 'nexthop', 'prefix-len', rule_config['match']['ip-nexthop-plen']])
+                    if 'ip-nexthop-type' in rule_config['match']:
+                        self.cli_set(path + ['rule', rule, 'match', 'ip', 'nexthop', 'type', rule_config['match']['ip-nexthop-type']])
                     if 'ip-route-source-acl' in rule_config['match']:
                         self.cli_set(path + ['rule', rule, 'match', 'ip', 'route-source', 'access-list', rule_config['match']['ip-route-source-acl']])
                     if 'ip-route-source-pfx' in rule_config['match']:
@@ -1062,6 +1091,15 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                         self.assertIn(tmp, config)
                     if 'ip-nexthop-pfx' in rule_config['match']:
                         tmp = f'match ip next-hop prefix-list {rule_config["match"]["ip-nexthop-pfx"]}'
+                        self.assertIn(tmp, config)
+                    if 'ip-nexthop-addr' in rule_config['match']:
+                        tmp = f'match ip next-hop address {rule_config["match"]["ip-nexthop-addr"]}'
+                        self.assertIn(tmp, config)
+                    if 'ip-nexthop-plen' in rule_config['match']:
+                        tmp = f'match ip next-hop prefix-len {rule_config["match"]["ip-nexthop-plen"]}'
+                        self.assertIn(tmp, config)
+                    if 'ip-nexthop-type' in rule_config['match']:
+                        tmp = f'match ip next-hop type {rule_config["match"]["ip-nexthop-type"]}'
                         self.assertIn(tmp, config)
                     if 'ip-route-source-acl' in rule_config['match']:
                         tmp = f'match ip route-source {rule_config["match"]["ip-route-source-acl"]}'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Extend matching options for route-map ip nexthop

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4449

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
Policy
## Proposed changes
<!--- Describe your changes in detail -->
Extend matching options for route-map ip nexthop.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
VyOS cli:
```
vyos@vyos# set policy route-map TEST rule 10 match ip nexthop 
Possible completions:
   access-list  IP access-list to match
   address      IP address to match
   prefix-len   IP prefix-lenght to match
   prefix-list  IP prefix-list to match
   type         Match type

```


VyOS and FRR config:
```
vyos@vyos# run show config comm | grep pol
set policy access-list 10 rule 1 action 'deny'
set policy access-list 10 rule 1 source host '198.51.100.1'
set policy prefix-list PL01 rule 10 action 'permit'
set policy prefix-list PL01 rule 10 prefix '192.0.2.0/24'
set policy route-map TEST rule 10 action 'permit'
set policy route-map TEST rule 10 match ip nexthop address '1.2.3.4'
set policy route-map TEST rule 20 action 'deny'
set policy route-map TEST rule 20 match ip nexthop type 'blackhole'
set policy route-map TEST rule 30 action 'permit'
set policy route-map TEST rule 30 match ip nexthop prefix-len '22'
set policy route-map TEST rule 40 action 'deny'
set policy route-map TEST rule 40 match ip nexthop prefix-list 'PL01'
set policy route-map TEST rule 50 action 'permit'
set policy route-map TEST rule 50 match ip nexthop access-list '10'
[edit]

vyos@vyos# sudo vtysh -c "show run"
...
access-list 10 seq 1 deny 198.51.100.1
!
ip prefix-list PL01 seq 10 permit 192.0.2.0/24
!
route-map TEST permit 10
 match ip next-hop address 1.2.3.4
exit
!
route-map TEST deny 20
 match ip next-hop type blackhole
exit
!
route-map TEST permit 30
 match ip next-hop prefix-len 22
exit
!
route-map TEST deny 40
 match ip next-hop prefix-list PL01
exit
!
route-map TEST permit 50
 match ip next-hop 10
exit
```



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
