### PR TITLE
smoketest: T4485: Add CRL for configtest, add script for configtest PKI objects

### DIFF
--- a/debian/vyos-1x-smoketest.install
+++ b/debian/vyos-1x-smoketest.install
@@ -1,4 +1,5 @@
 usr/bin/vyos-smoketest
 usr/bin/vyos-configtest
+usr/bin/vyos-configtest-pki
 usr/libexec/vyos/tests/smoke
 usr/libexec/vyos/tests/config

--- a/smoketest/bin/vyos-configtest-pki
+++ b/smoketest/bin/vyos-configtest-pki
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022, VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from os import system
+from vyos.pki import create_private_key
+from vyos.pki import create_certificate_request
+from vyos.pki import create_certificate
+from vyos.pki import create_certificate_revocation_list
+from vyos.pki import create_dh_parameters
+from vyos.pki import encode_certificate
+from vyos.pki import encode_dh_parameters
+from vyos.pki import encode_private_key
+
+subject = {'country': 'DE', 'state': 'BY', 'locality': 'Cloud', 'organization': 'VyOS', 'common_name': 'vyos'}
+ca_subject = {'country': 'DE', 'state': 'BY', 'locality': 'Cloud', 'organization': 'VyOS', 'common_name': 'vyos CA'}
+subca_subject = {'country': 'DE', 'state': 'BY', 'locality': 'Cloud', 'organization': 'VyOS', 'common_name': 'vyos SubCA'}
+
+ca_cert = '/config/auth/ovpn_test_ca.pem'
+ca_key = '/config/auth/ovpn_test_ca.key'
+ca_cert_chain = '/config/auth/ovpn_test_chain.pem'
+ca_crl = '/config/auth/ovpn_test_ca.crl'
+subca_cert = '/config/auth/ovpn_test_subca.pem'
+subca_csr = '/tmp/subca.csr'
+subca_key = '/config/auth/ovpn_test_subca.key'
+ssl_cert = '/config/auth/ovpn_test_server.pem'
+ssl_key  = '/config/auth/ovpn_test_server.key'
+dh_pem   = '/config/auth/ovpn_test_dh.pem'
+s2s_key  = '/config/auth/ovpn_test_site2site.key'
+auth_key = '/config/auth/ovpn_test_tls_auth.key'
+
+def create_cert(subject, cert_path, key_path, sign_by=None, sign_by_key=None, ca=False, sub_ca=False):
+    priv_key = create_private_key('rsa', 2048)
+    cert_req = create_certificate_request(subject, priv_key)
+    cert = create_certificate(
+        cert_req,
+        sign_by if sign_by else cert_req,
+        sign_by_key if sign_by_key else priv_key,
+        is_ca=ca, is_sub_ca=sub_ca)
+
+    with open(cert_path, 'w') as f:
+        f.write(encode_certificate(cert))
+
+    with open(key_path, 'w') as f:
+        f.write(encode_private_key(priv_key))
+
+    return cert, priv_key
+
+def create_empty_crl(crl_path, sign_by, sign_by_key):
+    crl = create_certificate_revocation_list(sign_by, sign_by_key, [1])
+
+    with open(crl_path, 'w') as f:
+        f.write(encode_certificate(crl))
+
+    return crl
+
+if __name__ == '__main__':
+    # Create Root CA
+    ca_cert_obj, ca_key_obj = create_cert(ca_subject, ca_cert, ca_key, ca=True)
+
+    # Create Empty CRL
+    create_empty_crl(ca_crl, ca_cert_obj, ca_key_obj)
+
+    # Create Intermediate CA
+    subca_cert_obj, subca_key_obj = create_cert(
+        subca_subject, subca_cert, subca_key,
+        sign_by=ca_cert_obj, sign_by_key=ca_key_obj,
+        ca=True, sub_ca=True)
+
+    # Create Chain
+    with open(ca_cert_chain, 'w') as f:
+        f.write(encode_certificate(subca_cert_obj) + "\n")
+        f.write(encode_certificate(ca_cert_obj) + "\n")
+
+    # Create Server Cert
+    create_cert(subject, ssl_cert, ssl_key, sign_by=subca_cert_obj, sign_by_key=subca_key_obj)
+
+    # Create DH params
+    dh_params = create_dh_parameters()
+
+    with open(dh_pem, 'w') as f:
+        f.write(encode_dh_parameters(dh_params))
+
+    # OpenVPN S2S Key
+    system(f'openvpn --genkey secret {s2s_key}')
+
+    # OpenVPN Auth Key
+    system(f'openvpn --genkey secret {auth_key}')

--- a/smoketest/configs/dialup-router-medium-vpn
+++ b/smoketest/configs/dialup-router-medium-vpn
@@ -122,6 +122,7 @@ interfaces {
         tls {
             ca-cert-file /config/auth/ovpn_test_chain.pem
             cert-file /config/auth/ovpn_test_server.pem
+            crl-file /config/auth/ovpn_test_ca.crl
             key-file /config/auth/ovpn_test_server.key
             auth-file /config/auth/ovpn_test_tls_auth.key
         }


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
* Add `crl-file` to configtest to test migration of CRL to corresponding PKI CA
* Add `vyos-configtest-pki` script to generate PKI objects for configtest instead of in `check-qemu-install`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4485

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
smoketest

## Proposed changes
<!--- Describe your changes in detail -->
Add `crl-file` to configtest to ensure CRL is migrated and assigned to the PKI CA object

Move configtest PKI file generation from `check-qemu-install` in vyos-build to a python script. Uses `vyos.pki` module to generate objects and can be run manually to generate required files for testing migrations on developer systems.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
