### PR TITLE
smoketest: T4643: Delete vpn sstp from config as we have HTTP

### DIFF
--- a/smoketest/configs/pki-misc
+++ b/smoketest/configs/pki-misc
@@ -74,26 +74,6 @@ vpn {
             key-file /config/auth/ovpn_test_server.key
         }
     }
-    sstp {
-        authentication {
-            local-users {
-                username test {
-                    password test
-                }
-            }
-            mode local
-            protocols mschap-v2
-        }
-        client-ip-pool {
-            subnet 192.168.170.0/24
-        }
-        gateway-address 192.168.150.1
-        ssl {
-            ca-cert-file /config/auth/ovpn_test_ca.pem
-            cert-file /config/auth/ovpn_test_server.pem
-            key-file /config/auth/ovpn_test_server.key
-        }
-    }
 }
 
 


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix smoketest
HTTP and sstp cannot work together and in the test config
1.4-rolling-202106290839 we did not have configurable port for
such services
So we should delete sstp from this smoketest config test
In fact, it is never working at all `smoketest/configs/pki-misc`
It commits without errors before, but in the real life we get 3
services (https openconnect sstp) that bound the same port (only one service can bind the 443 port)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Smoketest

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4643

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
smoketest
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
vyos@r14:~$ /usr/bin/vyos-configtest
Generating tests
... completed: 0.000608
test_pki_misc (__main__.TestConfigPkiMisc) ...  time: 16.943
ok

----------------------------------------------------------------------
Ran 1 test in 16.952s

OK
vyos@r14:~$ 


```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
