### PR TITLE
ocserv: T4597: Check bind port before openconnect commit

### DIFF
--- a/src/conf_mode/vpn_openconnect.py
+++ b/src/conf_mode/vpn_openconnect.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2020 VyOS maintainers and contributors
+# Copyright (C) 2018-2022 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -23,6 +23,7 @@ from vyos.pki import wrap_certificate
 from vyos.pki import wrap_private_key
 from vyos.template import render
 from vyos.util import call
+from vyos.util import check_port_availability
 from vyos.util import is_systemd_service_running
 from vyos.util import dict_search
 from vyos.xml import defaults
@@ -75,6 +76,10 @@ def get_config():
 def verify(ocserv):
     if ocserv is None:
         return None
+    # Check if listen-ports not binded other services
+    for proto, port in ocserv.get('listen_ports').items():
+        if check_port_availability('0.0.0.0', int(port), proto) is not True:
+            raise ConfigError(f'"{proto}" port "{port}" is used by another service')
     # Check authentication
     if "authentication" in ocserv:
         if "mode" in ocserv["authentication"]:


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Check if openconnect listen port is available and not used by
another service

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4597

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openconnect
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure 2 services that bind the same port or port is already used by another service:
```
set service https api gql
set service https api keys id KID key 'foo'
set service https api socket
commit

set vpn openconnect authentication local-users username foo password 'bar'
set vpn openconnect authentication mode local 'password'
set vpn openconnect network-settings client-ip-settings subnet '100.64.0.0/24'
set vpn openconnect ssl ca-certificate 'ca-ocserv'
set vpn openconnect ssl certificate 'srv-ocserv'
commit
```
Service `ocserv` not started:
```
vyos@r14# sudo netstat -tulpn | grep 443
tcp        0      0 0.0.0.0:443             0.0.0.0:*               LISTEN      15283/nginx: master 
tcp6       0      0 :::443                  :::*                    LISTEN      15283/nginx: master 
[edit]
vyos@r14# sudo systemctl status ocserv.service
● ocserv.service - OpenConnect SSL VPN server
     Loaded: loaded (/lib/systemd/system/ocserv.service; disabled; vendor preset: enabled)
    Drop-In: /etc/systemd/system/ocserv.service.d
             └─override.conf
     Active: failed (Result: exit-code) since Fri 2022-08-05 14:36:51 EEST; 9s ago
       Docs: man:ocserv(8)
    Process: 15405 ExecStart=/usr/sbin/ocserv --foreground --pid-file /run/ocserv/ocserv.pid --config /run/ocserv/ocserv.conf (code=exited, status=1/FAILURE)
   Main PID: 15405 (code=exited, status=1/FAILURE)
        CPU: 6ms

Aug 05 14:36:51 r14 ocserv[15405]: main: CN=vyos.io,O=VyOS,L=Dnipro,ST=Denwer,C=US certificate key usage prevents key encipherment; unable to support the RSA ciphersuites; if that is not intentiona>
Aug 05 14:36:51 r14 ocserv[15405]: error connecting to sec-mod socket '/run/ocserv/ocserv.socket.e4a4a64e': No such file or directory
Aug 05 14:36:51 r14 ocserv[15405]: note: setting 'file' as supplemental config option
Aug 05 14:36:51 r14 ocserv[15405]: listening (TCP) on 0.0.0.0:443...
Aug 05 14:36:51 r14 ocserv[15405]: bind() failed: Address already in use
Aug 05 14:36:51 r14 ocserv[15405]: listening (TCP) on [::]:443...
Aug 05 14:36:51 r14 ocserv[15405]: bind() failed: Address already in use
Aug 05 14:36:51 r14 ocserv[15405]: Could not listen to any TCP or UNIX ports
Aug 05 14:36:51 r14 systemd[1]: ocserv.service: Main process exited, code=exited, status=1/FAILURE
Aug 05 14:36:51 r14 systemd[1]: ocserv.service: Failed with result 'exit-code'.
lines 1-20/20 (END)
```

After fix:
```
vyos@r14# commit
[ vpn openconnect ]
"tcp" port "443" is used by another service

[[vpn openconnect]] failed
Commit failed
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
