### PR TITLE
T4971: PPPoE server add named ip pool and attr Framed-Pool 

### DIFF
--- a/data/templates/accel-ppp/config_ip_pool.j2
+++ b/data/templates/accel-ppp/config_ip_pool.j2
@@ -11,4 +11,14 @@ gw-ip-address={{ gateway_address }}
 {{ subnet }}
 {%     endfor %}
 {%   endif %}
+{%   if client_ip_pool.name is defined and client_ip_pool.name is not none %}
+{%     for pool, pool_config in client_ip_pool.name.items() %}
+{%       if pool_config.subnet is defined and pool_config.subnet is not none %}
+{{ pool_config.subnet }},name={{ pool }}
+{%       endif %}
+{%       if pool_config.gateway_address is defined and pool_config.gateway_address is not none %}
+gw-ip-address={{ pool_config.gateway_address }}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
 {% endif %}

--- a/data/templates/accel-ppp/pppoe.config.tmpl
+++ b/data/templates/accel-ppp/pppoe.config.tmpl
@@ -136,6 +136,21 @@ pado-delay={{ pado_delay_param.value }}
 called-sid={{ authentication.radius.called_sid_format }}
 {% endif %}
 
+{% if authentication is defined and authentication.mode is defined and authentication.mode == 'local' %}
+{%   if client_ip_pool is defined and client_ip_pool is not none %}
+{%     if client_ip_pool.name is defined and client_ip_pool.name is not none %}
+{%       for pool, pool_config in client_ip_pool.name.items() %}
+{%         if pool_config.subnet is defined and pool_config.subnet is not none %}
+ip-pool={{ pool }}
+{%           if pool_config.gateway_address is defined and pool_config.gateway_address is not none %}
+gw-ip-address={{ pool_config.gateway_address }}/{{ pool_config.subnet.split('/')[1] }}
+{%           endif %}
+{%         endif %}
+{%       endfor %}
+{%     endif %}
+{%  endif %}
+{% endif %}
+
 {% if limits is defined %}
 [connlimit]
 {%   if limits.connection_limit is defined and limits.connection_limit is not none %}

--- a/interface-definitions/include/accel-ppp/client-ip-pool-name.xml.i
+++ b/interface-definitions/include/accel-ppp/client-ip-pool-name.xml.i
@@ -1,0 +1,18 @@
+<!-- include start from accel-ppp/client-ip-pool-name.xml.i -->
+<tagNode name="name">
+  <properties>
+    <help>Pool name</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>Name of IP pool</description>
+    </valueHelp>
+    <constraint>
+      <regex>[-_a-zA-Z0-9.]+</regex>
+    </constraint>
+  </properties>
+  <children>
+    #include <include/accel-ppp/gateway-address.xml.i>
+    #include <include/accel-ppp/client-ip-pool-subnet-single.xml.i>
+  </children>
+</tagNode>
+<!-- include end -->

--- a/interface-definitions/service_ipoe-server.xml.in
+++ b/interface-definitions/service_ipoe-server.xml.in
@@ -117,19 +117,7 @@
               <help>Client IP pools and gateway setting</help>
             </properties>
             <children>
-              <tagNode name="name">
-                <properties>
-                  <help>Pool name</help>
-                  <constraint>
-                    <regex>[-_a-zA-Z0-9]+</regex>
-                  </constraint>
-                  <constraintErrorMessage>Client IP pool is limited to alphanumerical characters and can contain hyphen and underscores</constraintErrorMessage>
-                </properties>
-                <children>
-                  #include <include/accel-ppp/gateway-address.xml.i>
-                  #include <include/accel-ppp/client-ip-pool-subnet-single.xml.i>
-                </children>
-              </tagNode>
+              #include <include/accel-ppp/client-ip-pool-name.xml.i>
             </children>
           </node>
           #include <include/accel-ppp/client-ipv6-pool.xml.i>

--- a/interface-definitions/service_pppoe-server.xml.in
+++ b/interface-definitions/service_pppoe-server.xml.in
@@ -56,6 +56,7 @@
             <children>
               #include <include/accel-ppp/client-ip-pool-start-stop.xml.i>
               #include <include/accel-ppp/client-ip-pool-subnet.xml.i>
