### PR TITLE
T4480: webproxy: Add safe-ports and ssl-safe-ports for acl squid config

### DIFF
--- a/data/templates/squid/squid.conf.j2
+++ b/data/templates/squid/squid.conf.j2
@@ -2,6 +2,11 @@
 
 acl net src all
 acl SSL_ports port 443
+{% if ssl_safe_ports is vyos_defined %}
+{%     for port in ssl_safe_ports %}
+acl SSL_ports port {{ port }}
+{%     endfor %}
+{% endif %}
 acl Safe_ports port 80          # http
 acl Safe_ports port 21          # ftp
 acl Safe_ports port 443         # https
@@ -13,6 +18,11 @@ acl Safe_ports port 280         # http-mgmt
 acl Safe_ports port 488         # gss-http
 acl Safe_ports port 591         # filemaker
 acl Safe_ports port 777         # multiling http
+{% if safe_ports is vyos_defined %}
+{%     for port in safe_ports %}
+acl Safe_ports port {{ port }}
+{%     endfor %}
+{% endif %}
 acl CONNECT method CONNECT
 
 {% if authentication is vyos_defined %}

--- a/interface-definitions/service-webproxy.xml.in
+++ b/interface-definitions/service-webproxy.xml.in
@@ -8,6 +8,32 @@
           <priority>500</priority>
         </properties>
         <children>
+          <leafNode name="safe-ports">
+            <properties>
+              <help>Safe port ACL</help>
+              <valueHelp>
+                <format>u32:1-1024</format>
+                <description>Port number. Ports included by default: 21,70,80,210,280,443,488,591,777,873,1025-65535</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 1-20 --range 22-69 --range 71-79 --range 81-209 --range 211-279 --range 281-442 --range 444-487 --range 489-590 --range 592-776 --range 778-872 --range 874-1024"/>
+              </constraint>
+              <multi/>
+            </properties>
+          </leafNode>
+          <leafNode name="ssl-safe-ports">
+            <properties>
+              <help>SSL safe port</help>
+              <valueHelp>
+                <format>u32:1-65535</format>
+                <description>Port number. Ports included by default: 443</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 1-442 --range 444-65535"/>
+              </constraint>
+              <multi/>
+            </properties>
+          </leafNode>
           <leafNode name="append-domain">
             <properties>
               <help>Default domain name</help>

--- a/smoketest/scripts/cli/test_service_webproxy.py
+++ b/smoketest/scripts/cli/test_service_webproxy.py
@@ -87,6 +87,8 @@ class TestServiceWebProxy(VyOSUnitTestSHIM.TestCase):
         max_obj_size = '8192'
         block_mine = ['application/pdf', 'application/x-sh']
         body_max_size = '4096'
+        safe_port = '88'
+        ssl_safe_port = '8443'
 
         self.cli_set(base_path + ['listen-address', listen_ip])
         self.cli_set(base_path + ['append-domain', domain])
@@ -103,6 +105,9 @@ class TestServiceWebProxy(VyOSUnitTestSHIM.TestCase):
             self.cli_set(base_path + ['reply-block-mime', mime])
 
         self.cli_set(base_path + ['reply-body-max-size', body_max_size])
+
+        self.cli_set(base_path + ['safe-ports', safe_port])
+        self.cli_set(base_path + ['ssl-safe-ports', ssl_safe_port])
 
         # commit changes
         self.cli_commit()
@@ -121,6 +126,9 @@ class TestServiceWebProxy(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'http_reply_access deny BLOCK_MIME', config)
 
         self.assertIn(f'reply_body_max_size {body_max_size} KB', config)
+
+        self.assertIn(f'acl Safe_ports port {safe_port}', config)
+        self.assertIn(f'acl SSL_ports port {ssl_safe_port}', config)
 
         # Check for running process
         self.assertTrue(process_named_running(PROCESS_NAME))


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add options for safe-ports and SSL-ports acls

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4480

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
webproxy

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
cli:
```
vyos@vyos# set service webproxy 
Possible completions:
   append-domain        Default domain name
 > authentication       Proxy Authentication Settings
+> cache-peer           Specify other caches in a hierarchy
   cache-size           Disk cache size in MB (default: 100)
   default-port         Default Proxy Port (default: 3128)
   disable-access-log   Disable logging of HTTP accesses
+  domain-block         Domain name to block
+  domain-noncache      Domain name to access without caching
+> listen-address       IPv4 listen-address for WebProxy
   maximum-object-size  Maximum size of object to be stored in cache in kilobytes
   mem-cache-size       Memory cache size in MB (default: 20)
   minimum-object-size  Maximum size of object to be stored in cache in kilobytes
   outgoing-address     Outgoing IP address for webproxy
+  reply-block-mime     MIME type to block
   reply-body-max-size  Maximum reply body size in KB
+  safe-ports           Safe port ACL
+  ssl-safe-ports       SSL safe port
 > url-filtering        URL filtering settings

vyos@vyos# set service webproxy safe-ports 
Possible completions:
   <1-1024>             Port number. Ports included by default: 21,70,80,210,280,443,488,591,777,873,1025-65535
vyos@vyos# set service webproxy ssl-safe-ports 
Possible completions:
   <1-65535>            Port number. Ports included by default: 443
      
[edit]

```
Configuration:
```
vyos@vyos# run show config comm | grep webp
set service webproxy safe-ports '88'
set service webproxy safe-ports '99'
set service webproxy ssl-safe-ports '8443'
set service webproxy ssl-safe-ports '8080'
set service webproxy listen-address 5.5.5.5

vyos@vyos# cat /etc/squid/squid.conf | grep acl
acl net src all
acl SSL_ports port 443
acl SSL_ports port 8443
acl SSL_ports port 8080
acl Safe_ports port 80          # http
acl Safe_ports port 21          # ftp
acl Safe_ports port 443         # https
acl Safe_ports port 873         # rsync
acl Safe_ports port 70          # gopher
acl Safe_ports port 210         # wais
acl Safe_ports port 1025-65535  # unregistered ports
acl Safe_ports port 280         # http-mgmt
acl Safe_ports port 488         # gss-http
acl Safe_ports port 591         # filemaker
acl Safe_ports port 777         # multiling http
acl Safe_ports port 88
acl Safe_ports port 99
acl CONNECT method CONNECT

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
