### PR TITLE
bgp: T4744: Directly connected neighbors and ebgp-multihop check

### DIFF
--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -159,6 +159,11 @@ def verify(bgp):
             if 'ebgp_multihop' in peer_config and 'ttl_security' in peer_config:
                 raise ConfigError('You can not set both ebgp-multihop and ttl-security hops')
 
+            # interface and ebgp-multihop can't be used in the same configration
+            if 'ebgp_multihop' in peer_config and 'interface' in peer_config:
+                raise ConfigError(f'Ebgp-multihop can not be used with directly connected '\
+                                  f'neighbor "{peer}"')
+
             # Check if neighbor has both override capability and strict capability match
             # configured at the same time.
             if 'override_capability' in peer_config and 'strict_capability_match' in peer_config:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
BGP directly connected neighbors (interface neighbors) do not compatible with `ebgp-multihop` option

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4744

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set protocols bgp neighbor eth0 interface peer-group 'PGRP'
set protocols bgp neighbor eth0 ebgp-multihop 10
set protocols bgp peer-group PGRP address-family ipv4-unicast
set protocols bgp peer-group PGRP remote-as '65001'
set protocols bgp system-as '65001'
```
Before fix:
```
vyos@r14# commit
[ protocols bgp ]

WARNING: BGP neighbor "eth0" requires address-family!
VyOS had an issue completing a command.

We are sorry that you encountered a problem while using VyOS.
There are a few things you can do to help us (and yourself):
- Contact us using the online help desk if you have a subscription:
  https://support.vyos.io/
- Make sure you are running the latest version of VyOS available at:
  https://vyos.net/get/
- Consult the community forum to see how to handle this issue:
  https://forum.vyos.io


Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/protocols_bgp.py", line 383, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/protocols_bgp.py", line 374, in apply
    frr_cfg.commit_configuration(bgp_daemon)
  File "/usr/lib/python3/dist-packages/vyos/frr.py", line 480, in commit_configuration
    raise ConfigurationNotValid(f'Config commit retry counter ({count_max}) exceeded')
vyos.frr.ConfigurationNotValid: Config commit retry counter (5) exceeded

[[protocols bgp]] failed
Commit failed
```
original FRR error:
```
r14# conf t
r14(config)# router bg
r14(config-router)# neighbor eth0 ebgp-multihop 10
% Operation not allowed on a directly connected neighbor
r14(config-router)#
```
After fix:
```
vyos@r14# commit
[ protocols bgp ]
Ebgp-multihop can not be used with directly connected neighbor "eth0"

[[protocols bgp]] failed
Commit failed
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
