### PR TITLE
T4848: Fix for default route vpn openconnect

### DIFF
--- a/src/conf_mode/vpn_openconnect.py
+++ b/src/conf_mode/vpn_openconnect.py
@@ -157,7 +157,7 @@ def verify(ocserv):
                 ocserv["network_settings"]["push_route"].remove("0.0.0.0/0")
                 ocserv["network_settings"]["push_route"].append("default")
         else:
-            ocserv["network_settings"]["push_route"] = "default"
+            ocserv["network_settings"]["push_route"] = ["default"]
     else:
         raise ConfigError('openconnect network settings required')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
`ocserv` template expects a list of routes but gets str "default" it cause wrong routes like:
Fix it
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4848

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openconnect, ocserv
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Vyos config:
```
set vpn openconnect authentication local-users username foo password 'bar'
set vpn openconnect authentication mode local 'password'
set vpn openconnect network-settings client-ip-settings subnet '192.0.2.0/24'
set vpn openconnect ssl ca-certificate 'ca'
set vpn openconnect ssl certificate 'server'
```
before fix:
```
vyos@r1# cat /run/ocserv/ocserv.conf | grep route
route = d
route = e
route = f
route = a
route = u
route = l
route = t
[edit]
vyos@r1# 
```
After fix:
```
vyos@r1# cat /run/ocserv/ocserv.conf | grep default
route = default
[edit]
vyos@r1# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
