### PR TITLE
T4904: keepalived virtual-server allow multiple ports with fwmark

### DIFF
--- a/data/templates/high-availability/keepalived.conf.j2
+++ b/data/templates/high-availability/keepalived.conf.j2
@@ -126,7 +126,12 @@ vrrp_sync_group {{ name }} {
 {% if virtual_server is vyos_defined %}
 # Virtual-server configuration
 {%     for vserver, vserver_config in virtual_server.items() %}
+# Vserver {{ vserver }}
+{%         if vserver_config.port is vyos_defined %}
 virtual_server {{ vserver }} {{ vserver_config.port }} {
+{%         else %}
+virtual_server fwmark {{ vserver_config.fwmark }} {
+{%         endif %}
     delay_loop {{ vserver_config.delay_loop }}
 {%         if vserver_config.algorithm is vyos_defined('round-robin') %}
     lb_algo rr
@@ -156,9 +161,14 @@ virtual_server {{ vserver }} {{ vserver_config.port }} {
 {%             for rserver, rserver_config in vserver_config.real_server.items() %}
     real_server {{ rserver }} {{ rserver_config.port }} {
         weight 1
+{%                 if rserver_config.health_check.script is vyos_defined %}
+        MISC_CHECK {
+            misc_path {{ rserver_config.health_check.script }}
+{%                 else %}
         {{ vserver_config.protocol | upper }}_CHECK {
-{%                 if rserver_config.connection_timeout is vyos_defined %}
+{%                     if rserver_config.connection_timeout is vyos_defined %}
             connect_timeout {{ rserver_config.connection_timeout }}
+{%                     endif %}
 {%                 endif %}
         }
     }

--- a/interface-definitions/high-availability.xml.in
+++ b/interface-definitions/high-availability.xml.in
@@ -365,7 +365,8 @@
             </properties>
             <defaultValue>nat</defaultValue>
           </leafNode>
-          #include <include/port-number.xml.i>
+          #include <include/firewall/fwmark.xml.i>
+          #include <include/port-number-start-zero.xml.i>
           <leafNode name="persistence-timeout">
             <properties>
               <help>Timeout for persistent connections</help>
@@ -404,7 +405,7 @@
               <help>Real server address</help>
             </properties>
             <children>
-              #include <include/port-number.xml.i>
+              #include <include/port-number-start-zero.xml.i>
               <leafNode name="connection-timeout">
                 <properties>
                   <help>Server connection timeout</help>
@@ -417,6 +418,21 @@
                   </constraint>
                 </properties>
               </leafNode>
+              <node name="health-check">
+                <properties>
+                  <help>Health check script</help>
+                </properties>
+                <children>
+                  <leafNode name="script">
+                    <properties>
+                      <help>Health check script file</help>
+                      <constraint>
+                        <validator name="script"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
             </children>
           </tagNode>
         </children>

--- a/interface-definitions/include/firewall/fwmark.xml.i
+++ b/interface-definitions/include/firewall/fwmark.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from firewall/fwmark.xml.i -->
+<leafNode name="fwmark">
+  <properties>
+    <help>Match fwmark value</help>
+    <valueHelp>
+      <format>u32:1-2147483647</format>
+      <description>Match firewall mark value</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-2147483647"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/port-number-start-zero.xml.i
+++ b/interface-definitions/include/port-number-start-zero.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from port-number-start-zero.xml.i -->
+<leafNode name="port">
+  <properties>
+    <help>Port number used by connection</help>
+    <valueHelp>
+      <format>u32:0-65535</format>
+      <description>Numeric IP port</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 0-65535"/>
+    </constraint>
+    <constraintErrorMessage>Port number must be in range 0 to 65535</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/src/conf_mode/high-availability.py
+++ b/src/conf_mode/high-availability.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2022 VyOS maintainers and contributors
+# Copyright (C) 2018-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -144,8 +144,10 @@ def verify(ha):
     # Virtual-server
     if 'virtual_server' in ha:
         for vs, vs_config in ha['virtual_server'].items():
-            if 'port' not in vs_config:
-                raise ConfigError(f'Port is required but not set for virtual-server "{vs}"')
+            if 'port' not in vs_config and 'fwmark' not in vs_config:
+                raise ConfigError(f'Port or fwmark is required but not set for virtual-server "{vs}"')
+            if 'port' in vs_config and 'fwmark' in vs_config:
+                raise ConfigError(f'Cannot set both port and fwmark for virtual-server "{vs}"')
             if 'real_server' not in vs_config:
                 raise ConfigError(f'Real-server ip is required but not set for virtual-server "{vs}"')
         # Real-server


### PR DESCRIPTION
Allow multiple ports for high-availability virtual-server The current implementation allows balance only one "virtual" address and port between several "real servers"
Allow matching "fwmark" to set traffic which should be balanced.

Allow setting port 0 (all traffic) if we use "fwmark" Add health-check script.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4904

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
keepalive, virtual-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
We can mark just required ports without IP addresses or with them
And use `fwmark` value for virtual-server
Also, we use "port 0" as we mark several ports

VyOS config:
```
set interfaces ethernet eth0 address '192.0.2.1/24'
set interfaces ethernet eth0 description 'LAN'
set interfaces ethernet eth4 address 'dhcp'
set interfaces ethernet eth4 description 'WAN'

set policy route PR interface 'eth4'
set policy route PR rule 10 destination port '80,2222,8888'
set policy route PR rule 10 protocol 'tcp'
set policy route PR rule 10 set mark '111'

set high-availability virtual-server 203.0.113.1 fwmark '111'
set high-availability virtual-server 203.0.113.1 protocol 'tcp'
set high-availability virtual-server 203.0.113.1 real-server 192.0.2.11 health-check script '/bin/true'
set high-availability virtual-server 203.0.113.1 real-server 192.0.2.11 port '0'
set high-availability virtual-server 203.0.113.1 real-server 192.0.2.12 health-check script '/bin/true'
set high-availability virtual-server 203.0.113.1 real-server 192.0.2.12 port '0'

set nat source rule 100 outbound-interface 'eth4'
set nat source rule 100 source address '192.0.2.0/24'
set nat source rule 100 translation address 'masquerade'
```
Keepal;lived config
```
vyos@r1# cat /run/keepalived/keepalived.conf 
...
# Virtual-server configuration
# Vserver 203.0.113.1
virtual_server fwmark 111 {
    delay_loop 10
    lb_algo lc
    lb_kind NAT
    persistence_timeout 300
    protocol TCP
    real_server 192.0.2.11 0 {
        weight 1
        MISC_CHECK {
            misc_path /bin/true
        }
    }
    real_server 192.0.2.12 0 {
        weight 1
        MISC_CHECK {
            misc_path /bin/true
        }
    }
}

```
Show virtual-server
```
vyos@r1# run show virtual-server 
IP Virtual Server version 1.2.1 (size=4096)
Prot LocalAddress:Port Scheduler Flags
  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn
FWM  111 lc persistent 300
  -> 192.0.2.11:0                 Masq    1      0          0         
  -> 192.0.2.12:0                 Masq    1      1          0
[edit]
vyos@r1# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
