### PR TITLE
firewall: T478: Add support for nesting groups

### DIFF
--- a/data/templates/firewall/nftables-defines.j2
+++ b/data/templates/firewall/nftables-defines.j2
@@ -1,32 +1,38 @@
 {% if group is vyos_defined %}
 {%     if group.address_group is vyos_defined %}
-{%         for group_name, group_conf in group.address_group.items() %}
-define A_{{ group_name }} = { {{ group_conf.address | join(",") }} }
+{%         for group_name, group_conf in group.address_group | sort_nested_groups %}
+{%             set includes = group_conf.include if group_conf.include is vyos_defined else [] %}
+define A_{{ group_name }} = { {{ group_conf.address | nft_nested_group(includes, 'A_') | join(",") }} }
 {%         endfor %}
 {%     endif %}
 {%     if group.ipv6_address_group is vyos_defined %}
-{%         for group_name, group_conf in group.ipv6_address_group.items() %}
-define A6_{{ group_name }} = { {{ group_conf.address | join(",") }} }
+{%         for group_name, group_conf in group.ipv6_address_group | sort_nested_groups %}
+{%             set includes = group_conf.include if group_conf.include is vyos_defined else [] %}
+define A6_{{ group_name }} = { {{ group_conf.address | nft_nested_group(includes, 'A6_') | join(",") }} }
 {%         endfor %}
 {%     endif %}
 {%     if group.mac_group is vyos_defined %}
-{%         for group_name, group_conf in group.mac_group.items() %}
-define M_{{ group_name }} = { {{ group_conf.mac_address | join(",") }} }
+{%         for group_name, group_conf in group.mac_group | sort_nested_groups %}
+{%             set includes = group_conf.include if group_conf.include is vyos_defined else [] %}
+define M_{{ group_name }} = { {{ group_conf.mac_address | nft_nested_group(includes, 'M_') | join(",") }} }
 {%         endfor %}
 {%     endif %}
 {%     if group.network_group is vyos_defined %}
-{%         for group_name, group_conf in group.network_group.items() %}
-define N_{{ group_name }} = { {{ group_conf.network | join(",") }} }
+{%         for group_name, group_conf in group.network_group | sort_nested_groups %}
+{%             set includes = group_conf.include if group_conf.include is vyos_defined else [] %}
+define N_{{ group_name }} = { {{ group_conf.network | nft_nested_group(includes, 'N_') | join(",") }} }
 {%         endfor %}
 {%     endif %}
 {%     if group.ipv6_network_group is vyos_defined %}
-{%         for group_name, group_conf in group.ipv6_network_group.items() %}
-define N6_{{ group_name }} = { {{ group_conf.network | join(",") }} }
+{%         for group_name, group_conf in group.ipv6_network_group | sort_nested_groups %}
+{%             set includes = group_conf.include if group_conf.include is vyos_defined else [] %}
+define N6_{{ group_name }} = { {{ group_conf.network | nft_nested_group(includes, 'N6_') | join(",") }} }
 {%         endfor %}
 {%     endif %}
 {%     if group.port_group is vyos_defined %}
-{%         for group_name, group_conf in group.port_group.items() %}
-define P_{{ group_name }} = { {{ group_conf.port | join(",") }} }
+{%         for group_name, group_conf in group.port_group | sort_nested_groups %}
+{%             set includes = group_conf.include if group_conf.include is vyos_defined else [] %}
+define P_{{ group_name }} = { {{ group_conf.port | nft_nested_group(includes, 'P_') | join(",") }} }
 {%         endfor %}
 {%     endif %}
 {% endif %}

--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -97,6 +97,15 @@
                   <multi/>
                 </properties>
               </leafNode>
+              <leafNode name="include">
+                <properties>
+                  <help>Include another address-group</help>
+                  <completionHelp>
+                    <path>firewall group address-group</path>
+                  </completionHelp>
+                  <multi/>
+                </properties>
+              </leafNode>
               #include <include/generic-description.xml.i>
             </children>
           </tagNode>
@@ -151,6 +160,15 @@
                   <multi/>
                 </properties>
               </leafNode>
+              <leafNode name="include">
+                <properties>
+                  <help>Include another ipv6-address-group</help>
+                  <completionHelp>
+                    <path>firewall group ipv6-address-group</path>
+                  </completionHelp>
+                  <multi/>
+                </properties>
+              </leafNode>
               #include <include/generic-description.xml.i>
             </children>
           </tagNode>
@@ -173,6 +191,15 @@
                   <constraint>
                     <validator name="ipv6-prefix"/>
                   </constraint>
+                  <multi/>
+                </properties>
+              </leafNode>
+              <leafNode name="include">
+                <properties>
+                  <help>Include another ipv6-network-group</help>
+                  <completionHelp>
+                    <path>firewall group ipv6-network-group</path>
+                  </completionHelp>
                   <multi/>
                 </properties>
               </leafNode>
@@ -200,6 +227,15 @@
                   <multi/>
                 </properties>
               </leafNode>
+              <leafNode name="include">
+                <properties>
+                  <help>Include another mac-group</help>
+                  <completionHelp>
+                    <path>firewall group mac-group</path>
+                  </completionHelp>
+                  <multi/>
+                </properties>
+              </leafNode>
             </children>
           </tagNode>
           <tagNode name="network-group">
@@ -221,6 +257,15 @@
                   <constraint>
                     <validator name="ipv4-prefix"/>
                   </constraint>
+                  <multi/>
+                </properties>
+              </leafNode>
+              <leafNode name="include">
+                <properties>
+                  <help>Include another network-group</help>
+                  <completionHelp>
+                    <path>firewall group network-group</path>
+                  </completionHelp>
                   <multi/>
                 </properties>
               </leafNode>
@@ -254,6 +299,15 @@
                   <constraint>
                     <validator name="port-range"/>
                   </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="include">
+                <properties>
+                  <help>Include another port-group</help>
+                  <completionHelp>
+                    <path>firewall group port-group</path>
+                  </completionHelp>
+                  <multi/>
                 </properties>
               </leafNode>
             </children>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow for nesting/chaining of firewall groups

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T478

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->
```
set firewall group network-group EXAMPLE network 172.16.1.0/24
set firewall group network-group EXAMPLE1 network 172.16.10.0/24
set firewall group network-group EXAMPLE2 network 172.22.100.0/24
set firewall group network-group ALL_EXAMPLE include EXAMPLE
set firewall group network-group ALL_EXAMPLE include EXAMPLE1
set firewall group network-group ALL_EXAMPLE include EXAMPLE2
```
Result: ALL_EXAMPLE -> 172.16.1.0/24, 172.16.10.0/24, 172.22.100.0/24

Includes smoketests and checks against circular references.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
