### PR TITLE
http-api: T4859: correct calling of script dependencies from http-api.py

### DIFF
--- a/data/config-mode-dependencies.json
+++ b/data/config-mode-dependencies.json
@@ -1,5 +1,6 @@
 {
   "firewall": {"group_resync": ["nat", "policy-route"]},
+  "http_api": {"https": ["https"]},
   "pki": {
            "ethernet": ["interfaces-ethernet"],
            "openvpn": ["interfaces-openvpn"],

--- a/src/conf_mode/http-api.py
+++ b/src/conf_mode/http-api.py
@@ -25,6 +25,7 @@ import vyos.defaults
 
 from vyos.config import Config
 from vyos.configdict import dict_merge
+from vyos.configdep import set_dependents, call_dependents
 from vyos.template import render
 from vyos.util import cmd
 from vyos.util import call
@@ -60,6 +61,11 @@ def get_config(config=None):
         conf = config
     else:
         conf = Config()
+
+    # reset on creation/deletion of 'api' node
+    https_base = ['service', 'https']
+    if conf.exists(https_base):
+        set_dependents("https", conf)
 
     base = ['service', 'https', 'api']
     if not conf.exists(base):
@@ -132,7 +138,7 @@ def apply(http_api):
     # Let uvicorn settle before restarting Nginx
     sleep(1)
 
-    cmd(f'{vyos_conf_scripts_dir}/https.py', raising=ConfigError)
+    call_dependents()
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Final sub-task for T4820: use set/call_dependents for http-api.py. A simple application of the method used for firewall.py and pki.py.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4859

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

http-api

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
