### PR TITLE
equuleus: Bond and Bridge interface fixes + new smoketests

### DIFF
--- a/interface-definitions/interfaces-bonding.xml.in
+++ b/interface-definitions/interfaces-bonding.xml.in
@@ -92,6 +92,23 @@
           #include <include/interface/ipv4-options.xml.i>
           #include <include/interface/ipv6-options.xml.i>
           #include <include/interface/mac.xml.i>
+          <leafNode name="mii-mon-interval">
+            <properties>
+              <help>Specifies the MII link monitoring frequency in milliseconds</help>
+              <valueHelp>
+                <format>u32:0</format>
+                <description>Disable MII link monitoring</description>
+              </valueHelp>
+              <valueHelp>
+                <format>u32:50-1000</format>
+                <description>MII link monitoring frequency in milliseconds</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 0-0 --range 50-1000"/>
+              </constraint>
+            </properties>
+            <defaultValue>100</defaultValue>
+          </leafNode>
           <leafNode name="min-links">
             <properties>
               <help>Minimum number of member interfaces required up before enabling bond</help>

--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -203,11 +203,12 @@ def is_member(conf, interface, intftype=None):
     intftype is optional, if not passed it will search all known types
     (currently bridge and bonding)
 
-    Returns:
-    None -> Interface is not a member
-    interface name -> Interface is a member of this interface
-    False -> interface type cannot have members
+    Returns: dict
+    empty -> Interface is not a member
+    key -> Interface is a member of this interface
     """
+    from vyos.ifconfig import Section
+
     ret_val = {}
     intftypes = ['bonding', 'bridge']
 
@@ -227,9 +228,8 @@ def is_member(conf, interface, intftype=None):
         for intf in conf.list_nodes(base):
             member = base + [intf, 'member', 'interface', interface]
             if conf.exists(member):
-                tmp = conf.get_config_dict(member, key_mangling=('-', '_'),
-                                           get_first_key=True, no_tag_node_value_mangle=True)
-                ret_val.update({intf : tmp})
+                if conf.exists(['interfaces', Section.section(interface), interface]):
+                    ret_val.update({intf : {}})
 
     old_level = conf.set_level(old_level)
     return ret_val

--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -233,13 +233,19 @@ def is_member(conf, interface, intftype=None):
                 interface = interface.split('.')
                 if len(interface) == 3:
                     if conf.exists(['interfaces', member_type, interface[0], 'vif-s', interface[1], 'vif-c', interface[2]]):
-                        ret_val.update({intf : {}})
+                        tmp = conf.get_config_dict(['interfaces', member_type, interface[0]],
+                                                   key_mangling=('-', '_'), get_first_key=True)
+                        ret_val.update({intf : tmp})
                 elif len(interface) == 2:
                     if conf.exists(['interfaces', member_type, interface[0], 'vif', interface[1]]):
-                        ret_val.update({intf : {}})
+                        tmp = conf.get_config_dict(['interfaces', member_type, interface[0]],
+                                                   key_mangling=('-', '_'), get_first_key=True)
+                        ret_val.update({intf : tmp})
                 else:
                     if conf.exists(['interfaces', member_type, interface[0]]):
-                        ret_val.update({intf : {}})
+                        tmp = conf.get_config_dict(['interfaces', member_type, interface[0]],
+                                                   key_mangling=('-', '_'), get_first_key=True)
+                        ret_val.update({intf : tmp})
 
     old_level = conf.set_level(old_level)
     return ret_val

--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -228,8 +228,18 @@ def is_member(conf, interface, intftype=None):
         for intf in conf.list_nodes(base):
             member = base + [intf, 'member', 'interface', interface]
             if conf.exists(member):
-                if conf.exists(['interfaces', Section.section(interface), interface]):
-                    ret_val.update({intf : {}})
+                member_type = Section.section(interface)
+                # Check if it's a VLAN (QinQ) interface
+                interface = interface.split('.')
+                if len(interface) == 3:
+                    if conf.exists(['interfaces', member_type, interface[0], 'vif-s', interface[1], 'vif-c', interface[2]]):
+                        ret_val.update({intf : {}})
+                elif len(interface) == 2:
+                    if conf.exists(['interfaces', member_type, interface[0], 'vif', interface[1]]):
+                        ret_val.update({intf : {}})
+                else:
+                    if conf.exists(['interfaces', member_type, interface[0]]):
+                        ret_val.update({intf : {}})
 
     old_level = conf.set_level(old_level)
     return ret_val

--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -84,6 +84,18 @@ def verify_mtu_ipv6(config):
             tmp = dict_search('ipv6.address.eui64', config)
             if tmp != None: raise ConfigError(error_msg)
 
+def verify_bond_bridge_member(config):
+    """
+    Checks if interface has a VRF configured and is also part of a bond or
+    bridge, which is not allowed!
+    """
+    if 'vrf' in config:
+        ifname = config['ifname']
+        if 'is_bond_member' in config:
+            raise ConfigError(f'Can not add interface "{ifname}" to bond, it has a VRF assigned!')
+        if 'is_bridge_member' in config:
+            raise ConfigError(f'Can not add interface "{ifname}" to bridge, it has a VRF assigned!')
+
 def verify_tunnel(config):
     """
     This helper is used to verify the common part of the tunnel

