### PR TITLE
container: T4834: Limit network names to 11 characters (15 char max including "cni-" prefix)

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -272,6 +272,10 @@
       <tagNode name="network">
         <properties>
           <help>Network name</help>
+          <constraint>
+            <regex>[-_a-zA-Z0-9]{1,11}</regex>
+          </constraint>
+          <constraintErrorMessage>Network name cannot be longer than 11 characters</constraintErrorMessage>
         </properties>
         <children>
           <leafNode name="description">


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Limit container network names to 11 characters to prevent issue starting containers

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4834

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
containers

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
[edit]
vyos@vyos# set container network thisismorethan15chars prefix 172.16.0.0/24
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# sudo podman network ls
NETWORK ID    NAME                   DRIVER
2f259bab93aa  podman                 bridge
d8ef4c03d58a  thisismorethan15chars  bridge
[edit]
vyos@vyos# set container name busybox image busybox:stable
[edit]
vyos@vyos# set container name busybox network thisismorethan15chars address 172.16.0.5
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# sudo podman start busybox
WARN[0000] Failed to load cached network config: network thisismorethan15chars not found in CNI cache, falling back to loading network thisismorethan15chars from disk
Error: unable to start container "ad1397e0c623cc0322734f1fff90e421e4664c43ac42a0b0c978be73408de197": plugin type="bridge" failed (add): cni plugin bridge failed: failed to create bridge "cni-thisismorethan15chars": could not add "cni-thisismorethan15chars": numerical result out of range
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
