### PR TITLE
ospf: T4707: Add OSPF segment routing for FRR

### DIFF
--- a/data/templates/frr/ospfd.frr.j2
+++ b/data/templates/frr/ospfd.frr.j2
@@ -181,6 +181,33 @@ router ospf {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {% if refresh.timers is vyos_defined %}
  refresh timer {{ refresh.timers }}
 {% endif %}
+{% if segment_routing is vyos_defined %}
+ segment-routing on
+{%     if segment_routing.maximum_label_depth is vyos_defined %}
+ segment-routing node-msd {{ segment_routing.maximum_label_depth }}
+{%     endif %}
+{%     if segment_routing.global_block is vyos_defined %}
+{%         if segment_routing.local_block is vyos_defined %}
+ segment-routing global-block {{ segment_routing.global_block.low_label_value }} {{ segment_routing.global_block.high_label_value }} local-block {{ segment_routing.local_block.low_label_value }} {{ segment_routing.local_block.high_label_value }}
+{%         else %}
+ segment-routing global-block {{ segment_routing.global_block.low_label_value }} {{ segment_routing.global_block.high_label_value }}
+{%         endif %}
+{%     endif %}
+{%     if segment_routing.prefix is vyos_defined %}
+{%         for prefix, prefix_config in segment_routing.prefix.items() %}
+{%             if prefix_config.index is vyos_defined %}
+{%                 if prefix_config.index.value is vyos_defined %}
+ segment-routing prefix {{ prefix }} index {{ prefix_config.index.value }}
+{%                     if prefix_config.index.explicit_null is vyos_defined %}
+ segment-routing prefix {{ prefix }} index {{ prefix_config.index.value }} explicit-null
+{%                     elif prefix_config.index.no_php_flag is vyos_defined %}
+ segment-routing prefix {{ prefix }} index {{ prefix_config.index.value }} no-php-flag
+{%                     endif %}
+{%                 endif %}
+{%             endif %}
+{%         endfor %}
+{%     endif %}
+{% endif %}
 {% if timers.throttle.spf.delay is vyos_defined and timers.throttle.spf.initial_holdtime is vyos_defined and timers.throttle.spf.max_holdtime is vyos_defined %}
 {#   Timer values have default values #}
  timers throttle spf {{ timers.throttle.spf.delay }} {{ timers.throttle.spf.initial_holdtime }} {{ timers.throttle.spf.max_holdtime }}

--- a/interface-definitions/include/ospf/high-low-label-value.xml.i
+++ b/interface-definitions/include/ospf/high-low-label-value.xml.i
@@ -1,0 +1,26 @@
+<!-- include start from ospf/high-low-label-value.xml.i -->
+<leafNode name="low-label-value">
+  <properties>
+    <help>MPLS label lower bound</help>
+    <valueHelp>
+      <format>u32:100-1048575</format>
+      <description>Label value</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 16-1048575"/>
+    </constraint>
+  </properties>
+</leafNode>
+<leafNode name="high-label-value">
+  <properties>
+    <help>MPLS label upper bound</help>
+    <valueHelp>
+      <format>u32:100-1048575</format>
+      <description>Label value</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 16-1048575"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/ospf/protocol-common-config.xml.i
+++ b/interface-definitions/include/ospf/protocol-common-config.xml.i
@@ -621,6 +621,86 @@
     </constraint>
   </properties>
 </leafNode>
+<node name="segment-routing">
+  <properties>
+    <help>Segment-Routing (SPRING) settings</help>
+  </properties>
+  <children>
+    <node name="global-block">
+      <properties>
+        <help>Segment Routing Global Block label range</help>
+      </properties>
+      <children>
+        #include <include/ospf/high-low-label-value.xml.i>
+      </children>
+    </node>
+    <node name="local-block">
+      <properties>
+        <help>Segment Routing Local Block label range</help>
+      </properties>
+      <children>
+        #include <include/ospf/high-low-label-value.xml.i>
+      </children>
+    </node>
+    <leafNode name="maximum-label-depth">
+      <properties>
+        <help>Maximum MPLS labels allowed for this router</help>
+        <valueHelp>
+          <format>u32:1-16</format>
+            <description>MPLS label depth</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-16"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <tagNode name="prefix">
+      <properties>
+        <help>Static IPv4 prefix segment/label mapping</help>
+        <valueHelp>
+          <format>ipv4net</format>
+          <description>IPv4 prefix segment</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv4-prefix"/>
+        </constraint>
+      </properties>
+      <children>
+        <node name="index">
+          <properties>
+            <help>Specify the index value of prefix segment/label ID</help>
+          </properties>
+          <children>
+            <leafNode name="value">
+              <properties>
+                <help>Specify the index value of prefix segment/label ID</help>
+                <valueHelp>
+                  <format>u32:0-65535</format>
+                    <description>The index segment/label ID value</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 0-65535"/>
+                </constraint>
+              </properties>
+            </leafNode>
+            <leafNode name="explicit-null">
+              <properties>
+                <help>Request upstream neighbor to replace segment/label with explicit null label</help>
+                <valueless/>
+              </properties>
+            </leafNode>
+            <leafNode name="no-php-flag">
+              <properties>
+                <help>Do not request penultimate hop popping for segment/label</help>
+                <valueless/>
+              </properties>
+            </leafNode>
+          </children>
+        </node>
+      </children>
+    </tagNode>
+  </children>
+</node>
 <node name="redistribute">
   <properties>
     <help>Redistribute information from another routing protocol</help>

--- a/smoketest/scripts/cli/test_protocols_ospf.py
+++ b/smoketest/scripts/cli/test_protocols_ospf.py
@@ -395,6 +395,42 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f' timers throttle spf 200 1000 10000', frrconfig) # default
         self.assertIn(f' network {network} area {area}', frrconfig)
         self.assertIn(f' area {area} export-list {acl}', frrconfig)
+        
+        
+    def test_ospf_14_segment_routing_configuration(self):
+        global_block_low = "100"
+        global_block_high = "199"
+        local_block_low = "200"
+        local_block_high = "299"
+        interface = 'lo'
+        maximum_stack_size = '5'
+        prefix_one = '192.168.0.1/32'
+        prefix_two = '192.168.0.2/32'
+        prefix_one_value = '1'
+        prefix_two_value = '2'
+
+        self.cli_set(base_path + ['interface', interface])
+        self.cli_set(base_path + ['segment-routing', 'maximum-label-depth', maximum_stack_size])
+        self.cli_set(base_path + ['segment-routing', 'global-block', 'low-label-value', global_block_low])
+        self.cli_set(base_path + ['segment-routing', 'global-block', 'high-label-value', global_block_high])
+        self.cli_set(base_path + ['segment-routing', 'local-block', 'low-label-value', local_block_low])
+        self.cli_set(base_path + ['segment-routing', 'local-block', 'high-label-value', local_block_high])
+        self.cli_set(base_path + ['segment-routing', 'prefix', prefix_one, 'index', 'value', prefix_one_value])
+        self.cli_set(base_path + ['segment-routing', 'prefix', prefix_one, 'index', 'explicit-null'])
+        self.cli_set(base_path + ['segment-routing', 'prefix', prefix_two, 'index', 'value', prefix_two_value])
+        self.cli_set(base_path + ['segment-routing', 'prefix', prefix_two, 'index', 'no-php-flag'])
+
+        # Commit all changes
+        self.cli_commit()
+
+        # Verify all changes
+        frrconfig = self.getFRRconfig('router ospf')
+        self.assertIn(f' segment-routing on', frrconfig)
+        self.assertIn(f' segment-routing global-block {global_block_low} {global_block_high} local-block {local_block_low} {local_block_high}', frrconfig)
+        self.assertIn(f' segment-routing node-msd {maximum_stack_size}', frrconfig)
+        self.assertIn(f' segment-routing prefix {prefix_one} index {prefix_one_value} explicit-null', frrconfig)
+        self.assertIn(f' segment-routing prefix {prefix_two} index {prefix_two_value} no-php-flag', frrconfig)
+
 
 if __name__ == '__main__':
     logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)


