### PR TITLE
DMVPN IPSec T4667: Fix security issue with cleartext GRE escaping when IPSec reconnecting in DMVPN environment

### DIFF
--- a/data/templates/ipsec/swanctl/profile.j2
+++ b/data/templates/ipsec/swanctl/profile.j2
@@ -29,6 +29,7 @@
                 local_ts = dynamic[gre]
                 remote_ts = dynamic[gre]
                 mode = {{ esp.mode }}
+                start_action = trap
 {%         if ike.dead_peer_detection.action is vyos_defined %}
                 dpd_action = {{ ike.dead_peer_detection.action }}
 {%         endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Added start_action = trap to data/templates/ipsec/swanctl/profile.j2  This prevents almost all unencrypted GRE packets from escaping DMVPN when IPSec is configured

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4667

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

IPSec, DMVPN

## Proposed changes
Added start_action = trap to data/templates/ipsec/swanctl/profile.j2 

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

I tested this fix by making the same change in an existing fresh install of VyOS 1.4.  Without this fix, all traffic that would normally be encrypted will be sent out of the WAN interface encapsulated, but not encrypted.  With the fix in place, only a single NHRP Registration Request is sent in the cleartext.  I ran Wireshark to view packets traversing my simulated WAN bridge and confirmed that this fix prevented any application traffic from escaping unencrypted.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
