### PR TITLE
openvpn: T4679: Fix incorrect verify local and remote address 1.3

### DIFF
--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2020-2022 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -623,6 +623,11 @@ def is_admin() -> bool:
     (_, _, _, admin_group_members) = getgrnam('sudo')
     return current_user in admin_group_members
 
+def is_list_equal(first: list, second: list) -> bool:
+    """ Check if 2 lists are equal and list not empty """
+    if len(first) != len(second) or len(first) == 0:
+        return False
+    return sorted(first) == sorted(second)
 
 def mac2eui64(mac, prefix=None):
     """

--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -43,6 +43,7 @@ from vyos.util import chown
 from vyos.util import chmod_600
 from vyos.util import cmd
 from vyos.util import dict_search
+from vyos.util import is_list_equal
 from vyos.util import makedir
 from vyos.validate import is_addr_assigned
 
@@ -159,7 +160,7 @@ def verify(openvpn):
             elif v6remAddr and not v6loAddr:
                 raise ConfigError('IPv6 "remote-address" requires IPv6 "local-address"')
 
-            if (v4loAddr == v4remAddr) or (v6remAddr == v4remAddr):
+            if is_list_equal(v4loAddr, v4remAddr) or is_list_equal(v6loAddr, v6remAddr):
                 raise ConfigError('"local-address" and "remote-address" cannot be the same')
 
             if dict_search('local_host', openvpn) in dict_search('local_address', openvpn):


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
In the OpenVPN site-to-site config we can use IPv6 peers without IPv4 configurations but "verify()" also checks local and remote IPv4 addresses that in this case will be empty lists For example:

```
set interfaces openvpn vtun2 local-address 2001:db8::1
set interfaces openvpn vtun2 remote-address 2001:db8::2
```
Check in the commit (v4loAddr == v4remAddr) <= both empty lists commit
```
DEBUG: [] == [] or ['2001:db8::2'] == []
```
So we should also check v4loAddr, v4remAddr, v6loAddr, v6remAddr are not empty


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4679

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openvpn
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces openvpn vtun2 mode site-to-site
set interfaces openvpn vtun2 protocol udp
set interfaces openvpn vtun2 persistent-tunnel
set interfaces openvpn vtun2 remote-host dead:beaf::f
set interfaces openvpn vtun2 local-port '1195'
set interfaces openvpn vtun2 remote-port '1195'
set interfaces openvpn vtun2 shared-secret-key-file '/config/auth/openvpn-1.key'
set interfaces openvpn vtun2 local-address 2001:db8::1
set interfaces openvpn vtun2 remote-address 2001:db8::2
```
before fix:
```
vyos@r1# commit

"local-address" and "remote-address" cannot be the same

[[interfaces openvpn vtun2]] failed
Commit failed
[edit]
vyos@r1#
```
After fix 
```
vyos@r1# run show int
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
eth0             192.168.122.11/24                 u/u  BARfff
eth1             192.0.2.2/24                      u/u  
lo               127.0.0.1/8                       u/u  
                 ::1/128                                
vtun2            2001:db8::1/64                    u/u  
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