### PR DESCRIPTION
This change is to add OSPF segment routing for FRR. 

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

With this change, we will be introducing the code to configure segment routing for OSPF.

We will be adding to the ospfd jinja2 template, adding tie breakers for the protocol handler,
adding smoketests, adding the CLI hierarchy. This configuration should make OSPF be able
to enable segment routing for prefixes, as well as enable it for interfaces. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4707

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
OSPF

## Proposed changes
<!--- Describe your changes in detail -->

We added the XML hierarchy. This involved adding the actual segment routing nodes, as well as
adding the high and low label file for segment routing. We added smoketests so that if for some
reason the config hierarchy fails between builds then we should catch it. We added the jinja2
FRR template changes for ospfd that way we can configure the actual lines in FRR. 


## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Here is the baseline VyOS config here:

```
vyos@vyos:~$ vtysh -c "show run"
Building configuration...

Current configuration:
!
frr version 8.3.1
frr defaults traditional
hostname vyos
log syslog
log facility local7
service integrated-vtysh-config
!
ip route 0.0.0.0/0 10.0.0.65
!
end
```

Here is what we are adding:

```
set protocols ospf interface lo passive
set protocols ospf segment-routing enable
set protocols ospf segment-routing global-block high-label-value '100'
set protocols ospf segment-routing global-block low-label-value '50'
set protocols ospf segment-routing prefix 192.168.0.1/32 index explicit-null
set protocols ospf segment-routing prefix 192.168.0.1/32 index value '1'
set protocols ospf segment-routing prefix 192.168.0.2/32 index no-php-flag
set protocols ospf segment-routing prefix 192.168.0.2/32 index value '2'
set protocols ospf segment-routing prefix 192.168.0.3/32 index explicit-null
set protocols ospf segment-routing prefix 192.168.0.3/32 index value '3'
set protocols ospf segment-routing prefix 192.168.0.4/32 index no-php-flag
set protocols ospf segment-routing prefix 192.168.0.4/32 index value '4'
```

