### PR TITLE
container: T4880: expose 'add/delete container image' in HTTP-API

### DIFF
--- a/data/templates/https/nginx.default.j2
+++ b/data/templates/https/nginx.default.j2
@@ -34,7 +34,7 @@ server {
         ssl_protocols TLSv1.2 TLSv1.3;
 
         # proxy settings for HTTP API, if enabled; 503, if not
-        location ~ /(retrieve|configure|config-file|image|generate|show|reset|docs|openapi.json|redoc|graphql) {
+        location ~ /(retrieve|configure|config-file|image|container-image|generate|show|reset|docs|openapi.json|redoc|graphql) {
 {%     if server.api %}
 {%         if server.api.socket %}
                 proxy_pass http://unix:/run/api.sock;

--- a/op-mode-definitions/container.xml.in
+++ b/op-mode-definitions/container.xml.in
@@ -11,7 +11,7 @@
             <properties>
               <help>Pull a new image for container</help>
             </properties>
-            <command>sudo podman image pull "${4}"</command>
+            <command>sudo ${vyos_op_scripts_dir}/container.py add_image --name "${4}"</command>
           </tagNode>
         </children>
       </node>
@@ -44,7 +44,7 @@
                 <script>sudo podman image ls -q</script>
               </completionHelp>
             </properties>
-            <command>sudo podman image rm --force "${4}"</command>
+            <command>sudo ${vyos_op_scripts_dir}/container.py delete_image --name "${4}"</command>
           </tagNode>
         </children>
       </node>

--- a/python/vyos/configsession.py
+++ b/python/vyos/configsession.py
@@ -34,6 +34,8 @@ REMOVE_IMAGE = ['/opt/vyatta/bin/vyatta-boot-image.pl', '--del']
 GENERATE = ['/opt/vyatta/bin/vyatta-op-cmd-wrapper', 'generate']
 SHOW = ['/opt/vyatta/bin/vyatta-op-cmd-wrapper', 'show']
 RESET = ['/opt/vyatta/bin/vyatta-op-cmd-wrapper', 'reset']
+ADD = ['/opt/vyatta/bin/vyatta-op-cmd-wrapper', 'add']
+DELETE = ['/opt/vyatta/bin/vyatta-op-cmd-wrapper', 'delete']
 
 # Default "commit via" string
 APP = "vyos-http-api"
@@ -203,4 +205,16 @@ class ConfigSession(object):
 
     def reset(self, path):
         out = self.__run_command(RESET + path)
+        return out
+
+    def add_container_image(self, name):
+        out = self.__run_command(ADD + ['container', 'image'] + [name])
+        return out
+
+    def delete_container_image(self, name):
+        out = self.__run_command(DELETE + ['container', 'image'] + [name])
+        return out
+
+    def show_container_image(self):
+        out = self.__run_command(SHOW + ['container', 'image'])
         return out

--- a/python/vyos/opmode.py
+++ b/python/vyos/opmode.py
@@ -66,7 +66,7 @@ class InternalError(Error):
 
 
 def _is_op_mode_function_name(name):
-    if re.match(r"^(show|clear|reset|restart)", name):
+    if re.match(r"^(show|clear|reset|restart|add|delete)", name):
         return True
     else:
         return False

--- a/src/op_mode/container.py
+++ b/src/op_mode/container.py
@@ -35,6 +35,19 @@ def _get_raw_data(command: str) -> list:
     data = json.loads(json_data)
     return data
 
+def add_image(name: str):
+    from vyos.util import rc_cmd
+
+    rc, output = rc_cmd(f'podman image pull {name}')
+    if rc != 0:
+        raise vyos.opmode.InternalError(output)
+
+def delete_image(name: str):
+    from vyos.util import rc_cmd
+
+    rc, output = rc_cmd(f'podman image rm --force {name}')
+    if rc != 0:
+        raise vyos.opmode.InternalError(output)
 
 def show_container(raw: bool):
     command = 'podman ps --all'

--- a/src/services/api/graphql/libs/op_mode.py
+++ b/src/services/api/graphql/libs/op_mode.py
@@ -30,7 +30,7 @@ def load_op_mode_as_module(name: str):
     return load_as_module(name, path)
 
 def is_op_mode_function_name(name):
-    if re.match(r"^(show|clear|reset|restart)", name):
+    if re.match(r"^(show|clear|reset|restart|add|delete)", name):
         return True
     return False
 

--- a/src/services/vyos-http-api-server
+++ b/src/services/vyos-http-api-server
@@ -175,6 +175,19 @@ class ImageModel(ApiModel):
             }
         }
 
+class ContainerImageModel(ApiModel):
+    op: StrictStr
+    name: StrictStr = None
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "key": "id_key",
+                "op": "add | delete | show",
+                "name": "imagename",
+            }
+        }
+
 class GenerateModel(ApiModel):
     op: StrictStr
     path: List[StrictStr]
