### PR TITLE
opennhrp: T1070: Fixed removal all SAs in script

### DIFF
--- a/src/etc/opennhrp/opennhrp-script.py
+++ b/src/etc/opennhrp/opennhrp-script.py
@@ -18,44 +18,120 @@ import os
 import re
 import sys
 import vici
-from json import loads
 
+from json import loads
+from pathlib import Path
+
+from vyos.logger import getLogger
 from vyos.util import cmd
 from vyos.util import process_named_running
 
-NHRP_CONFIG = "/run/opennhrp/opennhrp.conf"
+NHRP_CONFIG: str = '/run/opennhrp/opennhrp.conf'
 
 
-def parse_type_ipsec(interface):
-    with open(NHRP_CONFIG, 'r') as f:
-        lines = f.readlines()
-        match = rf'^interface {interface} #(hub|spoke)(?:\s([\w-]+))?$'
-        for line in lines:
-            m = re.match(match, line)
-            if m:
-                return m[1], m[2]
-    return None, None
+def vici_get_ipsec_uniqueid(conn: str, src_nbma: str,
+                            dst_nbma: str) -> list[str]:
+    """ Find and return IKE SAs by src nbma and dst nbma
+
+    Args:
+        conn (str): a connection name
+        src_nbma (str): an IP address of NBMA source
+        dst_nbma (str): an IP address of NBMA destination
+
+    Returns:
+        list: a list of IKE connections that match a criteria
+    """
+    if not conn or not src_nbma or not dst_nbma:
+        logger.error(
+            f'Incomplete input data for resolving IKE unique ids: '
+            f'conn: {conn}, src_nbma: {src_nbma}, dst_nbma: {dst_nbma}')
+        return []
+
+    try:
+        logger.info(
+            f'Resolving IKE unique ids for: conn: {conn}, '
+            f'src_nbma: {src_nbma}, dst_nbma: {dst_nbma}')
+        session: vici.Session = vici.Session()
+        list_ikeid: list[str] = []
+        list_sa = session.list_sas({'ike': conn})
+        for sa in list_sa:
+            if sa[conn]['local-host'].decode('ascii') == src_nbma \
+                    and sa[conn]['remote-host'].decode('ascii') == dst_nbma:
+                list_ikeid.append(sa[conn]['uniqueid'].decode('ascii'))
+        return list_ikeid
+    except Exception as err:
+        logger.error(f'Unable to find unique ids for IKE: {err}')
+        return []
+
+
+def vici_ike_terminate(list_ikeid: list[str]) -> bool:
+    """Terminating IKE SAs by list of IKE IDs
+
+    Args:
+        list_ikeid (list[str]): a list of IKE ids to terminate
+
+    Returns:
+        bool: result of termination action
+    """
+    if not list:
+        logger.warning('An empty list for termination was provided')
+        return False
+
+    try:
+        session = vici.Session()
+        for ikeid in list_ikeid:
+            logger.info(f'Terminating IKE SA with id {ikeid}')
+            session.terminate({'ike-id': ikeid, 'timeout': '-1'})
+        return True
+    except Exception as err:
+        logger.error(f'Failed to terminate SA for IKE ids {list_ikeid}: {err}')
+        return False
+
+
+def parse_type_ipsec(interface: str) -> tuple[str, str]:
+    """Get DMVPN Type and NHRP Profile from the configuration
+
+    Args:
+        interface (str): a name of interface
+
+    Returns:
+        tuple[str, str]: `peer_type` and `profile_name`
+    """
+    if not interface:
+        logger.error('Cannot find peer type - no input provided')
+        return '', ''
+
+    config_file: str = Path(NHRP_CONFIG).read_text()
+    regex: str = rf'^interface {interface} #(?P<peer_type>hub|spoke) ?(?P<profile_name>[^\n]*)$'
+    match = re.search(regex, config_file, re.M)
+    if match:
+        return match.groupdict()['peer_type'], match.groupdict()[
+            'profile_name']
+    return '', ''
 
 
 def add_peer_route(nbma_src: str, nbma_dst: str, mtu: str) -> None:
     """Add a route to a NBMA peer
 
     Args:
-        nmba_src (str): a local IP address
+        nbma_src (str): a local IP address
         nbma_dst (str): a remote IP address
         mtu (str): a MTU for a route
     """
+    logger.info(f'Adding route from {nbma_src} to {nbma_dst} with MTU {mtu}')
     # Find routes to a peer
-    route_get_cmd = f'sudo ip -j route get {nbma_dst} from {nbma_src}'
+    route_get_cmd: str = f'sudo ip --json route get {nbma_dst} from {nbma_src}'
     try:
         route_info_data = loads(cmd(route_get_cmd))
     except Exception as err:
