### PR TITLE
dns: T4799: fixed powerdns not being reloaded by vyos-hostsd

### DIFF
--- a/src/services/vyos-hostsd
+++ b/src/services/vyos-hostsd
@@ -406,8 +406,7 @@ def validate_schema(data):
 
 
 def pdns_rec_control(command):
-    # pdns-r process name is NOT equal to the name shown in ps
-    if not process_named_running('pdns-r/worker'):
+    if not process_named_running('pdns_recursor'):
         logger.info(f'pdns_recursor not running, not sending "{command}"')
         return
 


### PR DESCRIPTION
## Change Summary

After the upgrade from PowerDNS 4.5 to 4.7 (and above) a regression was introduced which prevented `vyos-hostsd` from ever reloading `pdns-recursor`. A change in the name of the main powerdns process is to blame for this and this PR addresses that by changing the name of the process being checked for in `vyos-hostsd`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T4799
* https://phabricator.vyos.net/T4652

## Component(s) name

pdns, vyos-hostsd

## Proposed changes

PowerDNS version 4.7 and above has changed the main process name from 'pdns-r/worker' to 'pdns_recursor'. This commit updates the process name check to use the new name.

## How to test

Ensure the dns forwarding service is running by at least having a minimal config akin to:
```
service {
    dns {
        forwarding {
            allow-from ::1/128
            listen-address ::1
        }
    }
}

```
Make a change to the active configuration that would cause `vyos-hostsd` to send a reload to `pdns_recursor` such as by adding a static host mapping as such:
```
system {
    static-host-mapping {
        host-name example {
            inet 0.0.0.0
        }
    }
}
```
Check `journalctl -eu vyos-hostsd` to ensure the following is present:
> vyos-hostsd[740]: Running "rec_control reload-lua-config"
> vyos-hostsd[740]: Running "rec_control reload-zones"

or simply check that the new entries are correctly loaded by PowerDNS by querying the resolver.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
