### PR TITLE
isis: T4693: Fix ISIS segment routing configurations, part deux

### DIFF
--- a/data/templates/frr/isisd.frr.j2
+++ b/data/templates/frr/isisd.frr.j2
@@ -127,8 +127,7 @@ router isis VyOS {{ 'vrf ' + vrf if vrf is vyos_defined }}
  segment-routing prefix {{ prefix }} absolute {{ prefix_config.absolute.value }}
 {%                     if prefix_config.absolute.explicit_null is vyos_defined %}
  segment-routing prefix {{ prefix }} absolute {{ prefix_config.absolute.value }} explicit-null
-{%                     endif %}
-{%                     if prefix_config.absolute.no_php_flag is vyos_defined %}
+{%                     elif prefix_config.absolute.no_php_flag is vyos_defined %}
  segment-routing prefix {{ prefix }} absolute {{ prefix_config.absolute.value }} no-php-flag
 {%                     endif %}
 {%                 endif %}
@@ -138,8 +137,7 @@ router isis VyOS {{ 'vrf ' + vrf if vrf is vyos_defined }}
  segment-routing prefix {{ prefix }} index {{ prefix_config.index.value }}
 {%                     if prefix_config.index.explicit_null is vyos_defined %}
  segment-routing prefix {{ prefix }} index {{ prefix_config.index.value }} explicit-null
-{%                     endif %}
-{%                     if prefix_config.index.no_php_flag is vyos_defined %}
+{%                     elif prefix_config.index.no_php_flag is vyos_defined %}
  segment-routing prefix {{ prefix }} index {{ prefix_config.index.value }} no-php-flag
 {%                     endif %}
 {%                 endif %}

--- a/src/conf_mode/protocols_isis.py
+++ b/src/conf_mode/protocols_isis.py
@@ -203,6 +203,28 @@ def verify(isis):
         if list(set(global_range) & set(local_range)):
             raise ConfigError(f'Segment-Routing Global Block ({g_low_label_value}/{g_high_label_value}) '\
                               f'conflicts with Local Block ({l_low_label_value}/{l_high_label_value})!')
+        
+    # Check for a blank or invalid value per prefix
+    if dict_search('segment_routing.prefix', isis):
+        for prefix, prefix_config in isis['segment_routing']['prefix'].items():
+            if 'absolute' in prefix_config:
+                if prefix_config['absolute'].get('value') is None:
+                    raise ConfigError(f'Segment routing prefix {prefix} absolute value cannot be blank.')
+            elif 'index' in prefix_config:
+                if prefix_config['index'].get('value') is None:
+                    raise ConfigError(f'Segment routing prefix {prefix} index value cannot be blank.')
+
+    # Check for explicit-null and no-php-flag configured at the same time per prefix
+    if dict_search('segment_routing.prefix', isis):
+        for prefix, prefix_config in isis['segment_routing']['prefix'].items():
+            if 'absolute' in prefix_config:
+                if ("explicit_null" in prefix_config['absolute']) and ("no_php_flag" in prefix_config['absolute']): 
+                    raise ConfigError(f'Segment routing prefix {prefix} cannot have both explicit-null '\
+                                      f'and no-php-flag configured at the same time.')
+            elif 'index' in prefix_config:
+                if ("explicit_null" in prefix_config['index']) and ("no_php_flag" in prefix_config['index']):
+                    raise ConfigError(f'Segment routing prefix {prefix} cannot have both explicit-null '\
+                                      f'and no-php-flag configured at the same time.')
 
     return None
 


### PR DESCRIPTION
This change is to fix more bugs in which ISIS segment routing was broken due to a refactor. This change also introduces a few additions to the ISIS handler for checking per prefix validations for segment value and mutual exclusivity for two options.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Made small changes to the ISIS jinja2 profile so that now it better works 
when adding/removing changes to explicit null as well as no php hop. 

Added two config checks in the ISIS handler for per prefix value checks as
well as for mutual exclusivity for explicit null as well as no php hop.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4693

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ISIS

## Proposed changes
<!--- Describe your changes in detail -->

