### PR TITLE
T2408: dhcp-relay: Add listen-interface and upstream-interface feature

### DIFF
--- a/data/templates/dhcp-relay/dhcrelay.conf.j2
+++ b/data/templates/dhcp-relay/dhcrelay.conf.j2
@@ -2,5 +2,8 @@
 
 {% set max_size = '-A ' ~ relay_options.max_size if relay_options.max_size is vyos_defined %}
 {# hop_count and relay_agents_packets is a default option, thus it is always present #}
+{% if interface is vyos_defined %}
 OPTIONS="-c {{ relay_options.hop_count }} -a -m {{ relay_options.relay_agents_packets }} {{ max_size }} -i {{ interface | join(' -i ') }} {{ server | join(' ') }}"
-
+{% else %}
+OPTIONS="-c {{ relay_options.hop_count }} -a -m {{ relay_options.relay_agents_packets }} {{ max_size }} -id {{ listen_interface | join(' -id ') }} -iu {{ upstream_interface | join(' -iu ') }} {{ server | join(' ') }}"
+{% endif %}

--- a/interface-definitions/dhcp-relay.xml.in
+++ b/interface-definitions/dhcp-relay.xml.in
@@ -9,7 +9,54 @@
           <priority>910</priority>
         </properties>
         <children>
-          #include <include/generic-interface-multi-broadcast.xml.i>
+          <leafNode name="interface">
+            <properties>
+              <help>Interface Name to use [To be deprecated]. Only for backward compatibility. Use listen-interface and upstream-interface instead of this option </help>
+              <completionHelp>
+                <script>${vyos_completion_dir}/list_interfaces.py --broadcast</script>
+              </completionHelp>
+              <valueHelp>
+                <format>txt</format>
+                <description>Interface name</description>
+              </valueHelp>
+              <constraint>
+                <validator name="interface-name"/>
+              </constraint>
+              <multi/>
+            </properties>
+          </leafNode>
+          <leafNode name="listen-interface">
+            <properties>
+              <help>Interface for DHCP Relay Agent to listen for requests</help>
+              <completionHelp>
+                <script>${vyos_completion_dir}/list_interfaces.py</script>
+              </completionHelp>
+              <valueHelp>
+                <format>txt</format>
+                <description>Interface name</description>
+              </valueHelp>
+              <constraint>
+                <validator name="interface-name"/>
+              </constraint>
+              <multi/>
+            </properties>
+          </leafNode>
+          <leafNode name="upstream-interface">
+            <properties>
+              <help>Interface for DHCP Relay Agent forward requests out</help>
+              <completionHelp>
+                <script>${vyos_completion_dir}/list_interfaces.py</script>
+              </completionHelp>
+              <valueHelp>
+                <format>txt</format>
+                <description>Interface name</description>
+              </valueHelp>
+              <constraint>
+                <validator name="interface-name"/>
+              </constraint>
+              <multi/>
+            </properties>
+          </leafNode>
           <node name="relay-options">
             <properties>
               <help>Relay options</help>

--- a/src/conf_mode/dhcp_relay.py
+++ b/src/conf_mode/dhcp_relay.py
@@ -21,6 +21,7 @@ from sys import exit
 from vyos.config import Config
 from vyos.configdict import dict_merge
 from vyos.template import render
+from vyos.base import Warning
 from vyos.util import call
 from vyos.util import dict_search
 from vyos.xml import defaults
@@ -58,6 +59,18 @@ def verify(relay):
     if 'server' not in relay :
         raise ConfigError('No DHCP relay server(s) configured.\n' \
                           'At least one DHCP relay server required.')
+
+    if 'interface' in relay:
+        if 'upstream_interface' in relay or 'listen_interface' in relay:
+            raise ConfigError('<interface> configuration is not compatible with upstream/listen interface')
+        else:
+            Warning('<interface> is going to be deprecated.\n'  \
+                    'Please use <listen-interface> and <upstream-interface>')
+
+    if 'upstream_interface' in relay and 'listen_interface' not in relay:
+        raise ConfigError('No listen-interface configured')
+    if 'listen_interface' in relay and 'upstream_interface' not in relay:
+        raise ConfigError('No upstream-interface configured')
 
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add support for defining listen-interface and upstream-interface in dhcp-relay. Also keep <interface> option for backward s compatibility.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T2408

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-relay
## Proposed changes
<!--- Describe your changes in detail -->
Add support for defining listen-interface and upstream-interface in dhcp-relay (same names as used in dhcpv6-relay). Also keep <interface> option for backwards compatibility (print warning message when this legacy option is used).


## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
cli:
```
vyos@VyOS-130-2# set service dhcp-relay 
Possible completions:
+  interface            Interface Name to use [To be deprecated]. Only for backward
                        compatibility. Use listen-interface and upstream-interface
                        instead of this option
+  listen-interface     Interface for DHCP Relay Agent to listen for requests
 > relay-options        Relay options
+  server               DHCP server address
+  upstream-interface   Interface for DHCP Relay Agent forward requests out
```
Legacy config:
```
vyos@VyOS-130-2# set serv dhcp-relay interface eth3.10 
[edit]
vyos@VyOS-130-2# set serv dhcp-relay interface eth1
[edit]
vyos@VyOS-130-2# set serv dhcp-relay server 203.0.113.2
[edit]
vyos@VyOS-130-2# commit

WARNING: <interface> is going to be deprecated. Please use <listen-interface> and
<upstream-interface>
[edit]
vyos@VyOS-130-2# cat /run/dhcp-relay/dhcrelay.conf 
### Autogenerated by dhcp_relay.py ###

OPTIONS="-c 10 -a -m forward -A 576 -i eth3.10 -i eth1 203.0.113.2"
[edit]
```

And new config:
```
vyos@VyOS-130-2# set service dhcp-relay listen-interface eth3.10
[edit]
vyos@VyOS-130-2# set service dhcp-relay upstream-interface eth1
[edit]
vyos@VyOS-130-2# set service dhcp-relay server 203.0.113.2
[edit]
vyos@VyOS-130-2# commit
[edit]
vyos@VyOS-130-2# cat /run/dhcp-relay/dhcrelay.conf 
### Autogenerated by dhcp_relay.py ###

OPTIONS="-c 10 -a -m forward -A 576 -id eth3.10 -iu eth1 203.0.113.2"
[edit]

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
