### PR TITLE
config: T4919: Add support for encrypted config with TPM

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -304,6 +304,10 @@ Depends:
 # For "run monitor bandwidth"
   bmon,
 # End Operational mode
+## TPM tools
+  cryptsetup,
+  tpm2-tools,
+## End TPM tools
 ## Optional utilities
   easy-rsa,
   tcptraceroute,

--- a/op-mode-definitions/crypt.xml.in
+++ b/op-mode-definitions/crypt.xml.in
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="encryption">
+    <properties>
+      <help>Manage config encryption</help>
+    </properties>
+    <children>
+      <node name="disable">
+        <properties>
+          <help>Disable config encryption using TPM or recovery key</help>
+        </properties>
+        <command>sudo ${vyos_libexec_dir}/vyos-config-encrypt.py --disable</command>
+      </node>
+      <node name="enable">
+        <properties>
+          <help>Enable config encryption using TPM</help>
+        </properties>
+        <command>sudo ${vyos_libexec_dir}/vyos-config-encrypt.py --enable</command>
+      </node>
+      <node name="load">
+        <properties>
+          <help>Load encrypted config volume using TPM or recovery key</help>
+        </properties>
+        <command>sudo ${vyos_libexec_dir}/vyos-config-encrypt.py --load</command>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/python/vyos/tpm.py
+++ b/python/vyos/tpm.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import tempfile
+
+from vyos.util import rc_cmd
+
+default_pcrs = ['0','2','4','7']
+tpm_handle = 0x81000000
+
+def init_tpm(clear=False):
+    """
+    Initialize TPM
+    """
+    code, output = rc_cmd('tpm2_startup' + (' -c' if clear else ''))
+    if code != 0:
+        raise Exception('init_tpm: Failed to initialize TPM')
+
+def clear_tpm_key():
+    """
+    Clear existing key on TPM
+    """
+    code, output = rc_cmd(f'tpm2_evictcontrol -C o -c {tpm_handle}')
+    if code != 0:
+        raise Exception('clear_tpm_key: Failed to clear TPM key')
+
+def read_tpm_key(index=0, pcrs=default_pcrs):
+    """
+    Read existing key on TPM
+    """
+    with tempfile.TemporaryDirectory() as tpm_dir:
+        pcr_str = ",".join(pcrs)
+
+        tpm_key_file = os.path.join(tpm_dir, 'tpm_key.key')
+        code, output = rc_cmd(f'tpm2_unseal -c {tpm_handle + index} -p pcr:sha256:{pcr_str} -o {tpm_key_file}')
+        if code != 0:
+            raise Exception('read_tpm_key: Failed to read key from TPM')
+
+        with open(tpm_key_file, 'rb') as f:
+            tpm_key = f.read()
+
+        return tpm_key
+
+def write_tpm_key(key, index=0, pcrs=default_pcrs):
+    """
+    Saves key to TPM
+    """
+    with tempfile.TemporaryDirectory() as tpm_dir:
+        pcr_str = ",".join(pcrs)
+
+        policy_file = os.path.join(tpm_dir, 'policy.digest')
+        code, output = rc_cmd(f'tpm2_createpolicy --policy-pcr -l sha256:{pcr_str} -L {policy_file}')
+        if code != 0:
+            raise Exception('write_tpm_key: Failed to create policy digest')
+
+        primary_context_file = os.path.join(tpm_dir, 'primary.ctx')
+        code, output = rc_cmd(f'tpm2_createprimary -C e -g sha256 -G rsa -c {primary_context_file}')
+        if code != 0:
+            raise Exception('write_tpm_key: Failed to create primary key')
+
+        key_file = os.path.join(tpm_dir, 'crypt.key')
+        with open(key_file, 'wb') as f:
+            f.write(key)
+
+        public_obj = os.path.join(tpm_dir, 'obj.pub')
+        private_obj = os.path.join(tpm_dir, 'obj.key')
+        code, output = rc_cmd(
+            f'tpm2_create -g sha256 \
+            -u {public_obj} -r {private_obj} \
+            -C {primary_context_file} -L {policy_file} -i {key_file}')
+
+        if code != 0:
+            raise Exception('write_tpm_key: Failed to create object')
+
+        load_context_file = os.path.join(tpm_dir, 'load.ctx')
+        code, output = rc_cmd(f'tpm2_load -C {primary_context_file} -u {public_obj} -r {private_obj} -c {load_context_file}')
+
+        if code != 0:
+            raise Exception('write_tpm_key: Failed to load object')
+
+        code, output = rc_cmd(f'tpm2_evictcontrol -c {load_context_file} -C o {tpm_handle + index}')
+
+        if code != 0:
+            raise Exception('write_tpm_key: Failed to write object to TPM')

