### PR TITLE
T4922: T4922: ssh-client backports for equuleus

### DIFF
--- a/data/templates/system/ssh_config.tmpl
+++ b/data/templates/system/ssh_config.tmpl
@@ -1,3 +1,8 @@
-{% if ssh_client is defined and ssh_client.source_address is defined and ssh_client.source_address is not none %}
+{% if ssh_client is defined %}
+{%   if ssh_client.source_address is defined and ssh_client.source_address is not none %}
 BindAddress {{ ssh_client.source_address }}
+{%   endif %}
+{%   if ssh_client.source_interface is defined and ssh_client.source_address is not none %}
+BindInterface {{ ssh_client.source_interface }}
+{%   endif %}
 {% endif %}

--- a/interface-definitions/system-option.xml.in
+++ b/interface-definitions/system-option.xml.in
@@ -105,6 +105,7 @@
              </properties>
              <children>
                #include <include/source-address-ipv4-ipv6.xml.i>
+               #include <include/source-interface.xml.i>
              </children>
            </node>
            <leafNode name="startup-beep">

--- a/src/conf_mode/system-option.py
+++ b/src/conf_mode/system-option.py
@@ -31,7 +31,7 @@ from vyos import airbag
 airbag.enable()
 
 curlrc_config = r'/etc/curlrc'
-ssh_config = r'/etc/ssh/ssh_config'
+ssh_config = r'/etc/ssh/ssh_config.d/91-vyos-ssh-client-options.conf'
 systemd_action_file = '/lib/systemd/system/ctrl-alt-del.target'
 
 def get_config(config=None):

--- a/src/conf_mode/system-option.py
+++ b/src/conf_mode/system-option.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2020 VyOS maintainers and contributors
+# Copyright (C) 2019-2022 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -22,6 +22,7 @@ from time import sleep
 
 from vyos.config import Config
 from vyos.configdict import dict_merge
+from vyos.configverify import verify_source_interface
 from vyos.template import render
 from vyos.util import cmd
 from vyos.validate import is_addr_assigned
@@ -69,6 +70,8 @@ def verify(options):
         if 'source_address' in config:
             if not is_addr_assigned(config['source_address']):
                 raise ConfigError('No interface with give address specified!')
+        if 'source_interface' in config:
+            verify_source_interface(config)
 
     return None
 

--- a/src/conf_mode/system-option.py
+++ b/src/conf_mode/system-option.py
@@ -26,6 +26,7 @@ from vyos.configverify import verify_source_interface
 from vyos.template import render
 from vyos.util import cmd
 from vyos.validate import is_addr_assigned
+from vyos.validate import is_intf_addr_assigned
 from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
@@ -68,10 +69,17 @@ def verify(options):
     if 'ssh_client' in options:
         config = options['ssh_client']
         if 'source_address' in config:
+            address = config['source_address']
             if not is_addr_assigned(config['source_address']):
-                raise ConfigError('No interface with give address specified!')
+                raise ConfigError('No interface with address "{address}" configured!')
+
         if 'source_interface' in config:
             verify_source_interface(config)
+            if 'source_address' in config:
+                address = config['source_address']
+                interface = config['source_interface']
+                if not is_intf_addr_assigned(interface, address):
+                    raise ConfigError(f'Address "{address}" not assigned on interface "{interface}"!')
 
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Commit 846e306700a ("ssh: T2651: add cli options for source address") added support for a basic SSH client option, but it grabbed the entire `/etc/ssh/ssh_config` file without the ability to make custom user adjustments via the `/etc/ssh/ssh_config.d/` folder. This commit places the VyOS SSH options under `/etc/ssh/ssh_config.d/` leaving the common override system alive.

Add source-interface support ssh-client CLI options
* `set system option ssh-client source-interface 'dum0'`


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* T4922
* T4922

Requires PR:
* https://github.com/vyos/vyos-1x/pull/1743

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ssh client

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

smoketests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
