### PR TITLE
container: T4947: support mounting container volumes as ro or rw (equuleus backport)

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -274,6 +274,26 @@
                   </valueHelp>
                 </properties>
               </leafNode>
+              <leafNode name="mode">
+                <properties>
+                  <help>Volume access mode ro/rw</help>
+                  <completionHelp>
+                    <list>ro rw</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>ro</format>
+                    <description>Volume mounted into the container as read-only</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>rw</format>
+                    <description>Volume mounted into the container as read-write</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(ro|rw)</regex>
+                  </constraint>
+                </properties>
+                <defaultValue>rw</defaultValue>
+              </leafNode>
             </children>
           </tagNode>
         </children>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Whenever a container is used and a folder is mounted, this happenes as read-write which is the default in Docker/Podman - so is the default in VyOS.

A new option is added "set container name foo volume mode <ro|rw>" to specify explicitly if rw (default) or ro should be used for this mounted folder.

(cherry picked from commit 275ea7303cfdb79c042da1b710622aee17a488a8)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4947

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
container

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set container name unifi environment TZ value 'Europe/Berlin'
set container name unifi image 'jacobalberty/unifi:v7.2'
set container name unifi memory '1024'
set container name unifi network test address '172.29.2.20'
set container name unifi volume config destination '/unifi'
set container name unifi volume config source '/config/unifi'
set container name unifi volume config mode rw
set container network test prefix '172.29.2.0/24'
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
