### PR TITLE
T4496: Added lists of values in the help of op-mode ping command

### DIFF
--- a/src/op_mode/ping.py
+++ b/src/op_mode/ping.py
@@ -18,6 +18,32 @@ import os
 import sys
 import socket
 import ipaddress
+import json
+from vyos.util import cmd, rc_cmd
+from vyos.ifconfig import Section
+
+
+def interface_list() -> list:
+    """
+    Get list of interfaces in system
+    :rtype: list
+    """
+    return Section.interfaces()
+
+
+def vrf_list() -> list:
+    """
+    Get list of VRFs in system
+    :rtype: list
+    """
+    result = cmd(f'sudo ip --json --brief link show type vrf')
+    data = json.loads(result)
+    vrflist: list = []
+    for o in data:
+        if 'ifname' in o:
+            vrflist.append(o['ifname'])
+    return vrflist
+
 
 options = {
     'audible': {
@@ -63,6 +89,7 @@ options = {
     'interface': {
         'ping': '{command} -I {value}',
         'type': '<interface>',
+        'helpfunction': interface_list,
         'help': 'Source interface'
     },
     'interval': {
@@ -128,6 +155,7 @@ options = {
         'ping': 'sudo ip vrf exec {value} {command}',
         'type': '<vrf>',
         'help': 'Use specified VRF table',
+        'helpfunction': vrf_list,
         'dflt': 'default',
     },
     'verbose': {
@@ -142,20 +170,33 @@ ping = {
 }
 
 
-class List (list):
-    def first (self):
+class List(list):
+    def first(self):
         return self.pop(0) if self else ''
 
     def last(self):
         return self.pop() if self else ''
 
-    def prepend(self,value):
-        self.insert(0,value)
+    def prepend(self, value):
+        self.insert(0, value)
+
+
+def completion_failure(option: str) -> None:
+    """
+    Shows failure message after TAB when option is wrong
+    :param option: failure option
+    :type str:
+    """
+    sys.stderr.write('\n\n Invalid option: {}\n\n'.format(option))
+    sys.stdout.write('<nocomps>')
+    sys.exit(1)
 
 
 def expension_failure(option, completions):
     reason = 'Ambiguous' if completions else 'Invalid'
-    sys.stderr.write('\n\n  {} command: {} [{}]\n\n'.format(reason,' '.join(sys.argv), option))
+    sys.stderr.write(
+        '\n\n  {} command: {} [{}]\n\n'.format(reason, ' '.join(sys.argv),
+                                               option))
     if completions:
         sys.stderr.write('  Possible completions:\n   ')
         sys.stderr.write('\n   '.join(completions))
@@ -196,28 +237,44 @@ if __name__ == '__main__':
     if host == '--get-options':
         args.first()  # pop ping
         args.first()  # pop IP
+        usedoptionslist = []
         while args:
-            option = args.first()
-
-            matched = complete(option)
+            option = args.first()  # pop option
+            matched = complete(option)  # get option parameters
+            usedoptionslist.append(option)  # list of used options
+            # Select options
             if not args:
+                # remove from Possible completions used options
+                for o in usedoptionslist:
+                    if o in matched:
+                        matched.remove(o)
                 sys.stdout.write(' '.join(matched))
                 sys.exit(0)
 
-            if len(matched) > 1 :
+            if len(matched) > 1:
                 sys.stdout.write(' '.join(matched))
                 sys.exit(0)
+            # If option doesn't have value
+            if matched:
+                if options[matched[0]]['type'] == 'noarg':
+                    continue
+            else:
+                # Unexpected option
+                completion_failure(option)
 
-            if options[matched[0]]['type'] == 'noarg':
-                continue
-
-            value = args.first()
+            value = args.first()  # pop option's value
             if not args:
                 matched = complete(option)
-                sys.stdout.write(options[matched[0]]['type'])
+                helplines = options[matched[0]]['type']
+                # Run helpfunction to get list of possible values
+                if 'helpfunction' in options[matched[0]]:
+                    result = options[matched[0]]['helpfunction']()
+                    if result:
+                        helplines = '\n' + ' '.join(result)
+                sys.stdout.write(helplines)
                 sys.exit(0)
 
-    for name,option in options.items():
+    for name, option in options.items():
         if 'dflt' in option and name not in args:
             args.append(name)
             args.append(option['dflt'])
@@ -234,8 +291,7 @@ if __name__ == '__main__':
     except ValueError:
         sys.exit(f'ping: Unknown host: {host}')
 
-    command = convert(ping[version],args)
+    command = convert(ping[version], args)
 
     # print(f'{command} {host}')
     os.system(f'{command} {host}')
-


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added list of possible VRFs in the help of the ping command.
Added list of possible interfaces in the help of the ping command.
Changed, if an option was selected before in the ping command, it does not appear in possible completion.
Added error message when an unexpected option was selected.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4496

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
op-mode
## Proposed changes
<!--- Describe your changes in detail -->
Added list of possible VRFs in the help of the ping command.
If a vrf exists
Before:
```
vyos@vyos:~$ ping 10.10.10.10 vrf
Possible completions:
  <Enter>               Execute the current command
  <vrf>                 Ping options
```
After:
```
vyos@vyos:~$ ping 10.10.10.10 vrf
Possible completions:
  <Enter>               Execute the current command
  TEST2                 Ping options
```
Added list of possible interfaces in the help of the ping command.
Before:
```
vyos@vyos:~$ ping 10.10.10.10 interface
Possible completions:
  <Enter>               Execute the current command
  <interface>         Ping options
```

After:
```
vyos@vyos:~$ ping 10.10.10.10 interface
Possible completions:
  <Enter>               Execute the current command
  eth0                  Ping options
  eth1
  eth2
  eth3
  lo

```
Changed, if an option was selected before in the ping command, it does not appear in possible completion.
Before:
```
vyos@vyos:~$ ping 10.10.10 vrf TEST
Possible completions:
  <Enter>               Execute the current command
  adaptive              Ping options
  allow-broadcast
  audible
  bypass-route
  count
  deadline
  do-not-fragment
  flood
  interface
  interval
  mark
  no-loopback
  numeric
  pattern
  quiet
  record-route
  size
  source-address
  timestamp
  tos
  ttl
  verbose
  vrf

```

After:
```
vyos@vyos:~$ ping 10.10.10 vrf TEST
Possible completions:
  <Enter>               Execute the current command
  adaptive              Ping options
  allow-broadcast
  audible
  bypass-route
  count
  deadline
  do-not-fragment
  flood
  interface
  interval
  mark
  no-loopback
  numeric
  pattern
  quiet
  record-route
  size
  source-address
  timestamp
  tos
  ttl
  verbose

```
Added error message when an unexpected option was selected.
Before:
```
vyos@vyos:~$ ping 10.10.10 dsadj;kfj Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/ping.py", line 211, in <module>
    if options[matched[0]]['type'] == 'noarg':
IndexError: list index out of range

Possible completions:
  <Enter>               Execute the current command
  <text>                Ping options

```
After:
```
vyos@vyos:~$ ping 10.10.10.10 kdsfj

  Invalid command: /usr/libexec/vyos/op_mode/ping.py --get-options ping 10.10.10.10 kdsfj  [kdsfj]


Possible completions:
  <Enter>               Execute the current command
  <nocomps>             Ping options

```
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
