### PR TITLE
ipsec: T4288 fix IPsec SA renegotiation

### DIFF
--- a/data/templates/ipsec/swanctl/peer.j2
+++ b/data/templates/ipsec/swanctl/peer.j2
@@ -62,7 +62,7 @@
 {%     if vti_esp.life_packets is vyos_defined %}
                 life_packets = {{ vti_esp.life_packets }}
 {%     endif %}
-                life_time = {{ vti_esp.lifetime }}s
+                rekey_time = {{ vti_esp.lifetime }}s
                 local_ts = 0.0.0.0/0,::/0
                 remote_ts = 0.0.0.0/0,::/0
                 updown = "/etc/ipsec.d/vti-up-down {{ peer_conf.vti.bind }}"
@@ -105,7 +105,7 @@
 {%         if tunnel_esp.life_packets is vyos_defined %}
                 life_packets = {{ tunnel_esp.life_packets }}
 {%         endif %}
-                life_time = {{ tunnel_esp.lifetime }}s
+                rekey_time = {{ tunnel_esp.lifetime }}s
 {%         if tunnel_esp.mode is not defined or tunnel_esp.mode == 'tunnel' %}
 {%             if tunnel_conf.local.prefix is vyos_defined %}
 {%                 set local_prefix = tunnel_conf.local.prefix if 'any' not in tunnel_conf.local.prefix else ['0.0.0.0/0', '::/0'] %}


### PR DESCRIPTION
Due to live-time being set and rekey-time being missed (1h default) an IPsec SA can be closed before the new one is established or it can go in loop and be renegotiation every second if a big value is set. Only rekey-time should be set because life-time is derived from it as per https://docs.strongswan.org/docs/5.9/swanctl/swanctlConf.html

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4288

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec
## Proposed changes
<!--- Describe your changes in detail -->
Set IPsec SA rekey_time instead of life_time as per https://docs.strongswan.org/docs/5.9/swanctl/swanctlConf.html
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics

-->
all details in https://vyos.dev/T4288 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
