### PR TITLE
T4857: snmp: Fix error when not defining client|network under community

### DIFF
--- a/data/templates/snmp/etc.snmpd.conf.j2
+++ b/data/templates/snmp/etc.snmpd.conf.j2
@@ -78,8 +78,8 @@ agentaddress unix:/run/snmpd.socket{{ ',' ~ options | join(',') if options is vy
 {%             endfor %}
 {%         endif %}
 {%         if comm_config.client is not vyos_defined and comm_config.network is not vyos_defined %}
-{{ comm_config.authorization }}community {{ comm }} -V RESTRICTED
-{{ comm_config.authorization }}community6 {{ comm }} -V RESTRICTED
+{{ comm_config.authorization }}community {{ comm }} 0.0.0.0/0 -V RESTRICTED
+{{ comm_config.authorization }}community6 {{ comm }} ::/0 -V RESTRICTED
 {%         endif %}
 {%     endfor %}
 {% endif %}

--- a/data/templates/snmp/etc.snmpd.conf.j2
+++ b/data/templates/snmp/etc.snmpd.conf.j2
@@ -77,10 +77,6 @@ agentaddress unix:/run/snmpd.socket{{ ',' ~ options | join(',') if options is vy
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
-{%         if comm_config.client is not vyos_defined and comm_config.network is not vyos_defined %}
-{{ comm_config.authorization }}community {{ comm }} 0.0.0.0/0 -V RESTRICTED
-{{ comm_config.authorization }}community6 {{ comm }} ::/0 -V RESTRICTED
-{%         endif %}
 {%     endfor %}
 {% endif %}
 

--- a/interface-definitions/snmp.xml.in
+++ b/interface-definitions/snmp.xml.in
@@ -13,9 +13,9 @@
             <properties>
               <help>Community name</help>
               <constraint>
-                <regex>[a-zA-Z0-9\-_!@*#]{1,100}</regex>
+                <regex>[[:alnum:]-_!@*#]{1,100}</regex>
               </constraint>
-              <constraintErrorMessage>Community string is limited to alphanumerical characters, !, @, * and # with a total lenght of 100</constraintErrorMessage>
+              <constraintErrorMessage>Community string is limited to alphanumerical characters, -, _, !, @, *, and # with a total lenght of 100</constraintErrorMessage>
             </properties>
             <children>
               <leafNode name="authorization">
@@ -65,6 +65,7 @@
                   </constraint>
                   <multi/>
                 </properties>
+                <defaultValue>0.0.0.0/0 ::/0</defaultValue>
               </leafNode>
             </children>
           </tagNode>

--- a/src/conf_mode/snmp.py
+++ b/src/conf_mode/snmp.py
@@ -103,6 +103,9 @@ def get_config(config=None):
 
     if 'community' in snmp:
         default_values = defaults(base + ['community'])
+        if 'network' in default_values:
+            # convert multiple default networks to list
+            default_values['network'] = default_values['network'].split()
         for community in snmp['community']:
             snmp['community'][community] = dict_merge(
                 default_values, snmp['community'][community])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
After including FRR recommendations on snmp, we get error when not defining client or network under community.
Error reported in this [blog post](https://forum.vyos.io/t/unable-to-query-snmp-anymore-in-a-more-recent-1-4-version/10388).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4857

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
snmp

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
## Simple config, with no client/network defined
vyos@vyos:~$ show config comm | grep snmp
set service snmp community FOO authorization 'ro'
set service snmp contact 'EMAIL'
set service snmp location 'LOCATION'

## Check service is running (before this patch an error was noted here)
vyos@vyos:~$ sudo systemctl status snmpd
● snmpd.service - Simple Network Management Protocol (SNMP) Daemon.
     Loaded: loaded (/lib/systemd/system/snmpd.service; disabled; vendor preset: enabled)
    Drop-In: /run/systemd/system/snmpd.service.d
             └─override.conf
     Active: active (running) since Wed 2023-02-08 13:24:31 UTC; 1min 12s ago
    Process: 3918 ExecStartPre=/bin/mkdir -p /var/run/agentx (code=exited, status=0/SUCCESS)
   Main PID: 3919 (snmpd)
      Tasks: 1 (limit: 536)
     Memory: 7.5M
        CPU: 73ms
     CGroup: /system.slice/snmpd.service
             └─3919 /usr/sbin/snmpd -LS0-5d -Lf /dev/null -u Debian-snmp -g Debian-snmp -f -p /run/snmpd.pid

Feb 08 13:24:31 vyos systemd[1]: Starting Simple Network Management Protocol (SNMP) Daemon....
Feb 08 13:24:31 vyos systemd[1]: Started Simple Network Management Protocol (SNMP) Daemon..
vyos@vyos:~$ 

## Check snmpwalk from localhost
vyos@vyos:~$ snmpwalk -v 2c -c FOO localhost
SNMPv2-MIB::sysDescr.0 = STRING: VyOS 1.4-rolling-202302080317
SNMPv2-MIB::sysObjectID.0 = OID: SNMPv2-SMI::enterprises.44641
DISMAN-EVENT-MIB::sysUpTimeInstance = Timeticks: (17050) 0:02:50.50
SNMPv2-MIB::sysContact.0 = STRING: EMAIL
...
...
# Check restrictions when trying to get routing table:
vyos@vyos:~$ snmpwalk -v 2c -c FOO localhost .1.3.6.1.2.1.4.21
IP-MIB::ip.21 = No Such Object available on this agent at this OID

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
