### PR TITLE
T4898: add MTU config option for dummy interfaces (equuleus)

### DIFF
--- a/interface-definitions/interfaces-dummy.xml.in
+++ b/interface-definitions/interfaces-dummy.xml.in
@@ -25,6 +25,24 @@
             </properties>
             <children>
               #include <include/interface/source-validation.xml.i>
+              #include <include/interface/disable-forwarding.xml.i>
+            </children>
+          </node>
+          <node name="ipv6">
+            <properties>
+              <help>IPv6 routing parameters</help>
+            </properties>
+            <children>
+              #include <include/interface/disable-forwarding.xml.i>
+              <node name="address">
+                <properties>
+                  <help>IPv6 address configuration modes</help>
+                </properties>
+                <children>
+                  #include <include/interface/ipv6-address-eui64.xml.i>
+                  #include <include/interface/ipv6-address-no-default-link-local.xml.i>
+                </children>
+              </node>
             </children>
           </node>
           #include <include/interface/mtu-68-16000.xml.i>

--- a/interface-definitions/interfaces-dummy.xml.in
+++ b/interface-definitions/interfaces-dummy.xml.in
@@ -27,6 +27,7 @@
               #include <include/interface/source-validation.xml.i>
             </children>
           </node>
+          #include <include/interface/mtu-68-16000.xml.i>
           #include <include/interface/vrf.xml.i>
         </children>
       </tagNode>

--- a/smoketest/scripts/cli/test_interfaces_dummy.py
+++ b/smoketest/scripts/cli/test_interfaces_dummy.py
@@ -21,6 +21,7 @@ from base_interfaces_test import BasicInterfaceTest
 class DummyInterfaceTest(BasicInterfaceTest.TestCase):
     @classmethod
     def setUpClass(cls):
+        cls._test_mtu = True
         cls._base_path = ['interfaces', 'dummy']
         cls._interfaces = ['dum435', 'dum8677', 'dum0931', 'dum089']
         # call base-classes classmethod


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4898

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dummy

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests

```
cpo@LR2.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_dummy.py
test_add_multiple_ip_addresses (__main__.DummyInterfaceTest) ... ok
test_add_single_ip_address (__main__.DummyInterfaceTest) ... ok
test_dhcp_disable_interface (__main__.DummyInterfaceTest) ... skipped 'not supported'
test_dhcpv6_client_options (__main__.DummyInterfaceTest) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.DummyInterfaceTest) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.DummyInterfaceTest) ... skipped 'not supported'
test_interface_description (__main__.DummyInterfaceTest) ... ok
test_interface_disable (__main__.DummyInterfaceTest) ... ok
test_interface_ip_options (__main__.DummyInterfaceTest) ... skipped 'not supported'
test_interface_ipv6_options (__main__.DummyInterfaceTest) ... skipped 'not supported'
test_interface_mtu (__main__.DummyInterfaceTest) ... ok
test_ipv6_link_local_address (__main__.DummyInterfaceTest) ... skipped 'not supported'
test_mtu_1200_no_ipv6_interface (__main__.DummyInterfaceTest) ... ok
test_span_mirror (__main__.DummyInterfaceTest) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.DummyInterfaceTest) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.DummyInterfaceTest) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.DummyInterfaceTest) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.DummyInterfaceTest) ... skipped 'not supported'

----------------------------------------------------------------------
Ran 18 tests in 173.728s

OK (skipped=12)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
