### PR TITLE
T4886: Firewall and route policy: Add connection-mark feature to vyos.

### DIFF
--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -461,6 +461,7 @@
               #include <include/firewall/dscp.xml.i>
               #include <include/firewall/packet-length.xml.i>
               #include <include/firewall/hop-limit.xml.i>
+              #include <include/firewall/connection-mark.xml.i>
               <node name="icmpv6">
                 <properties>
                   <help>ICMPv6 type and code information</help>
@@ -628,6 +629,7 @@
               #include <include/firewall/common-rule.xml.i>
               #include <include/firewall/dscp.xml.i>
               #include <include/firewall/packet-length.xml.i>
+              #include <include/firewall/connection-mark.xml.i>
               <node name="icmp">
                 <properties>
                   <help>ICMP type and code information</help>

--- a/interface-definitions/include/firewall/connection-mark.xml.i
+++ b/interface-definitions/include/firewall/connection-mark.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from firewall/connection-mark.xml.i -->
+<leafNode name="connection-mark">
+  <properties>
+    <help>Connection mark</help>
+    <valueHelp>
+      <format>u32:1-2147483647</format>
+      <description>Connection-mark to match</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-2147483647"/>
+    </constraint>
+    <multi/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/policy/route-common.xml.i
+++ b/interface-definitions/include/policy/route-common.xml.i
@@ -159,6 +159,18 @@
     <help>Packet modifications</help>
   </properties>
   <children>
+    <leafNode name="connection-mark">
+      <properties>
+        <help>Connection marking</help>
+        <valueHelp>
+          <format>u32:1-2147483647</format>
+          <description>Connection marking</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-2147483647"/>
+        </constraint>
+      </properties>
+    </leafNode>
     <leafNode name="dscp">
       <properties>
         <help>Packet Differentiated Services Codepoint (DSCP)</help>

--- a/interface-definitions/policy-route.xml.in
+++ b/interface-definitions/policy-route.xml.in
@@ -52,6 +52,7 @@
               #include <include/firewall/dscp.xml.i>
               #include <include/firewall/packet-length.xml.i>
               #include <include/firewall/hop-limit.xml.i>
+              #include <include/firewall/connection-mark.xml.i>
             </children>
           </tagNode>
         </children>
@@ -106,6 +107,7 @@
               #include <include/firewall/dscp.xml.i>
               #include <include/firewall/packet-length.xml.i>
               #include <include/firewall/ttl.xml.i>
+              #include <include/firewall/connection-mark.xml.i>
             </children>
           </tagNode>
         </children>

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -322,6 +322,10 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
     if tcp_mss:
         output.append(f'tcp option maxseg size {tcp_mss}')
 
+    if 'connection_mark' in rule_conf:
+        conn_mark_str = ','.join(rule_conf['connection_mark'])
+        output.append(f'ct mark {{{conn_mark_str}}}')
+
     output.append('counter')
 
     if 'set' in rule_conf:
@@ -368,6 +372,9 @@ def parse_time(time):
 
 def parse_policy_set(set_conf, def_suffix):
     out = []
+    if 'connection_mark' in set_conf:
+        conn_mark = set_conf['connection_mark']
+        out.append(f'ct mark set {conn_mark}')
     if 'dscp' in set_conf:
         dscp = set_conf['dscp']
         out.append(f'ip{def_suffix} dscp set {dscp}')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add connection mark in policy route: as a matching option, and as a "set" option.
Add connection mark in firewall as a matching option

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4886

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
policy route
firewall

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
VyOS Config and mangle rules generated:
```
vyos@conn-mark:~$ show config comm | grep policy
set policy route LAN interface 'eth2'
set policy route LAN rule 10 connection-mark '111'
set policy route LAN rule 10 set table '51'
set policy route LAN rule 20 connection-mark '222'
set policy route LAN rule 20 set table '52'
set policy route WAN01 interface 'eth0'
set policy route WAN01 rule 10 set connection-mark '111'
set policy route WAN02 interface 'eth1'
set policy route WAN02 rule 10 set connection-mark '222'
vyos@conn-mark:~$ sudo nft -s list table ip vyos_mangle
table ip vyos_mangle {
        chain VYOS_PBR_PREROUTING {
                type filter hook prerouting priority mangle; policy accept;
                iifname "eth2" counter jump VYOS_PBR_LAN
                iifname "eth0" counter jump VYOS_PBR_WAN01
                iifname "eth1" counter jump VYOS_PBR_WAN02
        }

        chain VYOS_PBR_POSTROUTING {
                type filter hook postrouting priority mangle; policy accept;
        }

        chain VYOS_PBR_LAN {
                ct mark 0x0000006f counter meta mark set 0x7fffffcc return comment "LAN-10"
                ct mark 0x000000de counter meta mark set 0x7fffffcb return comment "LAN-20"
        }

        chain VYOS_PBR_WAN01 {
                counter ct mark set 0x0000006f return comment "WAN01-10"
        }

        chain VYOS_PBR_WAN02 {
                counter ct mark set 0x000000de return comment "WAN02-10"
        }
}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
