### PR TITLE
nhrp: T4546: Fixed gateway in route add command

### DIFF
--- a/src/etc/opennhrp/opennhrp-script.py
+++ b/src/etc/opennhrp/opennhrp-script.py
@@ -62,7 +62,7 @@ def add_peer_route(nbma_src: str, nbma_dst: str, mtu: str) -> None:
     for route_item in route_info_data:
         route_dev = route_item.get('dev')
         route_dst = route_item.get('dst')
-        route_gateway = route_item.get('route_gateway')
+        route_gateway = route_item.get('gateway')
         # Prepare a command to add a route
         route_add_cmd = 'sudo ip route add'
         if route_dst:


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Fixed incorrect key to get gateway for route add command

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4546

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nhrp
## Proposed changes
<!--- Describe your changes in detail -->
Fixed key name. 'gateway' instead 'route_gateway'.
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Cisco (DMVPN Spoke) NBMA - 10.0.0.2
Cisco (DMVPN Spoke) Tunnel IP - 172.16.253.129
VyOS (DMVPN Hub) NBMA - 10.0.1.2
VyOS (DMVPN Hub) Tunnel IP - 172.16.253.134

When Cisco connects to VyOS hub script creates an incorrect routing entry to 10.0.0.2

```
10.0.0.2 dev eth0 proto babel scope link mtu 17912
```
Must be
`10.0.0.2 via 10.0.1.1 dev eth0 proto babel mtu 17912
`
As we see from the output key name must be 'gateway'
```
vyos@vyos:~$ sudo ip -j route get 10.0.0.2 from 10.0.1.2
[{"dst":"10.0.0.2","from":"10.0.1.2","gateway":"10.0.1.1","dev":"eth0","flags":[],"uid":0,"cache":[],"metrics":[{"mtu":17912}]}]

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
