### PR TITLE
fastnetmon: T4556: Allows to configure networks that should be excluded

### DIFF
--- a/data/templates/ids/fastnetmon.j2
+++ b/data/templates/ids/fastnetmon.j2
@@ -5,6 +5,9 @@ logging:local_syslog_logging = on
 # list of all your networks in CIDR format
 networks_list_path = /run/fastnetmon/networks_list
 
+# list networks in CIDR format which will be not monitored for attacks
+white_list_path = /run/fastnetmon/excluded_networks_list
+
 # Enable/Disable any actions in case of attack
 enable_ban = on
 enable_ban_ipv6 = on

--- a/data/templates/ids/fastnetmon_excluded_networks_list.j2
+++ b/data/templates/ids/fastnetmon_excluded_networks_list.j2
@@ -1,5 +1,5 @@
 {% if excluded_network is vyos_defined %}
-{%     for net in network %}
+{%     for net in excluded_network %}
 {{ net }}
 {%     endfor %}
 {% endif %}

--- a/data/templates/ids/fastnetmon_excluded_networks_list.j2
+++ b/data/templates/ids/fastnetmon_excluded_networks_list.j2
@@ -1,0 +1,5 @@
+{% if excluded_network is vyos_defined %}
+{%     for net in network %}
+{{ net }}
+{%     endfor %}
+{% endif %}

--- a/interface-definitions/policy.xml.in
+++ b/interface-definitions/policy.xml.in
@@ -639,7 +639,7 @@
                           </leafNode>
                           <leafNode name="prefix-len">
                             <properties>
-                              <help>IP prefix-length to match (cannot be used for BGP routes)</help>
+                              <help>IP prefix-length to match (can be used for kernel routes only)</help>
                               <valueHelp>
                                 <format>u32:0-32</format>
                                 <description>Prefix length</description>
@@ -809,7 +809,7 @@
                           </leafNode>
                           <leafNode name="prefix-len">
                             <properties>
-                              <help>IPv6 prefix-length to match (cannot be used for BGP routes)</help>
+                              <help>IPv6 prefix-length to match (can be used for kernel routes only)</help>
                               <valueHelp>
                                 <format>u32:0-128</format>
                                 <description>Prefix length</description>

--- a/interface-definitions/service-ids-ddos-protection.xml.in
+++ b/interface-definitions/service-ids-ddos-protection.xml.in
@@ -43,6 +43,24 @@
                   <multi/>
                 </properties>
               </leafNode>
+              <leafNode name="excluded-network">
+                <properties>
+                  <help>Specify IPv4 and IPv6 networks which are going to be excluded from protection</help>
+                  <valueHelp>
+                    <format>ipv4net</format>
+                    <description>IPv4 prefix(es) to exclude</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ipv6net</format>
+                    <description>IPv6 prefix(es) to exclude</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="ipv4-prefix"/>
+                    <validator name="ipv6-prefix"/>
+                  </constraint>
+                  <multi/>
+                </properties>
+              </leafNode>
               <leafNode name="listen-interface">
                 <properties>
                   <help>Listen interface for mirroring traffic</help>

--- a/smoketest/scripts/cli/test_service_ids.py
+++ b/smoketest/scripts/cli/test_service_ids.py
@@ -26,6 +26,7 @@ from vyos.util import read_file
 PROCESS_NAME = 'fastnetmon'
 FASTNETMON_CONF = '/run/fastnetmon/fastnetmon.conf'
 NETWORKS_CONF = '/run/fastnetmon/networks_list'
+EXCLUDED_NETWORKS_CONF = '/run/fastnetmon/excluded_networks_list'
 base_path = ['service', 'ids', 'ddos-protection']
 
 class TestServiceIDS(VyOSUnitTestSHIM.TestCase):
@@ -50,6 +51,7 @@ class TestServiceIDS(VyOSUnitTestSHIM.TestCase):
 
     def test_fastnetmon(self):
         networks = ['10.0.0.0/24', '10.5.5.0/24', '2001:db8:10::/64', '2001:db8:20::/64']
+        excluded_networks = ['10.0.0.1/32', '2001:db8:10::1/128']
         interfaces = ['eth0', 'eth1']
         fps = '3500'
         mbps = '300'
@@ -61,6 +63,12 @@ class TestServiceIDS(VyOSUnitTestSHIM.TestCase):
             self.cli_commit()
         for tmp in networks:
             self.cli_set(base_path + ['network', tmp])
+
+        # optional excluded-network!
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        for tmp in excluded_networks:
+            self.cli_set(base_path + ['excluded-network', tmp])
 
         # Required interface(s)!
         with self.assertRaises(ConfigSessionError):
@@ -99,6 +107,10 @@ class TestServiceIDS(VyOSUnitTestSHIM.TestCase):
         network_config = read_file(NETWORKS_CONF)
         for tmp in networks:
             self.assertIn(f'{tmp}', network_config)
+
+        excluded_network_config = read_file(EXCLUDED_NETWORKS_CONF)
+        for tmp in excluded_networks:
+            self.assertIn(f'{tmp}', excluded_network_config)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/service_ids_fastnetmon.py
+++ b/src/conf_mode/service_ids_fastnetmon.py
@@ -29,6 +29,7 @@ airbag.enable()
 
 config_file = r'/run/fastnetmon/fastnetmon.conf'
 networks_list = r'/run/fastnetmon/networks_list'
+excluded_networks_list = r'/run/fastnetmon/excluded_networks_list'
 
 def get_config(config=None):
     if config:
@@ -75,6 +76,7 @@ def generate(fastnetmon):
 
     render(config_file, 'ids/fastnetmon.j2', fastnetmon)
     render(networks_list, 'ids/fastnetmon_networks_list.j2', fastnetmon)
+    render(excluded_networks_list, 'ids/fastnetmon_excluded_networks_list.j2', fastnetmon)
     return None
 
 def apply(fastnetmon):


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T4556

## Component(s) name
ddos-protection fastnetmon

## Proposed changes
This adds
set service ids ddos-protection excluded-network x.x.x.x/x
set service ids ddos-protection excluded-network xxxx::/x



## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
