### PR TITLE
pppoe: T4948: add CLI option to allow definition of host-uniq flag (equuleus backport)

### DIFF
--- a/data/templates/pppoe/peer.tmpl
+++ b/data/templates/pppoe/peer.tmpl
@@ -36,10 +36,13 @@ maxfail 0
 
 plugin rp-pppoe.so {{ source_interface }}
 {% if access_concentrator is defined and access_concentrator is not none %}
-rp_pppoe_ac '{{ access_concentrator }}'
+rp_pppoe_ac "{{ access_concentrator }}"
 {% endif %}
 {% if service_name is defined and service_name is not none %}
-rp_pppoe_service '{{ service_name }}'
+rp_pppoe_service "{{ service_name }}"
+{% endif %}
+{% if host_uniq is defined and host_uniq is not none %}
+host-uniq "{{ host_uniq }}"
 {% endif %}
 
 persist

--- a/interface-definitions/interfaces-pppoe.xml.in
+++ b/interface-definitions/interfaces-pppoe.xml.in
@@ -61,6 +61,19 @@
               <constraintErrorMessage>Timeout must be in range 0 to 86400</constraintErrorMessage>
             </properties>
           </leafNode>
+          <leafNode name="host-uniq">
+            <properties>
+              <help>PPPoE RFC2516 host-uniq tag</help>
+              <valueHelp>
+                <format>txt</format>
+                <description>Host-uniq tag as byte string in HEX</description>
+              </valueHelp>
+              <constraint>
+                <regex>([a-fA-F0-9][a-fA-F0-9]){1,18}</regex>
+              </constraint>
+              <constraintErrorMessage>Host-uniq must be specified as hex-adecimal byte-string (even number of HEX characters)</constraintErrorMessage>
+            </properties>
+          </leafNode>
           <node name="ip">
             <properties>
               <help>IPv4 routing parameters</help>

--- a/smoketest/scripts/cli/test_interfaces_pppoe.py
+++ b/smoketest/scripts/cli/test_interfaces_pppoe.py
@@ -192,5 +192,37 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + [interface, 'authentication', 'password', 'vyos'])
         self.cli_commit()
 
+    def test_pppoe_options(self):
+        # Check if PPPoE dialer can be configured with DHCPv6-PD
+        for interface in self._interfaces:
+            user = f'VyOS-user-{interface}'
+            passwd = f'VyOS-passwd-{interface}'
+            ac_name = f'AC{interface}'
+            service_name = f'SRV{interface}'
+            host_uniq = 'cafebeefBABE123456'
+
+            self.cli_set(base_path + [interface, 'authentication', 'user', user])
+            self.cli_set(base_path + [interface, 'authentication', 'password', passwd])
+            self.cli_set(base_path + [interface, 'source-interface', self._source_interface])
+
+            self.cli_set(base_path + [interface, 'access-concentrator', ac_name])
+            self.cli_set(base_path + [interface, 'service-name', service_name])
+            self.cli_set(base_path + [interface, 'host-uniq', host_uniq])
+
+        # commit changes
+        self.cli_commit()
+
+        for interface in self._interfaces:
+            ac_name = f'AC{interface}'
+            service_name = f'SRV{interface}'
+            host_uniq = 'cafebeefBABE123456'
+
+            tmp = get_config_value(interface, 'rp_pppoe_ac')[1]
+            self.assertEqual(tmp, f'"{ac_name}"')
+            tmp = get_config_value(interface, 'rp_pppoe_service')[1]
+            self.assertEqual(tmp, f'"{service_name}"')
+            tmp = get_config_value(interface, 'host-uniq')[1]
+            self.assertEqual(tmp, f'"{host_uniq}"')
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Some ISPs seem to use the host-uniq flag to authenticate client equipment. Add CLI option in VyOS to allow specification of the host-uniq flag.

set interfaces pppoe pppoeN host-uniq <value>

(cherry-picked from commit 38bab79324087df5a9057c23b85a0a784c09540a)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4948

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
PPPoE client

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Smoketests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
