### PR TITLE
policy: T4660: Changed CLI syntax in route-map set community

### DIFF
--- a/data/templates/frr/policy.frr.j2
+++ b/data/templates/frr/policy.frr.j2
@@ -274,11 +274,17 @@ route-map {{ route_map }} {{ rule_config.action }} {{ rule }}
 {%                     if rule_config.set.atomic_aggregate is vyos_defined %}
  set atomic-aggregate
 {%                     endif %}
-{%                     if rule_config.set.comm_list.comm_list is vyos_defined %}
- set comm-list {{ rule_config.set.comm_list.comm_list }} {{ 'delete' if rule_config.set.comm_list.delete is vyos_defined }}
+{%                     if rule_config.set.community.delete is vyos_defined %}
+ set comm-list {{ rule_config.set.community.delete }} delete
 {%                     endif %}
-{%                     if rule_config.set.community is vyos_defined %}
- set community {{ rule_config.set.community }}
+{%                     if rule_config.set.community.replace is vyos_defined %}
+ set community {{ rule_config.set.community.replace | join(' ') | replace("local-as" , "local-AS") }}
+{%                     endif %}
+{%                     if rule_config.set.community.add is vyos_defined %}
+ set community {{ rule_config.set.community.add | join(' ') | replace("local-as" , "local-AS") }} additive
+{%                     endif %}
+{%                     if rule_config.set.community.none is vyos_defined %}
+ set community none
 {%                     endif %}
 {%                     if rule_config.set.distance is vyos_defined %}
  set distance {{ rule_config.set.distance }}
@@ -290,13 +296,16 @@ route-map {{ route_map }} {{ rule_config.action }} {{ rule }}
  set evpn gateway-ip ipv6 {{ rule_config.set.evpn.gateway.ipv6 }}
 {%                     endif %}
 {%                     if rule_config.set.extcommunity.bandwidth is vyos_defined %}
- set extcommunity bandwidth {{ rule_config.set.extcommunity.bandwidth }}
+ set extcommunity bandwidth {{ rule_config.set.extcommunity.bandwidth }} {{ 'non-transitive' if rule_config.set.extcommunity.bandwidth_non_transitive is vyos_defined }}
 {%                     endif %}
 {%                     if rule_config.set.extcommunity.rt is vyos_defined %}
- set extcommunity rt {{ rule_config.set.extcommunity.rt }}
+ set extcommunity rt {{ rule_config.set.extcommunity.rt | join(' ') }}
 {%                     endif %}
 {%                     if rule_config.set.extcommunity.soo is vyos_defined %}
- set extcommunity soo {{ rule_config.set.extcommunity.soo }}
+ set extcommunity soo {{ rule_config.set.extcommunity.soo | join(' ') }}
+{%                     endif %}
+{%                     if rule_config.set.extcommunity.none is vyos_defined %}
+ set extcommunity none
 {%                     endif %}
 {%                     if rule_config.set.ip_next_hop is vyos_defined %}
  set ip next-hop {{ rule_config.set.ip_next_hop }}
@@ -313,11 +322,17 @@ route-map {{ route_map }} {{ rule_config.action }} {{ rule }}
 {%                     if rule_config.set.ipv6_next_hop.prefer_global is vyos_defined %}
  set ipv6 next-hop prefer-global
 {%                     endif %}
-{%                     if rule_config.set.large_community is vyos_defined %}
- set large-community {{ rule_config.set.large_community }}
+{%                     if rule_config.set.large_community.replace is vyos_defined %}
+ set large-community {{ rule_config.set.large_community.replace | join(' ') }}
 {%                     endif %}
-{%                     if rule_config.set.large_comm_list_delete is vyos_defined %}
- set large-comm-list {{ rule_config.set.large_comm_list_delete }} delete
+{%                     if rule_config.set.large_community.add is vyos_defined %}
+ set large-community {{ rule_config.set.large_community.add | join(' ') }} additive
+{%                     endif %}
+{%                     if rule_config.set.large_community.none is vyos_defined %}
+ set large-community none
+{%                     endif %}
+{%                     if rule_config.set.large_community.delete is vyos_defined %}
+ set large-comm-list {{ rule_config.set.large_community.delete }} delete
 {%                     endif %}
 {%                     if rule_config.set.local_preference is vyos_defined %}
  set local-preference {{ rule_config.set.local_preference }}

