### PR TITLE
graphql: T4753: generalize system_status to composite_{query,mutation}

### DIFF
--- a/src/services/api/graphql/graphql/directives.py
+++ b/src/services/api/graphql/graphql/directives.py
@@ -63,16 +63,25 @@ class GenOpMutationDirective(VyosDirective):
         super().visit_field_definition(field, object_type,
                                        make_resolver=make_gen_op_mutation_resolver)
 
-class SystemStatusDirective(VyosDirective):
+class CompositeQueryDirective(VyosDirective):
     """
     Class providing implementation of 'system_status' directive in schema.
     """
     def visit_field_definition(self, field, object_type):
         super().visit_field_definition(field, object_type,
-                                       make_resolver=make_system_status_resolver)
+                                       make_resolver=make_composite_query_resolver)
+
+class CompositeMutationDirective(VyosDirective):
+    """
+    Class providing implementation of 'system_status' directive in schema.
+    """
+    def visit_field_definition(self, field, object_type):
+        super().visit_field_definition(field, object_type,
+                                       make_resolver=make_composite_mutation_resolver)
 
 directives_dict = {"configsessionquery": ConfigSessionQueryDirective,
                    "configsessionmutation": ConfigSessionMutationDirective,
                    "genopquery": GenOpQueryDirective,
                    "genopmutation": GenOpMutationDirective,
-                   "systemstatus": SystemStatusDirective}
+                   "compositequery": CompositeQueryDirective,
+                   "compositemutation": CompositeMutationDirective}

--- a/src/services/api/graphql/graphql/mutations.py
+++ b/src/services/api/graphql/graphql/mutations.py
@@ -112,3 +112,7 @@ def make_config_session_mutation_resolver(mutation_name):
 
 def make_gen_op_mutation_resolver(mutation_name):
     return make_mutation_resolver(mutation_name, mutation_name, 'gen_op_mutation')
+
+def make_composite_mutation_resolver(mutation_name):
+    return make_mutation_resolver(mutation_name, mutation_name,
+                                  convert_camel_case_to_snake(mutation_name))

--- a/src/services/api/graphql/graphql/queries.py
+++ b/src/services/api/graphql/graphql/queries.py
@@ -113,5 +113,6 @@ def make_config_session_query_resolver(query_name):
 def make_gen_op_query_resolver(query_name):
     return make_query_resolver(query_name, query_name, 'gen_op_query')
 
-def make_system_status_resolver(query_name):
-    return make_query_resolver(query_name, query_name, 'system_status')
+def make_composite_query_resolver(query_name):
+    return make_query_resolver(query_name, query_name,
+                               convert_camel_case_to_snake(query_name))

