### PR TITLE
T1024: Firewall and Policy route: add option to match dscp value

### DIFF
--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -383,6 +383,7 @@
                 </children>
               </node>
               #include <include/firewall/common-rule.xml.i>
+              #include <include/firewall/dscp.xml.i>
               #include <include/firewall/packet-length.xml.i>
               #include <include/firewall/hop-limit.xml.i>
               <node name="icmpv6">
@@ -530,6 +531,7 @@
                 </children>
               </node>
               #include <include/firewall/common-rule.xml.i>
+              #include <include/firewall/dscp.xml.i>
               #include <include/firewall/packet-length.xml.i>
               <node name="icmp">
                 <properties>

--- a/interface-definitions/include/firewall/dscp.xml.i
+++ b/interface-definitions/include/firewall/dscp.xml.i
@@ -1,0 +1,38 @@
+<!-- include start from firewall/dscp.xml.i -->
+<leafNode name="dscp">
+  <properties>
+    <help>DSCP value</help>
+    <valueHelp>
+      <format>u32:0-63</format>
+      <description>DSCP value to match</description>
+    </valueHelp>
+    <valueHelp>
+      <format>&lt;start-end&gt;</format>
+      <description>DSCP range to match</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 0-63"/>
+      <validator name="range" argument="--min=0 --max=63"/>
+    </constraint>
+    <multi/>
+  </properties>
+</leafNode>
+<leafNode name="dscp-exclude">
+  <properties>
+    <help>DSCP value not to match</help>
+    <valueHelp>
+      <format>u32:0-63</format>
+      <description>DSCP value not to match</description>
+    </valueHelp>
+    <valueHelp>
+      <format>&lt;start-end&gt;</format>
+      <description>DSCP range not to match</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 0-63"/>
+      <validator name="range" argument="--min=0 --max=63"/>
+    </constraint>
+    <multi/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/policy-route.xml.in
+++ b/interface-definitions/policy-route.xml.in
@@ -47,6 +47,7 @@
                 </children>
               </node>
               #include <include/policy/route-common-rule-ipv6.xml.i>
+              #include <include/firewall/dscp.xml.i>
               #include <include/firewall/packet-length.xml.i>
               #include <include/firewall/hop-limit.xml.i>
             </children>
@@ -98,6 +99,7 @@
                 </children>
               </node>
               #include <include/policy/route-common-rule.xml.i>
+              #include <include/firewall/dscp.xml.i>
               #include <include/firewall/packet-length.xml.i>
               #include <include/firewall/ttl.xml.i>
             </children>

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -274,6 +274,13 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
         negated_lengths_str = ','.join(rule_conf['packet_length_exclude'])
         output.append(f'ip{def_suffix} length != {{{negated_lengths_str}}}')
 
+    if 'dscp' in rule_conf:
+        dscp_str = ','.join(rule_conf['dscp'])
+        output.append(f'ip{def_suffix} dscp {{{dscp_str}}}')
+
+    if 'dscp_exclude' in rule_conf:
+        negated_dscp_str = ','.join(rule_conf['dscp_exclude'])
+        output.append(f'ip{def_suffix} dscp != {{{negated_dscp_str}}}')
 
     if 'ipsec' in rule_conf:
         if 'match_ipsec' in rule_conf['ipsec']:

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -232,8 +232,8 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         self.verify_nftables(nftables_search, 'ip filter')
 
-    def test_ipv4_packet_length(self):
-        name = 'smoketest-plen'
+    def test_ipv4_advanced(self):
+        name = 'smoketest-adv'
         interface = 'eth0'
 
         self.cli_set(['firewall', 'name', name, 'default-action', 'drop'])
@@ -243,10 +243,14 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['firewall', 'name', name, 'rule', '6', 'packet-length', '64'])
         self.cli_set(['firewall', 'name', name, 'rule', '6', 'packet-length', '512'])
         self.cli_set(['firewall', 'name', name, 'rule', '6', 'packet-length', '1024'])
+        self.cli_set(['firewall', 'name', name, 'rule', '6', 'dscp', '17'])
+        self.cli_set(['firewall', 'name', name, 'rule', '6', 'dscp', '52'])
 
         self.cli_set(['firewall', 'name', name, 'rule', '7', 'action', 'accept'])
         self.cli_set(['firewall', 'name', name, 'rule', '7', 'packet-length', '1-30000'])
         self.cli_set(['firewall', 'name', name, 'rule', '7', 'packet-length-exclude', '60000-65535'])
+        self.cli_set(['firewall', 'name', name, 'rule', '7', 'dscp', '3-11'])
+        self.cli_set(['firewall', 'name', name, 'rule', '7', 'dscp-exclude', '21-25'])
 
         self.cli_set(['interfaces', 'ethernet', interface, 'firewall', 'in', 'name', name])
 