--- a/src/helpers/vyos-config-encrypt.py
+++ b/src/helpers/vyos-config-encrypt.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import re
+import shutil
+import sys
+
+from argparse import ArgumentParser
+from cryptography.fernet import Fernet
+from tempfile import NamedTemporaryFile
+from tempfile import TemporaryDirectory
+
+from vyos.tpm import clear_tpm_key
+from vyos.tpm import init_tpm
+from vyos.tpm import read_tpm_key
+from vyos.tpm import write_tpm_key
+from vyos.util import ask_input
+from vyos.util import ask_yes_no
+from vyos.util import cmd
+
+persistpath_cmd = '/opt/vyatta/sbin/vyos-persistpath'
+mount_paths = ['/config', '/opt/vyatta/etc/config']
+dm_device = '/dev/mapper/vyos_config'
+
+def is_opened():
+    return os.path.exists(dm_device)
+
+def get_current_image():
+    with open('/proc/cmdline', 'r') as f:
+        args = f.read().split(" ")
+        for arg in args:
+            if 'vyos-union' in arg:
+                k, v = arg.split("=")
+                path_split = v.split("/")
+                return path_split[-1]
+    return None
+
+def load_config(key):
+    if not key:
+        return
+
+    persist_path = cmd(persistpath_cmd).strip()
+    image_name = get_current_image()
+    image_path = os.path.join(persist_path, 'luks', image_name)
+
+    if not os.path.exists(image_path):
+        raise Exception("Encrypted config volume doesn't exist")
+
+    if is_opened():
+        print('Encrypted config volume is already mounted')
+        return
+
+    with NamedTemporaryFile(dir='/dev/shm', delete=False) as f:
+        f.write(key)
+        key_file = f.name
+
+    cmd(f'cryptsetup -q open {image_path} vyos_config --key-file={key_file}')
+
+    for path in mount_paths:
+        cmd(f'mount /dev/mapper/vyos_config {path}')
+        cmd(f'chgrp -R vyattacfg {path}')
+
+    os.unlink(key_file)
+
+    return True
+
+def encrypt_config(key, recovery_key):
+    if is_opened():
+        raise Exception('An encrypted config volume is already mapped')
+
+    # Clear and write key to TPM
+    try:
+        clear_tpm_key()
+    except:
+        pass
+    write_tpm_key(key)
+
+    persist_path = cmd(persistpath_cmd).strip()
+    size = ask_input('Enter size of encrypted config partition (MB): ', numeric_only=True, default=512)
+
+    luks_folder = os.path.join(persist_path, 'luks')
+
+    if not os.path.isdir(luks_folder):
+        os.mkdir(luks_folder)
+
+    image_name = get_current_image()
+    image_path = os.path.join(luks_folder, image_name)
+
+    # Create file for encrypted config
+    cmd(f'fallocate -l {size}M {image_path}')
+
+    # Write TPM key for slot #1
+    with NamedTemporaryFile(dir='/dev/shm', delete=False) as f:
+        f.write(key)
+        key_file = f.name
+
+    # Format and add main key to volume
+    cmd(f'cryptsetup -q luksFormat {image_path} {key_file}')
+
+    if recovery_key:
+        # Write recovery key for slot 2
+        with NamedTemporaryFile(dir='/dev/shm', delete=False) as f:
+            f.write(recovery_key)
+            recovery_key_file = f.name
+
+        cmd(f'cryptsetup -q luksAddKey {image_path} {recovery_key_file} --key-file={key_file}')
+
+    # Open encrypted volume and format with ext4
+    cmd(f'cryptsetup -q open {image_path} vyos_config --key-file={key_file}')
+    cmd('mkfs.ext4 /dev/mapper/vyos_config')
+
+    with TemporaryDirectory() as d:
+        cmd(f'mount /dev/mapper/vyos_config {d}')
+
+        # Move /config to encrypted volume
+        shutil.copytree('/config', d, copy_function=shutil.move, dirs_exist_ok=True)
+
+        cmd(f'umount {d}')
+
+    os.unlink(key_file)
+
+    if recovery_key:
+        os.unlink(recovery_key_file)
+
+    for path in mount_paths:
+        cmd(f'mount /dev/mapper/vyos_config {path}')
+        cmd(f'chgrp vyattacfg {path}')
+
+    return True
+
+def decrypt_config(key):
+    if not key:
+        return
+
+    persist_path = cmd(persistpath_cmd).strip()
+    image_name = get_current_image()
+    image_path = os.path.join(persist_path, 'luks', image_name)
+
+    if not os.path.exists(image_path):
+        raise Exception("Encrypted config volume doesn't exist")
+
+    key_file = None
+
+    if not is_opened():
+        with NamedTemporaryFile(dir='/dev/shm', delete=False) as f:
+            f.write(key)
+            key_file = f.name
+
+        cmd(f'cryptsetup -q open {image_path} vyos_config --key-file={key_file}')
+
+    # unmount encrypted volume mount points
+    for path in mount_paths:
+        if os.path.ismount(path):
+            cmd(f'umount {path}')
+
+    # If /config is populated, move to /config.old
+    if len(os.listdir('/config')) > 0:
+        print('Moving existing /config folder to /config.old')
+        shutil.move('/config', '/config.old')
+
+    # Temporarily mount encrypted volume and migrate files to /config on rootfs
+    with TemporaryDirectory() as d:
+        cmd(f'mount /dev/mapper/vyos_config {d}')
+
+        # Move encrypted volume to /config
+        shutil.copytree(d, '/config', copy_function=shutil.move, dirs_exist_ok=True)
+        cmd(f'chgrp -R vyattacfg /config')
+
+        cmd(f'umount {d}')
+
+    # Close encrypted volume
+    cmd('cryptsetup -q close vyos_config')
+
+    # Remove encrypted volume image file and key
+    if key_file:
+        os.unlink(key_file)
+    os.unlink(image_path)
+
+    try:
+        clear_tpm_key()
+    except:
+        pass
+
+    return True
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("Must specify action.")
+        sys.exit(1)
+
+    parser = ArgumentParser(description='Config encryption')
+    parser.add_argument('--disable', help='Disable encryption', action="store_true")
+    parser.add_argument('--enable', help='Enable encryption', action="store_true")
+    parser.add_argument('--load', help='Load encrypted config volume', action="store_true")
+    args = parser.parse_args()
+
+    tpm_exists = os.path.exists('/sys/class/tpm/tpm0')
+
+    key = None
+    recovery_key = None
+    need_recovery = False
+
+    question_key_str = 'recovery key' if tpm_exists else 'key'
+
+    if tpm_exists:
+        if args.enable:
+            key = Fernet.generate_key()
+        elif args.disable or args.load:
+            try:
+                key = read_tpm_key()
+                need_recovery = False
+            except:
+                print('Failed to read key from TPM, recovery key required')
+                need_recovery = True
+    else:
+        need_recovery = True
+
+    if args.enable and not tpm_exists:
+        print('WARNING: VyOS will boot into a default config when encrypted without a TPM')
+        print('You will need to manually login with default credentials and use "encryption load"')
+        print('to mount the encrypted volume and use "load /config/config.boot"')
+
+        if not ask_yes_no('Are you sure you want to proceed?'):
+            sys.exit(0)
+
+    if need_recovery or (args.enable and not ask_yes_no(f'Automatically generate a {question_key_str}?', default=True)):
+        while True:
+            recovery_key = ask_input(f'Enter {question_key_str}:', default=None).encode()
+
+            if len(recovery_key) >= 32:
+                break
+
+            print('Invalid key - must be at least 32 characters, try again.')
+    else:
+        recovery_key = Fernet.generate_key()
+
+    try:
+        if args.disable:
+            decrypt_config(key or recovery_key)
+
+            print('Encrypted config volume has been disabled')
+            print('Contents have been migrated to /config on rootfs')
+        elif args.load:
+            load_config(key or recovery_key)
+
+            print('Encrypted config volume has been mounted')
+            print('Use "load /config/config.boot" to load configuration')
+        elif args.enable and tpm_exists:
+            encrypt_config(key, recovery_key)
+
+            print('Encrypted config volume has been enabled with TPM')
+            print('Backup the recovery key in a safe place!')
+            print('Recovery key: ' + recovery_key.decode())
+        elif args.enable:
+            encrypt_config(recovery_key)
+
+            print('Encrypted config volume has been enabled without TPM')
+            print('Backup the key in a safe place!')
+            print('Key: ' + recovery_key.decode())
+    except Exception as e:
+        word = 'decrypt' if args.disable or args.load else 'encrypt'
+        print(f'Failed to {word} config: {e}')

