### PR TITLE
firewall: T4147: Use named sets for firewall groups 

### DIFF
--- a/data/templates/firewall/nftables-defines.j2
+++ b/data/templates/firewall/nftables-defines.j2
@@ -1,38 +1,76 @@
+{% macro groups(group, is_ipv6) %}
 {% if group is vyos_defined %}
-{%     if group.address_group is vyos_defined %}
-{%         for group_name, group_conf in group.address_group | sort_nested_groups %}
+{%     set ip_type = 'ipv6_addr' if is_ipv6 else 'ipv4_addr' %}
+{%     if group.address_group is vyos_defined and not is_ipv6 %}
+{%         for group_name, group_conf in group.address_group.items() %}
 {%             set includes = group_conf.include if group_conf.include is vyos_defined else [] %}
-define A_{{ group_name }} = { {{ group_conf.address | nft_nested_group(includes, 'A_') | join(",") }} }
+    set A_{{ group_name }} {
+        type {{ ip_type }}
+        flags interval
+{%             if group_conf.address is vyos_defined or includes %}
+        elements = { {{ group_conf.address | nft_nested_group(includes, group.address_group, 'address') | join(",") }} }
+{%             endif %}
+    }
 {%         endfor %}
 {%     endif %}
-{%     if group.ipv6_address_group is vyos_defined %}
-{%         for group_name, group_conf in group.ipv6_address_group | sort_nested_groups %}
+{%     if group.ipv6_address_group is vyos_defined and is_ipv6 %}
+{%         for group_name, group_conf in group.ipv6_address_group.items() %}
 {%             set includes = group_conf.include if group_conf.include is vyos_defined else [] %}
-define A6_{{ group_name }} = { {{ group_conf.address | nft_nested_group(includes, 'A6_') | join(",") }} }
+    set A6_{{ group_name }} {
+        type {{ ip_type }}
+        flags interval
+{%             if group_conf.address is vyos_defined or includes %}
+        elements = { {{ group_conf.address | nft_nested_group(includes, group.ipv6_address_group, 'address') | join(",") }} }
+{%             endif %}
+    }
 {%         endfor %}
 {%     endif %}
 {%     if group.mac_group is vyos_defined %}
-{%         for group_name, group_conf in group.mac_group | sort_nested_groups %}
+{%         for group_name, group_conf in group.mac_group.items() %}
 {%             set includes = group_conf.include if group_conf.include is vyos_defined else [] %}
-define M_{{ group_name }} = { {{ group_conf.mac_address | nft_nested_group(includes, 'M_') | join(",") }} }
+    set M_{{ group_name }} {
+        type ether_addr
+{%             if group_conf.mac_address is vyos_defined or includes %}
+        elements = { {{ group_conf.mac_address | nft_nested_group(includes, group.mac_group, 'mac_address') | join(",") }} }
+{%             endif %}
+    }
 {%         endfor %}
 {%     endif %}
-{%     if group.network_group is vyos_defined %}
-{%         for group_name, group_conf in group.network_group | sort_nested_groups %}
+{%     if group.network_group is vyos_defined and not is_ipv6 %}
+{%         for group_name, group_conf in group.network_group.items() %}
 {%             set includes = group_conf.include if group_conf.include is vyos_defined else [] %}
-define N_{{ group_name }} = { {{ group_conf.network | nft_nested_group(includes, 'N_') | join(",") }} }
+    set N_{{ group_name }} {
+        type {{ ip_type }}
+        flags interval
+{%             if group_conf.network is vyos_defined or includes %}
+        elements = { {{ group_conf.network | nft_nested_group(includes, group.network_group, 'network') | join(",") }} }
+{%             endif %}
+    }
 {%         endfor %}
 {%     endif %}
-{%     if group.ipv6_network_group is vyos_defined %}
-{%         for group_name, group_conf in group.ipv6_network_group | sort_nested_groups %}
+{%     if group.ipv6_network_group is vyos_defined and is_ipv6 %}
+{%         for group_name, group_conf in group.ipv6_network_group.items() %}
 {%             set includes = group_conf.include if group_conf.include is vyos_defined else [] %}
-define N6_{{ group_name }} = { {{ group_conf.network | nft_nested_group(includes, 'N6_') | join(",") }} }
+    set N6_{{ group_name }} {
+        type {{ ip_type }}
+        flags interval
+{%             if group_conf.network is vyos_defined or includes %}
+        elements = { {{ group_conf.network | nft_nested_group(includes, group.ipv6_network_group, 'network') | join(",") }} }
+{%             endif %}
+    }
 {%         endfor %}
 {%     endif %}
 {%     if group.port_group is vyos_defined %}
