### PR TITLE
migration: T4808: add details of configtree operations to migration log

### DIFF
--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -1,5 +1,5 @@
 # configtree -- a standalone VyOS config file manipulation library (Python bindings)
-# Copyright (C) 2018 VyOS maintainers and contributors
+# Copyright (C) 2018-2022 VyOS maintainers and contributors
 #
 # This library is free software; you can redistribute it and/or modify it under the terms of
 # the GNU Lesser General Public License as published by the Free Software Foundation;
@@ -12,6 +12,7 @@
 # You should have received a copy of the GNU Lesser General Public License along with this library;
 # if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
+import os
 import re
 import json
 
@@ -147,6 +148,8 @@ class ConfigTree(object):
             self.__config = address
             self.__version = ''
 
+        self.__migration = os.environ.get('VYOS_MIGRATION')
+
     def __del__(self):
         if self.__config is not None:
             self.__destroy(self.__config)
@@ -191,17 +194,26 @@ class ConfigTree(object):
             else:
                 self.__set_add_value(self.__config, path_str, str(value).encode())
 
+        if self.__migration:
+            print(f"- op: set path: {path} value: {value} replace: {replace}")
+
     def delete(self, path):
         check_path(path)
         path_str = " ".join(map(str, path)).encode()
 
         self.__delete(self.__config, path_str)
 
+        if self.__migration:
+            print(f"- op: delete path: {path}")
+
     def delete_value(self, path, value):
         check_path(path)
         path_str = " ".join(map(str, path)).encode()
 
         self.__delete_value(self.__config, path_str, value.encode())
+
+        if self.__migration:
+            print(f"- op: delete_value path: {path} value: {value}")
 
     def rename(self, path, new_name):
         check_path(path)
@@ -216,6 +228,9 @@ class ConfigTree(object):
         if (res != 0):
             raise ConfigTreeError("Path [{}] doesn't exist".format(path))
 
+        if self.__migration:
+            print(f"- op: rename old_path: {path} new_path: {new_path}")
+
     def copy(self, old_path, new_path):
         check_path(old_path)
         check_path(new_path)
@@ -228,6 +243,9 @@ class ConfigTree(object):
         res = self.__copy(self.__config, oldpath_str, newpath_str)
         if (res != 0):
             raise ConfigTreeError("Path [{}] doesn't exist".format(old_path))
+
+        if self.__migration:
+            print(f"- op: copy old_path: {old_path} new_path: {new_path}")
 
     def exists(self, path):
         check_path(path)

--- a/python/vyos/migrator.py
+++ b/python/vyos/migrator.py
@@ -137,6 +137,7 @@ class Migrator(object):
                 cfg_ver = next_ver
             rev_versions[key] = cfg_ver
 
+        del os.environ['VYOS_MIGRATION']
         return rev_versions
 
     def write_config_file_versions(self, cfg_versions):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This is an implementation of an idea of @sarthurdev :  Record the name/path/value of configtree operations (set, delete, delete_value, rename, copy) in the vyos-migrate.log file. Example output for syslog on migrtation 1.3.2 -> 1.4:
```
...
/opt/vyatta/etc/config-migrate/migrate/system/24-to-25
- op: set path: ['system', 'logs', 'logrotate', 'messages', 'rotate'] value: 10 replace: True
- op: set path: ['system', 'logs', 'logrotate', 'messages', 'max-size'] value: 1 replace: True
- op: delete path: ['system', 'syslog', 'global', 'archive']
...
```
This provides useful information for debugging and analysis, and may provide an approach to an open question regarding migration of configuration templates for a high-level API ([T2768](https://phabricator.vyos.net/T2768)).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4808

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
