### PR TITLE
T4956: fix 'show hardware cpu' issue on arm64

### DIFF
--- a/python/vyos/cpu.py
+++ b/python/vyos/cpu.py
@@ -73,7 +73,7 @@ def _find_physical_cpus():
             # On other architectures, e.g. on ARM, there's no such field.
             # We just assume they are different CPUs,
             # whether single core ones or cores of physical CPUs.
-            phys_cpus[num] = cpu[num]
+            phys_cpus[num] = cpus[num]
 
     return phys_cpus
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/cpu.py", line 76, in <module>
    res = vyos.opmode.run(sys.modules[__name__])
  File "/usr/lib/python3/dist-packages/vyos/opmode.py", line 200, in run
    res = func(**args)
  File "/usr/libexec/vyos/op_mode/cpu.py", line 58, in show
    cpu_data = _get_raw_data()
  File "/usr/libexec/vyos/op_mode/cpu.py", line 40, in _get_raw_data
    return vyos.cpu.get_cpus()
  File "/usr/lib/python3/dist-packages/vyos/cpu.py", line 83, in get_cpus
    cpus_dict = _find_physical_cpus()
  File "/usr/lib/python3/dist-packages/vyos/cpu.py", line 76, in _find_physical_cpus
    phys_cpus[num] = cpu[num]
NameError: name 'cpu' is not defined
```
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Simple typo fix.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4956

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->
-
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
No testing performed

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
