### PR TITLE
dhcp-relay: T4601:  restart dhcp relay-agent

### DIFF
--- a/src/op_mode/restart_dhcp_relay.py
+++ b/src/op_mode/restart_dhcp_relay.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
             if commit_in_progress():
                 print('Cannot restart DHCP relay while a commit is in progress')
                 exit(1)
-            call('systemctl restart isc-dhcp-server.service')
+            call('systemctl restart isc-dhcp-relay.service')
 
         sys.exit(0)
     elif args.ipv6:
@@ -54,7 +54,7 @@ if __name__ == '__main__':
             if commit_in_progress():
                 print('Cannot restart DHCPv6 relay while commit is in progress')
                 exit(1)
-            call('systemctl restart isc-dhcp-server6.service')
+            call('systemctl restart isc-dhcp-relay6.service')
 
         sys.exit(0)
     else:


### PR DESCRIPTION
The command "restart dhcp relay-agent" doesn't restart "isc-dhcp-relay" service.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

> ## Types of changes
> * [x]  Bug fix (non-breaking change which fixes an issue)
> * [ ]  New feature (non-breaking change which adds functionality)
> * [ ]  Code style update (formatting, renaming)
> * [ ]  Refactoring (no functional changes)
> * [ ]  Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
> * [ ]  Other (please describe):
> 
> ## Related Task(s)
> * https://phabricator.vyos.net/T4601
> 
> ## Component(s) name
> generate tech-support archive
> 
> ## Proposed changes
> ## How to test
> Execute "restart dhcp relay-agent" command after changing "relay agent IP address".
> dhcp pool should change
> 
> ## Checklist:
> * [x]  I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
> * [x]  I have linked this PR to one or more Phabricator Task(s)
> * [ ]  I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
> * [ ]  My commit headlines contain a valid Task id
> * [ ]  My change requires a change to the documentation
> * [ ]  I have updated the documentation accordingly