### PR TITLE
T3896(adjacent): Fix ocserv local user requirement, add groupconfig

### DIFF
--- a/data/templates/ocserv/ocserv_config.j2
+++ b/data/templates/ocserv/ocserv_config.j2
@@ -7,11 +7,11 @@ run-as-user = nobody
 run-as-group = daemon
 
 {% if "radius" in authentication.mode %}
-{%      if "yes" in authentication.radius.groupconfig %}
+{%     if "yes" in authentication.radius.groupconfig %}
 auth = "radius [config=/run/ocserv/radiusclient.conf,groupconfig=true]"
-{%      else %}
+{%     else %}
 auth = "radius [config=/run/ocserv/radiusclient.conf]"
-{%      endif %}
+{%     endif %}
 {% elif "local" in authentication.mode %}
 {%     if authentication.mode.local == "password-otp" %}
 auth = "plain[passwd=/run/ocserv/ocpasswd,otp=/run/ocserv/users.oath]"
@@ -66,6 +66,13 @@ device = sslvpn
 dns = {{ dns }}
 {%     endfor %}
 {% endif %}
+{% if network_settings.tunnel_all_dns is vyos_defined %}
+{%     if "yes" in network_settings.tunnel_all_dns %}
+tunnel-all-dns = true
+{%     else %}
+tunnel-all-dns = false
+{%     endif %}
+{% endif %}
 
 # IPv4 network pool
 {% if network_settings.client_ip_settings.subnet is vyos_defined %}
@@ -87,5 +94,12 @@ route = {{ route }}
 {% if network_settings.split_dns is vyos_defined %}
 {%     for tmp in network_settings.split_dns %}
 split-dns = {{ tmp }}
+{%     endfor %}
+{% endif %}
+
+{% if authentication.groups is vyos_defined %}
+# Group settings
+{%     for grp in authentication.groups %}
+select-group = {{ grp }}
 {%     endfor %}
 {% endif %}

--- a/data/templates/ocserv/ocserv_config.j2
+++ b/data/templates/ocserv/ocserv_config.j2
@@ -7,7 +7,11 @@ run-as-user = nobody
 run-as-group = daemon
 
 {% if "radius" in authentication.mode %}
+{%      if "yes" in authentication.radius.groupconfig %}
+auth = "radius [config=/run/ocserv/radiusclient.conf,groupconfig=true]"
+{%      else %}
 auth = "radius [config=/run/ocserv/radiusclient.conf]"
+{%      endif %}
 {% elif "local" in authentication.mode %}
 {%     if authentication.mode.local == "password-otp" %}
 auth = "plain[passwd=/run/ocserv/ocpasswd,otp=/run/ocserv/users.oath]"

--- a/data/templates/ocserv/ocserv_config.j2
+++ b/data/templates/ocserv/ocserv_config.j2
@@ -7,11 +7,7 @@ run-as-user = nobody
 run-as-group = daemon
 
 {% if "radius" in authentication.mode %}
-{%     if "yes" in authentication.radius.groupconfig %}
-auth = "radius [config=/run/ocserv/radiusclient.conf,groupconfig=true]"
-{%     else %}
-auth = "radius [config=/run/ocserv/radiusclient.conf]"
-{%     endif %}
+auth = "radius [config=/run/ocserv/radiusclient.conf{{ ',groupconfig=true' if authentication.radius.groupconfig is vyos_defined else '' }}]"
 {% elif "local" in authentication.mode %}
 {%     if authentication.mode.local == "password-otp" %}
 auth = "plain[passwd=/run/ocserv/ocpasswd,otp=/run/ocserv/users.oath]"

--- a/data/templates/ocserv/ocserv_config.j2
+++ b/data/templates/ocserv/ocserv_config.j2
@@ -93,9 +93,9 @@ split-dns = {{ tmp }}
 {%     endfor %}
 {% endif %}
 
-{% if authentication.groups is vyos_defined %}
+{% if authentication.group is vyos_defined %}
 # Group settings
-{%     for grp in authentication.groups %}
+{%     for grp in authentication.group %}
 select-group = {{ grp }}
 {%     endfor %}
 {% endif %}

--- a/interface-definitions/vpn-openconnect.xml.in
+++ b/interface-definitions/vpn-openconnect.xml.in
@@ -144,6 +144,26 @@
                     </properties>
                     <defaultValue>2</defaultValue>
                   </leafNode>
+                  <leafNode name="groupconfig">
+                    <properties>
+                      <help>If the groupconfig option is set to yes, then config-per-user will be overriden, and all configuration will be read from radius.</help>
+                      <completionHelp>
+                        <list>yes no</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>yes</format>
+                        <description>Enable RADIUS acquisition of group properties</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>no</format>
+                        <description>Disable RADIUS acquisition of group properties</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>(yes|no)</regex>
+                      </constraint>
+                    </properties>
+                    <defaultValue>no</defaultValue>
+                  </leafNode>
                 </children>
               </node>
             </children>

--- a/interface-definitions/vpn-openconnect.xml.in
+++ b/interface-definitions/vpn-openconnect.xml.in
@@ -50,6 +50,16 @@
                   </leafNode>
                 </children>
               </node>
+              <leafNode name="groups">
+                <properties>
+                  <help>Groups that a client is allowed to select from. Maps to RADIUS Class attribute.</help>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>Group string. The group may be followed by a user-friendly name in brackets: group1[First Group]</description>
+                  </valueHelp>
+                  <multi/>
+                </properties>
+              </leafNode>
               #include <include/auth-local-users.xml.i>
               <node name="local-users">
                 <children>
