### PR TITLE
ipsec: T4568: Fix debug IPsec peer op-mode

### DIFF
--- a/op-mode-definitions/vpn-ipsec.xml.in
+++ b/op-mode-definitions/vpn-ipsec.xml.in
@@ -76,6 +76,9 @@
               <tagNode name="peer">
                 <properties>
                   <help>Show debugging information for a peer</help>
+                  <completionHelp>
+                    <path>vpn ipsec site-to-site peer</path>
+                  </completionHelp>
                 </properties>
                 <children>
                   <tagNode name="tunnel">

--- a/src/op_mode/vpn_ipsec.py
+++ b/src/op_mode/vpn_ipsec.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 VyOS maintainers and contributors
+# Copyright (C) 2021-2022 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -87,6 +87,7 @@ def reset_profile(profile, tunnel):
     print('Profile reset result: ' + ('success' if result == 0 else 'failed'))
 
 def debug_peer(peer, tunnel):
+    peer = peer.replace(':', '-')
     if not peer or peer == "all":
         debug_commands = [
             "sudo ipsec statusall",
@@ -109,7 +110,7 @@ def debug_peer(peer, tunnel):
     if not tunnel or tunnel == 'all':
         tunnel = ''
 
-    conn = get_peer_connections(peer, tunnel)
+    conns = get_peer_connections(peer, tunnel, return_all = (tunnel == '' or tunnel == 'all'))
 
     if not conns:
         print('Peer not found, aborting')


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Debug Connections for a peer weren't checked because of a typo
in var `conns`

Replace ':' to '-' for IPv6 peers
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4568

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Before fix;
```
vyos@r14:~$ show vpn debug peer 192.0.2.2
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/vpn_ipsec.py", line 134, in <module>
    debug_peer(args.name, args.tunnel)
  File "/usr/libexec/vyos/op_mode/vpn_ipsec.py", line 114, in debug_peer
    if not conns:
NameError: name 'conns' is not defined
vyos@r14:~$
```
After fix:
```
vyos@r14:~$ show vpn debug peer 192.0.2.2 
peer_192-0-2-2_tunnel_0:   child:  100.64.0.0/24 === 100.64.55.0/24 TUNNEL, dpdaction=hold
peer_192-0-2-2_tunnel_0{1617}:  DELETED, TUNNEL, reqid 1
peer_192-0-2-2_tunnel_0{1617}:   100.64.0.0/24 === 100.64.55.0/24
peer_192-0-2-2_tunnel_0{1619}:  DELETED, TUNNEL, reqid 1
peer_192-0-2-2_tunnel_0{1619}:   100.64.0.0/24 === 100.64.55.0/24
peer_192-0-2-2_tunnel_0{1621}:  DELETED, TUNNEL, reqid 1
peer_192-0-2-2_tunnel_0{1621}:   100.64.0.0/24 === 100.64.55.0/24
peer_192-0-2-2_tunnel_0{1620}:  DELETED, TUNNEL, reqid 1
peer_192-0-2-2_tunnel_0{1620}:   100.64.0.0/24 === 100.64.55.0/24
peer_192-0-2-2_tunnel_0{1623}:  DELETED, TUNNEL, reqid 1
peer_192-0-2-2_tunnel_0{1623}:   100.64.0.0/24 === 100.64.55.0/24
peer_192-0-2-2_tunnel_0{1622}:  DELETED, TUNNEL, reqid 1
peer_192-0-2-2_tunnel_0{1622}:   100.64.0.0/24 === 100.64.55.0/24
peer_192-0-2-2_tunnel_0{1625}:  DELETED, TUNNEL, reqid 1
peer_192-0-2-2_tunnel_0{1625}:   100.64.0.0/24 === 100.64.55.0/24
peer_192-0-2-2_tunnel_0{1624}:  DELETED, TUNNEL, reqid 1
peer_192-0-2-2_tunnel_0{1624}:   100.64.0.0/24 === 100.64.55.0/24
peer_192-0-2-2_tunnel_0{1626}:  INSTALLED, TUNNEL, reqid 1, ESP SPIs: c20fdbf9_i c4432abe_o
peer_192-0-2-2_tunnel_0{1626}:  AES_GCM_16_256/MODP_2048, 0 bytes_i, 0 bytes_o, rekeying active
peer_192-0-2-2_tunnel_0{1626}:   100.64.0.0/24 === 100.64.55.0/24
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
