### PR TITLE
vrf: T4527: Prevent to create VRF with reserved names

### DIFF
--- a/src/conf_mode/vrf.py
+++ b/src/conf_mode/vrf.py
@@ -113,8 +113,14 @@ def verify(vrf):
                                   f'static routes installed!')
 
     if 'name' in vrf:
+        reserved_names = ["add", "all", "broadcast", "default", "delete", "dev", "get", "inet", "mtu", "link", "type",
+                          "vrf"]
         table_ids = []
         for name, config in vrf['name'].items():
+            # Reserved VRF names
+            if name in reserved_names:
+                raise ConfigError(f'VRF name "{name}" is reserved and connot be used!')
+
             # table id is mandatory
             if 'table' not in config:
                 raise ConfigError(f'VRF "{name}" table id is mandatory!')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
VRF names: "add, all, broadcast, default, delete, dev, get, inet,
mtu, link, type, vrf" are reserved and cannot be used for VRF name
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4527
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrf
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
vyos@r14# set vrf name default table 1010
[edit]
vyos@r14# commit
[ vrf ]
VRF name "default" is reserved and connot be used!

[[vrf]] failed
Commit failed
[edit]
vyos@r14# 


root@r14:/home/vyos# ip link add all type vrf table 1010
RTNETLINK answers: Invalid argument
root@r14:/home/vyos# 
root@r14:/home/vyos# ip link add link type vrf table 1010
Error: argument "table" is wrong: Not a valid VRF name

root@r14:/home/vyos# 
root@r14:/home/vyos# ip link add default type vrf table 1012
RTNETLINK answers: Invalid argument
root@r14:/home/vyos# 


```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
