### PR TITLE
T4868: Fix l2tp ppp IPv6 options in template and config get dict

### DIFF
--- a/data/templates/accel-ppp/l2tp.config.j2
+++ b/data/templates/accel-ppp/l2tp.config.j2
@@ -121,8 +121,10 @@ lcp-echo-failure={{ ppp_echo_failure }}
 {% if ccp_disable %}
 ccp=0
 {% endif %}
-{% if client_ipv6_pool %}
-ipv6=allow
+{% if ppp_ipv6 is vyos_defined %}
+ipv6={{ ppp_ipv6 }}
+{% else %}
+{{ 'ipv6=allow' if client_ipv6_pool_configured else '' }}
 {% endif %}
 
 

--- a/src/conf_mode/vpn_l2tp.py
+++ b/src/conf_mode/vpn_l2tp.py
@@ -46,6 +46,7 @@ default_config_data = {
     'client_ip_pool': None,
     'client_ip_subnets': [],
     'client_ipv6_pool': [],
+    'client_ipv6_pool_configured': False,
     'client_ipv6_delegate_prefix': [],
     'dnsv4': [],
     'dnsv6': [],
@@ -247,6 +248,7 @@ def get_config(config=None):
         l2tp['client_ip_subnets'] = conf.return_values(['client-ip-pool', 'subnet'])
 
     if conf.exists(['client-ipv6-pool', 'prefix']):
+        l2tp['client_ipv6_pool_configured'] = True
         l2tp['ip6_column'].append('ip6')
         for prefix in conf.list_nodes(['client-ipv6-pool', 'prefix']):
             tmp = {
@@ -308,6 +310,9 @@ def get_config(config=None):
 
     if conf.exists(['ppp-options', 'lcp-echo-interval']):
         l2tp['ppp_echo_interval'] = conf.return_value(['ppp-options', 'lcp-echo-interval'])
+
+    if conf.exists(['ppp-options', 'ipv6']):
+        l2tp['ppp_ipv6'] = conf.return_value(['ppp-options', 'ipv6'])
 
     return l2tp
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
L2TP `ppp-options ipv6 x` can work without declaring IPv6 pool As we can get addresses via RADIUS attributes:
  - Framed-IPv6-Prefix
  - Delegated-IPv6-Prefix
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4868

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
l2tp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set vpn l2tp remote-access authentication mode 'radius'
set vpn l2tp remote-access authentication radius dae-server ip-address '127.0.0.1'
set vpn l2tp remote-access authentication radius dae-server port '1700'
set vpn l2tp remote-access authentication radius dae-server secret 'testing1234'
set vpn l2tp remote-access authentication radius server 192.0.2.5 key 'key123'
set vpn l2tp remote-access client-ip-pool start '203.0.113.10'
set vpn l2tp remote-access client-ip-pool stop '203.0.113.100'
set vpn l2tp remote-access client-ip-pool subnet '203.0.113.0/24'
set vpn l2tp remote-access ppp-options ipv6 'allow'
```
Before fix: 
```
vyos@r1# cat /run/accel-pppd/l2tp.conf | grep ipv6
ipv6pool
ipv6_nd
ipv6_dhcp
[edit]
vyos@r1#
```
After fixing expecting `ipv6=allow`:
```
vyos@r1# cat /run/accel-pppd/l2tp.conf | grep ipv6
ipv6pool
ipv6_nd
ipv6_dhcp
ipv6=allow
[edit]
vyos@r1# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