--- a/interface-definitions/include/policy/community-clear.xml.i
+++ b/interface-definitions/include/policy/community-clear.xml.i
@@ -1,0 +1,8 @@
+<!-- include start from policy/community-clear.xml.i -->
+<leafNode name="none">
+  <properties>
+    <help>Completely remove communities attribute from a prefix</help>
+    <valueless/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/policy/community-value-list.xml.i
+++ b/interface-definitions/include/policy/community-value-list.xml.i
@@ -1,0 +1,90 @@
+<!-- include start from policy/community-value-list.xml.i -->
+<completionHelp>
+    <list>
+      local-as
+      no-advertise
+      no-export
+      internet
+      graceful-shutdown
+      accept-own
+      route-filter-translated-v4
+      route-filter-v4
+      route-filter-translated-v6
+      route-filter-v6
+      llgr-stale
+      no-llgr
+      accept-own-nexthop
+      blackhole
+      no-peer
+    </list>
+</completionHelp>
+<valueHelp>
+    <format>&lt;AS:VAL&gt;</format>
+    <description>Community number in &lt;0-65535:0-65535&gt; format</description>
+</valueHelp>
+<valueHelp>
+    <format>local-as</format>
+    <description>Well-known communities value NO_EXPORT_SUBCONFED 0xFFFFFF03</description>
+</valueHelp>
+<valueHelp>
+    <format>no-advertise</format>
+    <description>Well-known communities value NO_ADVERTISE 0xFFFFFF02</description>
+</valueHelp>
+<valueHelp>
+    <format>no-export</format>
+    <description>Well-known communities value NO_EXPORT 0xFFFFFF01</description>
+</valueHelp>
+<valueHelp>
+    <format>internet</format>
+    <description>Well-known communities value 0</description>
+</valueHelp>
+<valueHelp>
+    <format>graceful-shutdown</format>
+    <description>Well-known communities value GRACEFUL_SHUTDOWN 0xFFFF0000</description>
+</valueHelp>
+<valueHelp>
+    <format>accept-own</format>
+    <description>Well-known communities value ACCEPT_OWN 0xFFFF0001</description>
+</valueHelp>
+<valueHelp>
+    <format>route-filter-translated-v4</format>
+    <description>Well-known communities value ROUTE_FILTER_TRANSLATED_v4 0xFFFF0002</description>
+</valueHelp>
+<valueHelp>
+    <format>route-filter-v4</format>
+    <description>Well-known communities value ROUTE_FILTER_v4 0xFFFF0003</description>
+</valueHelp>
+<valueHelp>
+    <format>route-filter-translated-v6</format>
+    <description>Well-known communities value ROUTE_FILTER_TRANSLATED_v6 0xFFFF0004</description>
+</valueHelp>
+<valueHelp>
+    <format>route-filter-v6</format>
+    <description>Well-known communities value ROUTE_FILTER_v6 0xFFFF0005</description>
+</valueHelp>
+<valueHelp>
+    <format>llgr-stale</format>
+    <description>Well-known communities value LLGR_STALE 0xFFFF0006</description>
+</valueHelp>
+<valueHelp>
+    <format>no-llgr</format>
+    <description>Well-known communities value NO_LLGR 0xFFFF0007</description>
+</valueHelp>
+<valueHelp>
+    <format>accept-own-nexthop</format>
+    <description>Well-known communities value accept-own-nexthop 0xFFFF0008</description>
+</valueHelp>
+<valueHelp>
+    <format>blackhole</format>
+    <description>Well-known communities value BLACKHOLE 0xFFFF029A</description>
+</valueHelp>
+<valueHelp>
+    <format>no-peer</format>
+    <description>Well-known communities value NOPEER 0xFFFFFF04</description>
+</valueHelp>
+<multi/>
+<constraint>
+    <regex>local-as|no-advertise|no-export|internet|graceful-shutdown|accept-own|route-filter-translated-v4|route-filter-v4|route-filter-translated-v6|route-filter-v6|llgr-stale|no-llgr|accept-own-nexthop|blackhole|no-peer</regex>
+    <validator name="bgp-regular-community"/>
+</constraint>
+        <!-- include end -->

