### PR TITLE
T4971: PPPoE server add named ip pool and attr Framed-Pool

### DIFF
--- a/data/templates/accel-ppp/config_ip_pool.j2
+++ b/data/templates/accel-ppp/config_ip_pool.j2
@@ -11,4 +11,14 @@ gw-ip-address={{ gateway_address }}
 {{ subnet }}
 {%         endfor %}
 {%     endif %}
+{%     if client_ip_pool.name is vyos_defined %}
+{%         for pool, pool_config in client_ip_pool.name.items() %}
+{%             if pool_config.subnet is vyos_defined %}
+{{ pool_config.subnet }},name={{ pool }}
+{%             endif %}
+{%             if pool_config.gateway_address is vyos_defined %}
+gw-ip-address={{ pool_config.gateway_address }}
+{%             endif %}
+{%         endfor %}
+{%     endif %}
 {% endif %}

--- a/data/templates/accel-ppp/pppoe.config.j2
+++ b/data/templates/accel-ppp/pppoe.config.j2
@@ -135,6 +135,19 @@ pado-delay={{ pado_delay_param.value }}
 called-sid={{ authentication.radius.called_sid_format }}
 {% endif %}
 
+{% if authentication.mode is vyos_defined("local") %}
+{%     if client_ip_pool.name is vyos_defined %}
+{%         for pool, pool_config in client_ip_pool.name.items() %}
+{%             if pool_config.subnet is vyos_defined %}
+ip-pool={{ pool }}
+{%             endif %}
+{%             if pool_config.gateway_address is vyos_defined %}
+gw-ip-address={{ pool_config.gateway_address }}/{{ pool_config.subnet.split('/')[1] }}
+{%             endif %}
+{%         endfor %}
+{%     endif %}
+{% endif %}
+
 {% if limits is vyos_defined %}
 [connlimit]
 {%     if limits.connection_limit is vyos_defined %}

--- a/interface-definitions/include/accel-ppp/client-ip-pool-name.xml.i
+++ b/interface-definitions/include/accel-ppp/client-ip-pool-name.xml.i
@@ -1,0 +1,18 @@
+<!-- include start from accel-ppp/client-ip-pool-name.xml.i -->
+<tagNode name="name">
+  <properties>
+    <help>Pool name</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>Name of IP pool</description>
+    </valueHelp>
+    <constraint>
+      <regex>[-_a-zA-Z0-9.]+</regex>
+    </constraint>
+  </properties>
+  <children>
+    #include <include/accel-ppp/gateway-address.xml.i>
+    #include <include/accel-ppp/client-ip-pool-subnet-single.xml.i>
+  </children>
+</tagNode>
+<!-- include end -->

--- a/interface-definitions/service-ipoe-server.xml.in
+++ b/interface-definitions/service-ipoe-server.xml.in
@@ -108,22 +108,7 @@
               <help>Client IP pools and gateway setting</help>
             </properties>
             <children>
-              <tagNode name="name">
-                <properties>
-                  <help>Pool name</help>
-                  <valueHelp>
-                    <format>txt</format>
-                    <description>Name of IP pool</description>
-                  </valueHelp>
-                  <constraint>
-                    <regex>[-_a-zA-Z0-9.]+</regex>
-                  </constraint>
-                </properties>
-                <children>
-                  #include <include/accel-ppp/gateway-address.xml.i>
-                  #include <include/accel-ppp/client-ip-pool-subnet-single.xml.i>
-                </children>
-              </tagNode>
+              #include <include/accel-ppp/client-ip-pool-name.xml.i>
             </children>
           </node>
           #include <include/accel-ppp/client-ipv6-pool.xml.i>

--- a/interface-definitions/service-pppoe-server.xml.in
+++ b/interface-definitions/service-pppoe-server.xml.in
@@ -56,6 +56,7 @@
             <children>
               #include <include/accel-ppp/client-ip-pool-start-stop.xml.i>
               #include <include/accel-ppp/client-ip-pool-subnet.xml.i>
+              #include <include/accel-ppp/client-ip-pool-name.xml.i>
             </children>
           </node>
           #include <include/accel-ppp/client-ipv6-pool.xml.i>

--- a/smoketest/scripts/cli/test_service_pppoe-server.py
+++ b/smoketest/scripts/cli/test_service_pppoe-server.py
@@ -165,6 +165,35 @@ class TestServicePPPoEServer(BasicAccelPPPTest.TestCase):
         self.assertEqual(conf['ip-pool']['gw-ip-address'], self._gateway)
 
 
