### PR TITLE
policy: T4685: fix non-existent inbound-interface in local-policy(6)

### DIFF
--- a/interface-definitions/policy-local-route.xml.in
+++ b/interface-definitions/policy-local-route.xml.in
@@ -6,6 +6,7 @@
       <node name="local-route" owner="${vyos_conf_scripts_dir}/policy-local-route.py">
         <properties>
           <help>IPv4 policy route of local traffic</help>
+          <priority>500</priority>
         </properties>
         <children>
           <tagNode name="rule">
@@ -96,6 +97,7 @@
       <node name="local-route6" owner="${vyos_conf_scripts_dir}/policy-local-route.py">
         <properties>
           <help>IPv6 policy route of local traffic</help>
+          <priority>500</priority>
         </properties>
         <children>
           <tagNode name="rule">


### PR DESCRIPTION
## Change Summary

The `local-policy` and `local-policy6` nodes were missing their priority property causing an ordering issue between the creation of dynamic interfaces (like VLAN/Bonding) and referencing said interface in PBR rules.

We add a priority value to the local-policy(6) nodes to order the node after all interface definitions.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T4685

## Component(s) name
policy

## Proposed changes
Adds a priority node with value of `500` to the `local-policy` and `local-policy6` nodes to order them after all interface definitions.

## How to test
Using the following configuration (with appropriate MAC address in `hw-id`:
```
interfaces {
    ethernet eth0 {
        hw-id xx:xx:xx:xx:xx:xx
        vif 10 {
        }
    }
}

policy {
    local-policy {
        rule 1 {
            inbound-interface eth0.10

            set {
                table 100
            }
        }
    }
}
```
Validate that:
1. Commit does not fail on addition of new VLAN + changing the inbound-interface to point to this new VLAN
2. On reboot the configuration applies successfully.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
