### PR TITLE
T5007: Fix multicast implementation for the tunnel interfaces

### DIFF
--- a/python/vyos/ifconfig/tunnel.py
+++ b/python/vyos/ifconfig/tunnel.py
@@ -162,6 +162,15 @@ class TunnelIf(Interface):
         """ Get a synthetic MAC address. """
         return self.get_mac_synthetic()
 
+    def set_multicast(self):
+        """ Set multicast """
+        if self.config.get('multicast', 'disable') == 'enable':
+            cmd = 'ip link set dev {ifname} multicast on'
+        else:
+            cmd = 'ip link set dev {ifname} multicast off'
+
+        self._cmd(cmd.format(**self.config))
+
     def update(self, config):
         """ General helper function which works on a dictionary retrived by
         get_config_dict(). It's main intention is to consolidate the scattered
@@ -169,6 +178,9 @@ class TunnelIf(Interface):
         on any interface. """
         # Adjust iproute2 tunnel parameters if necessary
         self._change_options()
+
+        # Add multicast
+        self.set_multicast()
 
         # call base class first
         super().update(config)


### PR DESCRIPTION




<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Multicast has not been implemented for the tunnel interfaces. We have only configuration CLI commands that do anything. Fix it.
```
  ip link set dev <tag> multicast on
  ip link set dev <tag> multicast off
```
(cherry picked from commit ac821d0d1764e9623015e04c5158a06c00ab370b)
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): cherry-pick multicast for tunnels

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5007

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
tunnel
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS config:
```
set interfaces tunnel tun0 encapsulation 'gre'
set interfaces tunnel tun0 multicast 'enable'
set interfaces tunnel tun0 remote '192.0.2.85'
set interfaces tunnel tun0 source-address '203.0.113.1'

```
Before the fix, we don't see the flag **MULTICAST**
```
vyos@r1# ip -j link show dev tun0 |  python3 -c "import sys, json; print(json.load(sys.stdin)[0]['flags'])"
['POINTOPOINT', 'NOARP', 'UP', 'LOWER_UP']
[edit]
vyos@r1# 
[edit]
vyos@r1# sudo ip -d link show dev tun0
9: tun0@NONE: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1476 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/gre 203.0.113.1 peer 192.0.2.85 promiscuity 0 minmtu 68 maxmtu 65511 
    gre remote 192.0.2.85 local 203.0.113.1 ttl 64 tos inherit addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 
[edit]
vyos@r1# 
```

After the fix, the expected flag **MULTICAST**
```
vyos@r1# ip -j link show dev tun0 |  python3 -c "import sys, json; print(json.load(sys.stdin)[0]['flags'])"
['POINTOPOINT', 'MULTICAST', 'NOARP', 'UP', 'LOWER_UP']
[edit]
vyos@r1# 
[edit]
vyos@r1# sudo ip -d link show dev tun0
10: tun0@NONE: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1476 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/gre 203.0.113.1 peer 192.0.2.85 promiscuity 0 minmtu 68 maxmtu 65511 
    gre remote 192.0.2.85 local 203.0.113.1 ttl 64 tos inherit addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 
[edit]
vyos@r1# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