--- a/python/vyos/ifconfig/bond.py
+++ b/python/vyos/ifconfig/bond.py
@@ -372,7 +372,8 @@ class BondIf(Interface):
             self.set_admin_state('down')
 
         # Specifies the MII link monitoring frequency in milliseconds
-        self.set_miimon_interval('250')
+        value = config.get('mii_mon_interval')
+        self.set_miimon_interval(value)
 
         # Bonding transmit hash policy
         value = config.get('hash_policy')

--- a/python/vyos/ifconfig/bond.py
+++ b/python/vyos/ifconfig/bond.py
@@ -199,16 +199,7 @@ class BondIf(Interface):
         >>> from vyos.ifconfig import BondIf
         >>> BondIf('bond0').set_arp_interval('100')
         """
-        if int(interval) == 0:
-            """
-            Specifies the MII link monitoring frequency in milliseconds.
-            This determines how often the link state of each slave is
-            inspected for link failures. A value of zero disables MII
-            link monitoring. A value of 100 is a good starting point.
-            """
-            return self.set_interface('bond_miimon', interval)
-        else:
-            return self.set_interface('bond_arp_interval', interval)
+        return self.set_interface('bond_arp_interval', interval)
 
     def get_arp_ip_target(self):
         """
@@ -365,26 +356,6 @@ class BondIf(Interface):
         if 'shutdown_required' in config:
             self.set_admin_state('down')
 
-        # ARP monitor targets need to be synchronized between sysfs and CLI.
-        # Unfortunately an address can't be send twice to sysfs as this will
-        # result in the following exception:  OSError: [Errno 22] Invalid argument.
-        #
-        # We remove ALL addresses prior to adding new ones, this will remove
-        # addresses manually added by the user too - but as we are limited to 16 adresses
-        # from the kernel side this looks valid to me. We won't run into an error
-        # when a user added manual adresses which would result in having more
-        # then 16 adresses in total.
-        arp_tgt_addr = list(map(str, self.get_arp_ip_target().split()))
-        for addr in arp_tgt_addr:
-            self.set_arp_ip_target('-' + addr)
-
-        # Add configured ARP target addresses
-        value = dict_search('arp_monitor.target', config)
-        if isinstance(value, str):
-            value = [value]
-        if value:
-            for addr in value:
-                self.set_arp_ip_target('+' + addr)
 
         # Bonding transmit hash policy
         value = config.get('hash_policy')
@@ -413,6 +384,32 @@ class BondIf(Interface):
             # LACPDU transmission rate - default value
             if mode == '802.3ad':
                 self.set_lacp_rate(config.get('lacp_rate'))
