### PR TITLE
Policy: T4450: Expand options for ip|ipv6 address match.

### DIFF
--- a/data/templates/frr/policy.frr.j2
+++ b/data/templates/frr/policy.frr.j2
@@ -185,6 +185,9 @@ route-map {{ route_map }} {{ rule_config.action }} {{ rule }}
 {%                     if rule_config.match.ip.address.prefix_list is vyos_defined %}
  match ip address prefix-list {{ rule_config.match.ip.address.prefix_list }}
 {%                     endif %}
+{%                     if rule_config.match.ip.address.prefix_len is vyos_defined %}
+ match ip address prefix-len {{ rule_config.match.ip.address.prefix_len }}
+{%                     endif %}
 {%                     if rule_config.match.ip.nexthop.access_list is vyos_defined %}
  match ip next-hop {{ rule_config.match.ip.nexthop.access_list }}
 {%                     endif %}
@@ -211,6 +214,9 @@ route-map {{ route_map }} {{ rule_config.action }} {{ rule }}
 {%                     endif %}
 {%                     if rule_config.match.ipv6.address.prefix_list is vyos_defined %}
  match ipv6 address prefix-list {{ rule_config.match.ipv6.address.prefix_list }}
+{%                     endif %}
+{%                     if rule_config.match.ipv6.address.prefix_len is vyos_defined %}
+ match ipv6 address prefix-len {{ rule_config.match.ipv6.address.prefix_len }}
 {%                     endif %}
 {%                     if rule_config.match.ipv6.nexthop is vyos_defined %}
  match ipv6 next-hop address {{ rule_config.match.ipv6.nexthop }}

--- a/interface-definitions/policy.xml.in
+++ b/interface-definitions/policy.xml.in
@@ -637,6 +637,18 @@
                               </completionHelp>
                             </properties>
                           </leafNode>
+                          <leafNode name="prefix-len">
+                            <properties>
+                              <help>IP prefix-length to match</help>
+                              <valueHelp>
+                                <format>u32:0-32</format>
+                                <description>Prefix length</description>
+                              </valueHelp>
+                              <constraint>
+                                <validator name="numeric" argument="--range 0-32"/>
+                              </constraint>
+                            </properties>
+                          </leafNode>
                         </children>
                       </node>
                 <!--  T3304 but it overwrite node nexthop
@@ -692,7 +704,7 @@
                           </leafNode>
                           <leafNode name="prefix-len">
                             <properties>
-                              <help>IP prefix-lenght to match</help>
+                              <help>IP prefix-length to match</help>
                               <valueHelp>
                                 <format>u32:0-32</format>
                                 <description>Prefix length</description>
@@ -729,7 +741,7 @@
                       </node>
                       <node name="route-source">
                         <properties>
-                          <help>test</help>
+                          <help>Match advertising source address of route</help>
                         </properties>
                         <children>
                           <leafNode name="access-list">
@@ -793,6 +805,18 @@
                               <completionHelp>
                                 <path>policy prefix-list6</path>
                               </completionHelp>
+                            </properties>
+                          </leafNode>
+                          <leafNode name="prefix-len">
+                            <properties>
+                              <help>IPv6 prefix-length to match</help>
+                              <valueHelp>
+                                <format>u32:0-128</format>
+                                <description>Prefix length</description>
+                              </valueHelp>
+                              <constraint>
+                                <validator name="numeric" argument="--range 0-128"/>
+                              </constraint>
                             </properties>
                           </leafNode>
                         </children>

--- a/smoketest/scripts/cli/test_policy.py
+++ b/smoketest/scripts/cli/test_policy.py
@@ -719,7 +719,8 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
         goto = '25'
 
         ipv4_nexthop_address= '192.0.2.2'
-        ipv4_nexthop_plen= '18'
+        ipv4_prefix_len= '18'
+        ipv6_prefix_len= '122'
         ipv4_nexthop_type= 'blackhole'
         
 
