### PR TITLE
firewall: T4299: Add support for GeoIP filtering

### DIFF
--- a/data/templates/firewall/nftables-geoip-update.j2
+++ b/data/templates/firewall/nftables-geoip-update.j2
@@ -1,0 +1,33 @@
+#!/usr/sbin/nft -f
+
+{% if ipv4_sets is vyos_defined %}
+{%     for setname, ip_list in ipv4_sets.items() %}
+flush set ip filter {{ setname }}
+{%     endfor %}
+
+table ip filter {
+{%     for setname, ip_list in ipv4_sets.items() %}
+    set {{ setname }} {
+        type ipv4_addr
+        flags interval
+        elements = { {{ ','.join(ip_list) }} }
+    }
+{%     endfor %}
+}
+{% endif %}
+
+{% if ipv6_sets is vyos_defined %}
+{%     for setname, ip_list in ipv6_sets.items() %}
+flush set ip6 filter {{ setname }}
+{%     endfor %}
+
+table ip6 filter {
+{%     for setname, ip_list in ipv6_sets.items() %}
+    set {{ setname }} {
+        type ipv6_addr
+        flags interval
+        elements = { {{ ','.join(ip_list) }} }
+    }
+{%     endfor %}
+}
+{% endif %}

--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -60,6 +60,14 @@ table ip filter {
         flags dynamic
     }
 {%     endfor %}
+{%     if geoip_updated.name is vyos_defined %}
+{%         for setname in geoip_updated.name %}
+    set {{ setname }} {
+        type ipv4_addr
+        flags interval
+    }
+{%         endfor %}
+{%     endif %}
 {% endif %}
 {% if state_policy is vyos_defined %}
     chain VYOS_STATE_POLICY {
@@ -121,6 +129,14 @@ table ip6 filter {
         flags dynamic
     }
 {%     endfor %}
+{%     if geoip_updated.ipv6_name is vyos_defined %}
+{%         for setname in geoip_updated.ipv6_name %}
+    set {{ setname }} {
+        type ipv6_addr
+        flags interval
+    }
+{%         endfor %}
+{%     endif %}
 {% endif %}
 {% if state_policy is vyos_defined %}
     chain VYOS_STATE_POLICY6 {

--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -366,6 +366,7 @@
                 </properties>
                 <children>
                   #include <include/firewall/address-ipv6.xml.i>
+                  #include <include/firewall/geoip.xml.i>
                   #include <include/firewall/source-destination-group-ipv6.xml.i>
                   #include <include/firewall/port.xml.i>
                 </children>
@@ -376,6 +377,7 @@
                 </properties>
                 <children>
                   #include <include/firewall/address-ipv6.xml.i>
+                  #include <include/firewall/geoip.xml.i>
                   #include <include/firewall/source-destination-group-ipv6.xml.i>
                   #include <include/firewall/port.xml.i>
                 </children>
@@ -552,6 +554,7 @@
                 </properties>
                 <children>
                   #include <include/firewall/address.xml.i>
+                  #include <include/firewall/geoip.xml.i>
                   #include <include/firewall/source-destination-group.xml.i>
                   #include <include/firewall/port.xml.i>
                 </children>
@@ -562,6 +565,7 @@
                 </properties>
                 <children>
                   #include <include/firewall/address.xml.i>
+                  #include <include/firewall/geoip.xml.i>
                   #include <include/firewall/source-destination-group.xml.i>
                   #include <include/firewall/port.xml.i>
                 </children>

--- a/interface-definitions/include/firewall/geoip.xml.i
+++ b/interface-definitions/include/firewall/geoip.xml.i
@@ -1,0 +1,22 @@
+<!-- include start from firewall/geoip.xml.i -->
+<node name="geoip">
+  <properties>
+    <help>GeoIP options - Data provided by DB-IP.com</help>
+  </properties>
+  <children>
+    <leafNode name="country-code">
+      <properties>
+        <help>GeoIP country code</help>
+        <valueHelp>
+          <format>&lt;country&gt;</format>
+          <description>Country code (2 characters)</description>
+        </valueHelp>
+        <constraint>
+          <regex>^(ad|ae|af|ag|ai|al|am|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bl|bm|bn|bo|bq|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cu|cv|cw|cx|cy|cz|de|dj|dk|dm|do|dz|ec|ee|eg|eh|er|es|et|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mf|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|sk|sl|sm|sn|so|sr|ss|st|sv|sx|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tr|tt|tv|tw|tz|ua|ug|um|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|za|zm|zw)$</regex>
+        </constraint>
+        <multi />
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/op-mode-definitions/geoip.xml.in
+++ b/op-mode-definitions/geoip.xml.in
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="update">
+    <children>
+      <leafNode name="geoip">
+        <properties>
+          <help>Update GeoIP database and firewall sets</help>
+        </properties>
+        <command>sudo ${vyos_libexec_dir}/geoip-update.py --force</command>
+      </leafNode>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/src/conf_mode/zone_policy.py
+++ b/src/conf_mode/zone_policy.py
@@ -155,7 +155,7 @@ def get_local_from(zone_policy, local_zone_name):
 def cleanup_commands():
     commands = []
     for table in ['ip filter', 'ip6 filter']:
-        json_str = cmd(f'nft -j list table {table}')
+        json_str = cmd(f'nft -t -j list table {table}')
         obj = loads(json_str)
         if 'nftables' not in obj:
             continue

--- a/src/etc/cron.d/vyos-geoip
+++ b/src/etc/cron.d/vyos-geoip
@@ -1,0 +1,1 @@
+30 4 * * 1 root sg vyattacfg "/usr/libexec/vyos/geoip-update.py --force" >/tmp/geoip-update.log 2>&1

--- a/src/helpers/geoip-update.py
+++ b/src/helpers/geoip-update.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import sys
+
+from vyos.configquery import ConfigTreeQuery
+from vyos.firewall import geoip_update
+
+def get_config(config=None):
+    if config:
+        conf = config
+    else:
+        conf = ConfigTreeQuery()
+    base = ['firewall']
+
+    if not conf.exists(base):
+        return None
+
+    return conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True,
+                                    no_tag_node_value_mangle=True)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--force", help="Force update", action="store_true")
+    args = parser.parse_args()
+
+    firewall = get_config()
+
+    if not geoip_update(firewall, force=args.force):
+        sys.exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Adds support for GeoIP filtering on rule source/destination

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4299

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->
`set firewall [ipv6-]name NAME rule 1 [source | destination] geoip country-code [GB|DE|SE|US...]`

* Data is provided by DB-IP.com under CC-BY-4.0 license. Attribution required, permits redistribution so we can include a database in images (~3MB compressed).
* Includes cron script (manually callable by op-mode `update geoip`) to keep database and rules updated.

Notes/Caveats:
* cron script uses about ~90MB memory as needs to decompress the CSV and build IP range lists in memory.
* nft command output becomes bloated (e.g. if you run `nft list table ip filter` with active GeoIP rules without the `-t` option it will print all IP ranges in the sets)

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set firewall name asd rule 1 action accept
set firewall name asd rule 1 source geoip country-code SE
set firewall name asd rule 1 source geoip country-code US
set firewall name asd rule 1 source geoip country-code DE
[edit]
vyos@vyos# time commit
[ firewall ]
Updating GeoIP. Please wait...


real    0m4.005s
user    0m3.392s
sys     0m0.503s
[edit]
vyos@vyos# sudo nft list table ip filter | wc -l
44787
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