+
+            if mode not in ['802.3ad', 'balance-tlb', 'balance-alb']:
+                tmp = dict_search('arp_monitor.interval', config)
+                value = tmp if (tmp != None) else '0'
+                self.set_arp_interval(value)
+
+                # ARP monitor targets need to be synchronized between sysfs and CLI.
+                # Unfortunately an address can't be send twice to sysfs as this will
+                # result in the following exception:  OSError: [Errno 22] Invalid argument.
+                #
+                # We remove ALL addresses prior to adding new ones, this will remove
+                # addresses manually added by the user too - but as we are limited to 16 adresses
+                # from the kernel side this looks valid to me. We won't run into an error
+                # when a user added manual adresses which would result in having more
+                # then 16 adresses in total.
+                arp_tgt_addr = list(map(str, self.get_arp_ip_target().split()))
+                for addr in arp_tgt_addr:
+                    self.set_arp_ip_target('-' + addr)
+
+                # Add configured ARP target addresses
+                value = dict_search('arp_monitor.target', config)
+                if isinstance(value, str):
+                    value = [value]
+                if value:
+                    for addr in value:
+                        self.set_arp_ip_target('+' + addr)
 
             # Add (enslave) interfaces to bond
             value = dict_search('member.interface', config)

--- a/python/vyos/ifconfig/bond.py
+++ b/python/vyos/ifconfig/bond.py
@@ -176,6 +176,21 @@ class BondIf(Interface):
         """
         self.set_interface('bond_lacp_rate', slow_fast)
 
+    def set_miimon_interval(self, interval):
+        """
+        Specifies the MII link monitoring frequency in milliseconds. This
+        determines how often the link state of each slave is inspected for link
+        failures. A value of zero disables MII link monitoring. A value of 100
+        is a good starting point.
+
+        The default value is 0.
+
+        Example:
+        >>> from vyos.ifconfig import BondIf
+        >>> BondIf('bond0').set_miimon_interval('100')
+        """
+        return self.set_interface('bond_miimon', interval)
+
     def set_arp_interval(self, interval):
         """
         Specifies the ARP link monitoring frequency in milliseconds.
@@ -356,6 +371,8 @@ class BondIf(Interface):
         if 'shutdown_required' in config:
             self.set_admin_state('down')
 
+        # Specifies the MII link monitoring frequency in milliseconds
+        self.set_miimon_interval('250')
 
         # Bonding transmit hash policy
         value = config.get('hash_policy')

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1304,14 +1304,22 @@ class Interface(Control):
         if dhcpv6pd:
             self.set_dhcpv6(True)
 
-        # There are some items in the configuration which can only be applied
-        # if this instance is not bound to a bridge. This should be checked
-        # by the caller but better save then sorry!
-        if not any(k in ['is_bond_member', 'is_bridge_member'] for k in config):
-            # Bind interface to given VRF or unbind it if vrf node is not set.
-            # unbinding will call 'ip link set dev eth0 nomaster' which will
-            # also drop the interface out of a bridge or bond - thus this is
-            # checked before
+        # XXX: Bind interface to given VRF or unbind it if vrf is not set. Unbinding
+        # will call 'ip link set dev eth0 nomaster' which will also drop the
+        # interface out of any bridge or bond - thus this is checked before.
+        if 'is_bond_member' in config:
+            bond_if = next(iter(config['is_bond_member']))
+            tmp = get_interface_config(config['ifname'])
+            if 'master' in tmp and tmp['master'] != bond_if:
+                self.set_vrf('')
+
+        elif 'is_bridge_member' in config:
+            bridge_if = next(iter(config['is_bridge_member']))
+            tmp = get_interface_config(config['ifname'])
+            if 'master' in tmp and tmp['master'] != bridge_if:
+                self.set_vrf('')
+
+        else:
             self.set_vrf(config.get('vrf', ''))
 
         # Add this section after vrf T4331
@@ -1412,8 +1420,8 @@ class Interface(Control):
 
         # re-add ourselves to any bridge we might have fallen out of
         if 'is_bridge_member' in config:
-            bridge_dict = config.get('is_bridge_member')
-            self.add_to_bridge(bridge_dict)
+            tmp = config.get('is_bridge_member')
+            self.add_to_bridge(tmp)
 
         # configure port mirror
         self.set_mirror()