@@ -254,8 +258,8 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         nftables_search = [
             [f'iifname "{interface}"', f'jump NAME_{name}'],
-            ['ip length { 64, 512, 1024 }', 'return'],
-            ['ip length { 1-30000 }', 'ip length != { 60000-65535 }', 'return'],
+            ['ip length { 64, 512, 1024 }', 'ip dscp { 0x11, 0x34 }', 'return'],
+            ['ip length { 1-30000 }', 'ip length != { 60000-65535 }', 'ip dscp { 0x03-0x0b }', 'ip dscp != { 0x15-0x19 }', 'return'],
             [f'log prefix "[{name}-default-D]" drop']
         ]
 
@@ -291,8 +295,8 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         self.verify_nftables(nftables_search, 'ip6 filter')
 
-    def test_ipv6_packet_length(self):
-        name = 'v6-smoketest-plen'
+    def test_ipv6_advanced(self):
+        name = 'v6-smoketest-adv'
         interface = 'eth0'
 
         self.cli_set(['firewall', 'ipv6-name', name, 'default-action', 'drop'])
@@ -302,10 +306,14 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['firewall', 'ipv6-name', name, 'rule', '3', 'packet-length', '65'])
         self.cli_set(['firewall', 'ipv6-name', name, 'rule', '3', 'packet-length', '513'])
         self.cli_set(['firewall', 'ipv6-name', name, 'rule', '3', 'packet-length', '1025'])
+        self.cli_set(['firewall', 'ipv6-name', name, 'rule', '3', 'dscp', '18'])
+        self.cli_set(['firewall', 'ipv6-name', name, 'rule', '3', 'dscp', '53'])
 
         self.cli_set(['firewall', 'ipv6-name', name, 'rule', '4', 'action', 'accept'])
         self.cli_set(['firewall', 'ipv6-name', name, 'rule', '4', 'packet-length', '1-1999'])
         self.cli_set(['firewall', 'ipv6-name', name, 'rule', '4', 'packet-length-exclude', '60000-65535'])
+        self.cli_set(['firewall', 'ipv6-name', name, 'rule', '4', 'dscp', '4-14'])
+        self.cli_set(['firewall', 'ipv6-name', name, 'rule', '4', 'dscp-exclude', '31-35'])
 
         self.cli_set(['interfaces', 'ethernet', interface, 'firewall', 'in', 'ipv6-name', name])
 
@@ -313,8 +321,8 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         nftables_search = [
             [f'iifname "{interface}"', f'jump NAME6_{name}'],
-            ['ip6 length { 65, 513, 1025 }', 'return'],
-            ['ip6 length { 1-1999 }', 'ip6 length != { 60000-65535 }', 'return'],
+            ['ip6 length { 65, 513, 1025 }', 'ip6 dscp { af21, 0x35 }', 'return'],
+            ['ip6 length { 1-1999 }', 'ip6 length != { 60000-65535 }', 'ip6 dscp { 0x04-0x0e }', 'ip6 dscp != { 0x1f-0x23 }', 'return'],
             [f'log prefix "[{name}-default-D]"', 'drop']
         ]
 

--- a/smoketest/scripts/cli/test_policy_route.py
+++ b/smoketest/scripts/cli/test_policy_route.py
@@ -177,6 +177,9 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'packet-length', '1024-2048'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'log', 'enable'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'set', 'table', table_id])
+        self.cli_set(['policy', 'route', 'smoketest', 'rule', '5', 'dscp', '41'])
+        self.cli_set(['policy', 'route', 'smoketest', 'rule', '5', 'dscp', '57-59'])
+        self.cli_set(['policy', 'route', 'smoketest', 'rule', '5', 'set', 'table', table_id])
 
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '1', 'protocol', 'udp'])
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '1', 'action', 'drop'])
@@ -196,6 +199,9 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '4', 'packet-length-exclude', '1024-2048'])
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '4', 'log', 'enable'])
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '4', 'set', 'table', table_id])
+        self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '5', 'dscp-exclude', '61'])
+        self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '5', 'dscp-exclude', '14-19'])
+        self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '5', 'set', 'table', table_id])
 
         self.cli_set(['interfaces', 'ethernet', interface, 'policy', 'route', 'smoketest'])
         self.cli_set(['interfaces', 'ethernet', interface, 'policy', 'route6', 'smoketest6'])
@@ -210,7 +216,8 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
             ['meta l4proto udp', 'drop'],
             ['tcp flags & (syn | ack) == syn', 'meta mark set ' + mark_hex],
             ['ct state { new }', 'tcp dport { 22 }', 'ip saddr 198.51.100.0/24', 'ip ttl > 2', 'meta mark set ' + mark_hex],
