### PR TITLE
event-handler: T4508: Fixed environment variables

### DIFF
--- a/src/system/vyos-event-handler.py
+++ b/src/system/vyos-event-handler.py
@@ -15,14 +15,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
-import select
-import re
 import json
+import re
+import select
+from copy import deepcopy
 from os import getpid, environ
 from pathlib import Path
 from signal import signal, SIGTERM, SIGINT
-from systemd import journal
 from sys import exit
+from systemd import journal
+
 from vyos.util import run, dict_search
 
 # Identify this script
@@ -54,7 +56,7 @@ class Analyzer:
                 script_arguments = dict_search('script.arguments', event_config)
                 script = f'{script} {script_arguments}'
             # Prepare environment
-            environment = environ
+            environment = deepcopy(environ)
             # Check for additional environment options
             if dict_search('script.environment', event_config):
                 for env_variable, env_value in dict_search(


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed usage of environment variables - made an individual environment variable for an event a true copy, instead of a reference to a single environ dictionary.
Also, reorganized imports according to PEP8.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4508

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
event-handler

## Proposed changes
<!--- Describe your changes in detail -->
The `environment = environ` assignment is wrong because it creates a reference to `environ`, so each next event config will overwrite environment items. There must be a `deepcopy()` to do the assignment properly.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
A simple configuration to trigger the problem:
```
set service event-handler event event1 filter pattern 'testp1'
set service event-handler event event1 script environment vari1 value 'value11'
set service event-handler event event1 script environment vari2 value 'value21'
set service event-handler event event1 script path '/bin/true'
set service event-handler event event2 filter pattern 'testp2'
set service event-handler event event2 script environment vari1 value 'value12'
set service event-handler event event2 script environment vari2 value 'value22'
set service event-handler event event2 script path '/bin/true'
```
Without the fix, both events have the same environments.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