--- a/python/vyos/validate.py
+++ b/python/vyos/validate.py
@@ -260,3 +260,22 @@ def has_address_configured(conf, intf):
 
     conf.set_level(old_level)
     return ret
+
+def has_vrf_configured(conf, intf):
+    """
+    Checks if interface has a VRF configured.
+
+    Returns True if interface has VRF configured, False if it doesn't.
+    """
+    from vyos.ifconfig import Section
+    ret = False
+
+    old_level = conf.get_level()
+    conf.set_level([])
+
+    tmp = ['interfaces', Section.get_config_path(intf), 'vrf']
+    if conf.exists(tmp):
+        ret = True
+
+    conf.set_level(old_level)
+    return ret

--- a/smoketest/scripts/cli/test_interfaces_bonding.py
+++ b/smoketest/scripts/cli/test_interfaces_bonding.py
@@ -136,7 +136,7 @@ class BondingInterfaceTest(BasicInterfaceTest.TestCase):
 
     def test_bonding_hash_policy(self):
         # Define available bonding hash policies
-        hash_policies = ['layer2', 'layer2+3', 'layer2+3', 'encap2+3', 'encap3+4']
+        hash_policies = ['layer2', 'layer2+3', 'encap2+3', 'encap3+4']
         for hash_policy in hash_policies:
             for interface in self._interfaces:
                 for option in self._options.get(interface, []):

--- a/smoketest/scripts/cli/test_interfaces_bonding.py
+++ b/smoketest/scripts/cli/test_interfaces_bonding.py
@@ -185,6 +185,26 @@ class BondingInterfaceTest(BasicInterfaceTest.TestCase):
         slaves = read_file(f'/sys/class/net/{bond}/bonding/slaves').split()
         self.assertIn(member, slaves)
 
+    def test_bonding_source_bridge_interface(self):
+        # Re-use member interface that is already a source-interface
+        bond = 'bond1097'
+        bridge = 'br6327'
+        member = next(iter(self._members))
+
+        self.cli_set(self._base_path + [bond, 'member', 'interface', member])
+        self.cli_set(['interfaces', 'bridge', bridge, 'member', 'interface', member])
+
+        # check validate() - can not add interface to bond, it is a member of bridge ...
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_delete(['interfaces', 'bridge', bridge])
+        self.cli_commit()
+
+        # verify config
+        slaves = read_file(f'/sys/class/net/{bond}/bonding/slaves').split()
+        self.assertIn(member, slaves)
+
     def test_bonding_uniq_member_description(self):
         ethernet_path = ['interfaces', 'ethernet']
         for interface in self._interfaces:

--- a/smoketest/scripts/cli/test_interfaces_bonding.py
+++ b/smoketest/scripts/cli/test_interfaces_bonding.py
@@ -151,6 +151,29 @@ class BondingInterfaceTest(BasicInterfaceTest.TestCase):
                 defined_policy = read_file(f'/sys/class/net/{interface}/bonding/xmit_hash_policy').split()
                 self.assertEqual(defined_policy[0], hash_policy)
 
+    def test_bonding_mii_monitoring_interval(self):
+        for interface in self._interfaces:
+            for option in self._options.get(interface, []):
+                self.cli_set(self._base_path + [interface] + option.split())
+
+        self.cli_commit()
+
+        # verify default
+        for interface in self._interfaces:
+            tmp = read_file(f'/sys/class/net/{interface}/bonding/miimon').split()
+            self.assertIn('100', tmp)
+
+        mii_mon = '250'
+        for interface in self._interfaces:
+            self.cli_set(self._base_path + [interface, 'mii-mon-interval', mii_mon])
+
+        self.cli_commit()
+
+        # verify new CLI value
+        for interface in self._interfaces:
+            tmp = read_file(f'/sys/class/net/{interface}/bonding/miimon').split()
+            self.assertIn(mii_mon, tmp)
+
     def test_bonding_multi_use_member(self):
         # Define available bonding hash policies
         for interface in ['bond10', 'bond20']:

--- a/src/conf_mode/interfaces-bonding.py
+++ b/src/conf_mode/interfaces-bonding.py
@@ -35,6 +35,7 @@ from vyos.ifconfig import BondIf
 from vyos.ifconfig import Section
 from vyos.util import dict_search
 from vyos.validate import has_address_configured
