### PR TITLE
T2603: PPPoE-server change default min-mtu value 1280 for Equuleus

### DIFF
--- a/data/templates/accel-ppp/pppoe.config.tmpl
+++ b/data/templates/accel-ppp/pppoe.config.tmpl
@@ -65,8 +65,6 @@ ccp={{ "1" if ppp_options.ccp is defined else "0" }}
 unit-preallocate={{ "1" if authentication.radius.preallocate_vif is defined else "0" }}
 {% if ppp_options.min_mtu is defined and ppp_options.min_mtu is not none %}
 min-mtu={{ ppp_options.min_mtu }}
-{% else %}
-min-mtu={{ mtu }}
 {% endif %}
 {% if ppp_options.mru is defined and ppp_options.mru is not none %}
 mru={{ ppp_options.mru }}

--- a/interface-definitions/service_pppoe-server.xml.in
+++ b/interface-definitions/service_pppoe-server.xml.in
@@ -148,6 +148,7 @@
                     <validator name="numeric" argument="--range 68-65535"/>
                   </constraint>
                 </properties>
+                <defaultValue>1280</defaultValue>
               </leafNode>
               <leafNode name="mru">
                 <properties>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Minimum acceptable MTU. If client will try to negotiate less then specified MTU then it will be NAKed or disconnected if rejects greater MTU.

Change 'min-mtu' from 1492 to 1280 for 1.3.3
https://docs.accel-ppp.org/en/latest/configuration/ppp.html

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): change default value for min-mtu

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T2603

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set service pppoe-server authentication local-users username user1 password 'user1'
set service pppoe-server authentication mode 'local'
set service pppoe-server client-ip-pool start '192.0.2.10'
set service pppoe-server client-ip-pool stop '192.0.2.100'
set service pppoe-server gateway-address '192.0.2.1'
set service pppoe-server interface eth1
```
pppoe.conf
```
vyos@r1# cat /run/accel-pppd/pppoe.conf  | grep mtu -B 5
[ppp]
verbose=1
check-ip=1
ccp=0
unit-preallocate=0
min-mtu=1280
mppe=prefer
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
