### PR TITLE
ethernet: T4538: fix wrong systemd unit used for EAPoL (equuleus)

### DIFF
--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -153,9 +153,9 @@ def apply(ethernet):
     else:
         e.update(ethernet)
         if 'eapol' in ethernet:
-            eapol_action='restart'
+            eapol_action='reload-or-restart'
 
-    call(f'systemctl {eapol_action} wpa_supplicant-macsec@{ifname}')
+    call(f'systemctl {eapol_action} wpa_supplicant-wired@{ifname}')
 
 if __name__ == '__main__':
     try:

--- a/src/etc/systemd/system/wpa_supplicant-wired@.service.d/override.conf
+++ b/src/etc/systemd/system/wpa_supplicant-wired@.service.d/override.conf
@@ -1,0 +1,11 @@
+[Unit]
+After=
+After=vyos-router.service
+
+[Service]
+WorkingDirectory=
+WorkingDirectory=/run/wpa_supplicant
+PIDFile=/run/wpa_supplicant/%I.pid
+ExecStart=
+ExecStart=/sbin/wpa_supplicant -c/run/wpa_supplicant/%I.conf -Dwired -P/run/wpa_supplicant/%I.pid -i%I
+ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
When MACsec was bound to an ethernet interface and the underlaying
source-interface got changed (even description only) this terminated the
MACsec session running on top of it.

The root cause is when EAPoL was implemented in commit d59354e52a8a7f we
re-used the same systemd unit which is responsible for MACsec. That indeed lead
to the fact that wpa_supplicant was always stopped when anything happened on
the underlaying source-interface that was not related to EAPoL.

(cherry picked from commit f92a23ef9ab8be59681e5b7ba627e399d89bce53)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4538

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
MACsec

## Proposed changes
<!--- Describe your changes in detail -->

Use eapol (wired) systemd unit file

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests

```bash
cpo@LR2.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_macsec.py
test_add_multiple_ip_addresses (__main__.MACsecInterfaceTest) ... ok
test_add_single_ip_address (__main__.MACsecInterfaceTest) ... ok
test_dhcp_disable_interface (__main__.MACsecInterfaceTest) ... ok
test_dhcpv6_client_options (__main__.MACsecInterfaceTest) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.MACsecInterfaceTest) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.MACsecInterfaceTest) ... skipped 'not supported'
test_interface_description (__main__.MACsecInterfaceTest) ... ok
test_interface_disable (__main__.MACsecInterfaceTest) ... ok
test_interface_ip_options (__main__.MACsecInterfaceTest) ... ok
test_interface_ipv6_options (__main__.MACsecInterfaceTest) ... ok
test_interface_mtu (__main__.MACsecInterfaceTest) ... skipped 'not supported'
test_ipv6_link_local_address (__main__.MACsecInterfaceTest) ... ok
test_macsec_encryption (__main__.MACsecInterfaceTest) ... ok
test_macsec_gcm_aes_128 (__main__.MACsecInterfaceTest) ... ok
test_macsec_gcm_aes_256 (__main__.MACsecInterfaceTest) ... ok
test_macsec_source_interface (__main__.MACsecInterfaceTest) ... ok
test_mtu_1200_no_ipv6_interface (__main__.MACsecInterfaceTest) ... skipped 'not supported'
test_span_mirror (__main__.MACsecInterfaceTest) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.MACsecInterfaceTest) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.MACsecInterfaceTest) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.MACsecInterfaceTest) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.MACsecInterfaceTest) ... skipped 'not supported'

----------------------------------------------------------------------
Ran 22 tests in 138.318s

OK (skipped=10)

cpo@LR2.wue3:~$ TEST_ETH="eth1 eth2" /usr/libexec/vyos/tests/smoke/cli/test_interfaces_ethernet.py
test_add_multiple_ip_addresses (__main__.EthernetInterfaceTest) ... ok
test_add_single_ip_address (__main__.EthernetInterfaceTest) ... ok
test_dhcp_disable_interface (__main__.EthernetInterfaceTest) ... ok
test_dhcpv6_client_options (__main__.EthernetInterfaceTest) ... ok
test_dhcpv6pd_auto_sla_id (__main__.EthernetInterfaceTest) ... ok
test_dhcpv6pd_manual_sla_id (__main__.EthernetInterfaceTest) ... ok
test_eapol_support (__main__.EthernetInterfaceTest) ... ok
test_interface_description (__main__.EthernetInterfaceTest) ... ok
test_interface_disable (__main__.EthernetInterfaceTest) ... ok
test_interface_ip_options (__main__.EthernetInterfaceTest) ... ok
test_interface_ipv6_options (__main__.EthernetInterfaceTest) ... ok
test_interface_mtu (__main__.EthernetInterfaceTest) ... ok
test_ipv6_link_local_address (__main__.EthernetInterfaceTest) ... ok
test_mtu_1200_no_ipv6_interface (__main__.EthernetInterfaceTest) ... ok
test_non_existing_interface (__main__.EthernetInterfaceTest) ... ok
test_offloading_rps (__main__.EthernetInterfaceTest) ... ok
test_span_mirror (__main__.EthernetInterfaceTest) ... ok
test_speed_duplex_verify (__main__.EthernetInterfaceTest) ... ok
test_vif_8021q_interfaces (__main__.EthernetInterfaceTest) ... ok
test_vif_8021q_lower_up_down (__main__.EthernetInterfaceTest) ... ok
test_vif_8021q_mtu_limits (__main__.EthernetInterfaceTest) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.EthernetInterfaceTest) ... ok

----------------------------------------------------------------------
Ran 22 tests in 297.530s

OK

```



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
