### PR TITLE
T4823: Fix IPsec transport mode remote TS

### DIFF
--- a/data/templates/ipsec/swanctl/peer.j2
+++ b/data/templates/ipsec/swanctl/peer.j2
@@ -124,7 +124,7 @@
 {%             endif %}
 {%         elif tunnel_esp.mode == 'transport' %}
                 local_ts = {{ peer_conf.local_address }}{{ local_suffix }}
-                remote_ts = {{ peer }}{{ remote_suffix }}
+                remote_ts = {{ peer_conf.remote_address | join(",") }}{{ remote_suffix }}
 {%         endif %}
                 ipcomp = {{ 'yes' if tunnel_esp.compression is vyos_defined else 'no' }}
                 mode = {{ tunnel_esp.mode }}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Remote TS for transport mode GRE must be remote-address and not peer name

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4823

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vpn, ipsec
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set vpn ipsec esp-group ESP_GRP lifetime '7200'
set vpn ipsec esp-group ESP_GRP mode 'transport'
set vpn ipsec esp-group ESP_GRP pfs 'dh-group14'
set vpn ipsec esp-group ESP_GRP proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP_GRP proposal 1 hash 'sha256'
set vpn ipsec ike-group IKE_GRP dead-peer-detection action 'hold'
set vpn ipsec ike-group IKE_GRP key-exchange 'ikev2'
set vpn ipsec ike-group IKE_GRP lifetime '28800'
set vpn ipsec ike-group IKE_GRP proposal 1 dh-group '14'
set vpn ipsec ike-group IKE_GRP proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE_GRP proposal 1 hash 'sha256'
set vpn ipsec interface 'eth0'
set vpn ipsec site-to-site peer OFFICE authentication local-id '192.0.2.1'
set vpn ipsec site-to-site peer OFFICE authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer OFFICE authentication pre-shared-secret 'FooBarBaz'
set vpn ipsec site-to-site peer OFFICE authentication remote-id '192.0.2.2'
set vpn ipsec site-to-site peer OFFICE ike-group 'IKE_GRP'
set vpn ipsec site-to-site peer OFFICE local-address '192.0.2.1'
set vpn ipsec site-to-site peer OFFICE remote-address '192.0.2.2'
set vpn ipsec site-to-site peer OFFICE tunnel 0 esp-group 'ESP_GRP'
set vpn ipsec site-to-site peer OFFICE tunnel 0 protocol 'gre'
```
Before fix it generates a wrong `remote_ts = OFFICE[gre/]`
swanctl.conf
```
        children {
            OFFICE-tunnel-0 {
                esp_proposals = aes256-sha256-modp2048
                life_time = 7200s
                local_ts = 192.0.2.1[gre/]
                remote_ts = OFFICE[gre/]
```
After fix:
```
        children {
            OFFICE-tunnel-0 {
                esp_proposals = aes256-sha256-modp2048
                life_time = 7200s
                local_ts = 192.0.2.1[gre/]
                remote_ts = 192.0.2.2[gre/]
                ipcomp = no

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
