### PR TITLE
T4845: add smoketest to detect cycles in config-mode script dependency calls

### DIFF
--- a/data/config-mode-dependencies.json
+++ b/data/config-mode-dependencies.json
@@ -1,0 +1,1 @@
+{"firewall": {"group_resync": ["nat", "policy-route"]}}

--- a/smoketest/scripts/cli/test_dependency_graph.py
+++ b/smoketest/scripts/cli/test_dependency_graph.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import unittest
+from graphlib import TopologicalSorter, CycleError
+
+DEP_FILE = '/usr/share/vyos/config-mode-dependencies.json'
+
+def graph_from_dict(d):
+    g = {}
+    for k in list(d):
+        g[k] = set()
+        # add the dependencies for every sub-case; should there be cases
+        # that are mutally exclusive in the future, the graphs will be
+        # distinguished
+        for el in list(d[k]):
+            g[k] |= set(d[k][el])
+    return g
+
+class TestDependencyGraph(unittest.TestCase):
+    def setUp(self):
+        with open(DEP_FILE) as f:
+            dd = json.load(f)
+            self.dependency_graph = graph_from_dict(dd)
+
+    def test_cycles(self):
+        ts = TopologicalSorter(self.dependency_graph)
+        out = None
+        try:
+            # get node iterator
+            order = ts.static_order()
+            # try iteration
+            _ = [*order]
+        except CycleError as e:
+            out = e.args
+
+        self.assertIsNone(out)
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -26,7 +26,7 @@ from vyos.config import Config
 from vyos.configdict import dict_merge
 from vyos.configdict import node_changed
 from vyos.configdiff import get_config_diff, Diff
-from vyos.configdep import set_dependent, call_dependents
+from vyos.configdep import set_dependents, call_dependents
 # from vyos.configverify import verify_interface_exists
 from vyos.firewall import fqdn_config_parse
 from vyos.firewall import geoip_update
@@ -162,11 +162,8 @@ def get_config(config=None):
 
     firewall['group_resync'] = bool('group' in firewall or node_changed(conf, base + ['group']))
     if firewall['group_resync']:
-        # Update nat as firewall groups were updated
-        set_dependent(nat_conf_script, conf)
-        # Update policy route as firewall groups were updated
-        set_dependent(policy_route_conf_script, conf)
-
+        # Update nat and policy-route as firewall groups were updated
+        set_dependents('group_resync', conf)
 
     if 'config_trap' in firewall and firewall['config_trap'] == 'enable':
         diff = get_config_diff(conf)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

In order to support static analysis for a smoketest, the dict of config-mode script dependencies are moved to a file instead of being defined in place in the config-mode script. For example, the one case so far is for firewall.py (T4821), for which the entry in 'data/config-mode-dependencies.json' is:

{"firewall": {"group_resync": ["nat", "policy-route"]}}

Conditions ('group_resync') are being distinguished in use, but are merged in the smoketest, in order to consider the full graph of possible dependencies. Should there be cases of mutually exclusive conditions in the future, the smoketest will be extended.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe):
        Refactor to support smoketest.

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4845

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
