### PR TITLE
bgp: T4817: adjust CLI definition for local-role

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -10,9 +10,7 @@
  neighbor {{ neighbor }} remote-as {{ config.remote_as }}
 {% endif %}
 {% if config.local_role is vyos_defined %}
-{%     for role, strict in config.local_role.items() %}
- neighbor {{ neighbor }} local-role {{ role }} {{ 'strict-mode' if strict }}
-{%     endfor %}
+ neighbor {{ neighbor }} local-role {{ config.local_role }} {{ 'strict-mode' if config.local_role_strict is vyos_defined }}
 {% endif %}
 {% if config.interface.remote_as is vyos_defined %}
  neighbor {{ neighbor }} interface remote-as {{ config.interface.remote_as }}

--- a/interface-definitions/include/bgp/neighbor-local-role.xml.i
+++ b/interface-definitions/include/bgp/neighbor-local-role.xml.i
@@ -1,7 +1,7 @@
 <!-- include start from bgp/neigbhor-local-role.xml.i -->
-<tagNode name="local-role">
+<leafNode name="local-role">
   <properties>
-    <help>Local role for this bgp session.</help>
+    <help>Local role for neighbor</help>
     <completionHelp>
       <list>customer peer provider rs-client rs-server</list>
     </completionHelp>
@@ -30,13 +30,11 @@
     </constraint>
     <constraintErrorMessage>Invalid Option</constraintErrorMessage>
   </properties>
-  <children>
-    <leafNode name="strict">
-      <properties>
-        <help>Your neighbor must send you Capability with the value of his role. Otherwise, a Role Mismatch Notification will be sent.</help>
-        <valueless/>
-      </properties>
-    </leafNode>
-  </children>
-</tagNode>
+</leafNode>
+<leafNode name="local-role-strict">
+  <properties>
+    <help>Strict enforcement of local-role - role mismatch notification will be sent if unconfigured on peer</help>
+    <valueless/>
+  </properties>
+</leafNode>
 <!-- include end -->

--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -235,10 +235,8 @@ def verify(bgp):
                     raise ConfigError(f'Specified peer-group "{peer_group}" for '\
                                       f'neighbor "{neighbor}" does not exist!')
 
-            if 'local_role' in peer_config:
-                #Ensure Local Role has only one value.
-                if len(peer_config['local_role']) > 1:
-                    raise ConfigError(f'Only one local role can be specified for peer "{peer}"!')
+            if 'local_role_strict' in peer_config and 'local_role' not in peer_config:
+                raise ConfigError(f'Must configure local-role when using strict mode for peer "{peer}"!')
 
             if 'local_as' in peer_config:
                 if len(peer_config['local_as']) > 1:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Instead of making local-role a `tagNode` - which might look suitable in the first place - we change it to a `leafNode`.

Using a tagNode will suggest the user can enter "any data" indicated by `>` at the end.

```
vyos@vyos# set protocols bgp neighbor 1.1.1.1 local-role Possible completions:
 > customer             Using Transit
 > peer                 Public/Private Peering
 > provider             Providing Transit
 > rs-client            RS Client
 > rs-server            Route Server
 >
```

Moving to a `leafNode` will only five the user discrete choiced. The downside is that the require an additional `leafNode` for the strict parameter.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4817

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
BGP

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
