### PR TITLE
T4725: Fix Regex for correctly reset IPsec peers

### DIFF
--- a/src/op_mode/ipsec.py
+++ b/src/op_mode/ipsec.py
@@ -133,14 +133,13 @@ def _get_formatted_output_sas(sas):
 
 
 def get_peer_connections(peer, tunnel, return_all = False):
-    peer = peer.replace(':', '-')
-    search = rf'^[\s]*(peer_{peer}_(tunnel_[\d]+|vti)).*'
+    search = rf'^[\s]*({peer}-(tunnel-[\d]+|vti)).*'
     matches = []
     with open(SWANCTL_CONF, 'r') as f:
         for line in f.readlines():
             result = re.match(search, line)
             if result:
-                suffix = f'tunnel_{tunnel}' if tunnel.isnumeric() else tunnel
+                suffix = f'tunnel-{tunnel}' if tunnel.isnumeric() else tunnel
                 if return_all or (result[2] == suffix):
                     matches.append(result[1])
     return matches


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
As IPsec site-so-site was rewritten we do not need to replace ':' => '-' 
as ':' can not be in the connection name.
So connection name can not use IP(v6) address as the peer name.
And current peers/connections not required the prefix `peer_`
Fix template that searches correctly the connection name of the peers that allow to reset them again (reset ipsec peer was broken)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4725

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure IPsec from both sites and try to reset peer
Current peer name:
```
vyos@r14:~$ cat /etc/swanctl/swanctl.conf | grep tunnel- -B1
        children {
            OFFICE-B-tunnel-0 {
vyos@r14:~$ 
```
before fix
```
vyos@r14:~$ show vpn ipsec sa
Connection         State    Uptime    Bytes In/Out    Packets In/Out    Remote address    Remote ID    Proposal
-----------------  -------  --------  --------------  ----------------  ----------------  -----------  ----------------------------------
OFFICE-B-tunnel-0  up       17m38s    0B/0B           0/0               203.0.113.2       203.0.113.2  AES_CBC_256/HMAC_SHA1_96/MODP_1024
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ reset vpn ipsec-peer OFFICE-B 
Tunnel(s) not found, aborting
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ reset vpn ipsec-peer OFFICE-B tunnel 0
Tunnel(s) not found, aborting
vyos@r14:~$ 
```
After fix:
```
vyos@r14:~$ show vpn ipsec sa 
Connection         State    Uptime    Bytes In/Out    Packets In/Out    Remote address    Remote ID    Proposal
-----------------  -------  --------  --------------  ----------------  ----------------  -----------  ---------------------------------------
OFFICE-B-tunnel-0  up       4s        0B/0B           0/0               192.0.2.2         192.0.2.2    AES_CBC_256/HMAC_SHA2_256_128/MODP_1024
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ reset vpn ipsec-peer OFFICE-B 
closing CHILD_SA OFFICE-B-tunnel-0{16} with SPIs cc364877_i (0 bytes) c521f540_o (0 bytes) and TS 192.168.0.0/24 === 10.0.0.0/21
CHILD_SA {16} closed successfully
generating QUICK_MODE request 1449430238 [ HASH SA No KE ID ID ]
sending packet: from 192.0.2.1[500] to 192.0.2.2[500] (332 bytes)
received packet: from 192.0.2.2[500] to 192.0.2.1[500] (332 bytes)
parsed QUICK_MODE response 1449430238 [ HASH SA No KE ID ID ]
selected proposal: ESP:AES_CBC_256/HMAC_SHA2_256_128/MODP_1024/NO_EXT_SEQ
CHILD_SA OFFICE-B-tunnel-0{17} established with SPIs cd451e27_i cfb63c3c_o and TS 192.168.0.0/24 === 10.0.0.0/21
generating QUICK_MODE request 1449430238 [ HASH ]
sending packet: from 192.0.2.1[500] to 192.0.2.2[500] (76 bytes)
connection 'OFFICE-B-tunnel-0' established successfully
Peer reset result: success
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
