### PR TITLE
T4857: SNMP: Implement FRR SNMP Recomendations

### DIFF
--- a/data/templates/snmp/etc.snmpd.conf.j2
+++ b/data/templates/snmp/etc.snmpd.conf.j2
@@ -59,26 +59,45 @@ agentaddress unix:/run/snmpd.socket{{ ',' ~ options | join(',') if options is vy
 {%         if comm_config.client is vyos_defined %}
 {%             for client in comm_config.client %}
 {%                 if client | is_ipv4 %}
-{{ comm_config.authorization }}community {{ comm }} {{ client }}
+{{ comm_config.authorization }}community {{ comm }} {{ client }} -V RESTRICTED
 {%                 elif client | is_ipv6 %}
-{{ comm_config.authorization }}community6 {{ comm }} {{ client }}
+{{ comm_config.authorization }}community6 {{ comm }} {{ client }} -V RESTRICTED
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
 {%         if comm_config.network is vyos_defined %}
 {%             for network in comm_config.network %}
 {%                 if network | is_ipv4 %}
-{{ comm_config.authorization }}community {{ comm }} {{ network }}
+{{ comm_config.authorization }}community {{ comm }} {{ network }} -V RESTRICTED
 {%                 elif network | is_ipv6 %}
-{{ comm_config.authorization }}community6 {{ comm }} {{ network }}
+{{ comm_config.authorization }}community6 {{ comm }} {{ network }} -V RESTRICTED
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
 {%         if comm_config.client is not vyos_defined and comm_config.network is not vyos_defined %}
-{{ comm_config.authorization }}community {{ comm }}
-{{ comm_config.authorization }}community6 {{ comm }}
+{{ comm_config.authorization }}community {{ comm }} -V RESTRICTED
+{{ comm_config.authorization }}community6 {{ comm }} -V RESTRICTED
 {%         endif %}
 {%     endfor %}
+{% endif %}
+
+# Default RESTRICTED view
+view RESTRICTED    included .1 80
+{% if 'ip-route-table' not in oid_enable %}
+# ipRouteTable oid: excluded
+view RESTRICTED    excluded  .1.3.6.1.2.1.4.21
+{% endif %}
+{% if 'ip-net-to-media-table' not in oid_enable %}
+# ipNetToMediaTable oid: excluded
+view RESTRICTED    excluded  .1.3.6.1.2.1.4.22
+{% endif %}
+{% if 'ip-net-to-physical-phys-address' not in oid_enable %}
+# ipNetToPhysicalPhysAddress oid: excluded
+view RESTRICTED    excluded  .1.3.6.1.2.1.4.35
+{% endif %}
+{% if 'ip-forward' not in oid_enable %}
+# ipForward oid: excluded
+view RESTRICTED    excluded  .1.3.6.1.2.1.4.24
 {% endif %}
 
 {% if contact is vyos_defined %}

--- a/data/templates/snmp/override.conf.j2
+++ b/data/templates/snmp/override.conf.j2
@@ -1,5 +1,4 @@
 {% set vrf_command = 'ip vrf exec ' ~ vrf ~ ' ' if vrf is vyos_defined else '' %}
-{% set oid_route_table = ' ' if oid_enable is vyos_defined('route-table') else '-I -ipCidrRouteTable,inetCidrRouteTable' %}
 [Unit]
 StartLimitIntervalSec=0
 After=vyos-router.service
@@ -8,7 +7,7 @@ After=vyos-router.service
 Environment=
 Environment="MIBDIRS=/usr/share/snmp/mibs:/usr/share/snmp/mibs/iana:/usr/share/snmp/mibs/ietf:/usr/share/vyos/mibs"
 ExecStart=
-ExecStart={{ vrf_command }}/usr/sbin/snmpd -LS0-5d -Lf /dev/null -u Debian-snmp -g Debian-snmp {{ oid_route_table }} -f -p /run/snmpd.pid
+ExecStart={{ vrf_command }}/usr/sbin/snmpd -LS0-5d -Lf /dev/null -u Debian-snmp -g Debian-snmp -f -p /run/snmpd.pid
 Restart=always
 RestartSec=10
 

--- a/interface-definitions/include/version/snmp-version.xml.i
+++ b/interface-definitions/include/version/snmp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/snmp-version.xml.i -->
-<syntaxVersion component='snmp' version='2'></syntaxVersion>
+<syntaxVersion component='snmp' version='3'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/snmp.xml.in
+++ b/interface-definitions/snmp.xml.in
@@ -129,19 +129,19 @@
               </completionHelp>
               <valueHelp>
                 <format>ip-forward</format>
-                <description>Enable oid .1.3.6.1.2.1.4.24</description>
+                <description>Enable ipForward: .1.3.6.1.2.1.4.24</description>
               </valueHelp>
               <valueHelp>
                 <format>ip-route-table</format>
-                <description>Enable oid .1.3.6.1.2.1.4.21</description>
+                <description>Enable ipRouteTable: .1.3.6.1.2.1.4.21</description>
               </valueHelp>
               <valueHelp>
                 <format>ip-net-to-media-table</format>
-                <description>Enable oid .1.3.6.1.2.1.4.22</description>
+                <description>Enable ipNetToMediaTable: .1.3.6.1.2.1.4.22</description>
               </valueHelp>
               <valueHelp>
                 <format>ip-net-to-physical-phys-address</format>
-                <description>Enable oid .1.3.6.1.2.1.4.35</description>
+                <description>Enable ipNetToPhysicalPhysAddress: .1.3.6.1.2.1.4.35</description>
               </valueHelp>
               <constraint>
                 <regex>(ip-forward|ip-route-table|ip-net-to-media-table|ip-net-to-physical-phys-address)</regex>

--- a/interface-definitions/snmp.xml.in
+++ b/interface-definitions/snmp.xml.in
@@ -123,18 +123,31 @@
           </leafNode>
           <leafNode name="oid-enable">
             <properties>
-              <help>Enable specific OIDs</help>
+              <help>Enable specific OIDs that by default are disable</help>
               <completionHelp>
-                <list>route-table</list>
+                <list>ip-forward ip-route-table ip-net-to-media-table ip-net-to-physical-phys-address</list>
               </completionHelp>
               <valueHelp>
-                <format>route-table</format>
-                <description>Enable routing table OIDs (ipCidrRouteTable inetCidrRouteTable)</description>
+                <format>ip-forward</format>
+                <description>Enable oid .1.3.6.1.2.1.4.24</description>
+              </valueHelp>
+              <valueHelp>
+                <format>ip-route-table</format>
+                <description>Enable oid .1.3.6.1.2.1.4.21</description>
+              </valueHelp>
+              <valueHelp>
+                <format>ip-net-to-media-table</format>
+                <description>Enable oid .1.3.6.1.2.1.4.22</description>
+              </valueHelp>
+              <valueHelp>
+                <format>ip-net-to-physical-phys-address</format>
+                <description>Enable oid .1.3.6.1.2.1.4.35</description>
               </valueHelp>
               <constraint>
-                <regex>(route-table)</regex>
+                <regex>(ip-forward|ip-route-table|ip-net-to-media-table|ip-net-to-physical-phys-address)</regex>
               </constraint>
-              <constraintErrorMessage>OID must be 'route-table'</constraintErrorMessage>
+              <constraintErrorMessage>OID must be one of the liste options</constraintErrorMessage>
+              <multi/>
             </properties>
           </leafNode>
           #include <include/snmp/protocol.xml.i>

--- a/smoketest/scripts/cli/test_service_snmp.py
+++ b/smoketest/scripts/cli/test_service_snmp.py
@@ -123,6 +123,28 @@ class TestSNMPService(VyOSUnitTestSHIM.TestCase):
         self.assertTrue(process_named_running(PROCESS_NAME))
         self.cli_delete(['interfaces', 'dummy', dummy_if])
 
+        ## Check communities and default view RESTRICTED
+        for auth in ['ro', 'rw']:
+            community = 'VyOS' + auth
+            for addr in clients:
+                if is_ipv4(addr):
+                    entry = auth + 'community ' + community + ' ' + addr + ' -V'
+                else:
+                    entry = auth + 'community6 ' + community + ' ' + addr + ' -V'
+                config = get_config_value(entry)
+                expected = 'RESTRICTED'
+                self.assertIn(expected, config)
+            for addr in networks:
+                if is_ipv4(addr):
+                    entry = auth + 'community ' + community + ' ' + addr + ' -V'
+                else:
+                    entry = auth + 'community6 ' + community + ' ' + addr + ' -V'
+                config = get_config_value(entry)
+                expected = 'RESTRICTED'
+                self.assertIn(expected, config)
+        # And finally check global entry for RESTRICTED view
+        config = get_config_value('view RESTRICTED    included .1')
+        self.assertIn('80', config)
 
     def test_snmpv3_sha(self):
         # Check if SNMPv3 can be configured with SHA authentication

--- a/src/conf_mode/snmp.py
+++ b/src/conf_mode/snmp.py
@@ -167,7 +167,7 @@ def verify(snmp):
                 raise ConfigError(f'Trap target "{trap}" requires a community to be set!')
 
     if 'oid_enable' in snmp:
-        Warning(f'Custom oids are enabled and may lead to system instability and high resource consumption')
+        Warning(f'Custom OIDs are enabled and may lead to system instability and high resource consumption')
 
 
     verify_vrf(snmp)

--- a/src/conf_mode/snmp.py
+++ b/src/conf_mode/snmp.py
@@ -166,6 +166,10 @@ def verify(snmp):
             if 'community' not in trap_config:
                 raise ConfigError(f'Trap target "{trap}" requires a community to be set!')
 
+    if 'oid_enable' in snmp:
+        Warning(f'Custom oids are enabled and may lead to system instability and high resource consumption')
+
+
     verify_vrf(snmp)
 
     # bail out early if SNMP v3 is not configured

--- a/src/migration-scripts/snmp/2-to-3
+++ b/src/migration-scripts/snmp/2-to-3
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T4857: Implement FRR SNMP recomendations
+#  cli changes from:
+#  set service snmp oid-enable route-table
+#  To
+#  set service snmp oid-enable ip-forward
+
+import re
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+from vyos.ifconfig import Section
+
+if (len(argv) < 1):
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['service snmp']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+
+if config.exists(base + ['oid-enable']):
+    config.delete(base + ['oid-enable'])
+    config.set(base + ['oid-enable'], 'ip-forward')
+
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Implement FRR SNMP Recomendations:
http://docs.frrouting.org/en/stable-8.4/snmp.html#net-snmp-configuration

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):
Improvement for default configuration of snmp,

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4857

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
snmp

## Proposed changes
<!--- Describe your changes in detail -->
By default, use FRR recommendations, that prevents certain oids to be exposed.
Also, add commands in the cli to allow such oids.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Config without oid-enable, should not permit get routing table through snmp
```
vyos@vyos# run show config comm | grep snmp
set service snmp community VyOSro authorization 'ro'
set service snmp community VyOSro client '192.0.2.1'
set service snmp community VyOSro client '2001:db8::1'
set service snmp community VyOSro client '127.0.0.1'
set service snmp community VyOSro network '192.0.2.128/25'
set service snmp community VyOSro network '2001:db8:babe::/48'
set service snmp listen-address 127.0.0.1 port '5000'
set service snmp listen-address ::1 port '5000'
vyos@vyos# snmpwalk -v 2c -c VyOSro 127.0.0.1:5000 .1.3.6.1.2.1.4.21
MIB search path: /home/vyos/.snmp/mibs:/usr/share/snmp/mibs:/usr/share/snmp/mibs/iana:/usr/share/snmp/mibs/ietf
Cannot find module (IANAifType-MIB): At line 13 in /usr/share/snmp/mibs/IF-MIB.txt
Did not find 'IANAifType' in module #-1 (/usr/share/snmp/mibs/IF-MIB.txt)
Cannot find module (IANA-RTPROTO-MIB): At line 12 in /usr/share/snmp/mibs/IP-FORWARD-MIB.txt
Did not find 'IANAipRouteProtocol' in module #-1 (/usr/share/snmp/mibs/IP-FORWARD-MIB.txt)
IP-MIB::ip.21 = No Such Object available on this agent at this OID
[edit]
vyos@vyos# 
```
Now, adding and re-checking output, routing table should be accesible through snmp:
```
vyos@vyos# set service snmp oid-enable ip-route-table
[edit]
vyos@vyos# commit
[ service snmp ]

WARNING: Custom oids are enabled and may lead to system instability
and high resource consumption

[edit]
vyos@vyos# snmpwalk -v 2c -c VyOSro 127.0.0.1:5000 .1.3.6.1.2.1.4.21
MIB search path: /home/vyos/.snmp/mibs:/usr/share/snmp/mibs:/usr/share/snmp/mibs/iana:/usr/share/snmp/mibs/ietf
Cannot find module (IANAifType-MIB): At line 13 in /usr/share/snmp/mibs/IF-MIB.txt
Did not find 'IANAifType' in module #-1 (/usr/share/snmp/mibs/IF-MIB.txt)
Cannot find module (IANA-RTPROTO-MIB): At line 12 in /usr/share/snmp/mibs/IP-FORWARD-MIB.txt
Did not find 'IANAipRouteProtocol' in module #-1 (/usr/share/snmp/mibs/IP-FORWARD-MIB.txt)
IP-MIB::ip.21.1.1.0.0.0.0 = IpAddress: 0.0.0.0
IP-MIB::ip.21.1.1.192.168.0.0 = IpAddress: 192.168.0.0
IP-MIB::ip.21.1.2.0.0.0.0 = INTEGER: 2
IP-MIB::ip.21.1.2.192.168.0.0 = INTEGER: 2
IP-MIB::ip.21.1.3.0.0.0.0 = INTEGER: 1
IP-MIB::ip.21.1.3.192.168.0.0 = INTEGER: 0
IP-MIB::ip.21.1.7.0.0.0.0 = IpAddress: 192.168.0.1
IP-MIB::ip.21.1.7.192.168.0.0 = IpAddress: 0.0.0.0
IP-MIB::ip.21.1.8.0.0.0.0 = INTEGER: 4
IP-MIB::ip.21.1.8.192.168.0.0 = INTEGER: 3
IP-MIB::ip.21.1.9.0.0.0.0 = INTEGER: 2
IP-MIB::ip.21.1.9.192.168.0.0 = INTEGER: 2
IP-MIB::ip.21.1.11.0.0.0.0 = IpAddress: 0.0.0.0
IP-MIB::ip.21.1.11.192.168.0.0 = IpAddress: 255.255.255.0
IP-MIB::ip.21.1.13.0.0.0.0 = OID: SNMPv2-SMI::zeroDotZero
IP-MIB::ip.21.1.13.192.168.0.0 = OID: SNMPv2-SMI::zeroDotZero
[edit]
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
