### PR TITLE
ocserv: T4597: Fix check bounded port by service itself

### DIFF
--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -471,6 +471,29 @@ def process_named_running(name):
             return p.pid
     return None
 
+def is_listen_port_bind_service(port: int, service: str) -> bool:
+    """Check if listen port bound to expected program name
+    :param port: Bind port
+    :param service: Program name
+    :return: bool
+
+    Example:
+        % is_listen_port_bind_service(443, 'nginx')
+        True
+        % is_listen_port_bind_service(443, 'ocservr-main')
+        False
+    """
+    from psutil import net_connections as connections
+    from psutil import Process as process
+    for connection in connections():
+        addr = connection.laddr
+        pid = connection.pid
+        pid_name = process(pid).name()
+        pid_port = addr.port
+        if service == pid_name and port == pid_port:
+            return True
+    return False
+
 def seconds_to_human(s, separator=""):
     """ Converts number of seconds passed to a human-readable
     interval such as 1w4d18h35m59s

--- a/src/conf_mode/vpn_openconnect.py
+++ b/src/conf_mode/vpn_openconnect.py
@@ -25,6 +25,7 @@ from vyos.template import render
 from vyos.util import call
 from vyos.util import check_port_availability
 from vyos.util import is_systemd_service_running
+from vyos.util import is_listen_port_bind_service
 from vyos.util import dict_search
 from vyos.xml import defaults
 from vyos import ConfigError
@@ -77,8 +78,10 @@ def verify(ocserv):
     if ocserv is None:
         return None
     # Check if listen-ports not binded other services
+    # It can be only listen by 'ocserv-main'
     for proto, port in ocserv.get('listen_ports').items():
-        if check_port_availability('0.0.0.0', int(port), proto) is not True:
+        if check_port_availability('0.0.0.0', int(port), proto) is not True and \
+                not is_listen_port_bind_service(int(port), 'ocserv-main'):
             raise ConfigError(f'"{proto}" port "{port}" is used by another service')
     # Check authentication
     if "authentication" in ocserv:


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
We check listen port before commit service to if is a port available and
not bound, but when we start openconnect our own port starts be
bounded by `ocserv-main` process, and next commit will fail as
the port is already bound
To fix it, extend check if the port has already bonded and it is not our
self process `ocserv-main`

I.e., it is OK if the port is already bound by our expected process  `ocserv-main`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4597

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openconnect
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Initial configuration:
```
vyos@r14# run show conf com | match vpn
set vpn openconnect authentication local-users username foo password 'bar'
set vpn openconnect authentication mode local 'password'
set vpn openconnect listen-ports tcp '8443'
set vpn openconnect listen-ports udp '8443'
set vpn openconnect network-settings client-ip-settings subnet '100.64.0.0/24'
set vpn openconnect network-settings name-server '100.64.0.1'
set vpn openconnect ssl ca-certificate 'ca-ocserv'
set vpn openconnect ssl certificate 'srv-ocserv'
commit
[edit]
vyos@r14#
```
port 8443 already bonded to ocserv:
```
vyos@r14# sudo netstat -tulpn | grep 8443
tcp        0      0 0.0.0.0:8443            0.0.0.0:*               LISTEN      23880/ocserv-main   
tcp6       0      0 :::8443                 :::*                    LISTEN      23880/ocserv-main   
udp        0      0 0.0.0.0:8443            0.0.0.0:*                           23880/ocserv-main   
udp6       0      0 :::8443                 :::*                                23880/ocserv-main   
[edit]
```
Add new user after initial configuration
Before fix:
```
vyos@r14# set vpn openconnect authentication local-users username foo2 password 'bar2'
[edit]
vyos@r14# commit
[ vpn openconnect ]
"tcp" port "8443" is used by another service

[[vpn openconnect]] failed
Commit failed
[edit]
vyos@r14#
```
After fix:
```
vyos@r14# set vpn openconnect authentication local-users username foo2 password 'bar2'
[edit]
vyos@r14# commit
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
