### PR TITLE
T4762: Add check for show nat if nat config does not exist

### DIFF
--- a/op-mode-definitions/nat.xml.in
+++ b/op-mode-definitions/nat.xml.in
@@ -64,7 +64,7 @@
                 <properties>
                   <help>Show statistics for configured destination NAT rules</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/show_nat_statistics.py --destination</command>
+                <command>${vyos_op_scripts_dir}/nat.py show_statistics --direction destination --family inet</command>
               </node>
               <node name="translations">
                 <properties>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Op-mode
Add check for `show nat xxx` if nat configuration does not exist
Change XML to use the script `nat.py` for `show nat destination statistics`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4762
* https://phabricator.vyos.net/T4763

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Try to show nat without NAT configuration:
```
vyos@r14:~$ show nat source rules 
NAT is not configured
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ /usr/libexec/vyos/op_mode/nat.py show_rules --family inet --direction destination --raw
NAT is not configured
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
