### PR TITLE
ospf: T4739: Adding missing OSPF FRR template

### DIFF
--- a/data/templates/frr/ospfd.frr.j2
+++ b/data/templates/frr/ospfd.frr.j2
@@ -161,6 +161,12 @@ router ospf {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {% if parameters.abr_type is vyos_defined %}
  ospf abr-type {{ parameters.abr_type }}
 {% endif %}
+{% if parameters.opaque_lsa is vyos_defined %}
+ ospf opaque-lsa
+{% endif %}
+{% if parameters.rfc1583_compatibility is vyos_defined %}
+ ospf rfc1583compatibility
+{% endif %}
 {% if parameters.router_id is vyos_defined %}
  ospf router-id {{ parameters.router_id }}
 {% endif %}

--- a/smoketest/scripts/cli/test_protocols_ospf.py
+++ b/smoketest/scripts/cli/test_protocols_ospf.py
@@ -70,6 +70,8 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['auto-cost', 'reference-bandwidth', bandwidth])
         self.cli_set(base_path + ['parameters', 'router-id', router_id])
         self.cli_set(base_path + ['parameters', 'abr-type', abr_type])
+        self.cli_set(base_path + ['parameters', 'opaque-lsa'])
+        self.cli_set(base_path + ['parameters', 'rfc1583-compatibility'])
         self.cli_set(base_path + ['log-adjacency-changes', 'detail'])
         self.cli_set(base_path + ['default-metric', metric])
 
@@ -79,10 +81,12 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         # Verify FRR ospfd configuration
         frrconfig = self.getFRRconfig('router ospf')
         self.assertIn(f'router ospf', frrconfig)
+        self.assertIn(f' compatible rfc1583', frrconfig)
         self.assertIn(f' auto-cost reference-bandwidth {bandwidth}', frrconfig)
         self.assertIn(f' ospf router-id {router_id}', frrconfig)
         self.assertIn(f' ospf abr-type {abr_type}', frrconfig)
         self.assertIn(f' timers throttle spf 200 1000 10000', frrconfig) # defaults
+        self.assertIn(f' capability opaque', frrconfig)
         self.assertIn(f' default-metric {metric}', frrconfig)
 
 


### PR DESCRIPTION
Adding the parameters that were missing to the OSPF FRR template.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Adding configurations in the OSPF FRR Jinja2 template to fix the parameters that
were not properly being set into FRR when configured in the CLI.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4739

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ospf

## Proposed changes
<!--- Describe your changes in detail -->

I noticed that when I tried to configure Segment Routing for OSPF that the opaque LSA
capability was not being enabled. I figured out it was because of the OSPF FRR Jinja2
template not properly setting the configurations. Therefore I am fixing the template to
be able to set opaque LSA, and RFC 1583 compatibility.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Here it is normally.

```
vyos@vyos:~$ show configuration commands | match ospf
set protocols ospf parameters opaque-lsa
set protocols ospf parameters rfc1583-compatibility

vyos@vyos:~$ vtysh -c "show run"
Building configuration...

Current configuration:
!
frr version 8.3.1
frr defaults traditional
hostname vyos
log syslog
log facility local7
service integrated-vtysh-config
!
ip route 0.0.0.0/0 10.0.0.65
!
router ospf
 auto-cost reference-bandwidth 100
 timers throttle spf 200 1000 10000
exit
!
end
```

After making changes  to the OSPF FRR Jinja2 template:

```
vyos@vyos# compare
[edit protocols]
+ospf {
+    parameters {
+        opaque-lsa
+        rfc1583-compatibility
+    }
+}
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# exit
Warning: configuration changes have not been saved.
exit

vyos@vyos:~$ vtysh -c "show run"
Building configuration...

Current configuration:
!
frr version 8.3.1
frr defaults traditional
hostname vyos
log syslog
log facility local7
service integrated-vtysh-config
!
ip route 0.0.0.0/0 10.0.0.65
!
router ospf
 compatible rfc1583
 auto-cost reference-bandwidth 100
 timers throttle spf 200 1000 10000
 capability opaque
exit
!
end
```



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
