### PR TITLE
T4837: add VRF option for route summary

### DIFF
--- a/op-mode-definitions/show-ip-route.xml.in
+++ b/op-mode-definitions/show-ip-route.xml.in
@@ -77,6 +77,12 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
                 <children>
+                  <node name="summary">
+                    <properties>
+                      <help>Summary of all routes in the VRF</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/route.py show_summary --family inet --vrf $5</command>
+                  </node>
                   #include <include/show-route-bgp.xml.i>
                   #include <include/show-route-connected.xml.i>
                   #include <include/show-route-isis.xml.i>
@@ -84,7 +90,6 @@
                   #include <include/show-route-ospf.xml.i>
                   #include <include/show-route-rip.xml.i>
                   #include <include/show-route-static.xml.i>
-                  #include <include/show-route-summary.xml.i>
                   #include <include/show-route-supernets-only.xml.i>
                   #include <include/show-route-tag.xml.i>
                 </children>

--- a/op-mode-definitions/show-ipv6-route.xml.in
+++ b/op-mode-definitions/show-ipv6-route.xml.in
@@ -76,6 +76,12 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
                 <children>
+                  <node name="summary">
+                    <properties>
+                      <help>Summary of all routes in the VRF</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/route.py show_summary --family inet6 --vrf $5</command>
+                  </node>
                   #include <include/show-route-bgp.xml.i>
                   #include <include/show-route-connected.xml.i>
                   #include <include/show-route-isis.xml.i>
@@ -83,7 +89,6 @@
                   #include <include/show-route-ospfv3.xml.i>
                   #include <include/show-route-ripng.xml.i>
                   #include <include/show-route-static.xml.i>
-                  #include <include/show-route-summary.xml.i>
                   #include <include/show-route-supernets-only.xml.i>
                   #include <include/show-route-table.xml.i>
                   #include <include/show-route-tag.xml.i>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Adds `--vrf` option to `op_mode/route.py` and changes `show ip[v6] route vrf * summary` to use it.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): New op mode API option.

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4837

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Op mode.


## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
run show ip route vrf Foo summary
run show ipv6 route vrf Foo summary
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
