### PR TITLE
T4809: radvd: Allow the use of AdvRASrcAddress

### DIFF
--- a/data/templates/router-advert/radvd.conf.j2
+++ b/data/templates/router-advert/radvd.conf.j2
@@ -43,6 +43,13 @@ interface {{ iface }} {
     };
 {%             endfor %}
 {%         endif %}
+{%         if iface_config.source_address is vyos_defined %}
+    AdvRASrcAddress {
+{%             for source_address in iface_config.source_address %}
+        {{ source_address }}
+{%             endfor %}
+    };
+{%         endif %}
 {%         if iface_config.prefix is vyos_defined %}
 {%             for prefix, prefix_options in iface_config.prefix.items() %}
     prefix {{ prefix }} {

--- a/interface-definitions/service-router-advert.xml.in
+++ b/interface-definitions/service-router-advert.xml.in
@@ -305,6 +305,19 @@
                   </leafNode>
                 </children>
               </tagNode>
+              <leafNode name="source-address">
+                <properties>
+                  <help>Use IPv6 address as source address. Useful with VRRP.</help>
+                  <valueHelp>
+                    <format>ipv6</format>
+                    <description>IPv6 address to be advertized (must be configured on interface)</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="ipv6-address"/>
+                  </constraint>
+                  <multi/>
+                </properties>
+              </leafNode>
               <leafNode name="reachable-time">
                 <properties>
                   <help>Time, in milliseconds, that a node assumes a neighbor is reachable after having received a reachability confirmation</help>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This add the AdvRASrcAddress configuration option to configure a source address for the router advertisements. The source address still must be configured on the system. This is useful for VRRP setups where you want fe80::1 on the VRRP interface for cleaner VRRP failovers.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4809

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
radvd

## Proposed changes
<!--- Describe your changes in detail -->
Add: set service router-advert interface eth3 source-address <ipv6>

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
set service router-advert interface eth3 prefix 2001:fff::/64
set service router-advert interface eth3 source-address fe80::1
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
