### PR TITLE
T4934: ospf: Fix inter-area route summarization

### DIFF
--- a/data/templates/frr/ospfd.frr.j2
+++ b/data/templates/frr/ospfd.frr.j2
@@ -84,11 +84,13 @@ router ospf {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {%         endfor %}
 {%         if area_config.range is vyos_defined %}
 {%             for range, range_config in area_config.range.items() %}
-{%                 if range_config.cost is vyos_defined %}
- area {{ area_id }} range {{ range }} cost {{ range_config.cost }}
-{%                 endif %}
 {%                 if range_config.not_advertise is vyos_defined %}
  area {{ area_id }} range {{ range }} not-advertise
+{%                 else %}
+ area {{ area_id }} range {{ range }}
+{%                 endif %}
+{%                 if range_config.cost is vyos_defined %}
+ area {{ area_id }} range {{ range }} cost {{ range_config.cost }}
 {%                 endif %}
 {%                 if range_config.substitute is vyos_defined %}
  area {{ area_id }} range {{ range }} substitute {{ range_config.substitute }}

--- a/smoketest/scripts/cli/test_protocols_ospf.py
+++ b/smoketest/scripts/cli/test_protocols_ospf.py
@@ -75,6 +75,9 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['log-adjacency-changes', 'detail'])
         self.cli_set(base_path + ['default-metric', metric])
         self.cli_set(base_path + ['passive-interface', 'default'])
+        self.cli_set(base_path + ['area', '10', 'network', '10.0.0.0/16'])
+        self.cli_set(base_path + ['area', '10', 'range', '10.0.1.0/24'])
+        self.cli_set(base_path + ['area', '10', 'range', '10.0.2.0/24', 'not-advertise'])
 
         # commit changes
         self.cli_commit()
@@ -90,6 +93,11 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f' capability opaque', frrconfig)
         self.assertIn(f' default-metric {metric}', frrconfig)
         self.assertIn(f' passive-interface default', frrconfig)
+        self.assertIn(f' area 10 stub', frrconfig)
+        self.assertIn(f' area 10 network 10.0.0.0/16', frrconfig)
+        self.assertIn(f' area 10 range 10.0.1.0/24', frrconfig)
+        self.assertNotIn(f' area 10 range 10.0.1.0/24 not-advertise', frrconfig)
+        self.assertIn(f' area 10 range 10.0.2.0/24 not-advertise', frrconfig)
 
 
     def test_ospf_03_access_list(self):


### PR DESCRIPTION
Setting something like `protocols ospf area 10 range 10.10.0.0/16` without sub options doesn't work. This is because no range commands are generated when there is no leaf nodes set under the `range` tag node.

```
edit protocols ospf
set area 16 network 10.10.0.0/16
set area 16 range 10.10.0.0/16
commit
```

```
$ vtysh -c 'show run'
!
router ospf
 auto-cost reference-bandwidth 100
 timers throttle spf 200 1000 10000
 network 10.10.0.0/16 area 16
exit
```

The generated FRR commands above is missing something like:

```
 area 16 range 10.10.0.0/16
```

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4934

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