Here is how it looks after commit:

```
vyos@vyos# compare
[edit protocols]
+ospf {
+    interface lo {
+        passive {
+        }
+    }
+    segment-routing {
+        enable
+        global-block {
+            high-label-value 100
+            low-label-value 50
+        }
+        prefix 192.168.0.1/32 {
+            index {
+                explicit-null
+                value 1
+            }
+        }
+        prefix 192.168.0.2/32 {
+            index {
+                no-php-flag
+                value 2
+            }
+        }
+        prefix 192.168.0.3/32 {
+            index {
+                explicit-null
+                value 3
+            }
+        }
+        prefix 192.168.0.4/32 {
+            index {
+                no-php-flag
+                value 4
+            }
+        }
+    }
+}
[edit]
vyos@vyos# commit

vyos@vyos# save
Saving configuration to '/config/config.boot'...
Done
[edit]
vyos@vyos# exit
exit
vyos@vyos:~$ vtysh -c "show run"
Building configuration...

Current configuration:
!
frr version 8.3.1
frr defaults traditional
hostname vyos
log syslog
log facility local7
service integrated-vtysh-config
!
ip route 0.0.0.0/0 10.0.0.65
!
interface eth0
 bandwidth 10000
exit
!
interface eth1
 bandwidth 10000
exit
!
interface lo
 ip ospf dead-interval 40
 ip ospf passive
exit
!
router ospf
 auto-cost reference-bandwidth 100
 timers throttle spf 200 1000 10000
 segment-routing global-block 50 100
 segment-routing prefix 192.168.0.1/32 index 1 explicit-null
 segment-routing prefix 192.168.0.2/32 index 2 no-php-flag
 segment-routing prefix 192.168.0.3/32 index 3 explicit-null
 segment-routing prefix 192.168.0.4/32 index 4 no-php-flag
exit
!
```

When we try to configure both explicit-null and no-php-flag we get a proper failure:

```
vyos@vyos# set protocols ospf segment-routing prefix 192.168.0.1/32 index no-php-flag
[edit]
vyos@vyos# compare
[edit protocols ospf segment-routing prefix 192.168.0.1/32 index]
+no-php-flag
[edit]
vyos@vyos# commit

Segment routing prefix 192.168.0.1/32 cannot have both explicit-null and
no-php-flag configured at the same time.

[[protocols ospf]] failed
Commit failed
```


If we remove the "value" for the segment ID number we get the proper failure:

```
vyos@vyos# delete protocols ospf segment-routing prefix 192.168.0.1/32 index value
[edit]
vyos@vyos# compare
[edit protocols ospf segment-routing prefix 192.168.0.1/32 index]
-value 1
[edit]
vyos@vyos# commit

Segment routing prefix 192.168.0.1/32 index value cannot be blank.

[[protocols ospf]] failed
Commit failed
```



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly  <--- I plan on making ISIS and OSPF changes to documentation once merged