### PR TITLE
firewall: T4622: Add TCP MSS option

### DIFF
--- a/interface-definitions/include/firewall/tcp-flags.xml.i
+++ b/interface-definitions/include/firewall/tcp-flags.xml.i
@@ -114,6 +114,23 @@
         </node>
       </children>
     </node>
+    <leafNode name="mss">
+      <properties>
+        <help>Maximum segment size (MSS)</help>
+        <valueHelp>
+          <format>u32:1-16384</format>
+          <description>Maximum segment size</description>
+        </valueHelp>
+        <valueHelp>
+          <format>&lt;min&gt;-&lt;max&gt;</format>
+          <description>TCP MSS range (use '-' as delimiter)</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-16384"/>
+          <validator name="range" argument="--min=1 --max=16384"/>
+        </constraint>
+      </properties>
+    </leafNode>
   </children>
 </node>
 <!-- include end -->

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -297,6 +297,11 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
     if tcp_flags:
         output.append(parse_tcp_flags(tcp_flags))
 
+    # TCP MSS
+    tcp_mss = dict_search_args(rule_conf, 'tcp', 'mss')
+    if tcp_mss:
+        output.append(f'tcp option maxseg size {tcp_mss}')
+
     output.append('counter')
 
     if 'set' in rule_conf:


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to `drop|accept` packets based on TCP MSS size
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4622

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set firewall name FOO rule 10 action 'drop'
set firewall name FOO rule 10 protocol 'tcp'
set firewall name FOO rule 10 tcp flags syn
set firewall name FOO rule 10 tcp mss '1-500'
commit
```
nft rules:
```
vyos@r14# sudo nft -s list table ip filter
table ip filter {
...

	chain NAME_FOO {
		tcp flags & syn == syn tcp option maxseg size 1-500 counter drop comment "FOO-10"
		counter return comment "FOO default-action accept"
	}
}

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
