### PR TITLE
container: T4014: Add `command`, `arg` and `entrypoint` configuration options for containers

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -104,9 +104,36 @@
               </leafNode>
             </children>
           </tagNode>
+          <leafNode name="entrypoint">
+            <properties>
+              <help>Override the default ENTRYPOINT from the image</help>
+              <constraint>
+                <regex>[ !#-%&amp;(-~]+</regex>
+              </constraint>
+              <constraintErrorMessage>Entrypoint must be ascii characters, use &amp;quot; and &amp;apos for double and single quotes respectively</constraintErrorMessage>
+            </properties>
+          </leafNode>
           <leafNode name="image">
             <properties>
               <help>Image name in the hub-registry</help>
+            </properties>
+          </leafNode>
+          <leafNode name="command">
+            <properties>
+              <help>Override the default CMD from the image</help>
+              <constraint>
+                <regex>[ !#-%&amp;(-~]+</regex>
+              </constraint>
+              <constraintErrorMessage>Command must be ascii characters, use &amp;quot; and &amp;apos for double and single quotes respectively</constraintErrorMessage>
+            </properties>
+          </leafNode>
+          <leafNode name="arguments">
+            <properties>
+              <help>The command's arguments for this container</help>
+              <constraint>
+                <regex>[ !#-%&amp;(-~]+</regex>
+              </constraint>
+              <constraintErrorMessage>The command's arguments must be ascii characters, use &amp;quot; and &amp;apos for double and single quotes respectively</constraintErrorMessage>
             </properties>
           </leafNode>
           <leafNode name="memory">


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add `command`, `arguments` and `entrypoint` configuration options for containers

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4014
* https://phabricator.vyos.net/T4843

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
containers

## Proposed changes
<!--- Describe your changes in detail -->
I've created a pull request which add support for this, and yes, it does use raw command.
I know that here we want to avoid "raw options" but I think this is one of the most needed feature and I don't see any other way else to do this. Until a better option is found, I think my PR should do just fine.

I added 3 configuration options
- command
- arguments
- entrypoint

You can use `"` with `&quot;`
You can use `'` with `&apos;`

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
You can go ahead and add those configuration option to a container:

```shell
set container name test image docker.io/library/ubuntu:latest
set container name test allow-host-networks
set container name test command sleep
set container name test arguments 60
set container name test entrypoint /bin/bash
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
