### PR TITLE
containers: T4473: Fix create container with not exist network

### DIFF
--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -132,7 +132,7 @@ def verify(container):
 
                 # Check if the specified container network exists
                 network_name = list(container_config['network'])[0]
-                if network_name not in container['network']:
+                if network_name not in container.get('network', {}):
                     raise ConfigError(f'Container network "{network_name}" does not exist!')
 
                 if 'address' in container_config['network'][network_name]:


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix for a setting container without or wrong network declaration
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4473

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
container
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Create a container with a nonexistent network
Current behavior:
```
set container name alp01 image alpine
set container name alp01 network NET02

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/container.py", line 367, in <module>
    verify(c)
  File "/usr/libexec/vyos/conf_mode/container.py", line 135, in verify
    if network_name not in container['network']:
KeyError: 'network'
```
After Fix:
```
set container name alp01 image alpine
set container name alp01 network NET02

vyos@r14# commit
[ container ]
Container network "NET02" does not exist!

[[container]] failed
Commit failed
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
