### PR TITLE
T4790: Added check of the sum of radius timeouts

### DIFF
--- a/src/conf_mode/system-login.py
+++ b/src/conf_mode/system-login.py
@@ -43,6 +43,11 @@ airbag.enable()
 autologout_file = "/etc/profile.d/autologout.sh"
 radius_config_file = "/etc/pam_radius_auth.conf"
 
+# LOGIN_TIMEOUT from /etc/loign.defs minus 10 sec
+MAX_RADIUS_TIMEOUT: int = 50
+# MAX_RADIUS_TIMEOUT divided by 2 sec (minimum recomended timeout)
+MAX_RADIUS_COUNT: int = 25
+
 def get_local_users():
     """Return list of dynamically allocated users (see Debian Policy Manual)"""
     local_users = []
@@ -118,17 +123,26 @@ def verify(login):
     if 'radius' in login:
         if 'server' not in login['radius']:
             raise ConfigError('No RADIUS server defined!')
-
+        sum_timeout: int = 0
+        radius_servers_count: int = 0
         fail = True
         for server, server_config in dict_search('radius.server', login).items():
             if 'key' not in server_config:
                 raise ConfigError(f'RADIUS server "{server}" requires key!')
-
-            if 'disabled' not in server_config:
+            if 'disable' not in server_config:
+                sum_timeout += int(server_config['timeout'])
+                radius_servers_count += 1
                 fail = False
-                continue
+
         if fail:
             raise ConfigError('All RADIUS servers are disabled')
+
+        if radius_servers_count > MAX_RADIUS_COUNT:
+            raise ConfigError('Number of RADIUS servers more than 25 ')
+
+        if sum_timeout > MAX_RADIUS_TIMEOUT:
+            raise ConfigError('Sum of RADIUS servers timeouts '
+                              'has to be less or eq 50 sec')
 
         verify_vrf(login['radius'])
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added check of the sum of login radius timeouts.
It has to be less or eq 50 sec.
Added check of a number of login radius servers.
It has to be less or eq 25
Otherwise, log in to the device can be discarded.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4790

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
system login radius

## Proposed changes
<!--- Describe your changes in detail -->
If the timeout is more than 60 sec then login can be discarded.
On 1.4 login works but only after waiting 3 minutes 
On 1.3 login was discarded

Added check in commit on the sum of login radius timeouts
It has to be less or eq 50 sec.
Added check of a number of login radius servers.
It has to be less or eq 25
```
vyos@vyos# set system login radius server 10.10.10.10 key test
[edit]
vyos@vyos# set system login radius server 10.10.10.11 key test
[edit]
vyos@vyos# set system login radius server 10.10.10.11 timeout 30
[edit]
vyos@vyos# set system login radius server 10.10.10.10 timeout 21
[edit]
vyos@vyos# commit
[ system login ]
Sum of RADIUS servers timeouts has to be less er eq 50 sec

[[system login]] failed
Commit failed
[edit]

```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
