### PR TITLE
Smoketest fixes backport for equuleus

### DIFF
--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -102,17 +102,17 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
     def test_dhcp_single_pool_options(self):
         shared_net_name = 'SMOKE-0815'
 
-        range_0_start   = inc_ip(subnet, 10)
-        range_0_stop    = inc_ip(subnet, 20)
-        smtp_server     = '1.2.3.4'
-        time_server     = '4.3.2.1'
-        tftp_server     = 'tftp.vyos.io'
-        search_domains  = ['foo.vyos.net', 'bar.vyos.net']
-        bootfile_name   = 'vyos'
-        bootfile_server = '192.0.2.1'
-        wpad            = 'http://wpad.vyos.io/foo/bar'
-        server_identifier = bootfile_server
-        ipv6_only_preferred = 300
+        range_0_start       = inc_ip(subnet, 10)
+        range_0_stop        = inc_ip(subnet, 20)
+        smtp_server         = '1.2.3.4'
+        time_server         = '4.3.2.1'
+        tftp_server         = 'tftp.vyos.io'
+        search_domains      = ['foo.vyos.net', 'bar.vyos.net']
+        bootfile_name       = 'vyos'
+        bootfile_server     = '192.0.2.1'
+        wpad                = 'http://wpad.vyos.io/foo/bar'
+        server_identifier   = bootfile_server
+        ipv6_only_preferred = '300'
 
         pool = base_path + ['shared-network-name', shared_net_name, 'subnet', subnet]
         # we use the first subnet IP address as default gateway


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4832

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
Smoketests

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py
test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer) ... ok
test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer) ... ok
test_dhcp_failover (__main__.TestServiceDHCPServer) ... ok
test_dhcp_invalid_raw_options (__main__.TestServiceDHCPServer) ... ok
test_dhcp_multiple_pools (__main__.TestServiceDHCPServer) ... ok
test_dhcp_relay_server (__main__.TestServiceDHCPServer) ... ok
test_dhcp_single_pool_options (__main__.TestServiceDHCPServer) ... ok
test_dhcp_single_pool_range (__main__.TestServiceDHCPServer) ... ok
test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer) ... ok

----------------------------------------------------------------------
Ran 9 tests in 122.676s

OK

vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_tftp-server.py
test_01_tftpd_single (__main__.TestServiceTFTPD) ... ok
test_02_tftpd_multi (__main__.TestServiceTFTPD) ... ok
test_03_tftpd_vrf (__main__.TestServiceTFTPD) ... ok

----------------------------------------------------------------------
Ran 3 tests in 43.048s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