-        print(f'Unable to find a route to {nbma_dst}: {err}')
+        logger.error(f'Unable to find a route to {nbma_dst}: {err}')
+        return
 
     # Check if an output has an expected format
     if not isinstance(route_info_data, list):
-        print(f'Garbage returned from the "{route_get_cmd}" command: \
-            {route_info_data}')
+        logger.error(
+            f'Garbage returned from the "{route_get_cmd}" '
+            f'command: {route_info_data}')
         return
 
     # Add static routes to a peer
@@ -76,104 +152,217 @@ def add_peer_route(nbma_src: str, nbma_dst: str, mtu: str) -> None:
         try:
             cmd(route_add_cmd)
         except Exception as err:
-            print(f'Unable to add a route using command "{route_add_cmd}": \
-                    {err}')
+            logger.error(
+                f'Unable to add a route using command "{route_add_cmd}": '
+                f'{err}')
 
 
-def vici_initiate(conn, child_sa, src_addr, dest_addr):
+def vici_initiate(conn: str, child_sa: str, src_addr: str,
+                  dest_addr: str) -> bool:
+    """Initiate IKE SA connection with specific peer
+
+    Args:
+        conn (str): an IKE connection name
+        child_sa (str): a child SA profile name
+        src_addr (str): NBMA local address
+        dest_addr (str): NBMA address of a peer
+
+    Returns:
+        bool: a result of initiation command
+    """
+    logger.info(
+        f'Trying to initiate connection. Name: {conn}, child sa: {child_sa}, '
+        f'src_addr: {src_addr}, dst_addr: {dest_addr}')
     try:
         session = vici.Session()
