### PR TITLE
T4874: Added Warning message

### DIFF
--- a/python/vyos/base.py
+++ b/python/vyos/base.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2018-2022 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -15,11 +15,47 @@
 
 from textwrap import fill
 
+
+class BaseWarning:
+    def __init__(self, header, message, **kwargs):
+        self.message = message
+        self.kwargs = kwargs
+        if 'width' not in kwargs:
+            self.width = 72
+        if 'initial_indent' in kwargs:
+            del self.kwargs['initial_indent']
+        if 'subsequent_indent' in kwargs:
+            del self.kwargs['subsequent_indent']
+        self.textinitindent = header
+        self.standardindent = ''
+
+    def print(self):
+        messages = self.message.split('\n')
+        isfirstmessage = True
+        initial_indent = self.textinitindent
+        print('')
+        for mes in messages:
+            mes = fill(mes, initial_indent=initial_indent,
+                       subsequent_indent=self.standardindent, **self.kwargs)
+            if isfirstmessage:
+                isfirstmessage = False
+                initial_indent = self.standardindent
+            print(f'{mes}')
+        print('')
+
+
+class Warning():
+    def __init__(self, message, **kwargs):
+        self.BaseWarn = BaseWarning('WARNING: ', message, **kwargs)
+        self.BaseWarn.print()
+
+
 class DeprecationWarning():
-    def __init__(self, message):
+    def __init__(self, message, **kwargs):
         # Reformat the message and trim it to 72 characters in length
-        message = fill(message, width=72)
-        print(f'\nDEPRECATION WARNING: {message}\n')
+        self.BaseWarn = BaseWarning('DEPRECATION WARNING: ', message, **kwargs)
+        self.BaseWarn.print()
+
 
 class ConfigError(Exception):
     def __init__(self, message):


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added the ability to call Warning messages

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4874

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
messages
## Proposed changes
<!--- Describe your changes in detail -->
Added the ability to call Warning messages

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
