### PR TITLE
backport: T4815: Fix various name server config issues

### DIFF
--- a/data/templates/pppoe/ip-down.script.tmpl
+++ b/data/templates/pppoe/ip-down.script.tmpl
@@ -33,6 +33,6 @@ vtysh -c "conf t" ${VRF_NAME} -c "no ipv6 route ::/0 {{ ifname }} ${VRF_NAME}"
 {% endif %}
 
 {% if dhcpv6_options is defined and dhcpv6_options.pd is defined %}
-# Stop wide dhcpv6 client
-systemctl stop dhcp6c@{{ ifname }}.service
+# Stop wide dhcpv6 client without blocking (by default the ip-down script can only run up to 5 seconds)
+systemctl stop --no-block dhcp6c@{{ ifname }}.service
 {% endif %}

--- a/debian/vyos-1x.postinst
+++ b/debian/vyos-1x.postinst
@@ -36,7 +36,7 @@ chsh -s /bin/sh proxy
 
 # Remove unwanted daemon files from /etc
 # conntackd
-DELETE="/etc/logrotate.d/conntrackd.distrib /etc/init.d/conntrackd /etc/default/conntrackd"
+DELETE="/etc/logrotate.d/conntrackd.distrib /etc/init.d/conntrackd /etc/default/conntrackd /etc/ppp/ip-up.d/0000usepeerdns /etc/ppp/ip-down.d/0000usepeerdns"
 for file in $DELETE; do
     if [ -f ${file} ]; then
         rm -f ${file}

--- a/src/etc/dhcp/dhclient-enter-hooks.d/04-vyos-resolvconf
+++ b/src/etc/dhcp/dhclient-enter-hooks.d/04-vyos-resolvconf
@@ -33,8 +33,8 @@ if /usr/bin/systemctl -q is-active vyos-hostsd; then
         if [ -n "$new_dhcp6_name_servers" ]; then
             logmsg info "Deleting nameservers with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
             $hostsd_client --delete-name-servers --tag "dhcpv6-$interface"
-            logmsg info "Adding nameservers \"$new_dhcpv6_name_servers\" with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
-            $hostsd_client --add-name-servers $new_dhcpv6_name_servers --tag "dhcpv6-$interface"
+            logmsg info "Adding nameservers \"$new_dhcp6_name_servers\" with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
+            $hostsd_client --add-name-servers $new_dhcp6_name_servers --tag "dhcpv6-$interface"
             hostsd_changes=y
         fi
 

--- a/src/etc/dhcp/dhclient-exit-hooks.d/01-vyos-cleanup
+++ b/src/etc/dhcp/dhclient-exit-hooks.d/01-vyos-cleanup
@@ -8,7 +8,7 @@ hostsd_changes=
 /usr/bin/systemctl -q is-active vyos-hostsd
 hostsd_status=$?
 
-if [[ $reason =~ (EXPIRE|FAIL|RELEASE|STOP) ]]; then
+if [[ $reason =~ ^(EXPIRE|FAIL|RELEASE|STOP)$ ]]; then
     if [[ $hostsd_status -eq 0 ]]; then
         # delete search domains and nameservers via vyos-hostsd
         logmsg info "Deleting search domains with tag \"dhcp-$interface\" via vyos-hostsd-client"
@@ -96,7 +96,7 @@ if [[ $reason =~ (EXPIRE|FAIL|RELEASE|STOP) ]]; then
     fi
 fi
 
-if [[ $reason =~ (EXPIRE6|RELEASE6|STOP6) ]]; then
+if [[ $reason =~ ^(EXPIRE6|RELEASE6|STOP6)$ ]]; then
     if [[ $hostsd_status -eq 0 ]]; then
         # delete search domains and nameservers via vyos-hostsd
         logmsg info "Deleting search domains with tag \"dhcpv6-$interface\" via vyos-hostsd-client"

--- a/src/etc/dhcp/dhclient-exit-hooks.d/vyatta-dhclient-hook
+++ b/src/etc/dhcp/dhclient-exit-hooks.d/vyatta-dhclient-hook
@@ -8,12 +8,12 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation.
-# 
+#
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
-# 
+#
 # This code was originally developed by Vyatta, Inc.
 # Portions created by Vyatta are Copyright (C) 2006, 2007, 2008 Vyatta, Inc.
 # All Rights Reserved.
@@ -23,7 +23,7 @@
 RUN="yes"
 
 proto=""
-if [[ $reason =~ (REBOOT6|INIT6|EXPIRE6|RELEASE6|STOP6|INFORM6|BOUND6|REBIND6|DELEGATED6) ]]; then
+if [[ $reason =~ ^(REBOOT6|INIT6|EXPIRE6|RELEASE6|STOP6|INFORM6|BOUND6|REBIND6|DELEGATED6)$ ]]; then
         proto="v6"
 fi
 

--- a/src/etc/ppp/ip-down.d/98-vyos-pppoe-cleanup-nameservers
+++ b/src/etc/ppp/ip-down.d/98-vyos-pppoe-cleanup-nameservers
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+interface=$6
+if [ -z "$interface" ]; then
+    exit
+fi
+
+if ! /usr/bin/systemctl -q is-active vyos-hostsd; then
+    exit  # vyos-hostsd is not running
+fi
+
+hostsd_client="/usr/bin/vyos-hostsd-client"
+$hostsd_client --delete-name-servers --tag "dhcp-$interface"
+$hostsd_client --apply

--- a/src/etc/ppp/ip-up.d/98-vyos-pppoe-setup-nameservers
+++ b/src/etc/ppp/ip-up.d/98-vyos-pppoe-setup-nameservers
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+interface=$6
+if [ -z "$interface" ]; then
+    exit
+fi
+
+if ! /usr/bin/systemctl -q is-active vyos-hostsd; then
+    exit  # vyos-hostsd is not running
+fi
+
+hostsd_client="/usr/bin/vyos-hostsd-client"
+
+$hostsd_client --delete-name-servers --tag "dhcp-$interface"
+
+if [ "$USEPEERDNS" ] && [ -n "$DNS1" ]; then
+$hostsd_client --add-name-servers "$DNS1" --tag "dhcp-$interface"
+fi
+if [ "$USEPEERDNS" ] && [ -n "$DNS2" ]; then
+$hostsd_client --add-name-servers "$DNS2" --tag "dhcp-$interface"
+fi
+
+$hostsd_client --apply


### PR DESCRIPTION
This is a backport of https://github.com/vyos/vyos-1x/pull/1656.

Note I also changed `ip-down.script.tmpl` to not wait for `systemctl stop dhcp6c@$iface.service`, because that command is slow and pppd will kill the ip-down script if it times out.

I didn't see `ip-down.script.tmpl` or its equivalent in the 1.4 branch. Not sure if there is another mechanism to handle that functionality or it is missed.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4815

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
