### PR TITLE
mpls: T4489: Set priority 400 for MPLS after tunnel

### DIFF
--- a/interface-definitions/protocols-mpls.xml.in
+++ b/interface-definitions/protocols-mpls.xml.in
@@ -6,7 +6,7 @@
       <node name="mpls" owner="${vyos_conf_scripts_dir}/protocols_mpls.py">
         <properties>
           <help>Multiprotocol Label Switching (MPLS)</help>
-          <priority>299</priority>
+          <priority>400</priority>
         </properties>
         <children>
           <node name="ldp">


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix wrong behavior with priority by using tunnel interfaces
MPLS configuration must be applied after tunnel interfaces
as we use an addition sysctl option `net.mpls.conf.tun0.input = 1`
which doesn't exist without a tunnel interface

Change priority:
```
    299 protocols/mpls
    380 interfaces/tunnel
```
To:
```
    380 interfaces/tunnel
    400 protocols/mpls
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4489

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
mpls
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces dummy dum1 address '10.5.4.8/24'
set interfaces tunnel tun0 address '10.255.0.2/30'
set interfaces tunnel tun0 encapsulation 'gre'
set interfaces tunnel tun0 remote '192.0.2.254'
set interfaces tunnel tun0 source-address '192.0.2.1'
set protocols mpls interface 'dum1'
set protocols mpls interface 'tun0'
set protocols mpls ldp discovery transport-ipv4-address '192.0.2.1'
set protocols mpls ldp interface 'dum1'
set protocols mpls ldp interface 'tun0'
set protocols mpls ldp router-id '192.0.2.1'

```
Before fix:
```
vyos@r1# sysctl net.mpls.conf.tun0.input
net.mpls.conf.tun0.input = 0
```
After fix:
```
vyos@r1# sysctl net.mpls.conf.tun0.input
net.mpls.conf.tun0.input = 1

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
