### PR TITLE
vrf: T4562: Check VRF if it has not been configured

### DIFF
--- a/src/op_mode/vrf.py
+++ b/src/op_mode/vrf.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
+import jmespath
 import sys
 import typing
 
@@ -76,6 +77,8 @@ def _get_formatted_output(raw_data):
 
 def show(raw: bool, name: typing.Optional[str]):
     vrf_data = _get_raw_data(name=name)
+    if not jmespath.search('[*].ifname', vrf_data):
+        return "VRF is not configured"
     if raw:
         return vrf_data
     else:


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Op-mode
Check the list of VRFs, check key 'ifname' is configured
If not configured, return the message `VRF is not configured`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4562

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrf
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
`show vrf` without configured vrf
Current output:
```
vyos@r14:~$ /usr/libexec/vyos/op_mode/vrf.py show
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/vrf.py", line 89, in <module>
    res = vyos.opmode.run(sys.modules[__name__])
  File "/usr/lib/python3/dist-packages/vyos/opmode.py", line 118, in run
    res = func(**args)
  File "/usr/libexec/vyos/op_mode/vrf.py", line 84, in show
    return _get_formatted_output(vrf_data)
  File "/usr/libexec/vyos/op_mode/vrf.py", line 68, in _get_formatted_output
    state = vrf.get('operstate').lower()
AttributeError: 'NoneType' object has no attribute 'lower'
vyos@r14:~$ 
```
After fix:
```
vyos@r14:~$ show vrf
VRF is not configured
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
