### PR TITLE
wireguard: T4774: Prevent duplicate peer public keys

### DIFF
--- a/src/conf_mode/interfaces-wireguard.py
+++ b/src/conf_mode/interfaces-wireguard.py
@@ -87,6 +87,8 @@ def verify(wireguard):
                                'cannot be used for the interface!')
 
     # run checks on individual configured WireGuard peer
+    public_keys = []
+
     for tmp in wireguard['peer']:
         peer = wireguard['peer'][tmp]
 
@@ -99,6 +101,11 @@ def verify(wireguard):
         if ('address' in peer and 'port' not in peer) or ('port' in peer and 'address' not in peer):
             raise ConfigError('Both Wireguard port and address must be defined '
                               f'for peer "{tmp}" if either one of them is set!')
+
+        if peer['public_key'] in public_keys:
+            raise ConfigError(f'Duplicate public-key defined on peer "{tmp}"')
+
+        public_keys.append(peer['public_key'])
 
 def apply(wireguard):
     tmp = WireGuardIf(wireguard['ifname'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Prevent duplicate peer public keys for Wireguard interfaces, include smoketest.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4774

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireguard

## Proposed changes
<!--- Describe your changes in detail -->
Adds duplicate public key check to wireguard `verify()` and updates smoketest

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Tested duplicate public keys raise ConfigError, altered smoketest was successful.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
