### PR TITLE
nat: T4545: Rewrite show nat source rules script

### DIFF
--- a/op-mode-definitions/nat.xml.in
+++ b/op-mode-definitions/nat.xml.in
@@ -16,7 +16,7 @@
                 <properties>
                   <help>Show configured source NAT rules</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/show_nat_rules.py --source</command>
+                <command>${vyos_op_scripts_dir}/nat.py show_rules --direction source</command>
               </node>
               <node name="statistics">
                 <properties>

--- a/src/op_mode/nat.py
+++ b/src/op_mode/nat.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import jmespath
+import json
+import sys
+
+from sys import exit
+from tabulate import tabulate
+
+from vyos.util import cmd
+from vyos.util import dict_search
+
+import vyos.opmode
+
+
+def _get_json_data(direction):
+    """
+    Get NAT format JSON
+    """
+    if direction == 'source':
+        chain = 'POSTROUTING'
+    if direction == 'destination':
+        chain = 'PREROUTING'
+    return cmd(f'sudo nft --json list chain ip nat {chain}')
+
+
+def _get_raw_data_rules(direction):
+    """Get interested rules
+    :returns dict
+    """
+    data = _get_json_data(direction)
+    data_dict = json.loads(data)
+    rules = []
+    for rule in data_dict['nftables']:
+        if 'rule' in rule and 'comment' in rule['rule']:
+            rules.append(rule)
+    return rules
+
+
+def _get_formatted_output_rules(data, direction):
+    data_entries = []
+    for rule in data:
+        if 'comment' in rule['rule']:
+            comment = rule.get('rule').get('comment')
+            rule_number = comment.split('-')[-1]
+            rule_number = rule_number.split(' ')[0]
+        if 'expr' in rule['rule']:
+            interface = rule.get('rule').get('expr')[0].get('match').get('right') \
+                if jmespath.search('rule.expr[*].match.left.meta', rule) else 'any'
+        for index, match in enumerate(jmespath.search('rule.expr[*].match', rule)):
+            if 'payload' in match['left']:
+                if 'prefix' in match['right'] or 'set' in match['right']:
+                    # Merge dict src/dst l3_l4 parameters
+                    my_dict = {**match['left']['payload'], **match['right']}
+                    proto = my_dict.get('protocol').upper()
+                    if my_dict['field'] == 'saddr':
+                        saddr = f'{my_dict["prefix"]["addr"]}/{my_dict["prefix"]["len"]}'
+                    elif my_dict['field'] == 'daddr':
+                        daddr = f'{my_dict["prefix"]["addr"]}/{my_dict["prefix"]["len"]}'
+                    elif my_dict['field'] == 'sport':
+                        # Port range or single port
+                        if jmespath.search('set[*].range', my_dict):
+                            sport = my_dict['set'][0]['range']
+                            sport = '-'.join(map(str, sport))
+                        else:
+                            sport = my_dict.get('set')
+                            sport = ','.join(map(str, sport))
+                    elif my_dict['field'] == 'dport':
+                        # Port range or single port
+                        if jmespath.search('set[*].range', my_dict):
+                            dport = my_dict["set"][0]["range"]
+                            dport = '-'.join(map(str, dport))
+                        else:
+                            dport = my_dict.get('set')
+                            dport = ','.join(map(str, dport))
+                else:
+                    if jmespath.search('left.payload.field', match) == 'saddr':
+                        saddr = match.get('right')
+                    if jmespath.search('left.payload.field', match) == 'daddr':
+                        daddr = match.get('right')
+            else:
+                saddr = '0.0.0.0/0'
+                daddr = '0.0.0.0/0'
+                sport = 'any'
+                dport = 'any'
+                proto = 'any'
+
+            source = f'''{saddr}
+sport {sport}'''
+            destination = f'''{daddr}
+dport {dport}'''
+
+            if jmespath.search('left.payload.field', match) == 'protocol':
+                field_proto = match.get('right').upper()
+
+            for expr in rule.get('rule').get('expr'):
+                if 'snat' in expr:
+                    translation = dict_search('snat.addr', expr)
+                    if expr['snat'] and 'port' in expr['snat']:
+                        if jmespath.search('snat.port.range', expr):
+                            port = dict_search('snat.port.range', expr)
+                            port = '-'.join(map(str, port))
+                        else:
+                            port = expr['snat']['port']
+                        translation = f'''{translation}
+port {port}'''
+
+                elif 'masquerade' in expr:
+                    translation = 'masquerade'
+                    if expr['masquerade'] and 'port' in expr['masquerade']:
+                        if jmespath.search('masquerade.port.range', expr):
+                            port = dict_search('masquerade.port.range', expr)
+                            port = '-'.join(map(str, port))
+                        else:
+                            port = expr['masquerade']['port']
+
+                        translation = f'''{translation}
+port {port}'''
+                else:
+                    translation = 'exclude'
+        # Overwrite match loop 'proto' if specified filed 'protocol' exist
+        if 'protocol' in jmespath.search('rule.expr[*].match.left.payload.field', rule):
+            proto = jmespath.search('rule.expr[0].match.right', rule).upper()
+
+        data_entries.append([rule_number, source, destination, proto, interface, translation])
+
+    interface_header = 'Out-Int' if direction == 'source' else 'In-Int'
+    headers = ["Rule", "Source", "Destination", "Proto", interface_header, "Translation"]
+    output = tabulate(data_entries, headers, numalign="left")
+    return output
+
+
+def show_rules(raw: bool, direction: str):
+    nat_rules = _get_raw_data_rules(direction)
+    if raw:
+        return nat_rules
+    else:
+        return _get_formatted_output_rules(nat_rules, direction)
+
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except ValueError as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Rewrite `show nat source rules` due to a large number of bugs
in NAT rules statistics. Use new format 'vyos.opmode module'
Ability to get raw and formatted data

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4545
* https://phabricator.vyos.net/T4531
* https://phabricator.vyos.net/T3435

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set nat source rule 10 description 'Masquerade to NAT'
set nat source rule 10 outbound-interface 'eth0'
set nat source rule 10 translation address 'masquerade'
set nat source rule 20 destination address '192.0.2.0/24'
set nat source rule 20 exclude
set nat source rule 20 outbound-interface 'any'
set nat source rule 20 protocol 'all'
set nat source rule 30 destination address '192.0.2.0/24'
set nat source rule 30 outbound-interface 'any'
set nat source rule 30 protocol 'tcp'
set nat source rule 30 source address '203.0.113.0/24'
set nat source rule 30 translation address '100.64.0.5'
set nat source rule 40 destination address '192.0.2.85/32'
set nat source rule 40 destination port '22001-22005'
set nat source rule 40 outbound-interface 'eth0'
set nat source rule 40 protocol 'tcp_udp'
set nat source rule 40 source port '65001-65005'
set nat source rule 40 translation address 'masquerade'
set nat source rule 50 destination port '8080'
set nat source rule 50 outbound-interface 'any'
set nat source rule 50 protocol 'tcp'
set nat source rule 50 source address '100.64.0.0/24'
set nat source rule 50 source port '9999'
set nat source rule 50 translation address 'masquerade'
set nat source rule 50 translation port '8888'
set nat source rule 60 destination port '2222-2225'
set nat source rule 60 outbound-interface 'any'
set nat source rule 60 protocol 'tcp'
set nat source rule 60 source address '100.64.0.0/24'
set nat source rule 60 source port '4442-4445'
set nat source rule 60 translation address 'masquerade'
set nat source rule 60 translation port '8882-8885'
set nat source rule 70 destination address '192.0.2.5'
set nat source rule 70 destination port '2222'
set nat source rule 70 outbound-interface 'eth1'
set nat source rule 70 protocol 'tcp'
set nat source rule 70 translation address 'masquerade'
set nat source rule 70 translation port '22'
set nat source rule 80 destination port '22,80,443'
set nat source rule 80 outbound-interface 'eth1'
set nat source rule 80 protocol 'tcp'
set nat source rule 80 translation address '192.0.2.99'

