### PR TITLE
T4977: Add Babel routing protocol support

### DIFF
--- a/data/templates/frr/babeld.frr.j2
+++ b/data/templates/frr/babeld.frr.j2
@@ -1,0 +1,85 @@
+{% from 'frr/distribute_list_macro.j2' import render_distribute_list %}
+{% from 'frr/ipv6_distribute_list_macro.j2' import render_ipv6_distribute_list %}
+!
+{# Interface specific configuration #}
+{% if interface is vyos_defined %}
+{%     for iface, iface_config in interface.items() %}
+interface {{ iface }}
+{%         if iface_config.type is vyos_defined('wired') or iface_config.type is vyos_defined('wireless') %}
+ babel {{ iface_config.type }}
+{%         endif %}
+{%         if iface_config.split_horizon is vyos_defined("enable") %}
+ babel split-horizon
+{%         elif iface_config.split_horizon is vyos_defined("disable") %}
+ no babel split-horizon
+{%         endif %}
+{%         if iface_config.hello_interval is vyos_defined %}
+ babel hello-interval {{ iface_config.hello_interval }}
+{%         endif %}
+{%         if iface_config.update_interval is vyos_defined %}
+ babel update-interval {{ iface_config.update_interval }}
+{%         endif %}
+{%         if iface_config.rxcost is vyos_defined %}
+ babel rxcost {{ iface_config.rxcost }}
+{%         endif %}
+{%         if iface_config.rtt_decay is vyos_defined %}
+ babel rtt-decay {{ iface_config.rtt_decay }}
+{%         endif %}
+{%         if iface_config.rtt_min is vyos_defined %}
+ babel rtt-min {{ iface_config.rtt_min }}
+{%         endif %}
+{%         if iface_config.rtt_max is vyos_defined %}
+ babel rtt-max {{ iface_config.rtt_max }}
+{%         endif %}
+{%         if iface_config.max_rtt_penalty is vyos_defined %}
+ babel max-rtt-penalty {{ iface_config.max_rtt_penalty }}
+{%         endif %}
+{%         if iface_config.enable_timestamps is vyos_defined %}
+ babel enable-timestamps
+{%         endif %}
+{%         if iface_config.channel is vyos_defined %}
+ babel channel {{ iface_config.channel | replace("non-interfering", "noninterfering") }}
+{%         endif %}
+exit
+!
+{%     endfor %}
+{% endif %}
+!
+{# Babel configuration #}
+router babel
+{% if parameters.diversity is vyos_defined %}
+ babel diversity
+{% endif %}
+{% if parameters.diversity_factor is vyos_defined %}
+ babel diversity-factor {{ parameters.diversity_factor }}
+{% endif %}
+{% if parameters.resend_delay is vyos_defined %}
+ babel resend-delay {{ parameters.resend_delay }}
+{% endif %}
+{% if parameters.smoothing_half_life is vyos_defined %}
+ babel smoothing-half-life {{ parameters.smoothing_half_life }}
+{% endif %}
+{% if interface is vyos_defined %}
+{%     for iface, iface_config in interface.items() %}
+ network {{ iface }}
+{%     endfor %}
+{% endif %}
+{% if redistribute is vyos_defined %}
+{%     for address_family in redistribute %}
+{%         for protocol, protocol_config in redistribute[address_family].items() %}
+{%             if protocol is vyos_defined('ospfv3') %}
+{%                 set protocol = 'ospf6' %}
+{%             endif %}
+ redistribute {{ address_family }} {{ protocol }}
+{%         endfor %}
+{%     endfor %}
+{% endif %}
+{% if distribute_list.ipv4 is vyos_defined %}
+{{ render_distribute_list(distribute_list.ipv4) }}
+{% endif %}
+{% if distribute_list.ipv6 is vyos_defined %}
+{{ render_ipv6_distribute_list(distribute_list.ipv6) }}
+{% endif %}
+exit
+!
+end

--- a/data/templates/frr/daemons.frr.tmpl
+++ b/data/templates/frr/daemons.frr.tmpl
@@ -9,7 +9,7 @@ pimd=no
 ldpd=yes
 nhrpd=no
 eigrpd=yes
-babeld=no
+babeld=yes
 sharpd=no
 pbrd=no
 bfdd=yes
@@ -51,4 +51,3 @@ bfdd_options="  --daemon -A 127.0.0.1"
 
 watchfrr_enable=no
 valgrind_enable=no
-

--- a/data/templates/frr/distribute_list_macro.j2
+++ b/data/templates/frr/distribute_list_macro.j2
@@ -1,0 +1,30 @@
+{% macro render_distribute_list(distribute_list) %}
+{% if distribute_list.access_list.in is vyos_defined %}
+ distribute-list {{ distribute_list.access_list.in }} in
+{% endif %}
+{% if distribute_list.access_list.out is vyos_defined %}
+ distribute-list {{ distribute_list.access_list.out }} out
+{% endif %}
+{% if distribute_list.interface is vyos_defined %}
+{%     for interface, interface_config in distribute_list.interface.items() %}
+{%         if interface_config.access_list.in is vyos_defined %}
+ distribute-list {{ interface_config.access_list.in }} in {{ interface }}
+{%         endif %}
+{%         if interface_config.access_list.out is vyos_defined %}
+ distribute-list {{ interface_config.access_list.out }} out {{ interface }}
+{%         endif %}
+{%         if interface_config.prefix_list.in is vyos_defined %}
+ distribute-list prefix {{ interface_config.prefix_list.in }} in {{ interface }}
+{%         endif %}
+{%         if interface_config.prefix_list.out is vyos_defined %}
+ distribute-list prefix {{ interface_config.prefix_list.out }} out {{ interface }}
+{%         endif %}
+{%     endfor %}
+{% endif %}
+{% if distribute_list.prefix_list.in is vyos_defined %}
+ distribute-list prefix {{ distribute_list.prefix_list.in }} in
+{% endif %}
+{% if distribute_list.prefix_list.out is vyos_defined %}
+ distribute-list prefix {{ distribute_list.prefix_list.out }} out
+{% endif %}
+{% endmacro %}

--- a/data/templates/frr/ipv6_distribute_list_macro.j2
+++ b/data/templates/frr/ipv6_distribute_list_macro.j2
@@ -1,0 +1,30 @@
+{% macro render_ipv6_distribute_list(distribute_list) %}
+{% if distribute_list.access_list.in is vyos_defined %}
+ ipv6 distribute-list {{ distribute_list.access_list.in }} in
+{% endif %}
+{% if distribute_list.access_list.out is vyos_defined %}
+ ipv6 distribute-list {{ distribute_list.access_list.out }} out
+{% endif %}
+{% if distribute_list.interface is vyos_defined %}
+{%     for interface, interface_config in distribute_list.interface.items() %}
+{%         if interface_config.access_list.in is vyos_defined %}
+ ipv6 distribute-list {{ interface_config.access_list.in }} in {{ interface }}
+{%         endif %}
+{%         if interface_config.access_list.out is vyos_defined %}
+ ipv6 distribute-list {{ interface_config.access_list.out }} out {{ interface }}
+{%         endif %}
+{%         if interface_config.prefix_list.in is vyos_defined %}
+ ipv6 distribute-list prefix {{ interface_config.prefix_list.in }} in {{ interface }}
+{%         endif %}
+{%         if interface_config.prefix_list.out is vyos_defined %}
+ ipv6 distribute-list prefix {{ interface_config.prefix_list.out }} out {{ interface }}
+{%         endif %}
+{%     endfor %}
+{% endif %}
+{% if distribute_list.prefix_list.in is vyos_defined %}
+ ipv6 distribute-list prefix {{ distribute_list.prefix_list.in }} in
+{% endif %}
+{% if distribute_list.prefix_list.out is vyos_defined %}
+ ipv6 distribute-list prefix {{ distribute_list.prefix_list.out }} out
+{% endif %}
+{% endmacro %}

--- a/data/templates/frr/ripd.frr.j2
+++ b/data/templates/frr/ripd.frr.j2
@@ -1,3 +1,4 @@
+{% from 'frr/distribute_list_macro.j2' import render_distribute_list %}
 {# RIP key-chain definition #}
 {% if interface is vyos_defined %}
 {%     for iface, iface_config in interface.items() %}
@@ -60,34 +61,7 @@ router rip
 {%     endfor %}
 {% endif %}
 {% if distribute_list is vyos_defined %}
-{%     if distribute_list.access_list.in is vyos_defined %}
- distribute-list {{ distribute_list.access_list.in }} in
-{%     endif %}
-{%     if distribute_list.access_list.out is vyos_defined %}
- distribute-list {{ distribute_list.access_list.out }} out
-{%     endif %}
-{%     if distribute_list.interface is vyos_defined %}
-{%         for interface, interface_config in distribute_list.interface.items() %}
-{%             if interface_config.access_list.in is vyos_defined %}
- distribute-list {{ interface_config.access_list.in }} in {{ interface }}
-{%             endif %}
-{%             if interface_config.access_list.out is vyos_defined %}
- distribute-list {{ interface_config.access_list.out }} out {{ interface }}
-{%             endif %}
-{%             if interface_config.prefix_list.in is vyos_defined %}
- distribute-list prefix {{ interface_config.prefix_list.in }} in {{ interface }}
-{%             endif %}
-{%             if interface_config.prefix_list.out is vyos_defined %}
- distribute-list prefix {{ interface_config.prefix_list.out }} out {{ interface }}
-{%             endif %}
-{%         endfor %}
-{%     endif %}
-{%     if distribute_list.prefix_list.in is vyos_defined %}
- distribute-list prefix {{ distribute_list.prefix_list.in }} in
-{%     endif %}
-{%     if distribute_list.prefix_list.out is vyos_defined %}
- distribute-list prefix {{ distribute_list.prefix_list.out }} out
-{%     endif %}
+{{ render_distribute_list(distribute_list) }}
 {% endif %}
 {% include 'frr/rip_ripng.frr.j2' %}
 {% if version is vyos_defined %}

--- a/data/templates/frr/ripngd.frr.j2
+++ b/data/templates/frr/ripngd.frr.j2
@@ -1,3 +1,4 @@
+{% from 'frr/ipv6_distribute_list_macro.j2' import render_ipv6_distribute_list %}
 {# Interface specific configuration #}
 {% if interface is vyos_defined %}
 {%     for iface, iface_config in interface.items() %}
@@ -19,34 +20,7 @@ router ripng
 {%     endfor %}
 {% endif %}
 {% if distribute_list is vyos_defined %}
-{%     if distribute_list.access_list.in is vyos_defined %}
- ipv6 distribute-list {{ distribute_list.access_list.in }} in
-{%     endif %}
-{%     if distribute_list.access_list.out is vyos_defined %}
- ipv6 distribute-list {{ distribute_list.access_list.out }} out
-{%     endif %}
-{%     if distribute_list.interface is vyos_defined %}
-{%         for interface, interface_config in distribute_list.interface.items() %}
-{%             if interface_config.access_list.in is vyos_defined %}
- ipv6 distribute-list {{ interface_config.access_list.in }} in {{ interface }}
-{%             endif %}
-{%             if interface_config.access_list.out is vyos_defined %}
- ipv6 distribute-list {{ interface_config.access_list.out }} out {{ interface }}
-{%             endif %}
-{%             if interface_config.prefix_list.in is vyos_defined %}
- ipv6 distribute-list prefix {{ interface_config.prefix_list.in }} in {{ interface }}
-{%             endif %}
-{%             if interface_config.prefix_list.out is vyos_defined %}
- ipv6 distribute-list prefix {{ interface_config.prefix_list.out }} out {{ interface }}
-{%             endif %}
-{%         endfor %}
-{%     endif %}
-{%     if distribute_list.prefix_list.in is vyos_defined %}
- ipv6 distribute-list prefix {{ distribute_list.prefix_list.in }} in
-{%     endif %}
-{%     if distribute_list.prefix_list.out is vyos_defined %}
- ipv6 distribute-list prefix {{ distribute_list.prefix_list.out }} out
-{%     endif %}
+{{ render_ipv6_distribute_list(distribute_list) }}
 {% endif %}
 {% include 'frr/rip_ripng.frr.j2' %}
 exit

--- a/interface-definitions/include/babel/interface.xml.i
+++ b/interface-definitions/include/babel/interface.xml.i
@@ -1,0 +1,187 @@
+<!-- include start from babel/interface.xml.i -->
+<tagNode name="interface">
+  <properties>
+    <help>Interface name</help>
+    <completionHelp>
+      <script>${vyos_completion_dir}/list_interfaces.py</script>
+    </completionHelp>
+    <valueHelp>
+      <format>txt</format>
+      <description>Interface name</description>
+    </valueHelp>
+    <constraint>
+      #include <include/constraint/interface-name.xml.in>
+    </constraint>
+  </properties>
+  <children>
+    <leafNode name="type">
+      <properties>
+        <help>Interface type</help>
+        <completionHelp>
+          <list>auto wired wireless</list>
+        </completionHelp>
+        <valueHelp>
+          <format>auto</format>
+          <description>Automatically detect interface type</description>
+        </valueHelp>
+        <valueHelp>
+          <format>wired</format>
+          <description>Wired interface</description>
+        </valueHelp>
+        <valueHelp>
+          <format>wireless</format>
+          <description>Wireless interface</description>
+        </valueHelp>
+        <constraint>
+          <regex>(auto|wired|wireless)</regex>
+        </constraint>
+      </properties>
+      <defaultValue>auto</defaultValue>
+    </leafNode>
+    <leafNode name="split-horizon">
+      <properties>
+        <help>Split horizon parameters</help>
+        <completionHelp>
+          <list>default enable disable</list>
+        </completionHelp>
+        <valueHelp>
+          <format>default</format>
+          <description>Enable on wired interfaces, and disable on wireless interfaces</description>
+        </valueHelp>
+        <valueHelp>
+          <format>enable</format>
+          <description>Enable split horizon processing</description>
+        </valueHelp>
+        <valueHelp>
+          <format>disable</format>
+          <description>Disable split horizon processing</description>
+        </valueHelp>
+        <constraint>
+          <regex>(default|enable|disable)</regex>
+        </constraint>
+      </properties>
+      <defaultValue>default</defaultValue>
+    </leafNode>
+    <leafNode name="hello-interval">
+      <properties>
+        <help>Time between scheduled hellos</help>
+        <valueHelp>
+          <format>u32:20-655340</format>
+          <description>Milliseconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 20-655340"/>
+        </constraint>
+      </properties>
+      <defaultValue>4000</defaultValue>
+    </leafNode>
+    <leafNode name="update-interval">
+      <properties>
+        <help>Time between scheduled updates</help>
+        <valueHelp>
+          <format>u32:20-655340</format>
+          <description>Milliseconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 20-655340"/>
+        </constraint>
+      </properties>
+      <defaultValue>20000</defaultValue>
+    </leafNode>
+    <leafNode name="rxcost">
+      <properties>
+        <help>Base receive cost for this interface</help>
+        <valueHelp>
+          <format>u32:1-65534</format>
+          <description>Base receive cost</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-65534"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="rtt-decay">
+      <properties>
+        <help>Decay factor for exponential moving average of RTT samples</help>
+        <valueHelp>
+          <format>u32:1-256</format>
+          <description>Decay factor, in units of 1/256</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-256"/>
+        </constraint>
+      </properties>
+      <defaultValue>42</defaultValue>
+    </leafNode>
+    <leafNode name="rtt-min">
+      <properties>
+        <help>Minimum RTT</help>
+        <valueHelp>
+          <format>u32:1-65535</format>
+          <description>Milliseconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-65535"/>
+        </constraint>
+      </properties>
+      <defaultValue>10</defaultValue>
+    </leafNode>
+    <leafNode name="rtt-max">
+      <properties>
+        <help>Maximum RTT</help>
+        <valueHelp>
+          <format>u32:1-65535</format>
+          <description>Milliseconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-65535"/>
+        </constraint>
+      </properties>
+      <defaultValue>120</defaultValue>
+    </leafNode>
+    <leafNode name="max-rtt-penalty">
+      <properties>
+        <help>Maximum additional cost due to RTT</help>
+        <valueHelp>
+          <format>u32:0-65535</format>
+          <description>Milliseconds (0 to disable the use of RTT-based cost)</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 0-65535"/>
+        </constraint>
+      </properties>
+      <defaultValue>150</defaultValue>
+    </leafNode>
+    <leafNode name="enable-timestamps">
+      <properties>
+        <help>Enable timestamps with each Hello and IHU message in order to compute RTT values</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+    <leafNode name="channel">
+      <properties>
+        <help>Channel number for diversity routing</help>
+        <completionHelp>
+          <list>interfering non-interfering</list>
+        </completionHelp>
+        <valueHelp>
+          <format>u32:1-254</format>
+          <description>Interfaces with a channel number interfere with interfering interfaces and interfaces with the same channel number</description>
+        </valueHelp>
+        <valueHelp>
+          <format>interfering</format>
+          <description>Interfering interfaces are assumed to interfere with all other channels except non-interfering channels</description>
+        </valueHelp>
+        <valueHelp>
+          <format>non-interfering</format>
+          <description>Non-interfering interfaces only interfere with themselves</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-254"/>
+          <regex>(interfering|non-interfering)</regex>
+        </constraint>
+      </properties>
+    </leafNode>
+  </children>
+</tagNode>
+<!-- include end -->

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -165,6 +165,14 @@
                 #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
               </children>
             </node>
+            <node name="babel">
+              <properties>
+                <help>Redistribute Babel routes into BGP</help>
+              </properties>
+              <children>
+                #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
+              </children>
+            </node>
             <node name="static">
               <properties>
                 <help>Redistribute static routes into BGP</help>
@@ -537,6 +545,14 @@
             <node name="ripng">
               <properties>
                 <help>Redistribute RIPng routes into BGP</help>
+              </properties>
+              <children>
+                #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
+              </children>
+            </node>
+            <node name="babel">
+              <properties>
+                <help>Redistribute Babel routes into BGP</help>
               </properties>
               <children>
                 #include <include/bgp/afi-redistribute-metric-route-map.xml.i>

--- a/interface-definitions/include/eigrp/protocol-common-config.xml.i
+++ b/interface-definitions/include/eigrp/protocol-common-config.xml.i
@@ -87,6 +87,10 @@
       <description>Routing Information Protocol (RIP)</description>
     </valueHelp>
     <valueHelp>
+      <format>babel</format>
+      <description>Babel routing protocol (Babel)</description>
+    </valueHelp>
+    <valueHelp>
       <format>static</format>
       <description>Statically configured routes</description>
     </valueHelp>
@@ -98,7 +102,7 @@
       <list>bgp connected nhrp ospf rip static vnc</list>
     </completionHelp>
     <constraint>
-      <regex>(bgp|connected|nhrp|ospf|rip|static|vnc)</regex>
+      <regex>(bgp|connected|nhrp|ospf|rip|babel|static|vnc)</regex>
     </constraint>
     <multi/>
   </properties>

--- a/interface-definitions/include/isis/protocol-common-config.xml.i
+++ b/interface-definitions/include/isis/protocol-common-config.xml.i
@@ -394,6 +394,14 @@
             #include <include/isis/redistribute-level-1-2.xml.i>
           </children>
         </node>
+        <node name="babel">
+          <properties>
+            <help>Redistribute Babel routes into IS-IS</help>
+          </properties>
+          <children>
+            #include <include/isis/redistribute-level-1-2.xml.i>
+          </children>
+        </node>
         <node name="static">
           <properties>
             <help>Redistribute static routes into IS-IS</help>
@@ -444,6 +452,14 @@
         <node name="ripng">
           <properties>
             <help>Redistribute RIPng routes into IS-IS</help>
+          </properties>
+          <children>
+            #include <include/isis/redistribute-level-1-2.xml.i>
+          </children>
+        </node>
+        <node name="babel">
+          <properties>
+            <help>Redistribute Babel routes into IS-IS</help>
           </properties>
           <children>
             #include <include/isis/redistribute-level-1-2.xml.i>

--- a/interface-definitions/include/ospf/protocol-common-config.xml.i
+++ b/interface-definitions/include/ospf/protocol-common-config.xml.i
@@ -756,6 +756,16 @@
         #include <include/route-map.xml.i>
       </children>
     </node>
+    <node name="babel">
+      <properties>
+        <help>Redistribute Babel routes</help>
+      </properties>
+      <children>
+        #include <include/ospf/metric.xml.i>
+        #include <include/ospf/metric-type.xml.i>
+        #include <include/route-map.xml.i>
+      </children>
+    </node>
     <node name="static">
       <properties>
         <help>Redistribute statically configured routes</help>

--- a/interface-definitions/include/ospfv3/protocol-common-config.xml.i
+++ b/interface-definitions/include/ospfv3/protocol-common-config.xml.i
@@ -238,6 +238,14 @@
         #include <include/route-map.xml.i>
       </children>
     </node>
+    <node name="babel">
+      <properties>
+        <help>Redistribute Babel routes</help>
+      </properties>
+      <children>
+        #include <include/route-map.xml.i>
+      </children>
+    </node>
     <node name="static">
       <properties>
         <help>Redistribute static routes</help>

--- a/interface-definitions/protocols-babel.xml.in
+++ b/interface-definitions/protocols-babel.xml.in
@@ -1,0 +1,254 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="protocols">
+    <children>
+      <node name="babel" owner="${vyos_conf_scripts_dir}/protocols_babel.py">
+        <properties>
+          <help>Babel Routing Protocol</help>
+          <priority>650</priority>
+        </properties>
+        <children>
+          <node name="parameters">
+            <properties>
+              <help>Babel-specific parameters</help>
+            </properties>
+            <children>
+              <leafNode name="diversity">
+                <properties>
+                  <help>Enable diversity-aware routing</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="diversity-factor">
+                <properties>
+                  <help>Multiplicative factor used for diversity routing</help>
+                  <valueHelp>
+                    <format>u32:1-256</format>
+                    <description>Multiplicative factor, in units of 1/256</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 1-256"/>
+                  </constraint>
+                </properties>
+                <defaultValue>256</defaultValue>
+              </leafNode>
+              <leafNode name="resend-delay">
+                <properties>
+                  <help>Time before resending a message</help>
+                  <valueHelp>
+                    <format>u32:20-655340</format>
+                    <description>Milliseconds</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 20-655340"/>
+                  </constraint>
+                </properties>
+                <defaultValue>2000</defaultValue>
+              </leafNode>
+              <leafNode name="smoothing-half-life">
+                <properties>
+                  <help>Smoothing half-life</help>
+                  <valueHelp>
+                    <format>u32:0-65534</format>
+                    <description>Seconds</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-65534"/>
+                  </constraint>
+                </properties>
+                <defaultValue>4</defaultValue>
+              </leafNode>
+            </children>
+          </node>
+          #include <include/babel/interface.xml.i>
+          <node name="redistribute">
+            <properties>
+              <help>Redistribute information from another routing protocol</help>
+            </properties>
+            <children>
+              <node name="ipv4">
+                <properties>
+                  <help>Redistribute IPv4 routes</help>
+                </properties>
+                <children>
+                  <leafNode name="bgp">
+                    <properties>
+                      <help>Redistribute BGP routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="connected">
+                    <properties>
+                      <help>Redistribute connected routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="eigrp">
+                    <properties>
+                      <help>Redistribute EIGRP routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="isis">
+                    <properties>
+                      <help>Redistribute IS-IS routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="kernel">
+                    <properties>
+                      <help>Redistribute kernel routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="nhrp">
+                    <properties>
+                      <help>Redistribute NHRP routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="ospf">
+                    <properties>
+                      <help>Redistribute OSPF routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="rip">
+                    <properties>
+                      <help>Redistribute RIP routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="static">
+                    <properties>
+                      <help>Redistribute static routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+              <node name="ipv6">
+                <properties>
+                  <help>Redistribute IPv6 routes</help>
+                </properties>
+                <children>
+                  <leafNode name="bgp">
+                    <properties>
+                      <help>Redistribute BGP routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="connected">
+                    <properties>
+                      <help>Redistribute connected routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="isis">
+                    <properties>
+                      <help>Redistribute IS-IS routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="kernel">
+                    <properties>
+                      <help>Redistribute kernel routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="nhrp">
+                    <properties>
+                      <help>Redistribute NHRP routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="ospfv3">
+                    <properties>
+                      <help>Redistribute OSPFv3 routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="ripng">
+                    <properties>
+                      <help>Redistribute RIPng routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="static">
+                    <properties>
+                      <help>Redistribute static routes</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+            </children>
+          </node>
+          <node name="distribute-list">
+            <properties>
+              <help>Filter networks in routing updates</help>
+            </properties>
+            <children>
+              <node name="ipv4">
+                <properties>
+                  <help>Filter IPv4 routes</help>
+                </properties>
+                <children>
+                  #include <include/rip/access-list.xml.i>
+                  <tagNode name="interface">
+                    <properties>
+                      <help>Apply filtering to an interface</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Apply filtering to an interface</description>
+                      </valueHelp>
+                      <completionHelp>
+                        <script>${vyos_completion_dir}/list_interfaces.py</script>
+                      </completionHelp>
+                      <constraint>
+                        #include <include/constraint/interface-name.xml.in>
+                      </constraint>
+                    </properties>
+                    <children>
+                      #include <include/rip/access-list.xml.i>
+                      #include <include/rip/prefix-list.xml.i>
+                    </children>
+                  </tagNode>
+                  #include <include/rip/prefix-list.xml.i>
+                </children>
+              </node>
+              <node name="ipv6">
+                <properties>
+                  <help>Filter IPv6 routes</help>
+                </properties>
+                <children>
+                  #include <include/rip/access-list6.xml.i>
+                  <tagNode name="interface">
+                    <properties>
+                      <help>Apply filtering to an interface</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Apply filtering to an interface</description>
+                      </valueHelp>
+                      <completionHelp>
+                        <script>${vyos_completion_dir}/list_interfaces.py</script>
+                      </completionHelp>
+                      <constraint>
+                        #include <include/constraint/interface-name.xml.in>
+                      </constraint>
+                    </properties>
+                    <children>
+                      #include <include/rip/access-list6.xml.i>
+                      #include <include/rip/prefix-list6.xml.i>
+                    </children>
+                  </tagNode>
+                  #include <include/rip/prefix-list6.xml.i>
+                </children>
+              </node>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/interface-definitions/protocols-rip.xml.in
+++ b/interface-definitions/protocols-rip.xml.in
@@ -225,6 +225,14 @@
                   #include <include/rip/redistribute.xml.i>
                 </children>
               </node>
+              <node name="babel">
+                <properties>
+                  <help>Redistribute Babel routes</help>
+                </properties>
+                <children>
+                  #include <include/rip/redistribute.xml.i>
+                </children>
+              </node>
             </children>
           </node>
           <leafNode name="route">
@@ -248,4 +256,3 @@
     </children>
   </node>
 </interfaceDefinition>
-

--- a/interface-definitions/protocols-ripng.xml.in
+++ b/interface-definitions/protocols-ripng.xml.in
@@ -123,6 +123,14 @@
                   #include <include/rip/redistribute.xml.i>
                 </children>
               </node>
+              <node name="babel">
+                <properties>
+                  <help>Redistribute Babel routes</help>
+                </properties>
+                <children>
+                  #include <include/rip/redistribute.xml.i>
+                </children>
+              </node>
             </children>
           </node>
           <leafNode name="route">

--- a/op-mode-definitions/restart-frr.xml.in
+++ b/op-mode-definitions/restart-frr.xml.in
@@ -68,6 +68,12 @@
         </properties>
         <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon zebra</command>
       </leafNode>
+      <leafNode name="babel">
+        <properties>
+          <help>Restart Babel routing daemon</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon babeld</command>
+      </leafNode>
     </children>
   </node>
 </interfaceDefinition>

--- a/op-mode-definitions/show-babel.xml.in
+++ b/op-mode-definitions/show-babel.xml.in
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="show">
+    <children>
+      <node name="babel">
+        <properties>
+          <help>Show Babel routing protocol information</help>
+        </properties>
+        <children>
+          <leafNode name="interface">
+            <properties>
+              <help>Show Babel Interface information</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          </leafNode>
+          <leafNode name="neighbor">
+            <properties>
+              <help>Show Babel neighbor information</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          </leafNode>
+          <tagNode name="neighbor">
+            <properties>
+              <help>Show Babel neighbor information for specified interface</help>
+              <completionHelp>
+                <script>${vyos_completion_dir}/list_interfaces.py</script>
+              </completionHelp>
+            </properties>
+            <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          </tagNode>
+          <leafNode name="route">
+            <properties>
+              <help>Show Babel route information</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          </leafNode>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/python/vyos/frr.py
+++ b/python/vyos/frr.py
@@ -85,7 +85,7 @@ LOG.addHandler(ch2)
 
 _frr_daemons = ['zebra', 'bgpd', 'fabricd', 'isisd', 'ospf6d', 'ospfd', 'pbrd',
                 'pimd', 'ripd', 'ripngd', 'sharpd', 'staticd', 'vrrpd', 'ldpd',
-                'bfdd', 'eigrpd']
+                'bfdd', 'eigrpd', 'babeld']
 
 path_vtysh = '/usr/bin/vtysh'
 path_frr_reload = '/usr/lib/frr/frr-reload.py'

--- a/src/conf_mode/protocols_babel.py
+++ b/src/conf_mode/protocols_babel.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021-2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from sys import exit
+
+from vyos.config import Config
+from vyos.configdict import dict_merge
+from vyos.configdict import node_changed
+from vyos.configverify import verify_common_route_maps
+from vyos.configverify import verify_access_list
+from vyos.configverify import verify_prefix_list
+from vyos.util import dict_search
+from vyos.xml import defaults
+from vyos.template import render_to_string
+from vyos import ConfigError
+from vyos import frr
+from vyos import airbag
+airbag.enable()
+
+def get_config(config=None):
+    if config:
+        conf = config
+    else:
+        conf = Config()
+    base = ['protocols', 'babel']
+    babel = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
+
+    # FRR has VRF support for different routing daemons. As interfaces belong
+    # to VRFs - or the global VRF, we need to check for changed interfaces so
+    # that they will be properly rendered for the FRR config. Also this eases
+    # removal of interfaces from the running configuration.
+    interfaces_removed = node_changed(conf, base + ['interface'])
+    if interfaces_removed:
+        babel['interface_removed'] = list(interfaces_removed)
+
+    # Bail out early if configuration tree does not exist
+    if not conf.exists(base):
+        babel.update({'deleted' : ''})
+        return babel
+
+    # We have gathered the dict representation of the CLI, but there are default
+    # options which we need to update into the dictionary retrived.
+    default_values = defaults(base)
+
+    # XXX: T2665: we currently have no nice way for defaults under tag nodes,
+    # clean them out and add them manually :(
+    del default_values['interface']
+
+    # merge in remaining default values
+    babel = dict_merge(default_values, babel)
+
+    # We also need some additional information from the config, prefix-lists
+    # and route-maps for instance. They will be used in verify().
+    #
+    # XXX: one MUST always call this without the key_mangling() option! See
+    # vyos.configverify.verify_common_route_maps() for more information.
+    tmp = conf.get_config_dict(['policy'])
+    # Merge policy dict into "regular" config dict
+    babel = dict_merge(tmp, babel)
+    return babel
+
+def verify(babel):
+    if not babel:
+        return None
+
+    # verify distribute_list
+    if "distribute_list" in babel:
+        acl_keys = {
+            "ipv4": [
+                "distribute_list.ipv4.access_list.in",
+                "distribute_list.ipv4.access_list.out",
+            ],
+            "ipv6": [
+                "distribute_list.ipv6.access_list.in",
+                "distribute_list.ipv6.access_list.out",
+            ]
+        }
+        prefix_list_keys = {
+            "ipv4": [
+                "distribute_list.ipv4.prefix_list.in",
+                "distribute_list.ipv4.prefix_list.out",
+            ],
+            "ipv6":[
+                "distribute_list.ipv6.prefix_list.in",
+                "distribute_list.ipv6.prefix_list.out",
+            ]
+        }
+        for address_family in ["ipv4", "ipv6"]:
+            for iface_key in babel["distribute_list"].get(address_family, {}).get("interface", {}).keys():
+                acl_keys[address_family].extend([
+                    f"distribute_list.{address_family}.interface.{iface_key}.access_list.in",
+                    f"distribute_list.{address_family}.interface.{iface_key}.access_list.out"
+                ])
+                prefix_list_keys[address_family].extend([
+                    f"distribute_list.{address_family}.interface.{iface_key}.prefix_list.in",
+                    f"distribute_list.{address_family}.interface.{iface_key}.prefix_list.out"
+                ])
+
+        for address_family, keys in acl_keys.items():
+            for key in keys:
+                acl = dict_search(key, babel)
+                if acl:
+                    verify_access_list(acl, babel, version='6' if address_family == 'ipv6' else '')
+
+        for address_family, keys in prefix_list_keys.items():
+            for key in keys:
+                prefix_list = dict_search(key, babel)
+                if prefix_list:
+                    verify_prefix_list(prefix_list, babel, version='6' if address_family == 'ipv6' else '')
+
+
+def generate(babel):
+    if not babel or 'deleted' in babel:
+        return None
+
+    babel['new_frr_config'] = render_to_string('frr/babeld.frr.j2', babel)
+    return None
+
+def apply(babel):
+    babel_daemon = 'babeld'
+
+    # Save original configuration prior to starting any commit actions
+    frr_cfg = frr.FRRConfig()
+
+    frr_cfg.load_configuration(babel_daemon)
+    frr_cfg.modify_section('^router babel', stop_pattern='^exit', remove_stop_mark=True)
+
+    for key in ['interface', 'interface_removed']:
+        if key not in babel:
+            continue
+        for interface in babel[key]:
+            frr_cfg.modify_section(f'^interface {interface}', stop_pattern='^exit', remove_stop_mark=True)
+
+    if 'new_frr_config' in babel:
+        frr_cfg.add_before(frr.default_add_before, babel['new_frr_config'])
+    frr_cfg.commit_configuration(babel_daemon)
+
+    return None
+
+if __name__ == '__main__':
+    try:
+        c = get_config()
+        verify(c)
+        generate(c)
+        apply(c)
+    except ConfigError as e:
+        print(e)
+        exit(1)

--- a/src/op_mode/restart_frr.py
+++ b/src/op_mode/restart_frr.py
@@ -139,7 +139,7 @@ def _reload_config(daemon):
 # define program arguments
 cmd_args_parser = argparse.ArgumentParser(description='restart frr daemons')
 cmd_args_parser.add_argument('--action', choices=['restart'], required=True, help='action to frr daemons')
-cmd_args_parser.add_argument('--daemon', choices=['bfdd', 'bgpd', 'ldpd', 'ospfd', 'ospf6d', 'isisd', 'ripd', 'ripngd', 'staticd', 'zebra'], required=False,  nargs='*', help='select single or multiple daemons')
+cmd_args_parser.add_argument('--daemon', choices=['bfdd', 'bgpd', 'ldpd', 'ospfd', 'ospf6d', 'isisd', 'ripd', 'ripngd', 'staticd', 'zebra', 'babeld'], required=False,  nargs='*', help='select single or multiple daemons')
 # parse arguments
 cmd_args = cmd_args_parser.parse_args()
 


### PR DESCRIPTION
This PR adds basic Babel routing protocol support using the implementation in FRR.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4977

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
configure
edit protocols babel
set distribute-list ipv4 prefix-list out 'my-filter-4'
set distribute-list ipv6 prefix-list out 'my-filter-6'
set interface wlan0 type wireless
set interface eth0 type wired
set interface wg160 type wired
set interface wg160 enable-timestamps
set interface wg160 max-rtt-penalty '96'
set interface wg160 type 'wired'
set interface wg160 update-interval '300000'
set interface wg160 wired
set redistribute ipv4 connected
set redistribute ipv6 connected
commit

run show babel interface
run show babel route
```

Note: frr-reload.py in FRR 8.4 used by VyOS 1.4 doesn't support apply configs for babel. In order to make this PR work, the following PRs need to be backported:
- https://github.com/FRRouting/frr/pull/12611
- https://github.com/FRRouting/frr/pull/12640

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