+              #include <include/accel-ppp/client-ip-pool-name.xml.i>
             </children>
           </node>
           #include <include/accel-ppp/client-ipv6-pool.xml.i>

--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2020-2023 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -23,6 +23,7 @@
 
 from vyos import ConfigError
 from vyos.util import dict_search
+from vyos.util import dict_search_recursive
 
 def verify_mtu(config):
     """
@@ -355,7 +356,17 @@ def verify_accel_ppp_base_service(config):
             if 'key' not in radius_config:
                 raise ConfigError(f'Missing RADIUS secret key for server "{server}"')
 
-    if 'gateway_address' not in config:
+    # Check global gateway or gateway in named pool
+    gateway = False
+    if 'gateway_address' in config:
+        gateway = True
+    else:
+        if dict_search_recursive(config, 'gateway_address', ['client_ip_pool', 'name']):
+            for _, v in config['client_ip_pool']['name'].items():
+                if 'gateway_address' in v:
+                    gateway = True
+                    break
+    if not gateway:
         raise ConfigError('Server requires gateway-address to be configured!')
 
     if 'name_server_ipv4' in config:
@@ -427,4 +438,3 @@ def verify_common_route_maps(config):
         for protocol, protocol_config in config['redistribute'].items():
             if 'route_map' in protocol_config:
                 verify_route_map(protocol_config['route_map'], config)
-

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2020-2023 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -719,6 +719,26 @@ def dict_search(path, dict_object):
     for p in parts[:-1]:
         c = c.get(p, {})
     return c.get(parts[-1], None)
+
+def dict_search_recursive(dict_object, key, path=[]):
+    """ Traverse a dictionary recurisvely and return the value of the key
+    we are looking for.
+    Thankfully copied from https://stackoverflow.com/a/19871956
+    Modified to yield optional path to found keys
+    """
+    if isinstance(dict_object, list):
+        for i in dict_object:
+            new_path = path + [i]
+            for x in dict_search_recursive(i, key, new_path):
+                yield x
+    elif isinstance(dict_object, dict):
+        if key in dict_object:
+            new_path = path + [key]
+            yield dict_object[key], new_path
+        for k, j in dict_object.items():
+            new_path = path + [k]
+            for x in dict_search_recursive(j, key, new_path):
+                yield x
 
 def convert_data(data):
     """Convert multiple types of data to types usable in CLI

--- a/smoketest/scripts/cli/test_service_pppoe-server.py
+++ b/smoketest/scripts/cli/test_service_pppoe-server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020 VyOS maintainers and contributors
+# Copyright (C) 2020-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -170,6 +170,35 @@ class TestServicePPPoEServer(BasicAccelPPPTest.TestCase):
 
         # Check for running process
         self.assertTrue(process_named_running(self._process_name))
+
+
+    def test_pppoe_server_client_ip_pool_name(self):
+        # Test configuration of named client pools
+        self.basic_config()
+
+        subnet = '192.0.2.0/24'
+        gateway = '192.0.2.1'
+        pool = 'VYOS'
+
+        subnet_name = f'{subnet},name'
+        gw_ip_prefix = f'{gateway}/24'
+
+        self.set(['client-ip-pool', 'name', pool, 'subnet', subnet])
+        self.set(['client-ip-pool', 'name', pool, 'gateway-address', gateway])
+        self.cli_delete(self._base_path + ['gateway-address'])
+
+        # commit changes
+        self.cli_commit()
+
+        # Validate configuration values
+        conf = ConfigParser(allow_no_value=True, delimiters='=')
+        conf.read(self._config_file)
+
+        # Validate configuration
+        self.assertEqual(conf['ip-pool'][subnet_name], pool)
+        self.assertEqual(conf['ip-pool']['gw-ip-address'], gateway)
+        self.assertEqual(conf['pppoe']['ip-pool'], pool)
+        self.assertEqual(conf['pppoe']['gw-ip-address'], gw_ip_prefix)
 
 
     def test_pppoe_server_client_ipv6_pool(self):

--- a/src/tests/test_dict_search.py
+++ b/src/tests/test_dict_search.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020 VyOS maintainers and contributors
+# Copyright (C) 2020-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -16,13 +16,27 @@
 
 from unittest import TestCase
 from vyos.util import dict_search
