### PR TITLE
conntrack-sync: T4730: Fix listen-address jinja2 template

### DIFF
--- a/data/templates/conntrackd/conntrackd.conf.j2
+++ b/data/templates/conntrackd/conntrackd.conf.j2
@@ -9,7 +9,9 @@ Sync {
 {%     if iface_config.peer is vyos_defined %}
     UDP {
 {%         if listen_address is vyos_defined %}
-        IPv4_address {{ listen_address }}
+{%             for address in listen_address %}
+        IPv4_address {{ address }}
+{%             endfor %}
 {%         endif %}
         IPv4_Destination_Address {{ iface_config.peer }}
         Port {{ iface_config.port if iface_config.port is vyos_defined else '3780' }}


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Listen address has option 'multi'
As result we have an incorrect template value for listen-address
- conntrack-sync listen-address '192.0.2.11' in template It looks like "IPv4_address ['192.0.2.11']" in the conntrackd.conf but the correct string expected without brackets
Fix it

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4730

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
conntrack-sync
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration
```
set interfaces ethernet eth0 address '192.168.122.14/24'
set interfaces ethernet eth0 address '203.0.113.11/24'
set interfaces ethernet eth1 address '192.0.2.11/24'
set interfaces ethernet eth1 address '192.0.2.12/24'

set high-availability vrrp group GRP01 address 203.0.113.254/24
set high-availability vrrp group GRP01 hello-source-address '203.0.113.11'
set high-availability vrrp group GRP01 interface 'eth0'
set high-availability vrrp group GRP01 no-preempt
set high-availability vrrp group GRP01 peer-address '203.0.113.14'
set high-availability vrrp group GRP01 priority '150'
set high-availability vrrp group GRP01 vrid '10'
set high-availability vrrp group GRP02 address 192.0.2.254/24
set high-availability vrrp group GRP02 hello-source-address '192.0.2.11'
set high-availability vrrp group GRP02 interface 'eth1'
set high-availability vrrp group GRP02 no-preempt
set high-availability vrrp group GRP02 peer-address '192.0.2.14'
set high-availability vrrp group GRP02 priority '150'
set high-availability vrrp group GRP02 vrid '20'
set high-availability vrrp sync-group SGR member 'GRP01'
set high-availability vrrp sync-group SGR member 'GRP02'

set service conntrack-sync accept-protocol 'tcp'
set service conntrack-sync accept-protocol 'udp'
set service conntrack-sync accept-protocol 'icmp'
set service conntrack-sync event-listen-queue-size '8'
set service conntrack-sync failover-mechanism vrrp sync-group 'SGR'
set service conntrack-sync interface eth1 peer '192.0.2.14'
set service conntrack-sync listen-address '192.0.2.11'

```
Before fix:
Service does not start
```
vyos@r14# sudo systemctl status conntrackd
● conntrackd.service - Conntrack Daemon
     Loaded: loaded (/lib/systemd/system/conntrackd.service; disabled; vendor preset: enabled)
    Drop-In: /etc/systemd/system/conntrackd.service.d
             └─override.conf
     Active: failed (Result: exit-code) since Mon 2022-10-10 16:52:29 EEST; 1s ago
       Docs: man:conntrackd(8)
             man:conntrackd.conf(5)
    Process: 18823 ExecStart=/usr/sbin/conntrackd -C /run/conntrackd/conntrackd.conf (code=exited, status=1/FAILURE)
   Main PID: 18823 (code=exited, status=1/FAILURE)
        CPU: 10ms

Oct 10 16:52:29 r14 systemd[1]: conntrackd.service: Scheduled restart job, restart counter is at 5.
Oct 10 16:52:29 r14 systemd[1]: Stopped Conntrack Daemon.
Oct 10 16:52:29 r14 systemd[1]: conntrackd.service: Start request repeated too quickly.
Oct 10 16:52:29 r14 systemd[1]: conntrackd.service: Failed with result 'exit-code'.
Oct 10 16:52:29 r14 systemd[1]: Failed to start Conntrack Daemon.
[edit]
vyos@r14#
```
```
vyos@r14# sudo /usr/sbin/conntrackd -C /run/conntrackd/conntrackd.conf
[Mon Oct 10 16:53:05 2022] (pid=18829) [ERROR] parsing config file in line (9), symbol '[': syntax error
[edit]
vyos@r14# 
```
conntrackd.conf
```
# Synchronizer settings
Sync {
    Mode FTFW {
        DisableExternalCache off
    }
    UDP {
        IPv4_address ['192.0.2.11']   <===  LINE 9
        IPv4_Destination_Address 192.0.2.14

```

After fix service starts correctly:
```
vyos@r14# sudo systemctl status conntrackd
● conntrackd.service - Conntrack Daemon
     Loaded: loaded (/lib/systemd/system/conntrackd.service; disabled; vendor preset: enabled)
    Drop-In: /etc/systemd/system/conntrackd.service.d
             └─override.conf
     Active: active (running) since Mon 2022-10-10 16:55:42 EEST; 12min ago
       Docs: man:conntrackd(8)
             man:conntrackd.conf(5)
   Main PID: 19192 (conntrackd)
      Tasks: 1 (limit: 9404)
     Memory: 2.5M
        CPU: 80ms
     CGroup: /system.slice/conntrackd.service
             └─19192 /usr/sbin/conntrackd -C /run/conntrackd/conntrackd.conf

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
