### PR TITLE
T4779: output raw memory and storage values in bytes

### DIFF
--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -574,6 +574,37 @@ def bytes_to_human(bytes, initial_exponent=0):
     size_string = "{0:.2f} {1}".format(value, suffix)
     return size_string
 
+def human_to_bytes(value):
+    """ Converts a data amount with a unit suffix to bytes, like 2K to 2048 """
+
+    from re import match as re_match
+
+    res = re_match(r'^\s*(\d+(?:\.\d+)?)\s*([a-zA-Z]+)\s*$', value)
+
+    if not res:
+        raise ValueError(f"'{value}' is not a valid data amount")
+    else:
+        amount = float(res.group(1))
+        unit = res.group(2).lower()
+
+        if unit == 'b':
+            res = amount
+        elif (unit == 'k') or (unit == 'kb'):
+            res = amount * 1024
+        elif (unit == 'm') or (unit == 'mb'):
+            res = amount * 1024**2
+        elif (unit == 'g') or (unit == 'gb'):
+            res = amount * 1024**3
+        elif (unit == 't') or (unit == 'tb'):
+            res = amount * 1024**4
+        else:
+            raise ValueError(f"Unsupported data unit '{unit}'")
+
+    # There cannot be fractional bytes, so we convert them to integer.
+    # However, truncating causes problems with conversion back to human unit,
+    # so we round instead -- that seems to work well enough.
+    return round(res)
+
 def get_cfg_group_id():
     from grp import getgrnam
     from vyos.defaults import cfg_group

--- a/src/op_mode/memory.py
+++ b/src/op_mode/memory.py
@@ -20,7 +20,7 @@ import sys
 import vyos.opmode
 
 
-def _get_system_memory():
+def _get_raw_data():
     from re import search as re_search
 
     def find_value(keyword, mem_data):
@@ -38,7 +38,7 @@ def _get_system_memory():
 
     used = total - available
 
-    res = {
+    mem_data = {
       "total":   total,
       "free":    available,
       "used":    used,
@@ -46,24 +46,21 @@ def _get_system_memory():
       "cached":  cached
     }
 
-    return res
-
-def _get_system_memory_human():
-    from vyos.util import bytes_to_human
-
-    mem = _get_system_memory()
-
-    for key in mem:
+    for key in mem_data:
         # The Linux kernel exposes memory values in kilobytes,
         # so we need to normalize them
-        mem[key] = bytes_to_human(mem[key], initial_exponent=10)
+        mem_data[key] = mem_data[key] * 1024
 
-    return mem
-
-def _get_raw_data():
-    return _get_system_memory_human()
+    return mem_data
 
 def _get_formatted_output(mem):
+    from vyos.util import bytes_to_human
+
+    # For human-readable outputs, we convert bytes to more convenient units
+    # (100M, 1.3G...)
+    for key in mem:
+        mem[key] = bytes_to_human(mem[key])
+
     out = "Total: {}\n".format(mem["total"])
     out += "Free:  {}\n".format(mem["free"])
     out += "Used:  {}".format(mem["used"])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): output format change.

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4779

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Op mode.

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
vyos@vyos-test-2:~$ sudo /usr/libexec/vyos/op_mode/storage.py show --raw
{
    "filesystem": "/dev/sda1",
    "size": 17179869184,
    "used": 8267812045,
    "avail": 7730941133,
    "use_percentage": "52"
}
vyos@vyos-test-2:~$ sudo /usr/libexec/vyos/op_mode/memory.py show --raw
{
    "total": 2088947712,
    "free": 1513439232,
    "used": 575508480,
    "buffers": 171884544,
    "cached": 477032448
}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