--- a/interface-definitions/include/policy/extended-community-value-list.xml.i
+++ b/interface-definitions/include/policy/extended-community-value-list.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from policy/community-value-list.xml.i -->
+<valueHelp>
+  <format>ASN:NN</format>
+  <description>based on autonomous system number in format &lt;0-65535:0-4294967295&gt;</description>
+</valueHelp>
+<valueHelp>
+  <format>IP:NN</format>
+  <description>Based on a router-id IP address in format &lt;IP:0-65535&gt;</description>
+</valueHelp>
+<constraint>
+  <validator name="bgp-extended-community"/>
+</constraint>
+<constraintErrorMessage>Should be in form: ASN:NN or IPADDR:NN where ASN is autonomous system number</constraintErrorMessage>
+<multi/>
+        <!-- include end -->

--- a/interface-definitions/include/policy/large-community-value-list.xml.i
+++ b/interface-definitions/include/policy/large-community-value-list.xml.i
@@ -1,0 +1,10 @@
+<!-- include start from policy/community-value-list.xml.i -->
+<valueHelp>
+    <description>Community in format &lt;0-4294967295:0-4294967295:0-4294967295&gt;</description>
+    <format>&lt;GA:LDP1:LDP2&gt;</format>
+</valueHelp>
+<multi/>
+<constraint>
+    <validator name="bgp-large-community"/>
+</constraint>
+        <!-- include end -->

--- a/interface-definitions/include/version/policy-version.xml.i
+++ b/interface-definitions/include/version/policy-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/policy-version.xml.i -->
-<syntaxVersion component='policy' version='3'></syntaxVersion>
+<syntaxVersion component='policy' version='4'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/policy.xml.in
+++ b/interface-definitions/policy.xml.in
@@ -1118,67 +1118,120 @@
                       <valueless/>
                     </properties>
                   </leafNode>
-                  <node name="comm-list">
+                  <node name="community">
                     <properties>
-                      <help>BGP communities matching a community-list</help>
+                      <help>BGP community attribute</help>
                     </properties>
                     <children>
-                      <leafNode name="comm-list">
+                      <leafNode name="add">
                         <properties>
-                          <help>BGP communities with a community-list</help>
+                          <help>Add communities to a prefix</help>
+                          #include <include/policy/community-value-list.xml.i>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="replace">
+                        <properties>
+                          <help>Set communities for a prefix</help>
+                          #include <include/policy/community-value-list.xml.i>
+                        </properties>
+                      </leafNode>
+                      #include <include/policy/community-clear.xml.i>
+                      <leafNode name="delete">
+                        <properties>
+                          <help>Remove communities defined in a list from a prefix</help>
                           <completionHelp>
                             <path>policy community-list</path>
                           </completionHelp>
                           <valueHelp>
+                            <description>Community-list</description>
                             <format>txt</format>
-                            <description>BGP communities with a community-list</description>
                           </valueHelp>
-                        </properties>
-                      </leafNode>
-                      <leafNode name="delete">
-                        <properties>
-                          <help>Delete BGP communities matching the community-list</help>
-                          <valueless/>
                         </properties>
                       </leafNode>
                     </children>
                   </node>
-                  <leafNode name="community">
+                  <node name="large-community">
                     <properties>
-                      <help>Border Gateway Protocl (BGP) community attribute</help>
-                      <completionHelp>
-                        <list>local-AS no-advertise no-export internet additive none</list>
-                      </completionHelp>
-                      <valueHelp>
-                        <format>&lt;aa:nn&gt;</format>
-                        <description>Community number in AA:NN format</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>local-AS</format>
-                        <description>Well-known communities value NO_EXPORT_SUBCONFED 0xFFFFFF03</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>no-advertise</format>
-                        <description>Well-known communities value NO_ADVERTISE 0xFFFFFF02</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>no-export</format>
-                        <description>Well-known communities value NO_EXPORT 0xFFFFFF01</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>internet</format>
-                        <description>Well-known communities value 0</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>additive</format>
-                        <description>New value is appended to the existing value</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>none</format>
-                        <description>No community attribute</description>
-                      </valueHelp>
+                      <help>BGP large community attribute</help>
                     </properties>
