### PR TITLE
ocserv: T3896: add CLI options to configure ocserv config-per-user/group

### DIFF
--- a/data/templates/ocserv/ocserv_config.j2
+++ b/data/templates/ocserv/ocserv_config.j2
@@ -12,6 +12,14 @@ run-as-group = daemon
 
 {% if "radius" in authentication.mode %}
 auth = "radius [config=/run/ocserv/radiusclient.conf{{ ',groupconfig=true' if authentication.radius.groupconfig is vyos_defined else '' }}]"
+{%     if "config_per_x" in authentication %}
+{%         if authentication.config_per_x.disabled is not vyos_defined %}
+{%             if "group" in authentication.config_per_x.mode %}
+config-per-group = {{ authentication.config_per_x.directory }}
+default-group-config = {{ authentication.config_per_x.default_config }}
+{%             endif %}
+{%         endif %}
+{%     endif %}
 {% elif "local" in authentication.mode %}
 {%     if authentication.mode.local == "password-otp" %}
 auth = "plain[passwd=/run/ocserv/ocpasswd,otp=/run/ocserv/users.oath]"
@@ -22,6 +30,13 @@ auth = "plain[/run/ocserv/ocpasswd]"
 {%     endif %}
 {% else %}
 auth = "plain[/run/ocserv/ocpasswd]"
+{% endif %}
+
+{% if "config_per_x" in authentication %}
+{%     if "user" in authentication.config_per_x.mode %}
+config-per-user = {{ authentication.config_per_x.directory }}
+default-user-config = {{ authentication.config_per_x.default_config }}
+{%     endif %}
 {% endif %}
 
 {% if ssl.certificate is vyos_defined %}

--- a/data/templates/ocserv/ocserv_config.j2
+++ b/data/templates/ocserv/ocserv_config.j2
@@ -12,11 +12,11 @@ run-as-group = daemon
 
 {% if "radius" in authentication.mode %}
 auth = "radius [config=/run/ocserv/radiusclient.conf{{ ',groupconfig=true' if authentication.radius.groupconfig is vyos_defined else '' }}]"
-{%     if "config_per_x" in authentication %}
-{%         if authentication.config_per_x.disabled is not vyos_defined %}
-{%             if "group" in authentication.config_per_x.mode %}
-config-per-group = {{ authentication.config_per_x.directory }}
-default-group-config = {{ authentication.config_per_x.default_config }}
+{%     if "identity_based_config" in authentication %}
+{%         if authentication.identity_based_config.disabled is not vyos_defined %}
+{%             if "group" in authentication.identity_based_config.mode %}
+config-per-group = {{ authentication.identity_based_config.directory }}
+default-group-config = {{ authentication.identity_based_config.default_config }}
 {%             endif %}
 {%         endif %}
 {%     endif %}
@@ -32,10 +32,10 @@ auth = "plain[/run/ocserv/ocpasswd]"
 auth = "plain[/run/ocserv/ocpasswd]"
 {% endif %}
 
-{% if "config_per_x" in authentication %}
-{%     if "user" in authentication.config_per_x.mode %}
-config-per-user = {{ authentication.config_per_x.directory }}
-default-user-config = {{ authentication.config_per_x.default_config }}
+{% if "identity_based_config" in authentication %}
+{%     if "user" in authentication.identity_based_config.mode %}
+config-per-user = {{ authentication.identity_based_config.directory }}
+default-user-config = {{ authentication.identity_based_config.default_config }}
 {%     endif %}
 {% endif %}
 

--- a/interface-definitions/include/openconnect-config-per-x.xml.i
+++ b/interface-definitions/include/openconnect-config-per-x.xml.i
@@ -1,24 +1,24 @@
 <!-- include start from openconnect-config-per-x.xml.i -->
 <node name="config-per-x">
     <properties>
-        <help>Configures ocserv to search the configured directory for a config file matching the Group name or username</help>
+        <help>Configures OpenConnect to search the configured directory for a config file matching the Group name or Username</help>
     </properties>
     <children>
         <leafNode name="mode">
             <properties>
