### PR TITLE
backport: bonding: T4668: Fix bond members not adding/interface state incorrect

### DIFF
--- a/python/vyos/ifconfig/bond.py
+++ b/python/vyos/ifconfig/bond.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2019-2022 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -389,10 +389,12 @@ class BondIf(Interface):
             # Remove ALL bond member interfaces
             for interface in self.get_slaves():
                 self.del_port(interface)
-                # Removing an interface from a bond will always place the underlaying
-                # physical interface in admin-down state! If physical interface is
-                # not disabled, re-enable it.
-                if not dict_search(f'member.interface_remove.{interface}.disable', config):
+
+                # Restore correct interface status based on config
+                if dict_search(f'member.interface.{interface}.disable', config) is not None or \
+                   dict_search(f'member.interface_remove.{interface}.disable', config) is not None:
+                    Interface(interface).set_admin_state('down')
+                else:
                     Interface(interface).set_admin_state('up')
 
             # Bonding policy/mode - default value, always present

--- a/src/conf_mode/interfaces-bonding.py
+++ b/src/conf_mode/interfaces-bonding.py
@@ -88,6 +88,11 @@ def get_config(config=None):
 
     # determine which members have been removed
     interfaces_removed = leaf_node_changed(conf, ['member', 'interface'])
+
+    # Reset config level to interfaces
+    old_level = conf.get_level()
+    conf.set_level(['interfaces'])
+
     if interfaces_removed:
         bond['shutdown_required'] = {}
         if 'member' not in bond:
@@ -96,7 +101,7 @@ def get_config(config=None):
         tmp = {}
         for interface in interfaces_removed:
             section = Section.section(interface) # this will be 'ethernet' for 'eth0'
-            if conf.exists(['insterfaces', section, interface, 'disable']):
+            if conf.exists([section, interface, 'disable']):
                 tmp[interface] = {'disable': ''}
             else:
                 tmp[interface] = {}
@@ -104,8 +109,24 @@ def get_config(config=None):
         # also present the interfaces to be removed from the bond as dictionary
         bond['member']['interface_remove'] = tmp
 
+    # Restore existing config level
+    conf.set_level(old_level)
+
     if dict_search('member.interface', bond):
         for interface, interface_config in bond['member']['interface'].items():
+            # Check if member interface is a new member
+            if not conf.exists_effective(['member', 'interface', interface]):
+                bond['shutdown_required'] = {}
+
+            # Check if member interface is disabled
+            conf.set_level(['interfaces'])
+
+            section = Section.section(interface) # this will be 'ethernet' for 'eth0'
+            if conf.exists([section, interface, 'disable']):
+                interface_config['disable'] = ''
+
+            conf.set_level(old_level)
+
             # Check if member interface is already member of another bridge
             tmp = is_member(conf, interface, 'bridge')
             if tmp: interface_config['is_bridge_member'] = tmp


### PR DESCRIPTION
## Change Summary

This is a backport of #1517 to equuleus with essentially the same changes. Cherry-pick does not apply cleanly so separate commits were made instead.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T4668

## Component(s) name
bonding

## Proposed changes
See #1517

## How to test
See #1517

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