-                  </leafNode>
+                    <children>
+                      <leafNode name="add">
+                        <properties>
+                          <help>Add large communities to a prefix ;</help>
+                          #include <include/policy/large-community-value-list.xml.i>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="replace">
+                        <properties>
+                          <help>Set large communities for a prefix</help>
+                          #include <include/policy/large-community-value-list.xml.i>
+                        </properties>
+                      </leafNode>
+                      #include <include/policy/community-clear.xml.i>
+                      <leafNode name="delete">
+                        <properties>
+                          <help>Remove communities defined in a list from a prefix</help>
+                          <completionHelp>
+                            <path>policy large-community-list</path>
+                          </completionHelp>
+                          <valueHelp>
+                            <description>Community-list</description>
+                            <format>txt</format>
+                          </valueHelp>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </node>
+                  <node name="extcommunity">
+                    <properties>
+                      <help>BGP extended community attribute</help>
+                    </properties>
+                    <children>
+                      <leafNode name="bandwidth">
+                        <properties>
+                          <help>Bandwidth value in Mbps</help>
+                          <completionHelp>
+                            <list>cumulative num-multipaths</list>
+                          </completionHelp>
+                          <valueHelp>
+                            <format>u32:1-25600</format>
+                            <description>Bandwidth value in Mbps</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>cumulative</format>
+                            <description>Cumulative bandwidth of all multipaths (outbound-only)</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>num-multipaths</format>
+                            <description>Internally computed bandwidth based on number of multipaths (outbound-only)</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-25600"/>
+                            <regex>(cumulative|num-multipaths)</regex>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="bandwidth-non-transitive">
+                        <properties>
+                          <help>The link bandwidth extended community is encoded as non-transitive</help>
+                          <valueless/>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="rt">
+                        <properties>
+                          <help>Set route target value</help>
+                          #include <include/policy/extended-community-value-list.xml.i>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="soo">
+                        <properties>
+                          <help>Set Site of Origin value</help>
+                          #include <include/policy/extended-community-value-list.xml.i>
+                        </properties>
+                      </leafNode>
+                      #include <include/policy/community-clear.xml.i>
+                    </children>
+                  </node>
                   <leafNode name="distance">
                     <properties>
                       <help>Locally significant administrative distance</help>
@@ -1227,71 +1280,6 @@
                           </leafNode>
                         </children>
                       </node>
-                    </children>
-                  </node>
-                  <node name="extcommunity">
-                    <properties>
-                      <help>BGP extended community attribute</help>
-                    </properties>
-                    <children>
-                      <leafNode name="bandwidth">
-                        <properties>
-                          <help>Bandwidth value in Mbps</help>
-                          <completionHelp>
-                            <list>cumulative num-multipaths</list>
-                          </completionHelp>
-                          <valueHelp>
-                            <format>u32:1-25600</format>
-                            <description>Bandwidth value in Mbps</description>
-                          </valueHelp>
-                          <valueHelp>
-                            <format>cumulative</format>
-                            <description>Cumulative bandwidth of all multipaths (outbound-only)</description>
-                          </valueHelp>
-                          <valueHelp>
-                            <format>num-multipaths</format>
-                            <description>Internally computed bandwidth based on number of multipaths (outbound-only)</description>
-                          </valueHelp>
-                          <constraint>
-                            <validator name="numeric" argument="--range 1-25600"/>
-                            <regex>(cumulative|num-multipaths)</regex>
-                          </constraint>
-                        </properties>
-                      </leafNode>
-                      <leafNode name="rt">
-                        <properties>
-                          <help>Set route target value</help>
-                          <valueHelp>
-                            <format>ASN:NN</format>
-                            <description>based on autonomous system number</description>
-                          </valueHelp>
-                          <valueHelp>
-                            <format>IP:NN</format>
-                            <description>Based on a router-id IP address</description>
-                          </valueHelp>
-                          <constraint>
-                            <regex>(((\b(?:(?:2(?:[0-4][0-9]|5[0-5])|[0-1]?[0-9]?[0-9])\.){3}(?:(?:2([0-4][0-9]|5[0-5])|[0-1]?[0-9]?[0-9]))\b)|(\d+)):(\d+) ?)+</regex>
-                          </constraint>
-                          <constraintErrorMessage>Should be in form: ASN:NN or IPADDR:NN where ASN is autonomous system number</constraintErrorMessage>
-                        </properties>
-                      </leafNode>
-                      <leafNode name="soo">
-                        <properties>
-                          <help>Set Site of Origin value</help>
-                          <valueHelp>
-                            <format>ASN:NN</format>
-                            <description>based on autonomous system number</description>
-                          </valueHelp>
-                          <valueHelp>
-                            <format>IP:NN</format>
-                            <description>Based on a router-id IP address</description>
-                          </valueHelp>
-                          <constraint>
-                            <regex>((?:[0-9]{1,3}\.){3}[0-9]{1,3}|\d+):\d+</regex>
-                          </constraint>
-                          <constraintErrorMessage>Should be in form: ASN:NN or IPADDR:NN where ASN is autonomous system number</constraintErrorMessage>
-                        </properties>
-                      </leafNode>
                     </children>
                   </node>
                   <leafNode name="ip-next-hop">
