### PR TITLE
Protocols: T4460: Add input checks for cisco-authentication in nhrp

### DIFF
--- a/interface-definitions/protocols-nhrp.xml.in
+++ b/interface-definitions/protocols-nhrp.xml.in
@@ -27,6 +27,10 @@
                     <format>txt</format>
                     <description>Pass phrase for cisco authentication</description>
                   </valueHelp>
+                  <constraint>
+                    <regex>[^[:space:]]{1,8}</regex>
+                </constraint>
+                <constraintErrorMessage>Password must be 8 characters or less and not null</constraintErrorMessage>
                 </properties>
               </leafNode>
               <tagNode name="dynamic-map">


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add input checks for cisco-authentication value in nhrp protocol

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4460

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
protocols
## Proposed changes
<!--- Describe your changes in detail -->
Add constraint and error message, that checks that cisco-password is not empty value, ant not greater than 8 characters.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
vyos@vyos# set protocols nhrp tunnel tun0 cisco-authentication 

  Configuration path: [protocols nhrp tunnel tun0 cisco-authentication] requires a value
  Set failed

[edit]
vyos@vyos# set protocols nhrp tunnel tun0 cisco-authentication ""

  
  
  Password must be 8 characters or less and not null
  Value validation failed
  Set failed

[edit]
vyos@vyos# set protocols nhrp tunnel tun0 cisco-authentication "saojdpoasjd"

  
  
  Password must be 8 characters or less and not null
  Value validation failed
  Set failed

[edit]
vyos@vyos# set protocols nhrp tunnel tun0 cisco-authentication "1234"
[edit]
vyos@vyos# commit                                            

[edit]
vyos@vyos# cat /run/opennhrp/opennhrp.conf 
# Created by VyOS - manual changes will be overwritten

interface tun0 #hub 
    cisco-authentication 1234
    holding-time 300
    multicast dynamic
    redirect
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
