### PR TITLE
hosts: T2683: Allow multiple entries for static-host-mapping (equuleus)

### DIFF
--- a/data/templates/vyos-hostsd/hosts.tmpl
+++ b/data/templates/vyos-hostsd/hosts.tmpl
@@ -17,8 +17,9 @@ ff02::2         ip6-allrouters
 {%   for tag, taghosts in hosts.items() %}
 # {{ tag }}
 {%     for host, hostprops in taghosts.items() if hostprops.address is defined %}
-{{ "%-15s" | format(hostprops.address) }} {{ host }} {{ hostprops.aliases|join(' ') if hostprops.aliases is defined }}
+{%       for addr in hostprops.address %}
+{{ "%-15s" | format(addr) }} {{ host }} {{ hostprops.aliases|join(' ') if hostprops.aliases is defined }}
+{%       endfor %}
 {%     endfor %}
 {%   endfor %}
 {% endif %}
-

--- a/interface-definitions/dns-domain-name.xml.in
+++ b/interface-definitions/dns-domain-name.xml.in
@@ -102,11 +102,11 @@
                   <constraint>
                     <validator name="ip-address"/>
                   </constraint>
+                  <multi/>
                 </properties>
               </leafNode>
             </children>
           </tagNode>
-
         </children>
       </node>
     </children>

--- a/src/conf_mode/host_name.py
+++ b/src/conf_mode/host_name.py
@@ -79,7 +79,7 @@ def get_config(config=None):
     # system static-host-mapping
     for hn in conf.list_nodes(['system', 'static-host-mapping', 'host-name']):
         hosts['static_host_mapping'][hn] = {}
-        hosts['static_host_mapping'][hn]['address'] = conf.return_value(['system', 'static-host-mapping', 'host-name', hn, 'inet'])
+        hosts['static_host_mapping'][hn]['address'] = conf.return_values(['system', 'static-host-mapping', 'host-name', hn, 'inet'])
         hosts['static_host_mapping'][hn]['aliases'] = conf.return_values(['system', 'static-host-mapping', 'host-name', hn, 'alias'])
 
     return hosts

--- a/src/services/vyos-hostsd
+++ b/src/services/vyos-hostsd
@@ -317,7 +317,7 @@ hosts_add_schema = op_type_schema.extend({
     'data': {
         str: {
             str: {
-            'address': str,
+            'address': [str],
             'aliases': [str]
                 }
             }

--- a/src/utils/vyos-hostsd-client
+++ b/src/utils/vyos-hostsd-client
@@ -129,7 +129,8 @@ try:
             params = h.split(",")
             if len(params) < 2:
                 raise ValueError("Malformed host entry")
-            entry['address'] = params[1]
+            # Address needs to be a list because of changes made in T2683
+            entry['address'] = [params[1]]
             entry['aliases'] = params[2:]
             data[params[0]] = entry
         client.add_hosts({args.tag: data})


### PR DESCRIPTION
(cherry picked from commit b1db3de80b8b5f4e2dcbc6d687d342986345c4b2)

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T2683
* https://phabricator.vyos.net/T4510

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vyos-hostsd

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set system static-host-mapping host-name foo inet 100.64.0.1
set system static-host-mapping host-name foo inet 100.64.0.2
set system static-host-mapping host-name foo inet 2001:db8::1
```

results in 

```bash
cpo@LR2.wue3# cat /etc/hosts
### Autogenerated by VyOS ###
### Do not edit, your changes will get overwritten ###

# Local host
127.0.0.1       localhost
127.0.1.1       LR2.wue3.mybll.net LR2.wue3
# The following lines are desirable for IPv6 capable hosts
::1             localhost ip6-localhost ip6-loopback
fe00::0         ip6-localnet
ff00::0         ip6-mcastprefix
ff02::1         ip6-allnodes
ff02::2         ip6-allrouters

# From 'system static-host-mapping' and DHCP server
# system
100.64.0.1      foo bar
100.64.0.2      foo bar
2001:db8::1     foo bar

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
