### PR TITLE
vrrp: T4583: Rewrite show vrrp in the new op-mode format

### DIFF
--- a/data/op-mode-standardized.json
+++ b/data/op-mode-standardized.json
@@ -22,5 +22,6 @@
 "uptime.py",
 "version.py",
 "vrf.py",
+"vrrp.py",
 "zone.py"
 ]

--- a/op-mode-definitions/vrrp.xml.in
+++ b/op-mode-definitions/vrrp.xml.in
@@ -6,19 +6,19 @@
         <properties>
           <help>Show VRRP (Virtual Router Redundancy Protocol) information</help>
         </properties>
-        <command>sudo ${vyos_op_scripts_dir}/vrrp.py --summary</command>
+        <command>sudo ${vyos_op_scripts_dir}/vrrp.py show_summary</command>
         <children>
           <node name="statistics">
             <properties>
               <help>Show VRRP statistics</help>
             </properties>
-            <command>sudo ${vyos_op_scripts_dir}/vrrp.py --statistics</command>
+            <command>sudo ${vyos_op_scripts_dir}/vrrp.py show_statistics</command>
           </node>
           <node name="detail">
             <properties>
               <help>Show detailed VRRP state information</help>
             </properties>
-            <command>sudo ${vyos_op_scripts_dir}/vrrp.py --data</command>
+            <command>sudo ${vyos_op_scripts_dir}/vrrp.py show_state</command>
           </node>
         </children>
       </node>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
A simple rewrite of `show vrrp` in the new op-mode format. Leaving this as a draft so that we can discuss whether to keep the old behaviour as it is or take a scalpel at the way we interface with keepalived and do a fresh rewrite.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4583

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
op-mode, vrrp

## Proposed changes
<!--- Describe your changes in detail -->
The behaviour is otherwise identical besides the format change. There's now a separate routine (not accessible through op-mode) to get the raw JSON dump. None of the other routines support raw output.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
$ show vrrp
$ show vrrp statistics
$ show vrrp detail
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
