### PR TITLE
vyos.ethtool: T4963: improve driver name detection

### DIFF
--- a/python/vyos/ethtool.py
+++ b/python/vyos/ethtool.py
@@ -56,10 +56,10 @@ class Ethtool:
 
     def __init__(self, ifname):
         # Get driver used for interface
-        sysfs_file = f'/sys/class/net/{ifname}/device/driver/module'
-        if os.path.exists(sysfs_file):
-            link = os.readlink(sysfs_file)
-            self._driver_name = os.path.basename(link)
+        out, err = popen(f'ethtool --driver {ifname}')
+        driver = re.search(r'driver:\s(\w+)', out)
+        if driver:
+            self._driver_name = driver.group(1)
 
         # Build a dictinary of supported link-speed and dupley settings.
         out, err = popen(f'ethtool {ifname}')


### PR DESCRIPTION
The previous solution did not work for drivers that were no modules. e.g compiled with a kernel config set to CONFIG_VIRTIO_NET=y

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Switched driver name detection from reading "module" file from sysfs to a proper "ethtool" like way. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4963

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ethernet
vyos.ethtool

## Proposed changes
<!--- Describe your changes in detail -->
Using ethtool with the --driver option and parsing the output is a way more reliable way to obtain the currently in-use driver for an interface. Afterall the 'module' sysfs node might not exist if the driver is no loadble module.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics -->

```python
from vyos.util import popen
import re

ethtool_driver = None
sysfs_driver = None
ifname = "eth0"

out, err = popen(f'ethtool --driver {ifname}')
driver = re.search(r'driver:\s(\w+)', out)
if driver:
    ethtool_driver = driver.group(1)

import os
sysfs_file = f'/sys/class/net/{ifname}/device/driver/module'
if os.path.exists(sysfs_file):
    link = os.readlink(sysfs_file)
    sysfs_driver = os.path.basename(link)

if ethtool_driver != sysfs_driver:
    print("DriverName not identical, if your driver is not a module this is expected.")
    print(f'eth: {ethtool_driver} != sysfs: {sysfs_driver}'
```

Quick & Dirty test script, outputs
```
$ python3 test.py
DriverName not identical, if your driver is not a module this is expected.
eth: virtio_net != sysfs: None
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
