### PR TITLE
conserver: T4717: Support for setting a name for console-server devices

### DIFF
--- a/data/templates/conserver/conserver.conf.j2
+++ b/data/templates/conserver/conserver.conf.j2
@@ -25,6 +25,9 @@ console {{ key }} {
     baud {{ value.speed }};
     parity {{ value.parity }};
     options {{ "!" if value.stop_bits == "1" }}cstopb;
+{%     if value.alias is vyos_defined %}
+    aliases "{{ value.alias }}";
+{%     endif %}
 }
 {% endfor %}
 

--- a/interface-definitions/service-console-server.xml.in
+++ b/interface-definitions/service-console-server.xml.in
@@ -28,6 +28,14 @@
             </properties>
             <children>
               #include <include/interface/description.xml.i>
+              <leafNode name="alias">
+                <properties>
+                  <help>Human-readable name for this console</help>
+                  <constraint>
+                    <regex>[-_a-zA-Z0-9.]{1,128}</regex>
+                  </constraint>
+                </properties>
+              </leafNode>
               <leafNode name="speed">
                 <properties>
                   <help>Serial port baud rate</help>

--- a/op-mode-definitions/connect.xml.in
+++ b/op-mode-definitions/connect.xml.in
@@ -10,6 +10,7 @@
           <help>Connect to device attached to serial console server</help>
           <completionHelp>
             <path>service console-server device</path>
+            <script>${vyos_completion_dir}/list_consoles.sh</script>
           </completionHelp>
         </properties>
         <command>/usr/bin/console "$3"</command>

--- a/src/completion/list_consoles.sh
+++ b/src/completion/list_consoles.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# For lines like `aliases "foo";`, regex matches everything between the quotes
+grep -oP '(?<=aliases ").+(?=";)' /run/conserver/conserver.cf

--- a/src/conf_mode/service_console-server.py
+++ b/src/conf_mode/service_console-server.py
@@ -61,6 +61,7 @@ def verify(proxy):
     if not proxy:
         return None
 
+    aliases = []
     processes = process_iter(['name', 'cmdline'])
     if 'device' in proxy:
         for device, device_config in proxy['device'].items():
@@ -74,6 +75,12 @@ def verify(proxy):
 
             if 'ssh' in device_config and 'port' not in device_config['ssh']:
                 raise ConfigError(f'Port "{device}" requires SSH port to be set!')
+
+            if 'alias' in device_config:
+                if device_config['alias'] in aliases:
+                    raise ConfigError("Console aliases must be unique")
+                else:
+                    aliases.append(device_config['alias'])
 
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
This adds a new 'alias' property to the console-server device definition to allow users to connect to a console using a human-readable name rather than just the device name.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4717

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* conserver

## Proposed changes
<!--- Describe your changes in detail -->

For a configuration like:
```
service {
  console-server {
    device ttyUSB0 {
      speed 115200
      alias my-server
    }
  }
}
```

Users can connect either by doing `connect console ttyUSB0`, or `connect console my-server`.

Names:
* Must be unique
* Are limited to 128 characters
* Are optional - if not specified, only the `connect console ttyX` form can be used

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
1. Starting from a configuration like:
```
service {
  console-server {
    device ttyUSB0 {
      speed 115200
    }
    device ttyUSB1 {
      speed 115200
    }
  }
}
```
2. Observe that `connect console ttyUSB0` and `connect console ttyUSB1` work as existing behavior.
3. In config mode, `set service console-server device ttyUSB1 alias serverA; commit`
4. In operation mode, observe that `connect console serverA` connects to ttyUSB1`
5. In operation mode, observe that `connect console ttyUSB1` still connects to ttyUSB1`
6. In config mode, observe that `set service console-server device ttyUSB0 alias serverA; commit` raises an error

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