--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -64,6 +64,69 @@ disabled () {
     grep -q -w no-vyos-$1 /proc/cmdline
 }
 
+# Load encrypted config volume
+mount_encrypted_config() {
+    persist_path=$(/opt/vyatta/sbin/vyos-persistpath)
+    if [ $? == 0 ]; then
+        if [ -e $persist_path/boot ]; then
+            image_name=$(cat /proc/cmdline | sed -e s+^.*vyos-union=/boot/++ | sed -e 's/ .*$//')
+
+            if [ -z "$image_name" ]; then
+                return
+            fi
+
+            if [ ! -f $persist_path/luks/$image_name ]; then
+                return
+            fi
+
+            vyos_tpm_key=$(python3 -c 'from vyos.tpm import read_tpm_key; print(read_tpm_key().decode())' 2>/dev/null)
+
+            if [ $? -ne 0 ]; then
+                echo "ERROR: Failed to fetch encryption key from TPM. Encrypted config volume has not been mounted"
+                echo "Use 'encryption load' to load volume with recovery key"
+                echo "or 'encryption disable' to decrypt volume with recovery key"
+                return
+            fi
+
+            echo $vyos_tpm_key | tr -d '\r\n' | cryptsetup open $persist_path/luks/$image_name vyos_config --key-file=-
+
+            if [ $? -ne 0 ]; then
+                echo "ERROR: Failed to decrypt config volume. Encrypted config volume has not been mounted"
+                echo "Use 'encryption load' to load volume with recovery key"
+                echo "or 'encryption disable' to decrypt volume with recovery key"
+                return
+            fi
+
+            mount /dev/mapper/vyos_config /config
+            mount /dev/mapper/vyos_config $vyatta_sysconfdir/config
+
+            echo "Mounted encrypted config volume"
+        fi
+    fi
+}
+
+unmount_encrypted_config() {
+    persist_path=$(/opt/vyatta/sbin/vyos-persistpath)
+    if [ $? == 0 ]; then
+        if [ -e $persist_path/boot ]; then
+            image_name=$(cat /proc/cmdline | sed -e s+^.*vyos-union=/boot/++ | sed -e 's/ .*$//')
+
+            if [ -z "$image_name" ]; then
+                return
+            fi
+
+            if [ ! -f $persist_path/luks/$image_name ]; then
+                return
+            fi
+
+            umount /config
+            umount $vyatta_sysconfdir/config
+
+            cryptsetup close vyos_config
+        fi
+    fi
+}
+
 # if necessary, provide initial config
 init_bootfile () {
     if [ ! -r $BOOTFILE ] ; then
@@ -402,6 +465,8 @@ start ()
       && chgrp ${GROUP} ${vyatta_configdir}
     log_action_end_msg $?
 
+    mount_encrypted_config
+
     # T5239: early read of system hostname as this value is read-only once during
     # FRR initialisation
     tmp=$(${vyos_libexec_dir}/read-saved-value.py --path "system host-name")
@@ -470,6 +535,8 @@ stop()
     log_action_end_msg $?
 
     systemctl stop frr.service
+
+    unmount_encrypted_config
 }
 
 case "$action" in