-                <help>ocserv will ignore these configs if groupconfig is enabled TODO: explain this in better detail - need to make it clear this is in reference to the groupconfig vyos config that lives up one level from here</help>
+                <help>Configures OpenConnect to use config-per-group or config-per-user. Ignored if OpenConnect authentication group is configured.</help>
                 <valueHelp>
                     <format>user</format>
-                    <description>ocserv config file loaded by matching file in configured directory to the users username</description>
+                    <description>OpenConnect config file loaded by matching file in configured directory to the users username</description>
                 </valueHelp>
                 <valueHelp>
                     <format>group</format>
-                    <description>ocserv config file loaded by matching RADIUS class attribute in the RADIUS server response to a file in the configured directory</description>
+                    <description>OpenConnect config file loaded by matching RADIUS class attribute in the RADIUS server response to a file in the configured directory</description>
                 </valueHelp>
                 <constraint>
                     <regex>(user|group)</regex>
                 </constraint>
-                <constraintErrorMessage>Invalid config-per-x. Must be one of: user,  group </constraintErrorMessage>
+                <constraintErrorMessage>Invalid mode. Must be one of: user, group</constraintErrorMessage>
                 <completionHelp>
                     <list>user group</list>
                 </completionHelp>
@@ -26,10 +26,10 @@
         </leafNode>
         <leafNode name="directory">
             <properties>
-                <help>Child directory of /config/auth e.g. /config/auth/ocserv/config-per-user</help>
+                <help>Directory to configure OpenConnect to use for matching username/group to config file</help>
                 <valueHelp>
                     <format>filename</format>
-                    <description>Child directory of /config/auth e.g. /config/auth/ocserv/config-per-user</description>
+                    <description>Must be a child directory of /config/auth e.g. /config/auth/ocserv/config-per-user</description>
                 </valueHelp>
                 <constraint>
                     <validator name="file-path" argument="--directory --parent-dir /config/auth --strict"/>

--- a/interface-definitions/include/openconnect-config-per-x.xml.i
+++ b/interface-definitions/include/openconnect-config-per-x.xml.i
@@ -1,0 +1,54 @@
+<!-- include start from openconnect-config-per-x.xml.i -->
+<node name="config-per-x">
+    <properties>
+        <help>Configures ocserv to search the configured directory for a config file matching the Group name or username</help>
+    </properties>
+    <children>
+        <leafNode name="mode">
+            <properties>
+                <help>ocserv will ignore these configs if groupconfig is enabled TODO: explain this in better detail - need to make it clear this is in reference to the groupconfig vyos config that lives up one level from here</help>
+                <valueHelp>
+                    <format>user</format>
+                    <description>ocserv config file loaded by matching file in configured directory to the users username</description>
+                </valueHelp>
+                <valueHelp>
+                    <format>group</format>
+                    <description>ocserv config file loaded by matching RADIUS class attribute in the RADIUS server response to a file in the configured directory</description>
+                </valueHelp>
+                <constraint>
+                    <regex>(user|group)</regex>
+                </constraint>
+                <constraintErrorMessage>Invalid config-per-x. Must be one of: user,  group </constraintErrorMessage>
+                <completionHelp>
+                    <list>user group</list>
+                </completionHelp>
+            </properties>
+        </leafNode>
+        <leafNode name="directory">
+            <properties>
+                <help>Child directory of /config/auth e.g. /config/auth/ocserv/config-per-user</help>
+                <valueHelp>
+                    <format>filename</format>
+                    <description>Child directory of /config/auth e.g. /config/auth/ocserv/config-per-user</description>
+                </valueHelp>
+                <constraint>
+                    <validator name="file-path" argument="--directory --parent-dir /config/auth --strict"/>
+                </constraint>
+            </properties>
+        </leafNode>
+        <leafNode name="default-config">
+            <properties>
+                <help>Default/fallback config to use when a file cannot be found in the configured directory that matches the username/group</help>
+                <valueHelp>
+                    <format>filename</format>
+                    <description>Child directory of /config/auth e.g. /config/auth/ocserv/defaults/user.conf</description>
+                </valueHelp>
+                <constraint>
+                    <validator name="file-path" argument="--file --parent-dir /config/auth --strict"/>
+                </constraint>
+            </properties>
+        </leafNode>
+        #include <include/generic-disable-node.xml.i>
+    </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/openconnect-identity-based-config.xml.i
+++ b/interface-definitions/include/openconnect-identity-based-config.xml.i
@@ -1,5 +1,5 @@
-<!-- include start from openconnect-config-per-x.xml.i -->
-<node name="config-per-x">
+<!-- include start from openconnect-identity-based-config.xml.i -->
+<node name="identity-based-config">
     <properties>
         <help>Configures OpenConnect to search the configured directory for a config file matching the Group name or Username</help>
     </properties>

