### PR TITLE
nat: T4531: Fix op-mode NAT rules add default values

### DIFF
--- a/src/op_mode/nat.py
+++ b/src/op_mode/nat.py
@@ -52,6 +52,9 @@ def _get_raw_data_rules(direction):
 
 
 def _get_formatted_output_rules(data, direction):
+    # Add default values before loop
+    sport, dport, proto = 'any', 'any', 'any'
+    saddr, daddr = '0.0.0.0/0', '0.0.0.0/0'
     data_entries = []
     for rule in data:
         if 'comment' in rule['rule']:


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Op-mode Fix `show nat source rules`
Add default values for the function `_get_formatted_output_rules()`
For variables:
  sport, dport, proto, saddr, daddr
As in parser and loop those values or some of them may not occur
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4531

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS config1:
```
set nat source rule 10 destination address '192.0.2.0/24'
set nat source rule 10 exclude
set nat source rule 10 outbound-interface 'any'
set nat source rule 10 protocol 'all'
set nat source rule 10 source address '0.0.0.0/0'
set nat source rule 100 outbound-interface 'eth0'
set nat source rule 100 source address '203.0.113.0/24'
set nat source rule 100 translation address 'masquerade'
```
Before fix:
```
vyos@r14# run show nat source rules 
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/nat.py", line 157, in <module>
    res = vyos.opmode.run(sys.modules[__name__])
  File "/usr/lib/python3/dist-packages/vyos/opmode.py", line 118, in run
    res = func(**args)
  File "/usr/libexec/vyos/op_mode/nat.py", line 152, in show_rules
    return _get_formatted_output_rules(nat_rules, direction)
  File "/usr/libexec/vyos/op_mode/nat.py", line 103, in _get_formatted_output_rules
    sport {sport}'''
UnboundLocalError: local variable 'sport' referenced before assignment
[edit]
vyos@r14# 

```
After Fix:
```
vyos@r14:~$ show nat source rules 
Rule    Source          Destination    Proto    Out-Int    Translation
------  --------------  -------------  -------  ---------  -------------
10      0.0.0.0/0       192.0.2.0/24   IP       any        exclude
        sport any       dport any
100     203.0.113.0/24  0.0.0.0/0      IP       eth0       masquerade
        sport any       dport any
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
