### PR TITLE
bgp: T4817: add support for RFC9234

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -9,6 +9,11 @@
 {% if config.remote_as is vyos_defined %}
  neighbor {{ neighbor }} remote-as {{ config.remote_as }}
 {% endif %}
+{% if config.local_role is vyos_defined %}	
+{%     for role, strict in config.local_role.items() %}	
+ neighbor {{ neighbor }} local-role {{ role }} {{ 'strict-mode' if strict }}	
+{%     endfor %}	
+{% endif %}
 {% if config.interface.remote_as is vyos_defined %}
  neighbor {{ neighbor }} interface remote-as {{ config.interface.remote_as }}
 {% endif %}

--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -9,10 +9,10 @@
 {% if config.remote_as is vyos_defined %}
  neighbor {{ neighbor }} remote-as {{ config.remote_as }}
 {% endif %}
-{% if config.local_role is vyos_defined %}	
-{%     for role, strict in config.local_role.items() %}	
- neighbor {{ neighbor }} local-role {{ role }} {{ 'strict-mode' if strict }}	
-{%     endfor %}	
+{% if config.local_role is vyos_defined %}
+{%     for role, strict in config.local_role.items() %}
+ neighbor {{ neighbor }} local-role {{ role }} {{ 'strict-mode' if strict }}
+{%     endfor %}
 {% endif %}
 {% if config.interface.remote_as is vyos_defined %}
  neighbor {{ neighbor }} interface remote-as {{ config.interface.remote_as }}

--- a/interface-definitions/include/bgp/neighbor-local-role.xml.i
+++ b/interface-definitions/include/bgp/neighbor-local-role.xml.i
@@ -1,0 +1,42 @@
+<!-- include start from bgp/neigbhor-local-role.xml.i -->
+<tagNode name="local-role">
+  <properties>
+    <help>Local role for this bgp session.</help>
+    <completionHelp>
+      <list>customer peer provider rs-client rs-server</list>
+    </completionHelp>
+    <valueHelp>
+      <format>customer</format>
+      <description>Using Transit</description>
+    </valueHelp>
+    <valueHelp>
+      <format>peer</format>
+      <description>Public/Private Peering</description>
+    </valueHelp>
+    <valueHelp>
+      <format>provider</format>
+      <description>Providing Transit</description>
+    </valueHelp>
+    <valueHelp>
+      <format>rs-client</format>
+      <description>RS Client</description>
+    </valueHelp>
+    <valueHelp>
+      <format>rs-server</format>
+      <description>Route Server</description>
+    </valueHelp>
+    <constraint>
+      <regex>(provider|rs-server|rs-client|customer|peer)</regex>
+    </constraint>
+    <constraintErrorMessage>Invalid Option</constraintErrorMessage>
+  </properties>
+  <children>
+    <leafNode name="strict">
+      <properties>
+        <help>Your neighbor must send you Capability with the value of his role. Otherwise, a Role Mismatch Notification will be sent.</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+  </children>
+</tagNode>
+<!-- include end -->

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -1004,6 +1004,7 @@
       </properties>
     </leafNode>
     #include <include/bgp/remote-as.xml.i>
+    #include <include/bgp/neighbor-local-role.xml.i>
     #include <include/bgp/neighbor-shutdown.xml.i>
     <leafNode name="solo">
       <properties>

--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -235,6 +235,11 @@ def verify(bgp):
                     raise ConfigError(f'Specified peer-group "{peer_group}" for '\
                                       f'neighbor "{neighbor}" does not exist!')
 
+            if 'local_role' in peer_config:
+                #Ensure Local Role has only one value.
+                if len(peer_config['local_role']) > 1:
+                    raise ConfigError(f'Only one local role can be specified for peer "{peer}"!')
+
             if 'local_as' in peer_config:
                 if len(peer_config['local_as']) > 1:
                     raise ConfigError(f'Only one local-as number can be specified for peer "{peer}"!')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T4817

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
BGP, FRR

## Proposed changes
<!--- Describe your changes in detail -->
Added support for RFC 9234 to the BGP configuration templates since it is already supported in FRR 8.4+

https://www.rfc-editor.org/rfc/rfc9234.html

https://docs.frrouting.org/en/latest/bgp.html#bgp-roles-and-only-to-customers
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Build an image with the purposed changes, you will not have the options to configure the local-role under the bgp neigbor config

```
vyos@vyos# set vrf name AS50842 protocols bgp neighbor 2a06:a004:c023::1 local-role 
Possible completions:
 > customer             Using Transit
 > peer                 Public/Private Peering
 > provider             Providing Transit
 > rs-client            RS Client
 > rs-server            Route Server
```

```
vyos@vyos# run show bgp vrf AS50842 neighbors 2a06:a004:c023::1 
BGP neighbor is 2a06:a004:c023::1, remote AS 44570, local AS 50842, external link
  Local Role: peer
```
Image with the changes should you want to try it without building it. 
https://repo.serverforge.org/vyos/dev/sagitta/vyos-1.4-rolling-202302040124-amd64.iso

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
