### PR TITLE
IPsec: T4552: Fix reset vpn ipsec peer

### DIFF
--- a/op-mode-definitions/vpn-ipsec.xml.in
+++ b/op-mode-definitions/vpn-ipsec.xml.in
@@ -19,16 +19,16 @@
                 <properties>
                   <help>Reset a specific tunnel for given peer</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/vpn_ipsec.py --action="reset-peer" --name="$4" --tunnel="$6"</command>
+                <command>sudo ${vyos_op_scripts_dir}/ipsec.py reset_peer --peer="$4" --tunnel="$6"</command>
               </tagNode>
               <node name="vti">
                 <properties>
                   <help>Reset the VTI tunnel for given peer</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/vpn_ipsec.py --action="reset-peer" --name="$4" --tunnel="vti"</command>
+                <command>sudo ${vyos_op_scripts_dir}/ipsec.py reset_peer --peer="$4" --tunnel="vti"</command>
               </node>
             </children>
-            <command>sudo ${vyos_op_scripts_dir}/vpn_ipsec.py --action="reset-peer" --name="$4" --tunnel="all"</command>
+            <command>sudo ${vyos_op_scripts_dir}/ipsec.py reset_peer --peer="$4" --tunnel="all"</command>
           </tagNode>
           <tagNode name="ipsec-profile">
             <properties>

--- a/src/op_mode/ipsec.py
+++ b/src/op_mode/ipsec.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import sys
+from vyos.util import call
+import vyos.opmode
+
+
+SWANCTL_CONF = '/etc/swanctl/swanctl.conf'
+
+
+def get_peer_connections(peer, tunnel, return_all = False):
+    peer = peer.replace(':', '-')
+    search = rf'^[\s]*(peer_{peer}_(tunnel_[\d]+|vti)).*'
+    matches = []
+    with open(SWANCTL_CONF, 'r') as f:
+        for line in f.readlines():
+            result = re.match(search, line)
+            if result:
+                suffix = f'tunnel_{tunnel}' if tunnel.isnumeric() else tunnel
+                if return_all or (result[2] == suffix):
+                    matches.append(result[1])
+    return matches
+
+
+def reset_peer(peer: str, tunnel:str):
+    if not peer:
+        print('Invalid peer, aborting')
+        return
+
+    conns = get_peer_connections(peer, tunnel, return_all = (not tunnel or tunnel == 'all'))
+
+    if not conns:
+        print('Tunnel(s) not found, aborting')
+        return
+
+    result = True
+    for conn in conns:
+        try:
+            call(f'sudo /usr/sbin/ipsec down {conn}{{*}}', timeout = 10)
+            call(f'sudo /usr/sbin/ipsec up {conn}', timeout = 10)
+        except TimeoutExpired as e:
+            print(f'Timed out while resetting {conn}')
+            result = False
+
+
+    print('Peer reset result: ' + ('success' if result else 'failed'))
+
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except ValueError as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
When we use IPv6 peer we need to make a replacement `:` => `-`
for correct resetting as it doesn't match get_peer_connections()
regex
Use new format `vyos.opmode`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4552

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vpn, ipsec
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Before fix
```
vyos@r14:~$ reset vpn ipsec-peer 2001:db8::2 
Tunnel(s) not found, aborting
vyos@r14:~$
```
After fix:
```
vyos@r14:~$ reset vpn ipsec-peer 2001:db8::2 
CHILD_SA {20548} closed successfully
CHILD_SA {20551} closed successfully
CHILD_SA {20555} closed successfully
CHILD_SA {20554} closed successfully
CHILD_SA {20558} closed successfully
CHILD_SA {20561} closed successfully
closing CHILD_SA peer_2001-db8--2_tunnel_0{20563} with SPIs cc9180c9_i (0 bytes) cbbcdd4a_o (0 bytes) and TS 2001:db8:1111::/64 === 2001:db8:2222::/64
sending DELETE for ESP CHILD_SA with SPI cc9180c9
generating INFORMATIONAL request 13663 [ D ]
sending packet: from 2001:db8::1[500] to 2001:db8::2[500] (69 bytes)
received packet: from 2001:db8::2[500] to 2001:db8::1[500] (69 bytes)
parsed INFORMATIONAL response 13663 [ D ]
received DELETE for ESP CHILD_SA with SPI cbbcdd4a
CHILD_SA closed
CHILD_SA {20563} closed successfully
establishing CHILD_SA peer_2001-db8--2_tunnel_0{20564}
generating CREATE_CHILD_SA request 13664 [ SA No KE TSi TSr ]
sending packet: from 2001:db8::1[500] to 2001:db8::2[500] (497 bytes)
received packet: from 2001:db8::2[500] to 2001:db8::1[500] (497 bytes)
parsed CREATE_CHILD_SA response 13664 [ SA No KE TSi TSr ]
selected proposal: ESP:AES_GCM_16_256/MODP_2048/NO_EXT_SEQ
CHILD_SA peer_2001-db8--2_tunnel_0{20564} established with SPIs c4490e21_i ce62da22_o and TS 2001:db8:1111::/64 === 2001:db8:2222::/64
connection 'peer_2001-db8--2_tunnel_0' established successfully
Peer reset result: success
vyos@r14:~$ 

```
Reset with the script:
```
vyos@r14:~$ /usr/libexec/vyos/op_mode/ipsec.py reset_peer --peer 2001:db8::2 --tunnel 0
CHILD_SA {2022} closed successfully
CHILD_SA {2025} closed successfully
CHILD_SA {2024} closed successfully
CHILD_SA {2028} closed successfully
CHILD_SA {2027} closed successfully
CHILD_SA {2031} closed successfully
CHILD_SA {2030} closed successfully
CHILD_SA {2035} closed successfully
CHILD_SA {2034} closed successfully
CHILD_SA {2038} closed successfully
closing CHILD_SA peer_2001-db8--2_tunnel_0{2037} with SPIs c08cb946_i (0 bytes) cc888f04_o (0 bytes) and TS 2001:db8:1111::/64 === 2001:db8:2222::/64
sending DELETE for ESP CHILD_SA with SPI c08cb946
generating INFORMATIONAL request 624 [ D ]
sending packet: from 2001:db8::1[500] to 2001:db8::2[500] (69 bytes)
received packet: from 2001:db8::2[500] to 2001:db8::1[500] (69 bytes)
parsed INFORMATIONAL response 624 [ D ]
received DELETE for ESP CHILD_SA with SPI cc888f04
CHILD_SA closed
CHILD_SA {2037} closed successfully
establishing CHILD_SA peer_2001-db8--2_tunnel_0{2041}
generating CREATE_CHILD_SA request 625 [ SA No KE TSi TSr ]
sending packet: from 2001:db8::1[500] to 2001:db8::2[500] (497 bytes)
received packet: from 2001:db8::2[500] to 2001:db8::1[500] (497 bytes)
parsed CREATE_CHILD_SA response 625 [ SA No KE TSi TSr ]
selected proposal: ESP:AES_GCM_16_256/MODP_2048/NO_EXT_SEQ
CHILD_SA peer_2001-db8--2_tunnel_0{2041} established with SPIs c05bfc18_i cf49ddc8_o and TS 2001:db8:1111::/64 === 2001:db8:2222::/64
connection 'peer_2001-db8--2_tunnel_0' established successfully
Peer reset result: success
vyos@r14:~$ 

```

There is a lot of `CHILD_SA` due to another bug (CHILD_REKEY collision) https://phabricator.vyos.net/T4551
So it is OK when we see multiple `CHILD_SA` in resetting output

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
