### PR TITLE
T4890: Fixed op_mode show conntrack table ipv4

### DIFF
--- a/src/op_mode/conntrack.py
+++ b/src/op_mode/conntrack.py
@@ -116,7 +116,7 @@ def get_formatted_output(dict_data):
                 reply_src = f'{reply_src}:{reply_sport}' if reply_sport else reply_src
                 reply_dst = f'{reply_dst}:{reply_dport}' if reply_dport else reply_dst
                 state = meta['state'] if 'state' in meta else ''
-                mark = meta['mark']
+                mark = meta['mark'] if 'mark' in meta else ''
                 zone = meta['zone'] if 'zone' in meta else ''
                 data_entries.append(
                     [conn_id, orig_src, orig_dst, reply_src, reply_dst, proto, state, timeout, mark, zone])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed op_mode show conntrack table ipv4
Created check on empty column "mark"

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4890

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
conntrack, op_mode

## Proposed changes
<!--- Describe your changes in detail -->
Created check on empty column "mark"

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Before:
```
vyos@vyos:~$ show conntrack table ipv4
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/conntrack.py", line 148, in <module>
    res = vyos.opmode.run(sys.modules[__name__])
  File "/usr/lib/python3/dist-packages/vyos/opmode.py", line 212, in run
    res = func(**args)
  File "/usr/libexec/vyos/op_mode/conntrack.py", line 135, in show
    return get_formatted_output(conntrack_data)
  File "/usr/libexec/vyos/op_mode/conntrack.py", line 119, in get_formatted_output
    mark = meta['mark']
KeyError: 'mark'
```
After:
```
vyos@vyos:~$ show conntrack table ipv4
Id          Original src           Original dst           Reply src              Reply dst              Protocol    State    Timeout    Mark    Zone
----------  ---------------------  ---------------------  ---------------------  ---------------------  ----------  -------  ---------  ------  ------
2234560588  192.168.192.196:34029  8.8.8.8:53             8.8.8.8:53             192.168.192.196:34029  udp                  14
1841226412  192.168.192.196:123    34.206.168.146:123     34.206.168.146:123     192.168.192.196:123    udp                  179
1279964298  192.168.192.196:123    18.193.41.138:123      18.193.41.138:123      192.168.192.196:123    udp                  171
605922200   192.168.192.196:44429  8.8.8.8:53             8.8.8.8:53             192.168.192.196:44429  udp                  14
710672287   192.168.192.1:17500    192.168.192.255:17500  192.168.192.255:17500  192.168.192.1:17500    udp                  17
1903267021  192.168.192.196:123    122.248.201.177:123    122.248.201.177:123    192.168.192.196:123    udp                  178
3526679841  192.168.192.196:47083  8.8.8.8:53             8.8.8.8:53             192.168.192.196:47083  udp                  14
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
