### PR TITLE
T4825: Add interface type veth

### DIFF
--- a/interface-definitions/interfaces-virtual-ethernet.xml.in
+++ b/interface-definitions/interfaces-virtual-ethernet.xml.in
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="interfaces">
+    <children>
+      <tagNode name="virtual-ethernet" owner="${vyos_conf_scripts_dir}/interfaces-virtual-ethernet.py">
+        <properties>
+          <help>Virtual Ethernet Interface (veth)</help>
+          <priority>300</priority>
+          <constraint>
+            <regex>veth[0-9]+</regex>
+          </constraint>
+          <constraintErrorMessage>Virutal Ethernet interface must be named vethN</constraintErrorMessage>
+          <valueHelp>
+            <format>vethN</format>
+            <description>Virtual Ethernet interface name</description>
+          </valueHelp>
+        </properties>
+        <children>
+          #include <include/interface/address-ipv4-ipv6-dhcp.xml.i>
+          #include <include/interface/description.xml.i>
+          #include <include/interface/disable.xml.i>
+          #include <include/interface/vrf.xml.i>
+          <leafNode name="peer-name">
+            <properties>
+              <help>Virtual ethernet peer interface name</help>
+              <constraint>
+                <regex>veth[0-9]+</regex>
+              </constraint>
+              <constraintErrorMessage>Virutal Ethernet interface must be named vethN</constraintErrorMessage>
+            </properties>
+          </leafNode>
+        </children>
+      </tagNode>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/python/vyos/ifconfig/__init__.py
+++ b/python/vyos/ifconfig/__init__.py
@@ -36,4 +36,5 @@ from vyos.ifconfig.tunnel import TunnelIf
 from vyos.ifconfig.wireless import WiFiIf
 from vyos.ifconfig.l2tpv3 import L2TPv3If
 from vyos.ifconfig.macsec import MACsecIf
+from vyos.ifconfig.veth import VethIf
 from vyos.ifconfig.wwan import WWANIf

--- a/python/vyos/ifconfig/veth.py
+++ b/python/vyos/ifconfig/veth.py
@@ -1,0 +1,54 @@
+# Copyright 2022 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+from vyos.ifconfig.interface import Interface
+
+
+@Interface.register
+class VethIf(Interface):
+    """
+    Abstraction of a Linux veth interface
+    """
+    iftype = 'veth'
+    definition = {
+        **Interface.definition,
+        **{
+            'section': 'virtual-ethernet',
+            'prefixes': ['veth', ],
+            'bridgeable': True,
+        },
+    }
+
+    def _create(self):
+        """
+        Create veth interface in OS kernel. Interface is administrative
+        down by default.
+        """
+        # check before create, as we have 2 veth interfaces in our CLI
+        # interface virtual-ethernet veth0 peer-name 'veth1'
+        # interface virtual-ethernet veth1 peer-name 'veth0'
+        #
+        # but iproute2 creates the pair with one command:
+        # ip link add vet0 type veth peer name veth1
+        if self.exists(self.config['peer_name']):
+            return
+
+        # create virtual-ethernet interface
+        cmd = 'ip link add {ifname} type {type}'.format(**self.config)
+        cmd += f' peer name {self.config["peer_name"]}'
+        self._cmd(cmd)
+
+        # interface is always A/D down. It needs to be enabled explicitly
+        self.set_admin_state('down')

