### PR TITLE
monitoring: T4680: Bracketize prometheus listen-address

### DIFF
--- a/data/templates/monitoring/telegraf.tmpl
+++ b/data/templates/monitoring/telegraf.tmpl
@@ -25,7 +25,7 @@
 {% if prometheus_client is defined %}
  [[outputs.prometheus_client]]
    ## Address to listen on
-   listen = "{{ prometheus_client.listen_address if prometheus_client.listen_address is defined else '' }}:{{ prometheus_client.port }}"
+   listen = "{{ prometheus_client.listen_address | bracketize_ipv6 if prometheus_client.listen_address is defined else '' }}:{{ prometheus_client.port }}"
    metric_version = {{ prometheus_client.metric_version }}
 {%     if prometheus_client.authentication is defined %}
 {%          if prometheus_client.authentication.username is defined and prometheus_client.authentication.username is not none and prometheus_client.authentication.password is defined and prometheus_client.authentication.password is not none  %}


### PR DESCRIPTION
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
VyOS 1.3
Fix the correct format for the Prometheus listen-address 
when we use an IPv6 address, we must use square 'brackets' like `http://[2001:db8::11e]:9273`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4680

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
monitoring, prometheus
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service monitoring telegraf prometheus-client listen-address '2001:db8::11e'
```
Before fix
```

2022-10-11T17:08:26Z I! Loaded aggregators: 
2022-10-11T17:08:26Z I! Loaded processors: 
2022-10-11T17:08:26Z I! Loaded outputs: prometheus_client
2022-10-11T17:08:26Z I! Tags enabled: host=r1
2022-10-11T17:08:26Z I! [agent] Config: Interval:15s, Quiet:false, Hostname:"r1", Flush Interval:15s
2022-10-11T17:08:26Z E! [agent] Failed to connect to [outputs.prometheus_client], retrying in 15s, error was 'listen tcp: address 2001:db8::11e:9273: too many colons in address'
2022-10-11T17:08:30Z E! [telegraf] Error running agent: connecting output outputs.prometheus_client: context canceled

```
After fix:
```
2022-10-11T17:40:05Z I! Loaded aggregators: 
2022-10-11T17:40:05Z I! Loaded processors: 
2022-10-11T17:40:05Z I! Loaded outputs: prometheus_client
2022-10-11T17:40:05Z I! Tags enabled: host=r1
2022-10-11T17:40:05Z I! [agent] Config: Interval:15s, Quiet:false, Hostname:"r1", Flush Interval:15s
2022-10-11T17:40:05Z I! [outputs.prometheus_client] Listening on http://[2001:db8::11e]:9273/metrics
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
