### PR TITLE
T4117: Fix for L2TP DAE CoA server configuration

### DIFF
--- a/data/templates/accel-ppp/l2tp.config.j2
+++ b/data/templates/accel-ppp/l2tp.config.j2
@@ -88,6 +88,9 @@ verbose=1
 {%     for r in radius_server %}
 server={{ r.server }},{{ r.key }},auth-port={{ r.port }},acct-port={{ r.acct_port }},req-limit=0,fail-time={{ r.fail_time }}
 {%     endfor %}
+{%     if radius_dynamic_author.server is vyos_defined %}
+dae-server={{ radius_dynamic_author.server }}:{{ radius_dynamic_author.port }},{{ radius_dynamic_author.key }}
+{%     endif %}
 {%     if radius_acct_inter_jitter %}
 acct-interim-jitter={{ radius_acct_inter_jitter }}
 {%     endif %}

--- a/interface-definitions/vpn-l2tp.xml.in
+++ b/interface-definitions/vpn-l2tp.xml.in
@@ -230,6 +230,7 @@
                             <properties>
                               <help>Port for Dynamic Authorization Extension server (DM/CoA)</help>
                             </properties>
+                            <defaultValue>1700</defaultValue>
                           </leafNode>
                           <leafNode name="secret">
                             <properties>

--- a/src/conf_mode/vpn_l2tp.py
+++ b/src/conf_mode/vpn_l2tp.py
@@ -26,7 +26,10 @@ from ipaddress import ip_network
 from vyos.config import Config
 from vyos.template import is_ipv4
 from vyos.template import render
-from vyos.util import call, get_half_cpus
+from vyos.util import call
+from vyos.util import get_half_cpus
+from vyos.util import check_port_availability
+from vyos.util import is_listen_port_bind_service
 from vyos import ConfigError
 
 from vyos import airbag
@@ -64,7 +67,7 @@ default_config_data = {
     'radius_source_address': '',
     'radius_shaper_attr': '',
     'radius_shaper_vendor': '',
-    'radius_dynamic_author': '',
+    'radius_dynamic_author': {},
     'wins': [],
     'ip6_column': [],
     'thread_cnt': get_half_cpus()
@@ -205,21 +208,21 @@ def get_config(config=None):
             l2tp['radius_source_address'] = conf.return_value(['source-address'])
 
         # Dynamic Authorization Extensions (DOA)/Change Of Authentication (COA)
-        if conf.exists(['dynamic-author']):
+        if conf.exists(['dae-server']):
             dae = {
                 'port' : '',
                 'server' : '',
                 'key' : ''
             }
 
-            if conf.exists(['dynamic-author', 'server']):
-                dae['server'] = conf.return_value(['dynamic-author', 'server'])
+            if conf.exists(['dae-server', 'ip-address']):
+                dae['server'] = conf.return_value(['dae-server', 'ip-address'])
 
-            if conf.exists(['dynamic-author', 'port']):
-                dae['port'] = conf.return_value(['dynamic-author', 'port'])
+            if conf.exists(['dae-server', 'port']):
+                dae['port'] = conf.return_value(['dae-server', 'port'])
 
-            if conf.exists(['dynamic-author', 'key']):
-                dae['key'] = conf.return_value(['dynamic-author', 'key'])
+            if conf.exists(['dae-server', 'secret']):
+                dae['key'] = conf.return_value(['dae-server', 'secret'])
 
             l2tp['radius_dynamic_author'] = dae
 
@@ -328,6 +331,19 @@ def verify(l2tp):
         for radius in l2tp['radius_server']:
             if not radius['key']:
                 raise ConfigError(f"Missing RADIUS secret for server { radius['key'] }")
+
+        if l2tp['radius_dynamic_author']:
+            if not l2tp['radius_dynamic_author']['server']:
+                raise ConfigError("Missing ip-address for dae-server")
+            if not l2tp['radius_dynamic_author']['key']:
+                raise ConfigError("Missing secret for dae-server")
+            address = l2tp['radius_dynamic_author']['server']
+            port = l2tp['radius_dynamic_author']['port']
+            proto = 'tcp'
+            # check if dae listen port is not used by another service
+            if check_port_availability(address, int(port), proto) is not True and \
+                not is_listen_port_bind_service(int(port), 'accel-pppd'):
+                raise ConfigError(f'"{proto}" port "{port}" is used by another service')
 
     # check for the existence of a client ip pool
     if not (l2tp['client_ip_pool'] or l2tp['client_ip_subnets']):


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix l2tp dae server template and python config dict for correctly handling Dynamic Authorization Extension server configuration
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4117

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
l2tp, coa
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set vpn l2tp remote-access authentication mode 'radius'
set vpn l2tp remote-access authentication radius dae-server ip-address '127.0.0.1'
set vpn l2tp remote-access authentication radius dae-server port '1700'
set vpn l2tp remote-access authentication radius dae-server secret 'testing123'
set vpn l2tp remote-access authentication radius server 192.0.2.5 key 'key123'
set vpn l2tp remote-access client-ip-pool subnet '203.0.113.0/24'

```
expected config:
```
vyos@r14# cat /run/accel-pppd/l2tp.conf | grep dae-s
dae-server=127.0.0.1:1700,testing123
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
