### PR TITLE
T1993: PPPoE-server add section shaper and fwmark option

### DIFF
--- a/data/templates/accel-ppp/config_shaper_radius.j2
+++ b/data/templates/accel-ppp/config_shaper_radius.j2
@@ -1,13 +1,19 @@
-{% if authentication is defined and authentication.mode is defined and authentication.mode == 'radius' %}
-{%   if authentication is defined and authentication.radius is defined and authentication.radius.rate_limit is defined and authentication.radius.rate_limit.enable is defined %}
+{% if authentication is defined and authentication.mode is defined and authentication.mode == 'radius' or shaper is defined %}
 [shaper]
 verbose=1
+{%   if authentication is defined and authentication.radius is defined and authentication.radius.rate_limit is defined and authentication.radius.rate_limit.enable is defined %}
 attr={{ authentication.radius.rate_limit.attribute }}
 {%     if authentication.radius.rate_limit.vendor is defined and authentication.radius.rate_limit.vendor is not none %}
 vendor={{ authentication.radius.rate_limit.vendor }}
 {%     endif %}
 {%     if authentication.radius.rate_limit.multiplier is defined and authentication.radius.rate_limit.multiplier is not none %}
 rate-multiplier={{ authentication.radius.rate_limit.multiplier }}
+{%     endif %}
+{%   endif %}
+{%   if shaper is defined %}
+{%     if shaper.fwmark is defined and shaper.fwmark is not none %}
+fwmark={{ shaper.fwmark }}
+down-limiter=htb
 {%     endif %}
 {%   endif %}
 {% endif %}

--- a/interface-definitions/include/accel-ppp/shaper.xml.i
+++ b/interface-definitions/include/accel-ppp/shaper.xml.i
@@ -1,0 +1,21 @@
+<!-- include start from accel-ppp/shaper.xml.i -->
+<node name="shaper">
+  <properties>
+    <help>Traffic shaper bandwidth parameters</help>
+  </properties>
+  <children>
+    <leafNode name="fwmark">
+      <properties>
+        <help>Firewall mark value for traffic that excludes from shaping</help>
+        <valueHelp>
+          <format>u32:1-2147483647</format>
+          <description>Match firewall mark value</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-2147483647"/>
+        </constraint>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/service_pppoe-server.xml.in
+++ b/interface-definitions/service_pppoe-server.xml.in
@@ -324,6 +324,7 @@
             </properties>
             <defaultValue>replace</defaultValue>
           </leafNode>
+          #include <include/accel-ppp/shaper.xml.i>
           <node name="snmp">
             <properties>
               <help>Enable SNMP</help>

--- a/smoketest/scripts/cli/test_service_pppoe-server.py
+++ b/smoketest/scripts/cli/test_service_pppoe-server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020 VyOS maintainers and contributors
+# Copyright (C) 2020-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -147,6 +147,8 @@ class TestServicePPPoEServer(BasicAccelPPPTest.TestCase):
         self.basic_config()
 
         subnet = '172.18.0.0/24'
+        fwmark = '223'
+        limiter = 'htb'
         self.set(['client-ip-pool', 'subnet', subnet])
 
         start = '192.0.2.10'
@@ -155,6 +157,7 @@ class TestServicePPPoEServer(BasicAccelPPPTest.TestCase):
         start_stop = f'{start}-{stop_octet}'
         self.set(['client-ip-pool', 'start', start])
         self.set(['client-ip-pool', 'stop', stop])
+        self.set(['shaper', 'fwmark', fwmark])
 
         # commit changes
         self.cli_commit()


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Extended PPPoE-server rate-limiter to avoid shaping marked resources. This feature often needs ISP, which provides access to some IX or its resources.
VyOS 1.3
```
set service pppoe-server shaper fwmark '223'
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T1993

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set service pppoe-server authentication local-users username user1 password 'user1'
set service pppoe-server authentication mode 'local'
set service pppoe-server client-ip-pool start '192.0.2.10'
set service pppoe-server client-ip-pool stop '192.0.2.100'
set service pppoe-server gateway-address '192.0.2.1'
set service pppoe-server interface eth1
set service pppoe-server shaper fwmark '223'
```
pppoe-server conf:
```
vyos@r1# cat /run/accel-pppd/pppoe.conf | grep "\[shaper" -A 4
[shaper]
verbose=1
fwmark=223
down-limiter=htb
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