There's...really not more detail here than what I put up top. I am sorry :(

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Here is the config we're adding:
```
set protocols isis interface lo passive
set protocols isis level 'level-2'
set protocols isis metric-style 'wide'
set protocols isis net '49.0001.1921.6800.0001.00'
set protocols isis segment-routing enable
set protocols isis segment-routing global-block high-label-value '1999'
set protocols isis segment-routing global-block low-label-value '1000'
set protocols isis segment-routing maximum-label-depth '3'
set protocols isis segment-routing prefix 192.168.0.1/32 index explicit-null
set protocols isis segment-routing prefix 192.168.0.1/32 index value '1'
set protocols isis segment-routing prefix 192.168.0.2/32 index no-php-flag
set protocols isis segment-routing prefix 192.168.0.2/32 index value '2'
set protocols isis segment-routing prefix 192.168.0.3/32 absolute explicit-null
set protocols isis segment-routing prefix 192.168.0.3/32 absolute value '60000'
set protocols isis segment-routing prefix 192.168.0.4/32 absolute no-php-flag
set protocols isis segment-routing prefix 192.168.0.4/32 absolute value '65000'
```

Config compare is this:
```
vyos@vyos# compare
[edit protocols]
+isis {
+    interface lo {
+        passive
+    }
+    level level-2
+    metric-style wide
+    net 49.0001.1921.6800.0001.00
+    segment-routing {
+        enable
+        global-block {
+            high-label-value 1999
+            low-label-value 1000
+        }
+        maximum-label-depth 3
+        prefix 192.168.0.1/32 {
+            index {
+                explicit-null
+                value 1
+            }
+        }
+        prefix 192.168.0.2/32 {
+            index {
+                no-php-flag
+                value 2
+            }
+        }
+        prefix 192.168.0.3/32 {
+            absolute {
+                explicit-null
+                value 60000
+            }
+        }
+        prefix 192.168.0.4/32 {
+            absolute {
+                no-php-flag
+                value 65000
+            }
+        }
+    }
+}
```

Full commit shows properly:
```
vyos@vyos# save
Saving configuration to '/config/config.boot'...
Done
[edit]
vyos@vyos# exit
exit
vyos@vyos:~$ vtysh -c "show run"
Building configuration...

Current configuration:
!
frr version 8.3.1
frr defaults traditional
hostname vyos
log syslog
log facility local7
service integrated-vtysh-config
!
ip route 0.0.0.0/0 10.0.0.65
!
interface lo
 ip router isis VyOS
 ipv6 router isis VyOS
 isis passive
exit
!
router isis VyOS
 is-type level-2-only
 net 49.0001.1921.6800.0001.00
 segment-routing on
 segment-routing global-block 1000 1999
 segment-routing node-msd 3
 segment-routing prefix 192.168.0.1/32 index 1 explicit-null
 segment-routing prefix 192.168.0.2/32 index 2 no-php-flag
 segment-routing prefix 192.168.0.3/32 absolute 60000 explicit-null
 segment-routing prefix 192.168.0.4/32 absolute 65000 no-php-flag
exit
!
end
```

Showing one of the ISIS prefix checks here:
```
vyos@vyos# compare
[edit protocols isis segment-routing prefix 192.168.0.3/32 absolute]
+no-php-flag

vyos@vyos# commit

Segment routing prefix 192.168.0.3/32 cannot have both explicit-null and
no-php-flag configured at the same time.

[[protocols isis]] failed
Commit failed
```

Showing the other ISIS prefix check here:
```
vyos@vyos# compare
[edit protocols isis segment-routing prefix 192.168.0.1/32 index]
-value 1

vyos@vyos# commit

Segment routing prefix 192.168.0.1/32 index value cannot be blank.

[[protocols isis]] failed
Commit failed
```

Here is the smoketest:

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_isis.py
test_isis_01_redistribute (__main__.TestProtocolsISIS) ...
Network entity is mandatory!

ok
test_isis_02_vrfs (__main__.TestProtocolsISIS) ... ok
test_isis_03_zebra_route_map (__main__.TestProtocolsISIS) ... ok
test_isis_04_default_information (__main__.TestProtocolsISIS) ... ok
test_isis_05_password (__main__.TestProtocolsISIS) ...
Can use either md5 or plaintext-password for area-password!


Can use either md5 or plaintext-password for domain-password!

ok
test_isis_06_spf_delay_bfd (__main__.TestProtocolsISIS) ...
All types of spf-delay must be configured. Missing: time-to-learn,
short-delay, init-delay, long-delay


All types of spf-delay must be configured. Missing: time-to-learn,
short-delay, long-delay


All types of spf-delay must be configured. Missing: time-to-learn,
short-delay


All types of spf-delay must be configured. Missing: time-to-learn

ok
test_isis_07_segment_routing_configuration (__main__.TestProtocolsISIS) ... ok

----------------------------------------------------------------------
Ran 7 tests in 19.348s

OK
```




## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