-{%         for group_name, group_conf in group.port_group | sort_nested_groups %}
+{%         for group_name, group_conf in group.port_group.items() %}
 {%             set includes = group_conf.include if group_conf.include is vyos_defined else [] %}
-define P_{{ group_name }} = { {{ group_conf.port | nft_nested_group(includes, 'P_') | join(",") }} }
+    set P_{{ group_name }} {
+        type inet_service
+        flags interval
+{%             if group_conf.port is vyos_defined or includes %}
+        elements = { {{ group_conf.port | nft_nested_group(includes, group.port_group, 'port') | join(",") }} }
+{%             endif %}
+    }
 {%         endfor %}
 {%     endif %}
 {% endif %}
+{% endmacro %}

--- a/data/templates/firewall/nftables-policy.j2
+++ b/data/templates/firewall/nftables-policy.j2
@@ -1,12 +1,12 @@
 #!/usr/sbin/nft -f
 
+{% import 'firewall/nftables-defines.j2' as group_tmpl %}
+
 {% if cleanup_commands is vyos_defined %}
 {%     for command in cleanup_commands %}
 {{ command }}
 {%     endfor %}
 {% endif %}
-
-include "/run/nftables_defines.conf"
 
 table ip mangle {
 {% if first_install is vyos_defined %}
@@ -29,6 +29,8 @@ table ip mangle {
     }
 {%     endfor %}
 {% endif %}
+
+{{ group_tmpl.groups(firewall_group, False) }}
 }
 
 table ip6 mangle {
@@ -52,4 +54,5 @@ table ip6 mangle {
     }
 {%     endfor %}
 {% endif %}
+{{ group_tmpl.groups(firewall_group, True) }}
 }

--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -1,12 +1,12 @@
 #!/usr/sbin/nft -f
 
+{% import 'firewall/nftables-defines.j2' as group_tmpl %}
+
 {% if cleanup_commands is vyos_defined %}
 {%     for command in cleanup_commands %}
 {{ command }}
 {%     endfor %}
 {% endif %}
