### PR TITLE
T4906: Fix show vpn ipsec connections data

### DIFF
--- a/src/op_mode/ipsec.py
+++ b/src/op_mode/ipsec.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022 VyOS maintainers and contributors
+# Copyright (C) 2022-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -173,7 +173,7 @@ def _get_parent_sa_proposal(connection_name: str, data: list) -> dict:
     for sa in data:
         # check if parent SA exist
         if connection_name not in sa.keys():
-            return {}
+            continue
         if 'encr-alg' in sa[connection_name]:
             encr_alg = sa.get(connection_name, '').get('encr-alg')
             cipher = encr_alg.split('_')[0]
@@ -203,16 +203,17 @@ def _get_parent_sa_state(connection_name: str, data: list) -> str:
     Returns:
         Parent SA connection state
     """
+    ike_state = 'down'
     if not data:
-        return 'down'
+        return ike_state
     for sa in data:
         # check if parent SA exist
-        if connection_name not in sa.keys():
-            return 'down'
-        if sa[connection_name]['state'].lower() == 'established':
-            return 'up'
-        else:
-            return 'down'
+        for connection, connection_conf in sa.items():
+            if connection_name != connection:
+                continue
+            if connection_conf['state'].lower() == 'established':
+                ike_state = 'up'
+    return ike_state
 
 
 def _get_child_sa_state(connection_name: str, tunnel_name: str,
@@ -227,19 +228,20 @@ def _get_child_sa_state(connection_name: str, tunnel_name: str,
     Returns:
         str: `up` if child SA state is 'installed' otherwise `down`
     """
+    child_sa = 'down'
     if not data:
-        return 'down'
+        return child_sa
     for sa in data:
         # check if parent SA exist
         if connection_name not in sa.keys():
-            return 'down'
+            continue
         child_sas = sa[connection_name]['child-sas']
         # Get all child SA states
         # there can be multiple SAs per tunnel
         child_sa_states = [
             v['state'] for k, v in child_sas.items() if v['name'] == tunnel_name
         ]
