### PR TITLE
conntrack-sync: T4888: rewrite the op mode script in the new format

### DIFF
--- a/op-mode-definitions/conntrack-sync.xml.in
+++ b/op-mode-definitions/conntrack-sync.xml.in
@@ -11,13 +11,13 @@
             <properties>
               <help>Reset external cache and request resync with other systems</help>
             </properties>
-            <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py --reset-cache-external</command>
+            <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py reset_external_cache</command>
           </leafNode>
           <leafNode name="internal-cache">
             <properties>
               <help>Reset internal cache and request resync with other systems</help>
             </properties>
-            <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py --reset-cache-internal</command>
+            <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py reset_internal_cache</command>
           </leafNode>
         </children>
       </node>
@@ -27,9 +27,9 @@
     <children>
       <leafNode name="conntrack-sync">
         <properties>
-          <help>Restart connection tracking synchronization service</help>
+          <help>Restart the connection tracking synchronization service</help>
         </properties>
-        <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py --restart</command>
+        <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py restart</command>
       </leafNode>
     </children>
   </node>
@@ -49,19 +49,19 @@
                 <properties>
                   <help>Show external connection tracking cache entries</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py --show-external; ${vyos_op_scripts_dir}/conntrack_sync.py --show-external-expect</command>
+                <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py show_external_cache</command>
                 <children>
                   <leafNode name="main">
                     <properties>
                       <help>Show external main connection tracking cache entries</help>
                     </properties>
-                    <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py --show-external</command>
+                    <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py show_external_cache</command>
                   </leafNode>
                   <leafNode name="expect">
                     <properties>
                       <help>Show external expect connection tracking cache entries</help>
                     </properties>
-                    <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py --show-external-expect</command>
+                    <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py show_external_expect</command>
                   </leafNode>
                 </children>
               </node>
@@ -69,19 +69,19 @@
                 <properties>
                   <help>Show internal connection tracking cache entries</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py --show-internal; ${vyos_op_scripts_dir}/conntrack_sync.py --show-internal-expect</command>
+                <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py show_internal_cache</command>
                 <children>
                   <leafNode name="main">
                     <properties>
                       <help>Show internal main connection tracking cache entries</help>
                     </properties>
-                    <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py --show-internal</command>
+                    <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py show_internal_cache</command>
                   </leafNode>
                   <leafNode name="expect">
                     <properties>
                       <help>Show internal expect connection tracking cache entries</help>
                     </properties>
-                    <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py --show-internal-expect</command>
+                    <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py show_internal_expect</command>
                   </leafNode>
                 </children>
               </node>
@@ -91,13 +91,13 @@
             <properties>
               <help>Show connection syncing statistics</help>
             </properties>
-            <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py --show-statistics</command>
+            <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py show_statistics</command>
           </leafNode>
           <leafNode name="status">
             <properties>
               <help>Show conntrack-sync status</help>
             </properties>
-            <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py --show-status</command>
+            <command>sudo ${vyos_op_scripts_dir}/conntrack_sync.py show_status</command>
           </leafNode>
         </children>
       </node>

--- a/src/op_mode/conntrack_sync.py
+++ b/src/op_mode/conntrack_sync.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 VyOS maintainers and contributors
+# Copyright (C) 2022 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -15,8 +15,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import sys
 import syslog
 import xmltodict
+
+import vyos.opmode
 
 from argparse import ArgumentParser
 from vyos.configquery import CliShellApiConfigQuery
@@ -31,36 +34,23 @@ conntrackd_bin = '/usr/sbin/conntrackd'
 conntrackd_config = '/run/conntrackd/conntrackd.conf'
 failover_state_file = '/var/run/vyatta-conntrackd-failover-state'
 
-parser = ArgumentParser(description='Conntrack Sync')
-group = parser.add_mutually_exclusive_group()
-group.add_argument('--restart', help='Restart connection tracking synchronization service', action='store_true')
-group.add_argument('--reset-cache-internal', help='Reset internal cache', action='store_true')
-group.add_argument('--reset-cache-external', help='Reset external cache', action='store_true')
-group.add_argument('--show-internal', help='Show internal (main) tracking cache', action='store_true')
-group.add_argument('--show-external', help='Show external (main) tracking cache', action='store_true')
-group.add_argument('--show-internal-expect', help='Show internal (expect) tracking cache', action='store_true')
-group.add_argument('--show-external-expect', help='Show external (expect) tracking cache', action='store_true')
-group.add_argument('--show-statistics', help='Show connection syncing statistics', action='store_true')
-group.add_argument('--show-status', help='Show conntrack-sync status', action='store_true')
-
 def is_configured():
     """ Check if conntrack-sync service is configured """
     config = CliShellApiConfigQuery()
     if not config.exists(['service', 'conntrack-sync']):
