### PR TITLE
T4726: add completion help and validation for accel-ppp vendor option

### DIFF
--- a/interface-definitions/include/accel-ppp/radius-additions-rate-limit.xml.i
+++ b/interface-definitions/include/accel-ppp/radius-additions-rate-limit.xml.i
@@ -6,18 +6,24 @@
   <children>
     <leafNode name="attribute">
       <properties>
-        <help>Specifies which RADIUS attribute contains rate information. (default is Filter-Id)</help>
+        <help>RADIUS attribute that contains rate information. (default: Filter-Id)</help>
       </properties>
       <defaultValue>Filter-Id</defaultValue>
     </leafNode>
     <leafNode name="vendor">
       <properties>
-        <help>Specifies the vendor dictionary. (dictionary needs to be in /usr/share/accel-ppp/radius)</help>
+        <help>Vendor dictionary</help>
+        <completionHelp>
+          <list>alcatel cisco microsoft mikrotik</list>
+        </completionHelp>
+        <constraint>
+          <validator name="accel-radius-dictionary" />
+        </constraint>
       </properties>
     </leafNode>
     <leafNode name="enable">
       <properties>
-        <help>Enables Bandwidth shaping via RADIUS</help>
+        <help>Enable bandwidth shaping via RADIUS</help>
         <valueless />
       </properties>
     </leafNode>

--- a/interface-definitions/vpn-l2tp.xml.in
+++ b/interface-definitions/vpn-l2tp.xml.in
@@ -238,29 +238,7 @@
                           </leafNode>
                         </children>
                       </node>
-                      <node name="rate-limit">
-                        <properties>
-                          <help>Upload/Download speed limits</help>
-                        </properties>
-                        <children>
-                          <leafNode name="attribute">
-                            <properties>
-                              <help>Specifies which radius attribute contains rate information</help>
-                            </properties>
-                          </leafNode>
-                          <leafNode name="vendor">
-                            <properties>
-                              <help>Specifies the vendor dictionary. (dictionary needs to be in /usr/share/accel-ppp/radius)</help>
-                            </properties>
-                          </leafNode>
-                          <leafNode name="enable">
-                            <properties>
-                              <help>Enables Bandwidth shaping via RADIUS</help>
-                              <valueless />
-                            </properties>
-                          </leafNode>
-                        </children>
-                      </node>
+                      #include <include/accel-ppp/radius-additions-rate-limit.xml.i>
                     </children>
                   </node>
                 </children>

--- a/src/validators/accel-radius-dictionary
+++ b/src/validators/accel-radius-dictionary
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+DICT_PATH=/usr/share/accel-ppp/radius
+NAME=$1
+
+if [ -n "$NAME" -a -e $DICT_PATH/dictionary.$NAME ]; then
+    exit 0
+else
+    echo "$NAME is not a valid RADIUS dictionary name"
+    echo "Please make sure that $DICT_PATH/dictionary.$NAME file exists"
+    exit 1
+fi
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

Add completion for well-known vendors (alcatel, cisco, microsoft, mikrotik) to the `... authentication radius rate-limit vendor` option
and a validator to check if the dictionary file exists in `/usr/share/accel-ppp/radius`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4726

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

PPPoE, L2TP, SSTP



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
