### PR TITLE
netflow: T4532: Fix flow-accounting server IPv6 bug

### DIFF
--- a/data/templates/netflow/uacctd.conf.tmpl
+++ b/data/templates/netflow/uacctd.conf.tmpl
@@ -21,7 +21,7 @@ imt_mem_pools_number: 169
 {% endif %}
 plugins: {% if templatecfg['netflow']['servers'] != none %}
 {%   for server in templatecfg['netflow']['servers'] %}
-{%     if loop.last %}nfprobe[nf_{{ server['address'] }}]{% else %}nfprobe[nf_{{ server['address'] }}],{% endif %}
+{%     if loop.last %}nfprobe[nf_{{ server['address'] | dot_colon_to_dash }}]{% else %}nfprobe[nf_{{ server['address'] | dot_colon_to_dash }} ],{% endif %}
 {%   endfor %}
 {% set plugins_presented = true %}
 {% endif %}
@@ -41,35 +41,35 @@ plugins: {% if templatecfg['netflow']['servers'] != none %}
 
 {% if templatecfg['netflow']['servers'] != none %}
 {% for server in templatecfg['netflow']['servers'] %}
-nfprobe_receiver[nf_{{ server['address'] }}]: {{ server['address'] }}:{{ server['port'] }}
-nfprobe_version[nf_{{ server['address'] }}]: {{ templatecfg['netflow']['version'] }}
+nfprobe_receiver[nf_{{ server['address'] | dot_colon_to_dash }}]: {{ server['address'] | bracketize_ipv6 }}:{{ server['port'] }}
+nfprobe_version[nf_{{ server['address'] | dot_colon_to_dash }}]: {{ templatecfg['netflow']['version'] }}
 {% if templatecfg['netflow']['engine-id'] != none %}
-nfprobe_engine[nf_{{ server['address'] }}]: {{ templatecfg['netflow']['engine-id'] }}
+nfprobe_engine[nf_{{ server['address'] | dot_colon_to_dash }}]: {{ templatecfg['netflow']['engine-id'] }}
 {% endif %}
 {% if templatecfg['netflow']['max-flows'] != none %}
-nfprobe_maxflows[nf_{{ server['address'] }}]: {{ templatecfg['netflow']['max-flows'] }}
+nfprobe_maxflows[nf_{{ server['address'] | dot_colon_to_dash }}]: {{ templatecfg['netflow']['max-flows'] }}
 {% endif %}
 {% if templatecfg['netflow']['sampling-rate'] != none %}
-sampling_rate[nf_{{ server['address'] }}]: {{ templatecfg['netflow']['sampling-rate'] }}
+sampling_rate[nf_{{ server['address'] | dot_colon_to_dash }}]: {{ templatecfg['netflow']['sampling-rate'] }}
 {% endif %}
 {% if templatecfg['netflow']['source-ip'] != none %}
-nfprobe_source_ip[nf_{{ server['address'] }}]: {{ templatecfg['netflow']['source-ip'] }}
+nfprobe_source_ip[nf_{{ server['address'] | dot_colon_to_dash }}]: {{ templatecfg['netflow']['source-ip'] }}
 {% endif %}
 {% if templatecfg['netflow']['timeout_string'] != '' %}
-nfprobe_timeouts[nf_{{ server['address'] }}]: {{ templatecfg['netflow']['timeout_string'] }}
+nfprobe_timeouts[nf_{{ server['address'] | dot_colon_to_dash }}]: {{ templatecfg['netflow']['timeout_string'] }}
 {% endif %}
 {% endfor %}
 {% endif %}
 
 {% if templatecfg['sflow']['servers'] != none %}
 {% for server in templatecfg['sflow']['servers'] %}
-sfprobe_receiver[sf_{{ server['address'] }}]: {{ server['address'] }}:{{ server['port'] }}
-sfprobe_agentip[sf_{{ server['address'] }}]: {{ templatecfg['sflow']['agent-address'] }}
+sfprobe_receiver[sf_{{ server['address'] | dot_colon_to_dash }}]: {{ server['address'] | bracketize_ipv6 }}:{{ server['port'] }}
+sfprobe_agentip[sf_{{ server['address'] | dot_colon_to_dash }}]: {{ templatecfg['sflow']['agent-address'] }}
 {% if templatecfg['sflow']['sampling-rate'] != none %}
