### PR TITLE
openvpn: T4485: Accept multiple tls ca-certificate values

### DIFF
--- a/interface-definitions/include/pki/ca-certificate-multi.xml.i
+++ b/interface-definitions/include/pki/ca-certificate-multi.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from pki/ca-certificate-multi.xml.i -->
+<leafNode name="ca-certificate">
+  <properties>
+    <help>Certificate Authority chain in PKI configuration</help>
+    <completionHelp>
+      <path>pki ca</path>
+    </completionHelp>
+    <valueHelp>
+      <format>txt</format>
+      <description>Name of CA in PKI configuration</description>
+    </valueHelp>
+    <multi/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/interfaces-openvpn.xml.in
+++ b/interface-definitions/interfaces-openvpn.xml.in
@@ -741,7 +741,7 @@
                 </properties>
               </leafNode>
               #include <include/pki/certificate.xml.i>
-              #include <include/pki/ca-certificate.xml.i>
+              #include <include/pki/ca-certificate-multi.xml.i>
               <leafNode name="dh-params">
                 <properties>
                   <help>Diffie Hellman parameters (server only)</help>

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -197,7 +197,7 @@ def read_file(fname, defaultonfailure=None):
             return defaultonfailure
         raise e
 
-def write_file(fname, data, defaultonfailure=None, user=None, group=None, mode=None):
+def write_file(fname, data, defaultonfailure=None, user=None, group=None, mode=None, append=False):
     """
     Write content of data to given fname, should defaultonfailure be not None,
     it is returned on failure to read.
@@ -212,7 +212,7 @@ def write_file(fname, data, defaultonfailure=None, user=None, group=None, mode=N
     try:
         """ Write a file to string """
         bytes = 0
-        with open(fname, 'w') as f:
+        with open(fname, 'w' if not append else 'a') as f:
             bytes = f.write(data)
         chown(fname, user, group)
         chmod(fname, mode)

--- a/smoketest/configs/dialup-router-medium-vpn
+++ b/smoketest/configs/dialup-router-medium-vpn
@@ -120,7 +120,7 @@ interfaces {
         persistent-tunnel
         remote-host 192.0.2.10
         tls {
-            ca-cert-file /config/auth/ovpn_test_ca.pem
+            ca-cert-file /config/auth/ovpn_test_chain.pem
             cert-file /config/auth/ovpn_test_server.pem
             key-file /config/auth/ovpn_test_server.key
             auth-file /config/auth/ovpn_test_tls_auth.key
@@ -152,7 +152,7 @@ interfaces {
         remote-host 01.foo.com
         remote-port 1194
         tls {
-            ca-cert-file /config/auth/ovpn_test_ca.pem
+            ca-cert-file /config/auth/ovpn_test_chain.pem
             auth-file /config/auth/ovpn_test_tls_auth.key
         }
     }

--- a/src/migration-scripts/interfaces/24-to-25
+++ b/src/migration-scripts/interfaces/24-to-25
@@ -20,6 +20,7 @@
 import os
 import sys
 from vyos.configtree import ConfigTree
+from vyos.pki import CERT_BEGIN
 from vyos.pki import load_certificate
 from vyos.pki import load_crl
 from vyos.pki import load_dh_parameters
@@ -27,6 +28,7 @@ from vyos.pki import load_private_key
 from vyos.pki import encode_certificate
 from vyos.pki import encode_dh_parameters
 from vyos.pki import encode_private_key
+from vyos.pki import verify_crl
 from vyos.util import run
 
 def wrapped_pem_to_config_value(pem):
@@ -129,6 +131,8 @@ if config.exists(base):
 
             config.delete(base + [interface, 'tls', 'crypt-file'])
 
+        ca_certs = {}
+
         if config.exists(x509_base + ['ca-cert-file']):
             if not config.exists(pki_base + ['ca']):
                 config.set(pki_base + ['ca'])
@@ -136,20 +140,27 @@ if config.exists(base):
 
             cert_file = config.return_value(x509_base + ['ca-cert-file'])
             cert_path = os.path.join(AUTH_DIR, cert_file)
-            cert = None
 
             if os.path.isfile(cert_path):
                 if not os.access(cert_path, os.R_OK):
                     run(f'sudo chmod 644 {cert_path}')
 
                 with open(cert_path, 'r') as f:
-                    cert_data = f.read()
-                    cert = load_certificate(cert_data, wrap_tags=False)
+                    certs_str = f.read()
+                    certs_data = certs_str.split(CERT_BEGIN)
+                    index = 1
+                    for cert_data in certs_data[1:]:
+                        cert = load_certificate(CERT_BEGIN + cert_data, wrap_tags=False)
 
-            if cert:
-                cert_pem = encode_certificate(cert)
-                config.set(pki_base + ['ca', pki_name, 'certificate'], value=wrapped_pem_to_config_value(cert_pem))
-                config.set(x509_base + ['ca-certificate'], value=pki_name)
+                        if cert:
+                            ca_certs[f'{pki_name}_{index}'] = cert
+                            cert_pem = encode_certificate(cert)
+                            config.set(pki_base + ['ca', f'{pki_name}_{index}', 'certificate'], value=wrapped_pem_to_config_value(cert_pem))
+                            config.set(x509_base + ['ca-certificate'], value=f'{pki_name}_{index}', replace=False)
+                        else:
+                            print(f'Failed to migrate CA certificate on openvpn interface {interface}')
+
+                        index += 1
             else:
                 print(f'Failed to migrate CA certificate on openvpn interface {interface}')
 
@@ -163,6 +174,7 @@ if config.exists(base):
             crl_file = config.return_value(x509_base + ['crl-file'])
             crl_path = os.path.join(AUTH_DIR, crl_file)
             crl = None
+            crl_ca_name = None
 
             if os.path.isfile(crl_path):
                 if not os.access(crl_path, os.R_OK):
@@ -172,9 +184,14 @@ if config.exists(base):
                     crl_data = f.read()
                     crl = load_crl(crl_data, wrap_tags=False)
 
-            if crl:
+                    for ca_name, ca_cert in ca_certs.items():
+                        if verify_crl(crl, ca_cert):
+                            crl_ca_name = ca_name
+                            break
+
+            if crl and crl_ca_name:
                 crl_pem = encode_certificate(crl)
-                config.set(pki_base + ['ca', pki_name, 'crl'], value=wrapped_pem_to_config_value(crl_pem))
+                config.set(pki_base + ['ca', crl_ca_name, 'crl'], value=wrapped_pem_to_config_value(crl_pem))
             else:
                 print(f'Failed to migrate CRL on openvpn interface {interface}')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allows a chain of CA certificates on an OpenVPN interface

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4485

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openvpn

## Proposed changes
<!--- Describe your changes in detail -->
* Changes the `tls ca-certificate` to a multi value node
* Verifies values are a valid chain
* Sorts the CA chain and outputs into the OpenVPN CA pem file

Note: Code concatenates the CRL file but openssl/openVPN only uses the first CRL. Will be improved later to determine and use only the freshest CRL.

This PR provides the groundwork to also support CA chains in other scripts (ipsec, openconnect, sstp etc)

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
