### PR TITLE
firewall: T4612: Support arbitrary netmasks

### DIFF
--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -411,6 +411,7 @@
                   #include <include/firewall/geoip.xml.i>
                   #include <include/firewall/source-destination-group-ipv6.xml.i>
                   #include <include/firewall/port.xml.i>
+                  #include <include/firewall/address-mask-ipv6.xml.i>
                 </children>
               </node>
               <node name="source">
@@ -422,6 +423,7 @@
                   #include <include/firewall/geoip.xml.i>
                   #include <include/firewall/source-destination-group-ipv6.xml.i>
                   #include <include/firewall/port.xml.i>
+                  #include <include/firewall/address-mask-ipv6.xml.i>
                 </children>
               </node>
               #include <include/firewall/common-rule.xml.i>
@@ -575,6 +577,7 @@
                   #include <include/firewall/geoip.xml.i>
                   #include <include/firewall/source-destination-group.xml.i>
                   #include <include/firewall/port.xml.i>
+                  #include <include/firewall/address-mask.xml.i>
                 </children>
               </node>
               <node name="source">
@@ -586,6 +589,7 @@
                   #include <include/firewall/geoip.xml.i>
                   #include <include/firewall/source-destination-group.xml.i>
                   #include <include/firewall/port.xml.i>
+                  #include <include/firewall/address-mask.xml.i>
                 </children>
               </node>
               #include <include/firewall/common-rule.xml.i>

--- a/interface-definitions/include/firewall/address-mask-ipv6.xml.i
+++ b/interface-definitions/include/firewall/address-mask-ipv6.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from firewall/address-mask-ipv6.xml.i -->
+<leafNode name="address-mask">
+  <properties>
+    <help>IP mask</help>
+    <valueHelp>
+      <format>ipv6</format>
+      <description>IP mask to apply</description>
+    </valueHelp>
+    <constraint>
+      <validator name="ipv6"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/firewall/address-mask.xml.i
+++ b/interface-definitions/include/firewall/address-mask.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from firewall/address-mask.xml.i -->
+<leafNode name="address-mask">
+  <properties>
+    <help>IP mask</help>
+    <valueHelp>
+      <format>ipv4</format>
+      <description>IPv4 mask to apply</description>
+    </valueHelp>
+    <constraint>
+      <validator name="ipv4-address"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -144,12 +144,19 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
         if side in rule_conf:
             prefix = side[0]
             side_conf = rule_conf[side]
+            address_mask = side_conf.get('address_mask', None)
 
             if 'address' in side_conf:
                 suffix = side_conf['address']
-                if suffix[0] == '!':
-                    suffix = f'!= {suffix[1:]}'
-                output.append(f'{ip_name} {prefix}addr {suffix}')
+                operator = ''
+                exclude = suffix[0] == '!'
+                if exclude:
+                    operator = '!= '
+                    suffix = suffix[1:]
+                if address_mask:
+                    operator = '!=' if exclude else '=='
+                    operator = f'& {address_mask} {operator} '
+                output.append(f'{ip_name} {prefix}addr {operator}{suffix}')
 
             if dict_search_args(side_conf, 'geoip', 'country_code'):
                 operator = ''
@@ -192,9 +199,13 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
                 if 'address_group' in group:
                     group_name = group['address_group']
                     operator = ''
-                    if group_name[0] == '!':
+                    exclude = group_name[0] == "!"
+                    if exclude:
                         operator = '!='
                         group_name = group_name[1:]
+                    if address_mask:
+                        operator = '!=' if exclude else '=='
+                        operator = f'& {address_mask} {operator}'
                     output.append(f'{ip_name} {prefix}addr {operator} @A{def_suffix}_{group_name}')
                 # Generate firewall group domain-group
                 elif 'domain_group' in group:

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -274,6 +274,40 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         self.verify_nftables(nftables_search, 'ip vyos_filter')
 
