### PR TITLE
isis, ospf: T4739: ISIS and OSPF segment routing being refactored

### DIFF
--- a/data/templates/frr/isisd.frr.j2
+++ b/data/templates/frr/isisd.frr.j2
@@ -121,22 +121,12 @@ router isis VyOS {{ 'vrf ' + vrf if vrf is vyos_defined }}
 {%         for prefix, prefix_config in segment_routing.prefix.items() %}
 {%             if prefix_config.absolute is vyos_defined %}
 {%                 if prefix_config.absolute.value is vyos_defined %}
- segment-routing prefix {{ prefix }} absolute {{ prefix_config.absolute.value }}
-{%                     if prefix_config.absolute.explicit_null is vyos_defined %}
- segment-routing prefix {{ prefix }} absolute {{ prefix_config.absolute.value }} explicit-null
-{%                     elif prefix_config.absolute.no_php_flag is vyos_defined %}
- segment-routing prefix {{ prefix }} absolute {{ prefix_config.absolute.value }} no-php-flag
-{%                     endif %}
+ segment-routing prefix {{ prefix }} absolute {{ prefix_config.absolute.value }} {{ 'explicit-null' if prefix_config.absolute.explicit_null is vyos_defined }} {{ 'no-php-flag' if prefix_config.absolute.no_php_flag is vyos_defined }}
 {%                 endif %}
 {%             endif %}
 {%             if prefix_config.index is vyos_defined %}
 {%                 if prefix_config.index.value is vyos_defined %}
- segment-routing prefix {{ prefix }} index {{ prefix_config.index.value }}
-{%                     if prefix_config.index.explicit_null is vyos_defined %}
- segment-routing prefix {{ prefix }} index {{ prefix_config.index.value }} explicit-null
-{%                     elif prefix_config.index.no_php_flag is vyos_defined %}
- segment-routing prefix {{ prefix }} index {{ prefix_config.index.value }} no-php-flag
-{%                     endif %}
+ segment-routing prefix {{ prefix }} index {{ prefix_config.index.value }} {{ 'explicit-null' if prefix_config.index.explicit_null is vyos_defined }} {{ 'no-php-flag' if prefix_config.index.no_php_flag is vyos_defined }}
 {%                 endif %}
 {%             endif %}
 {%         endfor %}

--- a/interface-definitions/include/isis/protocol-common-config.xml.i
+++ b/interface-definitions/include/isis/protocol-common-config.xml.i
@@ -238,7 +238,7 @@
         <help>Segment Routing Global Block label range</help>
       </properties>
       <children>
-        #include <include/isis/high-low-label-value.xml.i>
+        #include <include/segment-routing-label-value.xml.i>
       </children>
     </node>
     <node name="local-block">
@@ -246,7 +246,7 @@
         <help>Segment Routing Local Block label range</help>
       </properties>
       <children>
-        #include <include/isis/high-low-label-value.xml.i>
+        #include <include/segment-routing-label-value.xml.i>
       </children>
     </node>
     <leafNode name="maximum-label-depth">

--- a/interface-definitions/include/ospf/protocol-common-config.xml.i
+++ b/interface-definitions/include/ospf/protocol-common-config.xml.i
@@ -631,7 +631,7 @@
         <help>Segment Routing Global Block label range</help>
       </properties>
       <children>
-        #include <include/isis/high-low-label-value.xml.i>
+        #include <include/segment-routing-label-value.xml.i>
       </children>
     </node>
     <node name="local-block">
@@ -639,7 +639,7 @@
         <help>Segment Routing Local Block label range</help>
       </properties>
       <children>
-        #include <include/isis/high-low-label-value.xml.i>
+        #include <include/segment-routing-label-value.xml.i>
       </children>
     </node>
     <leafNode name="maximum-label-depth">

