### PR TITLE
wireguard: T4702: actively revoke peer if it gets disabled

### DIFF
--- a/python/vyos/ifconfig/wireguard.py
+++ b/python/vyos/ifconfig/wireguard.py
@@ -171,12 +171,8 @@ class WireGuardIf(Interface):
 
         # remove no longer associated peers first
         if 'peer_remove' in config:
-            for tmp in config['peer_remove']:
-                peer = config['peer_remove'][tmp]
-                peer['ifname'] = config['ifname']
-
-                cmd = 'wg set {ifname} peer {pubkey} remove'
-                self._cmd(cmd.format(**peer))
+            for peer, public_key in config['peer_remove'].items():
+                self._cmd(f'wg set {self.ifname} peer {public_key} remove')
 
         # Wireguard base command is identical for every peer
         base_cmd  = 'wg set {ifname} private-key {private_key}'
@@ -187,44 +183,49 @@ class WireGuardIf(Interface):
 
         base_cmd = base_cmd.format(**config)
 
-        for tmp in config['peer']:
-            peer = config['peer'][tmp]
+        if 'peer' in config:
+            for peer, peer_config in config['peer'].items():
+                # T4702: No need to configure this peer when it was explicitly
+                # marked as disabled - also active sessions are terminated as
+                # the public key was already removed when entering this method!
+                if 'disable' in peer_config:
+                    continue
 
-            # start of with a fresh 'wg' command
-            cmd = base_cmd + ' peer {pubkey}'
+                # start of with a fresh 'wg' command
+                cmd = base_cmd + ' peer {pubkey}'
 
-            # If no PSK is given remove it by using /dev/null - passing keys via
-            # the shell (usually bash) is considered insecure, thus we use a file
-            no_psk_file = '/dev/null'
-            psk_file = no_psk_file
-            if 'preshared_key' in peer:
-                psk_file = '/tmp/tmp.wireguard.psk'
-                with open(psk_file, 'w') as f:
-                    f.write(peer['preshared_key'])
-            cmd += f' preshared-key {psk_file}'
+                # If no PSK is given remove it by using /dev/null - passing keys via
+                # the shell (usually bash) is considered insecure, thus we use a file
+                no_psk_file = '/dev/null'
+                psk_file = no_psk_file
+                if 'preshared_key' in peer_config:
+                    psk_file = '/tmp/tmp.wireguard.psk'
+                    with open(psk_file, 'w') as f:
+                        f.write(peer_config['preshared_key'])
+                cmd += f' preshared-key {psk_file}'
 
-            # Persistent keepalive is optional
-            if 'persistent_keepalive'in peer:
-                cmd += ' persistent-keepalive {persistent_keepalive}'
+                # Persistent keepalive is optional
+                if 'persistent_keepalive' in peer_config:
+                    cmd += ' persistent-keepalive {persistent_keepalive}'
 
-            # Multiple allowed-ip ranges can be defined - ensure we are always
-            # dealing with a list
-            if isinstance(peer['allowed_ips'], str):
-                peer['allowed_ips'] = [peer['allowed_ips']]
-            cmd += ' allowed-ips ' + ','.join(peer['allowed_ips'])
+                # Multiple allowed-ip ranges can be defined - ensure we are always
+                # dealing with a list
+                if isinstance(peer_config['allowed_ips'], str):
+                    peer_config['allowed_ips'] = [peer_config['allowed_ips']]
+                cmd += ' allowed-ips ' + ','.join(peer_config['allowed_ips'])
 
-            # Endpoint configuration is optional
-            if {'address', 'port'} <= set(peer):
-                if is_ipv6(peer['address']):
-                    cmd += ' endpoint [{address}]:{port}'
-                else:
-                    cmd += ' endpoint {address}:{port}'
+                # Endpoint configuration is optional
+                if {'address', 'port'} <= set(peer_config):
+                    if is_ipv6(peer_config['address']):
+                        cmd += ' endpoint [{address}]:{port}'
+                    else:
+                        cmd += ' endpoint {address}:{port}'
 
-            self._cmd(cmd.format(**peer))
+                self._cmd(cmd.format(**peer_config))
 
-            # PSK key file is not required to be stored persistently as its backed by CLI
-            if psk_file != no_psk_file and os.path.exists(psk_file):
-                os.remove(psk_file)
+                # PSK key file is not required to be stored persistently as its backed by CLI
+                if psk_file != no_psk_file and os.path.exists(psk_file):
+                    os.remove(psk_file)
 
         # call base class
         super().update(config)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

When any configured peer is set to `disable` while the Wireguard tunnel is up and running it does not get actively revoked and removed. This poses a security risk as connections keep beeing alive.

Whenever any parameter of a peer changes we actively remove the peer and fully recreate it on the fly.

(cherry picked from commit a4feb96af9ac45aff41ded1744cf302b5c5a9e7e)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4702

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireguard

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set interfaces wireguard wg10 address '100.64.0.1/30'
set interfaces wireguard wg10 peer LR1.wue3 address '172.18.254.201'
set interfaces wireguard wg10 peer LR1.wue3 allowed-ips '0.0.0.0/0'
set interfaces wireguard wg10 peer LR1.wue3 port '20000'
set interfaces wireguard wg10 peer LR1.wue3 pubkey 'D6BKY4xFfJJw1TgdjgjES+ZeCr752Oe8L1SThOLWJR8='
set interfaces wireguard wg10 port '20000'
```

```bash
cpo@LR2.wue3# sudo wg show wg10
interface: wg10
  public key: hAzUPHVVdBYKBjO3EDupwuMBR9mhOwzWhMHeif47RBs=
  private key: (hidden)
  listening port: 20000

peer: D6BKY4xFfJJw1TgdjgjES+ZeCr752Oe8L1SThOLWJR8=
  endpoint: 172.18.201.10:20000
  allowed ips: 0.0.0.0/0
  latest handshake: 10 seconds ago
  transfer: 1.43 KiB received, 1.34 KiB sent
```

Now disable the peer

```
set interfaces wireguard wg10 peer LR1.wue3 disable
```

```bash
cpo@LR2.wue3# sudo wg show wg10
interface: wg10
  public key: hAzUPHVVdBYKBjO3EDupwuMBR9mhOwzWhMHeif47RBs=
  private key: (hidden)
  listening port: 20000
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
