### PR TITLE
ethernet: T4653: bugfix copy-paste when processing NIC offloading

### DIFF
--- a/python/vyos/ifconfig/ethernet.py
+++ b/python/vyos/ifconfig/ethernet.py
@@ -230,7 +230,7 @@ class EthernetIf(Interface):
         enabled, fixed = self.ethtool.get_large_receive_offload()
         if enabled != state:
             if not fixed:
-                return self.set_interface('gro', 'on' if state else 'off')
+                return self.set_interface('lro', 'on' if state else 'off')
             else:
                 print('Adapter does not support changing large-receive-offload settings!')
         return False
@@ -267,7 +267,7 @@ class EthernetIf(Interface):
         enabled, fixed = self.ethtool.get_scatter_gather()
         if enabled != state:
             if not fixed:
-                return self.set_interface('gro', 'on' if state else 'off')
+                return self.set_interface('sg', 'on' if state else 'off')
             else:
                 print('Adapter does not support changing scatter-gather settings!')
         return False
@@ -287,7 +287,7 @@ class EthernetIf(Interface):
         enabled, fixed = self.ethtool.get_tcp_segmentation_offload()
         if enabled != state:
             if not fixed:
-                return self.set_interface('gro', 'on' if state else 'off')
+                return self.set_interface('tso', 'on' if state else 'off')
             else:
                 print('Adapter does not support changing tcp-segmentation-offload settings!')
         return False
@@ -353,5 +353,5 @@ class EthernetIf(Interface):
             for rx_tx, size in config['ring_buffer'].items():
                 self.set_ring_buffer(rx_tx, size)
 
-        # call base class first
+        # call base class last
         super().update(config)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Commit 31169fa8a763e ("vyos.ifconfig: T3619: only set offloading options if
supported by NIC") added the new implementation which handles NIC offloading.
Unfortunately every single implementation was copied from "gro" which resulted
in a change to gro for each offloading option - thus options like lro, sg, tso
had no effect at all.

It all comes down to copy/paste errors ... one way or another.

(cherry picked from commit b01f27b3bb3f4cbc6096011856d83009d0440313)


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4653

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ethernet offloading

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set interfaces ethernet eth0 offload gro
set interfaces ethernet eth0 offload lro
commit
run show interfaces ethernet eth0 physical offload
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
