### PR TITLE
op-mode: T1375: Allow to clear dhcp-server lease

### DIFF
--- a/op-mode-definitions/clear-dhcp-server-lease.xml.in
+++ b/op-mode-definitions/clear-dhcp-server-lease.xml.in
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="clear">
+    <children>
+      <node name="dhcp-server">
+        <properties>
+          <help>clear DHCP server lease</help>
+        </properties>
+        <children>
+          <tagNode name="lease">
+            <properties>
+              <help>DHCP server lease</help>
+            </properties>
+            <command>sudo ${vyos_op_scripts_dir}/clear_dhcp_lease.py --ip $4</command>
+          </tagNode>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/src/op_mode/clear_dhcp_lease.py
+++ b/src/op_mode/clear_dhcp_lease.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+
+from isc_dhcp_leases import Lease
+from isc_dhcp_leases import IscDhcpLeases
+
+from vyos.configquery import ConfigTreeQuery
+from vyos.util import ask_yes_no
+from vyos.util import call
+
+
+config = ConfigTreeQuery()
+base = ['service', 'dhcp-server']
+lease_file = '/config/dhcpd.leases'
+
+
+def del_lease_ip(address):
+    """
+    Read lease_file and write data to this file
+    without specific section "lease ip"
+    Delete section "lease x.x.x.x { x;x;x; }"
+    """
+    with open(lease_file, encoding='utf-8') as f:
+        data = f.read().rstrip()
+        lease_config_ip = '{(?P<config>[\s\S]+?)\n}'
+        pattern = rf"lease {address} {lease_config_ip}"
+        # Delete lease for ip block
+        data = re.sub(pattern, '', data)
+
+    # Write new data to original lease_file
+    with open(lease_file, 'w', encoding='utf-8') as f:
+        f.write(data)
+
+def is_ip_in_leases(address):
+    """
+    Return True if address found in the lease file
+    """
+    leases = IscDhcpLeases(lease_file)
+    lease_ips = []
+    for lease in leases.get():
+        lease_ips.append(lease.ip)
+    if address not in lease_ips:
+        print(f'Address "{address}" not found in "{lease_file}"')
+        return False
+    return True
+
+
+if not config.exists(base):
+    print('DHCP-server not configured!')
+    exit(0)
+
+if config.exists(base + ['failover']):
+    print('Lease cannot be reset in failover mode!')
+    exit(0)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--ip', help='IPv4 address', action='store', required=True)
+
+    args = parser.parse_args()
+    address = args.ip
+
+    if not is_ip_in_leases(address):
+        exit(1)
+
+    if not ask_yes_no(f'This will restart DHCP server.\nContinue?'):
+        exit(1)
+    else:
+        del_lease_ip(address)
+        call('systemctl restart isc-dhcp-server.service')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow to clear DHCP-leases per IP
Parse file '/config/dhcpd.leases' find match section 'lease x.x.x.x {}'
And remove this section

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T1375

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Reset lease:
```
vyos@r14:~$ show dhcp server leases 
IP address    Hardware address    State    Lease start          Lease expiration     Remaining    Pool    Hostname
------------  ------------------  -------  -------------------  -------------------  -----------  ------  ----------
100.64.0.18   96:b2:9e:44:66:f7   active   2022/06/16 08:20:26  2022/06/17 08:20:26  23:59:51     Lan201  r1
100.64.0.19   6e:20:b8:d7:fe:94   active   2022/06/16 08:20:23  2022/06/17 08:20:23  23:59:48     Lan201  r1
100.64.0.20   d2:ba:67:15:19:f1   active   2022/06/16 07:40:19  2022/06/17 07:40:19  23:19:44     Lan201  r1
100.64.0.21   1a:54:70:d9:ef:c8   active   2022/06/16 02:55:05  2022/06/17 02:55:05  18:34:30     Lan201  r1
100.64.0.22   4a:02:50:3c:41:a7   active   2022/06/16 03:47:06  2022/06/17 03:47:06  19:26:31     Lan201  r1
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ clear dhcp-server lease 100.64.0.18
This will restart DHCP server.
Continue? [y/N] y
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ show dhcp server leases 
IP address    Hardware address    State    Lease start          Lease expiration     Remaining    Pool    Hostname
------------  ------------------  -------  -------------------  -------------------  -----------  ------  ----------
100.64.0.19   6e:20:b8:d7:fe:94   active   2022/06/16 08:20:23  2022/06/17 08:20:23  23:59:41     Lan201  r1
100.64.0.20   d2:ba:67:15:19:f1   active   2022/06/16 07:40:19  2022/06/17 07:40:19  23:19:37     Lan201  r1
100.64.0.21   1a:54:70:d9:ef:c8   active   2022/06/16 02:55:05  2022/06/17 02:55:05  18:34:23     Lan201  r1
100.64.0.22   4a:02:50:3c:41:a7   active   2022/06/16 03:47:06  2022/06/17 03:47:06  19:26:24     Lan201  r1
vyos@r14:~$ 


```
If IP-address in not exists in the lease file, return the message:
```
vyos@r14:~$ clear dhcp-server lease 192.0.2.55
Address "192.0.2.55" not found in "/config/dhcpd.leases"
vyos@r14:~$ 
``` 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
