### PR TITLE
policy-route: T4697: Add missing rule_id for verify_rule func

### DIFF
--- a/src/conf_mode/policy-route.py
+++ b/src/conf_mode/policy-route.py
@@ -92,7 +92,7 @@ def get_config(config=None):
 
     return policy
 
-def verify_rule(policy, name, rule_conf, ipv6):
+def verify_rule(policy, name, rule_conf, ipv6, rule_id):
     icmp = 'icmp' if not ipv6 else 'icmpv6'
     if icmp in rule_conf:
         icmp_defined = False
@@ -166,7 +166,7 @@ def verify(policy):
             for name, pol_conf in policy[route].items():
                 if 'rule' in pol_conf:
                     for rule_id, rule_conf in pol_conf['rule'].items():
-                        verify_rule(policy, name, rule_conf, ipv6)
+                        verify_rule(policy, name, rule_conf, ipv6, rule_id)
 
     for ifname, if_policy in policy['interfaces'].items():
         name = dict_search_args(if_policy, 'route')


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
There is a missing `rule_id` in the `verify_rule()` function 
We call it from the loop but don't provide argument `rule_id`
It cause `NameError: name 'rule_id' is not defined`
Fix it
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4697

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
policy route
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Set change mss without SYN flag
```
set policy route mss rule 10 protocol tcp 
set policy route mss rule 10 set tcp-mss 1440
```
Commit before the fix:
```
vyos@r14# commit
[ policy route mss ]
VyOS had an issue completing a command.

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/policy-route.py", line 289, in <module>
    verify(c)
  File "/usr/libexec/vyos/conf_mode/policy-route.py", line 169, in verify
    verify_rule(policy, name, rule_conf, ipv6)
  File "/usr/libexec/vyos/conf_mode/policy-route.py", line 117, in verify_rule
    raise ConfigError(f'{name} rule {rule_id}: TCP SYN flag must be set to modify TCP-MSS')
NameError: name 'rule_id' is not defined

[[policy route mss]] failed
Commit failed
[edit]
vyos@r14# 
```
After fix:
```
vyos@r14# commit
[ policy route mss ]
mss rule 10: TCP SYN flag must be set to modify TCP-MSS

[[policy route mss]] failed
Commit failed
[edit]
vyos@r14#
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
