### PR TITLE
syslog: T4500: Remove max-size from rsyslog leaving rotation to logrotate

### DIFF
--- a/data/templates/syslog/rsyslog.conf.j2
+++ b/data/templates/syslog/rsyslog.conf.j2
@@ -10,7 +10,11 @@ $MarkMessagePeriod {{ files['global']['marker-interval'] }}
 $PreserveFQDN on
 {% endif %}
 {% for file, file_options in files.items() %}
+{%     if file_options['max-size'] is vyos_defined %}
 $outchannel {{ file }},{{ file_options['log-file'] }},{{ file_options['max-size'] }},{{ file_options['action-on-max-size'] }}
+{%     else %}
+$outchannel {{ file }},{{ file_options['log-file'] }}
+{%     endif %}
 {{ file_options['selectors'] }} :omfile:${{ file }}
 {% endfor %}
 {% if console is defined and console is not none %}

--- a/debian/vyos-1x.install
+++ b/debian/vyos-1x.install
@@ -1,4 +1,3 @@
-etc/cron.hourly
 etc/dhcp
 etc/ipsec.d
 etc/logrotate.d

--- a/interface-definitions/include/version/system-version.xml.i
+++ b/interface-definitions/include/version/system-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/system-version.xml.i -->
-<syntaxVersion component='system' version='24'></syntaxVersion>
+<syntaxVersion component='system' version='25'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/system-syslog.xml.in
+++ b/interface-definitions/system-syslog.xml.in
@@ -390,31 +390,6 @@
               <help>Logging to system standard location</help>
             </properties>
             <children>
-              <node name="archive">
-                <properties>
-                  <help>Log file size and rotation characteristics</help>
-                </properties>
-                <children>
-                  <leafNode name="file">
-                    <properties>
-                      <help>Number of saved files (default is 5)</help>
-                      <constraint>
-                        <regex>[0-9]+</regex>
-                      </constraint>
-                      <constraintErrorMessage>illegal characters in number of files</constraintErrorMessage>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="size">
-                    <properties>
-                      <help>Size of log files (in kbytes, default is 256)</help>
-                      <constraint>
-                        <regex>[0-9]+</regex>
-                      </constraint>
-                      <constraintErrorMessage>illegal characters in size</constraintErrorMessage>
-                    </properties>
-                  </leafNode>
-                </children>
-              </node>
               <tagNode name="facility">
                 <properties>
                   <help>Facility for logging</help>

--- a/smoketest/configs/basic-vyos
+++ b/smoketest/configs/basic-vyos
@@ -128,6 +128,10 @@ system {
     name-server 192.168.0.1
     syslog {
         global {
+            archive {
+                file 5
+                size 512
+            }
             facility all {
                 level info
             }

--- a/src/conf_mode/system-syslog.py
+++ b/src/conf_mode/system-syslog.py
@@ -52,8 +52,6 @@ def get_config(config=None):
         {
             'global': {
                 'log-file': '/var/log/messages',
-                'max-size': 262144,
-                'action-on-max-size': '/usr/sbin/logrotate /etc/logrotate.d/vyos-rsyslog',
                 'selectors': '*.notice;local7.debug',
                 'max-files': '5',
                 'preserver_fqdn': False

--- a/src/etc/cron.hourly/vyos-logrotate-hourly
+++ b/src/etc/cron.hourly/vyos-logrotate-hourly
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-test -x /usr/sbin/logrotate || exit 0
-/usr/sbin/logrotate /etc/logrotate.conf

--- a/src/etc/logrotate.d/vyos-rsyslog
+++ b/src/etc/logrotate.d/vyos-rsyslog
@@ -4,7 +4,7 @@
     nomail
     notifempty
     rotate 10
-    size 262144
+    size 1M
     postrotate
         # inform rsyslog service about rotation
         /usr/lib/rsyslog/rsyslog-rotate

--- a/src/etc/systemd/system/logrotate.timer.d/10-override.conf
+++ b/src/etc/systemd/system/logrotate.timer.d/10-override.conf
@@ -1,0 +1,2 @@
+[Timer]
+OnCalendar=hourly

--- a/src/migration-scripts/system/24-to-25
+++ b/src/migration-scripts/system/24-to-25
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Migrate system syslog global archive to system logs logrotate messages
+
+from sys import exit, argv
+from vyos.configtree import ConfigTree
+
+if (len(argv) < 1):
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['system', 'syslog', 'global', 'archive']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    exit(0)
+
+if config.exists(base + ['file']):
+    tmp = config.return_value(base + ['file'])
+    config.set(['system', 'logs', 'logrotate', 'messages', 'rotate'], value=tmp)
+
+if config.exists(base + ['size']):
+    tmp = config.return_value(base + ['size'])
+    tmp = max(round(int(tmp) / 1024), 1) # kb -> mb
+    config.set(['system', 'logs', 'logrotate', 'messages', 'max-size'], value=tmp)
+
+config.delete(base)
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print(f'Failed to save the modified config: {e}')
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4500

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
syslog

## Proposed changes
<!--- Describe your changes in detail -->

After discussion with @zdc this was decided the better long term fix

* Remove max-size from rsyslog leaving rotation to logrotate
* Remove hourly logrotate cron in favour of systemd timer override
* Remove and migrate obsolete `system syslog global archive` node

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
