### PR TITLE
ocserv: T4596: Rewrite show openconnect sessions op-mode

### DIFF
--- a/data/op-mode-standardized.json
+++ b/data/op-mode-standardized.json
@@ -6,6 +6,7 @@
 "memory.py",
 "nat.py",
 "neighbor.py",
+"openconnect.py",
 "route.py",
 "version.py",
 "vrf.py"

--- a/op-mode-definitions/openconnect.xml.in
+++ b/op-mode-definitions/openconnect.xml.in
@@ -11,7 +11,7 @@
             <properties>
               <help>Show active OpenConnect server sessions</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/openconnect-control.py --action="show_sessions"</command>
+            <command>${vyos_op_scripts_dir}/openconnect.py show_sessions</command>
           </leafNode>
           <tagNode name="user">
             <properties>

--- a/src/op_mode/openconnect-control.py
+++ b/src/op_mode/openconnect-control.py
@@ -19,7 +19,6 @@ import argparse
 import json
 
 from vyos.config import Config
-from vyos.util import commit_in_progress
 from vyos.util import popen
 from vyos.util import run
 from vyos.util import DEVNULL
@@ -59,10 +58,6 @@ def main():
 
     # Check is Openconnect server configured
     is_ocserv_configured()
-
-    if commit_in_progress():
-        print('Cannot restart openconnect while a commit is in progress')
-        exit(1)
 
     if args.action == "restart":
         run("sudo systemctl restart ocserv.service")

--- a/src/op_mode/openconnect.py
+++ b/src/op_mode/openconnect.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import json
+
+from tabulate import tabulate
+from vyos.configquery import ConfigTreeQuery
+from vyos.util import rc_cmd
+
+import vyos.opmode
+
+
+occtl        = '/usr/bin/occtl'
+occtl_socket = '/run/ocserv/occtl.socket'
+
+
+def _get_raw_data_sessions():
+    rc, out = rc_cmd(f'sudo {occtl} --json --socket-file {occtl_socket} show users')
+    if rc != 0:
+        output = {'openconnect':
+            {
+                'configured': False,
+                'return_code': rc,
+                'reason': out
+            }
+        }
+        return output
+
+    sessions = json.loads(out)
+    return sessions
+
+
+def _get_formatted_sessions(data):
+    headers = ["Interface", "Username", "IP", "Remote IP", "RX", "TX", "State", "Uptime"]
+    ses_list = []
+    for ses in data:
+        ses_list.append([
+            ses["Device"], ses["Username"], ses["IPv4"], ses["Remote IP"], 
+            ses["_RX"], ses["_TX"], ses["State"], ses["_Connected at"]
+        ])
+    if len(ses_list) > 0:
+        output = tabulate(ses_list, headers)
+    else:
+        output = 'No active openconnect sessions'
+    return output
+
+
+def show_sessions(raw: bool):
+    config = ConfigTreeQuery()
+    if not config.exists('vpn openconnect') and not raw:
+        print('Openconnect is not configured')
+        exit(0)
+
+    openconnect_data = _get_raw_data_sessions()
+    if raw:
+        return openconnect_data
+    return _get_formatted_sessions(openconnect_data)
+
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except (ValueError, vyos.opmode.Error) as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Rewrite `show openconnect-server sessions` to `vyos.opmode` format
Ability to get raw and formatted output
Ability to get data via API
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4596

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openconnect
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure `vpn openconnect` and check output:
Not configured:
```
vyos@r14# /usr/libexec/vyos/op_mode/openconnect.py show_sessions
Openconnect is not configured
[edit]
vyos@r14# 
```
Not Configured, raw:
```
vyos@r14# /usr/libexec/vyos/op_mode/openconnect.py show_sessions --raw
{
    "openconnect": {
        "configured": false,
        "return_code": 1,
        "reason": "error connecting to ocserv socket '/run/ocserv/occtl.socket': No such file or directory"
    }
}
[edit]
vyos@r14# 
```
Configured:
```
vyos@r14:~$ show openconnect-server sessions 
Interface    Username    IP            Remote IP        RX         TX         State      Uptime
-----------  ----------  ------------  ---------------  ---------  ---------  ---------  --------
sslvpn0      foo         100.64.0.225  192.168.122.220  384 bytes  152 bytes  connected  13m:18s
vyos@r14:~$ 
```
Configured raw:
```

vyos@r14:~$ /usr/libexec/vyos/op_mode/openconnect.py show_sessions --raw
[
    {
        "ID": 5303,
        "Username": "foo",
        "Groupname": "(none)",
        "State": "connected",
        "vhost": "default",
        "Device": "sslvpn0",
        "MTU": "1434",
        "Remote IP": "192.168.122.220",
        "Location": "unknown",
        "Local Device IP": "192.168.122.14",
        "IPv4": "100.64.0.225",
        "P-t-P IPv4": "100.64.0.1",
        "User-Agent": "OpenConnect VPN Agent (NetworkManager) v8.20-1",
        "RX": "384",
        "TX": "152",
        "_RX": "384 bytes",
        "_TX": "152 bytes",
        "Average RX": "0 bytes/sec",
        "Average TX": "0 bytes/sec",
        "DPD": "60",
        "KeepAlive": "300",
        "Hostname": "ubnt",
        "Connected at": "2022-08-06 12:52",
        "_Connected at": "13m:43s",
        "Full session": "3wd4NYDOA1OaxmDdCCJNf1RdaVE=",
        "Session": "3wd4NY",
        "TLS ciphersuite": "(TLS1.3)-(ECDHE-SECP256R1)-(RSA-PSS-RSAE-SHA256)-(AES-256-GCM)",
        "DTLS cipher": "(DTLS1.2)-(PSK)-(AES-256-GCM)",
        "DNS": [],
        "NBNS": [],
        "Split-DNS-Domains": [],
        "Routes": "defaultroute",
        "No-routes": [],
        "iRoutes": [],
        "Restricted to routes": "False",
        "Restricted to ports": []
    }
]
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