--- a/src/services/api/graphql/graphql/schema/composite.graphql
+++ b/src/services/api/graphql/graphql/schema/composite.graphql
@@ -1,7 +1,3 @@
-"""
-Use 'scalar Generic' for system status output, to avoid attempts to
-JSON-serialize in case of JSON output.
-"""
 
 input SystemStatusInput {
     key: String!
@@ -15,4 +11,8 @@ type SystemStatusResult {
     data: SystemStatus
     success: Boolean!
     errors: [String]
+}
+
+extend type Query {
+    SystemStatus(data: SystemStatusInput) : SystemStatusResult @compositequery
 }

--- a/src/services/api/graphql/graphql/schema/schema.graphql
+++ b/src/services/api/graphql/graphql/schema/schema.graphql
@@ -3,7 +3,8 @@ schema {
     mutation: Mutation
 }
 
-directive @systemstatus on FIELD_DEFINITION
+directive @compositequery on FIELD_DEFINITION
+directive @compositemutation on FIELD_DEFINITION
 directive @configsessionquery on FIELD_DEFINITION
 directive @configsessionmutation on FIELD_DEFINITION
 directive @genopquery on FIELD_DEFINITION
@@ -11,8 +12,5 @@ directive @genopmutation on FIELD_DEFINITION
 
 scalar Generic
 
-type Query {
-    SystemStatus(data: SystemStatusInput) : SystemStatusResult @systemstatus
-}
-
+type Query
 type Mutation

--- a/src/services/api/graphql/utils/composite_function.py
+++ b/src/services/api/graphql/utils/composite_function.py
@@ -1,0 +1,11 @@
+# typing information for composite functions: those that invoke several
+# elementary requests, and return the result as a single dict
+import typing
+
+def system_status():
+    pass
+
+queries = {'system_status': system_status}
+
+mutations = {}
+

--- a/src/services/api/graphql/utils/schema_from_composite.py
+++ b/src/services/api/graphql/utils/schema_from_composite.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+# A utility to generate GraphQL schema defintions from typing information of
+# composite functions comprising several requests.
+
+import os
+import json
+from inspect import signature, getmembers, isfunction, isclass, getmro
+from jinja2 import Template
+
+if __package__ is None or __package__ == '':
+    from util import snake_to_pascal_case, map_type_name
+else:
+    from . util import snake_to_pascal_case, map_type_name
+
+# this will be run locally before the build
+SCHEMA_PATH = '../graphql/schema'
+
+schema_data: dict = {'schema_name': '',
+                     'schema_fields': []}
+
+query_template  = """
+input {{ schema_name }}Input {
+    key: String!
+    {%- for field_entry in schema_fields %}
+    {{ field_entry }}
+    {%- endfor %}
+}
+
+type {{ schema_name }} {
+    result: Generic
+}
+
+type {{ schema_name }}Result {
+    data: {{ schema_name }}
+    success: Boolean!
+    errors: [String]
+}
+
+extend type Query {
+    {{ schema_name }}(data: {{ schema_name }}Input) : {{ schema_name }}Result @compositequery
+}
+"""
+
+mutation_template  = """
+input {{ schema_name }}Input {
+    key: String!
+    {%- for field_entry in schema_fields %}
+    {{ field_entry }}
+    {%- endfor %}
+}
+
+type {{ schema_name }} {
+    result: Generic
+}
+
+type {{ schema_name }}Result {
+    data: {{ schema_name }}
+    success: Boolean!
+    errors: [String]
+}
+
+extend type Mutation {
+    {{ schema_name }}(data: {{ schema_name }}Input) : {{ schema_name }}Result @compositemutation
+}
+"""
+
+def create_schema(func_name: str, func: callable, template: str) -> str:
+    sig = signature(func)
+
+    field_dict = {}
+    for k in sig.parameters:
+        field_dict[sig.parameters[k].name] = map_type_name(sig.parameters[k].annotation)
+
+    schema_fields = []
+    for k,v in field_dict.items():
+        schema_fields.append(k+': '+v)
+
+    schema_data['schema_name'] = snake_to_pascal_case(func_name)
+    schema_data['schema_fields'] = schema_fields
+
+    j2_template = Template(template)
+    res = j2_template.render(schema_data)
+
+    return res
+
+def generate_composite_definitions():
+    from composite_function import queries, mutations
+
+    results = []
+    for name,func in queries.items():
+        res = create_schema(name, func, query_template)
+        results.append(res)
+
+    for name,func in mutations.items():
+        res = create_schema(name, func, mutation_template)
+        results.append(res)
+
+    out = '\n'.join(results)
+    with open(f'{SCHEMA_PATH}/composite.graphql', 'w') as f:
+        f.write(out)
+
+if __name__ == '__main__':
+    generate_composite_definitions()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

For switching between REST-style key and token-based authentication methods, all schema definition files need to be automatically generated (as 'key' is defined in the schema itself). SystemStatus was the lone non-generated case; generalize to 'composite' query/mutation, a category that will be enlarged or dropped, as use cases require.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4753

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

http-api

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

The request query 'SystemStatus' will show no change in response.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
