### PR TITLE
pppoe: T4648: fix incorrect installation of IPv6 default route even when default-route is set to none 

### DIFF
--- a/data/templates/pppoe/ipv6-up.script.tmpl
+++ b/data/templates/pppoe/ipv6-up.script.tmpl
@@ -36,6 +36,14 @@ echo 1 > /proc/sys/net/ipv6/conf/{{ ifname }}/forwarding
 #
 echo 2 > /proc/sys/net/ipv6/conf/{{ ifname }}/accept_ra
 
+{% if default_route == 'none' %}
+# Prevent learning of default router from router advertisements
+echo 0 > /proc/sys/net/ipv6/conf/{{ ifname }}/accept_ra_defrtr
+{% else %}
+# Enable learning of default router from router advertisements
+echo 1 > /proc/sys/net/ipv6/conf/{{ ifname }}/accept_ra_defrtr
+{% endif %}
+
 # Autoconfigure addresses using Prefix Information in Router Advertisements.
 echo 1 > /proc/sys/net/ipv6/conf/{{ ifname }}/autoconf
 {% endif %}


### PR DESCRIPTION
## Change Summary
Currently an IPv6 default route is installed as a response to the received router advertisement on the PPPoE interface regardless of the `default-route` setting in the PPPoE interface.

This change suppresses the automated route installation by tuning the kernel sysctl `accept_ra_defrtr` to ignore default routers advertised in RAs on the ppp interface coming up in `/etc/ppp/ipv6-up.d/`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4648

## Component(s) name
pppoe

## Proposed changes

The template `ipv6-up.script.tmpl` is adjusted to add a line:
```sh
echo 0 > /proc/sys/net/ipv6/conf/{{ ifname }}/accept_ra_defrtr
```
to suppress automatic default route installation by the kernel, only when the `default-route` parameter is set to `none`.

## How to test

1. Create a basic PPPoE interface with `none` the `default-route` with IPv6 configured.  e.g.:
```
interfaces {
    pppoe pppoe0 {
        ...

        default-route none

        ipv6 {
            address {
                autoconf
            }
        }
    }
}
```
2. Once the interface is connected, run `show ipv6 route` and ensure there are no default routes installed.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
