### PR TITLE
nat66: T4586: Add SNAT destination prefix and DNAT address

### DIFF
--- a/data/templates/firewall/nftables-nat66.j2
+++ b/data/templates/firewall/nftables-nat66.j2
@@ -3,8 +3,10 @@
 {% macro nptv6_rule(rule,config, chain) %}
 {% set comment  = '' %}
 {% set base_log = '' %}
-{% set src_prefix  = 'ip6 saddr ' ~ config.source.prefix if config.source.prefix is vyos_defined %}
-{% set dest_address  = 'ip6 daddr ' ~ config.destination.address if config.destination.address is vyos_defined %}
+{% set dst_prefix  = 'ip6 daddr ' ~ config.destination.prefix.replace('!','!= ') if config.destination.prefix is vyos_defined %}
+{% set src_prefix  = 'ip6 saddr ' ~ config.source.prefix.replace('!','!= ') if config.source.prefix is vyos_defined %}
+{% set source_address  = 'ip6 saddr ' ~ config.source.address.replace('!','!= ') if config.source.address is vyos_defined %}
+{% set dest_address  = 'ip6 daddr ' ~ config.destination.address.replace('!','!= ') if config.destination.address is vyos_defined %}
 {% if chain is vyos_defined('PREROUTING') %}
 {%     set comment   = 'DST-NAT66-' ~ rule %}
 {%     set base_log  = '[NAT66-DST-' ~ rule %}
@@ -51,6 +53,12 @@
 {% endif %}
 {% if src_prefix is vyos_defined %}
 {%     set output = output ~ ' ' ~ src_prefix %}
+{% endif %}
+{% if dst_prefix is vyos_defined %}
+{%     set output = output ~ ' ' ~ dst_prefix %}
+{% endif %}
+{% if source_address is vyos_defined %}
+{%     set output = output ~ ' ' ~ source_address %}
 {% endif %}
 {% if dest_address is vyos_defined %}
 {%     set output = output ~ ' ' ~ dest_address %}

--- a/interface-definitions/nat66.xml.in
+++ b/interface-definitions/nat66.xml.in
@@ -49,6 +49,30 @@
                   </completionHelp>
                 </properties>
               </leafNode>
+              <node name="destination">
+                <properties>
+                  <help>IPv6 destination prefix options</help>
+                </properties>
+                <children>
+                  <leafNode name="prefix">
+                    <properties>
+                      <help>IPv6 prefix to be translated</help>
+                      <valueHelp>
+                        <format>ipv6net</format>
+                        <description>IPv6 prefix</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>!ipv6net</format>
+                        <description>Match everything except the specified IPv6 prefix</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="ipv6-prefix"/>
+                        <validator name="ipv6-prefix-exclude"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
               <node name="source">
                 <properties>
                   <help>IPv6 source prefix options</help>
@@ -61,8 +85,13 @@
                         <format>ipv6net</format>
                         <description>IPv6 prefix</description>
                       </valueHelp>
+                      <valueHelp>
+                        <format>!ipv6net</format>
+                        <description>Match everything except the specified IPv6 prefix</description>
+                      </valueHelp>
                       <constraint>
                         <validator name="ipv6-prefix"/>
+                        <validator name="ipv6-prefix-exclude"/>
                       </constraint>
                     </properties>
                   </leafNode>
@@ -164,9 +193,53 @@
                         <format>ipv6net</format>
                         <description>IPv6 prefix</description>
                       </valueHelp>
+                      <valueHelp>
+                        <format>!ipv6</format>
+                        <description>Match everything except the specified IPv6 address</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>!ipv6net</format>
+                        <description>Match everything except the specified IPv6 prefix</description>
+                      </valueHelp>
                       <constraint>
                         <validator name="ipv6-address"/>
                         <validator name="ipv6-prefix"/>
+                        <validator name="ipv6-address-exclude"/>
+                        <validator name="ipv6-prefix-exclude"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+              <node name="source">
+                <properties>
+                  <help>IPv6 source prefix options</help>
+                </properties>
+                <children>
+                  <leafNode name="address">
+                    <properties>
+                      <help>IPv6 address or prefix to be translated</help>
+                      <valueHelp>
+                        <format>ipv6</format>
+                        <description>IPv6 address</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>ipv6net</format>
+                        <description>IPv6 prefix</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>!ipv6</format>
+                        <description>Match everything except the specified IPv6 address</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>!ipv6net</format>
+                        <description>Match everything except the specified IPv6 prefix</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="ipv6-address"/>
+                        <validator name="ipv6-prefix"/>
+                        <validator name="ipv6-address-exclude"/>
+                        <validator name="ipv6-prefix-exclude"/>
                       </constraint>
                     </properties>
                   </leafNode>

--- a/src/validators/ipv6-address-exclude
+++ b/src/validators/ipv6-address-exclude
@@ -1,0 +1,7 @@
+#!/bin/sh
+arg="$1"
+if [ "${arg:0:1}" != "!" ]; then
+  exit 1
+fi
+path=$(dirname "$0")
+${path}/ipv6-address "${arg:1}"

--- a/src/validators/ipv6-prefix-exclude
+++ b/src/validators/ipv6-prefix-exclude
@@ -1,0 +1,7 @@
+#!/bin/sh
+arg="$1"
+if [ "${arg:0:1}" != "!" ]; then
+  exit 1
+fi
+path=$(dirname "$0")
+${path}/ipv6-prefix "${arg:1}"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to configure SNAT destination prefix and
DNAT source address
Add option `"!"` - not address/prefix for NAT66
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4586

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat66
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Nat configuration:
```
set nat66 source rule 10 destination prefix '2001:db8::2/128'
set nat66 source rule 10 outbound-interface 'eth1'
set nat66 source rule 10 source prefix '2001:db8:1111::/64'
set nat66 source rule 10 translation address 'masquerade'

set nat66 source rule 20 destination prefix '!2001:db8::6/127'
set nat66 source rule 20 outbound-interface 'eth1'
set nat66 source rule 20 source prefix '2001:db8:1111::/64'
set nat66 source rule 20 translation address 'masquerade'

set nat66 destination rule 10 destination address '2001:db8:1111::/64'
set nat66 destination rule 10 inbound-interface 'eth1'
set nat66 destination rule 10 source address '!2001:db8::6/127'
set nat66 destination rule 10 translation address '2001:db8::444'

```
Nftables:
```
vyos@r14# sudo nft list table ip6 nat
table ip6 nat {
	chain PREROUTING {
		type nat hook prerouting priority dstnat; policy accept;
		iifname "eth1" counter packets 1 bytes 166 ip6 saddr != 2001:db8::6/127 ip6 daddr 2001:db8:1111::/64 dnat to 2001:db8::444 comment "DST-NAT66-10"
	}

	chain POSTROUTING {
		type nat hook postrouting priority srcnat; policy accept;
		oifname "eth1" counter packets 0 bytes 0 ip6 saddr 2001:db8:1111::/64 ip6 daddr 2001:db8::2 masquerade comment "SRC-NAT66-10"
		oifname "eth1" counter packets 0 bytes 0 ip6 saddr 2001:db8:1111::/64 ip6 daddr != 2001:db8::6/127 masquerade comment "SRC-NAT66-20"
	}
...
}

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
