### PR TITLE
opmode: T4837: add family and table arguments for ShowRoute

### DIFF
--- a/op-mode-definitions/include/show-route-summary.xml.i
+++ b/op-mode-definitions/include/show-route-summary.xml.i
@@ -1,8 +1,0 @@
-<!-- included start from show-route-summary.xml.i -->
-<leafNode name="summary">
-  <properties>
-    <help>Summary of all routes</help>
-  </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-</leafNode>
-<!-- included end -->

--- a/op-mode-definitions/show-ip-route.xml.in
+++ b/op-mode-definitions/show-ip-route.xml.in
@@ -50,10 +50,23 @@
               #include <include/show-route-ospf.xml.i>
               #include <include/show-route-rip.xml.i>
               #include <include/show-route-static.xml.i>
-              #include <include/show-route-summary.xml.i>
               #include <include/show-route-supernets-only.xml.i>
               #include <include/show-route-table.xml.i>
               #include <include/show-route-tag.xml.i>
+              <node name="summary">
+                <properties>
+                  <help>Summary of all routes</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/route.py show_summary --family inet</command>
+                <children>
+                  <tagNode name="table">
+                    <properties>
+                      <help>Summary of routes in a particular table</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/route.py show_summary --family inet --table $6</command>
+                  </tagNode>
+                </children>
+              </node>
               <tagNode name="vrf">
                 <properties>
                   <help>Show IP routes in VRF</help>

--- a/op-mode-definitions/show-ipv6-route.xml.in
+++ b/op-mode-definitions/show-ipv6-route.xml.in
@@ -50,9 +50,22 @@
               #include <include/show-route-ospfv3.xml.i>
               #include <include/show-route-ripng.xml.i>
               #include <include/show-route-static.xml.i>
-              #include <include/show-route-summary.xml.i>
               #include <include/show-route-table.xml.i>
               #include <include/show-route-tag.xml.i>
+              <node name="summary">
+                <properties>
+                  <help>Summary of all routes</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/route.py show_summary --family inet6</command>
+                <children>
+                  <tagNode name="table">
+                    <properties>
+                      <help>Summary of routes in a particular table</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/route.py show_summary --family inet6 --table $6</command>
+                  </tagNode>
+                </children>
+              </node>
               <tagNode name="vrf">
                 <properties>
                   <help>Show IPv6 routes in VRF</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4837

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Op mode.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
vyos@vyos:~$ sudo /usr/libexec/vyos/op_mode/route.py show_summary --family inet --table 253 --raw
{}

vyos@vyos:~$ sudo /usr/libexec/vyos/op_mode/route.py show_summary --family inet --table 254 --raw
{
    "routes": [
        {
            "fib": 2,
            "rib": 2,
            "fib_off_loaded": 0,
            "fib_trapped": 0,
            "type": "connected"
        },
        {
            "fib": 1,
            "rib": 1,
            "fib_off_loaded": 0,
            "fib_trapped": 0,
            "type": "static"
        }
    ],
    "routes_total": 3,
    "routes_total_fib": 3
}

vyos@vyos:~$ sudo /usr/libexec/vyos/op_mode/route.py show_summary --family inet6 --table 254 --raw
{
    "routes": [
        {
            "fib": 3,
            "rib": 3,
            "fib_off_loaded": 0,
            "fib_trapped": 0,
            "type": "connected"
        }
    ],
    "routes_total": 3,
    "routes_total_fib": 3
}

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