```
Current output (bugs described in the T4545):
```
vyos@r14:~$ /usr/libexec/vyos/op_mode/show_nat_rules.py --source
Rule       Source                                             Translation                                        Outbound Interface
----       ------                                             -----------                                        ------------------
10         any                                                masquerade                                         eth0      
20         any                                                                                                   any       
30         192.0.2.0/24                                       100.64.0.5                                         tcp       
40         port 65001-65005                                   masquerade                                         eth0      
           192.0.2.85 port 22001-22005                                                                                     
40         port 65001-65005                                   masquerade                                         eth0      
           192.0.2.85 port 22001-22005                                                                                     
50         port 9999 port 8080                                masquerade                                         any       
60         port 4442-4445 port 2222-2225                      masquerade                                         any       
70         192.0.2.5 port 2222                                masquerade                                         eth1      
80         port 22                                            192.0.2.99                                         eth1      
vyos@r14:~$


vyos@r14:~$ show nat source rules 
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/show_nat_rules.py", line 117, in <module>
    print(format_nat_rule.format(rule, srcdests[0], tran_addr, interface))
TypeError: unsupported format string passed to dict.__format__
Rule       Source                                             Translation                                        Outbound Interface
----       ------                                             -----------                                        ------------------
10         any                                                masquerade                                         eth0 

```
New output:
```
vyos@r14:~$ show nat source rules 
Rule    Source             Destination        Proto    Out-Int    Translation
------  -----------------  -----------------  -------  ---------  --------------
10      0.0.0.0/0          0.0.0.0/0          any      eth0       masquerade
        sport any          dport any
20      0.0.0.0/0          192.0.2.0/24       IP       any        exclude
        sport any          dport any
30      203.0.113.0/24     192.0.2.0/24       TCP      any        100.64.0.5
        sport any          dport any
40      0.0.0.0/0          192.0.2.85         TCP      eth0       masquerade
        sport 65001-65005  dport 22001-22005
40      0.0.0.0/0          192.0.2.85         UDP      eth0       masquerade
        sport 65001-65005  dport 22001-22005
50      100.64.0.0/24      192.0.2.85         TCP      any        masquerade
        sport 9999         dport 8080                             port 8888
60      100.64.0.0/24      192.0.2.85         TCP      any        masquerade
        sport 4442-4445    dport 2222-2225                        port 8882-8885
70      0.0.0.0/0          192.0.2.5          TCP      eth1       masquerade
        sport any          dport 2222                             port 22
80      0.0.0.0/0          0.0.0.0/0          TCP      eth1       192.0.2.99
        sport any          dport 22,80,443
vyos@r14:~$ 

```
Example `raw format` with only one rule:
```
vyos@r14:~$ /usr/libexec/vyos/op_mode/nat.py show_rules --direction source --raw
[
    {
        "rule": {
            "family": "ip",
            "table": "nat",
            "chain": "POSTROUTING",
            "handle": 114,
            "comment": "SRC-NAT-10",
            "expr": [
                {
                    "match": {
                        "op": "==",
                        "left": {
                            "meta": {
                                "key": "oifname"
                            }
                        },
                        "right": "eth0"
                    }
                },
                {
                    "counter": {
                        "packets": 0,
                        "bytes": 0
                    }
                },
                {
                    "masquerade": null
                }
            ]
        }
    }
]
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
