### PR TITLE
ipsec: T4968: Added default values to dpd and close action

### DIFF
--- a/interface-definitions/vpn-ipsec.xml.in
+++ b/interface-definitions/vpn-ipsec.xml.in
@@ -269,6 +269,7 @@
                     <regex>(none|hold|restart)</regex>
                   </constraint>
                 </properties>
+                <defaultValue>none</defaultValue>
               </leafNode>
               <node name="dead-peer-detection">
                 <properties>
@@ -297,6 +298,7 @@
                         <regex>(hold|clear|restart)</regex>
                       </constraint>
                     </properties>
+                    <defaultValue>clear</defaultValue>
                   </leafNode>
                   <leafNode name="interval">
                     <properties>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Based on https://docs.strongswan.org/docs/5.9/swanctl/swanctlConf.html 
Added default value to dpd_action - clear
Added default value to close_action - none

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4968

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec

## Proposed changes
<!--- Describe your changes in detail -->
Based on https://docs.strongswan.org/docs/5.9/swanctl/swanctlConf.html 
Added default value to dpd_action - clear
Added default value to close_action - none

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configuration:
```
set vpn ipsec authentication psk bar id '192.0.2.1'
set vpn ipsec authentication psk bar id '192.0.2.3'
set vpn ipsec authentication psk bar id '192.0.2.1.local.peer-b'
set vpn ipsec authentication psk bar id '192.0.2.2.peer-b'
set vpn ipsec authentication psk bar secret 'SecretBar'
set vpn ipsec authentication psk baz id 'fsdfdf'
set vpn ipsec authentication psk baz secret 'bazdfwefsecrettt'
set vpn ipsec esp-group ESP-group-b lifetime '1800'
set vpn ipsec esp-group ESP-group-b mode 'tunnel'
set vpn ipsec esp-group ESP-group-b pfs 'enable'
set vpn ipsec esp-group ESP-group-b proposal 1 encryption 'aes128'
set vpn ipsec esp-group ESP-group-b proposal 1 hash 'sha1'
set vpn ipsec ike-group IKE-group-b key-exchange 'ikev1'
set vpn ipsec ike-group IKE-group-b lifetime '3600'
set vpn ipsec ike-group IKE-group-b proposal 1 dh-group '14'
set vpn ipsec ike-group IKE-group-b proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE-group-b proposal 1 hash 'sha256'
set vpn ipsec interface 'eth0'
set vpn ipsec site-to-site peer OFFICE-B authentication local-id '192.0.2.2.peer-b'
set vpn ipsec site-to-site peer OFFICE-B authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer OFFICE-B authentication remote-id '192.0.2.1.local.peer-b'
set vpn ipsec site-to-site peer OFFICE-B connection-type 'respond'
set vpn ipsec site-to-site peer OFFICE-B ike-group 'IKE-group-b'
set vpn ipsec site-to-site peer OFFICE-B local-address '192.0.2.2'
set vpn ipsec site-to-site peer OFFICE-B remote-address '192.0.2.1'
set vpn ipsec site-to-site peer OFFICE-B tunnel 0 esp-group 'ESP-group-b'
set vpn ipsec site-to-site peer OFFICE-B tunnel 0 local prefix '10.0.0.0/21'
set vpn ipsec site-to-site peer OFFICE-B tunnel 0 remote prefix '192.168.0.0/24'
```
Before:
```
vyos@vyos:~$ cat /etc/swanctl/swanctl.conf
### Autogenerated by vpn_ipsec.py ###

connections {
    OFFICE-B {
        proposals = aes256-sha256-modp2048
        version = 1
        local_addrs = 192.0.2.2 # dhcp:no
        remote_addrs = 192.0.2.1
        dpd_timeout = 120
        dpd_delay = 30
        rekey_time = 3600s
        mobike = yes
        keyingtries = 1
        local {
            id = "192.0.2.2.peer-b"
            auth = psk
        }
        remote {
            id = "192.0.2.1.local.peer-b"
            auth = psk
        }
        children {
            OFFICE-B-tunnel-0 {
                esp_proposals = aes128-sha1-modp2048
                life_time = 1800s
                local_ts = 10.0.0.0/21
                remote_ts = 192.168.0.0/24
                ipcomp = no
                mode = tunnel
                start_action = trap
                dpd_action = 
                close_action = 
            }
        }
    }

}
```
After:
```
vyos@vyos:~$ cat /etc/swanctl/swanctl.conf
### Autogenerated by vpn_ipsec.py ###

connections {
    OFFICE-B {
        proposals = aes256-sha256-modp2048
        version = 1
        local_addrs = 192.0.2.2 # dhcp:no
        remote_addrs = 192.0.2.1
        dpd_timeout = 120
        dpd_delay = 30
        rekey_time = 3600s
        mobike = yes
        keyingtries = 1
        local {
            id = "192.0.2.2.peer-b"
            auth = psk
        }
        remote {
            id = "192.0.2.1.local.peer-b"
            auth = psk
        }
        children {
            OFFICE-B-tunnel-0 {
                esp_proposals = aes128-sha1-modp2048
                life_time = 1800s
                local_ts = 10.0.0.0/21
                remote_ts = 192.168.0.0/24
                ipcomp = no
                mode = tunnel
                start_action = trap
                dpd_action = clear
                close_action = none
            }
        }
    }

}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
