### PR TITLE
T4665: Keepalived: Fix interface names

### DIFF
--- a/data/templates/high-availability/keepalived.conf.j2
+++ b/data/templates/high-availability/keepalived.conf.j2
@@ -47,10 +47,10 @@ vrrp_instance {{ name }} {
 {%             endif %}
 {%         endif %}
 {%         if group_config.rfc3768_compatibility is vyos_defined and group_config.peer_address is vyos_defined %}
-    use_vmac {{ group_config.interface }}v{{ group_config.vrid }}
+    use_vmac {{ group_config.interface }}v{{ group_config.vrid }}v{{ '4' if group_config['address'] | first | is_ipv4 else '6' }}
     vmac_xmit_base
 {%         elif group_config.rfc3768_compatibility is vyos_defined %}
-    use_vmac {{ group_config.interface }}v{{ group_config.vrid }}
+    use_vmac {{ group_config.interface }}v{{ group_config.vrid }}v{{ '4' if group_config['address'] | first | is_ipv4 else '6' }}
 {%         endif %}
 {%         if group_config.authentication is vyos_defined %}
     authentication {


### PR DESCRIPTION
## Change Summary

When applying the same VRID for IPv4 and IPv6 with RFC3768 compatibility enabled, the IPv6 interfaces came back with the wrong name. For example:

Name    Interface      VRID  State      Priority  Last Transition
------  -----------  ------  -------  ----------  -----------------
v4-10   eth1v10        10  MASTER          100  21s
v6-10   vrrpv10        10  MASTER          100  21s

Because of this, the IPv6 interface didn't show up in `show int`.

This change suffixes the interface with the IP version so `show int` works again.

Name    Interface      VRID  State      Priority  Last Transition
------  -----------  ------  -------  ----------  -----------------
v4-10   eth1v10v4        10  MASTER          100  21s
v6-10   eth1v10v6        10  MASTER          100  21s

vyos@vyos:~$ show interfaces
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
[....]
eth1v10v4        192.168.10.60/24                  u/u
eth1v10v6        2001:ffff::1/64                   u/u
[....]

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4665

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
keepalived

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
