### PR TITLE
nat: T4367: Move nat rules from /tmp to /run/nftables_nat.conf

### DIFF
--- a/src/conf_mode/nat.py
+++ b/src/conf_mode/nat.py
@@ -44,7 +44,7 @@ if LooseVersion(kernel_version()) > LooseVersion('5.1'):
 else:
     k_mod = ['nft_nat', 'nft_chain_nat_ipv4']
 
-nftables_nat_config = '/tmp/vyos-nat-rules.nft'
+nftables_nat_config = '/run/nftables_nat.conf'
 
 def get_handler(json, chain, target):
     """ Get nftable rule handler number of given chain/target combination.
@@ -186,16 +186,12 @@ def generate(nat):
     # dry-run newly generated configuration
     tmp = run(f'nft -c -f {nftables_nat_config}')
     if tmp > 0:
-        if os.path.exists(nftables_nat_config):
-            os.unlink(nftables_nat_config)
         raise ConfigError('Configuration file errors encountered!')
 
     return None
 
 def apply(nat):
     cmd(f'nft -f {nftables_nat_config}')
-    if os.path.isfile(nftables_nat_config):
-        os.unlink(nftables_nat_config)
 
     return None
 


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Move nftables nat configuration from `/tmp` to `/run`
As we have for other services like firewall, conntrack
Don't remove the config file '/run/nftables_nat.conf' after commit
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4367

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set nat destination rule 100 destination port '2222'
set nat destination rule 100 inbound-interface 'eth0'
set nat destination rule 100 protocol 'tcp'
set nat destination rule 100 translation address '192.0.2.2'
set nat destination rule 100 translation port '22'
```
Expect file `/run/nftables_nat.conf`
```
vyos@r14# cat /run/nftables_nat.conf 
#!/usr/sbin/nft -f


# Start with clean SNAT and DNAT chains
flush chain ip nat PREROUTING
flush chain ip nat POSTROUTING
add chain ip raw NAT_CONNTRACK
add rule ip raw NAT_CONNTRACK counter accept
add rule ip raw PREROUTING position 16    counter jump VYOS_CT_HELPER
add rule ip raw OUTPUT     position 21    counter jump VYOS_CT_HELPER
add rule ip raw PREROUTING position 18 counter jump NAT_CONNTRACK
add rule ip raw OUTPUT     position 23 counter jump NAT_CONNTRACK

#
# Destination NAT rules build up here
#
add rule ip nat PREROUTING counter jump VYOS_PRE_DNAT_HOOK

add rule ip nat PREROUTING iifname "eth0" ip protocol tcp tcp dport { 2222 } counter dnat to 192.0.2.2:22 comment "DST-NAT-100"

#
# Source NAT rules build up here
#
add rule ip nat POSTROUTING counter jump VYOS_PRE_SNAT_HOOK
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
