### PR TITLE
container: T4959: Add container registry authentication config for containers

### DIFF
--- a/data/templates/container/registries.conf.j2
+++ b/data/templates/container/registries.conf.j2
@@ -22,6 +22,11 @@
 # An array of host[:port] registries to try when pulling an unqualified image, in order.
 # unqualified-search-registries = ["example.com"]
 
-{% if registry is vyos_defined %}
-unqualified-search-registries = {{ registry }}
+{% set registry_value = [] %}
+{% if default_registry is vyos_defined %}
+{%     set registry_value = default_registry %}
 {% endif %}
+{% if registry is vyos_defined %}
+{%     set registry_value = ((registry_value + (registry.keys() | list)) | unique | list) %}
+{% endif %}
+unqualified-search-registries = {{ registry_value | tojson }}

--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -332,9 +332,27 @@
           </leafNode>
         </children>
       </tagNode>
-      <leafNode name="registry">
+      <tagNode name="registry">
         <properties>
           <help>Registry Name</help>
+        </properties>
+        <children>
+          #include <include/generic-disable-node.xml.i>
+          <leafNode name="username">
+            <properties>
+              <help>User name for authentication</help>
+            </properties>
+          </leafNode>
+          <leafNode name="password">
+            <properties>
+              <help>Password for authentication</help>
+            </properties>
+          </leafNode>
+        </children>
+      </tagNode>
+      <leafNode name="default-registry">
+        <properties>
+          <help>Default registry to use alongside registry configuration</help>
           <multi/>
         </properties>
         <defaultValue>docker.io quay.io</defaultValue>

--- a/op-mode-definitions/container.xml.in
+++ b/op-mode-definitions/container.xml.in
@@ -167,7 +167,7 @@
                 <path>container name</path>
               </completionHelp>
             </properties>
-            <command>if cli-shell-api existsActive container name "$4"; then sudo podman pull $(cli-shell-api returnActiveValue container name "$4" image); else echo "Container $4 does not exist"; fi</command>
+            <command>if cli-shell-api existsActive container name "$4"; then sudo podman pull --authfile /etc/containers/auth.json $(cli-shell-api returnActiveValue container name "$4" image); else echo "Container $4 does not exist"; fi</command>
           </tagNode>
         </children>
       </node>

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -18,8 +18,8 @@ import os
 
 from ipaddress import ip_address
 from ipaddress import ip_network
-from time import sleep
 from json import dumps as json_write
+from json import dump as json_write_file
 
 from vyos.base import Warning
 from vyos.config import Config
@@ -28,6 +28,7 @@ from vyos.configdict import node_changed
 from vyos.util import call
 from vyos.util import cmd
 from vyos.util import run
+from vyos.util import rc_cmd
 from vyos.util import write_file
 from vyos.template import inc_ip
 from vyos.template import is_ipv4
@@ -40,6 +41,7 @@ airbag.enable()
 
 config_containers_registry = '/etc/containers/registries.conf'
 config_containers_storage = '/etc/containers/storage.conf'
+config_containers_auth = '/etc/containers/auth.json'
 systemd_unit_path = '/run/systemd/system'
 
 def _cmd(command):
@@ -218,6 +220,10 @@ def verify(container):
             if v6_prefix > 1:
                 raise ConfigError(f'Only one IPv6 prefix can be defined for network "{network}"!')
 
+    if 'registry' in container:
+        for registry, registry_config in container['registry'].items():
+            if ('username' in registry_config) != ('password' in registry_config):
+                raise ConfigError(f'Must either not defined username and password, or defined both for registry {registry}')
 
     # A network attached to a container can not be deleted
     if {'network_remove', 'name'} <= set(container):
@@ -300,6 +306,12 @@ def generate(container):
             os.unlink(config_containers_storage)
         return None
 
+    # no matter we configure container registry or not, auth file is needed
+    if os.path.exists(config_containers_auth):
+        os.unlink(config_containers_auth)
+    with open(config_containers_auth, "w") as f:
+        json_write_file({}, f)
+
     if 'network' in container:
         for network, network_config in container['network'].items():
             tmp = {
@@ -330,6 +342,19 @@ def generate(container):
                 tmp['plugins'][0]['ipam']['routes'].append({'dst': default_route})
 
             write_file(f'/etc/cni/net.d/{network}.conflist', json_write(tmp, indent=2))
+
+    if 'registry' in container:
+        for registry, registry_config in container['registry'].items():
+            if 'disable' in registry_config:
+                continue
+
+            if 'username' in registry_config and 'password' in registry_config:
+                login_username = registry_config['username']
+                login_password = registry_config['password']
+                cmd = f'podman login --authfile {config_containers_auth} --username {login_username} --password {login_password} {registry}'
+                rc, out = rc_cmd(cmd)
+                if rc != 0:
+                    raise ConfigError(out)
 
     render(config_containers_registry, 'container/registries.conf.j2', container)
     render(config_containers_storage, 'container/storage.conf.j2', container)

--- a/src/op_mode/container.py
+++ b/src/op_mode/container.py
@@ -23,6 +23,8 @@ from vyos.util import cmd
 
 import vyos.opmode
 
+config_containers_auth = '/etc/containers/auth.json'
+
 def _get_json_data(command: str) -> list:
     """
     Get container command format JSON
@@ -38,7 +40,7 @@ def _get_raw_data(command: str) -> list:
 def add_image(name: str):
     from vyos.util import rc_cmd
 
-    rc, output = rc_cmd(f'podman image pull {name}')
+    rc, output = rc_cmd(f'podman image pull --authfile {config_containers_auth} {name}')
     if rc != 0:
         raise vyos.opmode.InternalError(output)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add container registry authentication config for containers

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4959

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
- containers

## Proposed changes
<!--- Describe your changes in detail -->
- Add `disable`, `username`, and, `password` to `container > registry` for authentication
- Add `default-registry` to container configuration to store default registry for using alongside registry config  

The way this works is by using the provided username and password to login with command `podman login` and save it to a json file `/etc/containers/auth.json`, and when command `add container image` is execute, make it load auth file from that location.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```bash
$ set container registry example.com
$ commit
$ set container registry docker.io username alice
$ set container registry docker.io password alices_password
$ commit
$ add container image SOME_LOCAL_OR_PRIVATE_REPO
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
