### PR TITLE
Allow to configure ban_time instead of only 1900 seconds default

### DIFF
--- a/data/templates/ids/fastnetmon.j2
+++ b/data/templates/ids/fastnetmon.j2
@@ -15,7 +15,11 @@ ban_details_records_count = 500
 
 ## How long (in seconds) we should keep an IP in blocked state
 ## If you set 0 here it completely disables unban capability
+{% if ban_time is vyos_defined %}
+ban_time = {{ ban_time }}
+{% else %}
 ban_time = 1900
+{% endif %}
 
 # Check if the attack is still active, before triggering an unban callback with this option
 # If the attack is still active, check each run of the unban watchdog

--- a/data/templates/ids/fastnetmon.j2
+++ b/data/templates/ids/fastnetmon.j2
@@ -15,7 +15,9 @@ ban_details_records_count = 500
 
 ## How long (in seconds) we should keep an IP in blocked state
 ## If you set 0 here it completely disables unban capability
-ban_time = 1900
+{% if ban_time is vyos_defined %}
+ban_time = {{ ban_time }}
+{% endif %}
 
 # Check if the attack is still active, before triggering an unban callback with this option
 # If the attack is still active, check each run of the unban watchdog

--- a/data/templates/ids/fastnetmon.j2
+++ b/data/templates/ids/fastnetmon.j2
@@ -17,8 +17,6 @@ ban_details_records_count = 500
 ## If you set 0 here it completely disables unban capability
 {% if ban_time is vyos_defined %}
 ban_time = {{ ban_time }}
-{% else %}
-ban_time = 1900
 {% endif %}
 
 # Check if the attack is still active, before triggering an unban callback with this option

--- a/interface-definitions/service-ids-ddos-protection.xml.in
+++ b/interface-definitions/service-ids-ddos-protection.xml.in
@@ -18,6 +18,19 @@
                   <help>Path to fastnetmon alert script</help>
                 </properties>
               </leafNode>
+              <leafNode name="ban-time">
+                <properties>
+                  <help>Time to ban (in seconds) an ip</help>
+                  <valueHelp>
+                    <format>u32:0-4294967294</format>
+                    <description>Time to ban (in seconds) an ip</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967294"/>
+                  </constraint>
+                </properties>
+                <defaultValue>1900</defaultValue>
+              </leafNode>
               <leafNode name="direction">
                 <properties>
                   <help>Direction for processing traffic</help>

--- a/interface-definitions/service-ids-ddos-protection.xml.in
+++ b/interface-definitions/service-ids-ddos-protection.xml.in
@@ -18,6 +18,18 @@
                   <help>Path to fastnetmon alert script</help>
                 </properties>
               </leafNode>
+              <leafNode name="ban_time">
+                <properties>
+                  <help>Time to ban (in seconds) an ip (Default: 1900 secs)</help>
+                  <valueHelp>
+                    <format>u32:0-4294967294</format>
+                    <description>Time to ban (in seconds) an ip (Default: 1900 secs)</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967294"/>
+                  </constraint>
+                </properties>
+              </leafNode>
               <leafNode name="direction">
                 <properties>
                   <help>Direction for processing traffic</help>

--- a/interface-definitions/service-ids-ddos-protection.xml.in
+++ b/interface-definitions/service-ids-ddos-protection.xml.in
@@ -18,17 +18,18 @@
                   <help>Path to fastnetmon alert script</help>
                 </properties>
               </leafNode>
-              <leafNode name="ban_time">
+              <leafNode name="ban-time">
                 <properties>
-                  <help>Time to ban (in seconds) an ip (Default: 1900 secs)</help>
+                  <help>Time to ban (in seconds) an ip</help>
                   <valueHelp>
                     <format>u32:0-4294967294</format>
-                    <description>Time to ban (in seconds) an ip (Default: 1900 secs)</description>
+                    <description>Time to ban (in seconds) an ip</description>
                   </valueHelp>
                   <constraint>
                     <validator name="numeric" argument="--range 0-4294967294"/>
                   </constraint>
                 </properties>
+                <defaultValue>1900</defaultValue>
               </leafNode>
               <leafNode name="direction">
                 <properties>


### PR DESCRIPTION
## Change Summary
Allow to add ban_time instead of just using 1900 seconds default value.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
There are no related tasks on phabritcator.vyos.net

## Component(s) name
ddos-protection

## Proposed changes
Add parameter ban_time to:
set service ids ddos-protection ban_time %value%


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
