### PR TITLE
Policy: T4475: add support for matching ipv6 addresses on peer option…

### DIFF
--- a/interface-definitions/policy.xml.in
+++ b/interface-definitions/policy.xml.in
@@ -961,8 +961,13 @@
                         <format>ipv4</format>
                         <description>Peer IP address</description>
                       </valueHelp>
+                      <valueHelp>
+                        <format>ipv6</format>
+                        <description>Peer IPv6 address</description>
+                      </valueHelp>
                       <constraint>
                         <validator name="ipv4-address"/>
+                        <validator name="ipv6-address"/>
                       </constraint>
                     </properties>
                   </leafNode>

--- a/smoketest/scripts/cli/test_policy.py
+++ b/smoketest/scripts/cli/test_policy.py
@@ -715,6 +715,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
         local_pref = '300'
         metric = '50'
         peer = '2.3.4.5'
+        peerv6 = '2001:db8::1'
         tag = '6542'
         goto = '25'
 
@@ -803,6 +804,14 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                             'peer' : peer,
                         },
                     },
+
+                    '31' : {
+                        'action' : 'permit',
+                        'match' : {
+                            'peer' : peerv6,
+                        },
+                    },
+
                     '40' : {
                         'action' : 'permit',
                         'match' : {


### PR DESCRIPTION
… in route-map

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
In route-map, add option for matching ipv6 address on peer match
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4475

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
policy
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
new cli:
```
vyos@vyos# set policy route-map test rule 99 match peer 
Possible completions:
   <x.x.x.x>    Peer IP address
   <h:h:h:h:h:h:h:h>
                Peer IPv6 address
```
Example config:
```
vyos@vyos:~$ show config comm | grep route-map
set policy route-map test rule 1 action 'permit'
set policy route-map test rule 1 match peer '1.2.3.4'
set policy route-map test rule 1 set table '12'
set policy route-map test rule 2 action 'permit'
set policy route-map test rule 2 match peer '2008:fce1::44'
set policy route-map test rule 2 set table '12'

vyos@vyos:~$ sudo vtysh -c "show run"
Building configuration...

Current configuration:
....

route-map test permit 1
 match peer 1.2.3.4
 set table 12
exit
!
route-map test permit 2
 match peer 2008:fce1::44
 set table 12
exit
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
