### PR TITLE
T4832: dhcp: Add IPv6-only dhcp option support (RFC 8925)

### DIFF
--- a/data/templates/dhcp-server/dhcpd.conf.j2
+++ b/data/templates/dhcp-server/dhcpd.conf.j2
@@ -22,6 +22,7 @@ ddns-update-style {{ 'interim' if dynamic_dns_update is vyos_defined else 'none'
 option rfc3442-static-route code 121 = array of integer 8;
 option windows-static-route code 249 = array of integer 8;
 option wpad-url code 252 = text;
+option rfc8925-ipv6-only-preferred code 108 = unsigned integer 32;
 
 # Vendor specific options - Ubiquiti Networks
 option space ubnt;
@@ -126,6 +127,9 @@ shared-network {{ network }} {
 {%                 endif %}
 {%                 if subnet_config.wins_server is vyos_defined %}
         option netbios-name-servers {{ subnet_config.wins_server | join(', ') }};
+{%                 endif %}
+{%                 if subnet_config.ipv6_only_preferred is vyos_defined %}
+        option rfc8925-ipv6-only-preferred {{ subnet_config.ipv6_only_preferred }};
 {%                 endif %}
 {%                 if subnet_config.static_route is vyos_defined %}
 {%                     set static_default_route = '' %}

--- a/interface-definitions/dhcp-server.xml.in
+++ b/interface-definitions/dhcp-server.xml.in
@@ -373,6 +373,19 @@
                       </leafNode>
                     </children>
                   </tagNode >
+                  <leafNode name="ipv6-only-preferred">
+                    <properties>
+                      <help>Disable IPv4 on IPv6 only hosts (RFC 8925)</help>
+                      <valueHelp>
+                        <format>u32</format>
+                        <description>Seconds</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-4294967295"/>
+                      </constraint>
+                      <constraintErrorMessage>Seconds must be between 0 and 4294967295 (49 days)</constraintErrorMessage>
+                    </properties>
+                  </leafNode>
                   <leafNode name="subnet-parameters">
                     <properties>
                       <help>Additional subnet parameters for DHCP server. You must use the syntax of dhcpd.conf in this text-field. Using this without proper knowledge may result in a crashed DHCP server. Check system log to look for errors.</help>

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -112,6 +112,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         bootfile_server = '192.0.2.1'
         wpad            = 'http://wpad.vyos.io/foo/bar'
         server_identifier = bootfile_server
+        ipv6_only_preferred = 300
 
         pool = base_path + ['shared-network-name', shared_net_name, 'subnet', subnet]
         # we use the first subnet IP address as default gateway
@@ -132,6 +133,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.cli_set(pool + ['server-identifier', server_identifier])
 
         self.cli_set(pool + ['static-route', '10.0.0.0/24', 'next-hop', '192.0.2.1'])
+        self.cli_set(pool + ['ipv6-only-preferred', ipv6_only_preferred])
 
         # check validate() - No DHCP address range or active static-mapping set
         with self.assertRaises(ConfigSessionError):
@@ -169,6 +171,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'max-lease-time 86400;', config)
         self.assertIn(f'range {range_0_start} {range_0_stop};', config)
         self.assertIn(f'set shared-networkname = "{shared_net_name}";', config)
+        self.assertIn(f'option rfc8925-ipv6-only-preferred {ipv6_only_preferred};', config)
 
         # weird syntax for those static routes
         self.assertIn(f'option rfc3442-static-route 24,10,0,0,192,0,2,1, 0,192,0,2,1;', config)


### PR DESCRIPTION
Clients supporting this DHCP option (DHCP option 108, RFC 8925) will disable its IPv4 network stack for configured number of seconds and operate in IPv6-only mode.

Clients supporting this option include iOS 15+ and macOS 12.0.1+.

Example command:
```sh
set service dhcp-server shared-network-name LAN6 subnet 192.168.64.0/24 ipv6-only-preferred 0
```

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4832

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
