### PR TITLE
T4550: router-advert: Add deprecate-prefix & decrement-lifetimes options

### DIFF
--- a/data/templates/router-advert/radvd.conf.j2
+++ b/data/templates/router-advert/radvd.conf.j2
@@ -50,6 +50,8 @@ interface {{ iface }} {
         AdvValidLifetime {{ prefix_options.valid_lifetime }};
         AdvOnLink {{ 'off' if prefix_options.no_on_link_flag is vyos_defined else 'on' }};
         AdvPreferredLifetime {{ prefix_options.preferred_lifetime }};
+        DeprecatePrefix {{ 'on' if prefix_options.deprecate_prefix is vyos_defined else 'off' }};
+        DecrementLifetimes {{ 'on' if prefix_options.decrement_lifetime is vyos_defined else 'off' }};
     };
 {%             endfor %}
 {%         endif %}

--- a/interface-definitions/service-router-advert.xml.in
+++ b/interface-definitions/service-router-advert.xml.in
@@ -249,6 +249,18 @@
                       <valueless/>
                     </properties>
                   </leafNode>
+                  <leafNode name="deprecate-prefix">
+                    <properties>
+                      <help>Upon shutdown, this option will deprecate the prefix by announcing it in the shutdown RA</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="decrement-lifetime">
+                    <properties>
+                      <help>Lifetime is decremented by the number of seconds since the last RA - use in conjunction with a DHCPv6-PD prefix</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
                   <leafNode name="preferred-lifetime">
                     <properties>
                       <help>Time in seconds that the prefix will remain preferred</help>


### PR DESCRIPTION
[DeprecatePrefix and DecrementLifetimes](https://manpages.debian.org/testing/radvd/radvd.conf.5.en.html#DeprecatePrefix) options in radvd is useful in a DHCPv6-PD environment to accommodate prefix changes from ISP's delegating router. Though there is currently no integration between the DHCP PD client (wide-dhcpv6-client) and radvd, it could be a good start point to have the 2 options configurable by the user.

- deprecate-prefix: Upon shutdown, deprecate the prefix. This is useful
  in a DHCPv6 PD environment: When ISP re-assigns a new prefix,
deprecate the old prefix that was advertised.
- decrement-lifetimes: Decrement the values of the preferred and valid
  lifetimes for the prefix over time. This is also useful in a DHCPv6
  PD environment to keep the advertised prefix's lifetimes in sync with
  the prefix from delegating router.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4550

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