--- a/interface-definitions/vpn-openconnect.xml.in
+++ b/interface-definitions/vpn-openconnect.xml.in
@@ -50,7 +50,7 @@
                   </leafNode>
                 </children>
               </node>
-              #include <include/openconnect-config-per-x.xml.i>
+              #include <include/openconnect-identity-based-config.xml.i>
               <leafNode name="group">
                 <properties>
                   <help>Group that a client is allowed to select (from a list). Maps to RADIUS Class attribute.</help>

--- a/interface-definitions/vpn-openconnect.xml.in
+++ b/interface-definitions/vpn-openconnect.xml.in
@@ -50,6 +50,7 @@
                   </leafNode>
                 </children>
               </node>
+              #include <include/openconnect-config-per-x.xml.i>
               <leafNode name="group">
                 <properties>
                   <help>Group that a client is allowed to select (from a list). Maps to RADIUS Class attribute.</help>

--- a/src/conf_mode/vpn_openconnect.py
+++ b/src/conf_mode/vpn_openconnect.py
@@ -113,6 +113,17 @@ def verify(ocserv):
                                 users_wo_pswd.append(user)
                         if users_wo_pswd:
                             raise ConfigError(f'password required for users:\n{users_wo_pswd}')
+            # Validate that if config-per-x is configured all child config nodes are set
+            if 'config_per_x' in ocserv["authentication"]:
+                if 'disabled' not in ocserv["authentication"]["config_per_x"]:
+                    if 'mode' not in ocserv["authentication"]["config_per_x"]:
+                        raise ConfigError('OpenConnect radius config-per-x enabled but mode not selected')
+                    elif 'group' in ocserv["authentication"]["config_per_x"]["mode"] and "radius" not in ocserv["authentication"]["mode"]:
+                        raise ConfigError('OpenConnect config-per-group must be used with radius authentication')
+                    if 'directory' not in ocserv["authentication"]["config_per_x"]:
+                        raise ConfigError('OpenConnect config-per-x enabled but directory not set')
+                    if 'default_config' not in ocserv["authentication"]["config_per_x"]:
+                        raise ConfigError('OpenConnect config-per-x enabled but default-config not set')
         else:
             raise ConfigError('openconnect authentication mode required')
     else:

--- a/src/conf_mode/vpn_openconnect.py
+++ b/src/conf_mode/vpn_openconnect.py
@@ -113,17 +113,17 @@ def verify(ocserv):
                                 users_wo_pswd.append(user)
                         if users_wo_pswd:
                             raise ConfigError(f'password required for users:\n{users_wo_pswd}')
-            # Validate that if config-per-x is configured all child config nodes are set
-            if 'config_per_x' in ocserv["authentication"]:
-                if 'disabled' not in ocserv["authentication"]["config_per_x"]:
-                    if 'mode' not in ocserv["authentication"]["config_per_x"]:
-                        raise ConfigError('OpenConnect radius config-per-x enabled but mode not selected')
-                    elif 'group' in ocserv["authentication"]["config_per_x"]["mode"] and "radius" not in ocserv["authentication"]["mode"]:
+            # Validate that if identity-based-config is configured all child config nodes are set
+            if 'identity_based_config' in ocserv["authentication"]:
+                if 'disabled' not in ocserv["authentication"]["identity_based_config"]:
+                    if 'mode' not in ocserv["authentication"]["identity_based_config"]:
+                        raise ConfigError('OpenConnect radius identity-based-config enabled but mode not selected')
+                    elif 'group' in ocserv["authentication"]["identity_based_config"]["mode"] and "radius" not in ocserv["authentication"]["mode"]:
                         raise ConfigError('OpenConnect config-per-group must be used with radius authentication')
