### PR TITLE
T4765: normalize dict fields in op mode ouputs

### DIFF
--- a/src/tests/test_op_mode.py
+++ b/src/tests/test_op_mode.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+
+import vyos.opmode
+
+class TestVyOSOpMode(TestCase):
+    def test_field_name_normalization(self):
+        from vyos.opmode import _normalize_field_name
+
+        self.assertEqual(_normalize_field_name(" foo bar "), "foo_bar")
+        self.assertEqual(_normalize_field_name("foo-bar"), "foo_bar")
+        self.assertEqual(_normalize_field_name("foo (bar) baz"), "foo_bar_baz")
+        self.assertEqual(_normalize_field_name("load%"), "load_percentage")
+
+    def test_dict_fields_normalization_non_unique(self):
+        from vyos.opmode import _normalize_field_names
+
+        # Space and dot are both replaced by an underscore,
+        # so dicts like this cannor be normalized uniquely
+        data = {"foo bar": True, "foo.bar": False}
+
+        with self.assertRaises(vyos.opmode.InternalError):
+            _normalize_field_names(data)
+
+    def test_dict_fields_normalization(self):
+        from vyos.opmode import _normalize_field_names
+
+        data = {"foo bar": True, "bar-baz": False}
+        self.assertEqual(_normalize_field_names(data), {"foo_bar": True, "bar_baz": False})


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

Prototype of op mode JSON output field normalization.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): JSON output format change.
 
## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4765

## Component(s) name

Op mode.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
