### PR TITLE
opmode: T4564: add generate to the list of op mode functions

### DIFF
--- a/python/vyos/opmode.py
+++ b/python/vyos/opmode.py
@@ -70,13 +70,13 @@ class InternalError(Error):
 
 
 def _is_op_mode_function_name(name):
-    if re.match(r"^(show|clear|reset|restart|add|delete)", name):
+    if re.match(r"^(show|clear|reset|restart|add|delete|generate)", name):
         return True
     else:
         return False
 
-def _is_show(name):
-    if re.match(r"^show", name):
+def _capture_output(name):
+    if re.match(r"^(show|generate)", name):
         return True
     else:
         return False
@@ -203,14 +203,14 @@ def run(module):
     # it would cause an extra argument error when we pass the dict to a function
     del args["subcommand"]
 
-    # Show commands must always get the "raw" argument,
-    # but other commands (clear/reset/restart) should not,
+    # Show and generate commands must always get the "raw" argument,
+    # but other commands (clear/reset/restart/add/delete) should not,
     # because they produce no output and it makes no sense for them.
-    if ("raw" not in args) and _is_show(function_name):
+    if ("raw" not in args) and _capture_output(function_name):
         args["raw"] = False
 
-    if re.match(r"^show", function_name):
-        # Show commands are slightly special:
+    if _capture_output(function_name):
+        # Show and generate commands are slightly special:
         # they may return human-formatted output
         # or a raw dict that we need to serialize in JSON for printing
         res = func(**args)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add `generate` to the list of functions so that generate commands can be exposed in the API.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): New op mode function.

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4564

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Op mode.



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
