### PR TITLE
op-mode: T4645: Show nat source statistics missing argument --family

### DIFF
--- a/op-mode-definitions/nat.xml.in
+++ b/op-mode-definitions/nat.xml.in
@@ -22,7 +22,7 @@
                 <properties>
                   <help>Show statistics for configured source NAT rules</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/nat.py show_statistics --direction source</command>
+                <command>${vyos_op_scripts_dir}/nat.py show_statistics --direction source --family inet</command>
               </node>
               <node name="translations">
                 <properties>

--- a/src/op_mode/nat.py
+++ b/src/op_mode/nat.py
@@ -188,8 +188,8 @@ def show_rules(raw: bool, direction: str, family: str):
         return _get_formatted_output_rules(nat_rules, direction, family)
 
 
-def show_statistics(raw: bool, direction: str):
-    nat_statistics = _get_raw_data_rules(direction)
+def show_statistics(raw: bool, direction: str, family: str):
+    nat_statistics = _get_raw_data_rules(direction, family)
     if raw:
         return nat_statistics
     else:


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
As we use in commit 8d4205a9 argument `--family` for the
function `_get_raw_data_rules(direction, family)` we must use it
and for `nat.py show_statistics` as it gets raw data from the same
function
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4645

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set nat source rule 100 outbound-interface 'eth0'
set nat source rule 100 source address '192.0.2.0/24'
set nat source rule 100 translation address 'masquerade'
set nat source rule 120 outbound-interface 'eth1'
set nat source rule 120 source address '192.168.122.1'
set nat source rule 120 translation address 'masquerade'
```
Before fix:
```
vyos@r14:~$ show nat source statistics 
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/nat.py", line 201, in <module>
    res = vyos.opmode.run(sys.modules[__name__])
  File "/usr/lib/python3/dist-packages/vyos/opmode.py", line 145, in run
    res = func(**args)
  File "/usr/libexec/vyos/op_mode/nat.py", line 192, in show_statistics
    nat_statistics = _get_raw_data_rules(direction)
TypeError: _get_raw_data_rules() missing 1 required positional argument: 'family'
vyos@r14:~$
```
After fix:
```
vyos@r14:~$ show nat source statistics 
Rule    Packets    Bytes    Interface
------  ---------  -------  -----------
100     1279       107896   eth0
120     1          60       eth1
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
