### PR TITLE
opennhrp: T1070: Fixed creating IPSEC tunnel to Hub

### DIFF
--- a/src/etc/opennhrp/opennhrp-script.py
+++ b/src/etc/opennhrp/opennhrp-script.py
@@ -81,7 +81,13 @@ def vici_ike_terminate(list_ikeid: list[str]) -> bool:
         session = vici.Session()
         for ikeid in list_ikeid:
             logger.info(f'Terminating IKE SA with id {ikeid}')
-            session.terminate({'ike-id': ikeid, 'timeout': '-1'})
+            session_generator = session.terminate(
+                {'ike-id': ikeid, 'timeout': '-1'})
+            # a dummy `for` loop is required because of requirements
+            # from vici. Without a full iteration on the output, the
+            # command to vici may not be executed completely
+            for _ in session_generator:
+                pass
         return True
     except Exception as err:
         logger.error(f'Failed to terminate SA for IKE ids {list_ikeid}: {err}')
@@ -175,13 +181,18 @@ def vici_initiate(conn: str, child_sa: str, src_addr: str,
         f'src_addr: {src_addr}, dst_addr: {dest_addr}')
     try:
         session = vici.Session()
-        session.initiate({
+        session_generator = session.initiate({
             'ike': conn,
             'child': child_sa,
             'timeout': '-1',
             'my-host': src_addr,
             'other-host': dest_addr
         })
+        # a dummy `for` loop is required because of requirements
+        # from vici. Without a full iteration on the output, the
+        # command to vici may not be executed completely
+        for _ in session_generator:
+            pass
         return True
     except Exception as err:
         logger.error(f'Unable to initiate connection {err}')


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed creating IPSEC tunnel to Hub. Added continues of execution
generator functions.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T1070

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
opennhrp

## Proposed changes
<!--- Describe your changes in detail -->
Added loop to continue execution generator functions. 
If we do not use loop for generator iteration, the function will end without
IPSEC tunnel creation.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Hub config
```
set interfaces ethernet eth0 address '10.0.1.2/24'
set interfaces ethernet eth1 address '192.168.1.1/24'
set interfaces tunnel tun100 address '10.10.100.1/24'
set interfaces tunnel tun100 encapsulation 'gre'
set interfaces tunnel tun100 mtu '1400'
set interfaces tunnel tun100 multicast 'enable'
set interfaces tunnel tun100 parameters ip key '1'
set interfaces tunnel tun100 source-address '10.0.1.2'
set protocols bgp address-family ipv4-unicast network 192.168.1.0/24
set protocols bgp neighbor 10.10.100.2 address-family ipv4-unicast route-reflector-client
set protocols bgp neighbor 10.10.100.2 remote-as '65000'
set protocols bgp neighbor 10.10.100.3 address-family ipv4-unicast route-reflector-client
set protocols bgp neighbor 10.10.100.3 remote-as '65000'
set protocols bgp parameters router-id '1.1.1.1'
set protocols bgp system-as '65000'
set protocols nhrp tunnel tun100 cisco-authentication 'dmvpn'
set protocols nhrp tunnel tun100 holding-time '300'
set protocols nhrp tunnel tun100 multicast 'dynamic'
set protocols nhrp tunnel tun100 shortcut
set protocols static route 0.0.0.0/0 next-hop 10.0.1.1
set vpn ipsec esp-group ESP-HUB compression 'disable'
set vpn ipsec esp-group ESP-HUB lifetime '1800'
set vpn ipsec esp-group ESP-HUB mode 'transport'
set vpn ipsec esp-group ESP-HUB pfs 'dh-group2'
set vpn ipsec esp-group ESP-HUB proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-HUB proposal 1 hash 'sha1'
set vpn ipsec esp-group ESP-HUB proposal 2 encryption '3des'
set vpn ipsec esp-group ESP-HUB proposal 2 hash 'md5'
set vpn ipsec ike-group IKE-HUB close-action 'none'
set vpn ipsec ike-group IKE-HUB dead-peer-detection action 'restart'
set vpn ipsec ike-group IKE-HUB dead-peer-detection interval '3'
set vpn ipsec ike-group IKE-HUB dead-peer-detection timeout '30'
set vpn ipsec ike-group IKE-HUB ikev2-reauth 'no'
set vpn ipsec ike-group IKE-HUB key-exchange 'ikev2'
set vpn ipsec ike-group IKE-HUB lifetime '3600'
set vpn ipsec ike-group IKE-HUB proposal 1 dh-group '2'
set vpn ipsec ike-group IKE-HUB proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE-HUB proposal 1 hash 'sha1'
set vpn ipsec ike-group IKE-HUB proposal 2 dh-group '2'
set vpn ipsec ike-group IKE-HUB proposal 2 encryption 'aes128'
set vpn ipsec ike-group IKE-HUB proposal 2 hash 'sha1'
set vpn ipsec interface 'eth0'
set vpn ipsec profile NHRPVPN authentication mode 'pre-shared-secret'
set vpn ipsec profile NHRPVPN authentication pre-shared-secret 'dmvpn'
set vpn ipsec profile NHRPVPN bind tunnel 'tun100'
set vpn ipsec profile NHRPVPN esp-group 'ESP-HUB'
set vpn ipsec profile NHRPVPN ike-group 'IKE-HUB'
```
Spoke config
```
set interfaces ethernet eth0 address '10.0.2.2/24'
set interfaces ethernet eth1 address '192.168.2.1/24'
set interfaces tunnel tun100 address '10.10.100.2/24'
set interfaces tunnel tun100 encapsulation 'gre'
set interfaces tunnel tun100 multicast 'enable'
set interfaces tunnel tun100 parameters ip key '1'
set interfaces tunnel tun100 source-address '10.0.2.2'
set protocols bgp address-family ipv4-unicast network 192.168.2.0/24
set protocols bgp neighbor 10.10.100.1 address-family ipv4-unicast
set protocols bgp neighbor 10.10.100.1 remote-as '65000'
set protocols bgp parameters router-id '2.2.2.2'
set protocols bgp system-as '65000'
set protocols nhrp tunnel tun100 cisco-authentication 'dmvpn'
set protocols nhrp tunnel tun100 holding-time '300'
set protocols nhrp tunnel tun100 map 10.10.100.1/24 nbma-address '10.0.1.2'
set protocols nhrp tunnel tun100 map 10.10.100.1/24 register
set protocols nhrp tunnel tun100 multicast 'nhs'
set protocols nhrp tunnel tun100 redirect
set protocols nhrp tunnel tun100 shortcut
set protocols static route 0.0.0.0/0 next-hop 10.0.2.1
set vpn ipsec esp-group ESP-HUB compression 'disable'
set vpn ipsec esp-group ESP-HUB lifetime '1800'
set vpn ipsec esp-group ESP-HUB mode 'transport'
set vpn ipsec esp-group ESP-HUB pfs 'dh-group2'
set vpn ipsec esp-group ESP-HUB proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-HUB proposal 1 hash 'sha1'
set vpn ipsec esp-group ESP-HUB proposal 2 encryption '3des'
set vpn ipsec esp-group ESP-HUB proposal 2 hash 'md5'
set vpn ipsec ike-group IKE-HUB close-action 'none'
set vpn ipsec ike-group IKE-HUB dead-peer-detection action 'restart'
set vpn ipsec ike-group IKE-HUB dead-peer-detection interval '3'
set vpn ipsec ike-group IKE-HUB dead-peer-detection timeout '30'
set vpn ipsec ike-group IKE-HUB ikev2-reauth 'no'
set vpn ipsec ike-group IKE-HUB key-exchange 'ikev2'
set vpn ipsec ike-group IKE-HUB lifetime '3600'
set vpn ipsec ike-group IKE-HUB proposal 1 dh-group '2'
set vpn ipsec ike-group IKE-HUB proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE-HUB proposal 1 hash 'sha1'
set vpn ipsec ike-group IKE-HUB proposal 2 dh-group '2'
set vpn ipsec ike-group IKE-HUB proposal 2 encryption 'aes128'
set vpn ipsec ike-group IKE-HUB proposal 2 hash 'sha1'
set vpn ipsec interface 'eth0'
set vpn ipsec profile NHRPVPN authentication mode 'pre-shared-secret'
set vpn ipsec profile NHRPVPN authentication pre-shared-secret 'dmvpn'
set vpn ipsec profile NHRPVPN bind tunnel 'tun100'
set vpn ipsec profile NHRPVPN esp-group 'ESP-HUB'
set vpn ipsec profile NHRPVPN ike-group 'IKE-HUB'
```

NHRP Peer UP log:
```
Aug 26 12:37:48 vyos opennhrp[2019]: NL-ARP(tun100) who-has 10.10.100.1
Aug 26 12:37:49 vyos opennhrp[2019]: NL-ARP(tun100) who-has 10.10.100.1
Aug 26 12:37:49 vyos opennhrp-script.py[2121]: Running script with arguments: ['/etc/opennhrp/opennhrp-script.py', 'peer-up'], environment: environ({'NHRP_TYPE': 'static', 'NHRP_SRCADDR': '10.10.100.2', 'NHRP_SRCNBMA': '10.0.2.2', 'NHRP_DESTADDR': '10.10.100.1', 'NHRP_DESTPREFIX': '24', 'NHRP_PEER_DOWN_REASON': 'user-request', 'NHRP_DESTNBMA': '10.0.1.2', 'NHR>
Aug 26 12:37:49 vyos opennhrp-script.py[2121]: Peer UP event for spoke using IKE profile dmvpn-NHRPVPN-tun100
Aug 26 12:37:49 vyos opennhrp-script.py[2121]: NBMA addresses: local 10.0.2.2, remote 10.0.1.2
Aug 26 12:37:49 vyos opennhrp-script.py[2121]: Terminating IKE connection dmvpn-NHRPVPN-tun100 between 10.0.2.2 and 10.0.1.2
Aug 26 12:37:49 vyos opennhrp-script.py[2121]: Resolving IKE unique ids for: conn: dmvpn-NHRPVPN-tun100, src_nbma: 10.0.2.2, dst_nbma: 10.0.1.2
Aug 26 12:37:49 vyos opennhrp-script.py[2121]: No active sessions found for IKE profile dmvpn-NHRPVPN-tun100, local NBMA 10.0.2.2, remote NBMA 10.0.1.2
Aug 26 12:37:49 vyos opennhrp-script.py[2121]: Trying to initiate connection. Name: dmvpn-NHRPVPN-tun100, child sa: dmvpn, src_addr: 10.0.2.2, dst_addr: 10.0.1.2
Aug 26 12:37:49 vyos opennhrp[2019]: [10.10.100.1] Peer up script: success
Aug 26 12:37:49 vyos opennhrp[2019]: NL-ARP(tun100) 10.10.100.1 is-at 10.0.1.2
Aug 26 12:37:49 vyos opennhrp[2019]: Sending Registration Request to 10.10.100.1 (my mtu=0)
Aug 26 12:37:49 vyos opennhrp[2019]: Sending packet 3, from: 10.10.100.2 (nbma 10.0.2.2), to: 10.10.100.1 (nbma 10.0.1.2)
Aug 26 12:37:50 vyos opennhrp[2019]: Received Registration Reply from 10.10.100.1: success
Aug 26 12:37:50 vyos opennhrp[2019]: Sending Purge Request (of local routes) to 10.10.100.1
Aug 26 12:37:50 vyos opennhrp[2019]: Sending packet 5, from: 10.10.100.2 (nbma 10.0.2.2), to: 10.10.100.1 (nbma 10.0.1.2)
Aug 26 12:37:50 vyos opennhrp[2019]: [10.10.100.1] Peer inserted to multicast list
Aug 26 12:37:50 vyos opennhrp-script.py[2122]: Running script with arguments: ['/etc/opennhrp/opennhrp-script.py', 'nhs-up'], environment: environ({'NHRP_TYPE': 'static', 'NHRP_SRCADDR': '10.10.100.2', 'NHRP_SRCNBMA': '10.0.2.2', 'NHRP_DESTADDR': '10.10.100.1', 'NHRP_DESTPREFIX': '24', 'NHRP_PEER_DOWN_REASON': 'user-request', 'NHRP_DESTNBMA': '10.0.1.2', 'NHRP>
```
As we can see opennhrp did not call vici to create the IPSEC tunnel
 
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