-
-include "/run/nftables_defines.conf"
 
 table ip filter {
 {% if first_install is vyos_defined %}
@@ -69,6 +69,9 @@ table ip filter {
 {%         endfor %}
 {%     endif %}
 {% endif %}
+
+{{ group_tmpl.groups(group, False) }}
+
 {% if state_policy is vyos_defined %}
     chain VYOS_STATE_POLICY {
 {%     if state_policy.established is vyos_defined %}
@@ -138,6 +141,9 @@ table ip6 filter {
 {%         endfor %}
 {%     endif %}
 {% endif %}
+
+{{ group_tmpl.groups(group, True) }}
+
 {% if state_policy is vyos_defined %}
     chain VYOS_STATE_POLICY6 {
 {%     if state_policy.established is vyos_defined %}

--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -47,7 +47,7 @@ table ip filter {
 {%     endfor %}
 {%     if group is vyos_defined and group.domain_group is vyos_defined %}
 {%         for name, name_config in group.domain_group.items() %}
-    set {{ name }} {
+    set D_{{ name }} {
         type ipv4_addr
         flags interval
     }

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -192,7 +192,7 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
                     if group_name[0] == '!':
                         operator = '!='
                         group_name = group_name[1:]
-                    output.append(f'{ip_name} {prefix}addr {operator} $A{def_suffix}_{group_name}')
+                    output.append(f'{ip_name} {prefix}addr {operator} @A{def_suffix}_{group_name}')
                 # Generate firewall group domain-group
                 elif 'domain_group' in group:
                     group_name = group['domain_group']
@@ -207,14 +207,14 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
                     if group_name[0] == '!':
                         operator = '!='
                         group_name = group_name[1:]
-                    output.append(f'{ip_name} {prefix}addr {operator} $N{def_suffix}_{group_name}')
+                    output.append(f'{ip_name} {prefix}addr {operator} @N{def_suffix}_{group_name}')
                 if 'mac_group' in group:
                     group_name = group['mac_group']
                     operator = ''
                     if group_name[0] == '!':
                         operator = '!='
                         group_name = group_name[1:]
-                    output.append(f'ether {prefix}addr {operator} $M_{group_name}')
+                    output.append(f'ether {prefix}addr {operator} @M_{group_name}')
                 if 'port_group' in group:
                     proto = rule_conf['protocol']
                     group_name = group['port_group']
@@ -227,7 +227,7 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
                         operator = '!='
                         group_name = group_name[1:]
 
-                    output.append(f'{proto} {prefix}port {operator} $P_{group_name}')
+                    output.append(f'{proto} {prefix}port {operator} @P_{group_name}')
 
     if 'log' in rule_conf and rule_conf['log'] == 'enable':
         action = rule_conf['action'] if 'action' in rule_conf else 'accept'

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -200,7 +200,7 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
                     if group_name[0] == '!':
                         operator = '!='
                         group_name = group_name[1:]
-                    output.append(f'{ip_name} {prefix}addr {operator} @{group_name}')
+                    output.append(f'{ip_name} {prefix}addr {operator} @D_{group_name}')
                 elif 'network_group' in group:
                     group_name = group['network_group']
                     operator = ''

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -592,37 +592,24 @@ def nft_intra_zone_action(zone_conf, ipv6=False):
     return 'return'
 
 @register_filter('nft_nested_group')
-def nft_nested_group(out_list, includes, prefix):
+def nft_nested_group(out_list, includes, groups, key):
     if not vyos_defined(out_list):
         out_list = []
+
+    def add_includes(name):
+        if key in groups[name]:
+            for item in groups[name][key]:
+                if item in out_list:
+                    continue
+                out_list.append(item)
+
+        if 'include' in groups[name]:
+            for name_inc in groups[name]['include']:
+                add_includes(name_inc)
+
     for name in includes:
-        out_list.append(f'${prefix}{name}')
+        add_includes(name)
     return out_list
-
-@register_filter('sort_nested_groups')
-def sort_nested_groups(groups):
-    seen = []
-    out = {}
-
-    def include_iterate(group_name):
-        group = groups[group_name]
-        if 'include' not in group:
-            if group_name not in out:
-                out[group_name] = groups[group_name]
-            return
-
-        for inc_group_name in group['include']:
-            if inc_group_name not in seen:
-                seen.append(inc_group_name)
-                include_iterate(inc_group_name)
-
-        if group_name not in out:
-            out[group_name] = groups[group_name]
-
-    for group_name in groups:
-        include_iterate(group_name)
-
-    return out.items()
 
 @register_test('vyos_defined')
 def vyos_defined(value, test_value=None, var_type=None):

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -62,7 +62,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['set M_smoketest_mac'],
             ['set N_smoketest_network'],
             ['set P_smoketest_port'],
-            ['set smoketest_domain'],
+            ['set D_smoketest_domain'],
             ['set RECENT_smoketest_4'],
             ['chain NAME_smoketest']
         ]
@@ -116,10 +116,10 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['elements = { 53, 123 }'],
             ['ether saddr @M_smoketest_mac', 'return'],
             ['elements = { 00:01:02:03:04:05 }'],
-            ['set smoketest_domain'],
+            ['set D_smoketest_domain'],
             ['elements = { 192.0.2.5, 192.0.2.8,'],
             ['192.0.2.10, 192.0.2.11 }'],
-            ['ip saddr @smoketest_domain', 'return']
+            ['ip saddr @D_smoketest_domain', 'return']
         ]
         self.verify_nftables(nftables_search, 'ip filter')
 

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -100,6 +100,7 @@ nested_group_types = [
 group_set_prefix = {
     'A_': 'address_group',
     'A6_': 'ipv6_address_group',
+    'D_': 'domain_group',
     'M_': 'mac_group',
     'N_': 'network_group',
     'N6_': 'ipv6_network_group',
@@ -535,8 +536,8 @@ def apply(firewall):
                 # and add elements to nft set
                 ip_dict = get_ips_domains_dict(domains)
                 elements = sum(ip_dict.values(), [])
-                nft_init_set(group)
-                nft_add_set_elements(group, elements)
+                nft_init_set(f'D_{group}')
+                nft_add_set_elements(f'D_{group}', elements)
         else:
             call('systemctl stop vyos-domain-group-resolve.service')
 

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -92,10 +92,19 @@ valid_groups = [
     'port_group'
 ]
 
-group_types = [
-    'address_group', 'network_group', 'port_group',
-    'ipv6_address_group', 'ipv6_network_group'
+nested_group_types = [
+    'address_group', 'network_group', 'mac_group',
+    'port_group', 'ipv6_address_group', 'ipv6_network_group'
 ]
+
+group_set_prefix = {
+    'A_': 'address_group',
+    'A6_': 'ipv6_address_group',
+    'M_': 'mac_group',
+    'N_': 'network_group',
+    'N6_': 'ipv6_network_group',
+    'P_': 'port_group'
+}
 
 snmp_change_type = {
     'unknown': 0,
@@ -165,18 +174,20 @@ def geoip_updated(conf, firewall):
     updated = False
 
     for key, path in dict_search_recursive(firewall, 'geoip'):
+        set_name = f'GEOIP_CC_{path[1]}_{path[3]}'
         if path[0] == 'name':
-            out['name'].append(f'GEOIP_CC_{path[1]}_{path[3]}')
+            out['name'].append(set_name)
         elif path[0] == 'ipv6_name':
-            out['ipv6_name'].append(f'GEOIP_CC_{path[1]}_{path[3]}')
+            out['ipv6_name'].append(set_name)
         updated = True
 
     if 'delete' in node_diff:
         for key, path in dict_search_recursive(node_diff['delete'], 'geoip'):
+            set_name = f'GEOIP_CC_{path[1]}_{path[3]}'
             if path[0] == 'name':
-                out['deleted_name'].append(f'GEOIP_CC_{path[1]}_{path[3]}')
+                out['deleted_name'].append(set_name)
             elif path[0] == 'ipv6-name':
-                out['deleted_ipv6_name'].append(f'GEOIP_CC_{path[1]}_{path[3]}')
+                out['deleted_ipv6_name'].append(set_name)
             updated = True
 
     if updated:
@@ -315,7 +326,7 @@ def verify(firewall):
             raise ConfigError(f'Firewall config-trap enabled but "service snmp trap-target" is not defined')
 
     if 'group' in firewall:
-        for group_type in group_types:
+        for group_type in nested_group_types:
             if group_type in firewall['group']:
                 groups = firewall['group'][group_type]
                 for group_name, group in groups.items():
@@ -352,62 +363,75 @@ def verify(firewall):
 
     return None
 
-def cleanup_rule(table, jump_chain):
-    commands = []
-    chains = nft_iface_chains if table == 'ip filter' else nft6_iface_chains
-    for chain in chains:
-        results = cmd(f'nft -a list chain {table} {chain}').split("\n")
-        for line in results:
-            if f'jump {jump_chain}' in line:
-                handle_search = re.search('handle (\d+)', line)
-                if handle_search:
-                    commands.append(f'delete rule {table} {chain} handle {handle_search[1]}')
-    return commands
-
 def cleanup_commands(firewall):
     commands = []
-    commands_end = []
+    commands_chains = []
+    commands_sets = []
     for table in ['ip filter', 'ip6 filter']:
+        name_node = 'name' if table == 'ip filter' else 'ipv6_name'
+        chain_prefix = NAME_PREFIX if table == 'ip filter' else NAME6_PREFIX
+        state_chain = 'VYOS_STATE_POLICY' if table == 'ip filter' else 'VYOS_STATE_POLICY6'
+        iface_chains = nft_iface_chains if table == 'ip filter' else nft6_iface_chains
+
         geoip_list = []
         if firewall['geoip_updated']:
             geoip_key = 'deleted_ipv6_name' if table == 'ip6 filter' else 'deleted_name'
             geoip_list = dict_search_args(firewall, 'geoip_updated', geoip_key) or []
-
-        state_chain = 'VYOS_STATE_POLICY' if table == 'ip filter' else 'VYOS_STATE_POLICY6'
+ 
         json_str = cmd(f'nft -t -j list table {table}')
         obj = loads(json_str)
+
         if 'nftables' not in obj:
             continue
+
         for item in obj['nftables']:
             if 'chain' in item:
                 chain = item['chain']['name']
-                if chain in ['VYOS_STATE_POLICY', 'VYOS_STATE_POLICY6']:
-                    if 'state_policy' not in firewall:
-                        commands.append(f'delete chain {table} {chain}')
-                    else:
-                        commands.append(f'flush chain {table} {chain}')
-                elif chain not in preserve_chains and not chain.startswith("VZONE"):
-                    if table == 'ip filter' and dict_search_args(firewall, 'name', chain.replace(NAME_PREFIX, "", 1)) != None:
-                        commands.append(f'flush chain {table} {chain}')
-                    elif table == 'ip6 filter' and dict_search_args(firewall, 'ipv6_name', chain.replace(NAME6_PREFIX, "", 1)) != None:
-                        commands.append(f'flush chain {table} {chain}')
-                    else:
-                        commands += cleanup_rule(table, chain)
-                        commands.append(f'delete chain {table} {chain}')
-            elif 'rule' in item:
-                rule = item['rule']
-                if rule['chain'] in ['VYOS_FW_FORWARD', 'VYOS_FW_OUTPUT', 'VYOS_FW_LOCAL', 'VYOS_FW6_FORWARD', 'VYOS_FW6_OUTPUT', 'VYOS_FW6_LOCAL']:
-                    if 'expr' in rule and any([True for expr in rule['expr'] if dict_search_args(expr, 'jump', 'target') == state_chain]):
-                        if 'state_policy' not in firewall:
-                            chain = rule['chain']
-                            handle = rule['handle']
-                            commands.append(f'delete rule {table} {chain} handle {handle}')
-            elif 'set' in item:
-                set_name = item['set']['name']
-                if set_name.startswith('GEOIP_CC_') and set_name not in geoip_list:
+                if chain in preserve_chains or chain.startswith("VZONE"):
                     continue
-                commands_end.append(f'delete set {table} {set_name}')
-    return commands + commands_end
+
+                if chain == state_chain:
+                    command = 'delete' if 'state_policy' not in firewall else 'flush'
+                    commands_chains.append(f'{command} chain {table} {chain}')
+                elif dict_search_args(firewall, name_node, chain.replace(chain_prefix, "", 1)) != None:
+                    commands.append(f'flush chain {table} {chain}')
+                else:
+                    commands_chains.append(f'delete chain {table} {chain}')
+
+            if 'rule' in item:
+                rule = item['rule']
+                chain = rule['chain']
+                handle = rule['handle']
+
+                if chain in iface_chains:
+                    target, _ = next(dict_search_recursive(rule['expr'], 'target'))
+
+                    if target == state_chain and 'state_policy' not in firewall:
+                        commands.append(f'delete rule {table} {chain} handle {handle}')
+
+                    if target.startswith(chain_prefix):
+                        if dict_search_args(firewall, name_node, target.replace(chain_prefix, "", 1)) == None:
+                            commands.append(f'delete rule {table} {chain} handle {handle}')
+
+            if 'set' in item:
+                set_name = item['set']['name']
+
+                if set_name.startswith('GEOIP_CC_') and set_name in geoip_list:
+                    commands_sets.append(f'delete set {table} {set_name}')
+                    continue
+                
+                if set_name.startswith("RECENT_"):
+                    commands_sets.append(f'delete set {table} {set_name}')
+                    continue
+
+                for prefix, group_type in group_set_prefix.items():
+                    if set_name.startswith(prefix):
+                        group_name = set_name.replace(prefix, "", 1)
+                        if dict_search_args(firewall, 'group', group_type, group_name) != None:
+                            commands_sets.append(f'flush set {table} {set_name}')
+                        else:
+                            commands_sets.append(f'delete set {table} {set_name}')
+    return commands + commands_chains + commands_sets
 
 def generate(firewall):
     if not os.path.exists(nftables_conf):
@@ -416,7 +440,6 @@ def generate(firewall):
         firewall['cleanup_commands'] = cleanup_commands(firewall)
 
     render(nftables_conf, 'firewall/nftables.j2', firewall)
-    render(nftables_defines_conf, 'firewall/nftables-defines.j2', firewall)
     return None
 
 def apply_sysfs(firewall):

--- a/src/conf_mode/policy-route.py
+++ b/src/conf_mode/policy-route.py
@@ -25,6 +25,7 @@ from vyos.config import Config
 from vyos.template import render
 from vyos.util import cmd
 from vyos.util import dict_search_args
+from vyos.util import dict_search_recursive
 from vyos.util import run
 from vyos import ConfigError
 from vyos import airbag
@@ -32,6 +33,9 @@ airbag.enable()
 
 mark_offset = 0x7FFFFFFF
 nftables_conf = '/run/nftables_policy.conf'
+
+ROUTE_PREFIX = 'VYOS_PBR_'
+ROUTE6_PREFIX = 'VYOS_PBR6_'
 
 preserve_chains = [
     'VYOS_PBR_PREROUTING',
@@ -45,6 +49,16 @@ valid_groups = [
     'network_group',
     'port_group'
 ]
+
+group_set_prefix = {
+    'A_': 'address_group',
+    'A6_': 'ipv6_address_group',
+#    'D_': 'domain_group',
+    'M_': 'mac_group',
+    'N_': 'network_group',
+    'N6_': 'ipv6_network_group',
+    'P_': 'port_group'
+}
 
 def get_policy_interfaces(conf):
     out = {}
@@ -166,37 +180,55 @@ def verify(policy):
 
     return None
 
-def cleanup_rule(table, jump_chain):
-    commands = []
-    results = cmd(f'nft -a list table {table}').split("\n")
-    for line in results:
-        if f'jump {jump_chain}' in line:
-            handle_search = re.search('handle (\d+)', line)
-            if handle_search:
-                commands.append(f'delete rule {table} {chain} handle {handle_search[1]}')
-    return commands
-
 def cleanup_commands(policy):
     commands = []
+    commands_chains = []
+    commands_sets = []
     for table in ['ip mangle', 'ip6 mangle']:
-        json_str = cmd(f'nft -j list table {table}')
+        route_node = 'route' if table == 'ip mangle' else 'route6'
+        chain_prefix = ROUTE_PREFIX if table == 'ip mangle' else ROUTE6_PREFIX
+
+        json_str = cmd(f'nft -t -j list table {table}')
         obj = loads(json_str)
         if 'nftables' not in obj:
             continue
         for item in obj['nftables']:
             if 'chain' in item:
                 chain = item['chain']['name']
-                if not chain.startswith("VYOS_PBR"):
+                if chain in preserve_chains or not chain.startswith("VYOS_PBR"):
                     continue
+
+                if dict_search_args(policy, route_node, chain.replace(chain_prefix, "", 1)) != None:
+                    commands.append(f'flush chain {table} {chain}')
+                else:
+                    commands_chains.append(f'delete chain {table} {chain}')
+
+            if 'rule' in item:
+                rule = item['rule']
+                chain = rule['chain']
+                handle = rule['handle']
+
                 if chain not in preserve_chains:
-                    if table == 'ip mangle' and dict_search_args(policy, 'route', chain.replace("VYOS_PBR_", "", 1)):
-                        commands.append(f'flush chain {table} {chain}')
-                    elif table == 'ip6 mangle' and dict_search_args(policy, 'route6', chain.replace("VYOS_PBR6_", "", 1)):
-                        commands.append(f'flush chain {table} {chain}')
-                    else:
-                        commands += cleanup_rule(table, chain)
-                        commands.append(f'delete chain {table} {chain}')
-    return commands
+                    continue
+
+                target, _ = next(dict_search_recursive(rule['expr'], 'target'))
+
+                if target.startswith(chain_prefix):
+                    if dict_search_args(policy, route_node, target.replace(chain_prefix, "", 1)) == None:
+                        commands.append(f'delete rule {table} {chain} handle {handle}')
+
+            if 'set' in item:
+                set_name = item['set']['name']
+
+                for prefix, group_type in group_set_prefix.items():
+                    if set_name.startswith(prefix):
+                        group_name = set_name.replace(prefix, "", 1)
+                        if dict_search_args(policy, 'firewall_group', group_type, group_name) != None:
+                            commands_sets.append(f'flush set {table} {set_name}')
+                        else:
+                            commands_sets.append(f'delete set {table} {set_name}')
+
+    return commands + commands_chains + commands_sets
 
 def generate(policy):
     if not os.path.exists(nftables_conf):

--- a/src/helpers/vyos-domain-group-resolve.py
+++ b/src/helpers/vyos-domain-group-resolve.py
@@ -56,5 +56,5 @@ if __name__ == '__main__':
 
                 # Resolve successful
                 if elements:
-                    nft_update_set_elements(set_name, elements)
+                    nft_update_set_elements(f'D_{set_name}', elements)
         time.sleep(timeout)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This PR changes the nftables logic to use named sets instead of anonymous sets

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4147

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall, policy route

## Proposed changes
<!--- Describe your changes in detail -->
* Use named sets in nftables instead of anonymous sets for firewall groups
* Refactor firewall/policy route cleanup code making it easier to read and require less operations
* Update smoketests to check named sets, adds PBR firewall group test
* Firewall/policy smoketest teardown checks to ensure nftables was properly cleaned up
* Add prefix to domain-group set name to avoid naming conflicts

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
`set firewall group network-group test network 127.0.0.0/8`
`set firewall name test rule 1 action accept`
`set firewall name test rule 1 source group network-group test`
`commit`

`sudo nft list table ip filter`
```
table ip filter {
        set N_test {
                type ipv4_addr
                flags interval
                elements = { 127.0.0.0/8 }
        }
        ...
        chain NAME_test {
                ip saddr @N_test counter packets 0 bytes 0 return comment "test-1"
                counter packets 0 bytes 0 return comment "test default-action accept"
        }
}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