@@ -1368,30 +1356,6 @@
                       </leafNode>
                     </children>
                   </node>
-                  <leafNode name="large-community">
-                    <properties>
-                      <help>Set BGP large community value</help>
-                      <valueHelp>
-                        <format>txt</format>
-                        <description>ASN:nn:mm BGP large community</description>
-                      </valueHelp>
-                      <completionHelp>
-                        <path>policy large-community-list</path>
-                      </completionHelp>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="large-comm-list-delete">
-                    <properties>
-                      <help>Delete BGP communities matching the large community-list</help>
-                      <completionHelp>
-                        <path>policy large-community-list</path>
-                      </completionHelp>
-                      <valueHelp>
-                        <format>txt</format>
-                        <description>BGP large community-list</description>
-                      </valueHelp>
-                    </properties>
-                  </leafNode>
                   <leafNode name="local-preference">
                     <properties>
                       <help>BGP local preference attribute</help>

--- a/src/migration-scripts/policy/3-to-4
+++ b/src/migration-scripts/policy/3-to-4
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T4660: change cli
+#     from: set policy route-map FOO rule 10 set community 'TEXT'
+#     Multiple value
+#     to: set policy route-map FOO rule 10 set community replace <community>
+#     Multiple value
+#     to: set policy route-map FOO rule 10 set community add <community>
+#     to: set policy route-map FOO rule 10 set community none
+#
+#     from: set policy route-map FOO rule 10 set large-community 'TEXT'
+#     Multiple value
+#     to: set policy route-map FOO rule 10 set large-community replace <community>
+#     Multiple value
+#     to: set policy route-map FOO rule 10 set large-community add <community>
+#     to: set policy route-map FOO rule 10 set large-community none
+#
+#     from: set policy route-map FOO rule 10 set extecommunity [rt|soo] 'TEXT'
+#     Multiple value
+#     to: set policy route-map FOO rule 10 set extcommunity [rt|soo] <community>
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+
+
+# Migration function for large and regular communities
+def community_migrate(config: ConfigTree, rule: list[str]) -> bool:
+    """
+
+    :param config: configuration object
+    :type config: ConfigTree
+    :param rule: Path to variable
+    :type rule: list[str]
+    :return: True if additive presents in community string
+    :rtype: bool
+    """
+    community_list = list((config.return_value(rule)).split(" "))
+    config.delete(rule)
+    if 'none' in community_list:
+        config.set(rule + ['none'])
+        return False
+    else:
+        community_action: str = 'replace'
+        if 'additive' in community_list:
+            community_action = 'add'
+            community_list.remove('additive')
+        for community in community_list:
+            config.set(rule + [community_action], value=community,
+                       replace=False)
+        if community_action == 'replace':
+            return False
+        else:
+            return True
+
+
+# Migration function for extcommunities
+def extcommunity_migrate(config: ConfigTree, rule: list[str]) -> None:
+    """
+
+    :param config: configuration object
+    :type config: ConfigTree
+    :param rule: Path to variable
+    :type rule: list[str]
+    """
+    # if config.exists(rule + ['bandwidth']):
+    #     bandwidth: str = config.return_value(rule + ['bandwidth'])
+    #     config.delete(rule + ['bandwidth'])
+    #     config.set(rule + ['bandwidth'], value=bandwidth)
+
+    if config.exists(rule + ['rt']):
+        community_list = list((config.return_value(rule + ['rt'])).split(" "))
+        config.delete(rule + ['rt'])
+        for community in community_list:
+            config.set(rule + ['rt'], value=community, replace=False)
+
+    if config.exists(rule + ['soo']):
+        community_list = list((config.return_value(rule + ['soo'])).split(" "))
+        config.delete(rule + ['soo'])
+        for community in community_list:
+            config.set(rule + ['soo'], value=community, replace=False)
+
+
+if (len(argv) < 1):
+    print("Must specify file name!")
+    exit(1)
+
+file_name: str = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base: list[str] = ['policy', 'route-map']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+
+for route_map in config.list_nodes(base):
+    if not config.exists(base + [route_map, 'rule']):
+        continue
+    for rule in config.list_nodes(base + [route_map, 'rule']):
+        base_rule: list[str] = base + [route_map, 'rule', rule, 'set']
+
+        # IF additive presents in coummunity then comm-list is redundant
+        isAdditive: bool = True
+        #### Change Set community ########
+        if config.exists(base_rule + ['community']):
+            isAdditive = community_migrate(config,
+                                           base_rule + ['community'])
+
+        #### Change Set community-list delete migrate ########
+        if config.exists(base_rule + ['comm-list', 'comm-list']):
+            if isAdditive:
+                tmp = config.return_value(
+                    base_rule + ['comm-list', 'comm-list'])
+                config.delete(base_rule + ['comm-list'])
+                config.set(base_rule + ['community', 'delete'], value=tmp)
+            else:
+                config.delete(base_rule + ['comm-list'])
+
+        isAdditive = False
+        #### Change Set large-community ########
+        if config.exists(base_rule + ['large-community']):
+            isAdditive = community_migrate(config,
+                                           base_rule + ['large-community'])
+
+        #### Change Set large-community delete by List ########
+        if config.exists(base_rule + ['large-comm-list-delete']):
+            if isAdditive:
+                tmp = config.return_value(
+                    base_rule + ['large-comm-list-delete'])
+                config.delete(base_rule + ['large-comm-list-delete'])
+                config.set(base_rule + ['large-community', 'delete'],
+                           value=tmp)
+            else:
+                config.delete(base_rule + ['large-comm-list-delete'])
+
+        #### Change Set extcommunity ########
+        extcommunity_migrate(config, base_rule + ['extcommunity'])
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print(f'Failed to save the modified config: {e}')
+    exit(1)