-        return 'up' if 'INSTALLED' in child_sa_states else 'down'
+        return 'up' if 'INSTALLED' in child_sa_states else child_sa
 
 
 def _get_child_sa_info(connection_name: str, tunnel_name: str,
@@ -257,7 +259,7 @@ def _get_child_sa_info(connection_name: str, tunnel_name: str,
     for sa in data:
         # check if parent SA exist
         if connection_name not in sa.keys():
-            return {}
+            continue
         child_sas = sa[connection_name]['child-sas']
         # Get all child SA data
         # Skip temp SA name (first key), get only SA values as dict


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
We get incorrect data when show connections
As we get a list of all connections, we should compare the connection name with entries in the list and set the correct data if they match, and "continue" if connection doesn't match
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4906

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
current output
```
root@r1:/home/vyos# ./ipsec.py show_connections
Connection         State    Type    Remote address    Local TS        Remote TS     Local id                Remote id         Proposal
-----------------  -------  ------  ----------------  --------------  ------------  ----------------------  ----------------  ----------
OFFICE-B           down     IKEv1   192.0.2.2         -               -             192.0.2.1.local.peer-b  192.0.2.2.peer-b  -
OFFICE-B-tunnel-0  down     IPsec   192.0.2.2         192.168.0.0/24  10.0.0.0/21   192.0.2.1.local.peer-b  192.0.2.2.peer-b  -
OFFICE-C           down     IKEv2   192.0.2.3         -               -             192.0.2.1.local.peer-c  192.0.2.3.peer-c  -
OFFICE-C-tunnel-0  down     IPsec   192.0.2.3         192.168.2.0/24  10.0.0.0/21   192.0.2.1.local.peer-c  192.0.2.3.peer-c  -
OFFICE-D           down     IKEv2   192.0.2.5         -               -             192.0.2.1.local.peer-d  192.0.2.5.peer-d  -
OFFICE-D-tunnel-0  down     IPsec   192.0.2.5         192.168.5.0/24  10.0.50.0/24  192.0.2.1.local.peer-d  192.0.2.5.peer-d  -
root@r1:/home/vyos# 
```
Fixed output:
```
root@r1:/home/vyos# /usr/libexec/vyos/op_mode/ipsec.py show_connections
Connection         State    Type    Remote address    Local TS        Remote TS     Local id                Remote id         Proposal
-----------------  -------  ------  ----------------  --------------  ------------  ----------------------  ----------------  ---------------------------------------
OFFICE-B           up       IKEv1   192.0.2.2         -               -             192.0.2.1.local.peer-b  192.0.2.2.peer-b  AES_CBC/256/HMAC_SHA2_256_128/MODP_2048
OFFICE-B-tunnel-0  up       IPsec   192.0.2.2         192.168.0.0/24  10.0.0.0/21   192.0.2.1.local.peer-b  192.0.2.2.peer-b  AES_CBC/128/HMAC_SHA1_96/MODP_2048
OFFICE-C           up       IKEv2   192.0.2.3         -               -             192.0.2.1.local.peer-c  192.0.2.3.peer-c  AES_CBC/128/HMAC_SHA1_96/MODP_1024
OFFICE-C-tunnel-0  up       IPsec   192.0.2.3         192.168.2.0/24  10.0.0.0/21   192.0.2.1.local.peer-c  192.0.2.3.peer-c  AES_CBC/256/HMAC_SHA2_256_128/None
OFFICE-D           down     IKEv2   192.0.2.5         -               -             192.0.2.1.local.peer-d  192.0.2.5.peer-d  -
OFFICE-D-tunnel-0  down     IPsec   192.0.2.5         192.168.5.0/24  10.0.50.0/24  192.0.2.1.local.peer-d  192.0.2.5.peer-d  -
root@r1:/home/vyos# 
```
Real data from swanctl
Phase1:
 OFFICE-B, OFFICE-C established
 OFFICE-D not established
Phase2:
 OFFICE-B, OFFICE-C installed
```
root@r1:/home/vyos# sudo swanctl -l
OFFICE-D: #3, CONNECTING, IKEv2, eaf9ca8cc93a6ad1_i* 0000000000000000_r
  local  '%any' @ 192.0.2.1[500]
  remote '%any' @ 192.0.2.5[500]
  active:  IKE_VENDOR IKE_INIT IKE_NATD IKE_CERT_PRE IKE_AUTH IKE_CERT_POST IKE_CONFIG CHILD_CREATE IKE_AUTH_LIFETIME IKE_MOBIKE
OFFICE-C: #2, ESTABLISHED, IKEv2, af88b0f57d59e101_i* 95586d5e18ced6e8_r
  local  '192.0.2.1.local.peer-c' @ 192.0.2.1[4500]
  remote '192.0.2.3.peer-c' @ 192.0.2.3[4500]
  AES_CBC-128/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
  established 26s ago, rekeying in 3531s
  OFFICE-C-tunnel-0: #1, reqid 1, INSTALLED, TUNNEL, ESP:AES_CBC-256/HMAC_SHA2_256_128
    installed 26s ago, rekeying in 3574s, expires in 1774s
    in  cf46d59e,      0 bytes,     0 packets
    out cb296e9f,      0 bytes,     0 packets
    local  192.168.2.0/24
    remote 10.0.0.0/21
OFFICE-B: #1, ESTABLISHED, IKEv1, b259b522ee162430_i* 8ef895d0b4fcd325_r
  local  '192.0.2.1.local.peer-b' @ 192.0.2.1[500]
  remote '192.0.2.2.peer-b' @ 192.0.2.2[500]
  AES_CBC-256/HMAC_SHA2_256_128/PRF_HMAC_SHA2_256/MODP_2048
  established 26s ago, rekeying in 3378s
  OFFICE-B-tunnel-0: #2, reqid 2, INSTALLED, TUNNEL, ESP:AES_CBC-128/HMAC_SHA1_96/MODP_2048
    installed 26s ago, rekeying in 3574s, expires in 1774s
    in  c0d93128,      0 bytes,     0 packets
    out c8e2c4a9,      0 bytes,     0 packets
    local  192.168.0.0/24
    remote 10.0.0.0/21
root@r1:/home/vyos# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
