### PR TITLE
mtu: T4572: Add DHCP-option MTU to get values from DHCP-server

### DIFF
--- a/interface-definitions/include/interface/dhcp-options.xml.i
+++ b/interface-definitions/include/interface/dhcp-options.xml.i
@@ -14,6 +14,12 @@
         <help>Override system host-name sent to DHCP server</help>
       </properties>
     </leafNode>
+    <leafNode name="mtu">
+      <properties>
+        <help>Use MTU value from DHCP server - ignore interface setting</help>
+        <valueless/>
+      </properties>
+    </leafNode>
     <leafNode name="vendor-class-id">
       <properties>
         <help>Identify the vendor client type to the DHCP server</help>

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1375,7 +1375,7 @@ class Interface(Control):
         # before mangling any IPv6 option. If MTU is less then 1280 IPv6 will be
         # automatically disabled by the kernel. Also MTU must be increased before
         # configuring any IPv6 address on the interface.
-        if 'mtu' in config:
+        if 'mtu' in config and dict_search('dhcp_options.mtu', config) == None:
             self.set_mtu(config.get('mtu'))
 
         # Only change IPv6 parameters if IPv6 was not explicitly disabled


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to get MTU from DHCP-server and don't touch it per
any interface change if interface 'dhcp-options mtu' is
configured

(cherry picked from commit 29b0ee30bf2622a40ca3d17e3f6b9e94e5b62072)
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4572

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
mtu, dhcp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
