### PR TITLE
monitoring: T4747: Fix template check influxdb config

### DIFF
--- a/data/templates/telegraf/telegraf.j2
+++ b/data/templates/telegraf/telegraf.j2
@@ -110,7 +110,7 @@
   server = "unixgram:///run/telegraf/telegraf_syslog.sock"
   best_effort = true
   syslog_standard = "RFC3164"
-{% if influxdb_configured is vyos_defined %}
+{% if influxdb is vyos_defined %}
 [[inputs.exec]]
   commands = [
     "{{ custom_scripts_dir }}/show_firewall_input_filter.py",

--- a/smoketest/scripts/cli/test_service_monitoring_telegraf.py
+++ b/smoketest/scripts/cli/test_service_monitoring_telegraf.py
@@ -60,6 +60,7 @@ class TestMonitoringTelegraf(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'  token = "$INFLUX_TOKEN"', config)
         self.assertIn(f'urls = ["{url}:{port}"]', config)
         self.assertIn(f'bucket = "{bucket}"', config)
+        self.assertIn(f'[[inputs.exec]]', config)
 
         for input in inputs:
             self.assertIn(input, config)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Due to monitoring telegraf was rewritten - fix the template for `inputs.exec` influxdb plugin
We do not use `influxdb_configured` in the dictionary anymore and use just `influxdb`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4747

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
monitoring
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```

set service monitoring telegraf influxdb authentication organization 'log@in.local'
set service monitoring telegraf influxdb authentication token 'GuRJc12tIzfjnYdKRAIYbxdWd2aTpOT9PVYNddzDnFV4HkAcD7u7-kndTFXjGuXzJN6TTxmrvPODB4mnFcseDV=='
set service monitoring telegraf influxdb port '8086'
set service monitoring telegraf influxdb url 'https://foo.local'
```
Expected `inputs.exec` in the configuration:
```
vyos@r14# cat /run/telegraf/telegraf.conf | grep 'inputs.exec' -A 8
[[inputs.exec]]
  commands = [
    "/etc/telegraf/custom_scripts/show_firewall_input_filter.py",
    "/etc/telegraf/custom_scripts/show_interfaces_input_filter.py",
    "/etc/telegraf/custom_scripts/vyos_services_input_filter.py"
  ]
  timeout = "10s"
  data_format = "influx"
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
