### PR TITLE
dns: T4509: Add dns64-prefix option

### DIFF
--- a/data/templates/dns-forwarding/recursor.conf.j2
+++ b/data/templates/dns-forwarding/recursor.conf.j2
@@ -32,6 +32,11 @@ local-address={{ listen_address | join(',') }}
 # dnssec
 dnssec={{ dnssec }}
 
+{% if dns64_prefix is vyos_defined %}
+# dns64-prefix
+dns64-prefix={{ dns64_prefix }}
+{% endif %}
+
 # serve rfc1918 records
 serve-rfc1918={{ 'no' if no_serve_rfc1918 is vyos_defined else 'yes' }}
 

--- a/interface-definitions/dns-forwarding.xml.in
+++ b/interface-definitions/dns-forwarding.xml.in
@@ -36,6 +36,18 @@
                   <multi/>
                 </properties>
               </leafNode>
+              <leafNode name="dns64-prefix">
+                <properties>
+                  <help>Help to communicate between IPv6-only client and IPv4-only server</help>
+                  <valueHelp>
+                    <format>ipv6net</format>
+                    <description>IPv6 address and /96 only prefix length</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="ipv6-prefix"/>
+                  </constraint>
+                </properties>
+              </leafNode>
               <leafNode name="dnssec">
                 <properties>
                   <help>DNSSEC mode</help>

--- a/smoketest/scripts/cli/test_service_dns_forwarding.py
+++ b/smoketest/scripts/cli/test_service_dns_forwarding.py
@@ -51,6 +51,7 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         # Check basic DNS forwarding settings
         cache_size = '20'
         negative_ttl = '120'
+        dns_prefix = '64:ff9b::/96'
 
         self.cli_set(base_path + ['cache-size', cache_size])
         self.cli_set(base_path + ['negative-ttl', negative_ttl])
@@ -66,6 +67,12 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
             self.cli_commit()
         for address in listen_adress:
             self.cli_set(base_path + ['listen-address', address])
+
+        # Check dns64-prefix - must be prefix /96
+        self.cli_set(base_path + ['dns64-prefix', '2001:db8:aabb::/64'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(base_path + ['dns64-prefix', dns_prefix])
 
         # configure DNSSEC
         self.cli_set(base_path + ['dnssec', 'validate'])
@@ -99,6 +106,10 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         # RFC1918 addresses are looked up by default
         tmp = get_config_value('serve-rfc1918')
         self.assertEqual(tmp, 'yes')
+
+        # dns64-prefix
+        tmp = get_config_value('dns64-prefix')
+        self.assertEqual(tmp, dns_prefix)
 
         # Check for running process
         self.assertTrue(process_named_running(PROCESS_NAME))

--- a/src/conf_mode/dns_forwarding.py
+++ b/src/conf_mode/dns_forwarding.py
@@ -266,6 +266,12 @@ def verify(dns):
             if 'server' not in dns['domain'][domain]:
                 raise ConfigError(f'No server configured for domain {domain}!')
 
+    if 'dns64_prefix' in dns:
+        dns_prefix = dns['dns64_prefix'].split('/')[1]
+        # RFC 6147 requires prefix /96
+        if int(dns_prefix) != 96:
+            raise ConfigError('DNS forwarding "dns64-prefix" must be /96')
+
     if ('authoritative_zone_errors' in dns) and dns['authoritative_zone_errors']:
         for error in dns['authoritative_zone_errors']:
             print(error)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
rfc6147: DNS Extensions for Network Address Translation
         from IPv6 Clients to IPv4 Servers

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4509

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dns
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service dns forwarding dns64-prefix 2001:db8:aabb::/96
```
Expected conf:
```
vyos@r14# cat /run/powerdns/recursor.conf | grep pref
# dns64-prefix
dns64-prefix=2001:db8:aabb::/96
[edit]
vyos@r14# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
