### PR TITLE
T4916: Rewrite IPsec peer authentication and psk migration

### DIFF
--- a/data/templates/ipsec/swanctl.conf.j2
+++ b/data/templates/ipsec/swanctl.conf.j2
@@ -58,23 +58,7 @@ secrets {
 {% if site_to_site.peer is vyos_defined %}
 {%     for peer, peer_conf in site_to_site.peer.items() if peer not in dhcp_no_address and peer_conf.disable is not vyos_defined %}
 {%         set peer_name = peer.replace("@", "") | dot_colon_to_dash %}
-{%         if peer_conf.authentication.mode is vyos_defined('pre-shared-secret') %}
-    ike_{{ peer_name }} {
-{%             if peer_conf.local_address is vyos_defined %}
-        id-local = {{ peer_conf.local_address }} # dhcp:{{ peer_conf.dhcp_interface if 'dhcp_interface' in peer_conf else 'no' }}
-{%             endif %}
-{%             for address in peer_conf.remote_address %}
-        id-remote_{{ address | dot_colon_to_dash }} = {{ address }}
-{%             endfor %}
-{%             if peer_conf.authentication.local_id is vyos_defined %}
-        id-localid = {{ peer_conf.authentication.local_id }}
-{%             endif %}
-{%             if peer_conf.authentication.remote_id is vyos_defined %}
-        id-remoteid = {{ peer_conf.authentication.remote_id }}
-{%             endif %}
-        secret = "{{ peer_conf.authentication.pre_shared_secret }}"
-    }
-{%         elif peer_conf.authentication.mode is vyos_defined('x509') %}
+{%         if peer_conf.authentication.mode is vyos_defined('x509') %}
     private_{{ peer_name }} {
         file = {{ peer_conf.authentication.x509.certificate }}.pem
 {%             if peer_conf.authentication.x509.passphrase is vyos_defined %}
@@ -91,6 +75,21 @@ secrets {
 {%         endif %}
 {%     endfor %}
 {% endif %}
+{% if authentication.psk is vyos_defined %}
+{%     for psk, psk_config in authentication.psk.items() %}
+    ike-{{ psk }} {
+{%         if psk_config.id is vyos_defined %}
+        # ID's from auth psk <tag> id xxx
+{%             for id in psk_config.id %}
+{%                 set gen_uuid = '' | generate_uuid4 %}
+        id-{{ gen_uuid }} = "{{ id }}"
+{%             endfor %}
+{%         endif %}
+        secret = "{{ psk_config.secret }}"
+    }
+{%     endfor %}
+{% endif %}
+
 {% if remote_access.connection is vyos_defined %}
 {%     for ra, ra_conf in remote_access.connection.items() if ra_conf.disable is not vyos_defined %}
 {%         if ra_conf.authentication.server_mode is vyos_defined('pre-shared-secret') %}
@@ -130,4 +129,3 @@ secrets {
 {%     endif %}
 {% endif %}
 }
-

--- a/interface-definitions/include/dhcp-interface-multi.xml.i
+++ b/interface-definitions/include/dhcp-interface-multi.xml.i
@@ -1,0 +1,18 @@
+<!-- include start from dhcp-interface-multi.xml.i -->
+<leafNode name="dhcp-interface">
+  <properties>
+    <help>DHCP interface supplying next-hop IP address</help>
+    <completionHelp>
+      <script>${vyos_completion_dir}/list_interfaces.py</script>
+    </completionHelp>
+    <valueHelp>
+      <format>txt</format>
+      <description>DHCP interface name</description>
+    </valueHelp>
+    <constraint>
+      #include <include/constraint/interface-name.xml.in>
+    </constraint>
+    <multi/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/version/ipsec-version.xml.i
+++ b/interface-definitions/include/version/ipsec-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/ipsec-version.xml.i -->
-<syntaxVersion component='ipsec' version='10'></syntaxVersion>
+<syntaxVersion component='ipsec' version='11'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/vpn-ipsec.xml.in
+++ b/interface-definitions/vpn-ipsec.xml.in
@@ -11,6 +11,40 @@
           <priority>901</priority>
         </properties>
         <children>
+          <node name="authentication">
+            <properties>
+              <help>Authentication</help>
+            </properties>
+            <children>
+              <tagNode name="psk">
+                <properties>
+                  <help>Pre-shared key name</help>
+                </properties>
+                <children>
+                  #include <include/dhcp-interface-multi.xml.i>
+                  <leafNode name="id">
+                    <properties>
+                      <help>ID for authentication</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>ID used for authentication</description>
+                      </valueHelp>
+                      <multi/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="secret">
+                    <properties>
+                      <help>IKE pre-shared secret key</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>IKE pre-shared secret key</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                </children>
+              </tagNode>
+            </children>
+          </node>
           <leafNode name="disable-uniqreqids">
             <properties>
               <help>Disable requirement for unique IDs in the Security Database</help>
@@ -948,7 +982,6 @@
                           </constraint>
                         </properties>
                       </leafNode>
-                      #include <include/ipsec/authentication-pre-shared-secret.xml.i>
                       <leafNode name="remote-id">
                         <properties>
                           <help>ID for remote authentication</help>

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -193,6 +193,16 @@ def dot_colon_to_dash(text):
     text = text.replace(".", "-")
     return text
 
+@register_filter('generate_uuid4')
+def generate_uuid4(text):
+    """ Generate random unique ID
+    Example:
+      % uuid4()
+      UUID('958ddf6a-ef14-4e81-8cfb-afb12456d1c5')
+    """
+    from uuid import uuid4
+    return uuid4()
+
 @register_filter('netmask_from_cidr')
 def netmask_from_cidr(prefix):
     """ Take CIDR prefix and convert the prefix length to a "subnet mask".

--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2022 VyOS maintainers and contributors
+# Copyright (C) 2021-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -34,12 +34,15 @@ swanctl_file = '/etc/swanctl/swanctl.conf'
 
 peer_ip = '203.0.113.45'
 connection_name = 'main-branch'
+local_id = 'left'
+remote_id = 'right'
 interface = 'eth1'
 vif = '100'
 esp_group = 'MyESPGroup'
 ike_group = 'MyIKEGroup'
 secret = 'MYSECRETKEY'
 PROCESS_NAME = 'charon'
+regex_uuid4 = '[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}'
 
 ca_pem = """
 MIIDSzCCAjOgAwIBAgIUQHK+ZgTUYZksvXY2/MyW+Jiels4wDQYJKoZIhvcNAQEL
@@ -151,10 +154,15 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         # Interface for dhcp-interface
         self.cli_set(ethernet_path + [interface, 'vif', vif, 'address', 'dhcp']) # Use VLAN to avoid getting IP from qemu dhcp server
 
+        # vpn ipsec auth psk <tag> id <x.x.x.x>
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', local_id])
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', remote_id])
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', peer_ip])
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'secret', secret])
+
         # Site to site
         peer_base_path = base_path + ['site-to-site', 'peer', connection_name]
         self.cli_set(peer_base_path + ['authentication', 'mode', 'pre-shared-secret'])
-        self.cli_set(peer_base_path + ['authentication', 'pre-shared-secret', secret])
         self.cli_set(peer_base_path + ['ike-group', ike_group])
         self.cli_set(peer_base_path + ['default-esp-group', esp_group])
         self.cli_set(peer_base_path + ['dhcp-interface', f'{interface}.{vif}'])
@@ -172,18 +180,25 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
     def test_02_site_to_site(self):
         self.cli_set(base_path + ['ike-group', ike_group, 'key-exchange', 'ikev2'])
 
-        # Site to site
         local_address = '192.0.2.10'
         priority = '20'
         life_bytes = '100000'
         life_packets = '2000000'
+
+        # vpn ipsec auth psk <tag> id <x.x.x.x>
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', local_id])
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', remote_id])
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', local_address])
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', peer_ip])
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'secret', secret])
+
+        # Site to site
         peer_base_path = base_path + ['site-to-site', 'peer', connection_name]
 
         self.cli_set(base_path + ['esp-group', esp_group, 'life-bytes', life_bytes])
         self.cli_set(base_path + ['esp-group', esp_group, 'life-packets', life_packets])
 
         self.cli_set(peer_base_path + ['authentication', 'mode', 'pre-shared-secret'])
