### PR TITLE
T4789: Ability to get op-mode raw data for PPPoE L2TP SSTP IPoE

### DIFF
--- a/data/op-mode-standardized.json
+++ b/data/op-mode-standardized.json
@@ -1,4 +1,5 @@
 [
+"accelppp.py",
 "bgp.py",
 "bridge.py",
 "conntrack.py",

--- a/python/vyos/accel_ppp.py
+++ b/python/vyos/accel_ppp.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import sys
+
+import vyos.opmode
+from vyos.util import rc_cmd
+
+
+def get_server_statistics(accel_statistics, pattern, sep=':') -> dict:
+    import re
+
+    stat_dict = {'sessions': {}}
+
+    cpu = re.search(r'cpu(.*)', accel_statistics).group(0)
+    # Find all lines with pattern, for example 'sstp:'
+    data = re.search(rf'{pattern}(.*)', accel_statistics, re.DOTALL).group(0)
+    session_starting = re.search(r'starting(.*)', data).group(0)
+    session_active = re.search(r'active(.*)', data).group(0)
+
+    for entry in {cpu, session_starting, session_active}:
+        if sep in entry:
+            key, value = entry.split(sep)
+            if key in ['starting', 'active', 'finishing']:
+                stat_dict['sessions'][key] = value.strip()
+                continue
+            stat_dict[key] = value.strip()
+    return stat_dict
+
+
+def accel_cmd(port: int, command: str) -> str:
+    _, output = rc_cmd(f'/usr/bin/accel-cmd -p{port} {command}')
+    return output
+
+
+def accel_out_parse(accel_output: list[str]) -> list[dict[str, str]]:
+    """ Parse accel-cmd show sessions output """
+    data_list: list[dict[str, str]] = list()
+    field_names: list[str] = list()
+
+    field_names_unstripped: list[str] = accel_output.pop(0).split('|')
+    for field_name in field_names_unstripped:
+        field_names.append(field_name.strip())
+
+    while accel_output:
+        if '|' not in accel_output[0]:
+            accel_output.pop(0)
+            continue
+
+        current_item: list[str] = accel_output.pop(0).split('|')
+        item_dict: dict[str, str] = {}
+
+        for field_index in range(len(current_item)):
+            field_name: str = field_names[field_index]
+            field_value: str = current_item[field_index].strip()
+            item_dict[field_name] = field_value
+
+        data_list.append(item_dict)
+
+    return data_list

--- a/src/op_mode/accelppp.py
+++ b/src/op_mode/accelppp.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import sys
+
+import vyos.accel_ppp
+import vyos.opmode
+
+from vyos.configquery import ConfigTreeQuery
+from vyos.util import rc_cmd
+
+
+accel_dict = {
+    'ipoe': {
+        'port': 2002,
+        'path': 'service ipoe-server'
+    },
+    'pppoe': {
+        'port': 2001,
+        'path': 'service pppoe-server'
+    },
+    'pptp': {
+        'port': 2003,
+        'path': 'vpn pptp'
+    },
+    'l2tp': {
+        'port': 2004,
+        'path': 'vpn l2tp'
+    },
+    'sstp': {
+        'port': 2005,
+        'path': 'vpn sstp'
+    }
+}
+
+
+def _get_raw_statistics(accel_output, pattern):
+    return vyos.accel_ppp.get_server_statistics(accel_output, pattern, sep=':')
+
+
+def _get_raw_sessions(port):
+    cmd_options = 'show sessions ifname,username,ip,ip6,ip6-dp,type,state,' \
+                  'uptime-raw,calling-sid,called-sid,sid,comp,rx-bytes-raw,' \
+                  'tx-bytes-raw,rx-pkts,tx-pkts'
+    output = vyos.accel_ppp.accel_cmd(port, cmd_options)
+    parsed_data: list[dict[str, str]] = vyos.accel_ppp.accel_out_parse(
+        output.splitlines())
+    return parsed_data
+
+
+def _verify(func):
+    """Decorator checks if accel-ppp protocol
+    ipoe/pppoe/pptp/l2tp/sstp is configured
+
+    for example:
+        service ipoe-server
+        vpn sstp
+    """
+    from functools import wraps
+
+    @wraps(func)
+    def _wrapper(*args, **kwargs):
+        config = ConfigTreeQuery()
+        protocol_list = accel_dict.keys()
+        protocol = kwargs.get('protocol')
+        # unknown or incorrect protocol query
+        if protocol not in protocol_list:
+            unconf_message = f'unknown protocol "{protocol}"'
+            raise vyos.opmode.UnconfiguredSubsystem(unconf_message)
+        # Check if config does not exist
+        config_protocol_path = accel_dict[protocol]['path']
+        if not config.exists(config_protocol_path):
+            unconf_message = f'"{config_protocol_path}" is not configured'
+            raise vyos.opmode.UnconfiguredSubsystem(unconf_message)
+        return func(*args, **kwargs)
+
+    return _wrapper
+
+
+@_verify
+def show_statistics(raw: bool, protocol: str):
+    """show accel-cmd statistics
+    CPU utilization and amount of sessions
+
+    protocol: ipoe/pppoe/ppptp/l2tp/sstp
+    """
+    pattern = f'{protocol}:'
+    port = accel_dict[protocol]['port']
+    rc, output = rc_cmd(f'/usr/bin/accel-cmd -p {port} show stat')
+
+    if raw:
+        return _get_raw_statistics(output, pattern)
+
+    return output
+
+
+@_verify
+def show_sessions(raw: bool, protocol: str):
+    """show accel-cmd sessions
+
+    protocol: ipoe/pppoe/ppptp/l2tp/sstp
+    """
+    port = accel_dict[protocol]['port']
+    if raw:
+        return _get_raw_sessions(port)
+
+    return vyos.accel_ppp.accel_cmd(port,
+                                    'show sessions ifname,username,ip,ip6,ip6-dp,'
+                                    'calling-sid,rate-limit,state,uptime,rx-bytes,tx-bytes')
+
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except (ValueError, vyos.opmode.Error) as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION
Ability to get 'raw' data sessions and statistics for accel-ppp protocols IPoE/PPPoE/L2TP/PPTP/SSTP server

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4789

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
l2tp, sstp, pptp, ipoe-server, pppoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set service pppoe-server access-concentrator 'ACN'
set service pppoe-server authentication local-users username userone password 'bar'
set service pppoe-server authentication mode 'local'
set service pppoe-server gateway-address '100.64.40.1'
set service pppoe-server interface eth1
set vpn sstp authentication local-users username bar password 'bar'
set vpn sstp authentication local-users username baz password 'bar'
set vpn sstp authentication local-users username foo password 'bar'
set vpn sstp authentication mode 'local'
set vpn sstp client-ip-pool subnet '100.64.0.0/24'
set vpn sstp client-ipv6-pool prefix 2001:db8::/48
set vpn sstp gateway-address '192.168.122.14'
set vpn sstp ssl ca-certificate 'ca'
set vpn sstp ssl certificate 'server'

```
get session and statistics:
```
vyos@r14:~$ /usr/libexec/vyos/op_mode/accelppp.py show_sessions --protocol sstp 
ifname | username |     ip     | ip6 | ip6-dp | calling-sid | rate-limit | state  |  uptime  | rx-bytes | tx-bytes 
--------+----------+------------+-----+--------+-------------+------------+--------+----------+----------+----------
 sstp0  | baz      | 100.64.0.0 |     |        | 10.0.3.2    |            | active | 02:35:08 | 687 B    | 409 B    
 sstp1  | bar      | 100.64.0.1 |     |        | 10.0.2.2    |            | active | 02:35:08 | 687 B    | 409 B    
 sstp2  | foo      | 100.64.0.2 |     |        | 10.0.1.2    |            | active | 02:35:08 | 687 B    | 409 B
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ /usr/libexec/vyos/op_mode/accelppp.py show_sessions --protocol sstp --raw
[
    {
        "ifname": "sstp0",
        "username": "baz",
        "ip": "100.64.0.0",
        "ip6": "",
        "ip6_dp": "",
        "type": "sstp",
        "state": "active",
        "uptime_raw": "9327",
        "calling_sid": "10.0.3.2",
        "called_sid": "203.0.113.1",
        "sid": "9524156d293dbed2",
        "comp": "",
        "rx_bytes_raw": "687",
        "tx_bytes_raw": "409",
        "rx_pkts": "22",
        "tx_pkts": "14"
    },
    {
        "ifname": "sstp1",
        "username": "bar",
        "ip": "100.64.0.1",
        "ip6": "",
        "ip6_dp": "",
        "type": "sstp",
        "state": "active",
        "uptime_raw": "9327",
        "calling_sid": "10.0.2.2",
        "called_sid": "203.0.113.1",
        "sid": "9524156d293dbed3",
        "comp": "",
        "rx_bytes_raw": "687",
        "tx_bytes_raw": "409",
        "rx_pkts": "22",
        "tx_pkts": "14"
    },
    {
        "ifname": "sstp2",
        "username": "foo",
        "ip": "100.64.0.2",
        "ip6": "",
        "ip6_dp": "",
        "type": "sstp",
        "state": "active",
        "uptime_raw": "9327",
        "calling_sid": "10.0.1.2",
        "called_sid": "203.0.113.1",
        "sid": "9524156d293dbed4",
        "comp": "",
        "rx_bytes_raw": "687",
        "tx_bytes_raw": "409",
        "rx_pkts": "22",
        "tx_pkts": "14"
    }
]
vyos@r14:~$ 



vyos@r14:~$ /usr/libexec/vyos/op_mode/accelppp.py show_statistics --protocol sstp --raw
{
    "sessions": {
        "starting": "0",
        "active": "3"
    },
    "cpu": "0%"
}
vyos@r14:~$
```
Unconfigured protocol:
```
vyos@r14:~$ /usr/libexec/vyos/op_mode/accelppp.py show_statistics --protocol pptp 
"vpn pptp" is not configured
vyos@r14:~$ 
```
Unknown protocol:
```
vyos@r14:~$ /usr/libexec/vyos/op_mode/accelppp.py show_statistics --protocol fooproto --raw
unknown protocol "fooproto"
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
