### PR TITLE
T5027: Enable legacy provider to support current ciphers

### DIFF
--- a/data/templates/openvpn/server.conf.j2
+++ b/data/templates/openvpn/server.conf.j2
@@ -213,6 +213,9 @@ keysize 256
 data-ciphers {{ encryption.ncp_ciphers | openvpn_ncp_ciphers }}
 {%     endif %}
 {% endif %}
+# https://vyos.dev/T5027
+# Required to support BF-CBC (default ciphername when none given)
+providers legacy default
 
 {% if hash is vyos_defined %}
 auth {{ hash }}


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
* We will need to remove insecure ciphers as a long-term solution (BF-CBC, DES...)
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5027

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openvpn
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces openvpn vtun5001 local-address 203.0.113.1
set interfaces openvpn vtun5001 mode 'site-to-site'
set interfaces openvpn vtun5001 remote-address '192.0.2.5'
set interfaces openvpn vtun5001 shared-secret-key 'ovpn_test'
set pki openvpn shared-secret ovpn_test key '9caf354e0f313b3a671d01e62ea2b512346a651dd30a9e51d6c45dc1031f1b0931eabdf7a0ddcbe1a147ff882ccce35dcb5e1d4d6ddb5e909ca012a8d8e16fe50dd332005dff9a836a2852f36e84e27bad07993a8094c56fb0553866ef74c6c5cc6ddb8f4673d3ff300c48068b944bd8ba1100d41f91d156bcd2629ff39837ddcb34d93147a4aabc7e6ad95d5800c82c8ab60ba302d6625a3b26fbfe183fd6c06d884be44edde344fd0ac91a33064529e010eba0c0f495fa44519fd98adb97452a27fb3340bc20efadd68c9538aa4a238c9f58f542e3571ec78790fdd03e678e18631b82edb9358a2c55ce581d68b71881cad0d0419d4cc58c13641f84281260'
set pki openvpn shared-secret ovpn_test version '1'
```
Before fix:
```
Feb 23 10:55:52 r14 systemd[1]: openvpn@vtun5001.service: Scheduled restart job, restart counter is at 10.
Feb 23 10:55:52 r14 systemd[1]: Stopped openvpn@vtun5001.service - OpenVPN connection to vtun5001.
Feb 23 10:55:52 r14 systemd[1]: Starting openvpn@vtun5001.service - OpenVPN connection to vtun5001...
Feb 23 10:55:52 r14 openvpn-vtun5001[10155]: DEPRECATED OPTION: The option --secret is deprecated.
Feb 23 10:55:52 r14 openvpn-vtun5001[10155]: No tls-client or tls-server option in configuration detected. Disabling data channel offload.
Feb 23 10:55:52 r14 openvpn-vtun5001[10155]: DEPRECATION: No tls-client or tls-server option in configuration detected. OpenVPN 2.7 will remove the functionality to run a VPN without TLS. See the examples section in the manual page for examples of a similar quick setup with peer-fingerprint.
Feb 23 10:55:52 r14 openvpn-vtun5001[10155]: WARNING: file '/run/openvpn/vtun5001_shared.key' is group or others accessible
Feb 23 10:55:52 r14 openvpn-vtun5001[10155]: OpenVPN 2.6.0 x86_64-pc-linux-gnu [SSL (OpenSSL)] [LZO] [LZ4] [EPOLL] [PKCS11] [MH/PKTINFO] [AEAD] [DCO]
Feb 23 10:55:52 r14 openvpn-vtun5001[10155]: library versions: OpenSSL 3.0.8 7 Feb 2023, LZO 2.10
Feb 23 10:55:52 r14 openvpn-vtun5001[10155]: Cipher BF-CBC not supported
Feb 23 10:55:52 r14 openvpn-vtun5001[10155]: Exiting due to fatal error
```
Tests openvpn site-to-site before fix:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py
test_openvpn_client_interfaces (__main__.TestInterfacesOpenVPN.test_openvpn_client_interfaces) ... ok
test_openvpn_client_verify (__main__.TestInterfacesOpenVPN.test_openvpn_client_verify) ... ok
test_openvpn_options (__main__.TestInterfacesOpenVPN.test_openvpn_options) ... FAIL
test_openvpn_server_net30_topology (__main__.TestInterfacesOpenVPN.test_openvpn_server_net30_topology) ... ok
test_openvpn_server_subnet_topology (__main__.TestInterfacesOpenVPN.test_openvpn_server_subnet_topology) ... ok
test_openvpn_server_verify (__main__.TestInterfacesOpenVPN.test_openvpn_server_verify) ... ok
test_openvpn_site2site_interfaces_tun (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_interfaces_tun) ... FAIL
test_openvpn_site2site_verify (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_verify) ... ok

======================================================================
FAIL: test_openvpn_options (__main__.TestInterfacesOpenVPN.test_openvpn_options)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py", line 600, in test_openvpn_options
    self.assertNotEqual(cur_pid, new_pid)
AssertionError: None == None

======================================================================
FAIL: test_openvpn_site2site_interfaces_tun (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_interfaces_tun)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py", line 676, in test_openvpn_site2site_interfaces_tun
    self.assertTrue(process_named_running(PROCESS_NAME))
AssertionError: None is not true

----------------------------------------------------------------------
Ran 8 tests in 91.286s

FAILED (failures=2)
vyos@r14:~$
```
Smoketest after fix:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py
test_openvpn_client_interfaces (__main__.TestInterfacesOpenVPN.test_openvpn_client_interfaces) ... ok
test_openvpn_client_verify (__main__.TestInterfacesOpenVPN.test_openvpn_client_verify) ... ok
test_openvpn_options (__main__.TestInterfacesOpenVPN.test_openvpn_options) ... ok
test_openvpn_server_net30_topology (__main__.TestInterfacesOpenVPN.test_openvpn_server_net30_topology) ... ok
test_openvpn_server_subnet_topology (__main__.TestInterfacesOpenVPN.test_openvpn_server_subnet_topology) ... ok
test_openvpn_server_verify (__main__.TestInterfacesOpenVPN.test_openvpn_server_verify) ... ok
test_openvpn_site2site_interfaces_tun (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_interfaces_tun) ... ok
test_openvpn_site2site_verify (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_verify) ... ok

----------------------------------------------------------------------
Ran 8 tests in 96.620s

OK
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
