### PR TITLE
nat: nat66: T4650: Rewrite op-mode nat translation

### DIFF
--- a/op-mode-definitions/nat.xml.in
+++ b/op-mode-definitions/nat.xml.in
@@ -45,7 +45,7 @@
                     <command>${vyos_op_scripts_dir}/show_nat_translations.py --type=source --verbose</command>
                   </node>
                 </children>
-                <command>${vyos_op_scripts_dir}/show_nat_translations.py --type=source</command>
+                <command>${vyos_op_scripts_dir}/nat.py show_translations --direction source --family inet</command>
               </node>
             </children>
           </node>
@@ -87,7 +87,7 @@
                     <command>${vyos_op_scripts_dir}/show_nat_translations.py --type=destination --verbose</command>
                   </node>
                 </children>
-                <command>${vyos_op_scripts_dir}/show_nat_translations.py --type=destination</command>
+                <command>${vyos_op_scripts_dir}/nat.py show_translations --direction destination --family inet</command>
               </node>
             </children>
           </node>

--- a/op-mode-definitions/nat66.xml.in
+++ b/op-mode-definitions/nat66.xml.in
@@ -45,7 +45,7 @@
                     <command>${vyos_op_scripts_dir}/show_nat66_translations.py --type=source --verbose</command>
                   </node>
                 </children>
-                <command>${vyos_op_scripts_dir}/show_nat66_translations.py --type=source</command>
+                <command>${vyos_op_scripts_dir}/nat.py show_translations --direction source --family inet6</command>
               </node>
             </children>
           </node>
@@ -87,7 +87,7 @@
                     <command>${vyos_op_scripts_dir}/show_nat66_translations.py --type=destination --verbose</command>
                   </node>
                 </children>
-                <command>${vyos_op_scripts_dir}/show_nat66_translations.py --type=destination</command>
+                <command>${vyos_op_scripts_dir}/nat.py show_translations --direction destination --family inet6</command>
               </node>
             </children>
           </node>

--- a/src/op_mode/nat.py
+++ b/src/op_mode/nat.py
@@ -17,6 +17,7 @@
 import jmespath
 import json
 import sys
+import xmltodict
 
 from sys import exit
 from tabulate import tabulate
@@ -25,6 +26,29 @@ from vyos.util import cmd
 from vyos.util import dict_search
 
 import vyos.opmode
+
+
+def _get_xml_translation(direction, family):
+    """
+    Get conntrack XML output --src-nat|--dst-nat
+    """
+    if direction == 'source':
+        opt = '--src-nat'
+    if direction == 'destination':
+        opt = '--dst-nat'
+    return cmd(f'sudo conntrack --dump --family {family} {opt} --output xml')
+
+
+def _xml_to_dict(xml):
+    """
+    Convert XML to dictionary
+    Return: dictionary
+    """
+    parse = xmltodict.parse(xml, attr_prefix='')
+    # If only one conntrack entry we must change dict
+    if 'meta' in parse['conntrack']['flow']:
+        return dict(conntrack={'flow': [parse['conntrack']['flow']]})
+    return parse
 
 
 def _get_json_data(direction, family):
@@ -50,6 +74,22 @@ def _get_raw_data_rules(direction, family):
         if 'rule' in rule and 'comment' in rule['rule']:
             rules.append(rule)
     return rules
+
+
+def _get_raw_translation(direction, family):
+    """
+    Return: dictionary
+    """
+    xml = _get_xml_translation(direction, family)
+    if len(xml) == 0:
+        output = {'conntrack':
+            {
+                'error': True,
+                'reason': 'entries not found'
+            }
+        }
+        return output
+    return _xml_to_dict(xml)
 
 
 def _get_formatted_output_rules(data, direction, family):
@@ -180,6 +220,58 @@ def _get_formatted_output_statistics(data, direction):
     return output
 
 
+def _get_formatted_translation(dict_data, nat_direction, family):
+    data_entries = []
+    if 'error' in dict_data['conntrack']:
+        return 'Entries not found'
+    for entry in dict_data['conntrack']['flow']:
+        orig_src, orig_dst, orig_sport, orig_dport = {}, {}, {}, {}
+        reply_src, reply_dst, reply_sport, reply_dport = {}, {}, {}, {}
+        proto = {}
+        for meta in entry['meta']:
+            direction = meta['direction']
+            if direction in ['original']:
+                if 'layer3' in meta:
+                    orig_src = meta['layer3']['src']
+                    orig_dst = meta['layer3']['dst']
+                if 'layer4' in meta:
+                    if meta.get('layer4').get('sport'):
+                        orig_sport = meta['layer4']['sport']
+                    if meta.get('layer4').get('dport'):
+                        orig_dport = meta['layer4']['dport']
+                    proto = meta['layer4']['protoname']
+            if direction in ['reply']:
+                if 'layer3' in meta:
+                    reply_src = meta['layer3']['src']
+                    reply_dst = meta['layer3']['dst']
+                if 'layer4' in meta:
+                    if meta.get('layer4').get('sport'):
+                        reply_sport = meta['layer4']['sport']
+                    if meta.get('layer4').get('dport'):
+                        reply_dport = meta['layer4']['dport']
+                    proto = meta['layer4']['protoname']
+            if direction == 'independent':
+                conn_id = meta['id']
+                timeout = meta['timeout']
+                orig_src = f'{orig_src}:{orig_sport}' if orig_sport else orig_src
+                orig_dst = f'{orig_dst}:{orig_dport}' if orig_dport else orig_dst
+                reply_src = f'{reply_src}:{reply_sport}' if reply_sport else reply_src
+                reply_dst = f'{reply_dst}:{reply_dport}' if reply_dport else reply_dst
+                state = meta['state'] if 'state' in meta else ''
+                mark = meta['mark']
+                zone = meta['zone'] if 'zone' in meta else ''
+                if nat_direction == 'source':
+                    data_entries.append(
+                        [orig_src, reply_dst, proto, timeout, mark, zone])
+                elif nat_direction == 'destination':
+                    data_entries.append(
+                        [orig_dst, reply_src, proto, timeout, mark, zone])
+
+    headers = ["Pre-NAT", "Post-NAT", "Proto", "Timeout", "Mark", "Zone"]
+    output = tabulate(data_entries, headers, numalign="left")
+    return output
+
+
 def show_rules(raw: bool, direction: str, family: str):
     nat_rules = _get_raw_data_rules(direction, family)
     if raw:
@@ -194,6 +286,15 @@ def show_statistics(raw: bool, direction: str, family: str):
         return nat_statistics
     else:
         return _get_formatted_output_statistics(nat_statistics, direction)
+
+
+def show_translations(raw: bool, direction: str, family: str):
+    family = 'ipv6' if family == 'inet6' else 'ipv4'
+    nat_translation = _get_raw_translation(direction, family)
+    if raw:
+        return nat_translation
+    else:
+        return _get_formatted_translation(nat_translation, direction, family)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Rewrite op-moe `show nat|nat66 translation` to `vyos.opmode` format
Ability to get machine-readable format "raw"
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4650

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat, nat66
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration
```
set nat destination rule 100 destination port '2222'
set nat destination rule 100 inbound-interface 'eth0'
set nat destination rule 100 protocol 'tcp'
set nat destination rule 100 translation address '192.0.2.2'
set nat destination rule 100 translation port '22'
set nat source rule 100 outbound-interface 'eth0'
set nat source rule 100 source address '192.0.2.0/24'
set nat source rule 100 translation address 'masquerade'
set nat source rule 120 outbound-interface 'eth1'
set nat source rule 120 source address '192.168.122.1'
set nat source rule 120 translation address 'masquerade'
set nat66 source rule 100 outbound-interface 'eth1'
set nat66 source rule 100 source prefix '2001:db8:1111::/64'
set nat66 source rule 100 translation address 'masquerade'
```
Show nat
```
vyos@r14:~$ show nat source translations 
Pre-NAT              Post-NAT              Proto    Timeout    Mark    Zone
-------------------  --------------------  -------  ---------  ------  ------
192.168.122.1:33944  192.0.2.1:33944       tcp      431371     0
192.0.2.2:42403      192.168.122.14:42403  udp      17         0
192.0.2.2:32839      192.168.122.14:32839  udp      17         0
192.0.2.2:51420      192.168.122.14:51420  udp      1          0
192.0.2.2:47771      192.168.122.14:47771  udp      1          0
192.168.122.1:35946  192.0.2.1:35946       tcp      430452     0
192.0.2.2:123        192.168.122.14:123    udp      17         0
192.0.2.2:41520      192.168.122.14:41520  udp      17         0
192.0.2.2:59143      192.168.122.14:59143  udp      1          0
192.0.2.2:48249      192.168.122.14:48249  udp      1          0
192.0.2.2:54454      192.168.122.14:54454  udp      1          0
192.0.2.2:58143      192.168.122.14:58143  udp      17         0
192.0.2.2:56119      192.168.122.14:56119  udp      17         0
192.0.2.2:49189      192.168.122.14:49189  udp      17         0
192.0.2.2:38128      192.168.122.14:38128  udp      1          0
vyos@r14:~$ 
vyos@r14:~$ show nat destination  translations 
Pre-NAT         Post-NAT      Proto    Timeout    Mark    Zone
--------------  ------------  -------  ---------  ------  ------
192.0.2.1:2222  192.0.2.2:22  tcp      431365     0
192.0.2.1:2222  192.0.2.2:22  tcp      430446     0
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ show nat66 source translations 
Entries not found
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ show nat66 destination  translations 
Entries not found
vyos@r14:~$
```
Raw entries not found:
```
vyos@r14:~$ /usr/libexec/vyos/op_mode/nat.py show_translations --direction source --family inet6 --raw
{
    "conntrack": {
        "error": true,
        "reason": "entries not found"
    }
}
vyos@r14:~$ 
```
Ping and check again
```
vyos@r14:~$ ping 2001:db8::2 source-address 2001:db8:1111::1
PING 2001:db8::2(2001:db8::2) from 2001:db8:1111::1 : 56 data bytes
64 bytes from 2001:db8::2: icmp_seq=1 ttl=64 time=0.275 ms
64 bytes from 2001:db8::2: icmp_seq=2 ttl=64 time=0.366 ms
64 bytes from 2001:db8::2: icmp_seq=3 ttl=64 time=0.372 ms
^C
--- 2001:db8::2 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2040ms
rtt min/avg/max/mdev = 0.275/0.337/0.372/0.044 ms
vyos@r14:~$ 
vyos@r14:~$ show nat66 source   translations 
Pre-NAT           Post-NAT     Proto    Timeout    Mark    Zone
----------------  -----------  -------  ---------  ------  ------
2001:db8:1111::1  2001:db8::1  icmpv6   20         0
vyos@r14:~$ 

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