+    def test_pppoe_server_client_ip_pool_name(self):
+        # Test configuration of named client pools
+        self.basic_config()
+
+        subnet = '192.0.2.0/24'
+        gateway = '192.0.2.1'
+        pool = 'VYOS'
+
+        subnet_name = f'{subnet},name'
+        gw_ip_prefix = f'{gateway}/24'
+
+        self.set(['client-ip-pool', 'name', pool, 'subnet', subnet])
+        self.set(['client-ip-pool', 'name', pool, 'gateway-address', gateway])
+        self.cli_delete(self._base_path + ['gateway-address'])
+
+        # commit changes
+        self.cli_commit()
+
+        # Validate configuration values
+        conf = ConfigParser(allow_no_value=True, delimiters='=')
+        conf.read(self._config_file)
+
+        # Validate configuration
+        self.assertEqual(conf['ip-pool'][subnet_name], pool)
+        self.assertEqual(conf['ip-pool']['gw-ip-address'], gateway)
+        self.assertEqual(conf['pppoe']['ip-pool'], pool)
+        self.assertEqual(conf['pppoe']['gw-ip-address'], gw_ip_prefix)
+
+
     def test_pppoe_server_client_ipv6_pool(self):
         # Test configuration of IPv6 client pools
         self.basic_config()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add a new feature to allow to use of named pools.
Also, it can be used with RADIUS attribute `Framed-Pool`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4971

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set service pppoe-server authentication local-users username user1 password 'user1'
set service pppoe-server authentication mode 'local'
set service pppoe-server client-ip-pool name POOL1 gateway-address '192.0.2.1'
set service pppoe-server client-ip-pool name POOL1 subnet '192.0.2.0/24'
set service pppoe-server interface eth1
```
Expected:
```
[ip-pool]
192.0.2.0/24,name=POOL1
gw-ip-address=192.0.2.1

[pppoe]
ip-pool=POOL1
gw-ip-address=192.0.2.1/24
```
pppoe.conf
```
vyos@r14# cat /run/accel-pppd/pppoe.conf 
### generated by accel_pppoe.py ###
[modules]
log_syslog
pppoe
shaper
chap-secrets
ippool
auth_pap
auth_chap_md5
auth_mschap_v1
auth_mschap_v2

[core]
thread-count=2

[log]
syslog=accel-pppoe,daemon
copy=1
level=5

[client-ip-range]
disable

[ip-pool]
192.0.2.0/24,name=POOL1
gw-ip-address=192.0.2.1

[chap-secrets]
chap-secrets=/run/accel-pppd/pppoe.chap-secrets

[common]
single-session=replace

[ppp]
verbose=1
check-ip=1
ccp=0
unit-preallocate=0
min-mtu=1492
mppe=prefer
lcp-echo-interval=30
lcp-echo-timeout=0
lcp-echo-failure=3
ipv6=deny
ipv6-accept-peer-intf-id=0
mtu=1492

[pppoe]
verbose=1
ac-name=vyos-ac
interface=eth1
ip-pool=POOL1
gw-ip-address=192.0.2.1/24

[cli]
tcp=127.0.0.1:2001
```
Check that a client can get address from named pool
```
vyos@r14# run show pppoe-server sessions 
 ifname | username |    ip     | ip6 | ip6-dp |    calling-sid    | rate-limit | state  |  uptime  | rx-bytes | tx-bytes 
--------+----------+-----------+-----+--------+-------------------+------------+--------+----------+----------+----------
 ppp0   | user1    | 192.0.2.0 |     |        | 52:54:00:38:cc:4f |            | active | 00:11:38 | 372 B    | 366 B
[edit]
vyos@r14# 

```

Smoketest
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py 
test_accel_local_authentication (__main__.TestServicePPPoEServer) ... ok
test_accel_name_servers (__main__.TestServicePPPoEServer) ... ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer) ... ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer) ... ok
test_pppoe_server_client_ip_pool (__main__.TestServicePPPoEServer) ... ok
test_pppoe_server_client_ipv6_pool (__main__.TestServicePPPoEServer) ... ok
test_pppoe_server_ppp_options (__main__.TestServicePPPoEServer) ... ok
test_pppoe_server_vlan (__main__.TestServicePPPoEServer) ... ok

----------------------------------------------------------------------
Ran 8 tests in 33.045s

OK
vyos@r14:~$ 

vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_ipoe-server.py 
test_accel_local_authentication (__main__.TestServiceIPoEServer) ... ok
test_accel_name_servers (__main__.TestServiceIPoEServer) ... ok
test_accel_radius_authentication (__main__.TestServiceIPoEServer) ... ok

----------------------------------------------------------------------
Ran 3 tests in 11.671s

OK
vyos@r14:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
