### PR TITLE
nat: T4713: Fix op-mode nat translation output

### DIFF
--- a/src/op_mode/nat.py
+++ b/src/op_mode/nat.py
@@ -109,7 +109,7 @@ def _get_formatted_output_rules(data, direction, family):
                 if jmespath.search('rule.expr[*].match.left.meta', rule) else 'any'
         for index, match in enumerate(jmespath.search('rule.expr[*].match', rule)):
             if 'payload' in match['left']:
-                if 'prefix' in match['right'] or 'set' in match['right']:
+                if isinstance(match['right'], dict) and ('prefix' in match['right'] or 'set' in match['right']):
                     # Merge dict src/dst l3_l4 parameters
                     my_dict = {**match['left']['payload'], **match['right']}
                     my_dict['op'] = match['op']
@@ -136,10 +136,15 @@ def _get_formatted_output_rules(data, direction, family):
                             dport = my_dict.get('set')
                             dport = ','.join(map(str, dport))
                 else:
-                    if jmespath.search('left.payload.field', match) == 'saddr':
+                    field = jmespath.search('left.payload.field', match)
+                    if field == 'saddr':
                         saddr = match.get('right')
-                    if jmespath.search('left.payload.field', match) == 'daddr':
+                    elif field == 'daddr':
                         daddr = match.get('right')
+                    elif field == 'sport':
+                        sport = match.get('right')
+                    elif field == 'dport':
+                        dport = match.get('right')
             else:
                 saddr = '::/0' if family == 'inet6' else '0.0.0.0/0'
                 daddr = '::/0' if family == 'inet6' else '0.0.0.0/0'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixes issue with output from nftables in NAT op-mode script

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4713

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat, op-mode

## Proposed changes
<!--- Describe your changes in detail -->
NAT op-mode script updated to verify type before dict object is used and fixes handling of single source/destination ports on nat rules.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Post-fix output from example config in Phabricator:
```
Rule    Source        Destination                     Proto    In-Int    Translation
------  ------------  ------------------------------  -------  --------  -------------
10      13.90.97.251  0.0.0.0/0                       any      eth2      172.16.136.16
        sport any     dport 22
100     0.0.0.0/0     0.0.0.0/0                       any      eth2      172.16.136.35
        sport any     dport 8123
110     0.0.0.0/0     0.0.0.0/0                       any      eth0      172.16.136.35
        sport any     dport 8123
120     0.0.0.0/0     0.0.0.0/0                       TCP      eth2      172.16.136.96
        sport any     dport 1935,3074,3478,3479,3480
```



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
