### PR TITLE
T4804: Add check for PPPoE server and use defaults values

### DIFF
--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -388,8 +388,10 @@ def verify_accel_ppp_base_service(config, local_users=True):
     """
     # vertify auth settings
     if local_users and dict_search('authentication.mode', config) == 'local':
-        if dict_search(f'authentication.local_users', config) == None:
-            raise ConfigError('Authentication mode local requires local users to be configured!')
+        if (dict_search(f'authentication.local_users', config) is None or
+                dict_search(f'authentication.local_users', config) == {}):
+            raise ConfigError(
+                'Authentication mode local requires local users to be configured!')
 
         for user in dict_search('authentication.local_users.username', config):
             user_config = config['authentication']['local_users']['username'][user]


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
We have XML default values but they not used for PPPoE server python script. Add default values.
Ignore default XML values if config doesn't exists

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4804

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoer-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add not full pppoe-server config
Before fix:
```
set service pppoe-server interface eth1
commit
vyos@r14# commit
[ service pppoe-server ]
VyOS had an issue completing a command.


Report time:      2022-11-07 18:25:11
Image version:    VyOS 1.4-rolling-202211010829
Release train:    current

Built by:         autobuild@vyos.net
Built on:         Tue 01 Nov 2022 08:29 UTC
Build UUID:       15370146-6844-4479-b4a6-b0d265eea441
Build commit ID:  64e77f12f66ce4

Architecture:     x86_64
Boot via:         installed image
System type:      KVM guest

Hardware vendor:  QEMU
Hardware model:   Standard PC (Q35 + ICH9, 2009)
Hardware S/N:     
Hardware UUID:    4d6f4d29-1ae8-446f-8d2b-3decd9da64c7

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/service_pppoe-server.py", line 103, in <module>
    verify(c)
  File "/usr/libexec/vyos/conf_mode/service_pppoe-server.py", line 52, in verify
    verify_accel_ppp_base_service(pppoe)
  File "/usr/lib/python3/dist-packages/vyos/configverify.py", line 394, in verify_accel_ppp_base_service
    for user in dict_search('authentication.local_users.username', config):
TypeError: 'NoneType' object is not iterable



[[service pppoe-server]] failed
```
After fix:
```
vyos@r1# set service pppoe-server interface eth0
[edit]
vyos@r1# commit
[ service pppoe-server ]
Authentication mode local requires local users to be configured!

[[service pppoe-server]] failed
Commit failed
[edit]
vyos@r1# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
