### PR TITLE
T4700: Firewall: add interface matching criteria

### DIFF
--- a/interface-definitions/include/firewall/common-rule.xml.i
+++ b/interface-definitions/include/firewall/common-rule.xml.i
@@ -26,6 +26,14 @@
     </leafNode>
   </children>
 </node>
+<leafNode name="inbound-interface">
+  <properties>
+    <help>Match inbound-interface</help>
+    <completionHelp>
+      <script>${vyos_completion_dir}/list_interfaces.py</script>
+    </completionHelp>
+  </properties>
+</leafNode>
 <node name="ipsec">
   <properties>
     <help>Inbound IPsec packets</help>
@@ -122,6 +130,14 @@
     </leafNode>
   </children>
 </node>
+<leafNode name="outbound-interface">
+  <properties>
+    <help>Match outbound-interface</help>
+    <completionHelp>
+      <script>${vyos_completion_dir}/list_interfaces.py</script>
+    </completionHelp>
+  </properties>
+</leafNode>
 <leafNode name="protocol">
   <properties>
     <help>Protocol to match (protocol name, number, or "all")</help>

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -248,6 +248,14 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
                 value = rule_conf['hop_limit'][op]
                 output.append(f'ip6 hoplimit {operator} {value}')
 
+    if 'inbound_interface' in rule_conf:
+        iiface = rule_conf['inbound_interface']
+        output.append(f'iifname {iiface}')
+
+    if 'outbound_interface' in rule_conf:
+        oiface = rule_conf['outbound_interface']
+        output.append(f'oifname {oiface}')
+
     if 'ttl' in rule_conf:
         operators = {'eq': '==', 'gt': '>', 'lt': '<'}
         for op, operator in operators.items():


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add interface matching criteria in firewall rules.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4700

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@Interface-Match# run show config comm | grep fire
set firewall ipv6-name FOO6 rule 10 action 'return'
set firewall ipv6-name FOO6 rule 10 inbound-interface 'vtun1'
set firewall ipv6-name FOO6 rule 20 action 'drop'
set firewall ipv6-name FOO6 rule 20 outbound-interface 'eth3'
set firewall name FOO rule 10 action 'accept'
set firewall name FOO rule 10 inbound-interface 'eth0'
set firewall name FOO rule 20 action 'reject'
set firewall name FOO rule 20 outbound-interface 'eth*'
[edit]
vyos@Interface-Match# sudo nft list chain ip vyos_filter NAME_FOO
table ip vyos_filter {
        chain NAME_FOO {
                iifname "eth0" counter packets 0 bytes 0 return comment "FOO-10"
                oifname "eth*" counter packets 0 bytes 0 reject comment "FOO-20"
                counter packets 0 bytes 0 drop comment "FOO default-action drop"
        }
}
[edit]
vyos@Interface-Match# sudo nft list chain ip6 vyos_filter NAME6_FOO6
table ip6 vyos_filter {
        chain NAME6_FOO6 {
                iifname "vtun1" counter packets 0 bytes 0 return comment "FOO6-10"
                oifname "eth3" counter packets 0 bytes 0 drop comment "FOO6-20"
                counter packets 0 bytes 0 drop comment "FOO6 default-action drop"
        }
}
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