-                    if 'directory' not in ocserv["authentication"]["config_per_x"]:
-                        raise ConfigError('OpenConnect config-per-x enabled but directory not set')
-                    if 'default_config' not in ocserv["authentication"]["config_per_x"]:
-                        raise ConfigError('OpenConnect config-per-x enabled but default-config not set')
+                    if 'directory' not in ocserv["authentication"]["identity_based_config"]:
+                        raise ConfigError('OpenConnect identity-based-config enabled but directory not set')
+                    if 'default_config' not in ocserv["authentication"]["identity_based_config"]:
+                        raise ConfigError('OpenConnect identity-based-config enabled but default-config not set')
         else:
             raise ConfigError('openconnect authentication mode required')
     else:


### PR DESCRIPTION
Adds CLI configurations under VPN - OpenConnect to facilitate per user/group vpn session configurations. Validation has been added to restrict config-per-group to be exclusive to OpenConnect RADIUS authentication as the config file is looked up based on a RADIUS response attribute - as well as sanity check that the necessary configs are configured when not disabled.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Adds:
* New interface include `openconnect-identity-based-config.xml.i`

Changes:
* Updates interface `vpn-openconnect.xml.in` to include `openconnect-identity-based-config.xml.i` as child node of authentication
* Updates template file `ocserv_config.j2` to add `config-per-user` or `config-per-group` where applicable based on CLI configuration
* Updates `vpn_openconnect.py` to add config validation in the `verify` stage

I wasn't sure what to name the configuration node - `config-per-user-or-group` seems too verbose and I think the help node does the job of explaining what the command is responsible for configuring, however I don't have a strong opinion either way - happy for you guys to change it.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3896

## Component(s) name
ocserv
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->
Adds ocserv configuration via VyOS CLI to specify per user/group configurations. When identity-based-config is set to user mode it can be used with the local authentication method as it matches the username to match to a config file. However if configured for group mode the openconnect authentication mode must be set to radius - `vpn_openconnect.py` validates that in its verify function.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
### Prerequisite
If you don't already have a valid ssl configuration for your openconnect vpn follow [these steps](https://docs.vyos.io/en/latest/configuration/vpn/openconnect.html?highlight=openconnect#ssl-certificates-generation) and setup a radius server for authentication

```
set vpn openconnect authentication mode radius
set vpn openconnect authentication radius server 10.0.95.49 port 1812
set vpn openconnect authentication radius server 10.0.95.49 key your_radius_secret_here
```

### Testing Generated Configs
```
sudo mkdir -p /config/auth/ocserv/config-per-user
sudo touch /config/auth/ocserv/default-user.conf

set vpn openconnect authentication identity-based-config mode user
set vpn openconnect authentication identity-based-config directory /config/auth/ocserv/config-per-user
set vpn openconnect authentication identity-based-config default-config /config/auth/ocserv/default-user.conf
commit

sudo cat /run/ocserv/ocserv.conf
```

The output ocserv.conf should include two lines as per below:
```
config-per-user = /config/auth/ocserv/config-per-user
default-user-config = /config/auth/ocserv/default-user.conf
```

### Testing by connecting to the VPN
Create a config file for the user you will be testing with and enter some data, e.g.
```
nano /config/auth/ocserv/config-per-user/{yourusername}
## enter the following:
dns = 8.8.4.4
```
Connect to the VPN with openconnect e.g. and observe your DNS change
```
openconnect -u {yourusername} https://{your openconnect vpn endpoint}
```

You can repeat these steps switching
* vpn authentication configuration mode to `local`
* change `identity-based-config` mode to group and have your RADIUS server reply with a Class attribute matching a file in the configured directory.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
