### PR TITLE
IPsec: T4829: tunnel argument to 'reset_peer' should have type hint Optional

### DIFF
--- a/src/op_mode/ipsec.py
+++ b/src/op_mode/ipsec.py
@@ -22,6 +22,7 @@ from collections import OrderedDict
 from hurry import filesize
 from re import split as re_split
 from tabulate import tabulate
+from subprocess import TimeoutExpired
 
 from vyos.util import call
 from vyos.util import convert_data


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The logic in 'reset_peer' allows for the case of tunnel=None, interpreting it as 'return_all' tunnels, without the argument being optional (in the sense of type hints). This translates to the argument being non-optional (in the sense of Python args), hence required. Set type to Optional[str], and drop redundant arg 'return_all'.

Some clarification, quoted from the task:

Note that the type hint Optional does not _implicitly_ have anything to do with default values; it is a simply a shorthand for type Union[..., None], so that type None is allowed by type checking. However, the technique of 'introspection+type_hints' used by the opmode module, respectively, the schema generation functions of the HTTP-API, _explicitly_ translates the type hint Optional to provide the default argument '=None'. This allows args of type Optional to be not required for the CLI, and nullable in the API graphql schema.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4829

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
