### PR TITLE
keepalived: T4526: keepalived-fifo.py unable to load config

### DIFF
--- a/src/system/keepalived-fifo.py
+++ b/src/system/keepalived-fifo.py
@@ -30,6 +30,7 @@ from vyos.ifconfig.vrrp import VRRP
 from vyos.configquery import ConfigTreeQuery
 from vyos.util import cmd
 from vyos.util import dict_search
+from vyos.util import commit_in_progress
 
 # configure logging
 logger = logging.getLogger(__name__)
@@ -63,6 +64,17 @@ class KeepalivedFifo:
 
     # load configuration
     def _config_load(self):
+        # For VRRP configuration to be read, the commit must be finished
+        count = 1
+        while commit_in_progress():
+            if ( count <= 40 ):
+                logger.debug(f'commit in progress try: {count}')
+            else:
+                logger.error(f'commit still in progress after {count} continuing anyway')
+                break
+            count += 1
+            time.sleep(0.5)
+
         try:
             base = ['high-availability', 'vrrp']
             conf = ConfigTreeQuery()


### PR DESCRIPTION
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
keepalived-fifo.py cannot load the VyOS config because the
script is started before the commit is completely finished.

This change makes sure the script waits for the commit
to be completed. It retries every 0.5 seconds. If the commit
is still not completed it will continue as did the original
implementation.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4526

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
keepalived

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Tested it by creating a new keepalived setup.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
