### PR TITLE
interfaces: T4709: raise minimum TCP MSS clamping value

### DIFF
--- a/interface-definitions/include/interface/adjust-mss.xml.i
+++ b/interface-definitions/include/interface/adjust-mss.xml.i
@@ -11,11 +11,11 @@
       <description>Automatically sets the MSS to the proper value</description>
     </valueHelp>
     <valueHelp>
-      <format>u32:500-65535</format>
+      <format>u32:536-65535</format>
       <description>TCP Maximum segment size in bytes</description>
     </valueHelp>
     <constraint>
-      <validator name="numeric" argument="--range 500-65535"/>
+      <validator name="numeric" argument="--range 536-65535"/>
       <regex>(clamp-mss-to-pmtu)</regex>
     </constraint>
   </properties>


### PR DESCRIPTION
## Change Summary

This commit raises the minimum TCP MSS clamping range to the MSS value corresponding to the minimum packet size that must be accepted for IPv4.

PR made for consistency with #1557.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T4709

## Component(s) name
interfaces, firewall

## Proposed changes

Raise the minimum TCP MSS clamping value from 500 to 536 octets in accordance with the rationale stated in #1557.

## How to test

Attempt to set a MSS value less than 536, see that the commit is rejected.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
