### PR TITLE
Policy: T3976-T4449-nexthop: add - match ipv6 nexthop type - 

### DIFF
--- a/data/templates/frr/policy.frr.j2
+++ b/data/templates/frr/policy.frr.j2
@@ -227,6 +227,9 @@ route-map {{ route_map }} {{ rule_config.action }} {{ rule }}
 {%                     if rule_config.match.ipv6.nexthop.prefix_list is vyos_defined %}
  match ipv6 next-hop prefix-list {{ rule_config.match.ipv6.nexthop.prefix_list }}
 {%                     endif %}
+{%                     if rule_config.match.ipv6.nexthop.type is vyos_defined %}
+ match ipv6 next-hop type {{ rule_config.match.ipv6.nexthop.type }}
+{%                     endif %}
 {%                     if rule_config.match.large_community.large_community_list is vyos_defined %}
  match large-community {{ rule_config.match.large_community.large_community_list }}
 {%                     endif %}

--- a/interface-definitions/policy.xml.in
+++ b/interface-definitions/policy.xml.in
@@ -873,6 +873,21 @@
                               </completionHelp>
                             </properties>
                           </leafNode>
+                          <leafNode name="type">
+                            <properties>
+                              <help>Match type</help>
+                              <completionHelp>
+                                <list>blackhole</list>
+                              </completionHelp>
+                              <valueHelp>
+                                <format>blackhole</format>
+                                <description>Blackhole</description>
+                              </valueHelp>
+                              <constraint>
+                                <regex>(blackhole)</regex>
+                              </constraint>
+                            </properties>
+                          </leafNode>
                         </children>
                       </node>
                     </children>

--- a/smoketest/scripts/cli/test_policy.py
+++ b/smoketest/scripts/cli/test_policy.py
@@ -722,6 +722,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
         ipv4_prefix_len= '18'
         ipv6_prefix_len= '122'
         ipv4_nexthop_type= 'blackhole'
+        ipv6_nexthop_type= 'blackhole'
         
 
         test_data = {
@@ -794,6 +795,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                             'ipv6-nexthop-address' : ipv6_nexthop_address,
                             'ipv6-nexthop-access-list' : access_list,
                             'ipv6-nexthop-prefix-list' : prefix_list,
+                            'ipv6-nexthop-type' : ipv6_nexthop_type,
                             'ipv6-address-pfx-len' : ipv6_prefix_len,
                             'large-community' : large_community_list,
                             'local-pref' : local_pref,
@@ -973,6 +975,8 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                         self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'nexthop', 'access-list', rule_config['match']['ipv6-nexthop-access-list']])
                     if 'ipv6-nexthop-prefix-list' in rule_config['match']:
                         self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'nexthop', 'prefix-list', rule_config['match']['ipv6-nexthop-prefix-list']])
+                    if 'ipv6-nexthop-type' in rule_config['match']:
+                        self.cli_set(path + ['rule', rule, 'match', 'ipv6', 'nexthop', 'type', rule_config['match']['ipv6-nexthop-type']])
                     if 'large-community' in rule_config['match']:
                         self.cli_set(path + ['rule', rule, 'match', 'large-community', 'large-community-list', rule_config['match']['large-community']])
                     if 'local-pref' in rule_config['match']:
@@ -1140,6 +1144,9 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                         self.assertIn(tmp, config)
                     if 'ipv6-nexthop-prefix-list' in rule_config['match']:
                         tmp = f'match ipv6 next-hop prefix-list {rule_config["match"]["ipv6-nexthop-prefix-list"]}'
+                        self.assertIn(tmp, config)
+                    if 'ipv6-nexthop-type' in rule_config['match']:
+                        tmp = f'match ipv6 next-hop type {rule_config["match"]["ipv6-nexthop-type"]}'
                         self.assertIn(tmp, config)
                     if 'large-community' in rule_config['match']:
                         tmp = f'match large-community {rule_config["match"]["large-community"]}'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add option for "match ipv6 nexthop type", since this feature was added for IPv4.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3976
* https://phabricator.vyos.net/T4449

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
policy
## Proposed changes
<!--- Describe your changes in detail -->
In previous PR for T3976 more options for `match ipv6 nexthop` were added, but did not include `type` option which is supported in FRR.
In previous PR for T4449 more options for `match ip nexthop` were added. Here all options supported by FRR were added, including `type` option.

This new PR, linked to both tasks, adds `match ipv6 nexthop type` option to vyos cli. This was the only option not supported yet for `match ip|ipv6 nexthop`
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
cli test:
```
vyos@vyos# set policy route-map FOO rule 1 match ip nexthop 
Possible completions:
   access-list  IP access-list to match
   address      IP address to match
   prefix-len   IP prefix-length to match
   prefix-list  IP prefix-list to match
   type         Match type

      
[edit]
vyos@vyos# set policy route-map FOO rule 1 match ipv6 nexthop 
Possible completions:
   access-list  IPv6 access-list to match
   address      IPv6 address of next-hop
   prefix-list  IPv6 prefix-list to match
   type         Match type

      
[edit]

```
Config test:
```
vyos@vyos:~$ show config comm | grep pol
set policy route-map FOO rule 10 action 'permit'
set policy route-map FOO rule 10 match ip nexthop type 'blackhole'
set policy route-map FOO rule 20 action 'deny'
set policy route-map FOO rule 20 match ipv6 nexthop type 'blackhole'

vyos@vyos:~$ sudo vtysh -c "show run"
Building configuration...

Current configuration:
...
route-map FOO permit 10
 match ip next-hop type blackhole
exit
!
route-map FOO deny 20
 match ipv6 next-hop type blackhole
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