@@ -297,6 +307,26 @@
                   </constraint>
                   <multi/>
                 </properties>
+              </leafNode>
+              <leafNode name="tunnel-all-dns">
+                <properties>
+                  <help>If the tunnel-all-dns option is set to yes, tunnel all DNS queries via the VPN. This is the default when a default route is set.</help>
+                  <completionHelp>
+                    <list>yes no</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>yes</format>
+                    <description>Enable tunneling of all DNS traffic</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>no</format>
+                    <description>Disable tunneling of all DNS traffic</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(yes|no)</regex>
+                  </constraint>
+                </properties>
+                <defaultValue>no</defaultValue>
               </leafNode>
             </children>
           </node>

--- a/interface-definitions/vpn-openconnect.xml.in
+++ b/interface-definitions/vpn-openconnect.xml.in
@@ -50,9 +50,9 @@
                   </leafNode>
                 </children>
               </node>
-              <leafNode name="groups">
+              <leafNode name="group">
                 <properties>
-                  <help>Groups that a client is allowed to select from. Maps to RADIUS Class attribute.</help>
+                  <help>Group that a client is allowed to select (from a list). Maps to RADIUS Class attribute.</help>
                   <valueHelp>
                     <format>txt</format>
                     <description>Group string. The group may be followed by a user-friendly name in brackets: group1[First Group]</description>

--- a/interface-definitions/vpn-openconnect.xml.in
+++ b/interface-definitions/vpn-openconnect.xml.in
@@ -156,23 +156,8 @@
                   </leafNode>
                   <leafNode name="groupconfig">
                     <properties>
-                      <help>If the groupconfig option is set to yes, then config-per-user will be overriden, and all configuration will be read from radius.</help>
-                      <completionHelp>
-                        <list>yes no</list>
-                      </completionHelp>
-                      <valueHelp>
-                        <format>yes</format>
-                        <description>Enable RADIUS acquisition of group properties</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>no</format>
-                        <description>Disable RADIUS acquisition of group properties</description>
-                      </valueHelp>
-                      <constraint>
-                        <regex>(yes|no)</regex>
-                      </constraint>
+                      <help>If the groupconfig option is set, then config-per-user will be overriden, and all configuration will be read from radius.</help>
                     </properties>
-                    <defaultValue>no</defaultValue>
                   </leafNode>
                 </children>
               </node>

--- a/src/conf_mode/vpn_openconnect.py
+++ b/src/conf_mode/vpn_openconnect.py
@@ -57,15 +57,16 @@ def get_config():
     default_values = defaults(base)
     ocserv = dict_merge(default_values, ocserv)
 
-    # workaround a "know limitation" - https://phabricator.vyos.net/T2665
-    del ocserv['authentication']['local_users']['username']['otp']
-    if not ocserv["authentication"]["local_users"]["username"]:
-        raise ConfigError('openconnect mode local required at least one user')
-    default_ocserv_usr_values = default_values['authentication']['local_users']['username']['otp']
-    for user, params in ocserv['authentication']['local_users']['username'].items():
-        # Not every configuration requires OTP settings
-        if ocserv['authentication']['local_users']['username'][user].get('otp'):
-            ocserv['authentication']['local_users']['username'][user]['otp'] = dict_merge(default_ocserv_usr_values, ocserv['authentication']['local_users']['username'][user]['otp'])
+    if "local" in ocserv["authentication"]["mode"]:
+        # workaround a "know limitation" - https://phabricator.vyos.net/T2665
+        del ocserv['authentication']['local_users']['username']['otp']
+        if not ocserv["authentication"]["local_users"]["username"]:
+            raise ConfigError('openconnect mode local required at least one user')
+        default_ocserv_usr_values = default_values['authentication']['local_users']['username']['otp']
+        for user, params in ocserv['authentication']['local_users']['username'].items():
+            # Not every configuration requires OTP settings
+            if ocserv['authentication']['local_users']['username'][user].get('otp'):
+                ocserv['authentication']['local_users']['username'][user]['otp'] = dict_merge(default_ocserv_usr_values, ocserv['authentication']['local_users']['username'][user]['otp'])
 
     if ocserv:
         ocserv['pki'] = conf.get_config_dict(['pki'], key_mangling=('-', '_'),


### PR DESCRIPTION
From ocserv documentation:
```
If the groupconfig option is set, then config-per-user will be
overriden, and all configuration will be read from radius. That
also includes the Acct-Interim-Interval, and Session-Timeout
values.
```
Implement yes/no configuration and parameter handling during jinja
rendering.

Fix bug wherein openconnect-server configuration requires creation
of local user accounts even when RADIUS authentication is used.

Testing:
  Set the groupconfig=yes param and observed change in generated
/run/ocserv/ocserv.conf.
  Removed the local users via `delete vpn openconnect
authentication local-users` and observed commit & service operation

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3896

## Component(s) name
ocserv

## Proposed changes
Bug fixes during code review to determine how we can implement per-group config and RADIUS-based group authorization:
1. Remove local openconnect account requirement when using RADIUS
2. Permit setting `groupconfig` parameter in `/run/ocserv/ocserv.conf` for the `radius` setting

## How to test
```
# delete vpn openconnect authentication local-users
# set vpn openconnect authentication radius groupconfig yes
# commit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
-- Run during build of the package
- [ ] My commit headlines contain a valid Task id
-- This is tangential to the task, done while grokking the code in praparation
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
