### PR TITLE
bridge: T4632: vlan aware bridge lacks CPU forwarding

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_bridge.py
+++ b/smoketest/scripts/cli/test_interfaces_bridge.py
@@ -19,6 +19,7 @@ import json
 import unittest
 
 from base_interfaces_test import BasicInterfaceTest
+from copy import deepcopy
 from glob import glob
 from netifaces import interfaces
 
@@ -144,85 +145,78 @@ class BridgeInterfaceTest(BasicInterfaceTest.TestCase):
         super().test_vif_8021q_mtu_limits()
 
     def test_bridge_vlan_filter(self):
-        def _verify_members() -> None:
-            # check member interfaces are added on the bridge
-            for interface in self._interfaces:
-                bridge_members = []
-                for tmp in glob(f'/sys/class/net/{interface}/lower_*'):
-                    bridge_members.append(os.path.basename(tmp).replace('lower_', ''))
+        vifs = ['10', '20', '30', '40']
+        native_vlan = '20'
 
-                # We can not use assertListEqual() b/c the position of the interface
-                # names within the list is not fixed
-                self.assertEqual(len(self._members), len(bridge_members))
-                for member in self._members:
-                    self.assertIn(member, bridge_members)
-
-        def _check_vlan_filter() -> None:
-            for interface in self._interfaces:
-                tmp = cmd(f'bridge -j vlan show dev {interface}')
-                tmp = json.loads(tmp)
-                self.assertIsNotNone(tmp)
-
-                for interface_status in tmp:
-                    ifname = interface_status['ifname']
-                    for interface in self._members:
-                        vlan_success = 0;
-                        if interface == ifname:
-                            vlans_status = interface_status['vlans']
-                            for vlan_status in vlans_status:
-                                vlan_id = vlan_status['vlan']
-                                flag_num = 0
-                                if 'flags' in vlan_status:
-                                    flags = vlan_status['flags']
-                                    for flag in flags:
-                                        flag_num = flag_num +1
-                                if vlan_id == 2:
-                                    if flag_num == 0:
-                                        vlan_success = vlan_success + 1
-                                else:
-                                    for id in range(4,10):
-                                        if vlan_id == id:
-                                            if flag_num == 0:
-                                                vlan_success = vlan_success + 1
-                                    if vlan_id >= 101:
-                                        if flag_num == 2:
-                                            vlan_success = vlan_success + 1
-                            self.assertGreaterEqual(vlan_success, 7)
-
-        vif_vlan = 2
         # Add member interface to bridge and set VLAN filter
         for interface in self._interfaces:
             base = self._base_path + [interface]
             self.cli_set(base + ['enable-vlan'])
             self.cli_set(base + ['address', '192.0.2.1/24'])
-            self.cli_set(base + ['vif', str(vif_vlan), 'address', '192.0.3.1/24'])
-            self.cli_set(base + ['vif', str(vif_vlan), 'mtu', self._mtu])
 
-            vlan_id = 101
-            allowed_vlan = 2
-            allowed_vlan_range = '4-9'
-            # assign members to bridge interface
+            for vif in vifs:
+                self.cli_set(base + ['vif', vif, 'address', f'192.0.{vif}.1/24'])
+                self.cli_set(base + ['vif', vif, 'mtu', self._mtu])
+
             for member in self._members:
                 base_member = base + ['member', 'interface', member]
-                self.cli_set(base_member + ['allowed-vlan', str(allowed_vlan)])
-                self.cli_set(base_member + ['allowed-vlan', allowed_vlan_range])
-                self.cli_set(base_member + ['native-vlan', str(vlan_id)])
-                vlan_id += 1
+                self.cli_set(base_member + ['native-vlan', native_vlan])
+                for vif in vifs:
+                    self.cli_set(base_member + ['allowed-vlan', vif])
 
         # commit config
         self.cli_commit()
+
+        def _verify_members(interface, members) -> None:
+            # check member interfaces are added on the bridge
+            bridge_members = []
+            for tmp in glob(f'/sys/class/net/{interface}/lower_*'):
+                bridge_members.append(os.path.basename(tmp).replace('lower_', ''))
+
+            self.assertListEqual(sorted(members), sorted(bridge_members))
+
+        def _check_vlan_filter(interface, vifs) -> None:
+            configured_vlan_ids = []
+
+            bridge_json = cmd(f'bridge -j vlan show dev {interface}')
+            bridge_json = json.loads(bridge_json)
+            self.assertIsNotNone(bridge_json)
+
+            for tmp in bridge_json:
+                self.assertIn('vlans', tmp)
+
+                for vlan in tmp['vlans']:
+                    self.assertIn('vlan', vlan)
+                    configured_vlan_ids.append(str(vlan['vlan']))
+
+                    # Verify native VLAN ID has 'PVID' flag set on individual member ports
+                    if not interface.startswith('br') and str(vlan['vlan']) == native_vlan:
+                        self.assertIn('flags', vlan)
+                        self.assertIn('PVID', vlan['flags'])
+
+            self.assertListEqual(sorted(configured_vlan_ids), sorted(vifs))
 
         # Verify correct setting of VLAN filter function
         for interface in self._interfaces:
             tmp = read_file(f'/sys/class/net/{interface}/bridge/vlan_filtering')
             self.assertEqual(tmp, '1')
 
