### PR TITLE
configtree: T4961: improve error reporting of function copy

### DIFF
--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -242,7 +242,8 @@ class ConfigTree(object):
             raise ConfigTreeError()
         res = self.__copy(self.__config, oldpath_str, newpath_str)
         if (res != 0):
-            raise ConfigTreeError("Path [{}] doesn't exist".format(old_path))
+            msg = self.__get_error().decode()
+            raise ConfigTreeError(msg)
 
         if self.__migration:
             print(f"- op: copy old_path: {old_path} new_path: {new_path}")


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The function `copy` in vyos.configtree does not recursively create intermediary nodes of the target path; only the last node of the path is created. However, the error was not  being caught/reported in case of a non-existent node. Corrected error reporting is provided in the PR's:
https://github.com/vyos/vyos1x-config/pull/12 (merged)
https://github.com/vyos/libvyosconfig/pull/6 (merged)

and is passed to `ConfigTreeError` in this PR.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4961

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
