### PR TITLE
T4907: op-mode nat add missing option verbose

### DIFF
--- a/src/op_mode/nat.py
+++ b/src/op_mode/nat.py
@@ -316,14 +316,20 @@ def show_statistics(raw: bool, direction: str, family: str):
 
 
 @_verify
-def show_translations(raw: bool, direction: str, family: str, address: typing.Optional[str]):
+def show_translations(raw: bool, direction:
+                      str, family: str,
+                      address: typing.Optional[str],
+                      verbose: typing.Optional[bool]):
     family = 'ipv6' if family == 'inet6' else 'ipv4'
-    nat_translation = _get_raw_translation(direction, family=family, address=address)
+    nat_translation = _get_raw_translation(direction,
+                                           family=family,
+                                           address=address)
 
     if raw:
         return nat_translation
     else:
-        return _get_formatted_translation(nat_translation, direction, family, verbose)
+        return _get_formatted_translation(nat_translation, direction, family,
+                                          verbose)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add missing option "verbose" for op-mode NAT
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4907

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set nat source rule 100 outbound-interface 'eth0'
set nat source rule 100 source address '192.0.2.0/24'
set nat source rule 100 translation address 'masquerade'
```
Before fix:
```
vyos@r14:~$ sudo /usr/libexec/vyos/op_mode/nat.py show_translations --direction source --family inet --raw
{
    "conntrack": {
        "error": true,
        "reason": "entries not found"
    }
}
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ sudo /usr/libexec/vyos/op_mode/nat.py show_translations --direction source --family inet 
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/nat.py", line 331, in <module>
    res = vyos.opmode.run(sys.modules[__name__])
  File "/usr/lib/python3/dist-packages/vyos/opmode.py", line 212, in run
    res = func(**args)
  File "/usr/libexec/vyos/op_mode/nat.py", line 296, in _wrapper
    return func(*args, **kwargs)
  File "/usr/libexec/vyos/op_mode/nat.py", line 326, in show_translations
    return _get_formatted_translation(nat_translation, direction, family, verbose)
NameError: name 'verbose' is not defined
vyos@r14:~$
```
After fix:
```
vyos@r14:~$ sudo /usr/libexec/vyos/op_mode/nat.py show_translations --direction source --family inet 
Entries not found
vyos@r14:~$ 
vyos@r14:~$ ping 1.1.1.1 source-address 192.0.2.1
PING 1.1.1.1 (1.1.1.1) from 192.0.2.1 : 56(84) bytes of data.
64 bytes from 1.1.1.1: icmp_seq=1 ttl=56 time=38.4 ms
64 bytes from 1.1.1.1: icmp_seq=2 ttl=56 time=38.3 ms
^C
--- 1.1.1.1 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1001ms
rtt min/avg/max/mdev = 38.326/38.343/38.361/0.017 ms


vyos@r14:~$ sudo /usr/libexec/vyos/op_mode/nat.py show_translations --direction source --family inet 
Pre-NAT    Post-NAT        Proto    Timeout    Mark    Zone
---------  --------------  -------  ---------  ------  ------
192.0.2.1  192.168.122.14  icmp     26
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
