### PR TITLE
Improve IPsec help strings

### DIFF
--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -19,7 +19,7 @@
           </leafNode>
           <tagNode name="esp-group">
             <properties>
-              <help>Encapsulated Security Payload (ESP) group name</help>
+              <help>Encapsulating Security Payload (ESP) group name</help>
             </properties>
             <children>
               <leafNode name="compression">
@@ -44,10 +44,10 @@
               </leafNode>
               <leafNode name="lifetime">
                 <properties>
-                  <help>ESP lifetime</help>
+                  <help>Security Association time to expire</help>
                   <valueHelp>
                     <format>u32:30-86400</format>
-                    <description>ESP lifetime in seconds</description>
+                    <description>SA lifetime in seconds</description>
                   </valueHelp>
                   <constraint>
                     <validator name="numeric" argument="--range 30-86400"/>
@@ -57,10 +57,10 @@
               </leafNode>
               <leafNode name="life-bytes">
                 <properties>
-                  <help>ESP life in bytes</help>
+                  <help>Security Association byte count to expire</help>
                   <valueHelp>
                     <format>u32:1024-26843545600000</format>
-                    <description>ESP life in bytes</description>
+                    <description>SA life in bytes</description>
                   </valueHelp>
                   <constraint>
                     <validator name="numeric" argument="--range 1024-26843545600000"/>
@@ -69,10 +69,10 @@
               </leafNode>
               <leafNode name="life-packets">
                 <properties>
-                  <help>ESP life in packets</help>
+                  <help>Security Association packet count to expire</help>
                   <valueHelp>
                     <format>u32:1000-26843545600000</format>
-                    <description>ESP life in packets</description>
+                    <description>SA life in packets</description>
                   </valueHelp>
                   <constraint>
                     <validator name="numeric" argument="--range 1000-26843545600000"/>
@@ -308,13 +308,13 @@
               </node>
               <leafNode name="ikev2-reauth">
                 <properties>
-                  <help>Re-authentication of the remote peer during an IKE re-key - IKEv2 only</help>
+                  <help>Re-authentication of the remote peer during an IKE re-key (IKEv2 only)</help>
                   <completionHelp>
                     <list>yes no</list>
                   </completionHelp>
                   <valueHelp>
                     <format>yes</format>
-                    <description>Enable remote host re-authentication during an IKE rekey. Currently broken due to a strongswan bug</description>
+                    <description>Enable remote host re-authentication during an IKE rekey (currently broken due to a strongswan bug)</description>
                   </valueHelp>
                   <valueHelp>
                     <format>no</format>
@@ -379,7 +379,7 @@
               </leafNode>
               <leafNode name="mode">
                 <properties>
-                  <help>IKEv1 phase 1 mode selection</help>
+                  <help>IKEv1 phase 1 mode</help>
                   <completionHelp>
                     <list>main aggressive</list>
                   </completionHelp>
@@ -530,10 +530,10 @@
             <children>
               <leafNode name="level">
                 <properties>
-                  <help>strongSwan logging Level</help>
+                  <help>Global IPsec logging Level</help>
                   <valueHelp>
                     <format>0</format>
-                    <description>Very basic auditing logs e.g. SA up/SA down</description>
+                    <description>Very basic auditing logs (e.g., SA up/SA down)</description>
                   </valueHelp>
                   <valueHelp>
                     <format>1</format>
@@ -663,7 +663,7 @@
           </node>
           <tagNode name="profile">
             <properties>
-              <help>VPN IPSec profile</help>
+              <help>VPN IPsec profile</help>
             </properties>
             <children>
               #include <include/generic-disable-node.xml.i>
@@ -689,7 +689,7 @@
               </node>
               <node name="bind">
                 <properties>
-                  <help>DMVPN crypto configuration</help>
+                  <help>DMVPN tunnel configuration</help>
                 </properties>
                 <children>
                   <leafNode name="tunnel">
@@ -1010,7 +1010,7 @@
                       </valueHelp>
                       <valueHelp>
                         <format>respond</format>
-                        <description>Bring the connection up only if traffic is detected</description>
+                        <description>Wait for the peer to initiate the connection</description>
                       </valueHelp>
                       <valueHelp>
                         <format>none</format>
@@ -1090,10 +1090,10 @@
                       #include <include/ip-protocol.xml.i>
                       <leafNode name="priority">
                         <properties>
-                          <help>Priority for IPSec policy (lowest value more preferable)</help>
+                          <help>Priority for IPsec policy (lowest value more preferable)</help>
                           <valueHelp>
                             <format>u32:1-100</format>
-                            <description>Priority for IPSec policy (lowest value more preferable)</description>
+                            <description>Priority for IPsec policy (lowest value more preferable)</description>
                           </valueHelp>
                           <constraint>
                             <validator name="numeric" argument="--range 1-100"/>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

Make IPsec help strings more consistent and informative.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): help text improvements



## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

IPsec