-        print('Service conntrackd-sync not configured!')
-        exit(1)
+        raise vyos.opmode.UnconfiguredSubsystem("conntrack-sync is not configured!")
 
 def send_bulk_update():
     """ send bulk update of internal-cache to other systems """
     tmp = run(f'{conntrackd_bin} -C {conntrackd_config} -B')
     if tmp > 0:
-        print('ERROR: failed to send bulk update to other conntrack-sync systems')
+        raise vyos.opmode.Error('Failed to send bulk update to other conntrack-sync systems')
 
 def request_sync():
     """ request resynchronization with other systems """
     tmp = run(f'{conntrackd_bin} -C {conntrackd_config} -n')
     if tmp > 0:
-        print('ERROR: failed to request resynchronization of external cache')
+        raise vyos.opmode.Error('Failed to request resynchronization of external cache')
 
 def flush_cache(direction):
     """ flush conntrackd cache (internal or external) """
@@ -68,9 +58,9 @@ def flush_cache(direction):
         raise ValueError()
     tmp = run(f'{conntrackd_bin} -C {conntrackd_config} -f {direction}')
     if tmp > 0:
-        print('ERROR: failed to clear {direction} cache')
+        raise vyos.opmode.Error('Failed to clear {direction} cache')
 
-def xml_to_stdout(xml):
+def from_xml(raw, xml):
     out = []
     for line in xml.splitlines():
         if line == '\n':
@@ -78,108 +68,131 @@ def xml_to_stdout(xml):
         parsed = xmltodict.parse(line)
         out.append(parsed)
 
-    print(render_to_string('conntrackd/conntrackd.op-mode.j2', {'data' : out}))
+    if raw:
+        return out
+    else:
+        return render_to_string('conntrackd/conntrackd.op-mode.j2', {'data' : out})
 
-if __name__ == '__main__':
-    args = parser.parse_args()
-    syslog.openlog(ident='conntrack-tools', logoption=syslog.LOG_PID,
-                   facility=syslog.LOG_INFO)
+def restart():
+    is_configured()
+    if commit_in_progress():
+        raise vyos.opmode.CommitInProgress('Cannot restart conntrackd while a commit is in progress')
 
-    if args.restart:
-        is_configured()
-        if commit_in_progress():
-            print('Cannot restart conntrackd while a commit is in progress')
-            exit(1)
+    syslog.syslog('Restarting conntrack sync service...')
+    cmd('systemctl restart conntrackd.service')
+    # request resynchronization with other systems
+    request_sync()
+    # send bulk update of internal-cache to other systems
+    send_bulk_update()
 
-        syslog.syslog('Restarting conntrack sync service...')
-        cmd('systemctl restart conntrackd.service')
-        # request resynchronization with other systems
-        request_sync()
-        # send bulk update of internal-cache to other systems
-        send_bulk_update()
+def reset_external_cache():
+    is_configured()
+    syslog.syslog('Resetting external cache of conntrack sync service...')
 
-    elif args.reset_cache_external:
-        is_configured()
-        syslog.syslog('Resetting external cache of conntrack sync service...')
+    # flush the external cache
+    flush_cache('external')
+    # request resynchronization with other systems
+    request_sync()
 
-        # flush the external cache
-        flush_cache('external')
-        # request resynchronization with other systems
-        request_sync()
+def reset_internal_cache():
+    is_configured()
+    syslog.syslog('Resetting internal cache of conntrack sync service...')
+    # flush the internal cache
+    flush_cache('internal')
 
-    elif args.reset_cache_internal:
-        is_configured()
-        syslog.syslog('Resetting internal cache of conntrack sync service...')
-        # flush the internal cache
-        flush_cache('internal')
+    # request resynchronization of internal cache with kernel conntrack table
+    tmp = run(f'{conntrackd_bin} -C {conntrackd_config} -R')
+    if tmp > 0:
+        print('ERROR: failed to resynchronize internal cache with kernel conntrack table')
 
-        # request resynchronization of internal cache with kernel conntrack table
-        tmp = run(f'{conntrackd_bin} -C {conntrackd_config} -R')
-        if tmp > 0:
-            print('ERROR: failed to resynchronize internal cache with kernel conntrack table')
+    # send bulk update of internal-cache to other systems
+    send_bulk_update()
 
