### PR TITLE
isis: T4693: Fix ISIS segment routing configurations

### DIFF
--- a/data/templates/frr/isisd.frr.j2
+++ b/data/templates/frr/isisd.frr.j2
@@ -124,23 +124,23 @@ router isis VyOS {{ 'vrf ' + vrf if vrf is vyos_defined }}
 {%         for prefix, prefix_config in segment_routing.prefix.items() %}
 {%             if prefix_config.absolute is vyos_defined %}
 {%                 if prefix_config.absolute.value is vyos_defined %}
- segment-routing prefix {{ prefixes }} absolute {{ prefix_config.absolute.value }}
+ segment-routing prefix {{ prefix }} absolute {{ prefix_config.absolute.value }}
 {%                     if prefix_config.absolute.explicit_null is vyos_defined %}
- segment-routing prefix {{ prefixes }} absolute {{ prefix_config.absolute.value }} explicit-null
+ segment-routing prefix {{ prefix }} absolute {{ prefix_config.absolute.value }} explicit-null
 {%                     endif %}
 {%                     if prefix_config.absolute.no_php_flag is vyos_defined %}
- segment-routing prefix {{ prefixes }} absolute {{ prefix_config.absolute.value }} no-php-flag
+ segment-routing prefix {{ prefix }} absolute {{ prefix_config.absolute.value }} no-php-flag
 {%                     endif %}
 {%                 endif %}
-{%                 if prefix_config.index is vyos_defined %}
-{%                     if prefix_config.index.value is vyos_defined %}
- segment-routing prefix {{ prefixes }} index {{ prefix_config.index.value }}
-{%                         if prefix_config.index.explicit_null is vyos_defined %}
- segment-routing prefix {{ prefixes }} index {{ prefix_config.index.value }} explicit-null
-{%                         endif %}
-{%                         if prefix_config.index.no_php_flag is vyos_defined %}
- segment-routing prefix {{ prefixes }} index {{ prefix_config.index.value }} no-php-flag
-{%                         endif %}
+{%             endif %}
+{%             if prefix_config.index is vyos_defined %}
+{%                 if prefix_config.index.value is vyos_defined %}
+ segment-routing prefix {{ prefix }} index {{ prefix_config.index.value }}
+{%                     if prefix_config.index.explicit_null is vyos_defined %}
+ segment-routing prefix {{ prefix }} index {{ prefix_config.index.value }} explicit-null
+{%                     endif %}
+{%                     if prefix_config.index.no_php_flag is vyos_defined %}
+ segment-routing prefix {{ prefix }} index {{ prefix_config.index.value }} no-php-flag
 {%                     endif %}
 {%                 endif %}
 {%             endif %}

--- a/smoketest/scripts/cli/test_protocols_isis.py
+++ b/smoketest/scripts/cli/test_protocols_isis.py
@@ -262,5 +262,52 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f' isis bfd', tmp)
             self.assertIn(f' isis bfd profile {bfd_profile}', tmp)
 
