### PR TITLE
T1297: VRRP: add garp options to vrrp

### DIFF
--- a/data/templates/high-availability/keepalived.conf.j2
+++ b/data/templates/high-availability/keepalived.conf.j2
@@ -8,6 +8,23 @@ global_defs {
 {% if vrrp.global_parameters.startup_delay is vyos_defined %}
     vrrp_startup_delay {{ vrrp.global_parameters.startup_delay }}
 {% endif %}
+{% if vrrp.global_parameters.garp is vyos_defined %}
+{%     if vrrp.global_parameters.garp.interval is vyos_defined %}
+    vrrp_garp_interval {{ vrrp.global_parameters.garp.interval }}
+{%     endif %}
+{%     if vrrp.global_parameters.garp.master_delay is vyos_defined %}
+    vrrp_garp_master_delay {{ vrrp.global_parameters.garp.master_delay }}
+{%     endif %}
+{%     if vrrp.global_parameters.garp.master_refresh is vyos_defined %}
+    vrrp_garp_master_refresh {{ vrrp.global_parameters.garp.master_refresh }}
+{%     endif %}
+{%     if vrrp.global_parameters.garp.master_refresh_repeat is vyos_defined %}
+    vrrp_garp_master_refresh_repeat {{ vrrp.global_parameters.garp.master_refresh_repeat }}
+{%     endif %}
+{%     if vrrp.global_parameters.garp.master_repeat is vyos_defined %}
+    vrrp_garp_master_repeat {{ vrrp.global_parameters.garp.master_repeat }}
+{%     endif %}
+{% endif %}
     notify_fifo /run/keepalived/keepalived_notify_fifo
     notify_fifo_script /usr/libexec/vyos/system/keepalived-fifo.py
 }