--- a/interface-definitions/include/segment-routing-label-value.xml.i
+++ b/interface-definitions/include/segment-routing-label-value.xml.i
@@ -1,10 +1,10 @@
-<!-- include start from isis/high-low-label-value.xml.i -->
+<!-- include start from segment-routing-label-value.xml.i -->
 <leafNode name="low-label-value">
   <properties>
     <help>MPLS label lower bound</help>
     <valueHelp>
       <format>u32:16-1048575</format>
-      <description>Label value (recommended minimum value: 100)</description>
+      <description>Label value (recommended minimum value: 300)</description>
     </valueHelp>
     <constraint>
       <validator name="numeric" argument="--range 16-1048575"/>

--- a/smoketest/scripts/cli/test_protocols_isis.py
+++ b/smoketest/scripts/cli/test_protocols_isis.py
@@ -263,10 +263,10 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f' isis bfd profile {bfd_profile}', tmp)
 
     def test_isis_07_segment_routing_configuration(self):
-        global_block_low = "100"
-        global_block_high = "199"
-        local_block_low = "200"
-        local_block_high = "299"
+        global_block_low = "300"
+        global_block_high = "399"
+        local_block_low = "400"
+        local_block_high = "499"
         interface = 'lo'
         maximum_stack_size = '5'
         prefix_one = '192.168.0.1/32'

--- a/smoketest/scripts/cli/test_protocols_ospf.py
+++ b/smoketest/scripts/cli/test_protocols_ospf.py
@@ -382,10 +382,10 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
 
 
     def test_ospf_14_segment_routing_configuration(self):
-        global_block_low = "100"
-        global_block_high = "199"
-        local_block_low = "200"
-        local_block_high = "299"
+        global_block_low = "300"
+        global_block_high = "399"
+        local_block_low = "400"
+        local_block_high = "499"
         interface = 'lo'
         maximum_stack_size = '5'
         prefix_one = '192.168.0.1/32'
@@ -408,15 +408,12 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify all changes
-
         frrconfig = self.getFRRconfig('router ospf')
+        self.assertIn(f' segment-routing on', frrconfig)
         self.assertIn(f' segment-routing global-block {global_block_low} {global_block_high} local-block {local_block_low} {local_block_high}', frrconfig)
         self.assertIn(f' segment-routing node-msd {maximum_stack_size}', frrconfig)
         self.assertIn(f' segment-routing prefix {prefix_one} index {prefix_one_value} explicit-null', frrconfig)
         self.assertIn(f' segment-routing prefix {prefix_two} index {prefix_two_value} no-php-flag', frrconfig)
-
-        self.skipTest('https://github.com/FRRouting/frr/issues/12007')
-        self.assertIn(f' segment-routing on', frrconfig)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixed more refactoring for segment routing for ISIS and OSPF

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

C-Po made more fixes and changes that were broke last time that somehow 
didn't work. I made those changes to ISIS that C-Po did to OSPF. Actually tested
them all and they did work, including the smoketests.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4739

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
isis, ospf

## Proposed changes
<!--- Describe your changes in detail -->

Moved the segment routing label range to its' own file in the main 
include folder. Increased the minimum recommended SRGB values 
from 100 to 300. Refactored the segment routing portions of the 
J2 template for ISIS like what C-Po did for OSPF.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Here is the ISIS smoketest:

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_isis.py
test_isis_01_redistribute (__main__.TestProtocolsISIS) ...
Network entity is mandatory!

ok
test_isis_02_vrfs (__main__.TestProtocolsISIS) ... ok
test_isis_03_zebra_route_map (__main__.TestProtocolsISIS) ... ok
test_isis_04_default_information (__main__.TestProtocolsISIS) ... ok
test_isis_05_password (__main__.TestProtocolsISIS) ...
Can use either md5 or plaintext-password for area-password!


Can use either md5 or plaintext-password for domain-password!

ok
test_isis_06_spf_delay_bfd (__main__.TestProtocolsISIS) ...
All types of spf-delay must be configured. Missing: short-delay, long-
delay, time-to-learn, init-delay


