### PR TITLE
ipsec: T4985: Fixed 'reset vpn ipsec-peer {peer}' command

### DIFF
--- a/op-mode-definitions/vpn-ipsec.xml.in
+++ b/op-mode-definitions/vpn-ipsec.xml.in
@@ -28,7 +28,7 @@
                 <command>sudo ${vyos_op_scripts_dir}/ipsec.py reset_peer --peer="$4" --tunnel="vti"</command>
               </node>
             </children>
-            <command>sudo ${vyos_op_scripts_dir}/ipsec.py reset_peer --peer="$4" --tunnel="all"</command>
+            <command>sudo ${vyos_op_scripts_dir}/ipsec.py reset_peer --peer="$4"</command>
           </tagNode>
           <tagNode name="ipsec-profile">
             <properties>

--- a/src/op_mode/ipsec.py
+++ b/src/op_mode/ipsec.py
@@ -425,7 +425,7 @@ def get_peer_connections(peer, tunnel):
     return matches
 
 
-def reset_peer(peer: str, tunnel:typing.Optional[str]):
+def reset_peer(peer: str, tunnel:typing.Optional[str] = None):
     conns = get_peer_connections(peer, tunnel)
 
     if not conns:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed 'reset vpn ipsec-peer {peer}' command.
The op-mode script uses value 'None' in the 'tunnel' parameter to clear all CHILD SAs.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4985

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec

## Proposed changes
<!--- Describe your changes in detail -->
Fixed 'reset vpn ipsec-peer {peer}' command.
The op-mode script uses value 'None' in the 'tunnel' parameter to clear all CHILD SAs.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configuration:
```
set vpn ipsec authentication psk TEST id '192.0.2.1'
set vpn ipsec authentication psk TEST secret 'test'
set vpn ipsec esp-group ESP pfs 'dh-group2'
set vpn ipsec esp-group ESP proposal 1 encryption 'aes128'
set vpn ipsec esp-group ESP proposal 1 hash 'sha1'
set vpn ipsec ike-group IKE close-action 'restart'
set vpn ipsec ike-group IKE dead-peer-detection action 'restart'
set vpn ipsec ike-group IKE proposal 1 dh-group '2'
set vpn ipsec ike-group IKE proposal 1 encryption 'aes128'
set vpn ipsec ike-group IKE proposal 1 hash 'sha1'
set vpn ipsec interface 'eth1'
set vpn ipsec site-to-site peer TEST authentication local-id '192.0.2.2'
set vpn ipsec site-to-site peer TEST authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer TEST authentication remote-id '192.0.2.1'
set vpn ipsec site-to-site peer TEST default-esp-group 'ESP'
set vpn ipsec site-to-site peer TEST ike-group 'IKE'
set vpn ipsec site-to-site peer TEST local-address '192.0.2.2'
set vpn ipsec site-to-site peer TEST remote-address '192.0.2.1'
set vpn ipsec site-to-site peer TEST tunnel 0 local prefix '192.168.10.0/24'
set vpn ipsec site-to-site peer TEST tunnel 0 remote prefix '192.168.11.0/24'
set vpn ipsec site-to-site peer TEST tunnel 1 local prefix '192.168.100.0/24'
set vpn ipsec site-to-site peer TEST tunnel 1 remote prefix '192.168.101.0/24'

```
Before:

```
vyos@vyos:~$ reset vpn ipsec-peer TEST 
Peer or tunnel(s) not found, aborting
```

After:
```
vyos@vyos:~$ reset vpn ipsec-peer TEST
closing CHILD_SA TEST-tunnel-0{1} with SPIs c59dac53_i (0 bytes) c3c5ebaf_o (0 bytes) and TS 192.168.10.0/24 === 192.168.11.0/24
sending DELETE for ESP CHILD_SA with SPI c59dac53
generating INFORMATIONAL request 3 [ D ]
sending packet: from 192.0.2.2[4500] to 192.0.2.1[4500] (76 bytes)
received packet: from 192.0.2.1[4500] to 192.0.2.2[4500] (76 bytes)
parsed INFORMATIONAL response 3 [ D ]
received DELETE for ESP CHILD_SA with SPI c3c5ebaf
CHILD_SA closed
received packet: from 192.0.2.1[4500] to 192.0.2.2[4500] (348 bytes)
parsed CREATE_CHILD_SA request 0 [ SA No KE TSi TSr ]
selected proposal: ESP:AES_CBC_128/HMAC_SHA1_96/MODP_1024/NO_EXT_SEQ
CHILD_SA {1} closed successfully
not establishing CHILD_SA TEST-tunnel-0{4} due to existing duplicate {3} with SPIs c1e614fc_i c7a08c47_o and TS 192.168.10.0/24 === 192.168.11.0/24
establishing connection 'TEST-tunnel-0' failed
closing CHILD_SA TEST-tunnel-1{2} with SPIs c7e252f9_i (0 bytes) c596ef3c_o (0 bytes) and TS 192.168.100.0/24 === 192.168.101.0/24
sending DELETE for ESP CHILD_SA with SPI c7e252f9
generating INFORMATIONAL request 4 [ D ]
sending packet: from 192.0.2.2[4500] to 192.0.2.1[4500] (76 bytes)
received packet: from 192.0.2.1[4500] to 192.0.2.2[4500] (348 bytes)
parsed CREATE_CHILD_SA request 1 [ SA No KE TSi TSr ]
selected proposal: ESP:AES_CBC_128/HMAC_SHA1_96/MODP_1024/NO_EXT_SEQ
CHILD_SA TEST-tunnel-1{5} established with SPIs c54ffc24_i c6e1f49d_o and TS 192.168.100.0/24 === 192.168.101.0/24
generating CREATE_CHILD_SA response 1 [ SA No KE TSi TSr ]
sending packet: from 192.0.2.2[4500] to 192.0.2.1[4500] (348 bytes)
received packet: from 192.0.2.1[4500] to 192.0.2.2[4500] (76 bytes)
parsed INFORMATIONAL response 4 [ D ]
received DELETE for ESP CHILD_SA with SPI c596ef3c
CHILD_SA closed
CHILD_SA {2} closed successfully
not establishing CHILD_SA TEST-tunnel-1{6} due to existing duplicate {5} with SPIs c54ffc24_i c6e1f49d_o and TS 192.168.100.0/24 === 192.168.101.0/24
establishing connection 'TEST-tunnel-1' failed
Peer reset result: success
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
