### PR TITLE
T4118: Add default value any for connection remote-id

### DIFF
--- a/data/templates/ipsec/swanctl/peer.j2
+++ b/data/templates/ipsec/swanctl/peer.j2
@@ -45,11 +45,7 @@
 {% endif %}
         }
         remote {
-{% if peer_conf.authentication.remote_id is vyos_defined %}
             id = "{{ peer_conf.authentication.remote_id }}"
-{% else %}
-            id = "{{ peer }}"
-{% endif %}
             auth = {{ 'psk' if peer_conf.authentication.mode == 'pre-shared-secret' else 'pubkey' }}
 {% if peer_conf.authentication.mode == 'rsa' %}
             pubkeys = {{ peer_conf.authentication.rsa.remote_key }}.pem

--- a/interface-definitions/vpn-ipsec.xml.in
+++ b/interface-definitions/vpn-ipsec.xml.in
@@ -957,6 +957,7 @@
                             <description>ID used for peer authentication</description>
                           </valueHelp>
                         </properties>
+                        <defaultValue>%any</defaultValue>
                       </leafNode>
                       <leafNode name="use-x509-id">
                         <properties>

--- a/src/conf_mode/vpn_ipsec.py
+++ b/src/conf_mode/vpn_ipsec.py
@@ -95,6 +95,7 @@ def get_config(config=None):
     del default_values['esp_group']
     del default_values['ike_group']
     del default_values['remote_access']
+    del default_values['site_to_site']
     ipsec = dict_merge(default_values, ipsec)
 
     if 'esp_group' in ipsec:
@@ -142,6 +143,14 @@ def get_config(config=None):
         for server in ipsec['remote_access']['radius']['server']:
             ipsec['remote_access']['radius']['server'][server] = dict_merge(default_values,
                 ipsec['remote_access']['radius']['server'][server])
+
+    # XXX: T2665: we can not safely rely on the defaults() when there are
+    # tagNodes in place, it is better to blend in the defaults manually.
+    if dict_search('site_to_site.peer', ipsec):
+        default_values = defaults(base + ['site-to-site', 'peer'])
+        for peer in ipsec['site_to_site']['peer']:
+            ipsec['site_to_site']['peer'][peer] = dict_merge(default_values,
+              ipsec['site_to_site']['peer'][peer])
 
     ipsec['dhcp_no_address'] = {}
     ipsec['install_routes'] = 'no' if conf.exists(base + ["options", "disable-route-autoinstall"]) else default_install_routes


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
If IPsec "peer <tag> authentication remote-id" is not set it should be "%any" by default
https://docs.strongswan.org/docs/5.9/swanctl/swanctlConf.html#_connections_conn_remote

Set XML default value and use it in the python vpn_ipsec.py script
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Change default remote-id value if not set

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4118

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
IPsec
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Set ipsec site-to-site config without peer authentication remote-id
```
set vpn ipsec esp-group ESP-group-c lifetime '1800'
set vpn ipsec esp-group ESP-group-c mode 'tunnel'
set vpn ipsec esp-group ESP-group-c pfs 'enable'
set vpn ipsec esp-group ESP-group-c proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-group-c proposal 1 hash 'sha256'
set vpn ipsec ike-group IKE-group-c key-exchange 'ikev2'
set vpn ipsec ike-group IKE-group-c lifetime '3600'
set vpn ipsec ike-group IKE-group-c proposal 1 dh-group '2'
set vpn ipsec ike-group IKE-group-c proposal 1 encryption 'aes128'
set vpn ipsec ike-group IKE-group-c proposal 1 hash 'sha1'
set vpn ipsec interface 'eth0'
set vpn ipsec site-to-site peer OFFICE-C authentication local-id '192.0.2.3.peer-c'
set vpn ipsec site-to-site peer OFFICE-C authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer OFFICE-C authentication pre-shared-secret 'SecretBar'
set vpn ipsec site-to-site peer OFFICE-C connection-type 'none'
set vpn ipsec site-to-site peer OFFICE-C ike-group 'IKE-group-c'
set vpn ipsec site-to-site peer OFFICE-C local-address '192.0.2.3'
set vpn ipsec site-to-site peer OFFICE-C tunnel 0 esp-group 'ESP-group-c'
set vpn ipsec site-to-site peer OFFICE-C tunnel 0 local prefix '10.0.0.0/21'
set vpn ipsec site-to-site peer OFFICE-C tunnel 0 remote prefix '192.168.2.0/24'
```
Expected connection.remote.id %any
```
vyos@r2# cat /etc/swanctl/swanctl.conf 
### Autogenerated by vpn_ipsec.py ###

connections {
    OFFICE-C {
        proposals = aes128-sha1-modp1024
        version = 2
        local_addrs = 192.0.2.3 # dhcp:no
        remote_addrs = %any
        dpd_timeout = 120
        dpd_delay = 30
        rekey_time = 3600s
        mobike = yes
        local {
            id = "192.0.2.3.peer-c"
            auth = psk
        }
        remote {
            id = "%any" ### <=== THERE IS from defaultValue ###
            auth = psk
        }
        children {
            OFFICE-C-tunnel-0 {
                esp_proposals = aes256-sha256-modp1024
                life_time = 1800s
                local_ts = 10.0.0.0/21
                remote_ts = 192.168.2.0/24
                ipcomp = no
                mode = tunnel
                start_action = none
                dpd_action = 
                close_action = 
            }
        }
    }

}

pools {
}

secrets {
    ike_OFFICE-C {
        id-local = 192.0.2.3 # dhcp:no
        id-localid = 192.0.2.3.peer-c
        id-remoteid = %any
        secret = "SecretBar"
    }
}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
