### PR TITLE
T4978: Default values of port rewrite default container values

### DIFF
--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2022 VyOS maintainers and contributors
+# Copyright (C) 2021-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -84,16 +84,16 @@ def get_config(config=None):
             # tagNodes in place, it is better to blend in the defaults manually.
             if 'port' in container['name'][name]:
                 for port in container['name'][name]['port']:
-                    default_values = defaults(base + ['name', 'port'])
+                    default_values_port = defaults(base + ['name', 'port'])
                     container['name'][name]['port'][port] = dict_merge(
-                        default_values, container['name'][name]['port'][port])
+                        default_values_port, container['name'][name]['port'][port])
             # XXX: T2665: we can not safely rely on the defaults() when there are
             # tagNodes in place, it is better to blend in the defaults manually.
             if 'volume' in container['name'][name]:
                 for volume in container['name'][name]['volume']:
-                    default_values = defaults(base + ['name', 'volume'])
+                    default_values_volume = defaults(base + ['name', 'volume'])
                     container['name'][name]['volume'][volume] = dict_merge(
-                        default_values, container['name'][name]['volume'][volume])
+                        default_values_volume, container['name'][name]['volume'][volume])
 
     # Delete container network, delete containers
     tmp = node_changed(conf, base + ['network'])


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
As we have the same variable name, `default_values` for container name, port, and volume, it rewrites default container parameters with `default port` parameters
Fix it
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4978

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS config:
```
set container name multitool description 'Network multitool container'
set container name multitool image 'wbitt/network-multitool:fedora'
set container name multitool network cntr-net
set container name multitool port http destination '80'
set container name multitool port http source '80'
set container name nrpe allow-host-networks
set container name nrpe image 'incitem/almalinux9:nrpe'
set container name radius allow-host-networks
set container name radius image 'dchidell/radius-web'
set container name radius volume clients destination '/etc/raddb/clients.conf'
set container name radius volume clients source '/config/containers/radius/clients'
set container name radius volume users destination '/etc/raddb/users'
set container name radius volume users source '/config/containers/radius/users'
set container network cntr-net description 'VyOS Container Network'
set container network cntr-net prefix '172.253.253.0/24'

```
Before the fix, it is not `memory` key as it was rewritten with `protocol`:
```
[ container ]
multitool
defaults: {'memory': '512', 'shared_memory': '64', 'restart': 'on-failure'}
nrpe
defaults: {'protocol': 'tcp'}
radius
defaults: {'protocol': 'tcp'}

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/container.py", line 401, in <module>
    generate(c)
  File "/usr/libexec/vyos/conf_mode/container.py", line 343, in generate
    run_args = generate_run_arguments(name, container_config)
  File "/usr/libexec/vyos/conf_mode/container.py", line 233, in generate_run_arguments
    memory = container_config['memory']
KeyError: 'memory'
```
After fix:
```
vyos@r14# run show container 
CONTAINER ID  IMAGE                                     COMMAND               CREATED        STATUS            PORTS               NAMES
b5716df1c3f3  docker.io/wbitt/network-multitool:fedora  nginx -g daemon o...  9 minutes ago  Up 9 minutes ago  0.0.0.0:80->80/tcp  multitool
8e2845795de3  docker.io/incitem/almalinux9:nrpe                               9 minutes ago  Up 9 minutes ago                      nrpe
769be6b3b88f  docker.io/dchidell/radius-web:latest                            9 minutes ago  Up 9 minutes ago                      radius

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