-        self.cli_set(peer_base_path + ['authentication', 'pre-shared-secret', secret])
         self.cli_set(peer_base_path + ['ike-group', ike_group])
         self.cli_set(peer_base_path + ['default-esp-group', esp_group])
         self.cli_set(peer_base_path + ['local-address', local_address])
@@ -230,12 +245,14 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             self.assertIn(line, swanctl_conf)
 
         swanctl_secrets_lines = [
-            f'id-local = {local_address} # dhcp:no',
-            f'id-remote_{peer_ip.replace(".","-")} = {peer_ip}',
+            f'id-{regex_uuid4} = "{local_id}"',
+            f'id-{regex_uuid4} = "{remote_id}"',
+            f'id-{regex_uuid4} = "{local_address}"',
+            f'id-{regex_uuid4} = "{peer_ip}"',
             f'secret = "{secret}"'
         ]
         for line in swanctl_secrets_lines:
-            self.assertIn(line, swanctl_conf)
+            self.assertRegex(swanctl_conf, fr'{line}')
 
 
     def test_03_site_to_site_vti(self):
@@ -249,10 +266,15 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         # VTI interface
         self.cli_set(vti_path + [vti, 'address', '10.1.1.1/24'])
 
+        # vpn ipsec auth psk <tag> id <x.x.x.x>
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', local_id])
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', remote_id])
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', peer_ip])
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'secret', secret])
+
         # Site to site
         peer_base_path = base_path + ['site-to-site', 'peer', connection_name]
         self.cli_set(peer_base_path + ['authentication', 'mode', 'pre-shared-secret'])
