### PR TITLE
smoketest: T4118: Fix smoketest for NHRP

### DIFF
--- a/smoketest/scripts/cli/test_protocols_nhrp.py
+++ b/smoketest/scripts/cli/test_protocols_nhrp.py
@@ -65,7 +65,6 @@ class TestProtocolsNHRP(VyOSUnitTestSHIM.TestCase):
         self.cli_set(nhrp_path + ["tunnel", tunnel_if, "shortcut"])
 
         # IKE/ESP Groups
-        self.cli_set(vpn_path + ["esp-group", esp_group, "compression", "disable"])
         self.cli_set(vpn_path + ["esp-group", esp_group, "lifetime", "1800"])
         self.cli_set(vpn_path + ["esp-group", esp_group, "mode", "transport"])
         self.cli_set(vpn_path + ["esp-group", esp_group, "pfs", "dh-group2"])
@@ -74,7 +73,6 @@ class TestProtocolsNHRP(VyOSUnitTestSHIM.TestCase):
         self.cli_set(vpn_path + ["esp-group", esp_group, "proposal", "2", "encryption", "3des"])
         self.cli_set(vpn_path + ["esp-group", esp_group, "proposal", "2", "hash", "md5"])
 
-        self.cli_set(vpn_path + ["ike-group", ike_group, "ikev2-reauth", "no"])
         self.cli_set(vpn_path + ["ike-group", ike_group, "key-exchange", "ikev1"])
         self.cli_set(vpn_path + ["ike-group", ike_group, "lifetime", "3600"])
         self.cli_set(vpn_path + ["ike-group", ike_group, "proposal", "1", "dh-group", "2"])


### PR DESCRIPTION
As we change syntax for IPSec 'esp <tag> compression disable' to delete 'compression' if it not used, so delete it from nhtp test

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Fix smoketest

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4118

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_nhrp.py
test_config (__main__.TestProtocolsNHRP) ... ok

----------------------------------------------------------------------
Ran 1 test in 3.035s

OK
vyos@r14:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
