### PR TITLE
T4830: nat66: fix how nat66 rules are written in nftables

### DIFF
--- a/python/vyos/nat.py
+++ b/python/vyos/nat.py
@@ -16,6 +16,8 @@
 
 from vyos.template import is_ip_network
 from vyos.util import dict_search_args
+from vyos.template import bracketize_ipv6
+
 
 def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
     output = []
@@ -69,6 +71,8 @@ def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
         else:
             translation_output.append('to')
             if addr:
+                if ipv6:
+                    addr = bracketize_ipv6(addr)
                 translation_output.append(addr)
 
         options = []

--- a/smoketest/scripts/cli/test_nat66.py
+++ b/smoketest/scripts/cli/test_nat66.py
@@ -136,7 +136,7 @@ class TestNAT66(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         nftables_search = [
-            ['iifname "eth1"', 'tcp dport 4545', 'ip6 saddr 2001:db8:2222::/64', 'tcp sport 8080', 'dnat to 2001:db8:1111::1:5555']
+            ['iifname "eth1"', 'tcp dport 4545', 'ip6 saddr 2001:db8:2222::/64', 'tcp sport 8080', 'dnat to [2001:db8:1111::1]:5555']
         ]
 
         self.verify_nftables(nftables_search, 'ip6 vyos_nat')
@@ -208,7 +208,7 @@ class TestNAT66(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         nftables_search = [
-            ['oifname "eth1"', 'ip6 saddr 2001:db8:2222::/64', 'tcp dport 9999', 'tcp sport 8080', 'snat to 2001:db8:1111::1:80']
+            ['oifname "eth1"', 'ip6 saddr 2001:db8:2222::/64', 'tcp dport 9999', 'tcp sport 8080', 'snat to [2001:db8:1111::1]:80']
         ]
 
         self.verify_nftables(nftables_search, 'ip6 vyos_nat')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix how nat66 rules are written in nftables

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4830

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat66

## Proposed changes
<!--- Describe your changes in detail -->


## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Smoketests:
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_nat.py
test_dnat (__main__.TestNAT) ... ok
test_dnat_negated_addresses (__main__.TestNAT) ... ok
test_dnat_without_translation_address (__main__.TestNAT) ... ok
test_nat_no_rules (__main__.TestNAT) ... ok
test_snat (__main__.TestNAT) ... ok
test_snat_groups (__main__.TestNAT) ... ok
test_snat_required_translation_address (__main__.TestNAT) ... 
Source NAT configuration error in rule 5: outbound-interface not
specified


Source NAT configuration error in rule 5: translation requires address
and/or port

ok
test_static_nat (__main__.TestNAT) ... ok

----------------------------------------------------------------------
Ran 8 tests in 10.770s

OK
vyos@vyos:~$ 
vyos@vyos:~$ 
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_nat66.py
test_destination_nat66 (__main__.TestNAT66) ... ok
test_destination_nat66_prefix (__main__.TestNAT66) ... ok
test_destination_nat66_protocol (__main__.TestNAT66) ... ok
test_destination_nat66_without_translation_address (__main__.TestNAT66) ... ok
test_nat66_no_rules (__main__.TestNAT66) ... ok
test_source_nat66 (__main__.TestNAT66) ... ok
test_source_nat66_address (__main__.TestNAT66) ... ok
test_source_nat66_protocol (__main__.TestNAT66) ... ok
test_source_nat66_required_translation_prefix (__main__.TestNAT66) ... 
Source NAT66 configuration error in rule 5: outbound-interface not
specified


Source NAT66 configuration error in rule 5: translation address not
specified

ok

----------------------------------------------------------------------
Ran 9 tests in 9.573s

OK
vyos@vyos:~$ 
```
Config example and nft rules:
```
vyos@vyos:~$ show config comm | grep nat66
set nat66 destination rule 10 destination address '2307:e4c0:3::85'
set nat66 destination rule 10 destination port '1522'
set nat66 destination rule 10 inbound-interface 'eth0'
set nat66 destination rule 10 protocol 'tcp'
set nat66 destination rule 10 translation address 'fc01::2'
set nat66 destination rule 10 translation port '2222'
set nat66 destination rule 20 destination address '2307:e4c0:3::85'
set nat66 destination rule 20 destination port '1522'
set nat66 destination rule 20 inbound-interface 'eth0'
set nat66 destination rule 20 protocol 'tcp'
set nat66 destination rule 20 translation address 'fc01:0:0:0:0:0:0:2'
set nat66 destination rule 20 translation port '2222'
set nat66 destination rule 30 destination address '2307:e4c0:3::85'
set nat66 destination rule 30 destination port '1522'
set nat66 destination rule 30 inbound-interface 'eth0'
set nat66 destination rule 30 protocol 'tcp'
set nat66 destination rule 30 translation address 'fc01::52:99'

vyos@vyos:~$ sudo nft -s list ruleset | grep NAT66
                iifname "eth0" ip6 daddr 2307:e4c0:3::85 tcp dport 1522 counter dnat to [fc01::2]:2222 comment "DST-NAT66-10"
                iifname "eth0" ip6 daddr 2307:e4c0:3::85 tcp dport 1522 counter dnat to [fc01::2]:2222 comment "DST-NAT66-20"
                iifname "eth0" ip6 daddr 2307:e4c0:3::85 tcp dport 1522 counter dnat to fc01::52:99 comment "DST-NAT66-30"
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
