### PR TITLE
login: T4975: Fixed broken CLI commands

### DIFF
--- a/src/conf_mode/system-login.py
+++ b/src/conf_mode/system-login.py
@@ -322,6 +322,9 @@ def apply(login):
     except Exception as e:
         raise ConfigError(f'RADIUS configuration failed: {e}')
 
+    # sync user data files to disk
+    os.sync()
+
     return None
 
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed broken CLI commands

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4975

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
login, CLI

## Proposed changes
<!--- Describe your changes in detail -->
User profile files are not saved to disk after configuration is fully applied. Because of this, after a fast system reset, profile files can be empty, and CLI is broken.

This fix adds a `sync()` call after the user's configuration, which should protect from data loss and fix the problem with profiles.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
1. Boot VyOS for the first time (after installation or from VM image).
2. After full boot, reset the VM.
3. Wait for the boot and log in.
4. Check the CLI.
5. VyOS-specific commands will not work.
```
vyos@vyos:~$ show 
showconsolefont  showkey          
vyos@vyos:~$ show interfaces

  Invalid command: [show]

vyos@vyos:~$
```
After the fix, everything should be OK.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
