### PR TITLE
T4810: fix show/monitor log of pppoe interface

### DIFF
--- a/op-mode-definitions/monitor-log.xml.in
+++ b/op-mode-definitions/monitor-log.xml.in
@@ -118,7 +118,7 @@
                     <script>${vyos_completion_dir}/list_interfaces.py -t pppoe</script>
                   </completionHelp>
                 </properties>
-                <command>journalctl --no-hostname --boot --follow --unit "ppp@$6.service"</command>
+                <command>journalctl --no-hostname --boot --follow --unit "ppp@$5.service"</command>
               </tagNode>
             </children>
           </node>

--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -267,7 +267,7 @@
                     <script>${vyos_completion_dir}/list_interfaces.py -t pppoe</script>
                   </completionHelp>
                 </properties>
-                <command>journalctl --no-hostname --boot --unit "ppp@$6.service"</command>
+                <command>journalctl --no-hostname --boot --unit "ppp@$5.service"</command>
               </tagNode>
             </children>
           </node>


### PR DESCRIPTION
## Change Summary

Fixes the op-mode command of `show log pppoe interface <interface>` and `monitor log pppoe interface <interface>`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T4810

## Component(s) name
op-mode

## Proposed changes

There is an off-by-one issue in the command template to show the logs for the appropriate pppoe interface. This PR fixes the off-by-one.

## How to test

Have a valid running pppoe interface on the system with some sort of configuration as such:
```
interfaces {
    pppoe pppoe0 {
        ...
    }
}
```
Try running `show log pppoe interface pppoe0` and validate logs are present.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
