### PR TITLE
T4777: Ability to get logs in machine-readable format

### DIFF
--- a/data/op-mode-standardized.json
+++ b/data/op-mode-standardized.json
@@ -3,6 +3,7 @@
 "conntrack.py",
 "container.py",
 "cpu.py",
+"log.py",
 "memory.py",
 "nat.py",
 "neighbor.py",

--- a/src/op_mode/log.py
+++ b/src/op_mode/log.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import re
+import sys
+import typing
+
+from jinja2 import Template
+
+from vyos.util import rc_cmd
+
+import vyos.opmode
+
+journalctl_command_template = Template("""
+--no-hostname
+--quiet
+
+{% if boot %}
+  --boot
+{% endif %}
+
+{% if count %}
+  --lines={{ count }}
+{% endif %}
+
+{% if reverse %}
+  --reverse
+{% endif %}
+
+{% if since %}
+  --since={{ since }}
+{% endif %}
+
+{% if unit %}
+  --unit={{ unit }}
+{% endif %}
+
+{% if utc %}
+  --utc
+{% endif %}
+
+{% if raw %}
+{# By default show 100 only lines for raw option if count does not set #}
+{# Protection from parsing the full log by default #}
+{%    if not boot %}
+  --lines={{ '' ~ count if count else '100' }}
+{%    endif %}
+  --no-pager
+  --output=json
+{% endif %}
+""")
+
+
+def show(raw: bool,
+         boot: typing.Optional[bool],
+         count: typing.Optional[int],
+         facility: typing.Optional[str],
+         reverse: typing.Optional[bool],
+         utc: typing.Optional[bool],
+         unit: typing.Optional[str]):
+    kwargs = dict(locals())
+
+    journalctl_options = journalctl_command_template.render(kwargs)
+    journalctl_options = re.sub(r'\s+', ' ', journalctl_options)
+    rc, output = rc_cmd(f'journalctl {journalctl_options}')
+    if raw:
+        # Each 'journalctl --output json' line is a separate JSON object
+        # So we should return list of dict
+        return [json.loads(line) for line in output.split('\n')]
+    return output
+
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except (ValueError, vyos.opmode.Error) as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to get logs in JSON format
Possible filter by unit. Options for count lines,
UTC time, facility or logs since boot
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4777

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
log
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
vyos@r14:~$ /usr/libexec/vyos/op_mode/log.py show --help
usage: log.py show [-h] [--raw] [--boot] [--count COUNT] [--facility FACILITY] [--reverse] [--utc] [--unit UNIT]

optional arguments:
  -h, --help           show this help message and exit
  --raw
  --boot
  --count COUNT
  --facility FACILITY
  --reverse
  --utc
  --unit UNIT
vyos@r14:~$ 

