### PR TITLE
T4825: Verify if you are trying to add a new vethX to exists pair

### DIFF
--- a/src/conf_mode/interfaces-virtual-ethernet.py
+++ b/src/conf_mode/interfaces-virtual-ethernet.py
@@ -68,11 +68,20 @@ def verify(veth):
     if 'peer_name' not in veth:
         raise ConfigError(f'Remote peer name must be set for "{veth["ifname"]}"!')
 
+    peer_name = veth['peer_name']
+    ifname = veth['ifname']
+
     if veth['peer_name'] not in veth['other_interfaces']:
-        peer_name = veth['peer_name']
-        ifname = veth['ifname']
         raise ConfigError(f'Used peer-name "{peer_name}" on interface "{ifname}" ' \
                           'is not configured!')
+
+    if veth['other_interfaces'][peer_name]['peer_name'] != ifname:
+        raise ConfigError(
+            f'Configuration mismatch between "{ifname}" and "{peer_name}"!')
+
+    if peer_name == ifname:
+        raise ConfigError(
+            f'Peer-name "{peer_name}" cannot be the same as interface "{ifname}"!')
 
     return None
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Verify if you are trying to add a new vethX to exists pair:
Verify veth-name and peer-name cannot be the same:

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4825

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
virtual-ethernet, veth
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add interface name == peer-name
Expected RaiseConfigerror 
```
vyos@r1# commit
[ interfaces virtual-ethernet veth0 ]
Peer-name "veth0" cannot be the same as interface "veth0"!

[[interfaces virtual-ethernet veth0]] failed
Commit failed
```
Add interface veth-peer that already exists in another veth pair
Expected RaiseConfigError
```
vyos@r1# set interfaces virtual-ethernet veth0 peer-name 'veth1'
[edit]
vyos@r1# set interfaces virtual-ethernet veth1 peer-name 'veth0'
[edit]
vyos@r1# set interfaces virtual-ethernet veth12 peer-name 'veth0'
[edit]
vyos@r1# commit
[ interfaces virtual-ethernet veth12 ]
Configuration mismatch between "veth12" and "veth0"!

[[interfaces virtual-ethernet veth12]] failed
Commit failed
[edit]
vyos@r1# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