-            ['meta l4proto icmp', 'log prefix "[smoketest-4-A]"', 'icmp type echo-request', 'ip length { 128, 1024-2048 }', 'meta mark set ' + mark_hex]
+            ['meta l4proto icmp', 'log prefix "[smoketest-4-A]"', 'icmp type echo-request', 'ip length { 128, 1024-2048 }', 'meta mark set ' + mark_hex],
+            ['ip dscp { 0x29, 0x39-0x3b }', 'meta mark set ' + mark_hex]
         ]
 
         self.verify_nftables(nftables_search, 'ip mangle')
@@ -221,7 +228,8 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
             ['meta l4proto udp', 'drop'],
             ['tcp flags & (syn | ack) == syn', 'meta mark set ' + mark_hex],
             ['ct state { new }', 'tcp dport { 22 }', 'ip6 saddr 2001:db8::/64', 'ip6 hoplimit > 2', 'meta mark set ' + mark_hex],
-            ['meta l4proto ipv6-icmp', 'log prefix "[smoketest6-4-A]"', 'icmpv6 type echo-request', 'ip6 length != { 128, 1024-2048 }', 'meta mark set ' + mark_hex]
+            ['meta l4proto ipv6-icmp', 'log prefix "[smoketest6-4-A]"', 'icmpv6 type echo-request', 'ip6 length != { 128, 1024-2048 }', 'meta mark set ' + mark_hex],
+            ['ip6 dscp != { 0x0e-0x13, 0x3d }', 'meta mark set ' + mark_hex]
         ]
 
         self.verify_nftables(nftables6_search, 'ip6 mangle')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add options to match dscp value, both in firewall and in policy route

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T1024

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall, policy
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Firewall config and validation:
```
vyos@fwall-ip:~$ show config comm | grep firewall
set firewall ipv6-name FOO6 rule 10 action 'accept'
set firewall ipv6-name FOO6 rule 10 dscp '11'
set firewall ipv6-name FOO6 rule 10 dscp '24'
set firewall ipv6-name FOO6 rule 20 action 'drop'
set firewall ipv6-name FOO6 rule 20 dscp '62'
set firewall ipv6-name FOO6 rule 20 dscp-exclude '17-19'
set firewall ipv6-name FOO6 rule 20 dscp-exclude '27'
set firewall name FOO rule 10 action 'accept'
set firewall name FOO rule 10 dscp '13'
set firewall name FOO rule 10 dscp '4-8'
set firewall name FOO rule 20 action 'reject'
set firewall name FOO rule 20 dscp-exclude '44'
set firewall name FOO rule 20 dscp-exclude '33-36'

vyos@fwall-ip:~$ sudo nft -S list chain ip filter NAME_FOO
table ip filter {
	chain NAME_FOO {
		ip dscp { 0x04-0x08, 0x0d } counter packets 0 bytes 0 return comment "FOO-10"
		ip dscp != { 0x21-0x24, 0x2c } counter packets 0 bytes 0 reject comment "FOO-20"
		counter packets 0 bytes 0 drop comment "FOO default-action drop"
	}
}

vyos@fwall-ip:~$ sudo nft -S list chain ip6 filter NAME6_FOO6
table ip6 filter {
	chain NAME6_FOO6 {
		ip6 dscp { 0x0b, cs3 } counter packets 0 bytes 0 return comment "FOO6-10"
		ip6 dscp { 0x3e } ip6 dscp != { 0x11-0x13, 0x1b } counter packets 0 bytes 0 drop comment "FOO6-20"
		counter packets 0 bytes 0 drop comment "FOO6 default-action drop"
	}
}
```
Policy route configuration and validation
```
vyos@fwall-ip:~$ show config comm | grep policy
set policy route PR rule 10 dscp '0-38'
set policy route PR rule 10 dscp-exclude '45'
set policy route PR rule 10 set table '14'
set policy route6 PR6 rule 10 dscp-exclude '24'
set policy route6 PR6 rule 10 dscp-exclude '34'
set policy route6 PR6 rule 10 set table '16'

vyos@fwall-ip:~$ sudo nft -S list chain ip mangle VYOS_PBR_PR
table ip mangle {
	chain VYOS_PBR_PR {
		ip dscp { 0x00-0x26 } ip dscp != { 0x2d } counter packets 0 bytes 0 meta mark set 0x7ffffff1 return comment "PR-10"
	}
}
vyos@fwall-ip:~$ sudo nft -S list chain ip6 mangle VYOS_PBR6_PR6
table ip6 mangle {
	chain VYOS_PBR6_PR6 {
		ip6 dscp != { cs3, af41 } counter packets 0 bytes 0 meta mark set 0x7fffffef return comment "PR6-10"
	}
}

vyos@fwall-ip:~$ sudo ip rule
0:	from all lookup local
14:	from all fwmark 0x7ffffff1 lookup 14
32766:	from all lookup main
32767:	from all lookup default
vyos@fwall-ip:~$ sudo ip -6 rule
0:	from all lookup local
16:	from all fwmark 0x7fffffef lookup 16
32766:	from all lookup main
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
