### PR TITLE
firewall: T2199: Fix migration when `icmpv6 type` is an integer

### DIFF
--- a/smoketest/configs/dialup-router-complex
+++ b/smoketest/configs/dialup-router-complex
@@ -66,6 +66,27 @@ firewall {
             action accept
             protocol icmpv6
         }
+        rule 15 {
+            action accept
+            icmpv6 {
+                type 1
+            }
+            protocol icmpv6
+        }
+        rule 16 {
+            action accept
+            icmpv6 {
+                type 1/1
+            }
+            protocol icmpv6
+        }
+        rule 17 {
+            action accept
+            icmpv6 {
+                type destination-unreachable
+            }
+            protocol icmpv6
+        }
     }
     ipv6-name ALLOW-ESTABLISHED-6 {
         default-action drop

--- a/src/migration-scripts/firewall/6-to-7
+++ b/src/migration-scripts/firewall/6-to-7
@@ -194,11 +194,12 @@ if config.exists(base + ['ipv6-name']):
 
             if config.exists(rule_icmp + ['type']):
                 tmp = config.return_value(rule_icmp + ['type'])
-                type_code_match = re.match(r'^(\d+)/(\d+)$', tmp)
+                type_code_match = re.match(r'^(\d+)(?:/(\d+))?$', tmp)
 
                 if type_code_match:
                     config.set(rule_icmp + ['type'], value=type_code_match[1])
-                    config.set(rule_icmp + ['code'], value=type_code_match[2])
+                    if type_code_match[2]:
+                        config.set(rule_icmp + ['code'], value=type_code_match[2])
                 elif tmp in icmpv6_remove:
                     config.delete(rule_icmp + ['type'])
                 elif tmp in icmpv6_translations:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixes firewall migrator for `icmpv6 type` not correctly handling a single integer

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T2199

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall, migrators

## Proposed changes
<!--- Describe your changes in detail -->
* Fixes firewall migrator for `icmpv6 type`
* Add cases to configtest `dialup-router-complex` for this specific migration

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
