### PR TITLE
T4893: Add ppp-options ipv6-interface-id for L2TP

### DIFF
--- a/data/templates/accel-ppp/l2tp.config.j2
+++ b/data/templates/accel-ppp/l2tp.config.j2
@@ -126,7 +126,13 @@ ipv6={{ ppp_ipv6 }}
 {% else %}
 {{ 'ipv6=allow' if client_ipv6_pool_configured else '' }}
 {% endif %}
-
+{% if ppp_ipv6_intf_id is vyos_defined %}
+ipv6-intf-id={{ ppp_ipv6_intf_id }}
+{% endif %}
+{% if ppp_ipv6_peer_intf_id is vyos_defined %}
+ipv6-peer-intf-id={{ ppp_ipv6_peer_intf_id }}
+{% endif %}
+ipv6-accept-peer-intf-id={{ "1" if ppp_ipv6_accept_peer_intf_id else "0" }}
 
 {% if client_ipv6_pool %}
 [ipv6-pool]

--- a/interface-definitions/include/accel-ppp/ppp-options-ipv6-interface-id.xml.i
+++ b/interface-definitions/include/accel-ppp/ppp-options-ipv6-interface-id.xml.i
@@ -1,0 +1,48 @@
+<!-- include start from accel-ppp/ppp-options-ipv6-interface-id.xml.i -->
+<leafNode name="ipv6-intf-id">
+  <properties>
+    <help>Fixed or random interface identifier for IPv6</help>
+    <completionHelp>
+      <list>random</list>
+    </completionHelp>
+    <valueHelp>
+      <format>random</format>
+      <description>Random interface identifier for IPv6</description>
+    </valueHelp>
+    <valueHelp>
+      <format>x:x:x:x</format>
+      <description>specify interface identifier for IPv6</description>
+    </valueHelp>
+  </properties>
+</leafNode>
+<leafNode name="ipv6-peer-intf-id">
+  <properties>
+    <help>Peer interface identifier for IPv6</help>
+    <completionHelp>
+      <list>random calling-sid ipv4</list>
+    </completionHelp>
+    <valueHelp>
+      <format>x:x:x:x</format>
+      <description>Interface identifier for IPv6</description>
+    </valueHelp>
+    <valueHelp>
+      <format>random</format>
+      <description>Use a random interface identifier for IPv6</description>
+    </valueHelp>
+    <valueHelp>
+      <format>ipv4</format>
+      <description>Calculate interface identifier from IPv4 address, for example 192:168:0:1</description>
+    </valueHelp>
+    <valueHelp>
+      <format>calling-sid</format>
+      <description>Calculate interface identifier from calling-station-id</description>
+    </valueHelp>
+  </properties>
+</leafNode>
+<leafNode name="ipv6-accept-peer-intf-id">
+  <properties>
+    <help>Accept peer interface identifier</help>
+    <valueless />
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/accel-ppp/ppp-options-ipv6-interface-id.xml.i
+++ b/interface-definitions/include/accel-ppp/ppp-options-ipv6-interface-id.xml.i
@@ -13,6 +13,9 @@
       <format>x:x:x:x</format>
       <description>specify interface identifier for IPv6</description>
     </valueHelp>
+    <constraint>
+      <regex>(random|((\d+){1,4}:){3}(\d+){1,4})</regex>
+    </constraint>
   </properties>
 </leafNode>
 <leafNode name="ipv6-peer-intf-id">
@@ -37,12 +40,15 @@
       <format>calling-sid</format>
       <description>Calculate interface identifier from calling-station-id</description>
     </valueHelp>
+    <constraint>
+      <regex>(random|calling-sid|ipv4|((\d+){1,4}:){3}(\d+){1,4})</regex>
+    </constraint>
   </properties>
 </leafNode>
 <leafNode name="ipv6-accept-peer-intf-id">
   <properties>
     <help>Accept peer interface identifier</help>
-    <valueless />
+    <valueless/>
   </properties>
 </leafNode>
 <!-- include end -->

--- a/interface-definitions/service-pppoe-server.xml.in
+++ b/interface-definitions/service-pppoe-server.xml.in
@@ -170,52 +170,7 @@
                 </properties>
               </leafNode>
               #include <include/accel-ppp/ppp-options-ipv6.xml.i>
