### PR TITLE
nat66: T4598: Add exclude options in nat66

### DIFF
--- a/data/templates/firewall/nftables-nat66.j2
+++ b/data/templates/firewall/nftables-nat66.j2
@@ -63,6 +63,10 @@
 {% if dest_address is vyos_defined %}
 {%     set output = output ~ ' ' ~ dest_address %}
 {% endif %}
+{% if config.exclude is vyos_defined %}
+{#     rule has been marked as 'exclude' thus we simply return here #}
+{%     set trns_address = 'return' %}
+{% endif %}
 {% if trns_address is vyos_defined %}
 {%     set output = output ~ ' ' ~ trns_address %}
 {% endif %}

--- a/interface-definitions/include/nat-exclude.xml.i
+++ b/interface-definitions/include/nat-exclude.xml.i
@@ -1,0 +1,8 @@
+<!-- include start from nat-exclude.xml.i -->
+<leafNode name="exclude">
+   <properties>
+     <help>Exclude packets matching this rule from NAT</help>
+     <valueless/>
+   </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/nat-rule.xml.i
+++ b/interface-definitions/include/nat-rule.xml.i
@@ -23,12 +23,7 @@
       </children>
     </node>
     #include <include/generic-disable-node.xml.i>
-    <leafNode name="exclude">
-      <properties>
-        <help>Exclude packets matching this rule from NAT</help>
-        <valueless/>
-      </properties>
-    </leafNode>
+    #include <include/nat-exclude.xml.i>
     <leafNode name="log">
       <properties>
         <help>NAT rule logging</help>

--- a/interface-definitions/nat66.xml.in
+++ b/interface-definitions/nat66.xml.in
@@ -35,6 +35,12 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <leafNode name="exclude">
+                <properties>
+                  <help>Exclude packets matching this rule from NAT</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
               <leafNode name="log">
                 <properties>
                   <help>NAT66 rule logging</help>
@@ -159,6 +165,12 @@
               <leafNode name="disable">
                 <properties>
                   <help>Disable NAT66 rule</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="exclude">
+                <properties>
+                  <help>Exclude packets matching this rule from NAT</help>
                   <valueless/>
                 </properties>
               </leafNode>

--- a/interface-definitions/nat66.xml.in
+++ b/interface-definitions/nat66.xml.in
@@ -35,12 +35,7 @@
                   <valueless/>
                 </properties>
               </leafNode>
-              <leafNode name="exclude">
-                <properties>
-                  <help>Exclude packets matching this rule from NAT</help>
-                  <valueless/>
-                </properties>
-              </leafNode>
+              #include <include/nat-exclude.xml.i>
               <leafNode name="log">
                 <properties>
                   <help>NAT66 rule logging</help>
@@ -168,12 +163,7 @@
                   <valueless/>
                 </properties>
               </leafNode>
-              <leafNode name="exclude">
-                <properties>
-                  <help>Exclude packets matching this rule from NAT</help>
-                  <valueless/>
-                </properties>
-              </leafNode>
+              #include <include/nat-exclude.xml.i>
               <leafNode name="log">
                 <properties>
                   <help>NAT66 rule logging</help>

--- a/src/conf_mode/nat66.py
+++ b/src/conf_mode/nat66.py
@@ -125,7 +125,8 @@ def verify(nat):
                 if addr != 'masquerade' and not is_ipv6(addr):
                     raise ConfigError(f'IPv6 address {addr} is not a valid address')
             else:
-                raise ConfigError(f'{err_msg} translation address not specified')
+                if 'exclude' not in config:
+                    raise ConfigError(f'{err_msg} translation address not specified')
 
             prefix = dict_search('source.prefix', config)
             if prefix != None:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add exclude options in nat66 rules.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4598

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat66

## Proposed changes
<!--- Describe your changes in detail -->
Add exclude option in nat66. Useful in many scenario, and already supported in nat.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configuration:
```
set nat66 destination rule 10 inbound-interface 'eth1'
set nat66 destination rule 10 destination address '2001:db8::1'
set nat66 destination rule 10 source address 'fc00::01'
set nat66 destination rule 10 exclude
set nat66 destination rule 20 inbound-interface 'eth1'
set nat66 destination rule 20 destination address '2001:db8::1'
set nat66 destination rule 20 translation address 'fc01::1'

set nat66 source rule 10 outbound-interface 'eth1'
set nat66 source rule 10 source prefix 'fc00::/64'
set nat66 source rule 10 destination prefix 'fc99::/64'
set nat66 source rule 10 exclude
set nat66 source rule 20 outbound-interface 'eth1'
set nat66 source rule 20 source prefix 'fc00::/64'
set nat66 source rule 20 translation address 'masquerade'
```
nftables:
```
vyos@vyos# sudo nft list table ip6 nat
table ip6 nat {
	chain PREROUTING {
		type nat hook prerouting priority dstnat; policy accept;
		iifname "eth1" counter packets 0 bytes 0 ip6 saddr fc00::1 ip6 daddr 2001:db8::1 return comment "DST-NAT66-10"
		iifname "eth1" counter packets 0 bytes 0 ip6 daddr 2001:db8::1 dnat to fc01::1 comment "DST-NAT66-20"
	}

	chain POSTROUTING {
		type nat hook postrouting priority srcnat; policy accept;
		oifname "eth1" counter packets 0 bytes 0 ip6 saddr fc00::/64 ip6 daddr fc99::/64 return comment "SRC-NAT66-10"
		oifname "eth1" counter packets 0 bytes 0 ip6 saddr fc00::/64 masquerade comment "SRC-NAT66-20"
	}

	chain VYOS_DNPT_HOOK {
	}

	chain VYOS_SNPT_HOOK {
	}
}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
