### PR TITLE
build: T3664: Add missing divert for /usr/share/pam-configs/radius

### DIFF
--- a/debian/vyos-1x.preinst
+++ b/debian/vyos-1x.preinst
@@ -2,3 +2,4 @@ dpkg-divert --package vyos-1x --add --rename /etc/securetty
 dpkg-divert --package vyos-1x --add --rename /etc/security/capability.conf
 dpkg-divert --package vyos-1x --add --rename /lib/systemd/system/lcdproc.service
 dpkg-divert --package vyos-1x --add --rename /etc/logrotate.d/conntrackd
+dpkg-divert --package vyos-1x --add --rename /usr/share/pam-configs/radius


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This fixes the weird issue found in https://github.com/vyos/vyos-build/pull/267 and allows builds to complete.

Remains a mystery why this issue is only apparent when https://github.com/vyos/vyos-build/pull/267 is applied.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3664

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Error found with https://github.com/vyos/vyos-build/pull/267
```
dpkg: error processing archive /tmp/apt-dpkg-install-Gg8Kx2/381-vyos-1x_1.4dev0-3377-g47984a6de_amd64.deb (--unpack):
 trying to overwrite '/usr/share/pam-configs/radius', which is also in package libpam-radius-auth 2.0.0-1
```

After divert:
```
Preparing to unpack .../381-vyos-1x_1.4dev0-3378-g20231b789_amd64.deb ...
Adding 'diversion of /etc/securetty to /etc/securetty.distrib by vyos-1x'
Adding 'diversion of /etc/security/capability.conf to /etc/security/capability.conf.distrib by vyos-1x'
Adding 'diversion of /lib/systemd/system/lcdproc.service to /lib/systemd/system/lcdproc.service.distrib by vyos-1x'
Adding 'diversion of /etc/logrotate.d/conntrackd to /etc/logrotate.d/conntrackd.distrib by vyos-1x'
Adding 'diversion of /usr/share/pam-configs/radius to /usr/share/pam-configs/radius.distrib by vyos-1x'
Unpacking vyos-1x (1.4dev0-3378-g20231b789) ...
Selecting previously unselected package vyos-1x-dbgsym.
...
P: \033[0;32mBuild completed successfully\033[0m
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