-        # Execute the program to obtain status information and verify proper
-        # VLAN filter setup
-        _check_vlan_filter()
+        # Obtain status information and verify proper VLAN filter setup.
+        # First check if all members are present, second check if all VLANs
+        # are assigned on the parend bridge interface, third verify all the
+        # VLANs are properly setup on the downstream "member" ports
+        for interface in self._interfaces:
+            # check member interfaces are added on the bridge
+            _verify_members(interface, self._members)
 
-        # check member interfaces are added on the bridge
-        _verify_members()
+            # Check if all VLAN ids are properly set up. Bridge interface always
+            # has native VLAN 1
+            tmp = deepcopy(vifs)
+            tmp.append('1')
+            _check_vlan_filter(interface, tmp)
+
+            for member in self._members:
+                _check_vlan_filter(member, vifs)
 
         # change member interface description to trigger config update,
         # VLANs must still exist (T4565)
@@ -233,12 +227,22 @@ class BridgeInterfaceTest(BasicInterfaceTest.TestCase):
         # commit config
         self.cli_commit()
 
-        # check member interfaces are added on the bridge
-        _verify_members()
+        # Obtain status information and verify proper VLAN filter setup.
+        # First check if all members are present, second check if all VLANs
+        # are assigned on the parend bridge interface, third verify all the
+        # VLANs are properly setup on the downstream "member" ports
+        for interface in self._interfaces:
+            # check member interfaces are added on the bridge
+            _verify_members(interface, self._members)
 
-        # Execute the program to obtain status information and verify proper
-        # VLAN filter setup
-        _check_vlan_filter()
+            # Check if all VLAN ids are properly set up. Bridge interface always
+            # has native VLAN 1
+            tmp = deepcopy(vifs)
+            tmp.append('1')
+            _check_vlan_filter(interface, tmp)
+
+            for member in self._members:
+                _check_vlan_filter(member, vifs)
 
         # delete all members
         for interface in self._interfaces:
@@ -256,7 +260,6 @@ class BridgeInterfaceTest(BasicInterfaceTest.TestCase):
             self.assertNotEqual(len(self._members), len(bridge_members))
             for member in self._members:
                 self.assertNotIn(member, bridge_members)
-
 
     def test_bridge_vif_members(self):
         # T2945: ensure that VIFs are not dropped from bridge


### PR DESCRIPTION
The VLAN aware bridge was forwarding traffic between member ports, but traffic
destined torwards the CPU was dropped. This resulted in a gateway not reachable
or DHCP leases that could not be handed out.

(cherry picked from commit f60d0e1ce029925b843f635b36154c90049b9577)

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4632

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bridge

## Proposed changes
<!--- Describe your changes in detail -->

Add VLAN id to CPU (self)

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests or:


VyOS
```
set interfaces bridge br0 enable-vlan
set interfaces bridge br0 member interface eth1 allowed-vlan '10'
set interfaces bridge br0 member interface eth1 allowed-vlan '20'
set interfaces bridge br0 member interface eth1 allowed-vlan '30'
set interfaces bridge br0 member interface eth1 allowed-vlan '40'
set interfaces bridge br0 member interface eth1 native-vlan '40'
set interfaces bridge br0 member interface eth2 allowed-vlan '30'
set interfaces bridge br0 member interface eth2 allowed-vlan '20'
set interfaces bridge br0 member interface eth2 allowed-vlan '10'
set interfaces bridge br0 member interface eth2 allowed-vlan '40'
set interfaces bridge br0 vif 10 address '10.0.10.1/24'
set interfaces bridge br0 vif 20 address '10.0.20.1/24'
set interfaces bridge br0 vif 30 address '10.0.30.1/24'
set interfaces bridge br0 vif 40 address '10.0.40.1/24'
```

Arista vEOS

```
vlan 10,20,30,40
interface Ethernet1
   switchport trunk allowed vlan 10,20,30,40
interface Vlan10
   ip address 10.0.10.2/24
interface Vlan20
   ip address 10.0.20.2/24
interface Vlan30
   ip address 10.0.30.2/24
interface Vlan40
   ip address 10.0.40.2/24
interface Ethernet1
   switchport trunk allowed vlan 10,20,30,40
   switchport mode trunk
   spanning-tree portfast
```

Cisco vIOS
```
interface GigabitEthernet0/0
 ip address 10.0.40.3 255.255.255.0
 duplex auto
 speed auto
 media-type rj45
!
interface GigabitEthernet0/0.10
 encapsulation dot1Q 10
 ip address 10.0.10.3 255.255.255.0
!
interface GigabitEthernet0/0.20
 encapsulation dot1Q 20
 ip address 10.0.20.3 255.255.255.0
!
interface GigabitEthernet0/0.30
 encapsulation dot1Q 30
 ip address 10.0.30.3 255.255.255.0
!
```

![image](https://user-images.githubusercontent.com/25299219/185965584-36d9ad01-c72a-492e-b835-1a456fcd1eb3.png)




## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
