### PR TITLE
T4526: use informative error messages for keepalived-fifo with commit in progress

### DIFF
--- a/src/system/keepalived-fifo.py
+++ b/src/system/keepalived-fifo.py
@@ -67,13 +67,13 @@ class KeepalivedFifo:
         # For VRRP configuration to be read, the commit must be finished
         count = 1
         while commit_in_progress():
-            if ( count <= 40 ):
-                logger.debug(f'commit in progress try: {count}')
+            if ( count <= 20 ):
+                logger.debug(f'Attempt to load keepalived configuration aborted due to a commit in progress (attempt {count}/20)')
             else:
-                logger.error(f'commit still in progress after {count} continuing anyway')
+                logger.error(f'Forced keepalived configuration loading despite a commit in progress ({count} wait time expired, not waiting further)')
                 break
             count += 1
-            time.sleep(0.5)
+            time.sleep(1)
 
         try:
             base = ['high-availability', 'vrrp']


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

Re: #1630. I was writing a review when @c-po merged it. ;)

I disagree with the wording of the log messages. If I didn't know what they were supposed to mean, I would have never guessed. We should tell the user what exactly is going on.

I also think 0.5s is too short an interval. At least now, most commits take at least a few seconds, so 0.5 second check interval would cause quite a lot of log spam with debug enabled.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): log message wording change.

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4526

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

VRRP


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