-        # send bulk update of internal-cache to other systems
-        send_bulk_update()
+def _show_cache(raw, opts):
+    is_configured()
+    out = cmd(f'{conntrackd_bin} -C {conntrackd_config} {opts} -x')
+    return from_xml(raw, out)
 
-    elif args.show_external or args.show_internal or args.show_external_expect or args.show_internal_expect:
-        is_configured()
-        opt = ''
-        if args.show_external:
-            opt = '-e ct'
-        elif args.show_external_expect:
-            opt = '-e expect'
-        elif args.show_internal:
-            opt = '-i ct'
-        elif args.show_internal_expect:
-            opt = '-i expect'
+def show_external_cache(raw: bool):
+    opts = '-e ct'
+    return _show_cache(raw, opts)
 
-        if args.show_external or args.show_internal:
-            print('Main Table Entries:')
-        else:
-            print('Expect Table Entries:')
-        out = cmd(f'sudo {conntrackd_bin} -C {conntrackd_config} {opt} -x')
-        xml_to_stdout(out)
+def show_external_expect(raw: bool):
+    opts = '-e expect'
+    return _show_cache(raw, opts)
 
-    elif args.show_statistics:
+def show_internal_cache(raw: bool):
+    opts = '-i ct'
+    return _show_cache(raw, opts)
+
+def show_internal_expect(raw: bool):
+    opts = '-i expect'
+    return _show_cache(raw, opts)
+
+def show_statistics(raw: bool):
+    if raw:
+        raise vyos.opmode.UnsupportedOperation("Machine-readable conntrack-sync statistics are not available yet")
+    else:
         is_configured()
         config = ConfigTreeQuery()
         print('\nMain Table Statistics:\n')
-        call(f'sudo {conntrackd_bin} -C {conntrackd_config} -s')
+        call(f'{conntrackd_bin} -C {conntrackd_config} -s')
         print()
         if config.exists(['service', 'conntrack-sync', 'expect-sync']):
             print('\nExpect Table Statistics:\n')
-            call(f'sudo {conntrackd_bin} -C {conntrackd_config} -s exp')
+            call(f'{conntrackd_bin} -C {conntrackd_config} -s exp')
             print()
 
-    elif args.show_status:
-        is_configured()
-        config = ConfigTreeQuery()
-        ct_sync_intf = config.list_nodes(['service', 'conntrack-sync', 'interface'])
-        ct_sync_intf = ', '.join(ct_sync_intf)
-        failover_state = "no transition yet!"
-        expect_sync_protocols = "disabled"
+def show_status(raw: bool):
+    is_configured()
+    config = ConfigTreeQuery()
+    ct_sync_intf = config.list_nodes(['service', 'conntrack-sync', 'interface'])
+    ct_sync_intf = ', '.join(ct_sync_intf)
+    failover_state = "no transition yet!"
+    expect_sync_protocols = []
 
-        if config.exists(['service', 'conntrack-sync', 'failover-mechanism', 'vrrp']):
-            failover_mechanism = "vrrp"
-            vrrp_sync_grp = config.value(['service', 'conntrack-sync', 'failover-mechanism', 'vrrp', 'sync-group'])
+    if config.exists(['service', 'conntrack-sync', 'failover-mechanism', 'vrrp']):
+        failover_mechanism = "vrrp"
+        vrrp_sync_grp = config.value(['service', 'conntrack-sync', 'failover-mechanism', 'vrrp', 'sync-group'])
 
-        if os.path.isfile(failover_state_file):
-            with open(failover_state_file, "r") as f:
-                failover_state = f.readline()
+    if os.path.isfile(failover_state_file):
+        with open(failover_state_file, "r") as f:
+            failover_state = f.readline()
 
-        if config.exists(['service', 'conntrack-sync', 'expect-sync']):
-            expect_sync_protocols = config.values(['service', 'conntrack-sync', 'expect-sync'])
-            if 'all' in expect_sync_protocols:
-                expect_sync_protocols = ["ftp", "sip", "h323", "nfs", "sqlnet"]
+    if config.exists(['service', 'conntrack-sync', 'expect-sync']):
+        expect_sync_protocols = config.values(['service', 'conntrack-sync', 'expect-sync'])
+        if 'all' in expect_sync_protocols:
+            expect_sync_protocols = ["ftp", "sip", "h323", "nfs", "sqlnet"]
+
+    if raw:
+        status_data = {
+            "sync_interface": ct_sync_intf,
+            "failover_mechanism": failover_mechanism,
+            "sync_group": vrrp_sync_grp,
+            "last_transition": failover_state,
+            "sync_protocols": expect_sync_protocols
+        }
+
+        return status_data
+    else:
+        if expect_sync_protocols:
             expect_sync_protocols = ', '.join(expect_sync_protocols)