@@ -31,6 +48,23 @@ vrrp_instance {{ name }} {
     virtual_router_id {{ group_config.vrid }}
     priority {{ group_config.priority }}
     advert_int {{ group_config.advertise_interval }}
+{%         if group_config.garp is vyos_defined %}
+{%             if group_config.garp.interval is vyos_defined %}
+    garp_interval {{ group_config.garp.interval }}
+{%             endif %}
+{%             if group_config.garp.master_delay is vyos_defined %}
+    garp_master_delay {{ group_config.garp.master_delay }}
+{%             endif %}
+{%             if group_config.garp.master_repeat is vyos_defined %}
+    garp_master_repeat {{ group_config.garp.master_repeat }}
+{%             endif %}
+{%             if group_config.garp.master_refresh is vyos_defined %}
+    garp_master_refresh {{ group_config.garp.master_refresh }}
+{%             endif %}
+{%             if group_config.garp.master_refresh_repeat is vyos_defined %}
+    garp_master_refresh_repeat {{ group_config.garp.master_refresh_repeat }}
+{%             endif %}
+{%         endif %}
 {%         if group_config.track.exclude_vrrp_interface is vyos_defined %}
     dont_track_primary
 {%         endif %}

--- a/interface-definitions/high-availability.xml.in
+++ b/interface-definitions/high-availability.xml.in
@@ -16,6 +16,7 @@
               <help>VRRP global parameters</help>
             </properties>
             <children>
+              #include <include/vrrp/garp.xml.i>
               <leafNode name="startup-delay">
                 <properties>
                   <help>Time VRRP startup process (in seconds)</help>
@@ -36,6 +37,7 @@
             </properties>
             <children>
               #include <include/generic-interface-broadcast.xml.i>
+              #include <include/vrrp/garp.xml.i>
               <leafNode name="advertise-interval">
                 <properties>
                   <help>Advertise interval</help>

--- a/interface-definitions/include/vrrp/garp.xml.i
+++ b/interface-definitions/include/vrrp/garp.xml.i
@@ -1,0 +1,74 @@
+<!-- include start from vrrp/garp.xml.i -->
+<node name="garp">
+  <properties>
+    <help>Gratuitous ARP parameters</help>
+  </properties>
+  <children>
+    <leafNode name="master-delay">
+      <properties>
+        <help>Delay for second set of gratuitous ARPs after transition to MASTER</help>
+        <valueHelp>
+          <format>u32:1-1000</format>
+          <description>Delay for second set of gratuitous ARPs after transition to MASTER</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-1000"/>
+        </constraint>
+      </properties>
+      <defaultValue>5</defaultValue>
+    </leafNode>
+    <leafNode name="master-repeat">
+      <properties>
+        <help>Number of gratuitous ARP messages to send at a time after transition to MASTER</help>
+        <valueHelp>
+          <format>u32:1-255</format>
+          <description>Number of gratuitous ARP messages to send at a time after transition to MASTER</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-255"/>
+        </constraint>
+      </properties>
+      <defaultValue>5</defaultValue>
+    </leafNode>
+    <leafNode name="master-refresh">
+      <properties>
+        <help>Minimum time interval for refreshing gratuitous ARPs while MASTER. 0 means no refresh</help>
+        <valueHelp>
+          <format>u32:1-255</format>
+          <description>Minimum time interval for refreshing gratuitous ARPs while MASTER. 0 means no refresh</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-255"/>
+        </constraint>
+      </properties>
+      <defaultValue>5</defaultValue>
+    </leafNode>
+    <leafNode name="master-refresh-repeat">
+      <properties>
+        <help>Number of gratuitous ARP messages to send at a time while MASTER</help>
+        <valueHelp>
+          <format>u32:1-255</format>
+          <description>Number of gratuitous ARP messages to send at a time while MASTER</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-255"/>
+        </constraint>
+      </properties>
+      <defaultValue>1</defaultValue>
+    </leafNode>
+    <leafNode name="interval">
+      <properties>
+        <help>Delay between gratuitous ARP messages sent on an interface</help>
+        <valueHelp>
+          <format>&lt;0.000-1000&gt;</format>
+          <description>Delay between gratuitous ARP messages sent on an interface</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 0.000-1000 --float"/>
+        </constraint>
+      </properties>
+      <defaultValue>0</defaultValue>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/smoketest/scripts/cli/test_ha_vrrp.py
+++ b/smoketest/scripts/cli/test_ha_vrrp.py
@@ -88,6 +88,14 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
         priority = '123'
         preempt_delay = '400'
         startup_delay = '120'
+        garp_master_delay = '2'
+        garp_master_repeat = '3'
+        garp_master_refresh = '4'
+        garp_master_refresh_repeat = '5'
+        garp_interval = '1.5'
+        group_garp_master_delay = '12'
+        group_garp_master_repeat = '13'
+        group_garp_master_refresh = '14'
 
         for group in groups:
             vlan_id = group.lstrip('VLAN')
@@ -112,12 +120,31 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
             self.cli_set(group_base + ['authentication', 'type', 'plaintext-password'])
             self.cli_set(group_base + ['authentication', 'password', f'{group}'])
 
-            # Global parameters
-            config = getConfig(f'global_defs')
-            self.cli_set(global_param_base + ['startup-delay', f'{startup_delay}'])
+            # GARP
+            self.cli_set(group_base + ['garp', 'master-delay', group_garp_master_delay])
+            self.cli_set(group_base + ['garp', 'master-repeat', group_garp_master_repeat])
+            self.cli_set(group_base + ['garp', 'master-refresh', group_garp_master_refresh])
+
+        # Global parameters
+        #config = getConfig(f'global_defs')
+        self.cli_set(global_param_base + ['startup-delay', f'{startup_delay}'])
+        self.cli_set(global_param_base + ['garp', 'interval', f'{garp_interval}'])
+        self.cli_set(global_param_base + ['garp', 'master-delay', f'{garp_master_delay}'])
+        self.cli_set(global_param_base + ['garp', 'master-repeat', f'{garp_master_repeat}'])
+        self.cli_set(global_param_base + ['garp', 'master-refresh', f'{garp_master_refresh}'])
+        self.cli_set(global_param_base + ['garp', 'master-refresh-repeat', f'{garp_master_refresh_repeat}'])
 
         # commit changes
         self.cli_commit()
+
+        # Check Global parameters
+        config = getConfig(f'global_defs')
+        self.assertIn(f'vrrp_startup_delay {startup_delay}', config)
+        self.assertIn(f'vrrp_garp_interval {garp_interval}', config)
+        self.assertIn(f'vrrp_garp_master_delay {garp_master_delay}', config)
+        self.assertIn(f'vrrp_garp_master_repeat {garp_master_repeat}', config)
+        self.assertIn(f'vrrp_garp_master_refresh {garp_master_refresh}', config)
+        self.assertIn(f'vrrp_garp_master_refresh_repeat {garp_master_refresh_repeat}', config)
 
         for group in groups:
             vlan_id = group.lstrip('VLAN')
@@ -137,9 +164,11 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
             # Authentication
             self.assertIn(f'auth_pass "{group}"', config)
             self.assertIn(f'auth_type PASS', config)
-            # Global parameters
-            config = getConfig(f'global_defs')
-            self.assertIn(f'vrrp_startup_delay {startup_delay}', config)
+
+            #GARP
+            self.assertIn(f'garp_master_delay {group_garp_master_delay}', config)
+            self.assertIn(f'garp_master_refresh {group_garp_master_refresh}', config)
+            self.assertIn(f'garp_master_repeat {group_garp_master_repeat}', config)
 
     def test_03_sync_group(self):
         sync_group = 'VyOS'

--- a/src/conf_mode/high-availability.py
+++ b/src/conf_mode/high-availability.py
@@ -51,6 +51,8 @@ def get_config(config=None):
     if 'vrrp' in ha:
         if 'group' in ha['vrrp']:
             default_values_vrrp = defaults(base_vrrp + ['group'])
+            if 'garp' in default_values_vrrp:
+                del default_values_vrrp['garp']
             for group in ha['vrrp']['group']:
                 ha['vrrp']['group'][group] = dict_merge(default_values_vrrp, ha['vrrp']['group'][group])
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add garp options.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T1297

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrrp

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
cli:
```
vyos@vyos# set high-availability vrrp global-parameters garp 
Possible completions:
   interval             Delay between gratuitous ARP messages sent on an interface.
                        Default is 0
   master-delay         Delay for second set of gratuitous ARPs after transition to
                        MASTER. Default is 5
   master-refresh       Minimum time interval for refreshing gratuitous ARPs while
                        MASTER. 0 means no refresh and default is 5
   master-refresh-repeat
                        Number of gratuitous ARP messages to send at a time while
                        MASTER. Default is 1
   master-repeat        Number of gratuitous ARP messages to send at a time after
                        transition to MASTER. Default is 5

      
[edit]
vyos@vyos# set high-availability vrrp group ETH0 garp 
Possible completions:
   interval             Delay between gratuitous ARP messages sent on an interface.
                        Default is 0
   master-delay         Delay for second set of gratuitous ARPs after transition to
                        MASTER. Default is 5
   master-refresh       Minimum time interval for refreshing gratuitous ARPs while
                        MASTER. 0 means no refresh and default is 5
   master-refresh-repeat
                        Number of gratuitous ARP messages to send at a time while
                        MASTER. Default is 1
   master-repeat        Number of gratuitous ARP messages to send at a time after
                        transition to MASTER. Default is 5

      
[edit]
vyos@vyos# set high-availability vrrp group ETH0 garp 
```

Config example and check vrrp config status:
```
vyos@vyos:~$ show config comm | grep garp
set high-availability vrrp global-parameters garp interval '1.334'
set high-availability vrrp global-parameters garp master-delay '4'
set high-availability vrrp global-parameters garp master-refresh '5'
set high-availability vrrp global-parameters garp master-repeat '7'
set high-availability vrrp global-parameters garp master-refresh-repeat '6'
set high-availability vrrp group ETH0 garp master-delay '11'
set high-availability vrrp group ETH0 garp master-refresh '12'
set high-availability vrrp group ETH0 garp master-repeat '14'
set high-availability vrrp group ETH0 garp master-refresh-repeat '13'
vyos@vyos:~$ show vrrp detail | grep ARP
 Gratuitous ARP delay = 4
 Gratuitous ARP repeat = 7
 Gratuitous ARP refresh timer = 5
 Gratuitous ARP refresh repeat = 6
 Gratuitous ARP lower priority delay = 4
 Gratuitous ARP lower priority repeat = 7
 Gratuitous ARP for each secondary VMAC = 0s
 Gratuitous ARP interval = 1.334000
------< Gratuitous ARP delays >------
------< GARP delay group 0 >------
 GARP interval = 1.334
 GARP next time 1674477211.040174 (Mon Jan 23 12:33:31.040174)
   Gratuitous ARP delay = 11
   Gratuitous ARP repeat = 14
   Gratuitous ARP refresh = 12
   Gratuitous ARP refresh repeat = 13
   Gratuitous ARP lower priority delay = 4
   Gratuitous ARP lower priority repeat = 7
   Reset ARP config counter 0
   Gratuitous ARP interval 1334ms
   Reset ARP config counter 0
   Reset ARP config counter 0
   Reset ARP config counter 0
   Reset ARP config counter 0
vyos@vyos:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
