### PR TITLE
router-advert: T4582: fix preferred cannot equal valid lifetime

### DIFF
--- a/src/conf_mode/service_router-advert.py
+++ b/src/conf_mode/service_router-advert.py
@@ -90,8 +90,8 @@ def verify(rtradv):
                 if preferred_lifetime == 'infinity':
                     preferred_lifetime = 4294967295
 
-                if not (int(valid_lifetime) > int(preferred_lifetime)):
-                    raise ConfigError('Prefix valid-lifetime must be greater then preferred-lifetime')
+                if not (int(valid_lifetime) >= int(preferred_lifetime)):
+                    raise ConfigError('Prefix valid-lifetime must be greater then or equal to preferred-lifetime')
 
         if 'name_server_lifetime' in interface_config:
             # man page states:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

Fixes the preferred lifetime versus valid lifetime check to allow for both values to be equal and modifies the error message to be more clear on what the new constrain is.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4582

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

router-advert

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Add the following configuration to the configuration:
```
 interface eth0 {
     prefix ::/64 {
         preferred-lifetime 86400
         valid-lifetime 86400
     }
 }
```
and validate that the commit passes successfully.

Trying this config:
```
 interface eth0 {
     prefix ::/64 {
         preferred-lifetime 86401
         valid-lifetime 86400
     }
 }
```
should yield a config error with:

> Prefix valid-lifetime must be greater then or equal to preferred-lifetime


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
