### PR TITLE
T4827: Route-map state continue must be with action permit only

### DIFF
--- a/src/conf_mode/policy.py
+++ b/src/conf_mode/policy.py
@@ -167,6 +167,11 @@ def verify(policy):
                 continue
 
             for rule, rule_config in route_map_config['rule'].items():
+                # Action 'deny' cannot be used with "continue"
+                # FRR does not validate it T4827
+                if rule_config['action'] == 'deny' and 'continue' in rule_config:
+                    raise ConfigError(f'rule {rule} "continue" cannot be used with action deny!')
+
                 # Specified community-list must exist
                 tmp = dict_search('match.community.community_list',
                                   rule_config)


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

route-map action 'deny' cannot be used for "continue" as FRR does not validate it
```
r14(config)# route-map FOO permit 100
r14(config-route-map)# route-map FOO deny 50
r14(config-route-map)#  on-match goto 100
% Configuration failed.

Error type: validation
r14(config-route-map)#
```

As a result, the configuration loaded to FRR without any route-map at all


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4827

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
policy, route-map
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
vyos@r14# set policy route-map FOO rule 100 action permit
[edit]
vyos@r14# set policy route-map FOO rule 50 action 'deny'
[edit]
vyos@r14# set policy route-map FOO rule 50 continue '100'
[edit]
vyos@r14# 
[edit]
vyos@r14# commit
[ policy ]
rule 50 "continue" cannot be used with action deny!

[[policy]] failed
Commit failed
[edit]

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
