### PR TITLE
Policy: T4641: allow only ipv4 prefixes on prefix-list

### DIFF
--- a/interface-definitions/policy.xml.in
+++ b/interface-definitions/policy.xml.in
@@ -392,7 +392,7 @@
                     <description>Prefix to match against</description>
                   </valueHelp>
                   <constraint>
-                    <validator name="ip-prefix"/>
+                    <validator name="ipv4-prefix"/>
                   </constraint>
                 </properties>
               </leafNode>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
While defining a prefix-list in 1.4, user can set an ipv6 prefix, when actually this should be done in **prefix-list6**.
Using an ipv6 prefix on **prefix-list** should be denied, as it is in 1.3 version


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4641

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
policy
## Proposed changes
<!--- Describe your changes in detail -->
Only allow ipv4 prefixes on **prefix-list**.
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Check that ipv4 prefixes are allowed, and check that ipv6 prefixes are denied:
```
vyos@vyos# run show config comm | grep prefix
set policy prefix-list PL-4 rule 10 action 'permit'
set policy prefix-list PL-4 rule 10 prefix '198.51.100.0/24'
set policy prefix-list PL-4 rule 20 action 'deny'
set policy prefix-list PL-4 rule 20 prefix '192.0.2.0/24'
[edit]
vyos@vyos# vtysh -c "show run" | grep prefix
ip prefix-list PL-4 seq 10 permit 198.51.100.0/24
ip prefix-list PL-4 seq 20 deny 192.0.2.0/24
[edit]
vyos@vyos# 
[edit]
vyos@vyos# set policy prefix-list PL-4 rule 30 action 'permit'
[edit]
vyos@vyos# set policy prefix-list PL-4 rule 30 prefix '2001:db8::0/64'

  Error: 2001:db8::0/64 is not a valid IPv4 prefix

  Invalid value
  Value validation failed
  Set failed

[edit]
vyos@vyos# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
