### PR TITLE
UPnP: T4211: T4620 Fix upnp template

### DIFF
--- a/data/templates/firewall/upnpd.conf.j2
+++ b/data/templates/firewall/upnpd.conf.j2
@@ -71,7 +71,7 @@ min_lifetime={{ pcp_lifetime.min }}
 
 {% if friendly_name is vyos_defined %}
 # Name of this service, default is "`uname -s` router"
-friendly_name= {{ friendly_name }}
+friendly_name={{ friendly_name }}
 {% endif  %}
 
 # Manufacturer name, default is "`uname -s`"
@@ -117,7 +117,10 @@ clean_ruleset_threshold=10
 clean_ruleset_interval=600
 
 # Anchor name in pf (default is miniupnpd)
-anchor=VyOS
+# Something wrong with this option "anchor", comment it out
+#   vyos@r14# miniupnpd -vv -f /run/upnp/miniupnp.conf
+#   invalid option in file /run/upnp/miniupnp.conf line 74 : anchor=VyOS
+#anchor=VyOS
 
 uuid={{ uuid }}
 
@@ -144,7 +147,7 @@ lease_file=/config/upnp.leases
 # CAUTION: failure to enforce any rules may permit insecure requests to be made!
 {%     for rule, config in rule.items() %}
 {%         if config.disable is not vyos_defined %}
-{{ config.action }} {{ config.external_port_range }} {{ config.ip }} {{ config.internal_port_range }}
+{{ config.action }} {{ config.external_port_range }} {{ config.ip }}{{ '/32' if '/' not in config.ip else '' }} {{ config.internal_port_range }}
 {%         endif %}
 {%     endfor %}
 {% endif %}

--- a/data/templates/firewall/upnpd.conf.j2
+++ b/data/templates/firewall/upnpd.conf.j2
@@ -129,7 +129,7 @@ lease_file=/config/upnp.leases
 #serial=12345678
 #model_number=1
 
-{% if rules is vyos_defined %}
+{% if rule is vyos_defined %}
 # UPnP permission rules
 # (allow|deny) (external port range) IP/mask (internal port range)
 # A port range is <min port>-<max port> or <port> if there is only
@@ -142,8 +142,8 @@ lease_file=/config/upnp.leases
 # modify the IP ranges to match their own internal networks, and
 # also consider implementing network-specific restrictions
 # CAUTION: failure to enforce any rules may permit insecure requests to be made!
-{%     for rule, config in rules.items() %}
-{%         if config.disable is vyos_defined %}
+{%     for rule, config in rule.items() %}
+{%         if config.disable is not vyos_defined %}
 {{ config.action }} {{ config.external_port_range }} {{ config.ip }} {{ config.internal_port_range }}
 {%         endif %}
 {%     endfor %}

--- a/interface-definitions/service-upnp.xml.in
+++ b/interface-definitions/service-upnp.xml.in
@@ -197,10 +197,15 @@
                   <help>The IP to which this rule applies (REQUIRE)</help>
                   <valueHelp>
                     <format>ipv4</format>
+                    <description>The IPv4 address to which this rule applies</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ipv4net</format>
                     <description>The IPv4 to which this rule applies</description>
                   </valueHelp>
                   <constraint>
-                    <validator name="ipv4-address" />
+                    <validator name="ipv4-address"/>
+                    <validator name="ipv4-host"/>
                   </constraint>
                 </properties>
               </leafNode>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix UPnP jinja2 template, incorrect value `rules` instead of `rule`
So rules didn't work at all.
Incorrect logic do `disabled` rule

Address must be in the format `address/mask` due to https://github.com/miniupnp/miniupnp/blob/fa42d8f9316bf9c1ca14317e5a6e0d4a21365629/miniupnpd/miniupnpd.conf#L174
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4620
* https://phabricator.vyos.net/T4611

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
upnp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS config:
```
set service upnp listen '192.0.2.2'
set service upnp rule 10 action 'allow'
set service upnp rule 10 external-port-range '1024-65535'
set service upnp rule 10 internal-port-range '1024-65535'
set service upnp rule 10 ip '10.0.0.1/24'
set service upnp wan-interface 'eth0'
set service upnp  nat-pmp
```
Expected:
```
vyos@r1# cat /run/upnp/miniupnp.conf | grep "allow 10"
allow 1024-65535 10.0.0.1/24 1024-65535
[edit]
vyos@r1# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
