### PR TITLE
isis: T4739: ISIS segment routing being refactored

### DIFF
--- a/data/templates/frr/isisd.frr.j2
+++ b/data/templates/frr/isisd.frr.j2
@@ -107,9 +107,6 @@ router isis VyOS {{ 'vrf ' + vrf if vrf is vyos_defined }}
  mpls-te inter-as{{ level }}
 {% endif %}
 {% if segment_routing is vyos_defined %}
-{%     if segment_routing.enable is vyos_defined %}
- segment-routing on
-{%     endif %}
 {%     if segment_routing.maximum_label_depth is vyos_defined %}
  segment-routing node-msd {{ segment_routing.maximum_label_depth }}
 {%     endif %}
@@ -144,6 +141,7 @@ router isis VyOS {{ 'vrf ' + vrf if vrf is vyos_defined }}
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+ segment-routing on
 {% endif %}
 {% if spf_delay_ietf.init_delay is vyos_defined %}
  spf-delay-ietf init-delay {{ spf_delay_ietf.init_delay }} short-delay {{ spf_delay_ietf.short_delay }} long-delay {{ spf_delay_ietf.long_delay }} holddown {{ spf_delay_ietf.holddown }} time-to-learn {{ spf_delay_ietf.time_to_learn }}

--- a/interface-definitions/include/isis/high-low-label-value.xml.i
+++ b/interface-definitions/include/isis/high-low-label-value.xml.i
@@ -4,7 +4,7 @@
     <help>MPLS label lower bound</help>
     <valueHelp>
       <format>u32:16-1048575</format>
-      <description>Label value</description>
+      <description>Label value - Suggested minimum value: 100</description>
     </valueHelp>
     <constraint>
       <validator name="numeric" argument="--range 16-1048575"/>

--- a/interface-definitions/include/isis/protocol-common-config.xml.i
+++ b/interface-definitions/include/isis/protocol-common-config.xml.i
@@ -233,12 +233,6 @@
     <help>Segment-Routing (SPRING) settings</help>
   </properties>
   <children>
-    <leafNode name="enable">
-      <properties>
-        <help>Enable segment-routing functionality</help>
-        <valueless/>
-      </properties>
-    </leafNode>
     <node name="global-block">
       <properties>
         <help>Segment Routing Global Block label range</help>

--- a/interface-definitions/include/ospf/high-low-label-value.xml.i
+++ b/interface-definitions/include/ospf/high-low-label-value.xml.i
@@ -3,8 +3,8 @@
   <properties>
     <help>MPLS label lower bound</help>
     <valueHelp>
-      <format>u32:100-1048575</format>
-      <description>Label value</description>
+      <format>u32:16-1048575</format>
+      <description>Label value - Suggested minimum value: 100</description>
     </valueHelp>
     <constraint>
       <validator name="numeric" argument="--range 16-1048575"/>
@@ -15,7 +15,7 @@
   <properties>
     <help>MPLS label upper bound</help>
     <valueHelp>
-      <format>u32:100-1048575</format>
+      <format>u32:16-1048575</format>
       <description>Label value</description>
     </valueHelp>
     <constraint>

--- a/interface-definitions/include/version/isis-version.xml.i
+++ b/interface-definitions/include/version/isis-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/isis-version.xml.i -->
-<syntaxVersion component='isis' version='1'></syntaxVersion>
+<syntaxVersion component='isis' version='2'></syntaxVersion>
 <!-- include end -->

--- a/smoketest/scripts/cli/test_protocols_isis.py
+++ b/smoketest/scripts/cli/test_protocols_isis.py
@@ -263,10 +263,10 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f' isis bfd profile {bfd_profile}', tmp)
 
     def test_isis_07_segment_routing_configuration(self):
-        global_block_low = "1000"
-        global_block_high = "1999"
-        local_block_low = "2000"
-        local_block_high = "2999"
+        global_block_low = "100"
+        global_block_high = "199"
+        local_block_low = "200"
+        local_block_high = "299"
         interface = 'lo'
         maximum_stack_size = '5'
         prefix_one = '192.168.0.1/32'
@@ -280,7 +280,6 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
 
         self.cli_set(base_path + ['net', net])
         self.cli_set(base_path + ['interface', interface])
-        self.cli_set(base_path + ['segment-routing', 'enable'])
         self.cli_set(base_path + ['segment-routing', 'maximum-label-depth', maximum_stack_size])
         self.cli_set(base_path + ['segment-routing', 'global-block', 'low-label-value', global_block_low])
         self.cli_set(base_path + ['segment-routing', 'global-block', 'high-label-value', global_block_high])

--- a/src/migration-scripts/isis/1-to-2
+++ b/src/migration-scripts/isis/1-to-2
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T4739 refactor, and remove "on" from segment routing from the configuration
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+
+if (len(argv) < 1):
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+
+# Check if ISIS segment routing is configured. Then check if segment routing "on" exists, then delete the "on" as it is no longer needed. This is for global configuration.
+if config.exists(['protocols', 'isis']):
+    if config.exists(['protocols', 'isis', 'segment-routing']):
+        if config.exists(['protocols', 'isis', 'segment-routing', 'enable']):
+            config.delete(['protocols', 'isis', 'segment-routing', 'enable'])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print(f'Failed to save the modified config: {e}')
+    exit(1)


