### PR TITLE
T3214: Fixed ovpn config incompatibilities for IPv4+IPv6 and IPv6-onl…

### DIFF
--- a/data/templates/openvpn/server.conf.j2
+++ b/data/templates/openvpn/server.conf.j2
@@ -71,28 +71,24 @@ topology {{ server.topology }}
 {%             endif %}
 {%             for subnet in server.subnet %}
 {%                 if subnet | is_ipv4 %}
-server {{ subnet | address_from_cidr }} {{ subnet | netmask_from_cidr }} nopool
+server {{ subnet | address_from_cidr }} {{ subnet | netmask_from_cidr }}
 {# First ip address is used as gateway. It's allows to use metrics #}
 {%                     if server.push_route is vyos_defined %}
 {%                         for route, route_config in server.push_route.items() %}
 {%                             if route | is_ipv4 %}
 push "route {{ route | address_from_cidr }} {{ route | netmask_from_cidr }} {{ subnet | first_host_address ~ ' ' ~ route_config.metric if route_config.metric is vyos_defined }}"
-{%                             elif route | is_ipv6 %}
+{%                             endif %}
+{%                         endfor %}
+{%                     endif %}
+{%                 elif subnet | is_ipv6 %}
+server-ipv6 {{ subnet }}
+{%                     if server.push_route is vyos_defined %}
+{%                         for route, route_config in server.push_route.items() %}
+{%                             if route | is_ipv6 %}
 push "route-ipv6 {{ route }}"
 {%                             endif %}
 {%                         endfor %}
 {%                     endif %}
-{# OpenVPN assigns the first IP address to its local interface so the pool used #}
-{# in net30 topology - where each client receives a /30 must start from the second subnet #}
-{%                     if server.topology is vyos_defined('net30') %}
-ifconfig-pool {{ subnet | inc_ip('4') }} {{ subnet | last_host_address | dec_ip('1') }} {{ subnet | netmask_from_cidr if device_type == 'tap' else '' }}
-{%                     else %}
-{# OpenVPN assigns the first IP address to its local interface so the pool must #}
-{# start from the second address and end on the last address #}
-ifconfig-pool {{ subnet | first_host_address | inc_ip('1') }} {{ subnet | last_host_address | dec_ip('1') }} {{ subnet | netmask_from_cidr if device_type == 'tun' else '' }}
-{%                     endif %}
-{%                 elif subnet | is_ipv6 %}
-server-ipv6 {{ subnet }}
 {%                 endif %}
 {%             endfor %}
 {%         endif %}

--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -319,9 +319,6 @@ def verify(openvpn):
             if v6_subnets > 1:
                 raise ConfigError('Cannot specify more than 1 IPv6 server subnet')
 
-            if v6_subnets > 0 and v4_subnets == 0:
-                raise ConfigError('IPv6 server requires an IPv4 server subnet')
-
             for subnet in tmp:
                 if is_ipv4(subnet):
                     subnet = IPv4Network(subnet)


### PR DESCRIPTION
## Change Summary
T3214: Fixed ovpn config incompatibilities for IPv4+IPv6 and IPv6-only use. "nopool" option not necessary. net30 "ifconfig-pool" statement handled by OpenVPN if "nopool" is omitted. IPv6 route push was nested inside IPv4 if block, now in IPv6 block. Removed mandatory IPv4 subnet for IPv6-only use.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T3214

## Component(s) name
openvpn

## Proposed changes
1) Fixed OpenVPN config incompatibilities for IPv4+IPv6 and IPv6-only use. "nopool" option not necessary in generated openvpn Configs because net30 "ifconfig-pool" statements are handled by OpenVPN if "nopool" is omitted. 
2) The generated config would allow a IPv6 only usage of the OpenVPN, but a commit error appears which prevent that saying that an IPv4 subnet is required. I have removed that check.
3) Another incompatibility after change of 2) is that if only IPv6 "push-route" statement is defined, the IPv6 route is not being pushed because it is nested inside an IPv4 if block. I have moved the code into the IPv6 block. 

## How to test
* Configure OpenVPN interface with mode=server. 
* Configure IPv4-only Subnet @ \[interfaces openvpn vtunN server] = PrePatch: OK - PostPatch: OK
* Configure IPv6-only Subnet @ \[interfaces openvpn vtunN server\] = PrePatch: FAIL - PostPatch: OK
* * Commit Error: IPv6 server requires an IPv4 server subnet
* Configure IPv6+IPv4 Subnet @ \[interfaces openvpn vtunN server] = PrePatch: FAIL - PostPatch: OK
* * OpenVPN Startup Error1: Options error: --server-ipv6 is incompatible with 'nopool' option
* * OpenVPN Startup Error2: Options error: --server already defines an ifconfig-pool, so you can't also specify --ifconfig-pool explicitly


## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