+from vyos.util import dict_search_recursive
 
 data = {
     'string': 'fooo',
     'nested': {'string': 'bar', 'empty': '', 'list': ['foo', 'bar']},
+    'non': {},
     'list': ['bar', 'baz'],
-    'dict': {'key_1': {}, 'key_2': 'vyos'}
+    'dict': {'key_1': {}, 'key_2': 'vyos'},
+    'interfaces': {'dummy': {'dum0': {'address': ['192.0.2.17/29']}},
+                'ethernet': {'eth0': {'address': ['2001:db8::1/64', '192.0.2.1/29'],
+                                      'description': 'Test123',
+                                      'duplex': 'auto',
+                                      'hw_id': '00:00:00:00:00:01',
+                                      'speed': 'auto'},
+                             'eth1': {'address': ['192.0.2.9/29'],
+                                      'description': 'Test456',
+                                      'duplex': 'auto',
+                                      'hw_id': '00:00:00:00:00:02',
+                                      'speed': 'auto'}}}
 }
+
 
 class TestDictSearch(TestCase):
     def setUp(self):
@@ -55,3 +69,10 @@ class TestDictSearch(TestCase):
     def test_nested_list(self):
         # TestDictSearch: Return list items when querying nested list
         self.assertEqual(dict_search('nested.list', data), data['nested']['list'])
+
+    def test_dict_search_recursive(self):
+        # Test nested search in dictionary
+        tmp = list(dict_search_recursive(data, 'hw_id'))
+        self.assertEqual(len(tmp), 2)
+        tmp = list(dict_search_recursive(data, 'address'))
+        self.assertEqual(len(tmp), 3)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add a new feature to allow to use of named pools.
Also, it can be used with RADIUS attribute `Framed-Pool`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4971
* https://vyos.dev/T4999

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set service pppoe-server authentication local-users username user1 password 'user1'
set service pppoe-server authentication mode 'local'
set service pppoe-server client-ip-pool name POOL1 gateway-address '192.0.2.1'
set service pppoe-server client-ip-pool name POOL1 subnet '192.0.2.0/24'
set service pppoe-server interface eth1
```
Expected:
```
[ip-pool]
192.0.2.0/24,name=POOL1
gw-ip-address=192.0.2.1

[pppoe]
ip-pool=POOL1
gw-ip-address=192.0.2.1/24
```
pppoe-server.conf
```
vyos@r1# cat /run/accel-pppd/pppoe.conf 
### generated by accel_pppoe.py ###
[modules]
log_syslog
pppoe
shaper
chap-secrets
ippool
auth_pap
auth_chap_md5
auth_mschap_v1
auth_mschap_v2

[core]
thread-count=1

[log]
syslog=accel-pppoe,daemon
copy=1
level=5

[client-ip-range]
disable

[ip-pool]
192.0.2.0/24,name=POOL1
gw-ip-address=192.0.2.1

[ipv6-nd]
AdvAutonomousFlag=1

[ipv6-pool]

[chap-secrets]
chap-secrets=/run/accel-pppd/pppoe.chap-secrets

[common]
single-session=replace

[ppp]
verbose=1
check-ip=1
ccp=0
unit-preallocate=0
min-mtu=1280
mppe=prefer
lcp-echo-interval=30
lcp-echo-timeout=0
lcp-echo-failure=3
mtu=1492

[pppoe]
verbose=1
ac-name=vyos-ac
interface=eth1
ip-pool=POOL1
gw-ip-address=192.0.2.1/24

[cli]
tcp=127.0.0.1:2001
```
Smoketest:
```
vyos@r1:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py 
test_accel_local_authentication (__main__.TestServicePPPoEServer) ... ok
test_accel_name_servers (__main__.TestServicePPPoEServer) ... ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer) ... ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer) ... ok
test_pppoe_server_client_ip_pool (__main__.TestServicePPPoEServer) ... ok
test_pppoe_server_client_ip_pool_name (__main__.TestServicePPPoEServer) ... ok
test_pppoe_server_client_ipv6_pool (__main__.TestServicePPPoEServer) ... ok
test_pppoe_server_ppp_options (__main__.TestServicePPPoEServer) ... ok

----------------------------------------------------------------------
Ran 8 tests in 35.063s

OK
vyos@r1:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
