### PR TITLE
op mode: T4951: add InsufficientResources error

### DIFF
--- a/python/vyos/opmode.py
+++ b/python/vyos/opmode.py
@@ -1,4 +1,4 @@
-# Copyright 2022 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2022-2023 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -22,6 +22,10 @@ from humps import decamelize
 class Error(Exception):
     """ Any error that makes requested operation impossible to complete
         for reasons unrelated to the user input or script logic.
+
+        This is the base class, scripts should not use it directly
+        and should raise more specific errors instead,
+        whenever possible.
     """
     pass
 
@@ -42,6 +46,13 @@ class DataUnavailable(Error):
 class PermissionDenied(Error):
     """ Requested operation is valid, but the caller has no permission
         to perform it.
+    """
+    pass
+
+class InsufficientResources(Error):
+    """ Requested operation and its arguments are valid but the system
+        does not have enough resources (such as drive space or memory)
+        to complete it.
     """
     pass
 

--- a/src/services/api/graphql/session/errors/op_mode_errors.py
+++ b/src/services/api/graphql/session/errors/op_mode_errors.py
@@ -4,6 +4,7 @@ op_mode_err_msg = {
     "UnconfiguredSubsystem": "subsystem is not configured or not running",
     "DataUnavailable": "data currently unavailable",
     "PermissionDenied": "client does not have permission",
+    "InsufficientResources": "insufficient system resources"
     "IncorrectValue": "argument value is incorrect",
     "UnsupportedOperation": "operation is not supported (yet)",
 }
@@ -11,6 +12,7 @@ op_mode_err_msg = {
 op_mode_err_code = {
     "UnconfiguredSubsystem": 2000,
     "DataUnavailable": 2001,
+    "InsufficientResources": 2002,
     "PermissionDenied": 1003,
     "IncorrectValue": 1002,
     "UnsupportedOperation": 1004,


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Adds a new op mode error that indicates insufficient resource conditions (not enough drive space, memory, etc.).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4951

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Op mode.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
