### PR TITLE
T4897: vxlan: Fix setting `source-address` and `source-interface`

### DIFF
--- a/src/conf_mode/interfaces-vxlan.py
+++ b/src/conf_mode/interfaces-vxlan.py
@@ -52,13 +52,11 @@ def get_config(config=None):
     # VXLAN interfaces are picky and require recreation if certain parameters
     # change. But a VXLAN interface should - of course - not be re-created if
     # it's description or IP address is adjusted. Feels somehow logic doesn't it?
-    for cli_option in ['external', 'gpe', 'group', 'port', 'remote',
+    for cli_option in ['parameters', 'external', 'gpe', 'group', 'port', 'remote',
                        'source-address', 'source-interface', 'vni']:
-        if leaf_node_changed(conf, base + [ifname, cli_option]):
+        if is_node_changed(conf, base + [ifname, cli_option]):
             vxlan.update({'rebuild_required': {}})
-
-    if is_node_changed(conf, base + [ifname, 'parameters']):
-        vxlan.update({'rebuild_required': {}})
+            break
 
     # We need to verify that no other VXLAN tunnel is configured when external
     # mode is in use - Linux Kernel limitation


### PR DESCRIPTION
`leaf_node_changed` returns `[]` (empty list) after a leaf node is
added.

e.g. Setting `source-interface` doesn't work on an existing vxlan
interface.

Steps to reproduce:

- Add a vxlan interface without `source-address` or `source-interface` options set:

```
set interfaces vxlan vxlan999 vni 999
set interfaces vxlan vxlan999 remote 192.168.100.100
commit
```

- Then set `source-address` or `source-interface`:

```
set interfaces vxlan vxlan999 source-interface eth0
commit
```

Actual result:

Source address or source-interface are not set:
```
ip -d link show dev vxlan999
76: vxlan999: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 56:08:ba:4d:4e:a8 brd ff:ff:ff:ff:ff:ff promiscuity 0 minmtu 68 maxmtu 65535
    vxlan id 999 remote 192.168.100.100 srcport 0 0 dstport 8472 tos inherit ttl 16 ageing 300 udpcsum noudp6zerocsumtx noudp6zerocsumrx addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535
```

Expected result:

```
77: vxlan999: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 9e:05:d9:58:1a:af brd ff:ff:ff:ff:ff:ff promiscuity 0 minmtu 68 maxmtu 65535
    vxlan id 999 remote 192.168.100.100 dev eth0 srcport 0 0 dstport 8472 tos inherit ttl 16 ageing 300 udpcsum noudp6zerocsumtx noudp6zerocsumrx addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535
```

All invocations of leaf_node_changed() should be migrated to is_node_changes() if you are only interested in if something changed and don‘t care what exactly changed (content).