+from vyos.validate import has_vrf_configured
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -125,6 +126,10 @@ def get_config(config=None):
             tmp = has_address_configured(conf, interface)
             if tmp: bond['member']['interface'][interface].update({'has_address' : {}})
 
+            # bond members must not have a VRF attached
+            tmp = has_vrf_configured(conf, interface)
+            if tmp: bond['member']['interface'][interface].update({'has_vrf' : {}})
+
     return bond
 
 
@@ -181,6 +186,8 @@ def verify(bond):
             if 'has_address' in interface_config:
                 raise ConfigError(error_msg + 'it has an address assigned!')
 
+            if 'has_vrf' in interface_config:
+                raise ConfigError(error_msg + 'it has a VRF assigned!')
 
     if 'primary' in bond:
         if bond['primary'] not in bond['member']['interface']:

--- a/src/conf_mode/interfaces-bonding.py
+++ b/src/conf_mode/interfaces-bonding.py
@@ -108,20 +108,22 @@ def get_config(config=None):
         for interface, interface_config in bond['member']['interface'].items():
             # Check if member interface is already member of another bridge
             tmp = is_member(conf, interface, 'bridge')
-            if tmp: interface_config.update({'is_bridge_member' : tmp})
+            if tmp: bond['member']['interface'][interface].update({'is_bridge_member' : tmp})
 
             # Check if member interface is already member of a bond
             tmp = is_member(conf, interface, 'bonding')
-            if tmp and bond['ifname'] not in tmp:
-                interface_config.update({'is_bond_member' : tmp})
+            for tmp in is_member(conf, interface, 'bonding'):
+                if bond['ifname'] == tmp:
+                    continue
+                bond['member']['interface'][interface].update({'is_bond_member' : tmp})
 
             # Check if member interface is used as source-interface on another interface
             tmp = is_source_interface(conf, interface)
-            if tmp: interface_config.update({'is_source_interface' : tmp})
+            if tmp: bond['member']['interface'][interface].update({'is_source_interface' : tmp})
 
             # bond members must not have an assigned address
             tmp = has_address_configured(conf, interface)
-            if tmp: interface_config.update({'has_address' : ''})
+            if tmp: bond['member']['interface'][interface].update({'has_address' : {}})
 
     return bond
 

--- a/src/conf_mode/interfaces-bridge.py
+++ b/src/conf_mode/interfaces-bridge.py
@@ -132,7 +132,7 @@ def verify(bridge):
 
             if 'enable_vlan' in bridge:
                 if 'has_vlan' in interface_config:
-                    raise ConfigError(error_msg + 'it has an VLAN subinterface assigned!')
+                    raise ConfigError(error_msg + 'it has VLAN subinterface(s) assigned!')
 
                 if 'wlan' in interface:
                     raise ConfigError(error_msg + 'VLAN aware cannot be set!')

--- a/src/conf_mode/interfaces-bridge.py
+++ b/src/conf_mode/interfaces-bridge.py
@@ -30,6 +30,7 @@ from vyos.configverify import verify_dhcpv6
 from vyos.configverify import verify_vrf
 from vyos.ifconfig import BridgeIf
 from vyos.validate import has_address_configured
+from vyos.validate import has_vrf_configured
 from vyos.xml import defaults
 
 from vyos.util import cmd
@@ -92,6 +93,10 @@ def get_config(config=None):
             tmp = has_address_configured(conf, interface)
             if tmp: bridge['member']['interface'][interface].update({'has_address' : ''})
 
+            # Bridge members must not have a VRF attached
+            tmp = has_vrf_configured(conf, interface)
+            if tmp: bridge['member']['interface'][interface].update({'has_vrf' : ''})
+
             # VLAN-aware bridge members must not have VLAN interface configuration
             tmp = has_vlan_subinterface_configured(conf,interface)
             if 'enable_vlan' in bridge and tmp:
@@ -129,6 +134,9 @@ def verify(bridge):
 
             if 'has_address' in interface_config:
                 raise ConfigError(error_msg + 'it has an address assigned!')
