### PR TITLE
vrf: T4562: Rewrite show vrf to vyos.opmode format

### DIFF
--- a/op-mode-definitions/show-vrf.xml.in
+++ b/op-mode-definitions/show-vrf.xml.in
@@ -6,7 +6,7 @@
         <properties>
           <help>Show VRF information</help>
         </properties>
-        <command>${vyos_op_scripts_dir}/show_vrf.py -e</command>
+        <command>${vyos_op_scripts_dir}/vrf.py show</command>
       </node>
       <tagNode name="vrf">
         <properties>

--- a/src/op_mode/vrf.py
+++ b/src/op_mode/vrf.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import sys
+
+from tabulate import tabulate
+from vyos.util import cmd
+
+import vyos.opmode
+
+
+def _get_raw_data():
+    """
+    :return: list
+    """
+    output = cmd('sudo ip --json --brief link show type vrf')
+    data = json.loads(output)
+    return data
+
+
+def _get_vrf_members(vrf: str) -> list:
+    """
+    Get list of interface VRF members
+    :param vrf: str
+    :return: list
+    """
+    output = cmd(f'sudo ip --json --brief link show master {vrf}')
+    answer = json.loads(output)
+    interfaces = []
+    for data in answer:
+        if 'ifname' in data:
+            interfaces.append(data.get('ifname'))
+    return interfaces if len(interfaces) > 0 else ['n/a']
+
+
+def _get_formatted_output(raw_data):
+    data_entries = []
+    for vrf in raw_data:
+        name = vrf.get('ifname')
+        state = vrf.get('operstate').lower()
+        hw_address = vrf.get('address')
+        flags = ','.join(vrf.get('flags')).lower()
+        members = ','.join(_get_vrf_members(name))
+        data_entries.append([name, state, hw_address, flags, members])
+
+    headers = ["Name", "State", "MAC address", "Flags", "Interfaces"]
+    output = tabulate(data_entries, headers, numalign="left")
+    return output
+
+
+def show(raw: bool):
+    vrf_data = _get_raw_data()
+    if raw:
+        return vrf_data
+    else:
+        return _get_formatted_output(vrf_data)
+
+
+if __name__ == "__main__":
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except ValueError as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Rewite op-mode `show vrf` to use `vyos.opmode`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4562

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrf
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS config:
```
set interfaces ethernet eth1 vif 50 vrf 'foo'
set interfaces ethernet eth1 vif 55 vrf 'foo'
set vrf name bar table '1020'
set vrf name foo table '1010'
```
Show vrf:
```
vyos@r14:~$ show vrf
Name    State    MAC address        Flags                     Interfaces
------  -------  -----------------  ------------------------  ---------------
foo     up       be:e3:5c:f1:54:99  noarp,master,up,lower_up  eth1.50,eth1.55
bar     up       1e:7c:94:da:e0:35  noarp,master,up,lower_up  n/a
vyos@r14:~$ 

```
Raw show:
```
vyos@r14:~$ /usr/libexec/vyos/op_mode/vrf.py show --raw
[
    {
        "ifname": "foo",
        "operstate": "UP",
        "address": "be:e3:5c:f1:54:99",
        "flags": [
            "NOARP",
            "MASTER",
            "UP",
            "LOWER_UP"
        ]
    },
    {
        "ifname": "bar",
        "operstate": "UP",
        "address": "1e:7c:94:da:e0:35",
        "flags": [
            "NOARP",
            "MASTER",
            "UP",
            "LOWER_UP"
        ]
    }
]
vyos@r14:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
