### PR TITLE
http-api: T4459: Fix to set VRF in http(s) service

### DIFF
--- a/src/conf_mode/https.py
+++ b/src/conf_mode/https.py
@@ -142,6 +142,10 @@ def get_config(config=None):
              'api_set': api_set,
              'certbot': certbot}
 
+    vrf_path = ['service', 'https', 'vrf']
+    if conf.exists(vrf_path):
+        https['vrf'] = conf.return_value(vrf_path)
+
     return https
 
 def verify(https):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The http service doesn't use VRF info in conf mode.
Even if users set any VRF, the info isn't propagated to the process.
This commit sets VRF parameter in http service.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4459

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
http-api
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
With following configurations
```
set interfaces ethernet eth0 address 'dhcp'
set interfaces ethernet eth0 vrf 'mgmt'
set service https api keys id vyos key 'vyos'
set service https vrf 'mgmt'
set vrf name mgmt table '65535'
```

The nginx runs in the VRF.
```
vyos@vyos:~$ show vrf mgmt processes
 6528  nginx
 6529  nginx
 6530  nginx
 6531  nginx
 6532  nginx
 6533  nginx
 6534  nginx
 6535  nginx
 6536  nginx
 6473  vyos-http-api-s
 6480  unionfs-fuse
vyos@vyos:~$ cat /etc/systemd/system/nginx.service.d/override.conf
[Unit]
StartLimitIntervalSec=0
After=vyos-router.service

[Service]
ExecStartPre=
ExecStartPre=ip vrf exec mgmt /usr/sbin/nginx -t -q -g 'daemon on; master_process on;'
ExecStart=
ExecStart=ip vrf exec mgmt /usr/sbin/nginx -g 'daemon on; master_process on;'
ExecReload=
ExecReload=ip vrf exec mgmt /usr/sbin/nginx -g 'daemon on; master_process on;' -s reload
Restart=always
RestartPreventExitStatus=
RestartSec=10
```

```
test@vm:~$ curl -sSfLk -X POST 'https://192.168.0.10/retrieve' -F data='{"op": "showConfig", "path": ["interfaces"]}' -F key='vyos' | jq .
{
  "success": true,
  "data": {
    "ethernet": {
      "eth0": {
        "address": "dhcp",
        "hw-id": "fa:16:3e:d6:40:f7",
        "offload": {
          "gro": {}
        },
        "vrf": "mgmt"
      }
}
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