-        self.cli_set(peer_base_path + ['authentication', 'pre-shared-secret', secret])
         self.cli_set(peer_base_path + ['connection-type', 'none'])
         self.cli_set(peer_base_path + ['force-udp-encapsulation'])
         self.cli_set(peer_base_path + ['ike-group', ike_group])
@@ -295,12 +317,12 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             self.assertIn(line, swanctl_conf)
 
         swanctl_secrets_lines = [
-            f'id-local = {local_address} # dhcp:no',
-            f'id-remote_{peer_ip.replace(".","-")} = {peer_ip}',
+            f'id-{regex_uuid4} = "{local_id}"',
+            f'id-{regex_uuid4} = "{remote_id}"',
             f'secret = "{secret}"'
         ]
         for line in swanctl_secrets_lines:
-            self.assertIn(line, swanctl_conf)
+            self.assertRegex(swanctl_conf, fr'{line}')
 
 
     def test_04_dmvpn(self):
@@ -453,9 +475,15 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['options', 'interface', 'tun1'])
         self.cli_set(base_path + ['ike-group', ike_group, 'key-exchange', 'ikev2'])
 
+        # vpn ipsec auth psk <tag> id <x.x.x.x>
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', local_id])
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', remote_id])
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', local_address])
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', peer_ip])
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'secret', secret])
+
         self.cli_set(peer_base_path + ['authentication', 'local-id', local_id])
         self.cli_set(peer_base_path + ['authentication', 'mode', 'pre-shared-secret'])
-        self.cli_set(peer_base_path + ['authentication', 'pre-shared-secret', secret])
         self.cli_set(peer_base_path + ['authentication', 'remote-id', remote_id])
         self.cli_set(peer_base_path + ['connection-type', 'initiate'])
         self.cli_set(peer_base_path + ['ike-group', ike_group])
@@ -485,15 +513,15 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             self.assertIn(line, swanctl_conf)
 
         swanctl_secrets_lines = [
-            f'id-local = {local_address} # dhcp:no',
-            f'id-remote_{peer_ip.replace(".","-")} = {peer_ip}',
-            f'id-localid = {local_id}',
-            f'id-remoteid = {remote_id}',
+            f'id-{regex_uuid4} = "{local_id}"',
+            f'id-{regex_uuid4} = "{remote_id}"',
+            f'id-{regex_uuid4} = "{peer_ip}"',
+            f'id-{regex_uuid4} = "{local_address}"',
             f'secret = "{secret}"',
         ]
 
         for line in swanctl_secrets_lines:
-            self.assertIn(line, swanctl_conf)
+            self.assertRegex(swanctl_conf, fr'{line}')
 
         # Verify charon configuration
         charon_conf = read_file(charon_file)

--- a/src/conf_mode/vpn_ipsec.py
+++ b/src/conf_mode/vpn_ipsec.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2022 VyOS maintainers and contributors
+# Copyright (C) 2021-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -17,6 +17,7 @@
 import ipaddress
 import os
 import re
+import jmespath
 
 from sys import exit
 from time import sleep
@@ -218,6 +219,12 @@ def verify_pki_rsa(pki, rsa_conf):
 def verify(ipsec):
     if not ipsec:
         return None
+
+    if 'authentication' in ipsec:
+        if 'psk' in ipsec['authentication']:
+            for psk, psk_config in ipsec['authentication']['psk'].items():
+                if 'id' not in psk_config or 'secret' not in psk_config:
+                    raise ConfigError(f'Authentication psk "{psk}" missing "id" or "secret"')
 
     if 'interfaces' in ipsec :
         for ifname in ipsec['interface']:
