### PR TITLE
ntp: T4456: support listening on specified interface (equuleus)

### DIFF
--- a/data/templates/ntp/ntpd.conf.tmpl
+++ b/data/templates/ntp/ntpd.conf.tmpl
@@ -33,10 +33,17 @@ restrict {{ address|address_from_cidr }} mask {{ address|netmask_from_cidr }} no
 {%   endfor %}
 {% endif %}
 
-{% if listen_address %}
+{% if listen_address is defined or interface is defined %}
 # NTP should listen on configured addresses only
 interface ignore wildcard
-{%   for address in listen_address %}
+{%   if listen_address is defined %}
+{%     for address in listen_address %}
 interface listen {{ address }}
-{%   endfor %}
+{%     endfor %}
+{%   endif %}
+{%   if interface is defined %}
+{%     for ifname in interface %}
+interface listen {{ ifname }}
+{%     endfor %}
+{%   endif %}
 {% endif %}

--- a/interface-definitions/include/generic-interface-multi.xml.i
+++ b/interface-definitions/include/generic-interface-multi.xml.i
@@ -1,0 +1,18 @@
+<!-- include start from generic-interface-multi.xml.i -->
+<leafNode name="interface">
+  <properties>
+    <help>Interface to use</help>
+    <completionHelp>
+      <script>${vyos_completion_dir}/list_interfaces.py</script>
+    </completionHelp>
+    <valueHelp>
+      <format>txt</format>
+      <description>Interface name</description>
+    </valueHelp>
+    <constraint>
+      <validator name="interface-name"/>
+    </constraint>
+    <multi/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/ntp.xml.in
+++ b/interface-definitions/ntp.xml.in
@@ -81,6 +81,7 @@
               </leafNode>
             </children>
           </node>
+          #include <include/generic-interface-multi.xml.i>
           #include <include/listen-address.xml.i>
           #include <include/interface/vrf.xml.i>
         </children>

--- a/smoketest/scripts/cli/test_system_ntp.py
+++ b/smoketest/scripts/cli/test_system_ntp.py
@@ -108,5 +108,22 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
         for listen in listen_address:
             self.assertIn(f'interface listen {listen}', config)
 
+    def test_03_ntp_interface(self):
+        interfaces = ['eth0', 'eth1']
+        for interface in interfaces:
+            self.cli_set(base_path + ['interface', interface])
+
+        servers = ['time1.vyos.net', 'time2.vyos.net']
+        for server in servers:
+            self.cli_set(base_path + ['server', server])
+
+        self.cli_commit()
+
+        # Check generated client address configuration
+        config = read_file(NTP_CONF)
+        self.assertIn('interface ignore wildcard', config)
+        for interface in interfaces:
+            self.assertIn(f'interface listen {interface}', config)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/ntp.py
+++ b/src/conf_mode/ntp.py
@@ -50,6 +50,8 @@ def verify(ntp):
     if 'allow_clients' in ntp and 'server' not in ntp:
         raise ConfigError('NTP server not configured')
 
+    verify_vrf(ntp)
+
     if 'interface' in ntp:
         # If ntpd should listen on a given interface, ensure it exists
         for interface in ntp['interface']:
@@ -63,7 +65,6 @@ def verify(ntp):
                     raise ConfigError(f'NTP runs in VRF "{vrf_name}" - "{interface}" '\
                                       f'does not belong to this VRF!')
 
-    verify_vrf(ntp)
     return None
 
 def generate(ntp):


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

When clients only use DHCP for interface addressing we can not bind NTPd to
an address - as it will fail if the address changes. This commit adds support
to bind ntpd to a given interface in addition to a given address.

`set system ntp interface <name>`

(cherry picked from commit 6732df1edd632b56d3d02970939f51d05d4262e9)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4456

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Integrated Smoketests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