+
+            if 'has_vrf' in interface_config:
+                raise ConfigError(error_msg + 'it has a VRF assigned!')
 
             if 'enable_vlan' in bridge:
                 if 'has_vlan' in interface_config:

--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -30,6 +30,7 @@ from vyos.configverify import verify_mtu
 from vyos.configverify import verify_mtu_ipv6
 from vyos.configverify import verify_vlan_config
 from vyos.configverify import verify_vrf
+from vyos.configverify import verify_bond_bridge_member
 from vyos.ethtool import Ethtool
 from vyos.ifconfig import EthernetIf
 from vyos.template import render
@@ -67,6 +68,7 @@ def verify(ethernet):
     verify_dhcpv6(ethernet)
     verify_address(ethernet)
     verify_vrf(ethernet)
+    verify_bond_bridge_member(ethernet)
     verify_eapol(ethernet)
     verify_mirror(ethernet)
 

--- a/src/conf_mode/interfaces-geneve.py
+++ b/src/conf_mode/interfaces-geneve.py
@@ -25,6 +25,7 @@ from vyos.configdict import leaf_node_changed
 from vyos.configverify import verify_address
 from vyos.configverify import verify_mtu_ipv6
 from vyos.configverify import verify_bridge_delete
+from vyos.configverify import verify_bond_bridge_member
 from vyos.ifconfig import GeneveIf
 from vyos import ConfigError
 
@@ -59,6 +60,7 @@ def verify(geneve):
 
     verify_mtu_ipv6(geneve)
     verify_address(geneve)
+    verify_bond_bridge_member(geneve)
 
     if 'remote' not in geneve:
         raise ConfigError('Remote side must be configured')

--- a/src/conf_mode/interfaces-l2tpv3.py
+++ b/src/conf_mode/interfaces-l2tpv3.py
@@ -25,6 +25,7 @@ from vyos.configdict import leaf_node_changed
 from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_mtu_ipv6
+from vyos.configverify import verify_bond_bridge_member
 from vyos.ifconfig import L2TPv3If
 from vyos.util import check_kmod
 from vyos.validate import is_addr_assigned
@@ -76,6 +77,7 @@ def verify(l2tpv3):
 
     verify_mtu_ipv6(l2tpv3)
     verify_address(l2tpv3)
+    verify_bond_bridge_member(l2tpv3)
     return None
 
 def generate(l2tpv3):

--- a/src/conf_mode/interfaces-macsec.py
+++ b/src/conf_mode/interfaces-macsec.py
@@ -30,6 +30,7 @@ from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_mtu_ipv6
 from vyos.configverify import verify_source_interface
+from vyos.configverify import verify_bond_bridge_member
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -66,6 +67,7 @@ def verify(macsec):
     verify_vrf(macsec)
     verify_mtu_ipv6(macsec)
     verify_address(macsec)
+    verify_bond_bridge_member(macsec)
 
     if not (('security' in macsec) and
             ('cipher' in macsec['security'])):

--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -33,6 +33,7 @@ from vyos.configdict import is_node_changed
 from vyos.configverify import verify_vrf
 from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_diffie_hellman_length
+from vyos.configverify import verify_bond_bridge_member
 from vyos.ifconfig import VTunIf
 from vyos.template import render
 from vyos.template import is_ipv4
@@ -425,6 +426,7 @@ def verify(openvpn):
             raise ConfigError('Username for authentication is missing')
 
     verify_vrf(openvpn)
+    verify_bond_bridge_member(openvpn)
 
     return None
 

--- a/src/conf_mode/interfaces-tunnel.py
+++ b/src/conf_mode/interfaces-tunnel.py
@@ -28,6 +28,7 @@ from vyos.configverify import verify_interface_exists
 from vyos.configverify import verify_mtu_ipv6
 from vyos.configverify import verify_vrf
 from vyos.configverify import verify_tunnel
+from vyos.configverify import verify_bond_bridge_member
 from vyos.ifconfig import Interface
 from vyos.ifconfig import Section
 from vyos.ifconfig import TunnelIf