@@ -602,6 +609,14 @@ def generate(ipsec):
 
                     ipsec['site_to_site']['peer'][peer]['tunnel'][tunnel]['passthrough'] = passthrough
 
+        # auth psk <tag> dhcp-interface <xxx>
+        if jmespath.search('authentication.psk.*.dhcp_interface', ipsec):
+            for psk, psk_config in ipsec['authentication']['psk'].items():
+                if 'dhcp_interface' in psk_config:
+                    for iface in psk_config['dhcp_interface']:
+                        id = get_dhcp_address(iface)
+                        if id:
+                            ipsec['authentication']['psk'][psk]['id'].append(id)
 
     render(ipsec_conf, 'ipsec/ipsec.conf.j2', ipsec)
     render(ipsec_secrets, 'ipsec/ipsec.secrets.j2', ipsec)

--- a/src/migration-scripts/ipsec/10-to-11
+++ b/src/migration-scripts/ipsec/10-to-11
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+
+
+if (len(argv) < 1):
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['vpn', 'ipsec']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+
+# PEER changes
+if config.exists(base + ['site-to-site', 'peer']):
+    for peer in config.list_nodes(base + ['site-to-site', 'peer']):
+        peer_base = base + ['site-to-site', 'peer', peer]
+
+        # replace: 'ipsec site-to-site peer <tag> authentication pre-shared-secret xxx'
+        #       => 'ipsec authentication psk <tag> secret xxx'
+        if config.exists(peer_base + ['authentication', 'pre-shared-secret']):
+            tmp = config.return_value(peer_base + ['authentication', 'pre-shared-secret'])
+            config.delete(peer_base + ['authentication', 'pre-shared-secret'])
+            config.set(base + ['authentication', 'psk', peer, 'secret'], value=tmp)
+            # format as tag node to avoid loading problems
+            config.set_tag(base + ['authentication', 'psk'])
+
+            # Get id's from peers for "ipsec auth psk <tag> id xxx"
+            if config.exists(peer_base + ['authentication', 'local-id']):
+                local_id = config.return_value(peer_base + ['authentication', 'local-id'])
+                config.set(base + ['authentication', 'psk', peer, 'id'], value=local_id, replace=False)
+            if config.exists(peer_base + ['authentication', 'remote-id']):
+                remote_id = config.return_value(peer_base + ['authentication', 'remote-id'])
+                config.set(base + ['authentication', 'psk', peer, 'id'], value=remote_id, replace=False)
+
+            if config.exists(peer_base + ['local-address']):
+                tmp = config.return_value(peer_base + ['local-address'])
+                config.set(base + ['authentication', 'psk', peer, 'id'], value=tmp, replace=False)
+            if config.exists(peer_base + ['remote-address']):
+                tmp = config.return_value(peer_base + ['remote-address'])
+                if tmp:
+                    for remote_addr in tmp:
+                        if remote_addr == 'any':
+                            remote_addr = '%any'
+                        config.set(base + ['authentication', 'psk', peer, 'id'], value=remote_addr, replace=False)
+
+            # get DHCP peer interface as psk dhcp-interface
+            if config.exists(peer_base + ['dhcp-interface']):
+                tmp = config.return_value(peer_base + ['dhcp-interface'])
+                config.set(base + ['authentication', 'psk', peer, 'dhcp-interface'], value=tmp)
+
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print(f'Failed to save the modified config: {e}')
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Rewrite strongswan IPsec site-to-site authentication to reflect structure from swanctl.conf
The most important change is that more than one local/remote ID in the same auth entry should be allowed.
```
replace: 'ipsec site-to-site peer <tag> authentication pre-shared-secret xxx'
      => 'ipsec authentication psk <tag> secret xxx'
```

Add
```
set vpn ipsec authentication psk <tag> dhcp-interface 'eth2'
set vpn ipsec authentication psk <tag> id '%any'
set vpn ipsec authentication psk <tag> secret 'SuperSecret'
```

One of the use cases is the capability with cisco Flex

## Related PR
https://github.com/vyos/vyatta-cfg-system/pull/195

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Migration ipsec auth

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4916

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec
## Proposed changes
<!--- Describe your changes in detail -->

## How to test

