### PR TITLE
nat: T4543: Fix and rewrite show nat source statistics

### DIFF
--- a/op-mode-definitions/nat.xml.in
+++ b/op-mode-definitions/nat.xml.in
@@ -22,7 +22,7 @@
                 <properties>
                   <help>Show statistics for configured source NAT rules</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/show_nat_statistics.py --source</command>
+                <command>${vyos_op_scripts_dir}/nat.py show_statistics --direction source</command>
               </node>
               <node name="translations">
                 <properties>

--- a/src/op_mode/nat.py
+++ b/src/op_mode/nat.py
@@ -147,12 +147,38 @@ port {port}'''
     return output
 
 
+def _get_formatted_output_statistics(data, direction):
+    data_entries = []
+    for rule in data:
+        if 'comment' in rule['rule']:
+            comment = rule.get('rule').get('comment')
+            rule_number = comment.split('-')[-1]
+            rule_number = rule_number.split(' ')[0]
+        if 'expr' in rule['rule']:
+            interface = rule.get('rule').get('expr')[0].get('match').get('right') \
+                if jmespath.search('rule.expr[*].match.left.meta', rule) else 'any'
+            packets = jmespath.search('rule.expr[*].counter.packets | [0]', rule)
+            _bytes = jmespath.search('rule.expr[*].counter.bytes | [0]', rule)
+        data_entries.append([rule_number, packets, _bytes, interface])
+    headers = ["Rule", "Packets", "Bytes", "Interface"]
+    output = tabulate(data_entries, headers, numalign="left")
+    return output
+
+
 def show_rules(raw: bool, direction: str):
     nat_rules = _get_raw_data_rules(direction)
     if raw:
         return nat_rules
     else:
         return _get_formatted_output_rules(nat_rules, direction)
+
+
+def show_statistics(raw: bool, direction: str):
+    nat_statistics = _get_raw_data_rules(direction)
+    if raw:
+        return nat_statistics
+    else:
+        return _get_formatted_output_statistics(nat_statistics, direction)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Rewrite `show nat source statistics`
Use new format `vyos.opmode module`
Ability to get raw and formatted output
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4543

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS config:
```
set nat source rule 10 description 'Masquerade to NAT'
set nat source rule 10 outbound-interface 'eth0'
set nat source rule 10 translation address 'masquerade'
set nat source rule 20 destination address '192.0.2.0/24'
set nat source rule 20 exclude
set nat source rule 20 outbound-interface 'any'
set nat source rule 20 protocol 'all'
set nat source rule 30 destination address '192.0.2.0/24'
set nat source rule 30 outbound-interface 'any'
set nat source rule 30 protocol 'tcp'
set nat source rule 30 source address '203.0.113.0/24'
set nat source rule 30 translation address '100.64.0.5'
set nat source rule 40 destination address '192.0.2.85/32'
set nat source rule 40 destination port '22001-22005'
set nat source rule 40 outbound-interface 'eth0'
set nat source rule 40 protocol 'tcp_udp'
set nat source rule 40 source port '65001-65005'
set nat source rule 40 translation address 'masquerade'

```
Current output (incorrect Interface for rule 20-30):
```
vyos@r14:~$ show nat source statistics 

rule      pkts        bytes   interface
----      ----        -----   ---------

10          79         5956   eth0

20           3          434   {'prefix': {'addr': '192.0.2.0', 'len': 24}}

30           0            0   tcp

40           0            0   eth0

40           0            0   eth0

vyos@r14:~$
```
New output after rewriting:
```
vyos@r14:~$ show nat source statistics 
Rule    Packets    Bytes    Interface
------  ---------  -------  -----------
10      5          380      eth0
20      0          0        any
30      0          0        any
40      0          0        eth0
40      0          0        eth0
vyos@r14:~$ 
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