+    def test_ipv4_mask(self):
+        name = 'smoketest-mask'
+        interface = 'eth0'
+
+        self.cli_set(['firewall', 'group', 'address-group', 'mask_group', 'address', '1.1.1.1'])
+
+        self.cli_set(['firewall', 'name', name, 'default-action', 'drop'])
+        self.cli_set(['firewall', 'name', name, 'enable-default-log'])
+
+        self.cli_set(['firewall', 'name', name, 'rule', '1', 'action', 'drop'])
+        self.cli_set(['firewall', 'name', name, 'rule', '1', 'destination', 'address', '0.0.1.2'])
+        self.cli_set(['firewall', 'name', name, 'rule', '1', 'destination', 'address-mask', '0.0.255.255'])
+
+        self.cli_set(['firewall', 'name', name, 'rule', '2', 'action', 'accept'])
+        self.cli_set(['firewall', 'name', name, 'rule', '2', 'source', 'address', '!0.0.3.4'])
+        self.cli_set(['firewall', 'name', name, 'rule', '2', 'source', 'address-mask', '0.0.255.255'])
+
+        self.cli_set(['firewall', 'name', name, 'rule', '3', 'action', 'drop'])
+        self.cli_set(['firewall', 'name', name, 'rule', '3', 'source', 'group', 'address-group', 'mask_group'])
+        self.cli_set(['firewall', 'name', name, 'rule', '3', 'source', 'address-mask', '0.0.255.255'])
+
+        self.cli_set(['firewall', 'interface', interface, 'in', 'name', name])
+
+        self.cli_commit()
+
+        nftables_search = [
+            [f'daddr & 0.0.255.255 == 0.0.1.2'],
+            [f'saddr & 0.0.255.255 != 0.0.3.4'],
+            [f'saddr & 0.0.255.255 == @A_mask_group']
+        ]
+
+        self.verify_nftables(nftables_search, 'ip vyos_filter')
+
+
     def test_ipv6_basic_rules(self):
         name = 'v6-smoketest'
         interface = 'eth0'
@@ -349,6 +383,39 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             [f'log prefix "[{name}-default-D]"', 'drop'],
             ['ip6 saddr 2001:db8::/64', f'jump NAME6_{name}'],
             [f'log prefix "[{name2}-default-J]"', f'jump NAME6_{name}']
+        ]
+
+        self.verify_nftables(nftables_search, 'ip6 vyos_filter')
+
+    def test_ipv6_mask(self):
+        name = 'v6-smoketest-mask'
+        interface = 'eth0'
+
+        self.cli_set(['firewall', 'group', 'ipv6-address-group', 'mask_group', 'address', '::beef'])
+
+        self.cli_set(['firewall', 'ipv6-name', name, 'default-action', 'drop'])
+        self.cli_set(['firewall', 'ipv6-name', name, 'enable-default-log'])
+
+        self.cli_set(['firewall', 'ipv6-name', name, 'rule', '1', 'action', 'drop'])
+        self.cli_set(['firewall', 'ipv6-name', name, 'rule', '1', 'destination', 'address', '::1111:2222:3333:4444'])
+        self.cli_set(['firewall', 'ipv6-name', name, 'rule', '1', 'destination', 'address-mask', '::ffff:ffff:ffff:ffff'])
+
+        self.cli_set(['firewall', 'ipv6-name', name, 'rule', '2', 'action', 'accept'])
+        self.cli_set(['firewall', 'ipv6-name', name, 'rule', '2', 'source', 'address', '!::aaaa:bbbb:cccc:dddd'])
+        self.cli_set(['firewall', 'ipv6-name', name, 'rule', '2', 'source', 'address-mask', '::ffff:ffff:ffff:ffff'])
+
+        self.cli_set(['firewall', 'ipv6-name', name, 'rule', '3', 'action', 'drop'])
+        self.cli_set(['firewall', 'ipv6-name', name, 'rule', '3', 'source', 'group', 'address-group', 'mask_group'])
+        self.cli_set(['firewall', 'ipv6-name', name, 'rule', '3', 'source', 'address-mask', '::ffff:ffff:ffff:ffff'])
+
+        self.cli_set(['firewall', 'interface', interface, 'in', 'ipv6-name', name])
+
+        self.cli_commit()
+
+        nftables_search = [
+            ['daddr & ::ffff:ffff:ffff:ffff == ::1111:2222:3333:4444'],
+            ['saddr & ::ffff:ffff:ffff:ffff != ::aaaa:bbbb:cccc:dddd'],
+            ['saddr & ::ffff:ffff:ffff:ffff == @A6_mask_group']
         ]
 
         self.verify_nftables(nftables_search, 'ip6 vyos_filter')


