### PR TITLE
T5005: PPPoE server allow any login with option noauth

### DIFF
--- a/data/templates/accel-ppp/pppoe.config.j2
+++ b/data/templates/accel-ppp/pppoe.config.j2
@@ -30,6 +30,11 @@ syslog=accel-pppoe,daemon
 copy=1
 level=5
 
+{% if authentication.mode is vyos_defined("noauth") %}
+[auth]
+noauth=1
+{% endif %}
+
 {% if snmp.master_agent is vyos_defined %}
 [snmp]
 master=1
@@ -133,7 +138,10 @@ pado-delay={{ pado_delay_param.value }}
 called-sid={{ authentication.radius.called_sid_format }}
 {% endif %}
 
-{% if authentication.mode is vyos_defined("local") %}
+{% if authentication.mode is vyos_defined("local") or authentication.mode is vyos_defined("noauth") %}
+{%     if authentication.mode is vyos_defined("noauth") %}
+noauth=1
+{%     endif %}
 {%     if client_ip_pool.name is vyos_defined %}
 {%         for pool, pool_config in client_ip_pool.name.items() %}
 {%             if pool_config.subnet is vyos_defined %}

--- a/interface-definitions/include/accel-ppp/auth-mode.xml.i
+++ b/interface-definitions/include/accel-ppp/auth-mode.xml.i
@@ -10,11 +10,15 @@
       <format>radius</format>
       <description>Use RADIUS server for user autentication</description>
     </valueHelp>
+    <valueHelp>
+      <format>noauth</format>
+      <description>Authentication disabled</description>
+    </valueHelp>
     <constraint>
-      <regex>(local|radius)</regex>
+      <regex>(local|radius|noauth)</regex>
     </constraint>
     <completionHelp>
-      <list>local radius</list>
+      <list>local radius noauth</list>
     </completionHelp>
   </properties>
   <defaultValue>local</defaultValue>

--- a/interface-definitions/service-ipoe-server.xml.in
+++ b/interface-definitions/service-ipoe-server.xml.in
@@ -117,29 +117,7 @@
               <help>Client authentication methods</help>
             </properties>
             <children>
-              <leafNode name="mode">
-                <properties>
-                  <help>Authetication mode</help>
-                  <completionHelp>
-                    <list>local radius noauth</list>
-                  </completionHelp>
-                  <constraint>
-                    <regex>(local|radius|noauth)</regex>
-                  </constraint>
-                  <valueHelp>
-                    <format>local</format>
-                    <description>Authentication based on local definition</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>radius</format>
-                    <description>Authentication based on a RADIUS server</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>noauth</format>
-                    <description>Authentication disabled</description>
-                  </valueHelp>
-                </properties>
-              </leafNode>
+              #include <include/accel-ppp/auth-mode.xml.i>
               <tagNode name="interface">
                 <properties>
                   <help>Network interface for client MAC addresses</help>


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->
Disabling authentication is useful in emergencies (e.g. RADIUS server is down) or testing purposes.
Clients can connect with any login and password.

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5005

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration
```
set service pppoe-server authentication mode 'noauth'
set service pppoe-server client-ip-pool name foo gateway-address '192.0.2.1'
set service pppoe-server client-ip-pool name foo subnet '192.0.2.0/24'
set service pppoe-server interface eth1
```
Any pppoe-client can connect with any login/pass

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