-sampling_rate[sf_{{ server['address'] }}]: {{ templatecfg['sflow']['sampling-rate'] }}
+sampling_rate[sf_{{ server['address'] | dot_colon_to_dash }}]: {{ templatecfg['sflow']['sampling-rate'] }}
 {% endif %}
 {% if templatecfg['sflow']['source-address'] != none %}
-sfprobe_source_ip[sf_{{ server['address'] }}]: {{ templatecfg['sflow']['source-address'] }}
+sfprobe_source_ip[sf_{{ server['address'] | dot_colon_to_dash }}]: {{ templatecfg['sflow']['source-address'] }}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -151,6 +151,16 @@ def bracketize_ipv6(address):
         return f'[{address}]'
     return address
 
+@register_filter('dot_colon_to_dash')
+def dot_colon_to_dash(text):
+    """ Replace dot and colon to dash for string
+    Example:
+    192.0.2.1 => 192-0-2-1, 2001:db8::1 => 2001-db8--1
+    """
+    text = text.replace(":", "-")
+    text = text.replace(".", "-")
+    return text
+
 @register_filter('netmask_from_cidr')
 def netmask_from_cidr(prefix):
     """ Take CIDR prefix and convert the prefix length to a "subnet mask".


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix for IPv6 netflow_plugin name
When we use IPv6 uacctd.conf doesn't expect colons in the plugin
name. Replace colons to dash. Place IPv6 address into [] brackets

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4532

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
netflow
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration
```
set system flow-accounting interface 'eth0'
set system flow-accounting interface 'eth1'
set system flow-accounting netflow engine-id '100'
set system flow-accounting netflow sampling-rate '1'
set system flow-accounting netflow server 2001:db8::1 port '2055'
set system flow-accounting netflow source-ip 2001:db8::2
set system flow-accounting netflow timeout expiry-interval '60'
set system flow-accounting netflow version '9'
```
Before fix:
```
root@r1:/home/vyos# pmacctd -f /etc/pmacct/uacctd.conf -i eth0
ERROR: [/etc/pmacct/uacctd.conf:14] Syntax error: illegal brackets. Exiting.
root@r1:/home/vyos#

root@r1:/home/vyos# cat /etc/pmacct/uacctd.conf 
# Genereated from VyOS configuration
.
.
.
plugins: nfprobe[nf_2001:db8::1],memory
nfprobe_receiver[nf_2001:db8::1]: 2001:db8::1:2055  <== line 14
nfprobe_version[nf_2001:db8::1]: 9
nfprobe_engine[nf_2001:db8::1]: 100
sampling_rate[nf_2001:db8::1]: 1
nfprobe_source_ip[nf_2001:db8::1]: 2001:db8::2
nfprobe_timeouts[nf_2001:db8::1]: expint=60
```

After fix:
```
vyos@r1:~$ sudo cat /etc/pmacct/
nfacctd.conf  pmacctd.conf  sfacctd.conf  uacctd.conf   
vyos@r1:~$ sudo cat /etc/pmacct/uacctd.conf 
# Genereated from VyOS configuration
.
.
.
plugins: nfprobe[nf_2001-db8--1],memory
nfprobe_receiver[nf_2001-db8--1]: [2001:db8::1]:2055
nfprobe_version[nf_2001-db8--1]: 9
nfprobe_engine[nf_2001-db8--1]: 100
sampling_rate[nf_2001-db8--1]: 1
nfprobe_source_ip[nf_2001-db8--1]: 2001:db8::2
nfprobe_timeouts[nf_2001-db8--1]: expint=60

```
Check service:
```
vyos@r1:~$ sudo systemctl status uacctd.service
● uacctd.service - ulog accounting daemon
   Loaded: loaded (/lib/systemd/system/uacctd.service; disabled; vendor preset: enabled)
   Active: active (running) since Thu 2022-07-14 16:37:20 EEST; 11min ago
  Process: 9802 ExecStart=/usr/sbin/uacctd -f ${UACCTD_CONF} $DAEMON_OPTS (code=exited, status=0/SUCCESS)
 Main PID: 9803 (uacctd)
    Tasks: 2 (limit: 1150)
   Memory: 34.3M
   CGroup: /system.slice/uacctd.service
           ├─9803 uacctd: Core Process [default]
           └─9809 uacctd: IMT Plugin [default_memory]

Jul 14 16:37:20 r1 systemd[1]: Starting ulog accounting daemon...
Jul 14 16:37:20 r1 systemd[1]: Started ulog accounting daemon.
vyos@r1:~$ 

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