### PR DESCRIPTION
Add support for arbitrary netmasks on source/destination addresses in firewall rules. This is particularly useful with DHCPv6-PD when the delegated prefix changes periodically.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
netfilter (and iptables) support using binary/bitwise operations to apply arbitrary netmasks to addresses but VyOS currently lacks a means of configuring this. This change adds support for arbitrary netmasks on `source` and `destination` addresses in firewall rules.

Arbitrary netmasks are particularly useful with IPv6. Coupled with a zone-based firewall, systems can be configured with a static IPv6 suffix (using IPv6 tokens, SLAAC, ect) and rules can be created to specifically match that suffix (ignoring the prefix entirely). The firewall rules then do not need to be updated if the prefix changes (by DHCPv6-PD, for example).

Arbirtary netmasks on IPv4 addresses are less useful, though since netfilter supports them, IPv4 support was added as well.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4612

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* firewall

## Proposed changes
<!--- Describe your changes in detail -->
Add `address-mask` field to `source` and `destination` in IPv4 and IPv6 firewall rules to allow masks to be defined.

Adjust `python/vyos/firewall.py` to output `& [mask] == [addr]` arbitrary netmask `nftables` syntax (see examples [here](https://lore.kernel.org/netfilter-devel/20210302143010.3362-1-phil@nwl.cc/) if `address-mask` is defined.

Example configurations:

    # Match any IPv6 address with the suffix ::0000:0000:0000:beef
    set firewall ipv6-name WAN-LAN-v6 rule 100 destination address ::beef
    set firewall ipv6-name WAN-LAN-v6 rule 100 destination address-mask ::ffff:ffff:ffff:ffff
    # Match any IPv4 address with `11` as the 2nd octet and `13` as the forth octet
    set firewall name WAN-LAN-v4 rule 100 destination address 0.11.0.13
    set firewall name WAN-LAN-v4 rule 100 destination address-mask 0.255.0.255
    # Address groups & ranges supported as well
    set firewall group ipv6-address-group WEBSERVERS address ::1000-1010
    set firewall group ipv6-address-group WEBSERVERS address ::2000
    set firewall name WAN-LAN-v6 rule 200 source group address-group WEBSERVERS
    set firewall name WAN-LAN-v6 rule 200 source address-mask ::ffff:ffff:ffff:ffff

## How to test
Testing was done with a few VMs and a VyOS VM between them as outlined below. Additionally, the firewall Smoketests all pass.

#### VyOS Configuration

    set interfaces ethernet eth1 address 192.168.1.1/24
    set interfaces ethernet eth1 address fd11::1/64
    set interfaces ethernet eth2 address 192.168.2.1/24
    set interfaces ethernet eth2 address fd22::1/64

    set firewall group address-group WEBSERVERS4 address 0.0.0.200
    set firewall group ipv6-address-group WEBSERVERS6 address ::f00d
    
    # IPv6
    set firewall ipv6-name ETH1-IN6 default-action drop
    set firewall ipv6-name ETH1-IN6 rule 10 action accept
    set firewall ipv6-name ETH1-IN6 rule 10 state established enable
    set firewall ipv6-name ETH1-IN6 rule 50 action accept
    set firewall ipv6-name ETH1-IN6 rule 50 destination group address-group WEBSERVERS6
    set firewall ipv6-name ETH1-IN6 rule 50 destination address-mask ::ffff:ffff:ffff:ffff
    set firewall ipv6-name ETH1-IN6 rule 50 destination port 8888
    set firewall ipv6-name ETH1-IN6 rule 50 protocol tcp
    set firewall ipv6-name ETH1-IN6 rule 60 action accept
    set firewall ipv6-name ETH1-IN6 rule 60 destination address ::ffff:0-::ffff:ffff
    set firewall ipv6-name ETH1-IN6 rule 60 destination address-mask ::ffff:ffff:ffff:ffff
    set firewall ipv6-name ETH1-IN6 rule 100 action accept
    set firewall ipv6-name ETH1-IN6 rule 100 destination address ::dead
    set firewall ipv6-name ETH1-IN6 rule 100 destination address-mask ::ffff:ffff:ffff:ffff
    set firewall ipv6-name ETH1-IN6 rule 200 action accept
    set firewall ipv6-name ETH1-IN6 rule 200 source address ::beef
    set firewall ipv6-name ETH1-IN6 rule 200 source address-mask ::ffff:ffff:ffff:ffff
    set firewall interface eth1 in ipv6-name ETH1-IN6

    # IPv4
    set firewall name ETH1-IN4 default-action drop
    set firewall name ETH1-IN4 rule 10 action accept
    set firewall name ETH1-IN4 rule 10 state established enable
    set firewall name ETH1-IN4 rule 50 action accept
    set firewall name ETH1-IN4 rule 50 destination group address-group WEBSERVERS4
    set firewall name ETH1-IN4 rule 50 destination address-mask 0.0.0.255
    set firewall name ETH1-IN4 rule 50 destination port 8888
    set firewall name ETH1-IN4 rule 50 protocol tcp
    set firewall name ETH1-IN4 rule 60 action accept
    set firewall name ETH1-IN4 rule 60 destination address 0.0.0.140-0.0.0.160
    set firewall name ETH1-IN4 rule 60 destination address-mask 0.0.0.255
    set firewall name ETH1-IN4 rule 100 action accept
    set firewall name ETH1-IN4 rule 100 destination address 0.0.0.101
    set firewall name ETH1-IN4 rule 100 destination address-mask 0.0.0.255
    set firewall name ETH1-IN4 rule 200 action accept
    set firewall name ETH1-IN4 rule 200 source address 0.0.0.101
    set firewall name ETH1-IN4 rule 200 source address-mask 0.0.0.255
    set firewall interface eth1 in name ETH1-IN4

#### Client B (Target, Connected to eth2)

    ip addr add 192.168.2.100/24 dev ens33
    ip addr add 192.168.2.101/24 dev ens33
    ip addr add 192.168.2.200/24 dev ens33
    ip addr add 192.168.2.150/24 dev ens33
    ip addr add fd22::1:dead/64 dev ens33
    ip addr add fd22::dead/64 dev ens33
    ip addr add fd22::f00d/64 dev ens33
    ip addr add fd22::ffff:dead dev ens33
    ip route add 192.168.1.0/24 via 192.168.2.1
    ip route add fd11::/64 via fd22::1
    python3 -m http.server --bind :: 8888
    
#### Client A (Connected to eth1)

    ip addr add 192.168.1.100/24 dev ens33
    ip addr add 192.168.1.101/24 dev ens33
    ip addr add fd11::1:beef/64 dev ens33
    ip addr add fd11::beef/64 dev ens33
    ip route add 192.168.2.0/24 via 192.168.1.1
    ip route add fd22::/64 via fd11::1
    
    # Connections *from* .100 and ::1:beef should be *blocked* (default-action)
    ping -I 192.168.1.100 192.168.2.200
    ping -I fd11::1:beef fd22::f00d

    # Connections *from* .101 and ::beef should be *allowed* (rule 200)
    ping -I 192.168.1.101 192.168.2.200
    ping -I fd11::beef fd22::f00d
    
    # Connections *to* .100 and ::1:dead should be *blocked* (rule default-action)
    ping -I 192.168.1.100 192.168.2.100
    ping -I fd11::1:beef fd22::1:dead

    # Connections *to* .101 and ::dead should be *allowed* (rule 100)
    ping -I 192.168.1.100 192.168.2.101
    ping -I fd11::1:beef fd22::dead

    # Address groups & ranges should work too (rule 50 & rule 60)
    wget --bind-address fd11::1:beef http://[fd22::f00d]:8888
    wget --bind-address 192.168.1.100 http://192.168.2.200:8888
    ping -I 192.168.1.100 192.168.2.150
    ping -I fd11::1:beef fd22::ffff:dead

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
