### PR TITLE
macsec: T5008: Changed length of CKN to (2..64 hex-digits)

### DIFF
--- a/interface-definitions/interfaces-macsec.xml.in
+++ b/interface-definitions/interfaces-macsec.xml.in
@@ -74,10 +74,10 @@
                       <help>Secure Connectivity Association Key Name</help>
                       <valueHelp>
                         <format>txt</format>
-                        <description>32-byte (256-bit) hex-string (64 hex-digits)</description>
+                        <description>>1..32-bytes (8..256 bit) hex-string (2..64 hex-digits)</description>
                       </valueHelp>
                       <constraint>
-                        <regex>^[A-Fa-f0-9]{64}$</regex>
+                        <regex>^[A-Fa-f0-9]{2,64}$</regex>
                       </constraint>
                     </properties>
                   </leafNode>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Based on wpa_supplicant documentation.
mka_ckn (CKN = CAK Name) takes a 1..32-bytes (8..256 bit) hex-string (2..64 hex-digits)
Changed allowable length of CKN from strong 64 hex-digits to the range (2..64 hex-digits)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5008

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
macsec

## Proposed changes
<!--- Describe your changes in detail -->
Based on wpa_supplicant documentation.
mka_ckn (CKN = CAK Name) takes a 1..32-bytes (8..256 bit) hex-string (2..64 hex-digits)
Changed allowable length of CKN from strong 64 hex-digits to the range (2..64 hex-digits)

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
