### PR TITLE
nhrp: T4905: Rewritten nhrp op-mode in new style

### DIFF
--- a/data/op-mode-standardized.json
+++ b/data/op-mode-standardized.json
@@ -14,6 +14,7 @@
 "memory.py",
 "nat.py",
 "neighbor.py",
+"nhrp.py",
 "openconnect.py",
 "openvpn.py",
 "route.py",

--- a/op-mode-definitions/nhrp.xml.in
+++ b/op-mode-definitions/nhrp.xml.in
@@ -50,13 +50,13 @@
             <properties>
               <help>Show NHRP interface connection information</help>
             </properties>
-            <command>if pgrep opennhrp >/dev/null; then sudo opennhrpctl interface show; else echo OpenNHRP is not running; fi</command>
+            <command>${vyos_op_scripts_dir}/nhrp.py show_interface</command>
           </leafNode>
           <leafNode name="tunnel">
             <properties>
               <help>Show NHRP tunnel connection information</help>
             </properties>
-            <command>if pgrep opennhrp >/dev/null; then sudo opennhrpctl show ; else echo OpenNHRP is not running; fi</command>
+            <command>${vyos_op_scripts_dir}/nhrp.py show_tunnel</command>
           </leafNode>
         </children>
       </node>

--- a/src/op_mode/nhrp.py
+++ b/src/op_mode/nhrp.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import tabulate
+import vyos.opmode
+
+from vyos.util import cmd
+from vyos.util import process_named_running
+from vyos.util import colon_separated_to_dict
+
+
+def _get_formatted_output(output_dict: dict) -> str:
+    """
+    Create formatted table for CLI output
+    :param output_dict: dictionary for API
+    :type output_dict: dict
+    :return: tabulate string
+    :rtype: str
+    """
+    print(f"Status: {output_dict['Status']}")
+    output: str = tabulate.tabulate(output_dict['routes'], headers='keys',
+                                    numalign="left")
+    return output
+
+
+def _get_formatted_dict(output_string: str) -> dict:
+    """
+    Format string returned from CMD to API list
+    :param output_string: String received by CMD
+    :type output_string: str
+    :return: dictionary for API
+    :rtype: dict
+    """
+    formatted_dict: dict = {
+        'Status': '',
+        'routes': []
+    }
+    output_list: list = output_string.split('\n\n')
+    for list_a in output_list:
+        output_dict = colon_separated_to_dict(list_a, True)
+        if 'Status' in output_dict:
+            formatted_dict['Status'] = output_dict['Status']
+        else:
+            formatted_dict['routes'].append(output_dict)
+    return formatted_dict
+
+
+def show_interface(raw: bool):
+    """
+    Command 'show nhrp interface'
+    :param raw: if API
+    :type raw: bool
+    """
+    if not process_named_running('opennhrp'):
+        raise vyos.opmode.UnconfiguredSubsystem('OpenNHRP is not running.')
+    interface_string: str = cmd('sudo opennhrpctl interface show')
+    interface_dict: dict = _get_formatted_dict(interface_string)
+    if raw:
+        return interface_dict
+    else:
+        return _get_formatted_output(interface_dict)
+
+
+def show_tunnel(raw: bool):
+    """
+    Command 'show nhrp tunnel'
+    :param raw: if API
+    :type raw: bool
+    """
+    if not process_named_running('opennhrp'):
+        raise vyos.opmode.UnconfiguredSubsystem('OpenNHRP is not running.')
+    tunnel_string: str = cmd('sudo opennhrpctl show')
+    tunnel_dict: list = _get_formatted_dict(tunnel_string)
+    if raw:
+        return tunnel_dict
+    else:
+        return _get_formatted_output(tunnel_dict)
+
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except (ValueError, vyos.opmode.Error) as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
1. Formatted output of 'show nhrp' commands to table view
2. Rewritten nhrp op-mode in new style

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4905

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nhrp, op-mode

## Proposed changes
<!--- Describe your changes in detail -->
1. Formatted output of 'show nhrp' commands to table view
```
vyos@vyos:~$ show nhrp interface
Status: ok
Interface    Index    Protocol-Address    Flags                         Holding-Time    Route-Table    GRE-Key    MTU    NBMA-MTU    NBMA-Address
-----------  -------  ------------------  ----------------------------  --------------  -------------  ---------  -----  ----------  --------------
tun100       9        10.100.100.2/24     shortcut redirect configured  300             254            1          1476   0           192.168.192.22
erspan0      8
gretap0      7
gre0         6
eth3         5
eth2         4
eth1         3
eth0         2
lo           1
vyos@vyos:~$ show nhrp tunnel
Status: ok
Interface    Type    Protocol-Address    Alias-Address    Flags    NBMA-Address
-----------  ------  ------------------  ---------------  -------  --------------
tun100       local   10.100.100.255/32   10.100.100.2     up
tun100       local   10.100.100.2/32                      up
tun100       static  10.100.100.1/24                      up       192.168.192.21
```

2. Rewritten nhrp op-mode in new style

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
