### PR TITLE
http-api: T5006: add explicit async to retrieve/configure methods for REST

### DIFF
--- a/src/services/vyos-http-api-server
+++ b/src/services/vyos-http-api-server
@@ -425,7 +425,7 @@ async def validation_exception_handler(request, exc):
     return error(400, str(exc.errors()[0]))
 
 @app.post('/configure')
-def configure_op(data: Union[ConfigureModel, ConfigureListModel]):
+async def configure_op(data: Union[ConfigureModel, ConfigureListModel]):
     session = app.state.vyos_session
     env = session.get_session_env()
     config = vyos.config.Config(session_env=env)
@@ -494,7 +494,7 @@ def configure_op(data: Union[ConfigureModel, ConfigureListModel]):
     return success(None)
 
 @app.post("/retrieve")
-def retrieve_op(data: RetrieveModel):
+async def retrieve_op(data: RetrieveModel):
     session = app.state.vyos_session
     env = session.get_session_env()
     config = vyos.config.Config(session_env=env)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The REST endpoints 'retrieve' and 'configure' can reveal a segfault under concurrent connections unless methods are defined explicitly as 'async'. Add async modifier to methods.

This affects only Sagitta REST requests; the segfault will occur in the underlying libc, in vyatta-cfg, respectively, libvyosconfig. Equuleus is not affected, nor are GraphQL requests.

Note that the underlying web framework for the http-api, FastAPI, automatically takes care of red/blue function issues, 'usually'; here is a case where we must be explicit.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5006

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Thanks to the user who opened the bug report, testing may be done with:

```
npx autocannon --duration 10 --connections 4 --renderStatusCodes --method POST --form '{"data": {"type":"text", "value": "{\"op\": \"showConfig\", \"path\": []}"}, "key": {"type":"text","value":"qwerty"}}' 'https://host-name/retrieve'
```

respectively

```
npx autocannon --duration 10 --connections 4 --renderStatusCodes --method POST --form '{"data": {"type":"text", "value": "{\"op\": \"set\", \"path\": [\"interfaces\", \"ethernet\", \"eth0\", \"description\", \"baz\"]}"}, "key": {"type":"text","value":"qwerty"}}' 'https://host-name/configure'
```

for suitable 'host-name'.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
