### PR TITLE
T4862: Added the generation config for webproxy domain-block

### DIFF
--- a/data/templates/squid/squid.conf.j2
+++ b/data/templates/squid/squid.conf.j2
@@ -24,7 +24,12 @@ acl Safe_ports port {{ port }}
 {%     endfor %}
 {% endif %}
 acl CONNECT method CONNECT
-
+{% if domain_block is vyos_defined %}
+{%     for domain in domain_block %}
+acl BLOCKDOMAIN dstdomain {{ domain }}
+{%     endfor %}
+http_access deny BLOCKDOMAIN
+{% endif %}
 {% if authentication is vyos_defined %}
 {%     if authentication.children is vyos_defined %}
 auth_param basic children {{ authentication.children }}


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added the generation in the config file /etc/squid/squid.conf
for command: set service webroxy  domain-block <domain>
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4862

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
webproxy

## Proposed changes
<!--- Describe your changes in detail -->
Added the generation in the config file /etc/squid/squid.conf
for command: set service webroxy  domain-block <domain>
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Config:
`set service webproxy domain-block 'monip.org'`
After changes created lines in config /etc/squid/squid.conf
```
acl BLOCKDOMAIN dstdomain monip.org
http_access deny BLOCKDOMAIN
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
