### PR TITLE
qos: T4688: add xml template for limiter actions

### DIFF
--- a/interface-definitions/include/qos/limiter-actions.xml.i
+++ b/interface-definitions/include/qos/limiter-actions.xml.i
@@ -1,0 +1,66 @@
+<!-- include start from qos/limiter-actions.xml.i -->
+<leafNode name="exceed-action">
+  <properties>
+    <help>Default action for packets exceeding the limiter (default: drop)</help>
+    <completionHelp>
+      <list>continue drop ok reclassify pipe</list>
+    </completionHelp>
+    <valueHelp>
+      <format>continue</format>
+      <description>Don't do anything, just continue with the next action in line</description>
+    </valueHelp>
+    <valueHelp>
+      <format>drop</format>
+      <description>Drop the packet immediately</description>
+    </valueHelp>
+    <valueHelp>
+      <format>ok</format>
+      <description>Accept the packet</description>
+    </valueHelp>
+    <valueHelp>
+      <format>reclassify</format>
+      <description>Treat the packet as non-matching to the filter this action is attached to and continue with the next filter in line (if any)</description>
+    </valueHelp>
+    <valueHelp>
+      <format>pipe</format>
+      <description>Pass the packet to the next action in line</description>
+    </valueHelp>
+    <constraint>
+      <regex>(continue|drop|ok|reclassify|pipe)</regex>
+    </constraint>
+  </properties>
+  <defaultValue>drop</defaultValue>
+</leafNode>
+<leafNode name="notexceed-action">
+  <properties>
+    <help>Default action for packets not exceeding the limiter (default: ok)</help>
+    <completionHelp>
+      <list>continue drop ok reclassify pipe</list>
+    </completionHelp>
+    <valueHelp>
+      <format>continue</format>
+      <description>Don't do anything, just continue with the next action in line</description>
+    </valueHelp>
+    <valueHelp>
+      <format>drop</format>
+      <description>Drop the packet immediately</description>
+    </valueHelp>
+    <valueHelp>
+      <format>ok</format>
+      <description>Accept the packet</description>
+    </valueHelp>
+    <valueHelp>
+      <format>reclassify</format>
+      <description>Treat the packet as non-matching to the filter this action is attached to and continue with the next filter in line (if any)</description>
+    </valueHelp>
+    <valueHelp>
+      <format>pipe</format>
+      <description>Pass the packet to the next action in line</description>
+    </valueHelp>
+    <constraint>
+      <regex>(continue|drop|ok|reclassify|pipe)</regex>
+    </constraint>
+  </properties>
+  <defaultValue>ok</defaultValue>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/qos.xml.in
+++ b/interface-definitions/qos.xml.in
@@ -188,6 +188,7 @@
                   #include <include/qos/burst.xml.i>
                   #include <include/generic-description.xml.i>
                   #include <include/qos/match.xml.i>
+                  #include <include/qos/limiter-actions.xml.i>
                   <leafNode name="priority">
                     <properties>
                       <help>Priority for rule evaluation</help>
@@ -211,6 +212,7 @@
                 <children>
                   #include <include/qos/bandwidth.xml.i>
                   #include <include/qos/burst.xml.i>
+                  #include <include/qos/limiter-actions.xml.i>
                 </children>
               </node>
               #include <include/generic-description.xml.i>


### PR DESCRIPTION
## Change Summary

Adds the relevant XML elements for the exceed/notexceed actions defined in https://github.com/vyos/vyatta-cfg-qos/pull/19. Merge after https://github.com/vyos/vyatta-cfg-qos/pull/19 is merged.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://phabricator.vyos.net/T4688

## Component(s) name

qos

## Proposed changes

New XML nodes defining the `exceed-action` and `notexceed-action` for the limiter policy have been added.

## How to test

Validate the new nodes are present.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
