### PR TITLE
T4860: Verify if mode in openconnect ocserv dict

### DIFF
--- a/src/conf_mode/vpn_openconnect.py
+++ b/src/conf_mode/vpn_openconnect.py
@@ -58,7 +58,7 @@ def get_config():
     default_values = defaults(base)
     ocserv = dict_merge(default_values, ocserv)
 
-    if "local" in ocserv["authentication"]["mode"]:
+    if 'mode' in ocserv["authentication"] and "local" in ocserv["authentication"]["mode"]:
         # workaround a "know limitation" - https://phabricator.vyos.net/T2665
         del ocserv['authentication']['local_users']['username']['otp']
         if not ocserv["authentication"]["local_users"]["username"]:


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
openconnect authentication mode must be set
check dict that 'mode' exists in openconnect authentication
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4860

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openconnect, ocserv
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Set incomplate config:
```
set vpn openconnect authentication local-users username foo password bar
commit
```
Before fix:
```
vyos@r1# commit
[ vpn openconnect ]
VyOS had an issue completing a command.

Report time:      2022-12-04 10:03:25
Image version:    VyOS 1.4-rolling-202211260318
Release train:    current

Built by:         autobuild@vyos.net
Built on:         Sat 26 Nov 2022 03:18 UTC
Build UUID:       b1a6eb3f-41f5-4731-a4be-bc332bea4b69
Build commit ID:  ef7d02b09c49b4

Architecture:     x86_64
Boot via:         installed image
System type:      KVM guest

Hardware vendor:  QEMU
Hardware model:   Standard PC (i440FX + PIIX, 1996)
Hardware S/N:     
Hardware UUID:    4f036c37-d678-4725-8222-8eb52d9ceae9

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/vpn_openconnect.py", line 265, in <module>
    c = get_config()
  File "/usr/libexec/vyos/conf_mode/vpn_openconnect.py", line 61, in get_config
    if "local" in ocserv["authentication"]["mode"]:
KeyError: 'mode'



[[vpn openconnect]] failed
Commit failed
[edit]
vyos@r1#
```
Aftre fix:
```
vyos@r1# commit
[ vpn openconnect ]
openconnect authentication mode required

[[vpn openconnect]] failed
Commit failed
[edit]
vyos@r1# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
