### PR TITLE
T4630: disallow same source-interface for macsec and pseudo-ethernet

### DIFF
--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -309,11 +309,17 @@ def is_source_interface(conf, interface, intftype=None):
     """
     ret_val = None
     intftypes = ['macsec', 'pppoe', 'pseudo-ethernet', 'tunnel', 'vxlan']
-    if intftype not in intftypes + [None]:
+    if not intftype:
+        intftype = intftypes
+
+    if isinstance(intftype, str):
+        intftype = [intftype]
+    elif not isinstance(intftype, list):
+        raise ValueError(f'Interface type "{type(intftype)}" must be either str or list!')
+
+    if not all(x in intftypes for x in intftype):
         raise ValueError(f'unknown interface type "{intftype}" or it can not '
             'have a source-interface')
-
-    intftype = intftypes if intftype == None else [intftype]
 
     # set config level to root
     old_level = conf.get_level()

--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -248,6 +248,12 @@ def verify_source_interface(config):
         raise ConfigError(f'Invalid source-interface "{src_ifname}". Interface '
                           f'is already a member of bond "{bond_name}"!')
 
+    if 'is_source_interface' in config:
+        tmp = config['is_source_interface']
+        src_ifname = config['source_interface']
+        raise ConfigError(f'Can not use source-interface "{src_ifname}", it already ' \
+                          f'belongs to interface "{tmp}"!')
+
 def verify_dhcpv6(config):
     """
     Common helper function used by interface implementations to perform

--- a/src/conf_mode/interfaces-macsec.py
+++ b/src/conf_mode/interfaces-macsec.py
@@ -67,7 +67,7 @@ def get_config(config=None):
         macsec.update({'shutdown_required': {}})
 
     if 'source_interface' in macsec:
-        tmp = is_source_interface(conf, macsec['source_interface'], 'macsec')
+        tmp = is_source_interface(conf, macsec['source_interface'], ['macsec', 'pseudo-ethernet'])
         if tmp and tmp != ifname: macsec.update({'is_source_interface' : tmp})
 
     return macsec
@@ -100,12 +100,6 @@ def verify(macsec):
         elif dict_search('security.cipher', macsec) == 'gcm-aes-256' and cak_len != 64:
             # gcm-aes-128 requires a 128bit long key - 64 characters (string) = 32byte = 256bit
             raise ConfigError('gcm-aes-128 requires a 256bit long key!')
-
-    if 'is_source_interface' in macsec:
-        tmp = macsec['is_source_interface']
-        src_ifname = macsec['source_interface']
-        raise ConfigError(f'Can not use source-interface "{src_ifname}", it already ' \
-                          f'belongs to interface "{tmp}"!')
 
     if 'source_interface' in macsec:
         # MACsec adds a 40 byte overhead (32 byte MACsec + 8 bytes VLAN 802.1ad

--- a/src/conf_mode/interfaces-pseudo-ethernet.py
+++ b/src/conf_mode/interfaces-pseudo-ethernet.py
@@ -19,6 +19,7 @@ from sys import exit
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
 from vyos.configdict import leaf_node_changed
+from vyos.configdict import is_source_interface
 from vyos.configverify import verify_vrf
 from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
@@ -49,6 +50,10 @@ def get_config(config=None):
     if 'source_interface' in peth:
         peth['parent'] = get_interface_dict(conf, ['interfaces', 'ethernet'],
                                             peth['source_interface'])
+        # test if source-interface is maybe already used by another interface
+        tmp = is_source_interface(conf, peth['source_interface'], ['macsec'])
+        if tmp and tmp != peth['ifname']: peth.update({'is_source_interface' : tmp})
+
     return peth
 
 def verify(peth):


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

A macsec interface requires a dedicated source interface, it can not be
shared with another macsec or a pseudo-ethernet interface.

```
set interfaces macsec macsec10 address '192.168.2.1/30'
set interfaces macsec macsec10 security cipher 'gcm-aes-256'
set interfaces macsec macsec10 security encrypt
set interfaces macsec macsec10 security mka cak '232e44b7fda6f8e2d88a07bf78a7aff4232e44b7fda6f8e2d88a07bf78a7aff4'
set interfaces macsec macsec10 security mka ckn '09924585a6f3010208cf5222ef24c821405b0e34f4b4f63b1f0ced474b9bb6e6'
set interfaces macsec macsec10 source-interface 'eth1'
commit
```

```
set interfaces pseudo-ethernet peth0 source-interface eth1
commit
```

results in
```
FileNotFoundError: [Errno 2] failed to run command: ip link add peth0 link eth1 type macvlan mode private
returned:
exit code: 2

noteworthy:
cmd 'ip link add peth0 link eth1 type macvlan mode private'
returned (out):

returned (err):
RTNETLINK answers: Device or resource busy

[[interfaces pseudo-ethernet peth0]] failed
Commit failed
```

(cherry picked from commit eb4a7ee3afc0765671ce0fa379ab5e3518e9e49e)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4630

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

see above or smoketests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
