### PR TITLE
http-api: T4749: transition to config_dict for conf_mode http-api.py

### DIFF
--- a/python/vyos/defaults.py
+++ b/python/vyos/defaults.py
@@ -49,8 +49,6 @@ api_data = {
     'port' : '8080',
     'socket' : False,
     'strict' : False,
-    'gql' : False,
-    'introspection' : False,
     'debug' : False,
     'api_keys' : [ {"id": "testapp", "key": "qwerty"} ]
 }

--- a/src/conf_mode/http-api.py
+++ b/src/conf_mode/http-api.py
@@ -24,9 +24,11 @@ from copy import deepcopy
 import vyos.defaults
 
 from vyos.config import Config
+from vyos.configdict import dict_merge
 from vyos.template import render
 from vyos.util import cmd
 from vyos.util import call
+from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -35,6 +37,15 @@ api_conf_file = '/etc/vyos/http-api.conf'
 systemd_service = '/run/systemd/system/vyos-http-api.service'
 
 vyos_conf_scripts_dir=vyos.defaults.directories['conf_mode']
+
+def _translate_values_to_boolean(d: dict) -> dict:
+    for k in list(d):
+        if d[k] == {}:
+            d[k] = True
+        elif isinstance(d[k], dict):
+            _translate_values_to_boolean(d[k])
+        else:
+            pass
 
 def get_config(config=None):
     http_api = deepcopy(vyos.defaults.api_data)
@@ -54,47 +65,39 @@ def get_config(config=None):
     if not conf.exists(base):
         return None
 
+    api_dict = conf.get_config_dict(base, key_mangling=('-', '_'),
+                                          no_tag_node_value_mangle=True,
+                                          get_first_key=True)
+
+    # One needs to 'flatten' the keys dict from the config into the
+    # http-api.conf format for api_keys:
+    if 'keys' in api_dict:
+        api_dict['api_keys'] = []
+        for el in list(api_dict['keys']['id']):
+            key = api_dict['keys']['id'][el]['key']
+            api_dict['api_keys'].append({'id': el, 'key': key})
+        del api_dict['keys']
+
     # Do we run inside a VRF context?
     vrf_path = ['service', 'https', 'vrf']
     if conf.exists(vrf_path):
         http_api['vrf'] = conf.return_value(vrf_path)
 
-    conf.set_level('service https api')
-    if conf.exists('strict'):
-        http_api['strict'] = True
+    if 'api_keys' in api_dict:
+        keys_added = True
 
-    if conf.exists('debug'):
-        http_api['debug'] = True
+    if 'gql' in api_dict:
+        api_dict = dict_merge(defaults(base), api_dict)
 
-    if conf.exists('gql'):
-        http_api['gql'] = True
-        if conf.exists('gql introspection'):
-            http_api['introspection'] = True
-
-    if conf.exists('socket'):
-        http_api['socket'] = True
-
-    if conf.exists('port'):
-        port = conf.return_value('port')
-        http_api['port'] = port
-
-    if conf.exists('cors'):
-        http_api['cors'] = {}
-        if conf.exists('cors allow-origin'):
-            origins = conf.return_values('cors allow-origin')
-            http_api['cors']['origins'] = origins[:]
-
-    if conf.exists('keys'):
-        for name in conf.list_nodes('keys id'):
-            if conf.exists('keys id {0} key'.format(name)):
-                key = conf.return_value('keys id {0} key'.format(name))
-                new_key = { 'id': name, 'key': key }
-                http_api['api_keys'].append(new_key)
-                keys_added = True
+    http_api.update(api_dict)
 
     if keys_added and default_key:
         if default_key in http_api['api_keys']:
             http_api['api_keys'].remove(default_key)
+
+    # Finally, translate entries in http_api into boolean settings for
+    # backwards compatability of JSON http-api.conf file
+    _translate_values_to_boolean(http_api)
 
     return http_api
 

--- a/src/services/vyos-http-api-server
+++ b/src/services/vyos-http-api-server
@@ -686,10 +686,16 @@ if __name__ == '__main__':
     app.state.vyos_keys = server_config['api_keys']
 
     app.state.vyos_debug = server_config['debug']
-    app.state.vyos_gql = server_config['gql']
-    app.state.vyos_introspection = server_config['introspection']
     app.state.vyos_strict = server_config['strict']
-    app.state.vyos_origins = server_config.get('cors', {}).get('origins', [])
+    app.state.vyos_origins = server_config.get('cors', {}).get('allow_origin', [])
+    if 'gql' in server_config:
+        app.state.vyos_gql = True
+        if isinstance(server_config['gql'], dict) and 'introspection' in server_config['gql']:
+            app.state.vyos_introspection = True
+        else:
+            app.state.vyos_introspection = False
+    else:
+        app.state.vyos_gql = False
 
     if app.state.vyos_gql:
         graphql_init(app)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Use config_dict for access to config settings. This is the standard modernization, and is useful for merging the defaultValue to be added for default authentication method (key | token). One needs a bit of manipulation of the http_api dict to maintain backwards compatibility of the generated /etc/vyos/http-api.conf file.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4749
* https://phabricator.vyos.net/T4574

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

http-api

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

The test is that nothing should have changed in behavior of REST form/json or graphql requests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