vyos@r14:~$ /usr/libexec/vyos/op_mode/log.py show --unit isc-dhcp-server --count 2
Nov 01 19:14:55 dhcpd[1912]: DHCPREQUEST for 192.0.2.59 from 12:df:c5:d4:f3:d1 (r1) via eth1
Nov 01 19:14:55 dhcpd[1912]: DHCPACK on 192.0.2.59 to 12:df:c5:d4:f3:d1 (r1) via eth1
vyos@r14:~$ 
```
Raw format:
```
vyos@r14:~$ /usr/libexec/vyos/op_mode/log.py show --unit isc-dhcp-server --count 2 --raw
[
    {
        "syslog_timestamp": "Nov  1 19:15:26 ",
        "message": "DHCPREQUEST for 192.0.2.59 from 12:df:c5:d4:f3:d1 (r1) via eth1",
        "cursor": "s=6da0a574521e4418b79d7461441efa2c;i=1dfe;b=30118e9a44914a35a10bf01f17e8dd2d;m=6237609f7;t=5ec6bdec30d02;x=b5215f103838ec34",
        "source_realtime_timestamp": "1667322926533534",
        "systemd_invocation_id": "6c0d1f1679184edba692e9a948650692",
        "syslog_pid": "1912",
        "systemd_slice": "system.slice",
        "systemd_unit": "isc-dhcp-server.service",
        "realtime_timestamp": "1667322926533890",
        "boot_id": "30118e9a44914a35a10bf01f17e8dd2d",
        "pid": "1912",
        "syslog_facility": "3",
        "hostname": "r14",
        "cap_effective": "0",
        "syslog_identifier": "dhcpd",
        "gid": "104",
        "exe": "/usr/sbin/dhcpd",
        "priority": "6",
        "systemd_cgroup": "/system.slice/isc-dhcp-server.service",
        "machine_id": "4d6f4d291ae8446f8d2b3decd9da64c7",
        "comm": "dhcpd",
        "transport": "syslog",
        "uid": "126",
        "monotonic_timestamp": "26364742135",
        "cmdline": "/usr/sbin/dhcpd -4 -q -user dhcpd -group vyattacfg -pf /run/dhcp-server/dhcpd.pid -cf /run/dhcp-server/dhcpd.conf -lf /config/dhcpd.leases"
    },
    {
        "hostname": "r14",
        "comm": "dhcpd",
        "gid": "104",
        "monotonic_timestamp": "26364742257",
        "message": "DHCPACK on 192.0.2.59 to 12:df:c5:d4:f3:d1 (r1) via eth1",
        "uid": "126",
        "realtime_timestamp": "1667322926534011",
        "systemd_slice": "system.slice",
        "syslog_timestamp": "Nov  1 19:15:26 ",
        "syslog_pid": "1912",
        "pid": "1912",
        "machine_id": "4d6f4d291ae8446f8d2b3decd9da64c7",
        "cap_effective": "0",
        "syslog_facility": "3",
        "priority": "6",
        "cmdline": "/usr/sbin/dhcpd -4 -q -user dhcpd -group vyattacfg -pf /run/dhcp-server/dhcpd.pid -cf /run/dhcp-server/dhcpd.conf -lf /config/dhcpd.leases",
        "syslog_identifier": "dhcpd",
        "source_realtime_timestamp": "1667322926533547",
        "boot_id": "30118e9a44914a35a10bf01f17e8dd2d",
        "systemd_cgroup": "/system.slice/isc-dhcp-server.service",
        "cursor": "s=6da0a574521e4418b79d7461441efa2c;i=1dff;b=30118e9a44914a35a10bf01f17e8dd2d;m=623760a71;t=5ec6bdec30d7b;x=f68b28ff98f1b8aa",
        "systemd_invocation_id": "6c0d1f1679184edba692e9a948650692",
        "exe": "/usr/sbin/dhcpd",
        "systemd_unit": "isc-dhcp-server.service",
        "transport": "syslog"
    }
]
vyos@r14:~$ 

```
Request via API
```
vyos@r14:~$ curl -k --raw 'https://localhost/graphql'  -H 'Content-Type: application/json'  -d '{"query":" {\n ShowLog (data: {key: \"foo\", count: 1}) {\n  success\n  errors\n  data {\n    result\n  }\n}\n}\n"}'

{"data":{"ShowLog":{"success":true,"errors":null,"data":{"result":[{"_SYSTEMD_UNIT":"isc-dhcp-server.service","_GID":"104","_MACHINE_ID":"4d6f4d291ae8446f8d2b3decd9da64c7","SYSLOG_TIMESTAMP":"Nov  1 19:15:49 ","__REALTIME_TIMESTAMP":"1667322949841153","__MONOTONIC_TIMESTAMP":"26388049398","_SYSTEMD_CGROUP":"/system.slice/isc-dhcp-server.service","SYSLOG_FACILITY":"3","_COMM":"dhcpd","_TRANSPORT":"syslog","PRIORITY":"6","_SYSTEMD_INVOCATION_ID":"6c0d1f1679184edba692e9a948650692","_HOSTNAME":"r14","_CMDLINE":"/usr/sbin/dhcpd -4 -q -user dhcpd -group vyattacfg -pf /run/dhcp-server/dhcpd.pid -cf /run/dhcp-server/dhcpd.conf -lf /config/dhcpd.leases","_PID":"1912","SYSLOG_PID":"1912","_CAP_EFFECTIVE":"0","__CURSOR":"s=6da0a574521e4418b79d7461441efa2c;i=1e10;b=30118e9a44914a35a10bf01f17e8dd2d;m=624d9adf6;t=5ec6be026b101;x=f5199e636168cd84","_SOURCE_REALTIME_TIMESTAMP":"1667322949840817","SYSLOG_IDENTIFIER":"dhcpd","_SYSTEMD_SLICE":"system.slice","_BOOT_ID":"30118e9a44914a35a10bf01f17e8dd2d","_EXE":"/usr/sbin/dhcpd","MESSAGE":"DHCPACK on 192.0.2.59 to 12:df:c5:d4:f3:d1 (r1) via eth1","_UID":"126"}]}}}}vyos@r14:~$ 
vyos@r14:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
