### PR TITLE
T4771: Ability to get raw format for op-mode BGP commands

### DIFF
--- a/data/op-mode-standardized.json
+++ b/data/op-mode-standardized.json
@@ -1,4 +1,5 @@
 [
+"bgp.py",
 "bridge.py",
 "conntrack.py",
 "container.py",

--- a/src/op_mode/bgp.py
+++ b/src/op_mode/bgp.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Purpose:
+#    Displays bgp neighbors information.
+#    Used by the "show bgp (vrf <tag>) ipv4|ipv6 neighbors" commands.
+
+import re
+import sys
+import typing
+
+import jmespath
+from jinja2 import Template
+from humps import decamelize
+
+from vyos.configquery import ConfigTreeQuery
+
+import vyos.opmode
+
+
+frr_command_template = Template("""
+{% if family %}
+    show bgp
+        {{ 'vrf ' ~ vrf if vrf else '' }}
+        {{ 'ipv6' if family == 'inet6' else 'ipv4'}}
+        {{ 'neighbor ' ~ peer if peer else 'summary' }}
+{% endif %}
+
+{% if raw %}
+    json
+{% endif %}
+""")
+
+
+def _verify(func):
+    """Decorator checks if BGP config exists
+    BGP configuration can be present under vrf <tag>
+    If we do npt get arg 'peer' then it can be 'bgp summary'
+    """
+    from functools import wraps
+
+    @wraps(func)
+    def _wrapper(*args, **kwargs):
+        config = ConfigTreeQuery()
+        afi = 'ipv6' if kwargs.get('family') == 'inet6' else 'ipv4'
+        global_vrfs = ['all', 'default']
+        peer = kwargs.get('peer')
+        vrf = kwargs.get('vrf')
+        unconf_message = f'BGP or neighbor is not configured'
+        # Add option to check the specific neighbor if we have arg 'peer'
+        peer_opt = f'neighbor {peer} address-family {afi}-unicast' if peer else ''
+        vrf_opt = ''
+        if vrf and vrf not in global_vrfs:
+            vrf_opt = f'vrf name {vrf}'
+        # Check if config does not exist
+        if not config.exists(f'{vrf_opt} protocols bgp {peer_opt}'):
+            raise vyos.opmode.UnconfiguredSubsystem(unconf_message)
+        return func(*args, **kwargs)
+
+    return _wrapper
+
+
+@_verify
+def show_neighbors(raw: bool,
+                   family: str,
+                   peer: typing.Optional[str],
+                   vrf: typing.Optional[str]):
+    kwargs = dict(locals())
+    frr_command = frr_command_template.render(kwargs)
+    frr_command = re.sub(r'\s+', ' ', frr_command)
+
+    from vyos.util import cmd
+    output = cmd(f"vtysh -c '{frr_command}'")
+
+    if raw:
+        from json import loads
+        data = loads(output)
+        # Get list of the peers
+        peers = jmespath.search('*.peers | [0]', data)
+        if peers:
+            # Create new dict, delete old key 'peers'
+            # add key 'peers' neighbors to the list
+            list_peers = []
+            new_dict = jmespath.search('* | [0]', data)
+            if 'peers' in new_dict:
+                new_dict.pop('peers')
+
+                for neighbor, neighbor_options in peers.items():
+                    neighbor_options['neighbor'] = neighbor
+                    list_peers.append(neighbor_options)
+                new_dict['peers'] = list_peers
+            return decamelize(new_dict)
+        data = jmespath.search('* | [0]', data)
+        return decamelize(data)
+
+    else:
+        return output
+
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except (ValueError, vyos.opmode.Error) as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to get raw data for `op.mode` BGP 
Related PR https://github.com/vyos/vyos-1x/pull/1631

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4771

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS conf:
```
set protocols bgp neighbor 192.168.122.11 address-family ipv4-unicast
set protocols bgp neighbor 192.168.122.11 remote-as '65001'
set protocols bgp neighbor 192.168.122.12 address-family ipv4-unicast
set protocols bgp neighbor 192.168.122.12 remote-as '65002'
set protocols bgp system-as '65001'
```
Formatted output:
```
vyos@r14:~$  /usr/libexec/vyos/op_mode/bgp.py show_neighbors --family inet --vrf default
IPv4 Unicast Summary (VRF default):
BGP router identifier 192.168.122.14, local AS number 65001 vrf-id 0
BGP table version 0
RIB entries 0, using 0 bytes of memory
Peers 2, using 1447 KiB of memory

Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
192.168.122.11  4      65001         3         3        0    0    0 00:00:56            0        0 N/A
192.168.122.12  4      65002         0         0        0    0    0    never       Active        0 N/A

Total number of neighbors 2
vyos@r14:~$ 

```
Raw summary:
```
vyos@r14:~$ /usr/libexec/vyos/op_mode/bgp.py show_neighbors --family inet --raw --vrf default
{
    "router_id": "192.168.122.14",
    "as": 65001,
    "vrf_id": 0,
    "vrf_name": "default",
    "table_version": 0,
    "rib_count": 0,
    "rib_memory": 0,
    "peer_count": 2,
    "peer_memory": 1481664,
    "failed_peers": 1,
    "displayed_peers": 2,
    "total_peers": 2,
    "dynamic_peers": 0,
    "best_path": {
        "multi_path_relax": "false"
    },
    "peers": [
        {
            "hostname": "r1",
            "remote_as": 65001,
            "local_as": 65001,
            "version": 4,
            "msg_rcvd": 3,
            "msg_sent": 3,
            "table_version": 0,
            "outq": 0,
            "inq": 0,
            "peer_uptime": "00:00:17",
            "peer_uptime_msec": 17000,
            "peer_uptime_established_epoch": 1667061971,
            "pfx_rcd": 0,
            "pfx_snt": 0,
            "state": "Established",
            "peer_state": "OK",
            "connections_established": 1,
            "connections_dropped": 0,
            "id_type": "ipv4",
            "neighbor": "192.168.122.11"
        },
        {
            "remote_as": 65002,
            "local_as": 65001,
            "version": 4,
            "msg_rcvd": 0,
            "msg_sent": 0,
            "table_version": 0,
            "outq": 0,
            "inq": 0,
            "peer_uptime": "never",
            "peer_uptime_msec": 0,
            "pfx_rcd": 0,
            "pfx_snt": 0,
            "state": "Active",
            "peer_state": "OK",
            "connections_established": 0,
            "connections_dropped": 0,
            "id_type": "ipv4",
            "neighbor": "192.168.122.12"
        }
    ]
}


```
Raw peer
```
vyos@r14:~$  /usr/libexec/vyos/op_mode/bgp.py show_neighbors --family inet --raw --peer 192.168.122.11
{
    "remote_as": 65001,
    "local_as": 65001,
    "nbr_internal_link": true,
    "hostname": "r1",
    "bgp_version": 4,
    "remote_router_id": "192.168.122.11",
    "local_router_id": "192.168.122.14",
    "bgp_state": "Established",
    "bgp_timer_up_msec": 89000,
    "bgp_timer_up_string": "00:01:29",
    "bgp_timer_up_established_epoch": 1667061970,
    "bgp_timer_last_read": 29000,
    "bgp_timer_last_write": 29000,
    "bgp_in_update_elapsed_time_msecs": 88000,
    "bgp_timer_hold_time_msecs": 180000,
    "bgp_timer_keep_alive_interval_msecs": 60000,
    "extended_optional_parameters_length": false,
    "bgp_timer_configured_conditional_advertisements_sec": 60,
    "neighbor_capabilities": {
        "4byte_as": "advertisedAndReceived",
        "extended_message": "advertised",
        "add_path": {
            "ipv4_unicast": {
                "rx_advertised_and_received": true
            }
        },
        "long_lived_graceful_restart": "advertised",
        "route_refresh": "advertisedAndReceivedOldNew",
        "enhanced_route_refresh": "advertised",
        "multiprotocol_extensions": {
            "ipv4_unicast": {
                "advertised_and_received": true
            }
        },
        "host_name": {
            "adv_host_name": "r14",
            "adv_domain_name": "n/a",
            "rcv_host_name": "r1",
            "rcv_domain_name": "n/a"
        },
        "graceful_restart": "advertisedAndReceived",
        "graceful_restart_remote_timer_msecs": 120000,
        "address_families_by_peer": "none"
    },
    "graceful_restart_info": {
        "end_of_rib_send": {
            "ipv4_unicast": true
        },
        "end_of_rib_recv": {
            "ipv4_unicast": true
        },
        "local_gr_mode": "Helper*",
        "remote_gr_mode": "Helper",
        "r_bit": false,
        "n_bit": false,
        "timers": {
            "configured_restart_timer": 120,
            "received_restart_timer": 120
        },
        "ipv4_unicast": {
            "f_bit": false,
            "end_of_rib_status": {
                "end_of_rib_send": true,
                "end_of_rib_sent_after_update": true,
                "end_of_rib_recv": true
            },
            "timers": {
                "stale_path_timer": 360
            }
        }
    },
    "message_stats": {
        "depth_inq": 0,
        "depth_outq": 0,
        "opens_sent": 1,
        "opens_recv": 1,
        "notifications_sent": 0,
        "notifications_recv": 0,
        "updates_sent": 1,
        "updates_recv": 1,
        "keepalives_sent": 2,
        "keepalives_recv": 2,
        "route_refresh_sent": 0,
        "route_refresh_recv": 0,
        "capability_sent": 0,
        "capability_recv": 0,
        "total_sent": 4,
        "total_recv": 4
    },
    "min_btwn_advertisement_runs_timer_msecs": 0,
    "address_family_info": {
        "ipv4_unicast": {
            "update_group_id": 9,
            "sub_group_id": 9,
            "packet_queue_length": 0,
            "comm_attri_sent_to_nbr": "extendedAndStandard",
            "accepted_prefix_counter": 0,
            "sent_prefix_counter": 0
        }
    },
    "connections_established": 1,
    "connections_dropped": 0,
    "last_reset_timer_msecs": 90000,
    "last_reset_due_to": "Waiting for peer OPEN",
    "last_reset_code": 32,
    "host_local": "192.168.122.14",
    "port_local": 33424,
    "host_foreign": "192.168.122.11",
    "port_foreign": 179,
    "nexthop": "192.168.122.14",
    "nexthop_global": "fe80::5054:ff:fef2:cace",
    "nexthop_local": "fe80::5054:ff:fef2:cace",
    "bgp_connection": "sharedNetwork",
    "connect_retry_timer": 120,
    "read_thread": "on",
    "write_thread": "on"
}


```
Raw fake peer:
```
vyos@r14:~$ /usr/libexec/vyos/op_mode/bgp.py show_neighbors --family inet --raw --peer 192.168.122.199
BGP or neighbor is not configured
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