--- a/src/validators/bgp-extended-community
+++ b/src/validators/bgp-extended-community
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+# Copyright 2019-2022 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+from argparse import ArgumentParser
+from sys import exit
+
+from vyos.template import is_ipv4
+
+COMM_MAX_2_OCTET: int = 65535
+COMM_MAX_4_OCTET: int = 4294967295
+
+if __name__ == '__main__':
+    # add an argument with community
+    parser: ArgumentParser = ArgumentParser()
+    parser.add_argument('community', type=str)
+    args = parser.parse_args()
+    community: str = args.community
+    if community.count(':') != 1:
+        print("Invalid community format")
+        exit(1)
+    try:
+        # try to extract community parts from an argument
+        comm_left: str = community.split(':')[0]
+        comm_right: int = int(community.split(':')[1])
+
+        # check if left part is an IPv4 address
+        if is_ipv4(comm_left) and 0 <= comm_right <= COMM_MAX_2_OCTET:
+            exit()
+        # check if a left part is a number
+        if 0 <= int(comm_left) <= COMM_MAX_2_OCTET \
+                and 0 <= comm_right <= COMM_MAX_4_OCTET:
+            exit()
+
+    except Exception:
+        # fail if something was wrong
+        print("Invalid community format")
+        exit(1)
+
+    # fail if none of validators catched the value
+    print("Invalid community format")
+    exit(1)

