### PR TITLE
nat: T4499: Fix NAT not showing a single flow entry

### DIFF
--- a/src/op_mode/show_nat_translations.py
+++ b/src/op_mode/show_nat_translations.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020 VyOS maintainers and contributors
+# Copyright (C) 2020-2022 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -83,11 +83,23 @@ def pipe():
     return xml
 
 
+def xml_to_dict(xml):
+    """
+    Convert XML to dictionary
+    Return: dictionary
+    """
+    parse = xmltodict.parse(xml)
+    # If only one NAT entry we must change dict T4499
+    if 'meta' in parse['conntrack']['flow']:
+        return dict(conntrack={'flow': [parse['conntrack']['flow']]})
+    return parse
+
+
 def process(data, stats, protocol, pipe, verbose, flowtype=''):
     if not data:
         return
 
-    parsed = xmltodict.parse(data)
+    parsed = xml_to_dict(data)
 
     print(headers(verbose, pipe))
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
We must change the dictionary if we get only one flow entry. Op-mode
I.e one NAT record
With single entry we get:
```
    OrderedDict([('meta', xxx]))
```
We expect:
```
    [OrderedDict([('meta', xxx]))]
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4499

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Get only one NAT flow:
```
vyos@r14:~$ sudo conntrack -L --src-nat
icmp     1 29 src=192.0.2.10 dst=1.1.1.1 type=8 code=0 id=2156 src=1.1.1.1 dst=192.168.122.14 type=0 code=0 id=2156 mark=0 use=1
conntrack v1.4.6 (conntrack-tools): 1 flow entries have been shown.
vyos@r14:~$ 
```
Before fix we don't see any data:
```
vyos@r14:~$ show nat source translations
Pre-NAT              Post-NAT             Prot  Timeout  
vyos@r14:~$ 
vyos@r14:~$ show nat source translations detail 
Pre-NAT src          Pre-NAT dst        Post-NAT src         Post-NAT dst      
vyos@r14:~$ 
```
After fix:
```
vyos@r14:~$ show nat source translations 
Pre-NAT              Post-NAT             Prot  Timeout  
192.0.2.10           192.168.122.14       icmp  29       
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ show nat source translations detail 
Pre-NAT src          Pre-NAT dst        Post-NAT src         Post-NAT dst      
192.0.2.10           1.1.1.1            192.168.122.14       1.1.1.1           
  icmp: 192.0.2.10 ==> 192.168.122.14 timeout: 29 use: 1 
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
