### PR TITLE
openvpn: T3214: fix server-ipv6 and nopool handling

### DIFF
--- a/data/templates/openvpn/server.conf.j2
+++ b/data/templates/openvpn/server.conf.j2
@@ -71,7 +71,7 @@ topology {{ server.topology }}
 {%             endif %}
 {%             for subnet in server.subnet %}
 {%                 if subnet | is_ipv4 %}
-server {{ subnet | address_from_cidr }} {{ subnet | netmask_from_cidr }} nopool
+server {{ subnet | address_from_cidr }} {{ subnet | netmask_from_cidr }} {{ 'nopool' if server.client_ip_pool is vyos_defined and server.client_ip_pool.disable is not vyos_defined else '' }}
 {# First ip address is used as gateway. It's allows to use metrics #}
 {%                     if server.push_route is vyos_defined %}
 {%                         for route, route_config in server.push_route.items() %}
@@ -81,15 +81,6 @@ push "route {{ route | address_from_cidr }} {{ route | netmask_from_cidr }} {{ s
 push "route-ipv6 {{ route }}"
 {%                             endif %}
 {%                         endfor %}
-{%                     endif %}
-{# OpenVPN assigns the first IP address to its local interface so the pool used #}
-{# in net30 topology - where each client receives a /30 must start from the second subnet #}
-{%                     if server.topology is vyos_defined('net30') %}
-ifconfig-pool {{ subnet | inc_ip('4') }} {{ subnet | last_host_address | dec_ip('1') }} {{ subnet | netmask_from_cidr if device_type == 'tap' else '' }}
-{%                     else %}
-{# OpenVPN assigns the first IP address to its local interface so the pool must #}
-{# start from the second address and end on the last address #}
-ifconfig-pool {{ subnet | first_host_address | inc_ip('1') }} {{ subnet | last_host_address | dec_ip('1') }} {{ subnet | netmask_from_cidr if device_type == 'tun' else '' }}
 {%                     endif %}
 {%                 elif subnet | is_ipv6 %}
 server-ipv6 {{ subnet }}

--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -329,9 +329,6 @@ def verify(openvpn):
             if v6_subnets > 1:
                 raise ConfigError('Cannot specify more than 1 IPv6 server subnet')
 
-            if v6_subnets > 0 and v4_subnets == 0:
-                raise ConfigError('IPv6 server requires an IPv4 server subnet')
-
             for subnet in tmp:
                 if is_ipv4(subnet):
                     subnet = IPv4Network(subnet)

--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -370,6 +370,10 @@ def verify(openvpn):
                         for v4PoolNet in v4PoolNets:
                             if IPv4Address(client['ip'][0]) in v4PoolNet:
                                 print(f'Warning: Client "{client["name"]}" IP {client["ip"][0]} is in server IP pool, it is not reserved for this client.')
+            # configuring a client_ip_pool will set 'server ... nopool' which is currently incompatible with 'server-ipv6' (probably to be fixed upstream)
+            for subnet in (dict_search('server.subnet', openvpn) or []):
+                if is_ipv6(subnet):
+                    raise ConfigError(f'Setting client-ip-pool is incompatible having an IPv6 server subnet.')
 
         for subnet in (dict_search('server.subnet', openvpn) or []):
             if is_ipv6(subnet):


### PR DESCRIPTION
## Change Summary
This PR implements the following changes:
1. allows again specifying an IPv6 subnet on an OpenVPN server interface;
1. gets rid of code handling client-ipv6-pool as it is currently not used at all when configuring the interface;
1. allow configuring a server with a v6 only subnet (possible since openvpn v2.5.0)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T3214

## Component(s) name
openvpn

## Proposed changes
1. instead of unconditionally specifying the 'nopool' keyword on the --server directive, do so only if a client-ip-pool was specified. Also, since nopool is incompatible with --server-ipv6, throw an error at commit time if a client-ip-pool is specified and a v6 subnet is configured as well;
2. client-ipv6-pool is not used at all, therefore code handling it can simply be removed. Once upstream fixes a bit the way an ipv6 pool can be specified, this code can then be reintroduced again (with some actual user);
3. since opnvpn 2.5.0 it is possible to have a tunnel with v6 only configured. For this reason this change drops the check allowing the existence of an ipv6 subnet only if an ipv4 one was specified too.

## How to test
1. simply specify a v6 subnet and commit. Add a client-ip-pool and check that now the config is rejected;
2. nothing to test;
3. specify only an ipv6 subnet and commit.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