--- a/src/validators/bgp-large-community
+++ b/src/validators/bgp-large-community
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+# Copyright 2019-2022 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+from argparse import ArgumentParser
+from sys import exit
+
+from vyos.template import is_ipv4
+
+COMM_MAX_4_OCTET: int = 4294967295
+
+if __name__ == '__main__':
+    # add an argument with community
+    parser: ArgumentParser = ArgumentParser()
+    parser.add_argument('community', type=str)
+    args = parser.parse_args()
+    community: str = args.community
+    if community.count(':') != 2:
+        print("Invalid community format")
+        exit(1)
+    try:
+        # try to extract community parts from an argument
+        comm_part1: int = int(community.split(':')[0])
+        comm_part2: int = int(community.split(':')[1])
+        comm_part3: int = int(community.split(':')[2])
+
+        # check compatibilities of left and right parts
+        if 0 <= comm_part1 <= COMM_MAX_4_OCTET \
+                and 0 <= comm_part2 <= COMM_MAX_4_OCTET \
+                and 0 <= comm_part3 <= COMM_MAX_4_OCTET:
+            exit(0)
+
+    except Exception:
+        # fail if something was wrong
+        print("Invalid community format")
+        exit(1)
+
+    # fail if none of validators catched the value
+    print("Invalid community format")
+    exit(1)

--- a/src/validators/bgp-regular-community
+++ b/src/validators/bgp-regular-community
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# Copyright 2019-2022 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+from argparse import ArgumentParser
+from sys import exit
+
+from vyos.template import is_ipv4
+
+COMM_MAX_2_OCTET: int = 65535
+
+if __name__ == '__main__':
+    # add an argument with community
+    parser: ArgumentParser = ArgumentParser()
+    parser.add_argument('community', type=str)
+    args = parser.parse_args()
+    community: str = args.community
+    if community.count(':') != 1:
+        print("Invalid community format")
+        exit(1)
+    try:
+        # try to extract community parts from an argument
+        comm_left: int = int(community.split(':')[0])
+        comm_right: int = int(community.split(':')[1])
+
+        # check compatibilities of left and right parts
+        if 0 <= comm_left <= COMM_MAX_2_OCTET \
+                and 0 <= comm_right <= COMM_MAX_2_OCTET:
+            exit(0)
+    except Exception:
+        # fail if something was wrong
+        print("Invalid community format")
+        exit(1)
+
+    # fail if none of validators catched the value
+    print("Invalid community format")
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Changed CLI syntax in route-map 
set community,
set large-community 
set extcommunity.
Allows to add multiple communities, large-communities and extcommunities in clear view.
Added new well-known communities.
Added non-transitive feature in extcommunities.
Fixed community's validators.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4660

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
policy
## Proposed changes
<!--- Describe your changes in detail -->
Changes in CLI in policy route-map  set sections
1. Changes in community section.
   Divided set community into 3 sections
  Moved comm-list to community section as delete <list> command
```
vyos@vyos# set policy route-map TEST rule 10 set community
Possible completions:
+  add                  Add communities to a prefix
   delete               Remove communities defined in a list from a prefix
   none                 Completely remove communities attribute from a prefix
+  replace              Set communities for a prefix
```
  Added validators to community values format.
        format <0-65535:0-65535>
         
  Added new well-known communities that are listed in frr
```
vyos@vyos# set policy route-map TEST rule 10 set community add
Possible completions:
   <AS:VAL>             Community number in <0-65535:0-65535> format
   local-as             Well-known communities value NO_EXPORT_SUBCONFED 0xFFFFFF03
   no-advertise         Well-known communities value NO_ADVERTISE 0xFFFFFF02
   no-export            Well-known communities value NO_EXPORT 0xFFFFFF01
   internet             Well-known communities value 0
   graceful-shutdown    Well-known communities value GRACEFUL_SHUTDOWN 0xFFFF0000
   accept-own           Well-known communities value ACCEPT_OWN 0xFFFF0001
   route-filter-translated-v4
                        Well-known communities value ROUTE_FILTER_TRANSLATED_v4 0xFFFF0002
   route-filter-v4      Well-known communities value ROUTE_FILTER_v4 0xFFFF0003
   route-filter-translated-v6
                        Well-known communities value ROUTE_FILTER_TRANSLATED_v6 0xFFFF0004
   route-filter-v6      Well-known communities value ROUTE_FILTER_v6 0xFFFF0005
   llgr-stale           Well-known communities value LLGR_STALE 0xFFFF0006
   no-llgr              Well-known communities value NO_LLGR 0xFFFF0007
   accept-own-nexthop   Well-known communities value accept-own-nexthop 0xFFFF0008
   blackhole            Well-known communities value BLACKHOLE 0xFFFF029A
   no-peer              Well-known communities value NOPEER 0xFFFFFF04
```
Added validations in commit action that validate community compatibility.
 - none can not be with other commanads (add, delete, replace)
 - replace can not be with commands (add, delete)
