### PR TITLE
bgp: T4257: Changing BGP "local-as" to "system-as"

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -231,7 +231,7 @@
 {% endif %}
 {% endmacro %}
 !
-router bgp {{ local_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
+router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {% if parameters.ebgp_requires_policy is vyos_defined %}
  bgp ebgp-requires-policy
 {% else %}

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -896,7 +896,7 @@
     </tagNode>
   </children>
 </node>
-<leafNode name="local-as">
+<leafNode name="system-as">
   <properties>
     <help>Autonomous System Number (ASN)</help>
     <valueHelp>

--- a/interface-definitions/include/version/bgp-version.xml.i
+++ b/interface-definitions/include/version/bgp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/bgp-version.xml.i -->
-<syntaxVersion component='bgp' version='2'></syntaxVersion>
+<syntaxVersion component='bgp' version='3'></syntaxVersion>
 <!-- include end -->

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -46,7 +46,7 @@ neighbor_config = {
         'shutdown'         : '',
         'cap_over'         : '',
         'ttl_security'     : '5',
-        'local_as'         : '300',
+        'system_as'        : '300',
         'route_map_in'     : route_map_in,
         'route_map_out'    : route_map_out,
         'no_send_comm_ext' : '',
@@ -87,7 +87,7 @@ neighbor_config = {
         'shutdown'         : '',
         'cap_over'         : '',
         'ttl_security'     : '5',
-        'local_as'         : '300',
+        'system_as'        : '300',
         'solo'             : '',
         'route_map_in'     : route_map_in,
         'route_map_out'    : route_map_out,
@@ -131,7 +131,7 @@ peer_group_config = {
         'remote_as'        : '200',
         'shutdown'         : '',
         'no_cap_nego'      : '',
-        'local_as'         : '300',
+        'system_as'        : '300',
         'pfx_list_in'      : prefix_list_in,
         'pfx_list_out'     : prefix_list_out,
         'no_send_comm_ext' : '',
@@ -177,7 +177,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         cls.cli_delete(cls, ['policy'])
 
     def setUp(self):
-        self.cli_set(base_path + ['local-as', ASN])
+        self.cli_set(base_path + ['system-as', ASN])
 
     def tearDown(self):
         self.cli_delete(['vrf'])
@@ -266,12 +266,12 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['parameters', 'router-id', router_id])
         self.cli_set(base_path + ['parameters', 'log-neighbor-changes'])
 
-        # Local AS number MUST be defined - as this is set in setUp() we remove
+        # System AS number MUST be defined - as this is set in setUp() we remove
         # this once for testing of the proper error
-        self.cli_delete(base_path + ['local-as'])
+        self.cli_delete(base_path + ['system-as'])
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
-        self.cli_set(base_path + ['local-as', ASN])
+        self.cli_set(base_path + ['system-as', ASN])
 
         # Default local preference (higher = more preferred, default value is 100)
         self.cli_set(base_path + ['parameters', 'default', 'local-pref', local_pref])
@@ -760,13 +760,13 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         # templates and Jinja2 FRR template.
         table = '1000'
 
-        self.cli_set(base_path + ['local-as', ASN])
+        self.cli_set(base_path + ['system-as', ASN])
         # testing only one AFI is sufficient as it's generic code
 
         for vrf in vrfs:
             vrf_base = ['vrf', 'name', vrf]
             self.cli_set(vrf_base + ['table', table])
-            self.cli_set(vrf_base + ['protocols', 'bgp', 'local-as', ASN])
+            self.cli_set(vrf_base + ['protocols', 'bgp', 'system-as', ASN])
             self.cli_set(vrf_base + ['protocols', 'bgp', 'parameters', 'router-id', router_id])
             self.cli_set(vrf_base + ['protocols', 'bgp', 'route-map', route_map_in])
             table = str(int(table) + 1000)
@@ -804,7 +804,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         confed_id = str(int(ASN) + 1)
         confed_asns = '10 20 30 40'
 
-        self.cli_set(base_path + ['local-as', ASN])
+        self.cli_set(base_path + ['system-as', ASN])
         self.cli_set(base_path + ['parameters', 'router-id', router_id])
         self.cli_set(base_path + ['parameters', 'confederation', 'identifier', confed_id])
         for asn in confed_asns.split():
@@ -825,7 +825,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         remote_asn = str(int(ASN) + 10)
         interface = 'eth0'
 
-        self.cli_set(base_path + ['local-as', ASN])
+        self.cli_set(base_path + ['system-as', ASN])
         self.cli_set(base_path + ['neighbor', interface, 'address-family', 'ipv6-unicast'])
         self.cli_set(base_path + ['neighbor', interface, 'interface', 'v6only', 'remote-as', remote_asn])
 
@@ -850,7 +850,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         rt_export = f'{neighbor}:1002 1.2.3.4:567'
         rt_import = f'{neighbor}:1003 500:100'
 
-        self.cli_set(base_path + ['local-as', ASN])
+        self.cli_set(base_path + ['system-as', ASN])
         # testing only one AFI is sufficient as it's generic code
         for afi in ['ipv4-unicast', 'ipv6-unicast']:
             self.cli_set(base_path + ['address-family', afi, 'export', 'vpn'])
@@ -889,7 +889,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         peer_group = 'bar'
         interface = 'eth0'
 
-        self.cli_set(base_path + ['local-as', ASN])
+        self.cli_set(base_path + ['system-as', ASN])
         self.cli_set(base_path + ['neighbor', neighbor, 'remote-as', remote_asn])
         self.cli_set(base_path + ['neighbor', neighbor, 'peer-group', peer_group])
         self.cli_set(base_path + ['peer-group', peer_group, 'remote-as', remote_asn])

--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -121,8 +121,8 @@ def verify(bgp):
                                       'dependent VRF instance(s) exist!')
         return None
 
-    if 'local_as' not in bgp:
-        raise ConfigError('BGP local-as number must be defined!')
+    if 'system_as' not in bgp:
+        raise ConfigError('BGP system-as number must be defined!')
 
     # Common verification for both peer-group and neighbor statements
     for neighbor in ['neighbor', 'peer_group']:
@@ -147,8 +147,8 @@ def verify(bgp):
                 # Neighbor local-as override can not be the same as the local-as
                 # we use for this BGP instane!
                 asn = list(peer_config['local_as'].keys())[0]
-                if asn == bgp['local_as']:
-                    raise ConfigError('Cannot have local-as same as BGP AS number')
+                if asn == bgp['system_as']:
+                    raise ConfigError('Cannot have local-as same as system-as number')
 
                 # Neighbor AS specified for local-as and remote-as can not be the same
                 if dict_search('remote_as', peer_config) == asn:

--- a/src/migration-scripts/bgp/2-to-3
+++ b/src/migration-scripts/bgp/2-to-3
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T4257: Discussion on changing BGP autonomous system number syntax
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+
+if (len(argv) < 1):
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+
+# Check if BGP is even configured. Then check if local-as exists, then add the system-as, then remove the local-as. This is for global configuration.
+if config.exists(['protocols', 'bgp']):
+    if config.exists(['protocols', 'bgp', 'local-as']):
+        config.rename(['protocols', 'bgp', 'local-as'], 'system-as')
+
+# Check if vrf names are configured. Then check if local-as exists inside of a name, then add the system-as, then remove the local-as. This is for vrf configuration.
+if config.exists(['vrf', 'name']):
+    for vrf in config.list_nodes(['vrf', 'name']):
+        if config.exists(['vrf', f'name {vrf}', 'protocols', 'bgp', 'local-as']):
+            config.rename(['vrf', f'name {vrf}', 'protocols', 'bgp', 'local-as'], 'system-as')
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print(f'Failed to save the modified config: {e}')
+    exit(1)


### PR DESCRIPTION
bgp: T4257: Changing BGP "local-as" to "system-as"

This change is to change the global BGP name for the node "local-as" to "system-as"
This change also does the same for VRFs that have BGP configured as well
This is needed so that there's less ambiguity with the local-as feature per neighbor

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

I just changed the node "local-as" to "system-as" for BGP configuration for global
and VRF configurations.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4257

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp, bgp inside of vrf

## Proposed changes
<!--- Describe your changes in detail -->

The main changes that I made was literally just a rename. I also made sure to add a migration script
that should properly change any thing of the "local-as" to "system-as" as well. I made changes to the
smoketests and they worked as expected.


## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics --->

The main changes take the configuration from this:
```
interfaces {
    ethernet eth0 {
        address 10.0.0.80/27
    }
    loopback lo {
    }
}
protocols {
    bgp {
        local-as 1
    }
    static {
        route 0.0.0.0/0 {
            next-hop 10.0.0.65 {
            }
        }
    }
}
service {
    ssh {
    }
}
system {
    config-management {
        commit-revisions 100
    }
    conntrack {
        modules {
            ftp
            h323
            nfs
            pptp
            sip
            sqlnet
            tftp
        }
    }
    console {
        device ttyS0 {
            speed 115200
        }
    }
    host-name vyos
    login {
        user vyos {
            authentication {
                encrypted-password ****************
                plaintext-password ****************
            }
        }
    }
    ntp {
        server time1.vyos.net {
        }
        server time2.vyos.net {
        }
        server time3.vyos.net {
        }
    }
    syslog {
        global {
            facility all {
                level info
            }
            facility protocols {
                level debug
            }
        }
    }
}
vrf {
    name blue {
        protocols {
            bgp {
                local-as 101
            }
        }
        table 101
    }
    name green {
        protocols {
            bgp {
                local-as 102
            }
        }
        table 102
    }
    name red {
        protocols {
            bgp {
                local-as 100
            }
        }
        table 100
    }
}
```

To this:
```
interfaces {
    ethernet eth0 {
        address 10.0.0.80/27
    }
    loopback lo {
    }
}
protocols {
    bgp {
        system-as 1
    }
    static {
        route 0.0.0.0/0 {
            next-hop 10.0.0.65 {
            }
        }
    }
}
service {
    ssh {
    }
}
system {
    config-management {
        commit-revisions 100
    }
    conntrack {
        modules {
            ftp
            h323
            nfs
            pptp
            sip
            sqlnet
            tftp
        }
    }
    console {
        device ttyS0 {
            speed 115200
        }
    }
    host-name vyos
    login {
        user vyos {
            authentication {
                encrypted-password ****************
                plaintext-password ****************
            }
        }
    }
    ntp {
        server time1.vyos.net {
        }
        server time2.vyos.net {
        }
        server time3.vyos.net {
        }
    }
    syslog {
        global {
            facility all {
                level info
            }
            facility protocols {
                level debug
            }
        }
    }
}
vrf {
    name blue {
        protocols {
            bgp {
                system-as 101
            }
        }
        table 101
    }
    name green {
        protocols {
            bgp {
                system-as 102
            }
        }
        table 102
    }
    name red {
        protocols {
            bgp {
                system-as 100
            }
        }
        table 100
    }
}
```

Here is the smoketest:
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP) ...
BGP system-as number must be defined!

ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP) ...
Must either speficy exist-map or non-exist-map when conditionally-
advertise is in use!

ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP) ...
Must either speficy exist-map or non-exist-map when conditionally-
advertise is in use!

ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP) ...
Listen range for prefix "192.0.2.0/25" has no peer group configured.