@@ -791,6 +792,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                         'action' : 'permit',
                         'match' : {
                             'ipv6-nexthop' : ipv6_nexthop,
+                            'ipv6-address-pfx-len' : ipv6_prefix_len,
                             'large-community' : large_community_list,
                             'local-pref' : local_pref,
                             'metric': metric,
@@ -802,12 +804,13 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                         'action' : 'permit',
                         'match' : {
                             'ip-nexthop-addr' : ipv4_nexthop_address,
+                            'ip-address-pfx-len' : ipv4_prefix_len,
                         },
                     },
                     '42' : {
                         'action' : 'deny',
                         'match' : {
-                            'ip-nexthop-plen' : ipv4_nexthop_plen,
+                            'ip-nexthop-plen' : ipv4_prefix_len,
                         },
                     },
                     '44' : {
@@ -940,6 +943,8 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                         self.cli_set(path + ['rule', rule, 'match', 'ip', 'address', 'access-list', rule_config['match']['ip-address-acl']])
                     if 'ip-address-pfx' in rule_config['match']:
                         self.cli_set(path + ['rule', rule, 'match', 'ip', 'address', 'prefix-list', rule_config['match']['ip-address-pfx']])
+                    if 'ip-address-pfx-len' in rule_config['match']:
+                        self.cli_set(path + ['rule', rule, 'match', 'ip', 'address', 'prefix-len', rule_config['match']['ip-address-pfx-len']])
                     if 'ip-nexthop-acl' in rule_config['match']:
                         self.cli_set(path + ['rule', rule, 'match', 'ip', 'nexthop', 'access-list', rule_config['match']['ip-nexthop-acl']])
                     if 'ip-nexthop-pfx' in rule_config['match']:
@@ -958,6 +963,8 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                         self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'address', 'access-list', rule_config['match']['ipv6-address-acl']])
                     if 'ipv6-address-pfx' in rule_config['match']:
                         self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'address', 'prefix-list', rule_config['match']['ipv6-address-pfx']])
+                    if 'ipv6-address-pfx-len' in rule_config['match']:
+                        self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'address', 'prefix-len', rule_config['match']['ipv6-address-pfx-len']])
                     if 'ipv6-nexthop' in rule_config['match']:
                         self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'nexthop', rule_config['match']['ipv6-nexthop']])
                     if 'large-community' in rule_config['match']:
@@ -1086,6 +1093,9 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                     if 'ip-address-pfx' in rule_config['match']:
                         tmp = f'match ip address prefix-list {rule_config["match"]["ip-address-pfx"]}'
                         self.assertIn(tmp, config)
+                    if 'ip-address-pfx-len' in rule_config['match']:
+                        tmp = f'match ip address prefix-len {rule_config["match"]["ip-address-pfx-len"]}'
+                        self.assertIn(tmp, config)
                     if 'ip-nexthop-acl' in rule_config['match']:
                         tmp = f'match ip next-hop {rule_config["match"]["ip-nexthop-acl"]}'
                         self.assertIn(tmp, config)
@@ -1112,6 +1122,9 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                         self.assertIn(tmp, config)
                     if 'ipv6-address-pfx' in rule_config['match']:
                         tmp = f'match ipv6 address prefix-list {rule_config["match"]["ipv6-address-pfx"]}'
+                        self.assertIn(tmp, config)
+                    if 'ipv6-address-pfx-len' in rule_config['match']:
+                        tmp = f'match ipv6 address prefix-len {rule_config["match"]["ipv6-address-pfx-len"]}'
                         self.assertIn(tmp, config)
                     if 'ipv6-nexthop' in rule_config['match']:
                         tmp = f'match ipv6 next-hop address {rule_config["match"]["ipv6-nexthop"]}'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add prefix-len match options for ip|ipv6 address.
Correct helper for route-source.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4450

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
policy
## Proposed changes
<!--- Describe your changes in detail -->
Add prefix-len macth options for ip|ipv6 address.
Correct helper for route-source (set policy route-map ASDASD rule 10 match ip)

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
VyOS cli:
```
# ipv4 
vyos@vyos# set policy route-map ASDASD rule 10 match ip address 
Possible completions:
   access-list  IP access-list to match
   prefix-len   IP prefix-lenght to match
   prefix-list  IP prefix-list to match

# ipv6
vyos@vyos# set policy route-map ASDASD rule 10 match ipv6 address 
Possible completions:
   access-list  IPv6 access-list to match
   prefix-len   IPv6 prefix-lenght to match
   prefix-list  IPv6 prefix-list to match

# new helper for route-source
vyos@vyos# set policy route-map ASDASD rule 10 match ip 
Possible completions:
 > address      IP address of route to match
 > nexthop      IP next-hop of route to match
 > route-source Match advertising source address of route
```
VyOS and FRR configs:
```
# VyOS Config:
vyos@vyos:~$ show config comm | grep policy
set policy route-map FOO rule 10 action 'permit'
set policy route-map FOO rule 10 match ip address prefix-len '28'
set policy route-map FOO rule 20 action 'deny'
set policy route-map FOO rule 20 match ipv6 address prefix-len '69'

# FRR Config:
vyos@vyos:~$ sudo vtysh -c "show run"
...
route-map FOO permit 10
 match ip address prefix-len 28
exit
!
route-map FOO deny 20
 match ipv6 address prefix-len 69
exit
...
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