-
+        else:
+            expect_sync_protocols = "disabled"
         show_status = (f'\nsync-interface        : {ct_sync_intf}\n'
                        f'failover-mechanism    : {failover_mechanism} [sync-group {vrrp_sync_grp}]\n'
-                       f'last state transition : {failover_state}'
+                       f'last state transition : {failover_state}\n'
                        f'ExpectationSync       : {expect_sync_protocols}')
 
-        print(show_status)
+        return show_status
 
-    else:
-        parser.print_help()
-        exit(1)
+if __name__ == '__main__':
+    syslog.openlog(ident='conntrack-tools', logoption=syslog.LOG_PID, facility=syslog.LOG_INFO)
+
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except (ValueError, vyos.opmode.Error) as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

Rewrite the conntrack-sync op mode script in the new format.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4888

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Conntrack sync.

## Proposed changes

```
# /usr/libexec/vyos/op_mode/conntrack_sync.py --help
usage: conntrack_sync.py [-h] {reset_external_cache,reset_internal_cache,restart,show_external_cache,show_external_expect,show_internal_cache,show_internal_expect,show_statistics,show_status} ...

positional arguments:
  {reset_external_cache,reset_internal_cache,restart,show_external_cache,show_external_expect,show_internal_cache,show_internal_expect,show_statistics,show_status}
    reset_external_cache
    reset_internal_cache
    restart
    show_external_cache
    show_external_expect
    show_internal_cache
    show_internal_expect
    show_statistics
    show_status
```

There are a few challeneges and discussion point, though.

## Issues

### No raw output for statistics

First, conntrackd has no machine-readable output for statistics so `show_statistics` does not work with `--raw` for now.  Worse yet, the human format is anything but easy to parse:

```
# sudo /usr/sbin/conntrackd -C /run/conntrackd/conntrackd.conf -s 
cache internal:
current active connections:	           9
connections created:		        1157	failed:	           0
connections updated:		          27	failed:	           0
connections destroyed:		        1148	failed:	           0

cache external:
current active connections:	           0
connections created:		           0	failed:	           0
connections updated:		           0	failed:	           0
connections destroyed:		           0	failed:	           0

traffic processed:
                   0 Bytes                         0 Pckts

multicast traffic (active device=eth0):
              152444 Bytes sent                    0 Bytes recv
                8336 Pckts sent                    0 Pckts recv
                   0 Error send                    0 Error recv

message tracking:
                   0 Malformed msgs                    0 Lost msgs
```

The best solution is to add support for XML output to conntrackd, of course. For now I just made it raise a `DataUnavailable` exception.

However, our convention so far is that `DataUnavailable` is meant for cases when requested data is __temporarily_ absent and retrying the request later may succeed. Since this never succeeds, I wonder if we need a new exception like `UnsupportedOperation`...

### Cache entry format

The machine-readable cache output looks like this:

```
vyos@vyos# /usr/libexec/vyos/op_mode/conntrack_sync.py show_internal_cache --raw
[
    {
        "flow": {
            "meta": [
                {
                    "at_direction": "original",
                    "layer3": {
                        "at_protonum": "2",
                        "at_protoname": "ipv4",
                        "src": "127.0.0.1",
                        "dst": "127.0.0.1"
                    },
                    "layer4": {
                        "at_protonum": "17",
                        "at_protoname": "udp",
                        "sport": "49882",
                        "dport": "53"
                    }
                },
                {
                    "at_direction": "reply",
                    "layer3": {
                        "at_protonum": "2",
                        "at_protoname": "ipv4",
                        "src": "127.0.0.1",
                        "dst": "127.0.0.1"
                    },
                    "layer4": {
                        "at_protonum": "17",
                        "at_protoname": "udp",
                        "sport": "53",
                        "dport": "49882"
                    }
                },
                {
                    "at_direction": "independent",
                    "id": "3978405999",
                    "unreplied": null
                }
            ]
        }
    },
```

Objects with a single `flow` field are inconvenient to work with. However, I wonder if there  are cases when there are more fields or the field name is not `flow`. Is there an XML schema for conntrack'd output?

### Main vs expect

In the old version, `show conntrack-sync cache <external|internal>` commands call the script twice with different options. For the op mode API, that's not an option, so we need to decide what to do.

Should `show_external_cache --raw` product a JSON dict with `main` and `expect` fields? 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
