### PR TITLE
T4533: Allow basic permissions to unprivileged RADIUS users

### DIFF
--- a/src/etc/sudoers.d/vyos
+++ b/src/etc/sudoers.d/vyos
@@ -40,10 +40,13 @@ Cmnd_Alias PCAPTURE = /usr/bin/tcpdump
 Cmnd_Alias HWINFO   = /usr/bin/lspci
 Cmnd_Alias FORCE_CLUSTER = /usr/share/heartbeat/hb_takeover, \
                            /usr/share/heartbeat/hb_standby
+Cmnd_Alias DIAGNOSTICS = /bin/ip vrf exec * /bin/ping *,       \
+                         /bin/ip vrf exec * /bin/traceroute *, \
+                         /usr/libexec/vyos/op_mode/*
 %operator ALL=NOPASSWD: DATE, IPTABLES, ETHTOOL, IPFLUSH, HWINFO, \
 			PPPOE_CMDS, PCAPTURE, /usr/sbin/wanpipemon, \
                         DMIDECODE, DISK, CONNTRACK, IP6TABLES,  \
-                        FORCE_CLUSTER
+                        FORCE_CLUSTER, DIAGNOSTICS
 
 # Allow any user to run files in sudo-users
 %users ALL=NOPASSWD: /opt/vyatta/bin/sudo-users/


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Unprivileged RADIUS users cannot do simple diagnostics like ping or traceroute. Allow them such tools.
Ability to execute op-mode commands for them.
It is not a new `operator mode` feature but it allows RADIUS users to execute op-mode commands

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Allow unprivileged RADIUS users to execute op-mode commands

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4533

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
radius, login
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add a simple RADIUS user, login via ssh and try to ping or traceroute some hots:
raddb/users
```
foo         Cleartext-Password := "bar"
```
Before fix:
```

radius_user@r14> ping 1.1.1.1

We trust you have received the usual lecture from the local System
Administrator. It usually boils down to these three things:

    #1) Respect the privacy of others.
    #2) Think before you type.
    #3) With great power comes great responsibility.

[sudo] password for foo: 



radius_user@r14> show vpn ipsec sa

We trust you have received the usual lecture from the local System
Administrator. It usually boils down to these three things:

    #1) Respect the privacy of others.
    #2) Think before you type.
    #3) With great power comes great responsibility.

:...skipping...

sudo: a password is required
```
Logs:
```
Oct 14 18:04:56 r14 sudo[6238]: pam_unix(sudo:auth): auth could not identify password for [radius_user]
Oct 14 18:04:56 r14 sudo[6238]: radius_user : command not allowed ; TTY=pts/1 ; PWD=/home/foo ; USER=root ; COMMAND=/usr/sbin/ip vrf exec default /bin/ping 1.1.1.1

Oct 14 20:25:59 r14 sudo[7987]: pam_unix(sudo:auth): auth could not identify password for [radius_user]
Oct 14 20:25:59 r14 sudo[7987]: radius_user : command not allowed ; TTY=pts/1 ; PWD=/home/foo ; USER=root ; COMMAND=/usr/libexec/vyos/op_mode/ipsec.py show_sa
```
After fix:
```
radius_user@r14> ping 192.0.2.2 count 1
PING 192.0.2.2 (192.0.2.2) 56(84) bytes of data.
64 bytes from 192.0.2.2: icmp_seq=1 ttl=64 time=0.493 ms

--- 192.0.2.2 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.493/0.493/0.493/0.000 ms
radius_user@r14> 
radius_user@r14> 
radius_user@r14> 
radius_user@r14> traceroute 192.0.2.2
traceroute to 192.0.2.2 (192.0.2.2), 30 hops max, 60 byte packets
 1  192.0.2.2 (192.0.2.2)  0.525 ms  0.462 ms  0.451 ms
radius_user@r14> 
radius_user@r14> 
radius_user@r14> 
radius_user@r14> show vpn ipsec sa
Connection         State    Uptime    Bytes In/Out    Packets In/Out    Remote address    Remote ID    Proposal
-----------------  -------  --------  --------------  ----------------  ----------------  -----------  ---------------------------------------
OFFICE-B-tunnel-0  down     15m49s    0B/0B           0/0               192.0.2.2         192.0.2.2    AES_CBC_256/HMAC_SHA2_256_128/MODP_1024
OFFICE-B-tunnel-0  down     29m43s    0B/0B           0/0               192.0.2.2         192.0.2.2    AES_CBC_256/HMAC_SHA2_256_128/MODP_1024
OFFICE-B-tunnel-0  up       2s        0B/0B           0/0               192.0.2.2         192.0.2.2    AES_CBC_256/HMAC_SHA2_256_128/MODP_1024
radius_user@r14> 
radius_user@r14> 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
