### PR TITLE
T4971: Accel-ppp verify if client_ip_pool key exists in config

### DIFF
--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -420,11 +420,12 @@ def verify_accel_ppp_base_service(config, local_users=True):
     if 'gateway_address' in config:
         gateway = True
     else:
-        if dict_search_recursive(config, 'gateway_address', ['client_ip_pool', 'name']):
-            for _, v in config['client_ip_pool']['name'].items():
-                if 'gateway_address' in v:
-                    gateway = True
-                    break
+        if 'client_ip_pool' in config:
+            if dict_search_recursive(config, 'gateway_address', ['client_ip_pool', 'name']):
+                for _, v in config['client_ip_pool']['name'].items():
+                    if 'gateway_address' in v:
+                        gateway = True
+                        break
     if not gateway:
         raise ConfigError('Server requires gateway-address to be configured!')
 


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

If **client_ip_pool** not exists in the config we cannot search for it in the dictionary
  `dict_search_recursive(config, 'gateway_address', ['client_ip_pool', 'name'])`
Add check

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4971

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS config:
```
set service pppoe-server authentication mode 'radius'
set service pppoe-server authentication radius server 192.168.122.14 key 'vyos-secret'
set service pppoe-server interface eth1
```
Before fix:
```

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/service_pppoe-server.py", line 116, in <module>
    verify(c)
  File "/usr/libexec/vyos/conf_mode/service_pppoe-server.py", line 62, in verify
    verify_accel_ppp_base_service(pppoe)
  File "/usr/lib/python3/dist-packages/vyos/configverify.py", line 424, in verify_accel_ppp_base_service
    for _, v in config['client_ip_pool']['name'].items():
KeyError: 'client_ip_pool'



[[service pppoe-server]] failed
Commit failed
[edit]
vyos@r14#
```
After fix (expected failed as gateway is not configured):
```
vyos@r14# commit
[ service pppoe-server ]
Server requires gateway-address to be configured!

[[service pppoe-server]] failed
Commit failed
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