--- a/src/op_mode/image_manager.py
+++ b/src/op_mode/image_manager.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2023 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2023-2024 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This file is part of VyOS.
 #
@@ -95,6 +95,15 @@ def delete_image(image_name: Optional[str] = None,
     except Exception as err:
         exit(f'Unable to remove the image "{image_name}": {err}')
 
+    # remove LUKS volume if it exists
+    luks_path: Path = Path(f'{persistence_storage}/luks/{image_name}')
+    if luks_path.is_file():
+        try:
+            luks_path.unlink()
+            print(f'The encrypted config for "{image_name}" was successfully deleted')
+        except Exception as err:
+            exit(f'Unable to remove the encrypted config for "{image_name}": {err}')
+
 
 @compat.grub_cfg_update
 def set_image(image_name: Optional[str] = None,
@@ -173,6 +182,16 @@ def rename_image(name_old: str, name_new: str) -> None:
         print(f'The image "{name_old}" was renamed to "{name_new}"')
     except Exception as err:
         exit(f'Unable to rename image "{name_old}" to "{name_new}": {err}')
+
+    # rename LUKS volume if it exists
+    old_luks_path: Path = Path(f'{persistence_storage}/luks/{name_old}')
+    if old_luks_path.is_file():
+        try:
+            new_luks_path: Path = Path(f'{persistence_storage}/luks/{name_new}')
+            old_luks_path.rename(new_luks_path)
+            print(f'The encrypted config for "{name_old}" was successfully renamed to "{name_new}"')
+        except Exception as err:
+            exit(f'Unable to rename the encrypted config for "{name_old}" to "{name_new}": {err}')
 
 
 def list_images() -> None:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
PR to implement how a TPM could be used to provide hardware backed encryption of the /config data.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4919

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
config

## Proposed changes
<!--- Describe your changes in detail -->

- Add module `vyos.tpm` for interacting with TPM device.
- Add encryption op-mode commands:
  - `encryption enable` generates an LUKS encrypted volume and stores one key in the TPM and also provides a recovery key to the user. /config contents is migrated to the volume and is mounted over /config.
  - `encryption disable` takes either the TPM key, or prompts for a recovery key to load the volume (if volume not already mounted), migrates config data to /config on rootfs and clears the TPM and removes volume.
  - `encryption load` allows for loading the encrypted config volume if VyOS failed to decrypt the volume on-boot.

Related PRs:
- https://github.com/vyos/vyos-build/pull/297

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Success boot message:
```
[   27.987068] vyos-router[1114]: Waiting for NICs to settle down: settled in 0sec..
[   31.555678] vyos-router[1114]: Mounting VyOS Config...done.
[   34.480597] vyos-router[1114]: Mounted encrypted config volume
[   39.571402] vyos-router[1114]: Starting VyOS router: migrate configure.
[   40.017721] vyos-config[1124]: Configuration success
```

Failed boot message:
```
[   19.619459] vyos-router[1008]: Waiting for NICs to settle down: settled in 0sec..
[   23.399971] vyos-router[1008]: Mounting VyOS Config...done.
[   23.797441] vyos-router[1008]: ERROR: Failed to fetch encryption key from TPM. Encrypted config volume has not been mounted
[   23.799499] vyos-router[1008]: Use 'encryption load' to load volume with recovery key
[   23.800669] vyos-router[1008]: or 'encryption disable' to decrypt volume with recovery key
[   35.614991] vyos-router[1008]: Starting VyOS router: migrate configure.
[   36.577641] vyos-config[1017]: Configuration success
```
(Note: configuration success because VyOS default config.boot is created and loaded)

Installing from ISO over an existing install with an encrypted config:
```
Install the image on? [sda]:

This will destroy all data on /dev/sda.
Continue? (Yes/No) [No]: yes

Looking for pre-existing RAID groups...none found.
Looking for config files from previous installations on sda1...
Looking for config files from previous installations on sda2...
Looking for config files from previous installations on sda3...
I found the following encrypted config volumes on sda3:
  1: 1.4-rolling-202301032140
Would you like to save config volume from it? (Yes/No) [Yes]
Saving config volume from image 1.4-rolling-202301032140.
Done.
How big of a root partition should I create? (2000MB - 4294MB) [4294]MB:
```

Op-mode commands:
```
vyos@vyos:~$ encryption enable
Automatically generate a recovery key? [Y/n]
Enter size of encrypted config partition (MB):  (Default: 512)
Encrypted config volume has been enabled
Backup the recovery key in a safe place!
Recovery key: eJIlCbNm_nptQ_joEEMCqtc4vtoIQyaRLlG5G3lRTVQ=

vyos@vyos:~$ encryption disable
Moving existing /config folder to /config.old
Encrypted config volume has been disabled
Contents have been migrated to /config on rootfs

(Below was run after clearing TPM and rebooting with failed boot decryption)
vyos@vyos:~$ encryption load
Failed to read key from TPM, recovery key required
Enter recovery key: eJIlCbNm_nptQ_joEEMCqtc4vtoIQyaRLlG5G3lRTVQ=
Encrypted config volume has been mounted
Use "load /config/config.boot" to load configuration
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
