### PR TITLE
graphql: T4640: add schema defs and resolver support for op-mode errors

### DIFF
--- a/src/services/api/graphql/bindings.py
+++ b/src/services/api/graphql/bindings.py
@@ -17,6 +17,7 @@ import vyos.defaults
 from . graphql.queries import query
 from . graphql.mutations import mutation
 from . graphql.directives import directives_dict
+from . graphql.errors import op_mode_error
 from . utils.schema_from_op_mode import generate_op_mode_definitions
 from ariadne import make_executable_schema, load_schema_from_path, snake_case_fallback_resolvers
 
@@ -27,6 +28,6 @@ def generate_schema():
 
     type_defs = load_schema_from_path(api_schema_dir)
 
-    schema = make_executable_schema(type_defs, query, mutation, snake_case_fallback_resolvers, directives=directives_dict)
+    schema = make_executable_schema(type_defs, query, op_mode_error, mutation, snake_case_fallback_resolvers, directives=directives_dict)
 
     return schema

--- a/src/services/api/graphql/graphql/errors.py
+++ b/src/services/api/graphql/graphql/errors.py
@@ -1,0 +1,8 @@
+
+from ariadne import InterfaceType
+
+op_mode_error = InterfaceType("OpModeError")
+
+@op_mode_error.type_resolver
+def resolve_op_mode_error(obj, *_):
+    return obj['name']

--- a/src/services/api/graphql/graphql/mutations.py
+++ b/src/services/api/graphql/graphql/mutations.py
@@ -22,6 +22,8 @@ from makefun import with_signature
 from .. import state
 from .. import key_auth
 from api.graphql.session.session import Session
+from api.graphql.session.errors.op_mode_errors import op_mode_err_msg, op_mode_err_code
+from vyos.opmode import Error as OpModeError
 
 mutation = ObjectType("Mutation")
 
@@ -86,10 +88,19 @@ def make_mutation_resolver(mutation_name, class_name, session_func):
                 "success": True,
                 "data": data
             }
+        except OpModeError as e:
+            typename = type(e).__name__
+            return {
+                "success": False,
+                "errore": ['op_mode_error'],
+                "op_mode_error": {"name": f"{typename}",
+                                 "message": op_mode_err_msg.get(typename, "Unknown"),
+                                 "vyos_code": op_mode_err_code.get(typename, 9999)}
+            }
         except Exception as error:
             return {
                 "success": False,
-                "errors": [str(error)]
+                "errors": [repr(error)]
             }
 
     return func_impl

--- a/src/services/api/graphql/graphql/queries.py
+++ b/src/services/api/graphql/graphql/queries.py
@@ -22,6 +22,8 @@ from makefun import with_signature
 from .. import state
 from .. import key_auth
 from api.graphql.session.session import Session
+from api.graphql.session.errors.op_mode_errors import op_mode_err_msg, op_mode_err_code
+from vyos.opmode import Error as OpModeError
 
 query = ObjectType("Query")
 
@@ -86,10 +88,19 @@ def make_query_resolver(query_name, class_name, session_func):
                 "success": True,
                 "data": data
             }
+        except OpModeError as e:
+            typename = type(e).__name__
+            return {
+                "success": False,
+                "errors": ['op_mode_error'],
+                "op_mode_error": {"name": f"{typename}",
+                                 "message": op_mode_err_msg.get(typename, "Unknown"),
+                                 "vyos_code": op_mode_err_code.get(typename, 9999)}
+            }
         except Exception as error:
             return {
                 "success": False,
-                "errors": [str(error)]
+                "errors": [repr(error)]
             }
 
     return func_impl

--- a/src/services/api/graphql/session/errors/op_mode_errors.py
+++ b/src/services/api/graphql/session/errors/op_mode_errors.py
@@ -1,0 +1,13 @@
+
+
+op_mode_err_msg = {
+    "UnconfiguredSubsystem": "subsystem is not configured or not running",
+    "DataUnavailable": "data currently unavailable",
+    "PermissionDenied": "client does not have permission"
+}
+
+op_mode_err_code = {
+    "UnconfiguredSubsystem": 2000,
+    "DataUnavailable": 2001,
+    "PermissionDenied": 1003
+}

--- a/src/services/api/graphql/session/session.py
+++ b/src/services/api/graphql/session/session.py
@@ -22,6 +22,7 @@ from vyos.config import Config
 from vyos.configtree import ConfigTree
 from vyos.defaults import directories
 from vyos.template import render
+from vyos.opmode import Error as OpModeError
 
 from api.graphql.utils.util import load_op_mode_as_module, split_compound_op_mode_name
 
@@ -177,10 +178,10 @@ class Session:
 
         mod = load_op_mode_as_module(f'{scriptname}')
         func = getattr(mod, func_name)
-        if len(list(data)) > 0:
+        try:
             res = func(True, **data)
-        else:
-            res = func(True)
+        except OpModeError as e:
+            raise e
 
         return res
 
@@ -199,9 +200,9 @@ class Session:
 
         mod = load_op_mode_as_module(f'{scriptname}')
         func = getattr(mod, func_name)
-        if len(list(data)) > 0:
+        try:
             res = func(**data)
-        else:
-            res = func()
+        except OpModeError as e:
+            raise e
 
         return res


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Updated based on comments below and discussion in dev meeting:

This PR integrates the op-mode script exception hierarchy into the GraphQL API. Op-mode errors are reported to the client in the form:

```
"op_mode_error": {
    "name": str
    "message": str
    "vyos_code": int
}
```

The error codes are from the document:
https://docs.google.com/document/d/1XPMCbid3O_R-6ITi4NpiWFoo2QqHMXYnCSeUzvOgOtA

The schema entity OpModeError is of interface type, with the specific errors implementing the type; consequently, queries need only a simple addition to return error information, yet it is possible to include extra error-specific fields should that be needed in the future. Example below.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4640

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

http-api

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

One can test this using the file 'dummy.py', a mock standardized op-mode script that will raise an error given a non-zero int argument 1--3:
https://github.com/jestabro/vyos-1x/blob/gql-op-mode-errors-single-type/src/op_mode/dummy.py

If one adds that to the 'op-mode-standardized.json' file and restarts vyos-http-api, a query such as:

```
query {ShowDummy (data: {key:"qwerty", trigger: 1}) {
  success
  errors
  op_mode_error {
    name
    message
    vyos_code
  }
  data {
    result
  }
}}
```
will return:

```
{
  "data": {
    "ShowDummy": {
      "success": false,
      "errors": [
        "op_mode_error"
      ],
      "op_mode_error": {
        "name": "UnconfiguredSubsystem",
        "message": "subsystem is not configured or not running",
        "vyos_code": 2000
      },
      "data": null
    }
  }
}
```

The equivalent curl command is, for example,

`curl -k --raw 'https://192.168.122.188/graphql' -H 'Content-Type: application/json' -d '{"query":" {\n ShowDummy (data: {key: \"qwerty\", trigger: 1}) {\n success\n errors\n op_mode_error {name, message, vyos_code}\n data {\n result\n }\n}\n}\n"}' | jq
`

The OpModeError implementation has been included in the script that generates schema definitions, such that, upon adding new errors, one will only need to update the dicts containing the field information, {message, codes}, or default to placeholder values.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
