### PR TITLE
T5011: Set default values for min_mtu max_mtu

### DIFF
--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -36,8 +36,14 @@ def verify_mtu(config):
         mtu = int(config['mtu'])
 
         tmp = Interface(config['ifname'])
-        min_mtu = tmp.get_min_mtu()
-        max_mtu = tmp.get_max_mtu()
+        # Not all interfaces support min/max MTU
+        # https://vyos.dev/T5011
+        try:
+            min_mtu = tmp.get_min_mtu()
+            max_mtu = tmp.get_max_mtu()
+        except: # Fallback to defaults
+            min_mtu = 68
+            max_mtu = 9000
 
         if mtu < min_mtu:
             raise ConfigError(f'Interface MTU too low, ' \


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Some interface drivers don't support/provide min_mtu and max_mtu values For example VyOS in a docker container with `veth` driver on some platforms
As a workaround add default values for min/max MTU for calculations and pass function "verify_mtu(config)"

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5011

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
interface mtu
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