@@ -137,6 +138,7 @@ def verify(tunnel):
     verify_mtu_ipv6(tunnel)
     verify_address(tunnel)
     verify_vrf(tunnel)
+    verify_bond_bridge_member(tunnel)
 
     if 'source_interface' in tunnel:
         verify_interface_exists(tunnel['source_interface'])

--- a/src/conf_mode/interfaces-vxlan.py
+++ b/src/conf_mode/interfaces-vxlan.py
@@ -26,6 +26,7 @@ from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_mtu_ipv6
 from vyos.configverify import verify_source_interface
+from vyos.configverify import verify_bond_bridge_member
 from vyos.ifconfig import Interface
 from vyos.ifconfig import VXLANIf
 from vyos.template import is_ipv6
@@ -113,6 +114,8 @@ def verify(vxlan):
 
     verify_mtu_ipv6(vxlan)
     verify_address(vxlan)
+    verify_bond_bridge_member(vxlan)
+
     return None
 
 def generate(vxlan):

--- a/src/conf_mode/interfaces-wireguard.py
+++ b/src/conf_mode/interfaces-wireguard.py
@@ -28,6 +28,7 @@ from vyos.configverify import verify_vrf
 from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_mtu_ipv6
+from vyos.configverify import verify_bond_bridge_member
 from vyos.ifconfig import WireGuardIf
 from vyos.util import check_kmod
 from vyos import ConfigError
@@ -69,6 +70,7 @@ def verify(wireguard):
     verify_mtu_ipv6(wireguard)
     verify_address(wireguard)
     verify_vrf(wireguard)
+    verify_bond_bridge_member(wireguard)
 
     if not os.path.exists(wireguard['private_key']):
         raise ConfigError('Wireguard private-key not found! Execute: ' \

--- a/src/conf_mode/interfaces-wireless.py
+++ b/src/conf_mode/interfaces-wireless.py
@@ -29,6 +29,7 @@ from vyos.configverify import verify_dhcpv6
 from vyos.configverify import verify_source_interface
 from vyos.configverify import verify_vlan_config
 from vyos.configverify import verify_vrf
+from vyos.configverify import verify_bond_bridge_member
 from vyos.ifconfig import WiFiIf
 from vyos.template import render
 from vyos.util import call
@@ -188,6 +189,7 @@ def verify(wifi):
 
     verify_address(wifi)
     verify_vrf(wifi)
+    verify_bond_bridge_member(wifi)
 
     # use common function to verify VLAN configuration
     verify_vlan_config(wifi)

--- a/src/conf_mode/vrf.py
+++ b/src/conf_mode/vrf.py
@@ -108,8 +108,14 @@ def verify(vrf):
                                   f'static routes installed!')
 
     if 'name' in vrf:
+        reserved_names = ["add", "all", "broadcast", "default", "delete", "dev", "get", "inet", "mtu", "link", "type",
+                          "vrf"]
         table_ids = []
         for name, config in vrf['name'].items():
+            # Reserved VRF names
+            if name in reserved_names:
+                raise ConfigError(f'VRF name "{name}" is reserved and connot be used!')
+
             # table id is mandatory
             if 'table' not in config:
                 raise ConfigError(f'VRF "{name}" table id is mandatory!')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): New Smoketests

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4522
* https://phabricator.vyos.net/T4521
* https://phabricator.vyos.net/T4228
* https://phabricator.vyos.net/T1557

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* bond interface
* bridge interface