All types of spf-delay must be configured. Missing: short-delay, long-
delay, time-to-learn


All types of spf-delay must be configured. Missing: short-delay, time-
to-learn


All types of spf-delay must be configured. Missing: time-to-learn

ok
test_isis_07_segment_routing_configuration (__main__.TestProtocolsISIS) ... ok

----------------------------------------------------------------------
Ran 7 tests in 20.449s

OK
```

Here is the OSPF smoketest:

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_ospf.py
test_ospf_01_defaults (__main__.TestProtocolsOSPF) ... ok
test_ospf_02_simple (__main__.TestProtocolsOSPF) ... ok
test_ospf_03_access_list (__main__.TestProtocolsOSPF) ... ok
test_ospf_04_default_originate (__main__.TestProtocolsOSPF) ... ok
test_ospf_05_options (__main__.TestProtocolsOSPF) ... ok
test_ospf_06_neighbor (__main__.TestProtocolsOSPF) ... ok
test_ospf_07_redistribute (__main__.TestProtocolsOSPF) ... ok
test_ospf_08_virtual_link (__main__.TestProtocolsOSPF) ... ok
test_ospf_09_interface_configuration (__main__.TestProtocolsOSPF) ... ok
test_ospf_10_zebra_route_map (__main__.TestProtocolsOSPF) ... ok
test_ospf_11_interface_area (__main__.TestProtocolsOSPF) ...
Can not use OSPF interface area and area network configuration at the
same time!

ok
test_ospf_12_vrfs (__main__.TestProtocolsOSPF) ... ok
test_ospf_13_export_list (__main__.TestProtocolsOSPF) ... ok
test_ospf_14_segment_routing_configuration (__main__.TestProtocolsOSPF) ... ok

----------------------------------------------------------------------
Ran 14 tests in 32.464s

OK
```

Here is the OSPF test config:

```
vyos@vyos#
[edit]
vyos@vyos# set protocols ospf interface lo passive
[edit]
vyos@vyos# set protocols ospf segment-routing global-block high-label-value '599'
[edit]
vyos@vyos# set protocols ospf segment-routing global-block low-label-value '550'
[edit]
vyos@vyos# set protocols ospf segment-routing prefix 192.168.0.5/32 index value 5
[edit]
vyos@vyos# set protocols ospf segment-routing prefix 192.168.0.5/32 index explicit-null
[edit]
vyos@vyos# set protocols ospf segment-routing prefix 192.168.0.6/32 index value 6
[edit]
vyos@vyos# set protocols ospf segment-routing prefix 192.168.0.6/32 index no-php-flag
[edit]
vyos@vyos# set protocols ospf segment-routing prefix 192.168.0.7/32 index value 7
[edit]
vyos@vyos# set protocols ospf segment-routing prefix 192.168.0.7/32 index explicit-null
[edit]
vyos@vyos# set protocols ospf segment-routing prefix 192.168.0.8/32 index value 8
[edit]
vyos@vyos# set protocols ospf segment-routing prefix 192.168.0.8/32 index no-php-flag
[edit]
vyos@vyos# compare
[edit protocols]
+ospf {
+    interface lo {
+        passive {
+        }
+    }
+    segment-routing {
+        global-block {
+            high-label-value 599
+            low-label-value 550
+        }
+        prefix 192.168.0.5/32 {
+            index {
+                explicit-null
+                value 5
+            }
+        }
+        prefix 192.168.0.6/32 {
+            index {
+                no-php-flag
+                value 6
+            }
+        }
+        prefix 192.168.0.7/32 {
+            index {
+                explicit-null
+                value 7
+            }
+        }
+        prefix 192.168.0.8/32 {
+            index {
+                no-php-flag
+                value 8
+            }
+        }
+    }
+}
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# exit
Warning: configuration changes have not been saved.
exit
vyos@vyos:~$ vtysh -c "show run"
Building configuration...

Current configuration:
!
frr version 8.3.1
frr defaults traditional
hostname vyos
log syslog
log facility local7
service integrated-vtysh-config
!
ip route 0.0.0.0/0 10.0.0.65
!
interface lo
 ip ospf dead-interval 40
 ip ospf passive
exit
!
router ospf
 auto-cost reference-bandwidth 100
 timers throttle spf 200 1000 10000
 segment-routing on
 segment-routing global-block 550 599
 segment-routing prefix 192.168.0.5/32 index 5 explicit-null
 segment-routing prefix 192.168.0.6/32 index 6 no-php-flag
 segment-routing prefix 192.168.0.7/32 index 7 explicit-null
 segment-routing prefix 192.168.0.8/32 index 8 no-php-flag
exit
!
end

```

