### PR TITLE
T4825: Verify if veth interface not used in conf before deleting

### DIFF
--- a/src/conf_mode/interfaces-virtual-ethernet.py
+++ b/src/conf_mode/interfaces-virtual-ethernet.py
@@ -53,6 +53,13 @@ def get_config(config=None):
 def verify(veth):
     if 'deleted' in veth:
         verify_bridge_delete(veth)
+        # Prevent to delete veth interface which used for another "vethX peer-name"
+        for iface, iface_config in veth['other_interfaces'].items():
+            if veth['ifname'] in iface_config['peer_name']:
+                ifname = veth['ifname']
+                raise ConfigError(
+                    f'Cannot delete "{ifname}" used for "interface {iface} peer-name"'
+                )
         return None
 
     verify_vrf(veth)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add verify check.
Prevent to delete interface `vethX` which used for another interface as `vethY peer-name vethX`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4825

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
interfaces, veth
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Expected raise error:
```
set interfaces virtual-ethernet veth0 peer-name 'veth1'
set interfaces virtual-ethernet veth1 peer-name 'veth0'
commit
delete interfaces virtual-ethernet veth0

vyos@r14# commit
[ interfaces virtual-ethernet veth0 ]
Cannot delete "veth0" used for "interface veth1 peer-name"

delete [ interfaces virtual-ethernet veth0 ] failed
Commit failed
[edit]
vyos@r14#
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
