### PR TITLE
backport: dns: T4799: fixed powerdns not being reloaded by vyos-hostsd

### DIFF
--- a/src/services/vyos-hostsd
+++ b/src/services/vyos-hostsd
@@ -378,8 +378,7 @@ def validate_schema(data):
 
 
 def pdns_rec_control(command):
-    # pdns-r process name is NOT equal to the name shown in ps
-    if not process_named_running('pdns-r/worker'):
+    if not process_named_running('pdns_recursor'):
         logger.info(f'pdns_recursor not running, not sending "{command}"')
         return
 


### PR DESCRIPTION
## Change Summary

Backport of #1639 to equuleus.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T4799
* https://phabricator.vyos.net/T4652

## Component(s) name
pdns, vyos-hostsd

## Proposed changes

See #1639.

## How to test

See #1639.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