-              <leafNode name="ipv6-intf-id">
-                <properties>
-                  <help>Fixed or random interface identifier for IPv6</help>
-                  <completionHelp>
-                    <list>random</list>
-                  </completionHelp>
-                  <valueHelp>
-                    <format>random</format>
-                    <description>Random interface identifier for IPv6</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>x:x:x:x</format>
-                    <description>specify interface identifier for IPv6</description>
-                  </valueHelp>
-                </properties>
-              </leafNode>
-              <leafNode name="ipv6-peer-intf-id">
-                <properties>
-                  <help>Peer interface identifier for IPv6</help>
-                  <completionHelp>
-                    <list>random calling-sid ipv4</list>
-                  </completionHelp>
-                  <valueHelp>
-                    <format>x:x:x:x</format>
-                    <description>Interface identifier for IPv6</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>random</format>
-                    <description>Use a random interface identifier for IPv6</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>ipv4</format>
-                    <description>Calculate interface identifier from IPv4 address, for example 192:168:0:1</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>calling-sid</format>
-                    <description>Calculate interface identifier from calling-station-id</description>
-                  </valueHelp>
-                </properties>
-              </leafNode>
-              <leafNode name="ipv6-accept-peer-intf-id">
-                <properties>
-                  <help>Accept peer interface identifier</help>
-                  <valueless />
-                </properties>
-              </leafNode>
+              #include <include/accel-ppp/ppp-options-ipv6-interface-id.xml.i>
             </children>
           </node>
           <tagNode name="pado-delay">

--- a/interface-definitions/vpn-l2tp.xml.in
+++ b/interface-definitions/vpn-l2tp.xml.in
@@ -251,6 +251,7 @@
                 <children>
                   #include <include/accel-ppp/lcp-echo-interval-failure.xml.i>
                   #include <include/accel-ppp/ppp-options-ipv6.xml.i>
+                  #include <include/accel-ppp/ppp-options-ipv6-interface-id.xml.i>
                 </children>
               </node>
             </children>

--- a/src/conf_mode/vpn_l2tp.py
+++ b/src/conf_mode/vpn_l2tp.py
@@ -58,6 +58,9 @@ default_config_data = {
     'ppp_echo_failure' : '3',
     'ppp_echo_interval' : '30',
     'ppp_echo_timeout': '0',
+    'ppp_ipv6_accept_peer_intf_id': False,
+    'ppp_ipv6_intf_id': None,
+    'ppp_ipv6_peer_intf_id': None,
     'radius_server': [],
     'radius_acct_inter_jitter': '',
     'radius_acct_tmo': '3',
@@ -313,6 +316,15 @@ def get_config(config=None):
 
     if conf.exists(['ppp-options', 'ipv6']):
         l2tp['ppp_ipv6'] = conf.return_value(['ppp-options', 'ipv6'])
+
+    if conf.exists(['ppp-options', 'ipv6-accept-peer-intf-id']):
+        l2tp['ppp_ipv6_accept_peer_intf_id'] = True
+
+    if conf.exists(['ppp-options', 'ipv6-intf-id']):
+        l2tp['ppp_ipv6_intf_id'] = conf.return_value(['ppp-options', 'ipv6-intf-id'])
+
+    if conf.exists(['ppp-options', 'ipv6-peer-intf-id']):
+        l2tp['ppp_ipv6_peer_intf_id'] = conf.return_value(['ppp-options', 'ipv6-peer-intf-id'])
 
     return l2tp
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add ppp-options IPv6 interface id for vpn L2TP

  - fixed or random interface identifier for IPv6
  - peer interface identifier for IPv6
  - whether to accept peer’s interface identifier
 
    set vpn l2tp remote-access ppp-options ipv6-accept-peer-intf-id
    set vpn l2tp remote-access ppp-options ipv6-intf-id 'random'
    set vpn l2tp remote-access ppp-options ipv6-peer-intf-id 'calling-sid'

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4893

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
l2tp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set vpn l2tp remote-access authentication local-users username mia password 'secretpass'
set vpn l2tp remote-access authentication mode 'local'
set vpn l2tp remote-access client-ip-pool subnet '100.64.27.0/24'
set vpn l2tp remote-access client-ipv6-pool prefix 2001:db8:a::/48
set vpn l2tp remote-access ppp-options ipv6-accept-peer-intf-id
set vpn l2tp remote-access ppp-options ipv6-intf-id 'random'
set vpn l2tp remote-access ppp-options ipv6-peer-intf-id 'calling-sid'
```
Expected IPv6 options:
```
vyos@r1# cat /run/accel-pppd/l2tp.conf | grep ^ipv6-
ipv6-intf-id=random
ipv6-peer-intf-id=calling-sid
ipv6-accept-peer-intf-id=1
[edit]
vyos@r1# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