### PR DESCRIPTION
This is to refactor ISIS segment routing to match up with OSPF segment routing.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

We removed the "enable" under ISIS for segment routing. It was redundant, and
C-Po pointed out the issues with it. This refactor should also make OSPF and ISIS
consistent configuration wise. A migrator was also added to delete the "enable"
command if it is indeed found in the configuration. We also increased the minimum
label allowed for segment routing from 16 up to 100. This was due to FRR having
label allocation issues under label value 100. OSPF and ISIS work differently on this
but just to keep things consistent we just decided to choose 100 as minimum label
value.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4739

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
isis

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Here's the migrator in action:

```
vyos@vyos:~$ more config.boot
interfaces {
    ethernet eth0 {
        address "10.0.0.80/27"
    }
    loopback     lo { }
}
protocols {
    isis {
        interface lo {
            passive { }
        }
        level "level-2"
        metric-style "wide"
        net "49.0001.1921.6825.5001.00"
        segment-routing {
            enable { }              <---- The enable is here before migration
            global-block {
                high-label-value "150"
                low-label-value "100"
            }
            maximum-label-depth "5"
            prefix 192.168.0.1/32 {
                index {
                    explicit-null { }
                    value "1"
                }
            }
            prefix 192.168.0.2/32 {
                index {
                    no-php-flag { }
                    value "2"
                }
            }
            prefix 192.168.0.3/32 {
                index {
                    explicit-null { }
                    value "3"
                }
            }
            prefix 192.168.0.4/32 {
                index {
                    no-php-flag { }
                    value "4"
                }
            }
        }
    }
    static {
        route 0.0.0.0/0 {
            next-hop             10.0.0.65 { }
        }
    }
}
vyos@vyos:~$
vyos@vyos:~$
vyos@vyos:~$
vyos@vyos:~$ ls -l
total 1480
-rwxr-xr-x 1 vyos users    2800 Oct  8 22:46 config.boot
-rwx------ 1 vyos users    1605 Oct  8 22:33 migration        <--- file was renamed from 1-to-2 for ease of use for here
-rw-r--r-- 1 vyos users 1505120 Oct  8 22:39 vyos-1x_0.0-no.git.tag_amd64.deb
vyos@vyos:~$
vyos@vyos:~$ diff /opt/vyatta/etc/config-migrate/migrate/isis/1-to-2 migration    <---- here's a diff showing zero diff
vyos@vyos:~$
vyos@vyos:~$ ./migration config.boot     <---- actual migration invocation
vyos@vyos:~$
vyos@vyos:~$
vyos@vyos:~$ more config.boot
interfaces {
    ethernet eth0 {
        address "10.0.0.80/27"
    }
    loopback     lo { }
}
protocols {
    isis {
        interface lo {
            passive { }
        }
        level "level-2"
        metric-style "wide"
        net "49.0001.1921.6825.5001.00"
        segment-routing {
            global-block {                                 <---- no longer has the "enable" keyword
                high-label-value "150"
                low-label-value "100"
            }
            maximum-label-depth "5"
            prefix 192.168.0.1/32 {
                index {
                    explicit-null { }
                    value "1"
                }
            }
            prefix 192.168.0.2/32 {
                index {
                    no-php-flag { }
                    value "2"
                }
            }
            prefix 192.168.0.3/32 {
                index {
                    explicit-null { }
                    value "3"
                }
            }
            prefix 192.168.0.4/32 {
                index {
                    no-php-flag { }
                    value "4"
                }
            }
        }
    }
    static {
        route 0.0.0.0/0 {
            next-hop             10.0.0.65 { }
        }
    }
}
```

Here is the new adjusted smoketest:

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_isis.py
test_isis_01_redistribute (__main__.TestProtocolsISIS) ...
Network entity is mandatory!

ok
test_isis_02_vrfs (__main__.TestProtocolsISIS) ... ok
test_isis_03_zebra_route_map (__main__.TestProtocolsISIS) ... ok
test_isis_04_default_information (__main__.TestProtocolsISIS) ... ok
test_isis_05_password (__main__.TestProtocolsISIS) ...
Can use either md5 or plaintext-password for area-password!


Can use either md5 or plaintext-password for domain-password!

ok
test_isis_06_spf_delay_bfd (__main__.TestProtocolsISIS) ...
All types of spf-delay must be configured. Missing: long-delay, short-
delay, time-to-learn, init-delay


All types of spf-delay must be configured. Missing: long-delay, short-
delay, time-to-learn


All types of spf-delay must be configured. Missing: short-delay, time-
to-learn


All types of spf-delay must be configured. Missing: time-to-learn

ok
test_isis_07_segment_routing_configuration (__main__.TestProtocolsISIS) ... ok

----------------------------------------------------------------------
Ran 7 tests in 21.399s

OK
```




## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ x I have linked this PR to one or more Phabricator Task(s)
- [ ]xI have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

Next commit that I will be doing will be adding segment routing changes, and MPLS changes for the documentation. It will be a rather large addition, but I will admit I have not done it yet. Nor will I do anymore PRs for vyos-1x until I finish documentation.
