### PR TITLE
vbash: beautify tab completion output/line breaks

### DIFF
--- a/interface-definitions/dhcp-server.xml.in
+++ b/interface-definitions/dhcp-server.xml.in
@@ -67,10 +67,7 @@
           </node>
           <leafNode name="global-parameters">
             <properties>
-              <help>Additional global parameters for DHCP server. You must
-                use the syntax of dhcpd.conf in this text-field. Using this
-                without proper knowledge may result in a crashed DHCP server.
-                Check system log to look for errors.</help>
+              <help>Additional global parameters for DHCP server. You must use the syntax of dhcpd.conf in this text-field. Using this without proper knowledge may result in a crashed DHCP server. Check system log to look for errors.</help>
               <multi/>
             </properties>
           </leafNode>
@@ -111,10 +108,7 @@
               #include <include/name-server-ipv4.xml.i>
               <leafNode name="shared-network-parameters">
                 <properties>
-                  <help>Additional shared-network parameters for DHCP server.
-                You must use the syntax of dhcpd.conf in this text-field.
-                Using this without proper knowledge may result in a crashed
-                DHCP server. Check system log to look for errors.</help>
+                  <help>Additional shared-network parameters for DHCP server. You must use the syntax of dhcpd.conf in this text-field. Using this without proper knowledge may result in a crashed DHCP server. Check system log to look for errors.</help>
                   <multi/>
                 </properties>
               </leafNode>
@@ -347,11 +341,7 @@
                       </leafNode>
                       <leafNode name="static-mapping-parameters">
                         <properties>
-                          <help>Additional static-mapping parameters for DHCP server.
-                Will be placed inside the "host" block of the mapping.
-                You must use the syntax of dhcpd.conf in this text-field.
-                Using this without proper knowledge may result in a crashed
-                DHCP server. Check system log to look for errors.</help>
+                          <help>Additional static-mapping parameters for DHCP server. Will be placed inside the "host" block of the mapping. You must use the syntax of dhcpd.conf in this text-field. Using this without proper knowledge may result in a crashed DHCP server. Check system log to look for errors.</help>
                           <multi/>
                         </properties>
                       </leafNode>
@@ -385,10 +375,7 @@
                   </tagNode >
                   <leafNode name="subnet-parameters">
                     <properties>
-                      <help>Additional subnet parameters for DHCP server. You must
-                use the syntax of dhcpd.conf in this text-field. Using this
-                without proper knowledge may result in a crashed DHCP server.
-                Check system log to look for errors.</help>
+                      <help>Additional subnet parameters for DHCP server. You must use the syntax of dhcpd.conf in this text-field. Using this without proper knowledge may result in a crashed DHCP server. Check system log to look for errors.</help>
                       <multi/>
                     </properties>
                   </leafNode>

--- a/interface-definitions/interfaces-openvpn.xml.in
+++ b/interface-definitions/interfaces-openvpn.xml.in
@@ -305,10 +305,7 @@
           </leafNode>
           <leafNode name="openvpn-option">
             <properties>
-              <help>Additional OpenVPN options. You must
-                use the syntax of openvpn.conf in this text-field. Using this
-                without proper knowledge may result in a crashed OpenVPN server.
-                Check system log to look for errors.</help>
+              <help>Additional OpenVPN options. You must use the syntax of openvpn.conf in this text-field. Using this without proper knowledge may result in a crashed OpenVPN server. Check system log to look for errors.</help>
               <multi/>
             </properties>
           </leafNode>
@@ -502,10 +499,7 @@
                   </leafNode>
                   <leafNode name="subnet-mask">
                     <properties>
-                      <help>Subnet mask pushed to dynamic clients.
-                If not set the server subnet mask will be used.
-                Only used with topology subnet or device type tap.
-                Not used with bridged interfaces.</help>
+                      <help>Subnet mask pushed to dynamic clients. If not set the server subnet mask will be used. Only used with topology subnet or device type tap. Not used with bridged interfaces.</help>
                       <constraint>
                         <validator name="ipv4-address"/>
                       </constraint>

--- a/interface-definitions/interfaces-wireless.xml.in
+++ b/interface-definitions/interfaces-wireless.xml.in
@@ -716,9 +716,7 @@
                   </leafNode>
                   <leafNode name="passphrase">
                     <properties>
-                      <help>WPA personal shared pass phrase. If you are
-                using special characters in the WPA passphrase then single
-                quotes are required.</help>
+                      <help>WPA personal shared pass phrase. If you are using special characters in the WPA passphrase then single quotes are required.</help>
                       <valueHelp>
                         <format>txt</format>
                         <description>Passphrase of at least 8 but not more than 63 printable characters</description>

--- a/scripts/build-command-templates
+++ b/scripts/build-command-templates
@@ -27,6 +27,7 @@ import copy
 import functools
 
 from lxml import etree as ET
+from textwrap import fill
 
 # Defaults
 
@@ -130,6 +131,7 @@ def get_properties(p, default=None):
             # DNS forwarding for instance has multiple defaults - specified as whitespace separated list
             tmp = ', '.join(default.text.split())
             help += f' (default: {tmp})'
+        help = fill(help, width=64, subsequent_indent='\t\t\t')
         props["help"] = help
     except:
         pass


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Commit a6f82bb484 ("T1748: vbash: beautify tab completion output/line breaks")
added a method to split the help string and insert newlines and leading tabs
in a deterministic way.

This commit cleans up the legacy implementations where leading whitespaces got
counted and added by humans in a try/error method.

Change from

```
cpo@LR2.wue3# set service dhcp-server
Possible completions:
   disable      Temporary disable
   dynamic-dns-update
                Dynamically update Domain Name System (RFC4702)
 > failover     DHCP failover configuration
+  global-parameters
                Additional global parameters for DHCP server. You must
                use the syntax of dhcpd.conf in this text-field. Using this
                without proper knowledge may result in a crashed DHCP server.
                Check system log to look for errors.
   host-decl-name
                Use host declaration name for forward DNS name
   hostfile-update
                Updating /etc/hosts file (per client lease)
+  listen-address
                Local IPv4 addresses for service to listen on
+> shared-network-name
                Name of DHCP shared network
```

to

```
cpo@LR1.wue3# set service dhcp-server
Possible completions:
   disable              Disable instance
   dynamic-dns-update   Dynamically update Domain Name System (RFC4702)
 > failover             DHCP failover configuration
+  global-parameters    Additional global parameters for DHCP server. You must use the
                        syntax of dhcpd.conf in this text-field. Using this without
                        proper knowledge may result in a crashed DHCP server. Check
                        system log to look for errors.
   host-decl-name       Use host declaration name for forward DNS name
   hostfile-update      Updating /etc/hosts file (per client lease)
+  listen-address       Local IPv4 addresses to listen on
+> shared-network-name  Name of DHCP shared network
```


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T1748
* https://github.com/vyos/vyatta-cfg/pull/48


## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bash

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
