### PR TITLE
login: T4943: Fixed 2FA + RADIUS compatibility

### DIFF
--- a/data/templates/ssh/sshd_config.j2
+++ b/data/templates/ssh/sshd_config.j2
@@ -29,7 +29,7 @@ PermitRootLogin no
 PidFile /run/sshd/sshd.pid
 AddressFamily any
 DebianBanner no
-PasswordAuthentication no
+KbdInteractiveAuthentication no
 
 #
 # User configurable section
@@ -48,7 +48,7 @@ Port {{ value }}
 LogLevel {{ loglevel | upper }}
 
 # Specifies whether password authentication is allowed
-ChallengeResponseAuthentication {{ "no" if disable_password_authentication is vyos_defined else "yes" }}
+PasswordAuthentication {{ "no" if disable_password_authentication is vyos_defined else "yes" }}
 
 {% if listen_address is vyos_defined %}
 # Specifies the local addresses sshd should listen on

--- a/debian/vyos-1x.postinst
+++ b/debian/vyos-1x.postinst
@@ -24,9 +24,9 @@ fi
 # Enable 2FA/MFA support for SSH and local logins
 for file in /etc/pam.d/sshd /etc/pam.d/login
 do
-    PAM_CONFIG="auth       required     pam_google_authenticator.so nullok"
-    grep -qF -- "${PAM_CONFIG}" $file || \
-    sed -i "/^@include common-auth/a # Check 2FA/MFA authentication token if enabled (per user)\n${PAM_CONFIG}" $file
+    PAM_CONFIG="# Check 2FA/MFA authentication token if enabled (per user)\nauth       required     pam_google_authenticator.so nullok forward_pass\n"
+    grep -qF -- "pam_google_authenticator.so" $file || \
+    sed -i "/^# Standard Un\*x authentication\./i${PAM_CONFIG}" $file
 done
 
 # Add RADIUS operator user for RADIUS authenticated users to map to


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed 2FA + RADIUS compatibility

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4943

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
login

## Proposed changes
<!--- Describe your changes in detail -->
MFA requires KbdInteractiveAuthentication to ask a second factor, and the RADIUS module for PAM does not like it, which makes them incompatible.

This commit:

* disables KbdInteractiveAuthentication
* changes order for PAM modules - make it first, before `pam_unix` or `pam_radius_auth`
* enables the `forward_pass` option for `pam_google_authenticator` to accept both password and MFA in a single input

As a result, local, RADIUS, and MFA work together.

Important change: MFA should be entered together with a password.

Before:

```
vyos login: <USERNAME>
Password: <PASSWORD>
Verification code: <MFA>
```

Now:
```
vyos login: <USERNAME>
Password & verification code: <PASSWORD><MFA>
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configure both RADIUS and MFA. It should be possible to log in using both types of authentication with no issues.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
