### PR TITLE
firewall: T4882: add missing ICMPv6 type names

### DIFF
--- a/interface-definitions/include/firewall/icmpv6-type-name.xml.i
+++ b/interface-definitions/include/firewall/icmpv6-type-name.xml.i
@@ -3,7 +3,7 @@
   <properties>
     <help>ICMPv6 type-name</help>
     <completionHelp>
-      <list>destination-unreachable packet-too-big time-exceeded echo-request echo-reply mld-listener-query mld-listener-report mld-listener-reduction nd-router-solicit nd-router-advert nd-neighbor-solicit nd-neighbor-advert nd-redirect parameter-problem router-renumbering</list>
+      <list>destination-unreachable packet-too-big time-exceeded echo-request echo-reply mld-listener-query mld-listener-report mld-listener-reduction nd-router-solicit nd-router-advert nd-neighbor-solicit nd-neighbor-advert nd-redirect parameter-problem router-renumbering ind-neighbor-solicit ind-neighbor-advert mld2-listener-report</list>
     </completionHelp>
     <valueHelp>
       <format>destination-unreachable</format>
@@ -65,8 +65,20 @@
       <format>router-renumbering</format>
       <description>ICMPv6 type 138: router-renumbering</description>
     </valueHelp>
+    <valueHelp>
+      <format>ind-neighbor-solicit</format>
+      <description>ICMPv6 type 141: ind-neighbor-solicit</description>
+    </valueHelp>
+    <valueHelp>
+      <format>ind-neighbor-advert</format>
+      <description>ICMPv6 type 142: ind-neighbor-advert</description>
+    </valueHelp>
+    <valueHelp>
+      <format>mld2-listener-report</format>
+      <description>ICMPv6 type 143: mld2-listener-report</description>
+    </valueHelp>
     <constraint>
-      <regex>(destination-unreachable|packet-too-big|time-exceeded|echo-request|echo-reply|mld-listener-query|mld-listener-report|mld-listener-reduction|nd-router-solicit|nd-router-advert|nd-neighbor-solicit|nd-neighbor-advert|nd-redirect|parameter-problem|router-renumbering)</regex>
+      <regex>(destination-unreachable|packet-too-big|time-exceeded|echo-request|echo-reply|mld-listener-query|mld-listener-report|mld-listener-reduction|nd-router-solicit|nd-router-advert|nd-neighbor-solicit|nd-neighbor-advert|nd-redirect|parameter-problem|router-renumbering|ind-neighbor-solicit|ind-neighbor-advert|mld2-listener-report)</regex>
     </constraint>
   </properties>
 </leafNode>


### PR DESCRIPTION
## Change Summary

Adds missing ICMPv6 type-names supported by nftables.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T4882

## Component(s) name
firewall

## Proposed changes

Adds the `ind-neighbor-solicit`, `ind-neighbor-advert`, and `mld2-listener-report` type-names to the list of supported ICMPv6 type names as these are natively supported by nftables.

## How to test
Create a firewall config as such:
```
firewall {
    ipv6-name test {
        rule 1 {
            action accept
            icmpv6 {
                type-name mld2-listener-report
            }
        }
    }
}
```
Substitute `mld2-listener-report` with the other type names mentioned above and validate commit is successful.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
