### PR TITLE
netflow: T4532: replace dot and colons to dash

### DIFF
--- a/data/templates/pmacct/uacctd.conf.j2
+++ b/data/templates/pmacct/uacctd.conf.j2
@@ -21,13 +21,13 @@ imt_mem_pools_number: 169
 {% set plugin = [] %}
 {% if netflow.server is vyos_defined %}
 {%     for server in netflow.server %}
-{%         set nf_server_key = 'nf_' ~ server | replace(':', '.') %}
+{%         set nf_server_key = 'nf_' ~ server | dot_colon_to_dash %}
 {%         set _ = plugin.append('nfprobe['~ nf_server_key ~ ']') %}
 {%     endfor %}
 {% endif %}
 {% if sflow.server is vyos_defined %}
 {%     for server in sflow.server %}
-{%         set sf_server_key = 'sf_' ~ server | replace(':', '.') %}
+{%         set sf_server_key = 'sf_' ~ server | dot_colon_to_dash %}
 {%         set _ = plugin.append('sfprobe[' ~ sf_server_key ~ ']') %}
 {%     endfor %}
 {% endif %}
@@ -40,7 +40,7 @@ plugins: {{ plugin | join(',') }}
 # NetFlow servers
 {%     for server, server_config in netflow.server.items() %}
 {#         # prevent pmacct syntax error when using IPv6 flow collectors #}
-{%         set nf_server_key = 'nf_' ~ server | replace(':', '.') %}
+{%         set nf_server_key = 'nf_' ~ server | dot_colon_to_dash %}
 nfprobe_receiver[{{ nf_server_key }}]: {{ server | bracketize_ipv6 }}:{{ server_config.port }}
 nfprobe_version[{{ nf_server_key }}]: {{ netflow.version }}
 {%         if netflow.engine_id is vyos_defined %}
@@ -66,7 +66,7 @@ nfprobe_timeouts[{{ nf_server_key }}]: expint={{ netflow.timeout.expiry_interval
 # sFlow servers
 {%     for server, server_config in sflow.server.items() %}
 {#         # prevent pmacct syntax error when using IPv6 flow collectors #}
-{%         set sf_server_key = 'sf_' ~ server | replace(':', '.') %}
+{%         set sf_server_key = 'sf_' ~ server | dot_colon_to_dash %}
 sfprobe_receiver[{{ sf_server_key }}]: {{ server | bracketize_ipv6 }}:{{ server_config.port }}
 sfprobe_agentip[{{ sf_server_key }}]: {{ sflow.agent_address }}
 {%         if sflow.sampling_rate is vyos_defined %}

--- a/smoketest/scripts/cli/test_system_flow-accounting.py
+++ b/smoketest/scripts/cli/test_system_flow-accounting.py
@@ -144,14 +144,15 @@ class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
         self.assertNotIn(f'plugins: memory', uacctd)
 
         for server, server_config in sflow_server.items():
+            plugin_name = server.replace('.', '-')
             if 'port' in server_config:
-                self.assertIn(f'sfprobe_receiver[sf_{server}]: {server}', uacctd)
+                self.assertIn(f'sfprobe_receiver[sf_{plugin_name}]: {server}', uacctd)
             else:
-                self.assertIn(f'sfprobe_receiver[sf_{server}]: {server}:6343', uacctd)
+                self.assertIn(f'sfprobe_receiver[sf_{plugin_name}]: {server}:6343', uacctd)
 
-            self.assertIn(f'sfprobe_agentip[sf_{server}]: {agent_address}', uacctd)
-            self.assertIn(f'sampling_rate[sf_{server}]: {sampling_rate}', uacctd)
-            self.assertIn(f'sfprobe_source_ip[sf_{server}]: {source_address}', uacctd)
+            self.assertIn(f'sfprobe_agentip[sf_{plugin_name}]: {agent_address}', uacctd)
+            self.assertIn(f'sampling_rate[sf_{plugin_name}]: {sampling_rate}', uacctd)
+            self.assertIn(f'sfprobe_source_ip[sf_{plugin_name}]: {source_address}', uacctd)
 
         self.cli_delete(['interfaces', 'dummy', dummy_if])
 
@@ -194,8 +195,7 @@ class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
 
         for server, server_config in sflow_server.items():
             tmp_srv = server
-            if is_ipv6(tmp_srv):
-                tmp_srv = tmp_srv.replace(':', '.')
+            tmp_srv = tmp_srv.replace(':', '-')
 
             if 'port' in server_config:
                 self.assertIn(f'sfprobe_receiver[sf_{tmp_srv}]: {bracketize_ipv6(server)}', uacctd)
@@ -265,16 +265,16 @@ class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
         tmp = []
         for server, server_config in netflow_server.items():
             tmp_srv = server
-            if is_ipv6(tmp_srv):
-                tmp_srv = tmp_srv.replace(':', '.')
+            tmp_srv = tmp_srv.replace('.', '-')
+            tmp_srv = tmp_srv.replace(':', '-')
             tmp.append(f'nfprobe[nf_{tmp_srv}]')
         tmp.append('memory')
         self.assertIn('plugins: ' + ','.join(tmp), uacctd)
 
         for server, server_config in netflow_server.items():
             tmp_srv = server
-            if is_ipv6(tmp_srv):
-                tmp_srv = tmp_srv.replace(':', '.')
+            tmp_srv = tmp_srv.replace('.', '-')
+            tmp_srv = tmp_srv.replace(':', '-')
 
             self.assertIn(f'nfprobe_engine[nf_{tmp_srv}]: {engine_id}', uacctd)
             self.assertIn(f'nfprobe_maxflows[nf_{tmp_srv}]: {max_flows}', uacctd)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix for IPv6 netflow_plugin name
When we use IPv6 `uacctd.conf` doesn't expect colons in the plugin
name. Replace dots and colons to dash.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4532

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
netflow
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set interfaces ethernet eth1 address '2001:db8::1/64'
set system flow-accounting interface 'eth0'
set system flow-accounting interface 'eth1'
set system flow-accounting netflow engine-id '100'
set system flow-accounting netflow sampling-rate '1'
set system flow-accounting netflow server 2001:db8::2 port '2055'
set system flow-accounting netflow source-address '2001:db8::1'
set system flow-accounting netflow timeout expiry-interval '60'
set system flow-accounting netflow version '9'

```
cat /run/pmacct/uacctd.conf
```
...
plugins: nfprobe[nf_2001-db8--2],memory

# NetFlow servers
nfprobe_receiver[nf_2001-db8--2]: [2001:db8::2]:2055
nfprobe_version[nf_2001-db8--2]: 9
nfprobe_engine[nf_2001-db8--2]: 100
sampling_rate[nf_2001-db8--2]: 1
nfprobe_source_ip[nf_2001-db8--2]: 2001:db8::1
nfprobe_timeouts[nf_2001-db8--2]: expint=60:general=3600:icmp=300:maxlife=604800:tcp.fin=300:tcp=3600:tcp.rst=120:udp=300

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