## Proposed changes
<!--- Describe your changes in detail -->
Backport bugfixes from current

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
cpo@LR2.wue3:~$ TEST_ETH="eth1 eth2" /usr/libexec/vyos/tests/smoke/cli/test_interfaces_bonding.py
test_add_multiple_ip_addresses (__main__.BondingInterfaceTest) ... ok
test_add_single_ip_address (__main__.BondingInterfaceTest) ... ok
test_bonding_hash_policy (__main__.BondingInterfaceTest) ... ok
test_bonding_lacp_rate (__main__.BondingInterfaceTest) ... ok
test_bonding_mii_monitoring_interval (__main__.BondingInterfaceTest) ... ok
test_bonding_min_links (__main__.BondingInterfaceTest) ... ok
test_bonding_multi_use_member (__main__.BondingInterfaceTest) ... ok
test_bonding_remove_member (__main__.BondingInterfaceTest) ... ok
test_bonding_source_bridge_interface (__main__.BondingInterfaceTest) ... ok
test_bonding_source_interface (__main__.BondingInterfaceTest) ... ok
test_bonding_uniq_member_description (__main__.BondingInterfaceTest) ... ok
test_dhcp_disable_interface (__main__.BondingInterfaceTest) ... ok
test_dhcpv6_client_options (__main__.BondingInterfaceTest) ... ok
test_dhcpv6pd_auto_sla_id (__main__.BondingInterfaceTest) ... ok
test_dhcpv6pd_manual_sla_id (__main__.BondingInterfaceTest) ... ok
test_interface_description (__main__.BondingInterfaceTest) ... ok
test_interface_disable (__main__.BondingInterfaceTest) ... ok
test_interface_ip_options (__main__.BondingInterfaceTest) ... ok
test_interface_ipv6_options (__main__.BondingInterfaceTest) ... ok
test_interface_mtu (__main__.BondingInterfaceTest) ... ok
test_ipv6_link_local_address (__main__.BondingInterfaceTest) ... ok
test_mtu_1200_no_ipv6_interface (__main__.BondingInterfaceTest) ... ok
test_span_mirror (__main__.BondingInterfaceTest) ... ok
test_vif_8021q_interfaces (__main__.BondingInterfaceTest) ... ok
test_vif_8021q_lower_up_down (__main__.BondingInterfaceTest) ... ok
test_vif_8021q_mtu_limits (__main__.BondingInterfaceTest) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.BondingInterfaceTest) ... ok

----------------------------------------------------------------------
Ran 27 tests in 420.522s

OK
cpo@LR2.wue3:~$ TEST_ETH="eth1 eth2" /usr/libexec/vyos/tests/smoke/cli/test_interfaces_bridge.py
test_add_multiple_ip_addresses (__main__.BridgeInterfaceTest) ... ok
test_add_remove_bridge_member (__main__.BridgeInterfaceTest) ... ok
test_add_single_ip_address (__main__.BridgeInterfaceTest) ... ok
test_bridge_vif_members (__main__.BridgeInterfaceTest) ... ok
test_bridge_vif_s_vif_c_members (__main__.BridgeInterfaceTest) ... ok
test_bridge_vlan_filter (__main__.BridgeInterfaceTest) ... ok
test_dhcp_disable_interface (__main__.BridgeInterfaceTest) ... ok
test_dhcpv6_client_options (__main__.BridgeInterfaceTest) ... ok
test_dhcpv6pd_auto_sla_id (__main__.BridgeInterfaceTest) ... ok
test_dhcpv6pd_manual_sla_id (__main__.BridgeInterfaceTest) ... ok
test_interface_description (__main__.BridgeInterfaceTest) ... ok
test_interface_disable (__main__.BridgeInterfaceTest) ... ok
test_interface_ip_options (__main__.BridgeInterfaceTest) ... ok
test_interface_ipv6_options (__main__.BridgeInterfaceTest) ... ok
test_interface_mtu (__main__.BridgeInterfaceTest) ... skipped 'not supported'
test_ipv6_link_local_address (__main__.BridgeInterfaceTest) ... ok
test_isolated_interfaces (__main__.BridgeInterfaceTest) ... ok
test_mtu_1200_no_ipv6_interface (__main__.BridgeInterfaceTest) ... skipped 'not supported'
test_span_mirror (__main__.BridgeInterfaceTest) ... ok
test_vif_8021q_interfaces (__main__.BridgeInterfaceTest) ... ok
test_vif_8021q_lower_up_down (__main__.BridgeInterfaceTest) ... ok
test_vif_8021q_mtu_limits (__main__.BridgeInterfaceTest) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.BridgeInterfaceTest) ... skipped 'not supported'

----------------------------------------------------------------------
Ran 23 tests in 360.585s

OK (skipped=3)
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
