### PR TITLE
T4619: Replacing instead of adding a static arp entry

### DIFF
--- a/src/conf_mode/arp.py
+++ b/src/conf_mode/arp.py
@@ -61,7 +61,7 @@ def apply(arp):
                 continue
             for address, address_config in interface_config['address'].items():
                 mac = address_config['mac']
-                call(f'ip neigh add {address} lladdr {mac} dev {interface}')
+                call(f'ip neigh replace {address} lladdr {mac} dev {interface}')
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Fix adding static arp entry.
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4619

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test

```
#run  show ip neighbors interface br3003780
Address         Interface    Link layer address    State
--------------  -----------  --------------------  ---------
194.55.234.49   br3003780                          FAILED

#set protocols static arp interface br3003780 address 194.55.234.49 mac 00:15:5d:a6:1a:01
commit
run  show ip neighbors interface br3003780
Address         Interface    Link layer address    State
--------------  -----------  --------------------  ---------
194.55.234.49   br3003780    00:15:5d:a6:1a:01     PERMANENT

```
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
