### PR TITLE
conf_mode: T4571 add sflow vrf to sflow agent address IP validation

### DIFF
--- a/src/conf_mode/flow_accounting_conf.py
+++ b/src/conf_mode/flow_accounting_conf.py
@@ -192,6 +192,11 @@ def verify(flow_config):
                     raise ConfigError("All sFlow servers must use the same IP protocol")
             else:
                 sflow_collector_ipver = ip_address(server).version
+	
+        # check if vrf is defined for Sflow
+        sflow_vrf = None
+        if 'vrf' in flow_config:
+            sflow_vrf = flow_config['vrf']
 
         # check agent-id for sFlow: we should avoid mixing IPv4 agent-id with IPv6 collectors and vice-versa
         for server in flow_config['sflow']['server']:
@@ -203,12 +208,12 @@ def verify(flow_config):
 
         if 'agent_address' in flow_config['sflow']:
             tmp = flow_config['sflow']['agent_address']
-            if not is_addr_assigned(tmp):
+            if not is_addr_assigned(tmp, sflow_vrf):
                 raise ConfigError(f'Configured "sflow agent-address {tmp}" does not exist in the system!')
 
         # Check if configured netflow source-address exist in the system
         if 'source_address' in flow_config['sflow']:
-            if not is_addr_assigned(flow_config['sflow']['source_address']):
+            if not is_addr_assigned(flow_config['sflow']['source_address'], sflow_vrf):
                 tmp = flow_config['sflow']['source_address']
                 raise ConfigError(f'Configured "sflow source-address {tmp}" does not exist on the system!')
 


### PR DESCRIPTION
## Change Summary
Add vrf configured for flow-accounting/ flow to the `is_addr_assigned()` call

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T4571

## Component(s) name
conf_mode

## Proposed changes
`is_addr_assigned()` already works with vrfs, the call from `flow_accounting_conf.py` `verify()` uses the default `None` so when a vrf is configured for sflow, non of the IP addresses of that VRF can be used as a sflow agent address, only non-vrf ones.
This change defaults to `None`, but in the case a vrf for sflow is configured it will validate for IPs assigned in that vrf

## How to test

- Create VRF, put interface in vrf, add IP address to interface
- Setup flow-accounting with sflow

  set system flow-accounting buffer-size 64
  set system flow-accounting disable-imt
  set system flow-accounting vrf <vrf name> 
  set system flow-accounting interface <interface name>
  set system flow-accounting sflow agent-address <IP from vrf/interface>
  set system flow-accounting sflow sampling-rate 100
  set system flow-accounting sflow server <sflow collector IP>  port 6343  

- commit, and we'll see

`Configured "sflow agent-address <IP> " does not exist in the system!`

- apply fix, restart vyos-configd, commit now succeeds, sflow data contains correct agent address


## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