@@ -389,7 +402,7 @@ class MultipartRoute(APIRoute):
                 if endpoint in ('/retrieve','/generate','/show','/reset'):
                     if request.ERR_NO_OP or request.ERR_NO_PATH:
                         return error(400, "Missing required field. \"op\" and \"path\" fields are required")
-                if endpoint in ('/config-file', '/image'):
+                if endpoint in ('/config-file', '/image', '/container-image'):
                     if request.ERR_NO_OP:
                         return error(400, "Missing required field \"op\"")
 
@@ -571,6 +584,37 @@ def image_op(data: ImageModel):
             else:
                 return error(400, "Missing required field \"name\"")
             res = session.remove_image(name)
+        else:
+            return error(400, "\"{0}\" is not a valid operation".format(op))
+    except ConfigSessionError as e:
+        return error(400, str(e))
+    except Exception as e:
+        logger.critical(traceback.format_exc())
+        return error(500, "An internal error occured. Check the logs for details.")
+
+    return success(res)
+
+@app.post('/container-image')
+def image_op(data: ContainerImageModel):
+    session = app.state.vyos_session
+
+    op = data.op
+
+    try:
+        if op == 'add':
+            if data.name:
+                name = data.name
+            else:
+                return error(400, "Missing required field \"name\"")
+            res = session.add_container_image(name)
+        elif op == 'delete':
+            if data.name:
+                name = data.name
+            else:
+                return error(400, "Missing required field \"name\"")
+            res = session.delete_container_image(name)
+        elif op == 'show':
+            res = session.show_container_image()
         else:
             return error(400, "\"{0}\" is not a valid operation".format(op))
     except ConfigSessionError as e:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Following a question in  vyos-general-discussion:

https://app.slack.com/client/T976FK7LJ/C01A6CJFW1F

the need was expressed for API access to op-mode container image commands add/delete. Encapsulating as functions in container.py generates the corresponding GraphQL schema; an explicit endpoint is added for the REST API.

Example GraphQL commands:

curl -k --raw 'https://192.168.122.28/graphql' -H 'Content-Type: application/json' -d '{"query":"mutation {\n AddImageContainer (data: {key: \"qwerty\", name: \"alpine\"}) {\n success\n errors\n op_mode_error {name, message, vyos_code}\n data {\n result\n }\n}\n}\n"}' | jq

curl -k --raw 'https://192.168.122.28/graphql' -H 'Content-Type: application/json' -d '{"query":" {\n ShowImageContainer (data: {key: \"qwerty\"}) {\n success\n errors\n op_mode_error {name, message, vyos_code}\n data {\n result\n }\n}\n}\n"}' | jq

curl -k --raw 'https://192.168.122.28/graphql' -H 'Content-Type: application/json' -d '{"query":"mutation {\n DeleteImageContainer (data: {key: \"qwerty\", name: \"alpine\"}) {\n success\n errors\n op_mode_error {name, message, vyos_code}\n data {\n result\n }\n}\n}\n"}' | jq

Example REST commands:

curl -k -X POST -Fkey=qwerty -Fdata='{"op": "add", "name": "alpine"}' https://192.168.122.28/container-image
curl -k -X POST -Fkey=qwerty -Fdata='{"op": "show"}' https://192.168.122.28/container-image
curl -k -X POST -Fkey=qwerty -Fdata='{"op": "delete", "name": "alpine"}' https://192.168.122.28/container-image

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4880

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

container

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
