### PR TITLE
T4629: Raised ConfigErrors contain dict instead of only the dict key (equuleus)

### DIFF
--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -322,8 +322,8 @@ def is_source_interface(conf, interface, intftype=None):
     for it in intftype:
         base = ['interfaces', it]
         for intf in conf.list_nodes(base):
-            lower_intf = base + [intf, 'source-interface']
-            if conf.exists(lower_intf) and interface in conf.return_values(lower_intf):
+            src_intf = base + [intf, 'source-interface']
+            if conf.exists(src_intf) and interface in conf.return_values(src_intf):
                 ret_val = intf
                 break
 

--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -237,15 +237,16 @@ def verify_source_interface(config):
         raise ConfigError('Specified source-interface {source_interface} does '
                           'not exist'.format(**config))
 
+    src_ifname = config['source_interface']
     if 'source_interface_is_bridge_member' in config:
-        raise ConfigError('Invalid source-interface {source_interface}. Interface '
-                          'is already a member of bridge '
-                          '{source_interface_is_bridge_member}'.format(**config))
+        bridge_name = next(iter(config['source_interface_is_bridge_member']))
+        raise ConfigError(f'Invalid source-interface "{src_ifname}". Interface '
+                          f'is already a member of bridge "{bridge_name}"!')
 
     if 'source_interface_is_bond_member' in config:
-        raise ConfigError('Invalid source-interface {source_interface}. Interface '
-                          'is already a member of bond '
-                          '{source_interface_is_bond_member}'.format(**config))
+        bond_name = next(iter(config['source_interface_is_bond_member']))
+        raise ConfigError(f'Invalid source-interface "{src_ifname}". Interface '
+                          f'is already a member of bond "{bond_name}"!')
 
 def verify_dhcpv6(config):
     """


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
 vyos.config.configdict: T4592: T4629: only print interface name, not interface dict on error

(cherry picked from commit 475fbb785dca76868715827833dc44115635c4a6)


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4629

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vyos.configverify

## Proposed changes
<!--- Describe your changes in detail -->
Do not print entire dict on error - only the key

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Smoketests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