--- a/smoketest/scripts/cli/test_interfaces_virtual_ethernet.py
+++ b/smoketest/scripts/cli/test_interfaces_virtual_ethernet.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+
+from vyos.ifconfig import Section
+from base_interfaces_test import BasicInterfaceTest
+
+class VEthInterfaceTest(BasicInterfaceTest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._test_dhcp = True
+        cls._base_path = ['interfaces', 'virtual-ethernet']
+
+        cls._options = {
+            'veth0': ['peer-name veth1'],
+            'veth1': ['peer-name veth0'],
+        }
+
+        cls._interfaces = list(cls._options)
+        # call base-classes classmethod
+        super(VEthInterfaceTest, cls).setUpClass()
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/src/conf_mode/interfaces-virtual-ethernet.py
+++ b/src/conf_mode/interfaces-virtual-ethernet.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from sys import exit
+
+from netifaces import interfaces
+from vyos import ConfigError
+from vyos import airbag
+from vyos.config import Config
+from vyos.configdict import get_interface_dict
+from vyos.configverify import verify_address
+from vyos.configverify import verify_bridge_delete
+from vyos.configverify import verify_vrf
+from vyos.ifconfig import VethIf
+
+airbag.enable()
+
+
+def get_config(config=None):
+    """
+    Retrive CLI config as dictionary. Dictionary can never be empty, as at
+    least the interface name will be added or a deleted flag
+    """
+    if config:
+        conf = config
+    else:
+        conf = Config()
+    base = ['interfaces', 'virtual-ethernet']
+    ifname, veth = get_interface_dict(conf, base)
+
+    veth_dict = conf.get_config_dict(base, key_mangling=('-', '_'),
+                                     get_first_key=True,
+                                     no_tag_node_value_mangle=True)
+    veth['config_dict'] = veth_dict
+
+    return veth
+
+
+def verify(veth):
+    if 'deleted' in veth:
+        verify_bridge_delete(veth)
+        return None
+
+    verify_vrf(veth)
+    verify_address(veth)
+
+    if 'peer_name' not in veth:
+        raise ConfigError(
+            f'Remote peer name must be set for \"{veth["ifname"]}\"!')
+
+    if veth['peer_name'] not in veth['config_dict'].keys():
+        raise ConfigError(
+            f'Interface \"{veth["peer_name"]}\" is not configured!')
+
+    return None
+
+
+def generate(peth):
+    return None
+
+
+def apply(veth):
+    # Check if the Veth interface already exists
+    if 'rebuild_required' in veth or 'deleted' in veth:
+        if veth['ifname'] in interfaces():
+            p = VethIf(veth['ifname'])
+            p.remove()
+
+    if 'deleted' not in veth:
+        p = VethIf(**veth)
+        p.update(veth)
+
+    return None
+
+
+if __name__ == '__main__':
+    try:
+        c = get_config()
+        verify(c)
+        generate(c)
+        apply(c)
+    except ConfigError as e:
+        print(e)
+        exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add interface type `veth` (Virtual ethernet)
One of the use cases it interconnects different vrf's and default vrf via a bridge of veth interfaces
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4825

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
interface, veth
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
connect  3 vrfs with default vrf in one network
```
set vrf name foo table '1010'
set vrf name bar table '1011'
set vrf name baz table '1012'

set interfaces virtual-ethernet veth0 peer-name 'veth1010'
set interfaces virtual-ethernet veth1 peer-name 'veth1011'
set interfaces virtual-ethernet veth2 peer-name 'veth1012'
set interfaces virtual-ethernet veth1010 address '10.0.0.10/24'
set interfaces virtual-ethernet veth1010 description 'vrf-foo'
set interfaces virtual-ethernet veth1010 peer-name 'veth0'
set interfaces virtual-ethernet veth1010 vrf 'foo'
set interfaces virtual-ethernet veth1011 address '10.0.0.11/24'
set interfaces virtual-ethernet veth1011 description 'vrf-bar'
set interfaces virtual-ethernet veth1011 peer-name 'veth1'
set interfaces virtual-ethernet veth1011 vrf 'bar'
set interfaces virtual-ethernet veth1012 address '10.0.0.12/24'
set interfaces virtual-ethernet veth1012 description 'vrf-baz'
set interfaces virtual-ethernet veth1012 peer-name 'veth2'
set interfaces virtual-ethernet veth1012 vrf 'baz'

set interfaces bridge br0 address '10.0.0.1/24'
set interfaces bridge br0 member interface veth0
set interfaces bridge br0 member interface veth1
set interfaces bridge br0 member interface veth2

```
Show interfaces:
```
vyos@r14:~$ show int
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
br0              10.0.0.1/24                       u/u  
eth0             192.168.122.14/24                 u/u  WAN
eth1             192.0.2.1/24                      u/u  
lo               127.0.0.1/8                       u/u  
                 ::1/128                                
veth0            -                                 u/u  
veth1            -                                 u/u  
veth2            -                                 u/u  
veth1010         10.0.0.10/24                      u/u  vrf-foo
veth1011         10.0.0.11/24                      u/u  vrf-bar
veth1012         10.0.0.12/24                      u/u  vrf-baz
vyos@r14:~$ 
```

From default vrf we can ping all others
```
vyos@r14:~$ ping 10.0.0.10 count 2
PING 10.0.0.10 (10.0.0.10) 56(84) bytes of data.
64 bytes from 10.0.0.10: icmp_seq=1 ttl=64 time=0.144 ms
64 bytes from 10.0.0.10: icmp_seq=2 ttl=64 time=0.066 ms

--- 10.0.0.10 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1013ms
rtt min/avg/max/mdev = 0.066/0.105/0.144/0.039 ms
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ ping 10.0.0.11 count 2
PING 10.0.0.11 (10.0.0.11) 56(84) bytes of data.
64 bytes from 10.0.0.11: icmp_seq=1 ttl=64 time=0.073 ms
64 bytes from 10.0.0.11: icmp_seq=2 ttl=64 time=0.080 ms

--- 10.0.0.11 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1060ms
rtt min/avg/max/mdev = 0.073/0.076/0.080/0.003 ms
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ ping 10.0.0.12 count 2
PING 10.0.0.12 (10.0.0.12) 56(84) bytes of data.
64 bytes from 10.0.0.12: icmp_seq=1 ttl=64 time=0.089 ms
64 bytes from 10.0.0.12: icmp_seq=2 ttl=64 time=0.077 ms

--- 10.0.0.12 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1005ms
rtt min/avg/max/mdev = 0.077/0.083/0.089/0.006 ms
vyos@r14:~$
```
Check bridges:
```
vyos@r14:~$ bridge link
132: veth0@veth1010: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 master br0 state forwarding priority 32 cost 100 
134: veth2@veth1012: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 master br0 state forwarding priority 32 cost 100 
136: veth1@veth1011: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 master br0 state forwarding priority 32 cost 100 
vyos@r14:~$ 
vyos@r14:~$ show bridge 
Bridge interface br0:
Member    State       MTU    Flags                            Prio
--------  ----------  -----  -------------------------------  ------
veth0     forwarding  1500   broadcast,multicast,up,lower_up  32
veth2     forwarding  1500   broadcast,multicast,up,lower_up  32
veth1     forwarding  1500   broadcast,multicast,up,lower_up  32

vyos@r14:~$ 

```
show vrf bindings:
```
vyos@r14:~$ show vrf 
Name    State    MAC address        Flags                     Interfaces
------  -------  -----------------  ------------------------  ------------
bar     up       92:07:3b:f4:79:06  noarp,master,up,lower_up  veth1011
baz     up       86:ce:c6:a8:bf:33  noarp,master,up,lower_up  veth1012
foo     up       9e:c2:bf:dd:29:3c  noarp,master,up,lower_up  veth1010
vyos@r14:~$ 
```
show routes
```
vyos@r14:~$ show ip route vrf all 
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

VRF bar:
C>* 10.0.0.0/24 is directly connected, veth1011, 00:13:52

VRF baz:
C>* 10.0.0.0/24 is directly connected, veth1012, 00:13:52

VRF default:
S>* 0.0.0.0/0 [1/0] via 192.168.122.1, eth0, weight 1, 05:28:55
C>* 10.0.0.0/24 is directly connected, br0, 00:13:51
C>* 192.0.2.0/24 is directly connected, eth1, 05:28:57
C>* 192.168.122.0/24 is directly connected, eth0, 05:28:57

VRF foo:
C>* 10.0.0.0/24 is directly connected, veth1010, 00:13:53
vyos@r14:~$ 
```
So we easy can configure also OSPF or BGP between vrf's

smoketest:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_virtual_ethernet.py
test_add_multiple_ip_addresses (__main__.VEthInterfaceTest) ... ok
test_add_single_ip_address (__main__.VEthInterfaceTest) ... ok
test_dhcp_disable_interface (__main__.VEthInterfaceTest) ... ok
test_dhcpv6_client_options (__main__.VEthInterfaceTest) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.VEthInterfaceTest) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.VEthInterfaceTest) ... skipped 'not supported'
test_interface_description (__main__.VEthInterfaceTest) ... ok
test_interface_disable (__main__.VEthInterfaceTest) ... ok
test_interface_ip_options (__main__.VEthInterfaceTest) ... skipped 'not supported'
test_interface_ipv6_options (__main__.VEthInterfaceTest) ... skipped 'not supported'
test_interface_mtu (__main__.VEthInterfaceTest) ... skipped 'not supported'
test_ipv6_link_local_address (__main__.VEthInterfaceTest) ... skipped 'not supported'
test_mtu_1200_no_ipv6_interface (__main__.VEthInterfaceTest) ... skipped 'not supported'
test_span_mirror (__main__.VEthInterfaceTest) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.VEthInterfaceTest) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.VEthInterfaceTest) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.VEthInterfaceTest) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.VEthInterfaceTest) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.VEthInterfaceTest) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.VEthInterfaceTest) ... skipped 'not supported'

----------------------------------------------------------------------
Ran 20 tests in 15.646s

OK (skipped=15)
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
