### PR TITLE
T4964: Fix template bgpd.frr.j2 for l2vpn vni route-targets

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -414,10 +414,14 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
    route-target both {{ vni_config.route_target.both }}
 {%                 endif %}
 {%                 if vni_config.route_target.export is vyos_defined %}
-   route-target export {{ vni_config.route_target.export }}
+{%                     for route_target in vni_config.route_target.export %}
+  route-target export {{ route_target }}
+{%                     endfor %}
 {%                 endif %}
 {%                 if vni_config.route_target.import is vyos_defined %}
-   route-target import {{ vni_config.route_target.import }}
+{%                     for route_target in vni_config.route_target.import %}
+  route-target import {{ route_target }}
+{%                     endfor %}
 {%                 endif %}
   exit-vni
 {%             endfor %}


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Route-target export/import for l2vpn-evpn vni xxx works as leafNode with multiple values
We have to use "for" for such values

```
vyos@r2# set protocols bgp address-family l2vpn-evpn vni 100 route-target export '65001:123'
[edit]
vyos@r2# compare 
                     rd "65023:100000100"
                     route-target {
                         export "65001:1"
+                        export "65001:123"
                         import "65000:102"
                     }
                 }
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4964

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
l2vpn-evpn, bgp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set protocols bgp address-family l2vpn-evpn advertise
set protocols bgp address-family l2vpn-evpn advertise-all-vni
set protocols bgp address-family l2vpn-evpn vni 100 advertise-svi-ip
set protocols bgp address-family l2vpn-evpn vni 100 rd '65023:100000100'
set protocols bgp address-family l2vpn-evpn vni 100 route-target export '65001:1'
set protocols bgp address-family l2vpn-evpn vni 100 route-target import '65000:102'
set protocols bgp system-as '65000'
```
Before fix there were not route-target expor|import in the FRR configuration

After fix:
```
!
router bgp 65000
 no bgp ebgp-requires-policy
 no bgp default ipv4-unicast
 no bgp network import-check
 !
 address-family l2vpn evpn
  advertise-all-vni
  vni 100
   rd 65023:100000100
   route-target import 65000:102
   route-target export 65001:1
   advertise-svi-ip
  exit-vni
 exit-address-family
exit
!
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
