### PR TITLE
nat66: T4631: Add port and protocol to nat66 conf

### DIFF
--- a/data/templates/firewall/nftables-nat66.j2
+++ b/data/templates/firewall/nftables-nat66.j2
@@ -7,6 +7,17 @@
 {% set src_prefix  = 'ip6 saddr ' ~ config.source.prefix.replace('!','!= ') if config.source.prefix is vyos_defined %}
 {% set source_address  = 'ip6 saddr ' ~ config.source.address.replace('!','!= ') if config.source.address is vyos_defined %}
 {% set dest_address  = 'ip6 daddr ' ~ config.destination.address.replace('!','!= ') if config.destination.address is vyos_defined %}
+{# Port #}
+{% if config.source.port is vyos_defined and config.source.port.startswith('!') %}
+{%     set src_port  = 'sport != { ' ~ config.source.port.replace('!','') ~ ' }' %}
+{% else %}
+{%     set src_port  = 'sport { ' ~ config.source.port ~ ' }' if config.source.port is vyos_defined %}
+{% endif %}
+{% if config.destination.port is vyos_defined and config.destination.port.startswith('!') %}
+{%     set dst_port  = 'dport != { ' ~ config.destination.port.replace('!','') ~ ' }' %}
+{% else %}
+{%     set dst_port  = 'dport { ' ~ config.destination.port ~ ' }' if config.destination.port is vyos_defined %}
+{% endif %}
 {% if chain is vyos_defined('PREROUTING') %}
 {%     set comment   = 'DST-NAT66-' ~ rule %}
 {%     set base_log  = '[NAT66-DST-' ~ rule %}
@@ -36,12 +47,25 @@
 {%     endif   %}
 {%     set interface = ' oifname "' ~ config.outbound_interface ~ '"' if config.outbound_interface is vyos_defined else '' %}
 {% endif %}
+{% set trns_port = ':' ~ config.translation.port if config.translation.port is vyos_defined %}
+{# protocol has a default value thus it is always present #}
+{% if config.protocol is vyos_defined('tcp_udp') %}
+{%     set protocol  = 'tcp' %}
+{%     set comment   = comment ~ ' tcp_udp' %}
+{% else %}
+{%     set protocol  = config.protocol %}
+{% endif %}
 {% if config.log is vyos_defined %}
 {%     if config.translation.address is vyos_defined('masquerade') %}
 {%         set log = base_log ~ '-MASQ]' %}
 {%     else %}
 {%         set log = base_log ~ ']' %}
 {%     endif %}
+{% endif %}
+{% if config.exclude is vyos_defined %}
+{#     rule has been marked as 'exclude' thus we simply return here #}
+{%     set trns_addr = 'return' %}
+{%     set trns_port = '' %}
 {% endif %}
 {% set output = 'add rule ip6 nat ' ~ chain ~ interface %}
 {# Count packets #}
@@ -54,11 +78,17 @@
 {% if src_prefix is vyos_defined %}
 {%     set output = output ~ ' ' ~ src_prefix %}
 {% endif %}
+{% if dst_port is vyos_defined %}
+{%     set output = output ~ ' ' ~ protocol ~ ' ' ~ dst_port %}
+{% endif %}
 {% if dst_prefix is vyos_defined %}
 {%     set output = output ~ ' ' ~ dst_prefix %}
 {% endif %}
 {% if source_address is vyos_defined %}
 {%     set output = output ~ ' ' ~ source_address %}
+{% endif %}
+{% if src_port is vyos_defined %}
+{%     set output = output ~ ' ' ~ protocol ~ ' ' ~ src_port %}
 {% endif %}
 {% if dest_address is vyos_defined %}
 {%     set output = output ~ ' ' ~ dest_address %}
@@ -70,11 +100,22 @@
 {% if trns_address is vyos_defined %}
 {%     set output = output ~ ' ' ~ trns_address %}
 {% endif %}
+{% if trns_port is vyos_defined %}
+{#     Do not add a whitespace here, translation port must be directly added after IP address #}
+{#     e.g. 2001:db8::1:3389                                                                   #}
+{%     set output = output ~ trns_port %}
+{% endif %}
 {% if comment is vyos_defined %}
 {%     set output = output ~ ' comment "' ~ comment ~ '"' %}
 {% endif %}
 {{ log_output if log_output is vyos_defined }}
 {{ output }}
+{# Special handling if protocol is tcp_udp, we must repeat the entire rule with udp as protocol #}
+{% if config.protocol is vyos_defined('tcp_udp') %}
+{#     Beware of trailing whitespace, without it the comment tcp_udp will be changed to udp_udp #}
+{{ log_output | replace('tcp ', 'udp ') if log_output is vyos_defined }}
+{{ output | replace('tcp ', 'udp ') }}
+{% endif %}
 {% endmacro %}
 
 # Start with clean NAT table

--- a/interface-definitions/include/nat/protocol.xml.i
+++ b/interface-definitions/include/nat/protocol.xml.i
@@ -1,0 +1,34 @@
+<!-- include start from nat/protocol.xml.i -->
+<leafNode name="protocol">
+  <properties>
+    <help>Protocol to match (protocol name, number, or "all")</help>
+    <completionHelp>
+      <script>${vyos_completion_dir}/list_protocols.sh</script>
+      <list>all tcp_udp</list>
+    </completionHelp>
+    <valueHelp>
+      <format>all</format>
+      <description>All IP protocols</description>
+    </valueHelp>
+    <valueHelp>
+      <format>tcp_udp</format>
+      <description>Both TCP and UDP</description>
+    </valueHelp>
+    <valueHelp>
+      <format>u32:0-255</format>
+      <description>IP protocol number</description>
+    </valueHelp>
+    <valueHelp>
+      <format>&lt;protocol&gt;</format>
+      <description>IP protocol name</description>
+    </valueHelp>
+    <valueHelp>
+      <format>!&lt;protocol&gt;</format>
+      <description>IP protocol name</description>
+    </valueHelp>
+    <constraint>
+      <validator name="ip-protocol"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/nat66.xml.in
+++ b/interface-definitions/nat66.xml.in
@@ -50,6 +50,7 @@
                   </completionHelp>
                 </properties>
               </leafNode>
+              #include <include/nat/protocol.xml.i>
               <node name="destination">
                 <properties>
                   <help>IPv6 destination prefix options</help>
@@ -72,6 +73,7 @@
                       </constraint>
                     </properties>
                   </leafNode>
+                  #include <include/nat-port.xml.i>
                 </children>
               </node>
               <node name="source">
@@ -96,6 +98,7 @@
                       </constraint>
                     </properties>
                   </leafNode>
+                  #include <include/nat-port.xml.i>
                 </children>
               </node>
               <node name="translation">
@@ -128,6 +131,7 @@
                       </constraint>
                     </properties>
                   </leafNode>
+                  #include <include/nat-translation-port.xml.i>
                 </children>
               </node>
             </children>
@@ -179,6 +183,7 @@
                   </completionHelp>
                 </properties>
               </leafNode>
+              #include <include/nat/protocol.xml.i>
               <node name="destination">
                 <properties>
                   <help>IPv6 destination prefix options</help>
@@ -211,6 +216,7 @@
                       </constraint>
                     </properties>
                   </leafNode>
+                  #include <include/nat-port.xml.i>
                 </children>
               </node>
               <node name="source">
@@ -245,6 +251,7 @@
                       </constraint>
                     </properties>
                   </leafNode>
+                #include <include/nat-port.xml.i>
                 </children>
               </node>
               <node name="translation">
@@ -269,6 +276,7 @@
                       </constraint>
                     </properties>
                   </leafNode>
+                  #include <include/nat-translation-port.xml.i>
                 </children>
               </node>
             </children>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to configure src/dst/translation port and protocol for
SNAT and DNAT IPv6

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4631

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat66
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add options src/dst/translation `port` and `protocol`
VyOS configuration:
```
set nat66 destination rule 120 description 'foo'
set nat66 destination rule 120 destination port '4545'
set nat66 destination rule 120 inbound-interface 'eth0'
set nat66 destination rule 120 protocol 'tcp'
set nat66 destination rule 120 source address '2001:db8:2222::/64'
set nat66 destination rule 120 source port '8080'
set nat66 destination rule 120 translation address '2001:db8:1111::1'
set nat66 destination rule 120 translation port '5555'

set nat66 source rule 10 description 'foo'
set nat66 source rule 10 destination port '9999'
set nat66 source rule 10 outbound-interface 'eth0'
set nat66 source rule 10 protocol 'tcp'
set nat66 source rule 10 source port '8080'
set nat66 source rule 10 source prefix '2001:db8:2222::/64'
set nat66 source rule 10 translation address '2001:db8:1111::1'
set nat66 source rule 10 translation port '80'

```
Nftables:
```
vyos@r14# sudo nft -s list table ip6 nat
table ip6 nat {
	chain PREROUTING {
		type nat hook prerouting priority dstnat; policy accept;
		iifname "eth0" counter tcp dport { 4545 } ip6 saddr 2001:db8:2222::/64 tcp sport { 8080 } dnat to 2001:db8:1111::1:5555 comment "DST-NAT66-120"
	}

	chain POSTROUTING {
		type nat hook postrouting priority srcnat; policy accept;
		oifname "eth0" counter ip6 saddr 2001:db8:2222::/64 tcp dport { 9999 } tcp sport { 8080 } snat to 2001:db8:1111::1:80 comment "SRC-NAT66-10"
	}

	chain VYOS_DNPT_HOOK {
	}

	chain VYOS_SNPT_HOOK {
	}
}
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
