### PR TITLE
ntp: T4980: change chrony deny all logic

### DIFF
--- a/data/templates/chrony/chrony.conf.j2
+++ b/data/templates/chrony/chrony.conf.j2
@@ -40,8 +40,9 @@ user {{ user }}
 {%     for address in allow_client.address %}
 allow {{ address }}
 {%     endfor %}
-{% endif %}
+{% else %}
 deny all
+{% endif %}
 
 {% if listen_address is vyos_defined or interface is vyos_defined %}
 # NTP should listen on configured addresses only


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Fix Chrony NTP Server

The "deny all" option that is always set currently in the chrony config overrides any allow option set. This forces chrony to never listen to NTP requests.

My change is 2 lines, it removes the deny all if there are allow IPs set. The deny all option may not be required at all.

https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#_ntp_server
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4980

## Component(s) name
ntp/chrony

## Proposed changes
The "deny all" option that is always set currently in the chrony config overrides any allow option set. This forces chrony to never listen to NTP requests.

I was not able to get chrony to listen to UDP port 123 until I removed the "deny all" option from the generated config. After restarting chrony I was able to use the NTP server as expected.
https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#_ntp_server

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics -->
Default generated config with allow IPs set. The deny all is always present:
```
# Allowed clients configuration
allow 0.0.0.0/0
allow ::/0
deny all
```
My test machine is unable to get NTP from vyos:
```
[nix-shell:~]$ ntpdate -q 10.0.1.1
 6 Feb 17:22:43 ntpdate[3877869]: no server suitable for synchronization found
```
After removing the deny all and restarting chrony:
```
[nix-shell:~]$ ntpdate -q 10.0.1.1
server 10.0.1.1, stratum 3, offset +0.000151, delay 0.02580
 6 Feb 17:25:15 ntpdate[3888512]: adjust time server 10.0.1.1 offset +0.000151 sec
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
