### PR TITLE
bonding: T4668: Fix bond members not adding/interface state incorrect

### DIFF
--- a/python/vyos/ifconfig/bond.py
+++ b/python/vyos/ifconfig/bond.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2019-2022 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -405,10 +405,12 @@ class BondIf(Interface):
             # Remove ALL bond member interfaces
             for interface in self.get_slaves():
                 self.del_port(interface)
-                # Removing an interface from a bond will always place the underlaying
-                # physical interface in admin-down state! If physical interface is
-                # not disabled, re-enable it.
-                if not dict_search(f'member.interface_remove.{interface}.disable', config):
+
+                # Restore correct interface status based on config
+                if dict_search(f'member.interface.{interface}.disable', config) is not None or \
+                   dict_search(f'member.interface_remove.{interface}.disable', config) is not None:
+                    Interface(interface).set_admin_state('down')
+                else:
                     Interface(interface).set_admin_state('up')
 
             # Bonding policy/mode - default value, always present

--- a/src/conf_mode/interfaces-bonding.py
+++ b/src/conf_mode/interfaces-bonding.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2020 VyOS maintainers and contributors
+# Copyright (C) 2019-2022 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -73,63 +73,62 @@ def get_config(config=None):
 
     # To make our own life easier transfor the list of member interfaces
     # into a dictionary - we will use this to add additional information
-    # later on for wach member
+    # later on for each member
     if 'member' in bond and 'interface' in bond['member']:
-        # convert list if member interfaces to a dictionary
-        bond['member']['interface'] = dict.fromkeys(
-            bond['member']['interface'], {})
+        # convert list of member interfaces to a dictionary
+        bond['member']['interface'] = {k: {} for k in bond['member']['interface']}
 
     if 'mode' in bond:
         bond['mode'] = get_bond_mode(bond['mode'])
 
     tmp = leaf_node_changed(conf, base + [ifname, 'mode'])
-    if tmp: bond.update({'shutdown_required': {}})
+    if tmp: bond['shutdown_required'] = {}
 
     tmp = leaf_node_changed(conf, base + [ifname, 'lacp-rate'])
-    if tmp: bond.update({'shutdown_required': {}})
+    if tmp: bond['shutdown_required'] = {}
 
     # determine which members have been removed
     interfaces_removed = leaf_node_changed(conf, base + [ifname, 'member', 'interface'])
     if interfaces_removed:
-        bond.update({'shutdown_required': {}})
+        bond['shutdown_required'] = {}
         if 'member' not in bond:
-            bond.update({'member': {}})
+            bond['member'] = {}
 
         tmp = {}
         for interface in interfaces_removed:
             section = Section.section(interface) # this will be 'ethernet' for 'eth0'
             if conf.exists(['insterfaces', section, interface, 'disable']):
-                tmp.update({interface : {'disable': ''}})
+                tmp[interface] = {'disable': ''}
             else:
-                tmp.update({interface : {}})
+                tmp[interface] = {}
 
         # also present the interfaces to be removed from the bond as dictionary
-        bond['member'].update({'interface_remove': tmp})
+        bond['member']['interface_remove'] = tmp
 
     if dict_search('member.interface', bond):
         for interface, interface_config in bond['member']['interface'].items():
             # Check if member interface is already member of another bridge
             tmp = is_member(conf, interface, 'bridge')
-            if tmp: bond['member']['interface'][interface].update({'is_bridge_member' : tmp})
+            if tmp: interface_config['is_bridge_member'] = tmp
 
             # Check if member interface is already member of a bond
             tmp = is_member(conf, interface, 'bonding')
             for tmp in is_member(conf, interface, 'bonding'):
                 if bond['ifname'] == tmp:
                     continue
-                bond['member']['interface'][interface].update({'is_bond_member' : tmp})
+                interface_config['is_bond_member'] = tmp
 
             # Check if member interface is used as source-interface on another interface
             tmp = is_source_interface(conf, interface)
-            if tmp: bond['member']['interface'][interface].update({'is_source_interface' : tmp})
+            if tmp: interface_config['is_source_interface'] = tmp
 
             # bond members must not have an assigned address
             tmp = has_address_configured(conf, interface)
-            if tmp: bond['member']['interface'][interface].update({'has_address' : {}})
+            if tmp: interface_config['has_address'] = {}
 
             # bond members must not have a VRF attached
             tmp = has_vrf_configured(conf, interface)
-            if tmp: bond['member']['interface'][interface].update({'has_vrf' : {}})
+            if tmp: interface_config['has_vrf'] = {}
 
     return bond
 


### PR DESCRIPTION
## Change Summary
Fixes bugs around bonding member interfaces not being added to the bond or being added/removed with incorrect interface states (as defined by if the interface is meant to be disabled).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4668

## Component(s) name
bonding

## Proposed changes
There were a few bugs ranging from simple typos to incorrect behavioral assumptions being made in the bonding code that have been corrected by cleaning the code and being more explicit about interface states. In particular:

In `interfaces-bonding.py`:
* There was a typo of `interfaces` which has been fixed
* A bug with assuming the wrong config level has been addressed

Additionally a new disabled configuration state has been added to track if a member interface is disabled such that we set correct interface states when enslaving interfaces.

## How to test
Create a simple bond using config similar to this:
```
interfaces {
    bonding bond0 {
        mode 802.3ad
        hash-policy layer2+3
        lacp-rate fast
        member {
            interface eth0
        }
    }
}
```
 * Attempt to add bonding members, one at a time (and committing), to the bond, observe that the current behavior eventually stops adding interfaces after the first two.
 * Mark any of the bond members as disabled whilst adding/removing the interface, observe the interface does not stay down.

After the patch is applied, validate both cases no longer hold true.
## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