-        logs = session.initiate({
+        session.initiate({
             'ike': conn,
             'child': child_sa,
             'timeout': '-1',
             'my-host': src_addr,
             'other-host': dest_addr
         })
-        for log in logs:
-            message = log['msg'].decode('ascii')
-            print('INIT LOG:', message)
         return True
-    except:
-        return None
+    except Exception as err:
+        logger.error(f'Unable to initiate connection {err}')
+        return False
 
 
-def vici_terminate(conn, child_sa, src_addr, dest_addr):
+def vici_terminate(conn: str, src_addr: str, dest_addr: str) -> None:
+    """Find and terminate IKE SAs by local NBMA and remote NBMA addresses
+
+    Args:
+        conn (str): IKE connection name
+        src_addr (str): NBMA local address
+        dest_addr (str): NBMA address of a peer
+    """
+    logger.info(
+        f'Terminating IKE connection {conn} between {src_addr} '
+        f'and {dest_addr}')
+
+    ikeid_list: list[str] = vici_get_ipsec_uniqueid(conn, src_addr, dest_addr)
+
+    if not ikeid_list:
+        logger.warning(
+            f'No active sessions found for IKE profile {conn}, '
+            f'local NBMA {src_addr}, remote NBMA {dest_addr}')
+    else:
+        vici_ike_terminate(ikeid_list)
+
+
+def iface_up(interface: str) -> None:
+    """Proceed tunnel interface UP event
+
+    Args:
+        interface (str): an interface name
+    """
+    if not interface:
+        logger.warning('No interface name provided for UP event')
+
+    logger.info(f'Turning up interface {interface}')
     try:
-        session = vici.Session()
-        logs = session.terminate({
-            'ike': conn,
-            'child': child_sa,
-            'timeout': '-1',
-            'my-host': src_addr,
-            'other-host': dest_addr
-        })
-        for log in logs:
-            message = log['msg'].decode('ascii')
-            print('TERM LOG:', message)
-        return True
-    except:
-        return None
+        cmd(f'sudo ip route flush proto 42 dev {interface}')
+        cmd(f'sudo ip neigh flush dev {interface}')
+    except Exception as err:
+        logger.error(
+            f'Unable to flush route on interface "{interface}": {err}')
 
 
-def iface_up(interface):
-    cmd(f'sudo ip route flush proto 42 dev {interface}')
-    cmd(f'sudo ip neigh flush dev {interface}')
+def peer_up(dmvpn_type: str, conn: str) -> None:
+    """Proceed NHRP peer UP event
 
-
-def peer_up(dmvpn_type, conn):
-    # src_addr = os.getenv('NHRP_SRCADDR')
+    Args:
+        dmvpn_type (str): a type of peer
+        conn (str): an IKE profile name
+    """
+    logger.info(f'Peer UP event for {dmvpn_type} using IKE profile {conn}')
     src_nbma = os.getenv('NHRP_SRCNBMA')
-    # dest_addr = os.getenv('NHRP_DESTADDR')
     dest_nbma = os.getenv('NHRP_DESTNBMA')
     dest_mtu = os.getenv('NHRP_DESTMTU')
 
+    if not src_nbma or not dest_nbma:
+        logger.error(
+            f'Can not get NHRP NBMA addresses: local {src_nbma}, '
+            f'remote {dest_nbma}')
+        return
+
+    logger.info(f'NBMA addresses: local {src_nbma}, remote {dest_nbma}')
     if dest_mtu:
         add_peer_route(src_nbma, dest_nbma, dest_mtu)
-
     if conn and dmvpn_type == 'spoke' and process_named_running('charon'):
-        vici_terminate(conn, 'dmvpn', src_nbma, dest_nbma)
+        vici_terminate(conn, src_nbma, dest_nbma)
         vici_initiate(conn, 'dmvpn', src_nbma, dest_nbma)
 
 
-def peer_down(dmvpn_type, conn):
+def peer_down(dmvpn_type: str, conn: str) -> None:
+    """Proceed NHRP peer DOWN event
+
+    Args:
+        dmvpn_type (str): a type of peer
+        conn (str): an IKE profile name
+    """
+    logger.info(f'Peer DOWN event for {dmvpn_type} using IKE profile {conn}')
+
     src_nbma = os.getenv('NHRP_SRCNBMA')
     dest_nbma = os.getenv('NHRP_DESTNBMA')
 
+    if not src_nbma or not dest_nbma:
+        logger.error(
+            f'Can not get NHRP NBMA addresses: local {src_nbma}, '
+            f'remote {dest_nbma}')
+        return
+
+    logger.info(f'NBMA addresses: local {src_nbma}, remote {dest_nbma}')
     if conn and dmvpn_type == 'spoke' and process_named_running('charon'):
-        vici_terminate(conn, 'dmvpn', src_nbma, dest_nbma)
+        vici_terminate(conn, src_nbma, dest_nbma)
+    try:
+        cmd(f'sudo ip route del {dest_nbma} src {src_nbma} proto 42')
+    except Exception as err:
+        logger.error(
+            f'Unable to del route from {src_nbma} to {dest_nbma}: {err}')
 
-    cmd(f'sudo ip route del {dest_nbma} src {src_nbma} proto 42')
 
+def route_up(interface: str) -> None:
+    """Proceed NHRP route UP event
 
-def route_up(interface):
+    Args:
+        interface (str): an interface name
+    """
+    logger.info(f'Route UP event for interface {interface}')
+
     dest_addr = os.getenv('NHRP_DESTADDR')
     dest_prefix = os.getenv('NHRP_DESTPREFIX')
     next_hop = os.getenv('NHRP_NEXTHOP')
 
-    cmd(f'sudo ip route replace {dest_addr}/{dest_prefix} proto 42 \
-        via {next_hop} dev {interface}')
-    cmd('sudo ip route flush cache')
+    if not dest_addr or not dest_prefix or not next_hop:
+        logger.error(
+            f'Can not get route details: dest_addr {dest_addr}, '
+            f'dest_prefix {dest_prefix}, next_hop {next_hop}')
+        return
+
+    logger.info(
+        f'Route details: dest_addr {dest_addr}, dest_prefix {dest_prefix}, '
+        f'next_hop {next_hop}')
+
+    try:
+        cmd(f'sudo ip route replace {dest_addr}/{dest_prefix} proto 42 \
+                via {next_hop} dev {interface}')
+        cmd('sudo ip route flush cache')
+    except Exception as err:
+        logger.error(
+            f'Unable replace or flush route to {dest_addr}/{dest_prefix} '
+            f'via {next_hop} dev {interface}: {err}')
 
 
-def route_down(interface):
+def route_down(interface: str) -> None:
+    """Proceed NHRP route DOWN event
+
+    Args:
+        interface (str): an interface name
+    """
+    logger.info(f'Route DOWN event for interface {interface}')
+
     dest_addr = os.getenv('NHRP_DESTADDR')
     dest_prefix = os.getenv('NHRP_DESTPREFIX')
 
-    cmd(f'sudo ip route del {dest_addr}/{dest_prefix} proto 42')
-    cmd('sudo ip route flush cache')
+    if not dest_addr or not dest_prefix:
+        logger.error(
+            f'Can not get route details: dest_addr {dest_addr}, '
+            f'dest_prefix {dest_prefix}')
+        return
+
+    logger.info(
+        f'Route details: dest_addr {dest_addr}, dest_prefix {dest_prefix}')
+    try:
+        cmd(f'sudo ip route del {dest_addr}/{dest_prefix} proto 42')
+        cmd('sudo ip route flush cache')
+    except Exception as err:
+        logger.error(
+            f'Unable delete or flush route to {dest_addr}/{dest_prefix}: '
+            f'{err}')
 
 
 if __name__ == '__main__':
+    logger = getLogger('opennhrp-script', syslog=True)
+    logger.debug(
+        f'Running script with arguments: {sys.argv}, '
+        f'environment: {os.environ}')
+
     action = sys.argv[1]
     interface = os.getenv('NHRP_INTERFACE')
+
+    if not interface:
+        logger.error('Can not get NHRP interface name')
+        sys.exit(1)
+
     dmvpn_type, profile_name = parse_type_ipsec(interface)
+    if not dmvpn_type:
+        logger.info(f'Interface {interface} is not NHRP tunnel')
+        sys.exit()
 
-    dmvpn_conn = None
-
+    dmvpn_conn: str = ''
     if profile_name:
-        dmvpn_conn = f'dmvpn-{profile_name}-{interface}'
-
+        dmvpn_conn: str = f'dmvpn-{profile_name}-{interface}'
     if action == 'interface-up':
         iface_up(interface)
     elif action == 'peer-register':
@@ -186,3 +375,5 @@ if __name__ == '__main__':
         route_up(interface)
     elif action == 'route-down':
         route_down(interface)
+
+    sys.exit()


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Fixed removal all dmvpn SAs on spokes when it tries to connect  to another spoke. 
Changed vici terminating by child-sa name on terminating by ike-id. 
Refactoring code.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T1070

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
opennhrp

## Proposed changes
<!--- Describe your changes in detail -->
The function that terminates ipsec tunnel in DMVPN was changed. Because this function deletes
all SAs which use dmvpn connection.
Now it tries to find all IKE IDs by src nbma and dst nbma. Then it tries to delete them using ike-id 

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
When DMVPN network is configured, we try to create a connection between spokes.
Then we can see on the spoke that the tunnel to HUB was deleted.

Hub configuration

```
vyos@vyos:~$ show configuration commands
set interfaces ethernet eth0 address '10.0.1.2/24'
set interfaces ethernet eth0 hw-id '0c:4b:e8:6d:00:00'
set interfaces ethernet eth1 address '192.168.1.1/24'
set interfaces ethernet eth1 hw-id '0c:4b:e8:6d:00:01'
set interfaces ethernet eth2 hw-id '0c:4b:e8:6d:00:02'
set interfaces ethernet eth3 hw-id '0c:4b:e8:6d:00:03'
set interfaces loopback lo
set interfaces tunnel tun100 address '10.10.100.1/24'
set interfaces tunnel tun100 encapsulation 'gre'
set interfaces tunnel tun100 mtu '1400'
set interfaces tunnel tun100 multicast 'enable'
set interfaces tunnel tun100 parameters ip key '1'
set interfaces tunnel tun100 source-address '10.0.1.2'
set protocols bgp address-family ipv4-unicast network 192.168.1.0/24
set protocols bgp local-as '65000'
set protocols bgp neighbor 10.10.100.2 address-family ipv4-unicast route-reflector-client
set protocols bgp neighbor 10.10.100.2 remote-as '65000'
set protocols bgp neighbor 10.10.100.3 address-family ipv4-unicast route-reflector-client
set protocols bgp neighbor 10.10.100.3 remote-as '65000'
set protocols bgp parameters router-id '1.1.1.1'
set protocols nhrp tunnel tun100 cisco-authentication 'dmvpn'
set protocols nhrp tunnel tun100 holding-time '300'
set protocols nhrp tunnel tun100 multicast 'dynamic'
set protocols nhrp tunnel tun100 shortcut
set protocols static route 0.0.0.0/0 next-hop 10.0.1.1
set service ssh port '22'
set system config-management commit-revisions '100'
set system conntrack modules ftp
set system conntrack modules h323
set system conntrack modules nfs
set system conntrack modules pptp
set system conntrack modules sip
set system conntrack modules sqlnet
set system conntrack modules tftp
set system host-name 'vyos'
set system login user vyos authentication encrypted-password '$6$MjV2YvKQ56q$QbL562qhRoyUu8OaqrXagicvcsNpF1HssCY06ZxxghDJkBCfSfTE/4FlFB41xZcd/HqYyVBuRt8Zyq3ozJ0dc.'
set system login user vyos authentication plaintext-password ''
set system ntp server time1.vyos.net
set system ntp server time2.vyos.net
set system ntp server time3.vyos.net
set system syslog global facility all level 'notice'
set system syslog global facility protocols level 'debug'
set vpn ipsec esp-group ESP-HUB compression 'disable'
set vpn ipsec esp-group ESP-HUB lifetime '1800'
set vpn ipsec esp-group ESP-HUB mode 'transport'
set vpn ipsec esp-group ESP-HUB pfs 'dh-group2'
set vpn ipsec esp-group ESP-HUB proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-HUB proposal 1 hash 'sha1'
set vpn ipsec esp-group ESP-HUB proposal 2 encryption '3des'
set vpn ipsec esp-group ESP-HUB proposal 2 hash 'md5'
set vpn ipsec ike-group IKE-HUB close-action 'none'
set vpn ipsec ike-group IKE-HUB dead-peer-detection action 'restart'
set vpn ipsec ike-group IKE-HUB dead-peer-detection interval '3'
set vpn ipsec ike-group IKE-HUB dead-peer-detection timeout '30'
set vpn ipsec ike-group IKE-HUB ikev2-reauth 'no'
set vpn ipsec ike-group IKE-HUB key-exchange 'ikev2'
set vpn ipsec ike-group IKE-HUB lifetime '3600'
set vpn ipsec ike-group IKE-HUB proposal 1 dh-group '2'
set vpn ipsec ike-group IKE-HUB proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE-HUB proposal 1 hash 'sha1'
set vpn ipsec ike-group IKE-HUB proposal 2 dh-group '2'
set vpn ipsec ike-group IKE-HUB proposal 2 encryption 'aes128'
set vpn ipsec ike-group IKE-HUB proposal 2 hash 'sha1'
set vpn ipsec interface 'eth0'
set vpn ipsec profile NHRPVPN authentication mode 'pre-shared-secret'
set vpn ipsec profile NHRPVPN authentication pre-shared-secret 'dmvpn'
set vpn ipsec profile NHRPVPN bind tunnel 'tun100'
set vpn ipsec profile NHRPVPN esp-group 'ESP-HUB'
set vpn ipsec profile NHRPVPN ike-group 'IKE-HUB'
```
Spoke configuration

```
set interfaces ethernet eth0 address '10.0.2.2/24'
set interfaces ethernet eth0 hw-id '0c:21:91:a1:00:00'
set interfaces ethernet eth1 address '192.168.2.1/24'
set interfaces ethernet eth1 hw-id '0c:21:91:a1:00:01'
set interfaces ethernet eth2 address '192.168.192.137/24'
set interfaces ethernet eth2 hw-id '0c:21:91:a1:00:02'
set interfaces ethernet eth3 address '10.0.5.1/24'
set interfaces ethernet eth3 hw-id '0c:21:91:a1:00:03'
set interfaces loopback lo
set interfaces tunnel tun100 address '10.10.100.2/24'
set interfaces tunnel tun100 encapsulation 'gre'
set interfaces tunnel tun100 multicast 'enable'
set interfaces tunnel tun100 parameters ip key '1'
set interfaces tunnel tun100 source-address '10.0.2.2'
set policy prefix-list TEST rule 101 action 'permit'
set policy prefix-list TEST rule 101 prefix '192.168.2.0/24'
set protocols bgp address-family ipv4-unicast network 192.168.2.0/24
set protocols bgp local-as '65000'
set protocols bgp neighbor 10.10.100.1 address-family ipv4-unicast
set protocols bgp neighbor 10.10.100.1 remote-as '65000'
set protocols bgp parameters router-id '2.2.2.2'
set protocols nhrp tunnel tun100 cisco-authentication 'dmvpn'
set protocols nhrp tunnel tun100 holding-time '300'
set protocols nhrp tunnel tun100 map 10.10.100.1/24 nbma-address '10.0.1.2'
set protocols nhrp tunnel tun100 map 10.10.100.1/24 register
set protocols nhrp tunnel tun100 multicast 'nhs'
set protocols nhrp tunnel tun100 redirect
set protocols nhrp tunnel tun100 shortcut
set protocols static route 0.0.0.0/0 next-hop 10.0.2.1
set service ssh port '22'
set system config-management commit-revisions '100'
set system conntrack modules ftp
set system conntrack modules h323
set system conntrack modules nfs
set system conntrack modules pptp
set system conntrack modules sip
set system conntrack modules sqlnet
set system conntrack modules tftp
set system host-name 'vyos'
set system login user vyos authentication encrypted-password '$6$MjV2YvKQ56q$QbL562qhRoyUu8OaqrXagicvcsNpF1HssCY06ZxxghDJkBCfSfTE/4FlFB41xZcd/HqYyVBuRt8Zyq3ozJ0dc.'
set system login user vyos authentication plaintext-password ''
set system name-server '8.8.8.8'
set system ntp server time1.vyos.net
set system ntp server time2.vyos.net
set system ntp server time3.vyos.net
set system syslog global facility all level 'notice'
set system syslog global facility protocols level 'debug'
set vpn ipsec esp-group ESP-HUB compression 'disable'
set vpn ipsec esp-group ESP-HUB lifetime '1800'
set vpn ipsec esp-group ESP-HUB mode 'transport'
set vpn ipsec esp-group ESP-HUB pfs 'dh-group2'
set vpn ipsec esp-group ESP-HUB proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-HUB proposal 1 hash 'sha1'
set vpn ipsec esp-group ESP-HUB proposal 2 encryption '3des'
set vpn ipsec esp-group ESP-HUB proposal 2 hash 'md5'
set vpn ipsec esp-group ESP-SITE compression 'disable'
set vpn ipsec esp-group ESP-SITE lifetime '1800'
set vpn ipsec esp-group ESP-SITE mode 'tunnel'
set vpn ipsec esp-group ESP-SITE pfs 'dh-group2'
set vpn ipsec esp-group ESP-SITE proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-SITE proposal 1 hash 'sha1'
set vpn ipsec esp-group ESP-SITE proposal 2 encryption '3des'
set vpn ipsec esp-group ESP-SITE proposal 2 hash 'md5'
set vpn ipsec ike-group IKE-HUB close-action 'none'
set vpn ipsec ike-group IKE-HUB dead-peer-detection action 'restart'
set vpn ipsec ike-group IKE-HUB dead-peer-detection interval '3'
set vpn ipsec ike-group IKE-HUB dead-peer-detection timeout '30'
set vpn ipsec ike-group IKE-HUB ikev2-reauth 'no'
set vpn ipsec ike-group IKE-HUB key-exchange 'ikev2'
set vpn ipsec ike-group IKE-HUB lifetime '3600'
set vpn ipsec ike-group IKE-HUB proposal 1 dh-group '2'
set vpn ipsec ike-group IKE-HUB proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE-HUB proposal 1 hash 'sha1'
set vpn ipsec ike-group IKE-HUB proposal 2 dh-group '2'
set vpn ipsec ike-group IKE-HUB proposal 2 encryption 'aes128'
set vpn ipsec ike-group IKE-HUB proposal 2 hash 'sha1'
set vpn ipsec interface 'eth0'
set vpn ipsec interface 'eth3'
set vpn ipsec log level '2'
set vpn ipsec log subsystem 'any'
set vpn ipsec profile NHRPVPN authentication mode 'pre-shared-secret'
set vpn ipsec profile NHRPVPN authentication pre-shared-secret 'dmvpn'
set vpn ipsec profile NHRPVPN bind tunnel 'tun100'
set vpn ipsec profile NHRPVPN esp-group 'ESP-HUB'
set vpn ipsec profile NHRPVPN ike-group 'IKE-HUB'
set vpn ipsec site-to-site peer 10.0.5.2 authentication id '10.0.5.1'
set vpn ipsec site-to-site peer 10.0.5.2 authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer 10.0.5.2 authentication pre-shared-secret 'test'
set vpn ipsec site-to-site peer 10.0.5.2 authentication remote-id '10.0.5.2'
set vpn ipsec site-to-site peer 10.0.5.2 connection-type 'initiate'
set vpn ipsec site-to-site peer 10.0.5.2 default-esp-group 'ESP-SITE'
set vpn ipsec site-to-site peer 10.0.5.2 ike-group 'IKE-HUB'
set vpn ipsec site-to-site peer 10.0.5.2 local-address '10.0.5.1'
set vpn ipsec site-to-site peer 10.0.5.2 tunnel 1 local prefix '192.168.2.0/24'
set vpn ipsec site-to-site peer 10.0.5.2 tunnel 1 remote prefix '192.168.5.0/24'

```


Before spoke-to-spoke connection
```
vyos@vyos:~$ show vpn ipsec sa
Connection    State    Uptime    Bytes In/Out    Packets In/Out    Remote address    Remote ID    Proposal
------------  -------  --------  --------------  ----------------  ----------------  -----------  ----------------------------------
dmvpn         up       10s       226B/186B       2B/2B             10.0.1.2          10.0.1.2     AES_CBC_256/HMAC_SHA1_96/MODP_1024
```
```
vyos@vyos:~$ sudo swanctl -l
dmvpn-NHRPVPN-tun100: #2, ESTABLISHED, IKEv2, d75034e2ff333694_i* 0f9fac76d6926722_r
  local  '10.0.2.2' @ 10.0.2.2[4500]
  remote '10.0.1.2' @ 10.0.1.2[4500]
  AES_CBC-256/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
  established 55s ago, rekeying in 3497s
  dmvpn: #3, reqid 1, INSTALLED, TRANSPORT, ESP:AES_CBC-256/HMAC_SHA1_96/MODP_1024
    installed 20s ago, rekeying in 1274s, expires in 1960s
    in  ce1a0942,    226 bytes,     2 packets,    20s ago
    out c20e1098,    186 bytes,     2 packets,    20s ago
    local  10.0.2.2/32[gre]
    remote 10.0.1.2/32[gre]
peer_10-0-5-2: #1, ESTABLISHED, IKEv2, a4c2fd9ce53c592e_i* afab7b89b90d8164_r
  local  '10.0.5.1' @ 10.0.5.1[4500]
  remote '10.0.5.2' @ 10.0.5.2[4500]
  AES_CBC-256/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
  established 55s ago, rekeying in 3384s

```
After spoke-to-spoke connection

```
Aug 23 14:38:35 vyos opennhrp[2187]: NL-ARP(tun100) who-has 10.10.100.3
Aug 23 14:38:35 vyos opennhrp[2187]: NL-ARP(tun100) 10.10.100.3 is-at 10.0.1.2
Aug 23 14:38:35 vyos opennhrp[2187]: Adding incomplete 10.10.100.3/32 dev tun100
Aug 23 14:38:35 vyos opennhrp[2187]: Sending Resolution Request to 10.10.100.3
Aug 23 14:38:35 vyos opennhrp[2187]: Sending packet 1, from: 10.10.100.2 (nbma 10.0.2.2), to: 10.10.100.3 (nbma 10.0.1.2)
Aug 23 14:38:35 vyos opennhrp[2187]: Received Resolution Reply 10.10.100.3/32 is at proto 10.10.100.3 nbma 10.0.3.2 (code 0)
Aug 23 14:38:35 vyos charon[1912]: 10[CFG] vici terminate IKE_SA 'dmvpn-NHRPVPN-tun100'
Aug 23 14:38:35 vyos charon[1912]: 10[CFG] vici terminate CHILD_SA 'dmvpn'
Aug 23 14:38:35 vyos charon[1912]: 10[IKE] <dmvpn-NHRPVPN-tun100|2> closing CHILD_SA dmvpn{3} with SPIs ce1a0942_i (986 bytes) c20e1098_o (970 bytes) and TS 10.0.2.2/32[gre] === 10.0.1.2/32[gre]
Aug 23 14:38:35 vyos charon[1912]: 10[IKE] <dmvpn-NHRPVPN-tun100|2> sending DELETE for ESP CHILD_SA with SPI ce1a0942
Aug 23 14:38:35 vyos charon[1912]: 10[ENC] <dmvpn-NHRPVPN-tun100|2> generating INFORMATIONAL request 4 [ D ]
Aug 23 14:38:35 vyos charon[1912]: 10[NET] <dmvpn-NHRPVPN-tun100|2> sending packet: from 10.0.2.2[4500] to 10.0.1.2[4500] (76 bytes)
Aug 23 14:38:35 vyos charon[1912]: 11[NET] <dmvpn-NHRPVPN-tun100|2> received packet: from 10.0.1.2[4500] to 10.0.2.2[4500] (76 bytes)
Aug 23 14:38:35 vyos charon[1912]: 11[ENC] <dmvpn-NHRPVPN-tun100|2> parsed INFORMATIONAL response 4 [ D ]
Aug 23 14:38:35 vyos charon[1912]: 11[IKE] <dmvpn-NHRPVPN-tun100|2> received DELETE for ESP CHILD_SA with SPI c20e1098
Aug 23 14:38:35 vyos charon[1912]: 11[IKE] <dmvpn-NHRPVPN-tun100|2> CHILD_SA closed
Aug 23 14:38:35 vyos charon[1912]: 16[CFG] vici initiate CHILD_SA 'dmvpn', me 10.0.2.2, other 10.0.3.2, limits 0
Aug 23 14:38:35 vyos charon[1912]: 16[IKE] <dmvpn-NHRPVPN-tun100|3> initiating IKE_SA dmvpn-NHRPVPN-tun100[3] to 10.0.3.2
Aug 23 14:38:35 vyos charon[1912]: 16[ENC] <dmvpn-NHRPVPN-tun100|3> generating IKE_SA_INIT request 0 [ SA KE No N(NATD_S_IP) N(NATD_D_IP) N(FRAG_SUP) N(HASH_ALG) N(REDIR_SUP) ]
Aug 23 14:38:35 vyos charon[1912]: 16[NET] <dmvpn-NHRPVPN-tun100|3> sending packet: from 10.0.2.2[500] to 10.0.3.2[500] (380 bytes)
Aug 23 14:38:35 vyos charon[1912]: 14[NET] <dmvpn-NHRPVPN-tun100|3> received packet: from 10.0.3.2[500] to 10.0.2.2[500] (344 bytes)
Aug 23 14:38:35 vyos charon[1912]: 14[ENC] <dmvpn-NHRPVPN-tun100|3> parsed IKE_SA_INIT response 0 [ SA KE No N(NATD_S_IP) N(NATD_D_IP) N(FRAG_SUP) N(HASH_ALG) N(CHDLESS_SUP) N(MULT_AUTH) ]
Aug 23 14:38:35 vyos charon[1912]: 14[CFG] <dmvpn-NHRPVPN-tun100|3> selected proposal: IKE:AES_CBC_256/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
Aug 23 14:38:35 vyos charon[1912]: 14[CFG] <dmvpn-NHRPVPN-tun100|3> no IDi configured, fall back on IP address
Aug 23 14:38:35 vyos charon[1912]: 14[IKE] <dmvpn-NHRPVPN-tun100|3> authentication of '10.0.2.2' (myself) with pre-shared key
Aug 23 14:38:35 vyos charon[1912]: 14[IKE] <dmvpn-NHRPVPN-tun100|3> establishing CHILD_SA dmvpn{4}
Aug 23 14:38:35 vyos charon[1912]: 14[ENC] <dmvpn-NHRPVPN-tun100|3> generating IKE_AUTH request 1 [ IDi AUTH N(USE_TRANSP) SA TSi TSr N(MOBIKE_SUP) N(ADD_4_ADDR) N(MULT_AUTH) N(EAP_ONLY) N(MSG_ID_SYN_SUP) ]
Aug 23 14:38:35 vyos charon[1912]: 14[NET] <dmvpn-NHRPVPN-tun100|3> sending packet: from 10.0.2.2[4500] to 10.0.3.2[4500] (284 bytes)
Aug 23 14:38:35 vyos charon[1912]: 10[NET] <dmvpn-NHRPVPN-tun100|3> received packet: from 10.0.3.2[4500] to 10.0.2.2[4500] (220 bytes)
Aug 23 14:38:35 vyos charon[1912]: 10[ENC] <dmvpn-NHRPVPN-tun100|3> parsed IKE_AUTH response 1 [ IDr AUTH N(USE_TRANSP) SA TSi TSr N(MOBIKE_SUP) N(NO_ADD_ADDR) ]
Aug 23 14:38:35 vyos charon[1912]: 10[IKE] <dmvpn-NHRPVPN-tun100|3> authentication of '10.0.3.2' with pre-shared key successful
Aug 23 14:38:35 vyos charon[1912]: 10[IKE] <dmvpn-NHRPVPN-tun100|3> IKE_SA dmvpn-NHRPVPN-tun100[3] established between 10.0.2.2[10.0.2.2]...10.0.3.2[10.0.3.2]
Aug 23 14:38:35 vyos charon[1912]: 10[IKE] <dmvpn-NHRPVPN-tun100|3> scheduling rekeying in 3595s
Aug 23 14:38:35 vyos charon[1912]: 10[IKE] <dmvpn-NHRPVPN-tun100|3> maximum IKE_SA lifetime 3955s
Aug 23 14:38:35 vyos charon[1912]: 10[CFG] <dmvpn-NHRPVPN-tun100|3> selected proposal: ESP:AES_CBC_256/HMAC_SHA1_96/NO_EXT_SEQ
Aug 23 14:38:35 vyos charon[1912]: 10[IKE] <dmvpn-NHRPVPN-tun100|3> CHILD_SA dmvpn{4} established with SPIs c71577cb_i cad4a83f_o and TS 10.0.2.2/32[gre] === 10.0.3.2/32[gre]
Aug 23 14:38:35 vyos charon[1912]: 10[IKE] <dmvpn-NHRPVPN-tun100|3> peer supports MOBIKE
Aug 23 14:38:35 vyos opennhrp[2187]: [10.10.100.3] Peer up script: success
```
```
vyos@vyos:~$ show vpn ipsec sa
Connection    State    Uptime    Bytes In/Out    Packets In/Out    Remote address    Remote ID    Proposal
------------  -------  --------  --------------  ----------------  ----------------  -----------  ------------------------
dmvpn         up       15s       1012B/1K        11B/12B           10.0.3.2          10.0.3.2     AES_CBC_256/HMAC_SHA1_96
```
```
vyos@vyos:~$ sudo swanctl -l
dmvpn-NHRPVPN-tun100: #3, ESTABLISHED, IKEv2, 284775c3b66933ea_i* f43c416009391d07_r
  local  '10.0.2.2' @ 10.0.2.2[4500]
  remote '10.0.3.2' @ 10.0.3.2[4500]
  AES_CBC-256/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
  established 25s ago, rekeying in 3570s
  dmvpn: #4, reqid 1, INSTALLED, TRANSPORT, ESP:AES_CBC-256/HMAC_SHA1_96
    installed 25s ago, rekeying in 1509s, expires in 1955s
    in  c71577cb,   1932 bytes,    21 packets,     0s ago
    out cad4a83f,   2024 bytes,    22 packets,     0s ago
    local  10.0.2.2/32[gre]
    remote 10.0.3.2/32[gre]
dmvpn-NHRPVPN-tun100: #2, ESTABLISHED, IKEv2, d75034e2ff333694_i* 0f9fac76d6926722_r
  local  '10.0.2.2' @ 10.0.2.2[4500]
  remote '10.0.1.2' @ 10.0.1.2[4500]
  AES_CBC-256/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
  established 133s ago, rekeying in 3419s


```

As we can see old SA to hub was deleted by vici.
Now traffic to the HUB is passing without IPSEC encryption.
 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