Here is the ISIS test config:

```
vyos@vyos#
[edit]
vyos@vyos# set protocols isis interface lo passive
[edit]
vyos@vyos# set protocols isis level 'level-2'
[edit]
vyos@vyos# set protocols isis metric-style 'wide'
[edit]
vyos@vyos# set protocols isis net '49.0001.1921.6825.5001.00'
[edit]
vyos@vyos# set protocols isis segment-routing global-block high-label-value '599'
[edit]
vyos@vyos# set protocols isis segment-routing global-block low-label-value '550'
[edit]
vyos@vyos# set protocols isis segment-routing prefix 192.168.0.1/32 index value 1
[edit]
vyos@vyos# set protocols isis segment-routing prefix 192.168.0.1/32 index explicit-null
[edit]
vyos@vyos# set protocols isis segment-routing prefix 192.168.0.2/32 index value 2
[edit]
vyos@vyos# set protocols isis segment-routing prefix 192.168.0.2/32 index no-php-flag
[edit]
vyos@vyos# set protocols isis segment-routing prefix 192.168.0.3/32 absolute value 600
[edit]
vyos@vyos# set protocols isis segment-routing prefix 192.168.0.3/32 absolute explicit-null
[edit]
vyos@vyos# set protocols isis segment-routing prefix 192.168.0.4/32 absolute value 601
[edit]
vyos@vyos# set protocols isis segment-routing prefix 192.168.0.4/32 absolute no-php-flag
[edit]
vyos@vyos# compare
[edit protocols]
+isis {
+    interface lo {
+        passive
+    }
+    level level-2
+    metric-style wide
+    net 49.0001.1921.6825.5001.00
+    segment-routing {
+        global-block {
+            high-label-value 599
+            low-label-value 550
+        }
+        prefix 192.168.0.1/32 {
+            index {
+                explicit-null
+                value 1
+            }
+        }
+        prefix 192.168.0.2/32 {
+            index {
+                no-php-flag
+                value 2
+            }
+        }
+        prefix 192.168.0.3/32 {
+            absolute {
+                explicit-null
+                value 600
+            }
+        }
+        prefix 192.168.0.4/32 {
+            absolute {
+                no-php-flag
+                value 601
+            }
+        }
+    }
+}
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# exit
Warning: configuration changes have not been saved.
exit
vyos@vyos:~$ vtysh -c "show run"
Building configuration...

Current configuration:
!
frr version 8.3.1
frr defaults traditional
hostname vyos
log syslog
log facility local7
service integrated-vtysh-config
!
ip route 0.0.0.0/0 10.0.0.65
!
interface lo
 ip router isis VyOS
 ipv6 router isis VyOS
 isis passive
exit
!
router isis VyOS
 is-type level-2-only
 net 49.0001.1921.6825.5001.00
 segment-routing on
 segment-routing global-block 550 599
 segment-routing prefix 192.168.0.1/32 index 1 explicit-null
 segment-routing prefix 192.168.0.2/32 index 2 no-php-flag
 segment-routing prefix 192.168.0.3/32 absolute 600 explicit-null
 segment-routing prefix 192.168.0.4/32 absolute 601 no-php-flag
exit
!
end

```




## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

Once all this is working, my next commit is going to be documentation.