### PR TITLE
T4765: support list and primitives in op mode output normalization

### DIFF
--- a/src/tests/test_op_mode.py
+++ b/src/tests/test_op_mode.py
@@ -37,8 +37,29 @@ class TestVyOSOpMode(TestCase):
         with self.assertRaises(vyos.opmode.InternalError):
             _normalize_field_names(data)
 
-    def test_dict_fields_normalization(self):
+    def test_dict_fields_normalization_simple_dict(self):
         from vyos.opmode import _normalize_field_names
 
-        data = {"foo bar": True, "bar-baz": False}
+        data = {"foo bar": True, "Bar-Baz": False}
         self.assertEqual(_normalize_field_names(data), {"foo_bar": True, "bar_baz": False})
+
+    def test_dict_fields_normalization_nested_dict(self):
+        from vyos.opmode import _normalize_field_names
+
+        data = {"foo bar": True, "bar-baz": {"baz-quux": {"quux-xyzzy": False}}}
+        self.assertEqual(_normalize_field_names(data),
+          {"foo_bar": True, "bar_baz": {"baz_quux": {"quux_xyzzy": False}}})
+
+    def test_dict_fields_normalization_mixed(self):
+        from vyos.opmode import _normalize_field_names
+
+        data = [{"foo bar": True, "bar-baz": [{"baz-quux": {"quux-xyzzy": [False]}}]}]
+        self.assertEqual(_normalize_field_names(data),
+          [{"foo_bar": True, "bar_baz": [{"baz_quux": {"quux_xyzzy": [False]}}]}])
+
+    def test_dict_fields_normalization_primitive(self):
+        from vyos.opmode import _normalize_field_names
+
+        data = [1, False, "foo"]
+        self.assertEqual(_normalize_field_names(data), [1, False, "foo"])
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

Support field name normalization for lists and primitive values.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): missed case handling.

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4765

## Component(s) name

Op mode.

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
