### PR TITLE
firewall: T4821: correct calling of conf_mode script dependencies

### DIFF
--- a/python/vyos/configdep.py
+++ b/python/vyos/configdep.py
@@ -1,0 +1,65 @@
+# Copyright 2022 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from inspect import stack
+
+from vyos.util import load_as_module
+
+dependents = {}
+
+def canon_name(name: str) -> str:
+    return os.path.splitext(name)[0].replace('-', '_')
+
+def canon_name_of_path(path: str) -> str:
+    script = os.path.basename(path)
+    return canon_name(script)
+
+def caller_name() -> str:
+    return stack()[-1].filename
+
+def run_config_mode_script(script: str, config):
+    from vyos.defaults import directories
+
+    path = os.path.join(directories['conf_mode'], script)
+    name = canon_name(script)
+    mod = load_as_module(name, path)
+
+    config.set_level([])
+    try:
+        c = mod.get_config(config)
+        mod.verify(c)
+        mod.generate(c)
+        mod.apply(c)
+    except (VyOSError, ConfigError) as e:
+        raise ConfigError(repr(e))
+
+def def_closure(script: str, config):
+    def func_impl():
+        run_config_mode_script(script, config)
+    return func_impl
+
+def set_dependent(target: str, config):
+    k = canon_name_of_path(caller_name())
+    l = dependents.setdefault(k, [])
+    func = def_closure(target, config)
+    l.append(func)
+
+def call_dependents():
+    k = canon_name_of_path(caller_name())
+    l = dependents.get(k, [])
+    while l:
+        f = l.pop(0)
+        f()

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -1143,3 +1143,11 @@ def camel_to_snake_case(name: str) -> str:
     pattern = r'\d+|[A-Z]?[a-z]+|\W|[A-Z]{2,}(?=[A-Z][a-z]|\d|\W|$)'
     words = re.findall(pattern, name)
     return '_'.join(map(str.lower, words))
+
+def load_as_module(name: str, path: str):
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The current manner of calling dependent conf_mode scripts (nat.py, policy-route.py) from firewall.py does not work under vyos-configd, as the called scripts are not provided the correct Config object. This PR provides a bug fix for that case, and the outline of a solution to be generalized for T4820.

Note that the technique used here should be adopted in other scripts with caution, as multiple use requires certain safeguards to be in place first. One should prefer the general solution of T4820, if possible.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4821

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

firewall

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Run smoketest `test_nat.py` with vyos-configd.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
