### PR TITLE
opmode: T2546: add UnsupportedOperation to op mode errors

### DIFF
--- a/python/vyos/opmode.py
+++ b/python/vyos/opmode.py
@@ -45,6 +45,10 @@ class PermissionDenied(Error):
     """
     pass
 
+class UnsupportedOperation(Error):
+    """ Requested operation is technically valid but is not implemented yet. """
+    pass
+
 class IncorrectValue(Error):
     """ Requested operation is valid, but an argument provided has an
         incorrect value, preventing successful completion.

--- a/src/services/api/graphql/session/errors/op_mode_errors.py
+++ b/src/services/api/graphql/session/errors/op_mode_errors.py
@@ -4,12 +4,14 @@ op_mode_err_msg = {
     "UnconfiguredSubsystem": "subsystem is not configured or not running",
     "DataUnavailable": "data currently unavailable",
     "PermissionDenied": "client does not have permission",
-    "IncorrectValue": "argument value is incorrect"
+    "IncorrectValue": "argument value is incorrect",
+    "UnsupportedOperation": "operation is not supported (yet)",
 }
 
 op_mode_err_code = {
     "UnconfiguredSubsystem": 2000,
     "DataUnavailable": 2001,
     "PermissionDenied": 1003,
-    "IncorrectValue": 1002
+    "IncorrectValue": 1002,
+    "UnsupportedOperation": 1004,
 }


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): New op mode exception

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T2546

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Op mode.

## Proposed changes
<!--- Describe your changes in detail -->

We strive to provide machine-readable outputs for all op mode commands.
However, some of our backends simply don't provide either a machine-readable output or even a parseable human format for some functions, so we cannot make API equivalents of CLI `show` commands for those functions.

The `DataUnavailable` error implies that data may become available and that the client should retry later. Using it in cases when the data will not be available in the current VyOS version at all is inappropriate for that reason — it gives the client false hope. We need a dedicated error for that purpose.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