Peer-group "listenfoobar" for listen range "192.0.2.0/25" does not
exist!


Peer-group "listenfoobar" for listen range "192.0.2.0/25" does not
exist!

ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP) ... ok
test_bgp_08_zebra_route_map (__main__.TestProtocolsBGP) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP) ... ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP) ...
WARNING: BGP neighbor "192.0.2.1" requires address-family!

Peer-group member "192.0.2.1" cannot override remote-as of peer-group
"bar"!


WARNING: BGP neighbor "192.0.2.1" requires address-family!

WARNING: BGP neighbor "eth0" requires address-family!

Peer-group member "eth0" cannot override remote-as of peer-group "bar"!


WARNING: BGP neighbor "192.0.2.1" requires address-family!

WARNING: BGP neighbor "eth0" requires address-family!

Peer-group member "eth0" cannot override remote-as of peer-group "bar"!


WARNING: BGP neighbor "192.0.2.1" requires address-family!

WARNING: BGP neighbor "eth0" requires address-family!
ok

----------------------------------------------------------------------
Ran 14 tests in 45.657s

OK
```

The configuration in the end should look like this:

```
vyos@vyos:~$ show configuration commands
set interfaces ethernet eth0 address '10.0.0.80/27'
set interfaces ethernet eth0 offload sg
set interfaces ethernet eth0 offload tso
set interfaces loopback lo
set protocols bgp system-as '1'
set protocols static route 0.0.0.0/0 next-hop 10.0.0.65
set service ssh
set system config-management commit-revisions '100'
set system conntrack modules ftp
set system conntrack modules h323
set system conntrack modules nfs
set system conntrack modules pptp
set system conntrack modules sip
set system conntrack modules sqlnet
set system conntrack modules tftp
set system console device ttyS0 speed '115200'
set system host-name 'vyos'
set system login user vyos authentication encrypted-password '$6$87MqZ/Uzl3WDgSMN$nZdtY2KEg8cCLt6DwekE5Sc7HvsM296FAk1kLMcbNQCW.FHG0lb3./yCRm1Lj1JcKAui14LyM.cUgPGuo3Xar0'
set system ntp server time1.vyos.net
set system ntp server time2.vyos.net
set system ntp server time3.vyos.net
set system syslog global facility all level 'info'
set system syslog global facility protocols level 'debug'
set vrf name blue protocols bgp system-as '101'
set vrf name blue table '101'
set vrf name green protocols bgp system-as '102'
set vrf name green table '102'
set vrf name red protocols bgp system-as '100'
set vrf name red table '100'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

I have not done the documentation yet, but will do if the PR is approved to be merged. 