### PR TITLE
system: T4682: standardize op-mode 'show system storage'

### DIFF
--- a/data/op-mode-standardized.json
+++ b/data/op-mode-standardized.json
@@ -9,6 +9,7 @@
 "openconnect.py",
 "route.py",
 "ipsec.py",
+"storage.py",
 "version.py",
 "vrf.py"
 ]

--- a/op-mode-definitions/show-system.xml.in
+++ b/op-mode-definitions/show-system.xml.in
@@ -162,7 +162,7 @@
             <properties>
               <help>Show filesystem usage</help>
             </properties>
-            <command>df -h -x squashfs</command>
+            <command>${vyos_op_scripts_dir}/storage.py show</command>
           </leafNode>
           <leafNode name="uptime">
             <properties>

--- a/src/op_mode/storage.py
+++ b/src/op_mode/storage.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import sys
+
+import vyos.opmode
+from vyos.util import cmd
+
+
+def _get_system_storage(only_persistent=False):
+    if not only_persistent:
+        cmd_str = 'df -h -x squashf'
+    else:
+        cmd_str = 'df -h -t ext4 --output=source,size,used,avail,pcent'
+
+    res = cmd(cmd_str)
+
+    return res
+
+def _get_raw_data():
+    out =  _get_system_storage(only_persistent=True)
+    lines = out.splitlines()
+    lists = [l.split() for l in lines]
+    res = {lists[0][i]: lists[1][i] for i in range(len(lists[0]))}
+
+    return res
+
+def _get_formatted_output():
+    return _get_system_storage()
+
+def show(raw: bool):
+    if raw:
+        return _get_raw_data()
+
+    return _get_formatted_output()
+
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except (ValueError, vyos.opmode.Error) as e:
+        print(e)
+        sys.exit(1)
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The local UI client requires a query showing storage statistics for the persistent file system. This motivates rewriting the op-mode command 'show system storage' (currently just a cal to 'df' within the XML) in terms of an op-mode script 'storage.py'.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4682

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
