### PR TITLE
T4865: Fix to generate container image from the file

### DIFF
--- a/op-mode-definitions/container.xml.in
+++ b/op-mode-definitions/container.xml.in
@@ -69,7 +69,7 @@
                     <list>&lt;filename&gt;</list>
                   </completionHelp>
                 </properties>
-                <command>sudo podman build --layers --force-rm --tag "$4" $6</command>
+                <command>sudo podman build --net host --layers --force-rm --tag "$4" $6</command>
               </tagNode>
             </children>
           </tagNode>


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
If we want to generate our container image from a Dockerfile and if it requires updating or installing packages in the container we get error. As it tries to use the default network `podman` and do its own NAT translations via `iptables`. If fact, we don't use iptables in 1.4 As a result it cannot build such image.
Use `--net host` to fix it.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4865

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
container
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Example of the Dockerfile:
```
vyos@r14:~$ cat /config/containers/pod/Dockerfile 
FROM alpine:3.16.2
RUN apk update
RUN apk add --no-cache bind
USER named
EXPOSE 53/udp
CMD ["named", "-c", "/etc/bind/named.conf", "-g"]
```
Before fix:
```
vyos@r1:~$ generate container image mypod path /config/containers/pod/
STEP 1/6: FROM alpine:3.16.2
STEP 2/6: RUN apk update
WARN[0004] Failed to load cached network config: network podman not found in CNI cache, falling back to loading network podman from disk 
WARN[0005] 1 error occurred:
  * plugin type="bridge" failed (delete): cni plugin bridge failed: running [/usr/sbin/iptables -t nat -D POSTROUTING -s 10.88.0.2 -j CNI-57e6a85bb66d0c7afb16dab3 -m comment --comment name: "podman" id: "buildah-buildah2575282138" --wait]: exit status 2: iptables v1.8.7 (nf_tables): Chain 'CNI-57e6a85bb66d0c7afb16dab3' does not exist
Try `iptables -h' or 'iptables --help' for more information.
 
2022-12-09T15:21:43.000994099Z: the container `buildah-buildah2575282138` is not in 'stopped' state
error running container: did not get container start message from parent: EOF
Error: error building at STEP "RUN apk update": plugin type="bridge" failed (add): cni plugin bridge failed: failed to list chains: running [/usr/sbin/iptables -t nat -S --wait]: exit status 1: iptables v1.8.7 (nf_tables): table `nat' is incompatible, use 'nft' tool.

vyos@r1:~$ 
```

After fixing:
```
vyos@r1:~$ generate container image mypod path /config/containers/pod/
STEP 1/6: FROM alpine:3.16.2
STEP 2/6: RUN apk update
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
v3.16.3-44-ge4585a2933 [https://dl-cdn.alpinelinux.org/alpine/v3.16/main]
v3.16.3-47-gce4bbb648c [https://dl-cdn.alpinelinux.org/alpine/v3.16/community]
OK: 17041 distinct packages available
--> b002adf7d68
STEP 3/6: RUN apk add --no-cache bind
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
(1/35) Installing ca-certificates (20220614-r0)
(2/35) Installing brotli-libs (1.0.9-r6)
(3/35) Installing nghttp2-libs (1.47.0-r0)
(4/35) Installing libcurl (7.83.1-r4)
(5/35) Installing curl (7.83.1-r4)
(6/35) Installing libgpg-error (1.45-r0)
(7/35) Installing libassuan (2.5.5-r0)
(8/35) Installing libcap (2.64-r0)
(9/35) Installing ncurses-terminfo-base (6.3_p20220521-r0)
(10/35) Installing ncurses-libs (6.3_p20220521-r0)
(11/35) Installing pinentry (1.2.0-r0)
Executing pinentry-1.2.0-r0.post-install
(12/35) Installing libgcrypt (1.10.1-r0)
(13/35) Installing gnupg-gpgconf (2.2.35-r4)
(14/35) Installing libbz2 (1.0.8-r1)
(15/35) Installing sqlite-libs (3.38.5-r0)
(16/35) Installing gpg (2.2.35-r4)
(17/35) Installing dns-root-hints (2019073000-r3)
(18/35) Installing fstrm (0.6.1-r0)
(19/35) Installing krb5-conf (1.0-r2)
(20/35) Installing libcom_err (1.46.5-r0)
(21/35) Installing keyutils-libs (1.6.3-r1)
(22/35) Installing libverto (0.3.2-r0)
(23/35) Installing krb5-libs (1.19.4-r0)
(24/35) Installing json-c (0.16-r0)
(25/35) Installing protobuf-c (1.4.1-r0)
(26/35) Installing libuv (1.44.1-r0)
(27/35) Installing xz-libs (5.2.5-r1)
(28/35) Installing libxml2 (2.9.14-r2)
(29/35) Installing bind-libs (9.16.33-r0)
(30/35) Installing bind-tools (9.16.33-r0)
(31/35) Installing bind-dnssec-root (9.16.33-r0)
(32/35) Installing gdbm (1.23-r0)
(33/35) Installing libsasl (2.1.28-r1)
(34/35) Installing libldap (2.6.3-r3)
(35/35) Installing bind (9.16.33-r0)
Executing bind-9.16.33-r0.pre-install
Executing bind-9.16.33-r0.post-install
wrote key file "/etc/bind/rndc.key"
Executing busybox-1.35.0-r17.trigger
Executing ca-certificates-20220614-r0.trigger
OK: 21 MiB in 49 packages
--> c9a1b60791f
STEP 4/6: USER named
--> f2115e7fe2f
STEP 5/6: EXPOSE 53/udp
--> a95fe6da3aa
STEP 6/6: CMD ["named", "-c", "/etc/bind/named.conf", "-g"]
COMMIT mypod
--> 1882dc86686
Successfully tagged localhost/mypod:latest
1882dc86686877105cdef950e7c74b477ff1435aa240fb4db85a3808a9d22cb7
vyos@r1:~$ 
vyos@r1:~$ 
vyos@r1:~$ 
vyos@r1:~$ show container image 
REPOSITORY                TAG         IMAGE ID      CREATED         SIZE
localhost/mypod           latest      1882dc866868  13 seconds ago  23.9 MB
docker.io/library/alpine  3.16.2      9c6f07244728  4 months ago    5.83 MB
vyos@r1:~$ 
vyos@r1:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