2. Changes in large-community section.
   Divided set large-community into 4 sections
   Moved large-comm-list-delete to large-community section as delete <list> command
```
vyos@vyos# set policy route-map TEST rule 10 set large-community
Possible completions:
+  add                  Add large communities to a prefix ;
   delete               Remove communities defined in a list from a prefix
   none                 Completely remove communities attribute from a prefix
+  replace              Set large communities for a prefix

```
 Added validators to large-community values format.
          format <0-4294967295:0-4294967295:0-4294967295>
 Added validations in commit action that validate large-community compatibility.
 - none can not be with other commanads (add, delete, replace)
 - replace can not be with commands (add, delete)
3. Changes in extcommunity section.
   Added bandwidth-non-transitive similar to non-transitive value in frr
   Added none option to remove all extcommunities
   Set rt and soo as multiple values.
```
vyos@vyos# set policy route-map TEST rule 10 set extcommunity
Possible completions:
   bandwidth            Bandwidth value in Mbps
   bandwidth-non-transitive
                        The link bandwidth extended community is encoded as non-
                        transitive
   none                 Completely remove communities attribute from a prefix
+  rt                   Set route target value
+  soo                  Set Site of Origin value
```
Added validators to extcommunity values format
        format <0-65535:0-4294967295> or <IP:0-65535>

These changes fixed possible bugs when communities values are added as a string in ''

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

These changes fixed possible bugs when communities values are added as a string in ''
for example if we add only additive community
```
vyos@vyos# set policy route-map TEST rule 10 set community additive
[edit]
vyos@vyos# set policy route-map TEST rule 10 action permit
[edit]
vyos@vyos# commit
[ policy ]
VyOS had an issue completing a command.

We are sorry that you encountered a problem while using VyOS.
There are a few things you can do to help us (and yourself):
- Contact us using the online help desk if you have a subscription:
  https://support.vyos.io/
- Make sure you are running the latest version of VyOS available at:
  https://vyos.net/get/
- Consult the community forum to see how to handle this issue:
  https://forum.vyos.io
- Join us on Slack where our users exchange help and advice:
  https://vyos.slack.com

When reporting problems, please include as much information as possible:
- do not obfuscate any data (feel free to contact us privately if your
  business policy requires it)
- and include all the information presented below

Report time:      2022-09-30 12:21:38
Image version:    VyOS 1.4-rolling-202209300217
Release train:    sagitta

Built by:         autobuild@vyos.net
Built on:         Fri 30 Sep 2022 02:18 UTC
Build UUID:       2f9125dd-67c8-4f2a-9af8-38234375435c
Build commit ID:  5852d5de3ac606

Architecture:     x86_64
Boot via:         installed image
System type:      KVM guest

Hardware vendor:  QEMU
Hardware model:   Standard PC (i440FX + PIIX, 1996)
Hardware S/N:
Hardware UUID:    e10a1768-cc0f-43fc-84ee-3bc2c92cc612

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/policy.py", line 229, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/policy.py", line 209, in apply
    frr_cfg.commit_configuration(bgp_daemon)
  File "/usr/lib/python3/dist-packages/vyos/frr.py", line 480, in commit_configuration
    raise ConfigurationNotValid(f'Config commit retry counter ({count_max}) exceeded')
vyos.frr.ConfigurationNotValid: Config commit retry counter (5) exceeded


[[policy]] failed
Commit failed

```
The same problem is after the next commands
```
vyos@vyos# set policy route-map TEST rule 10 set community '6500:10 none'
[edit]
vyos@vyos# commit
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
