### PR TITLE
login: T4715: Auto logout user after inactivity

### DIFF
--- a/data/templates/login/autologout.j2
+++ b/data/templates/login/autologout.j2
@@ -1,0 +1,5 @@
+{% if timeout is vyos_defined %}
+TMOUT={{ timeout }}
+readonly TMOUT
+export TMOUT
+{% endif %}

--- a/interface-definitions/system-login.xml.in
+++ b/interface-definitions/system-login.xml.in
@@ -151,6 +151,19 @@
               #include <include/interface/vrf.xml.i>
             </children>
           </node>
+          <leafNode name="timeout">
+            <properties>
+              <help>Session timeout</help>
+              <valueHelp>
+                <format>u32:5-604800</format>
+                <description>Session timeout in seconds</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 5-604800"/>
+              </constraint>
+              <constraintErrorMessage>Timeout must be between 5 and 604800 seconds</constraintErrorMessage>
+            </properties>
+          </leafNode>
         </children>
       </node>
     </children>

--- a/src/conf_mode/system-login.py
+++ b/src/conf_mode/system-login.py
@@ -40,6 +40,7 @@ from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
 
+autologout_file = "/etc/profile.d/autologout.sh"
 radius_config_file = "/etc/pam_radius_auth.conf"
 
 def get_local_users():
@@ -202,6 +203,13 @@ def generate(login):
     else:
         if os.path.isfile(radius_config_file):
             os.unlink(radius_config_file)
+
+    if 'timeout' in login:
+        render(autologout_file, 'login/autologout.j2', login,
+                   permission=0o755, user='root', group='root')
+    else:
+        if os.path.isfile(autologout_file):
+            os.unlink(autologout_file)
 
     return None
 


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to terminate interactive sessions (TTY/PTS) after a period of inactivity.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4715

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
login
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure any inactive timeout and re-login again to the system
After timeout time it must be logout
```
set system login autologout '10'
commit

```
Expected file:
```
vyos@r14:~$ cat /etc/profile.d/autologout.sh 
TMOUT=10
readonly TMOUT
export TMOUT
vyos@r14:~$ 
```
After re-login
```
Last login: Tue Sep 27 14:37:51 2022 from 192.168.122.1
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ timed out waiting for input: auto-logout
Connection to 192.168.122.14 closed.
$
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