+    def test_isis_07_segment_routing_configuration(self):
+        global_block_low = "1000"
+        global_block_high = "1999"
+        local_block_low = "2000"
+        local_block_high = "2999"
+        interface = 'lo'
+        maximum_stack_size = '5'
+        prefix_one = '192.168.0.1/32'
+        prefix_two = '192.168.0.2/32'
+        prefix_three = '192.168.0.3/32'
+        prefix_four = '192.168.0.4/32'
+        prefix_one_value = '1'
+        prefix_two_value = '2'
+        prefix_three_value = '60000'
+        prefix_four_value = '65000'
+
+        self.cli_set(base_path + ['net', net])
+        self.cli_set(base_path + ['interface', interface])
+        self.cli_set(base_path + ['segment-routing', 'enable'])
+        self.cli_set(base_path + ['segment-routing', 'maximum-label-depth', maximum_stack_size])
+        self.cli_set(base_path + ['segment-routing', 'global-block', 'low-label-value', global_block_low])
+        self.cli_set(base_path + ['segment-routing', 'global-block', 'high-label-value', global_block_high])
+        self.cli_set(base_path + ['segment-routing', 'local-block', 'low-label-value', local_block_low])
+        self.cli_set(base_path + ['segment-routing', 'local-block', 'high-label-value', local_block_high])
+        self.cli_set(base_path + ['segment-routing', 'prefix', prefix_one, 'index', 'value', prefix_one_value])
+        self.cli_set(base_path + ['segment-routing', 'prefix', prefix_one, 'index', 'explicit-null'])
+        self.cli_set(base_path + ['segment-routing', 'prefix', prefix_two, 'index', 'value', prefix_two_value])
+        self.cli_set(base_path + ['segment-routing', 'prefix', prefix_two, 'index', 'no-php-flag'])
+        self.cli_set(base_path + ['segment-routing', 'prefix', prefix_three, 'absolute', 'value',  prefix_three_value])
+        self.cli_set(base_path + ['segment-routing', 'prefix', prefix_three, 'absolute', 'explicit-null'])
+        self.cli_set(base_path + ['segment-routing', 'prefix', prefix_four, 'absolute', 'value', prefix_four_value])
+        self.cli_set(base_path + ['segment-routing', 'prefix', prefix_four, 'absolute', 'no-php-flag'])
+        
+        # Commit all changes
+        self.cli_commit()
+
+        # Verify all changes
+        tmp = self.getFRRconfig(f'router isis {domain}', daemon='isisd')
+        self.assertIn(f' net {net}', tmp)
+        self.assertIn(f' segment-routing on', tmp)
+        self.assertIn(f' segment-routing global-block {global_block_low} {global_block_high} local-block {local_block_low} {local_block_high}', tmp)
+        self.assertIn(f' segment-routing node-msd {maximum_stack_size}', tmp)
+        self.assertIn(f' segment-routing prefix {prefix_one} index {prefix_one_value} explicit-null', tmp)
+        self.assertIn(f' segment-routing prefix {prefix_two} index {prefix_two_value} no-php-flag', tmp)
+        self.assertIn(f' segment-routing prefix {prefix_three} absolute {prefix_three_value} explicit-null', tmp)
+        self.assertIn(f' segment-routing prefix {prefix_four} absolute {prefix_four_value} no-php-flag', tmp)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
This change is to fix a bug in which ISIS segment routing was broken due to a refactor. This change also is going to introduce a smoketest to make sure this is caught in the future.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The changes here are minimal. They are just restructuring the FRR Jinja2 template for ISIS to re-enable segment routing functionality. There's also an addition to the smoketest to hopefully keep this from occurring in the future. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4693

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ISIS

## Proposed changes
<!--- Describe your changes in detail -->

The main change was that the nesting that was within the FRR Jinja2 template for ISIS was incorrect. 
The segment routing "absolute" if statement was actually causing the entirety of the "prefix" portion
of the code to evaluate to a False. After that was redone, things worked correctly. 

Also added a smoketest to make sure that ISIS segment routing works. 

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics

-->

This is the config that we are using:
```
set protocols isis interface lo passive
set protocols isis level 'level-2'
set protocols isis metric-style 'wide'
set protocols isis net '49.0001.1921.6800.0001.00'
set protocols isis segment-routing enable
set protocols isis segment-routing global-block high-label-value '1999'
set protocols isis segment-routing global-block low-label-value '1000'
set protocols isis segment-routing maximum-label-depth '3'
set protocols isis segment-routing prefix 192.168.0.1/32 index value '1'
```

This is how the problem looked earlier before the fix:
```
router isis VyOS
 is-type level-2-only
 net 49.0001.1921.6800.0001.00
 segment-routing on
 segment-routing global-block 1000 1999
 segment-routing node-msd 3
exit
```

After the fix:
```
router isis VyOS
 is-type level-2-only
 net 49.0001.1921.6800.0001.00
 segment-routing on
 segment-routing global-block 1000 1999
 segment-routing node-msd 3
 segment-routing prefix 192.168.0.1/32 index 1   <--- This was broken
exit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
