### PR TITLE
vxlan: T4570: Verify MTU for remote address if source not defined

### DIFF
--- a/src/conf_mode/interfaces-vxlan.py
+++ b/src/conf_mode/interfaces-vxlan.py
@@ -118,6 +118,11 @@ def verify(vxlan):
             # in use.
             vxlan_overhead += 20
 
+        # If source_address is not used - check IPv6 'remote' list
+        elif 'remote' in vxlan:
+            if any(is_ipv6(a) for a in vxlan['remote']):
+                vxlan_overhead += 20
+
         lower_mtu = Interface(vxlan['source_interface']).get_mtu()
         if lower_mtu < (int(vxlan['mtu']) + vxlan_overhead):
             raise ConfigError(f'Underlaying device MTU is to small ({lower_mtu} '\


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
In some cases, `source_address` can be not defined in the configuration
So we should check list of `remote` vxlanX addresses
If the remote address is IPv6 - add overhead +20 bytes to the default
overhead 50. I.e., +70 bytes for IPv6
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4570

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vxlan
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set vrf name test table '1010'
set interfaces vxlan vxlan0 address 2001:db8:2020::1/64
set interfaces vxlan vxlan0 remote '2001:db8:2222::1'
set interfaces vxlan vxlan0 mtu '1370'
set interfaces vxlan vxlan0 port '4789'
set interfaces vxlan vxlan0 source-interface 'wg0'
set interfaces vxlan vxlan0 vni '123'
set interfaces wireguard wg0 address '2001:db8:4411::1/64'
set interfaces wireguard wg0 peer PEER01 allowed-ips '::/0'
set interfaces wireguard wg0 peer PEER01 public-key 'VVfR5S0yi+QPEJRLr25ZAfzFnwZM40G5WCZ/7ou7h3k='
set interfaces wireguard wg0 private-key 'yGOy08Kv8KUe8rsO6WHeo5jC7YdOAzQK0SJkDFQWlmA='
set interfaces wireguard wg0 vrf 'test'

```
Before fix:
```
Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/interfaces-vxlan.py", line 176, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/interfaces-vxlan.py", line 167, in apply
    v.update(vxlan)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 1539, in update
    self.set_mtu(config.get('mtu'))
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 443, in set_mtu
    return self.set_interface('mtu', mtu)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/control.py", line 183, in set_interface
    return self._set_command(self.config, name, value)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/control.py", line 110, in _set_command
    return self._command_set[name].get('format', lambda _: _)(self._cmd(cmd))
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/control.py", line 52, in _cmd
    return cmd(command, self.debug)
  File "/usr/lib/python3/dist-packages/vyos/util.py", line 161, in cmd
    raise OSError(code, feedback)
FileNotFoundError: [Errno 2] failed to run command: ip link set dev vxlan0 mtu 1370
returned: 
exit code: 2

noteworthy:
cmd 'nft -c delete element inet vrf_zones ct_iface_map { "vxlan0" }'
returned (out):

returned (err):
Error: Could not process rule: No such file or directory
delete element inet vrf_zones ct_iface_map { vxlan0 }
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cmd 'ip link set dev vxlan0 mtu 1370'
returned (out):
```
After fix:
```
vyos@r14# commit
[ interfaces vxlan vxlan0 ]

WARNING: RFC7348 recommends VXLAN tunnels preserve a 1500 byte MTU
Underlaying device MTU is to small (1420 bytes) for VXLAN overhead (70
bytes!)

[[interfaces vxlan vxlan0]] failed
Commit failed
[edit]
vyos@r14# 
```
Exptected MTU for vxlan = 1350
```
vyos@r14# set interfaces vxlan vxlan0 mtu '1350'
[edit]
vyos@r14# commit
[ interfaces vxlan vxlan0 ]

WARNING: RFC7348 recommends VXLAN tunnels preserve a 1500 byte MTU

[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
