### PR TITLE
T4559: fix xdp build error

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Build-Depends:
   gcc-multilib [amd64],
   clang [amd64],
   llvm [amd64],
+  libbpf-dev [amd64],
   libelf-dev (>= 0.2) [amd64],
   libpcap-dev [amd64],
   build-essential,
@@ -25,7 +26,8 @@ Build-Depends:
   python3-sphinx,
   python3-xmltodict,
   quilt,
-  whois
+  whois,
+  zlib1g-dev [amd64]
 Standards-Version: 3.9.6
 
 Package: vyos-1x
@@ -175,7 +177,8 @@ Depends:
   wireless-regdb,
   wpasupplicant (>= 0.6.7),
   ndppd,
-  miniupnpd-nftables
+  miniupnpd-nftables,
+  zlib1g [amd64]
 Description: VyOS configuration scripts and data
  VyOS configuration scripts, interface definitions, and everything
 

--- a/src/xdp/common/common.mk
+++ b/src/xdp/common/common.mk
@@ -39,7 +39,7 @@ KERN_USER_H ?= $(wildcard common_kern_user.h)
 CFLAGS ?= -g -I../include/
 BPF_CFLAGS ?= -I../include/
 
-LIBS = -l:libbpf.a -lelf $(USER_LIBS)
+LIBS = -l:libbpf.a -lelf -lz $(USER_LIBS)
 
 all: llvm-check $(USER_TARGETS) $(XDP_OBJ) $(COPY_LOADER) $(COPY_STATS)
 


### PR DESCRIPTION
I got an undefined reference error when building vyos-1x on Debian
bullseye amd64:
```
cc -Wall -g -I../include/  -o xdp_prog_user common/common_params.o common/common_user_bpf_xdp.o \
 xdp_prog_user.c -l:libbpf.a -lelf
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/10/../../../x86_64-linux-gnu/libbpf.a(libbpf.o): undefined reference to symbol 'gzopen64@@ZLIB_1.2.3.3'
/usr/bin/ld: /lib/x86_64-linux-gnu/libz.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

Seems `zlib` is missing when linking xdp and libbpf.
I don't know why VyOS's office build system doesn't have this issue. But
it would be better to update the build script to explicitly link with zlib.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4559

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