VyOS configuration:
```
set vpn ipsec authentication psk bar id '192.0.2.1'
set vpn ipsec authentication psk bar id '192.0.2.3'
set vpn ipsec authentication psk bar id '192.0.2.1.local.peer-b'
set vpn ipsec authentication psk bar id '192.0.2.2.peer-b'
set vpn ipsec authentication psk bar secret 'SecretBar'
set vpn ipsec authentication psk baz id 'fsdfdf'
set vpn ipsec authentication psk baz secret 'bazdfwefsecrettt'

set vpn ipsec esp-group ESP-group-b lifetime '1800'
set vpn ipsec esp-group ESP-group-b mode 'tunnel'
set vpn ipsec esp-group ESP-group-b pfs 'enable'
set vpn ipsec esp-group ESP-group-b proposal 1 encryption 'aes128'
set vpn ipsec esp-group ESP-group-b proposal 1 hash 'sha1'
set vpn ipsec ike-group IKE-group-b key-exchange 'ikev1'
set vpn ipsec ike-group IKE-group-b lifetime '3600'
set vpn ipsec ike-group IKE-group-b proposal 1 dh-group '14'
set vpn ipsec ike-group IKE-group-b proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE-group-b proposal 1 hash 'sha256'
set vpn ipsec interface 'eth0'

set vpn ipsec site-to-site peer OFFICE-B authentication local-id '192.0.2.1.local.peer-b'
set vpn ipsec site-to-site peer OFFICE-B authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer OFFICE-B authentication remote-id '192.0.2.2.peer-b'

set vpn ipsec site-to-site peer OFFICE-B connection-type 'initiate'
set vpn ipsec site-to-site peer OFFICE-B ike-group 'IKE-group-b'
set vpn ipsec site-to-site peer OFFICE-B local-address '192.0.2.1'
set vpn ipsec site-to-site peer OFFICE-B remote-address '192.0.2.2'
set vpn ipsec site-to-site peer OFFICE-B tunnel 0 esp-group 'ESP-group-b'
set vpn ipsec site-to-site peer OFFICE-B tunnel 0 local prefix '192.168.0.0/24'
set vpn ipsec site-to-site peer OFFICE-B tunnel 0 remote prefix '10.0.0.0/21'

```
swanctl.conf
```
vyos@r1# cat /etc/swanctl/swanctl.conf 
### Autogenerated by vpn_ipsec.py ###

connections {
    OFFICE-B {
        proposals = aes256-sha256-modp2048
        version = 1
        local_addrs = 192.0.2.1 # dhcp:no
        remote_addrs = 192.0.2.2
        dpd_timeout = 120
        dpd_delay = 30
        rekey_time = 3600s
        mobike = yes
        keyingtries = 0
        local {
            id = "192.0.2.1.local.peer-b"
            auth = psk
        }
        remote {
            id = "192.0.2.2.peer-b"
            auth = psk
        }
        children {
            OFFICE-B-tunnel-0 {
                esp_proposals = aes128-sha1-modp2048
                life_time = 1800s
                local_ts = 192.168.0.0/24
                remote_ts = 10.0.0.0/21
                ipcomp = no
                mode = tunnel
                start_action = start
                dpd_action = 
                close_action = 
            }
        }
    }

}

pools {
}

secrets {
    ike-bar {
        # ID's from auth psk <tag> id xxx
        id-a3692cfd-8b68-4416-b3c7-aababd20009d = "192.0.2.1"
        id-e68ef232-8a50-4232-b90e-17ae34cb1017 = "192.0.2.3"
        id-d506c8f2-9376-4b67-9fb6-0389f8dfb678 = "192.0.2.1.local.peer-b"
        id-240a69ba-683b-41e0-bcfa-4ed557a9f4da = "192.0.2.2.peer-b"
        secret = "SecretBar"
    }
    ike-baz {
        # ID's from auth psk <tag> id xxx
        id-da65889d-a931-4ed9-8cff-514331eb09ea = "fsdfdf"
        secret = "bazdfwefsecrettt"
    }

}
```
## Smoketests
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
test_01_dhcp_fail_handling (__main__.TestVPNIPsec) ... ok
test_02_site_to_site (__main__.TestVPNIPsec) ... ok
test_03_site_to_site_vti (__main__.TestVPNIPsec) ... ok
test_04_dmvpn (__main__.TestVPNIPsec) ... ok
test_05_x509_site2site (__main__.TestVPNIPsec) ... ok
test_06_flex_vpn_vips (__main__.TestVPNIPsec) ... ok

----------------------------------------------------------------------
Ran 6 tests in 24.576s

OK
vyos@r14:~$ 

````

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
