### PR TITLE
containers: T4585: Add option restart to containers.py

### DIFF
--- a/op-mode-definitions/container.xml.in
+++ b/op-mode-definitions/container.xml.in
@@ -149,7 +149,7 @@
             <path>container name</path>
           </completionHelp>
         </properties>
-        <command>sudo podman restart "$3"</command>
+        <command>sudo ${vyos_op_scripts_dir}/container.py restart name="$3"</command>
       </tagNode>
     </children>
   </node>

--- a/src/op_mode/container.py
+++ b/src/op_mode/container.py
@@ -64,6 +64,17 @@ def show_network(raw: bool):
         return cmd(command)
 
 
+def restart(name: str):
+    from vyos.util import rc_cmd
+
+    rc, output = rc_cmd(f'sudo podman restart {name}')
+    if rc != 0:
+        print(output)
+        return None
+    print(f'Container name "{name}" restarted!')
+    return output
+
+
 if __name__ == '__main__':
     try:
         res = vyos.opmode.run(sys.modules[__name__])


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add option restart to `containers.py`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4585

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
containers
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
vyos@r14:~$ /usr/libexec/vyos/op_mode/container.py restart --name alp01
Container name "alp01" restarted!
vyos@r14:~$ 
vyos@r14:~$ /usr/libexec/vyos/op_mode/container.py restart --name alp02
Error: no container with name or ID alp02 found: no such container
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
