### PR TITLE
accel-ppp: T4373: T4507: Add options multiplier for shaper

### DIFF
--- a/data/templates/accel-ppp/config_shaper_radius.j2
+++ b/data/templates/accel-ppp/config_shaper_radius.j2
@@ -6,5 +6,8 @@ attr={{ authentication.radius.rate_limit.attribute }}
 {%     if authentication.radius.rate_limit.vendor is defined and authentication.radius.rate_limit.vendor is not none %}
 vendor={{ authentication.radius.rate_limit.vendor }}
 {%     endif %}
+{%     if authentication.radius.rate_limit.multiplier is defined and authentication.radius.rate_limit.multiplier is not none %}
+rate-multiplier={{ authentication.radius.rate_limit.multiplier }}
+{%     endif %}
 {%   endif %}
 {% endif %}

--- a/data/templates/accel-ppp/ipoe.config.tmpl
+++ b/data/templates/accel-ppp/ipoe.config.tmpl
@@ -127,13 +127,18 @@ bind={{ radius_source_address }}
 dae-server={{ radius_dynamic_author.server }}:{{ radius_dynamic_author.port }},{{ radius_dynamic_author.key }}
 {% endif %}
 
-{% if radius_shaper_attr %}
+{% if radius_shaper_enable %}
 [shaper]
 verbose=1
+{%     if radius_shaper_attr %}
 attr={{ radius_shaper_attr }}
-{% if radius_shaper_vendor %}
+{%     endif %}
+{%     if radius_shaper_multiplier %}
+rate-multiplier={{ radius_shaper_multiplier }}
+{%     endif %}
+{%     if radius_shaper_vendor %}
 vendor={{ radius_shaper_vendor }}
-{% endif %}
+{%     endif %}
 {% endif %}
 {% endif %}
 

--- a/interface-definitions/include/accel-ppp/radius-additions-rate-limit.xml.i
+++ b/interface-definitions/include/accel-ppp/radius-additions-rate-limit.xml.i
@@ -21,6 +21,20 @@
         <valueless />
       </properties>
     </leafNode>
+    <leafNode name="multiplier">
+      <properties>
+        <help>Shaper multiplier</help>
+        <valueHelp>
+          <format>&lt;0.001-1000&gt;</format>
+          <description>Shaper multiplier</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 0.001-1000 --float"/>
+        </constraint>
+        <constraintErrorMessage>Multiplier needs to be between 0.001 and 1000</constraintErrorMessage>
+      </properties>
+      <defaultValue>1</defaultValue>
+    </leafNode>
   </children>
 </node>
 <!-- include end -->

--- a/interface-definitions/service_ipoe-server.xml.in
+++ b/interface-definitions/service_ipoe-server.xml.in
@@ -217,6 +217,11 @@
                   </tagNode>
                 </children>
               </tagNode>
+              <node name="radius">
+                <children>
+                  #include <include/accel-ppp/radius-additions-rate-limit.xml.i>
+                </children>
+              </node>
               #include <include/radius-server-ipv4.xml.i>
               #include <include/accel-ppp/radius-additions.xml.i>
             </children>

--- a/src/conf_mode/service_ipoe-server.py
+++ b/src/conf_mode/service_ipoe-server.py
@@ -53,6 +53,8 @@ default_config_data = {
     'radius_nas_ip': '',
     'radius_source_address': '',
     'radius_shaper_attr': '',
+    'radius_shaper_enable': False,
+    'radius_shaper_multiplier': '',
     'radius_shaper_vendor': '',
     'radius_dynamic_author': '',
     'thread_cnt': get_half_cpus()
@@ -195,6 +197,18 @@ def get_config(config=None):
 
     if conf.exists(['nas-ip-address']):
         ipoe['radius_nas_ip'] = conf.return_value(['nas-ip-address'])
+
+    if conf.exists(['rate-limit', 'attribute']):
+        ipoe['radius_shaper_attr'] = conf.return_value(['rate-limit', 'attribute'])
+
+    if conf.exists(['rate-limit', 'enable']):
+        ipoe['radius_shaper_enable'] = True
+
+    if conf.exists(['rate-limit', 'multiplier']):
+        ipoe['radius_shaper_multiplier'] = conf.return_value(['rate-limit', 'multiplier'])
+
+    if conf.exists(['rate-limit', 'vendor']):
+        ipoe['radius_shaper_vendor'] = conf.return_value(['rate-limit', 'vendor'])
 
     if conf.exists(['source-address']):
         ipoe['radius_source_address'] = conf.return_value(['source-address'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Accel-ppp add option multiplier for PPPoE and IPoE, VyOS 1.3
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4373
* https://phabricator.vyos.net/T4507

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe, ipoe
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
PPPoE server configuration:
```
set service pppoe-server authentication mode 'radius'
set service pppoe-server authentication radius rate-limit attribute 'Mikrotik-Rate-Limit'
set service pppoe-server authentication radius rate-limit enable
set service pppoe-server authentication radius rate-limit multiplier '0.001'
set service pppoe-server authentication radius rate-limit vendor 'Mikrotik'
set service pppoe-server authentication radius server 192.0.2.1 key 'foo'
set service pppoe-server client-ip-pool start '192.0.2.5'
set service pppoe-server client-ip-pool stop '192.0.2.254'
set service pppoe-server gateway-address '192.0.2.1'
set service pppoe-server interface eth1
```
IPoE server configuration:
```
set service ipoe-server authentication mode 'radius'
set service ipoe-server authentication radius rate-limit attribute 'Mikrotik-Rate-Limit'
set service ipoe-server authentication radius rate-limit enable
set service ipoe-server authentication radius rate-limit multiplier '0.001'
set service ipoe-server authentication radius rate-limit vendor 'Miktorik'
set service ipoe-server authentication radius server 192.0.2.1 key 'foo'
set service ipoe-server client-ip-pool name POOL_ONE gateway-address '192.0.2.1'
set service ipoe-server client-ip-pool name POOL_ONE subnet '192.0.2.0/24'
set service ipoe-server interface eth1
```
PPPoE conf section shaper:
```
cat /run/accel-pppd/pppoe.conf
[shaper]
verbose=1
attr=Mikrotik-Rate-Limit
vendor=Mikrotik
rate-multiplier=0.001

```
IPoE conf section shaper:
```
cat /run/accel-pppd/ipoe.conf
[shaper]
verbose=1
attr=Mikrotik-Rate-Limit
rate-multiplier=0.001
vendor=Miktorik

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
