### PR TITLE
Firewall:T4458: Add ttl match option in firewall

### DIFF
--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -545,6 +545,49 @@
                   #include <include/firewall/icmp-type-name.xml.i>
                 </children>
               </node>
+              <node name="ttl">
+                <properties>
+                  <help>Time to live limit</help>
+                </properties>
+                <children>
+                  <leafNode name="eq">
+                    <properties>
+                      <help>Value to match a ttl equal to it</help>
+                      <valueHelp>
+                        <format>u32:0-255</format>
+                        <description>ttl equal to value</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-255"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="gt">
+                    <properties>
+                      <help>Value to match a ttl greater than or equal to it</help>
+                      <valueHelp>
+                        <format>u32:0-255</format>
+                        <description>ttl greater than value</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-255"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="lt">
+                    <properties>
+                      <help>Value to match a ttl less than or equal to it</help>
+                      <valueHelp>
+                        <format>u32:0-255</format>
+                        <description>ttl less than value</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-255"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
             </children>
           </tagNode>
         </children>

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -231,6 +231,13 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
                 value = rule_conf['hop_limit'][op]
                 output.append(f'ip6 hoplimit {operator} {value}')
 
+    if 'ttl' in rule_conf:
+        operators = {'eq': '==', 'gt': '>', 'lt': '<'}
+        for op, operator in operators.items():
+            if op in rule_conf['ttl']:
+                value = rule_conf['ttl'][op]
+                output.append(f'ip ttl {operator} {value}')
+
     for icmp in ['icmp', 'icmpv6']:
         if icmp in rule_conf:
             if 'type_name' in rule_conf[icmp]:

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -116,6 +116,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '1', 'destination', 'address', '172.16.10.10'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '1', 'log', 'enable'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '1', 'log-level', 'debug'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '1', 'ttl', 'eq', '15'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '2', 'action', 'reject'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '2', 'protocol', 'tcp'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '2', 'destination', 'port', '8888'])
@@ -123,6 +124,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '2', 'log-level', 'err'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '2', 'tcp', 'flags', 'syn'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '2', 'tcp', 'flags', 'not', 'ack'])
+        self.cli_set(['firewall', 'name', 'smoketest', 'rule', '2', 'ttl', 'gt', '102'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '3', 'action', 'accept'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '3', 'protocol', 'tcp'])
         self.cli_set(['firewall', 'name', 'smoketest', 'rule', '3', 'destination', 'port', '22'])
@@ -135,8 +137,8 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         nftables_search = [
             ['iifname "eth0"', 'jump NAME_smoketest'],
-            ['saddr 172.16.20.10', 'daddr 172.16.10.10', 'log prefix "[smoketest-1-A]" level debug','return'],
-            ['tcp flags & (syn | ack) == syn', 'tcp dport { 8888 }', 'log prefix "[smoketest-2-R]" level err', 'reject'],
+            ['saddr 172.16.20.10', 'daddr 172.16.10.10', 'log prefix "[smoketest-1-A]" level debug', 'ip ttl 15','return'],
+            ['tcp flags & (syn | ack) == syn', 'tcp dport { 8888 }', 'log prefix "[smoketest-2-R]" level err', 'ip ttl > 102', 'reject'],
             ['tcp dport { 22 }', 'limit rate 5/minute', 'return'],
             ['log prefix "[smoketest-default-D]"','smoketest default-action', 'drop']
         ]


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add ttl match option in firewall

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4458

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->
Add ttl match option in firewall

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
cli test:
```
vyos@vyos# set firewall name FOO rule 10 
Possible completions:
   action       Rule action [REQUIRED]
 > connection-status
                Connection status
   description  Description
 > destination  Destination parameters
   disable      Option to disable firewall rule
 > fragment     IP fragment match
 > icmp         ICMP type and code information
 > ipsec        Inbound IPsec packets
 > limit        Rate limit using a token bucket filter
   log          Option to log packets matching rule
   log-level    Set log-level. Log must be enable.
   protocol     Protocol to match (protocol name, number, or "all")
 > recent       Parameters for matching recently seen sources
 > source       Source parameters
 > state        Session state
 > tcp          TCP flags to match
 > time         Time to match rule
 > ttl          Time to live limit

vyos@vyos# set firewall name FOO rule 10 ttl 
Possible completions:
   eq           Value to match a ttl equal to it
   gt           Value to match a ttl greater than or equal to it
   lt           Value to match a ttl less than or equal to it

      
[edit]

```

Configuration test:
```
vyos@vyos:~$ show config commands | grep firewall
set firewall name FOO rule 10 action 'accept'
set firewall name FOO rule 10 ttl eq '7'
set firewall name FOO rule 20 action 'drop'
set firewall name FOO rule 20 ttl gt '30'
vyos@vyos:~$ sudo nft list chain ip filter NAME_FOO
table ip filter {
	chain NAME_FOO {
		ip ttl 7 counter packets 0 bytes 0 return comment "FOO-10"
		ip ttl > 30 counter packets 0 bytes 0 drop comment "FOO-20"
		counter packets 0 bytes 0 return comment "FOO default-action accept"
	}
}
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
