### PR TITLE
conntrack: T4740: Set correct error msg if enrties not found

### DIFF
--- a/src/op_mode/conntrack.py
+++ b/src/op_mode/conntrack.py
@@ -48,6 +48,14 @@ def _get_raw_data(family):
     Return: dictionary
     """
     xml = _get_xml_data(family)
+    if len(xml) == 0:
+        output = {'conntrack':
+            {
+                'error': True,
+                'reason': 'entries not found'
+            }
+        }
+        return output
     return _xml_to_dict(xml)
 
 
@@ -72,7 +80,8 @@ def get_formatted_output(dict_data):
     :return: formatted output
     """
     data_entries = []
-    #dict_data = _get_raw_data(family)
+    if 'error' in dict_data['conntrack']:
+        return 'Entries not found'
     for entry in dict_data['conntrack']['flow']:
         orig_src, orig_dst, orig_sport, orig_dport = {}, {}, {}, {}
         reply_src, reply_dst, reply_sport, reply_dport = {}, {}, {}, {}


### PR DESCRIPTION
Set correct error message if conntrack entries not found If we get XML raw data with len 0 it means there are no entries in the conntrack table

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Set correct error message if conntrack entries are not found
If we get XML raw data with len 0 it means there are no entries in the conntrack table

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4740

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
conntrack
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Check conntrack table without entries:
Before fix:
```
vyos@r14:~$ show conntrack table ipv6
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/conntrack.py", line 139, in <module>
    res = vyos.opmode.run(sys.modules[__name__])
  File "/usr/lib/python3/dist-packages/vyos/opmode.py", line 147, in run
    res = func(**args)
  File "/usr/libexec/vyos/op_mode/conntrack.py", line 122, in show
    conntrack_data = _get_raw_data(family)
  File "/usr/libexec/vyos/op_mode/conntrack.py", line 51, in _get_raw_data
    return _xml_to_dict(xml)
  File "/usr/libexec/vyos/op_mode/conntrack.py", line 39, in _xml_to_dict
    parse = xmltodict.parse(xml, attr_prefix='')
  File "/usr/lib/python3/dist-packages/xmltodict.py", line 327, in parse
    parser.Parse(xml_input, True)
xml.parsers.expat.ExpatError: no element found: line 1, column 0
vyos@r14:~$
```
After fix:
```
vyos@r14:~$ show conntrack table ipv6
Entries not found
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
