### PR TITLE
IPsec: T4828: raise op-mode error on incorrect value

### DIFF
--- a/python/vyos/opmode.py
+++ b/python/vyos/opmode.py
@@ -45,6 +45,12 @@ class PermissionDenied(Error):
     """
     pass
 
+class IncorrectValue(Error):
+    """ Requested operation is valid, but an argument provided has an
+        incorrect value, preventing successful completion.
+    """
+    pass
+
 class InternalError(Error):
     """ Any situation when VyOS detects that it could not perform
         an operation correctly due to logic errors in its own code

--- a/src/services/api/graphql/session/errors/op_mode_errors.py
+++ b/src/services/api/graphql/session/errors/op_mode_errors.py
@@ -3,11 +3,13 @@
 op_mode_err_msg = {
     "UnconfiguredSubsystem": "subsystem is not configured or not running",
     "DataUnavailable": "data currently unavailable",
-    "PermissionDenied": "client does not have permission"
+    "PermissionDenied": "client does not have permission",
+    "IncorrectValue": "argument value is incorrect"
 }
 
 op_mode_err_code = {
     "UnconfiguredSubsystem": 2000,
     "DataUnavailable": 2001,
-    "PermissionDenied": 1003
+    "PermissionDenied": 1003,
+    "IncorrectValue": 1002
 }


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The function reset_peer was one of the early conversions to standardized op-mode, and as such, did not implement use of op-mode errors. Add the op-mode version of ValueError, and raise appropriate errors from the function.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4828

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
