### PR TITLE
T5032: Add VRRP aware dhcp relay

### DIFF
--- a/interface-definitions/service_dhcp-relay.xml.in
+++ b/interface-definitions/service_dhcp-relay.xml.in
@@ -119,6 +119,12 @@
               </constraint>
             </properties>
           </leafNode>
+          <leafNode name="vrrp-disable">
+            <properties>
+              <help>Disable DHCP relay on VRRP listen-interfaces not in the MASTER state</help>
+              <valueless/>
+            </properties>
+          </leafNode>
         </children>
       </node>
     </children>

--- a/src/system/keepalived-fifo.py
+++ b/src/system/keepalived-fifo.py
@@ -20,7 +20,6 @@ import signal
 import argparse
 import threading
 import re
-import json
 import logging
 
 from queue import Queue
@@ -42,6 +41,8 @@ logger.setLevel(logging.DEBUG)
 
 mdns_running_file = '/run/mdns_vrrp_active'
 mdns_update_command = 'sudo /usr/libexec/vyos/conf_mode/service_mdns_repeater.py'
+dhcp4_relay_running_file = '/run/dhcp4_vrrp_active'
+dhcp4_relay_update_command = 'sudo /usr/libexec/vyos/conf_mode/service_dhcp-relay.py'
 
 # class for all operations
 class KeepalivedFifo:
@@ -130,6 +131,8 @@ class KeepalivedFifo:
                         if n_type == 'INSTANCE':
                             if os.path.exists(mdns_running_file):
                                 cmd(mdns_update_command)
+                            if os.path.exists(dhcp4_relay_running_file):
+                                cmd(dhcp4_relay_update_command)
 
                             tmp = dict_search(f'group.{n_name}.transition_script.{n_state.lower()}', self.vrrp_config_dict)
                             if tmp != None:
@@ -138,6 +141,8 @@ class KeepalivedFifo:
                         elif n_type == 'GROUP':
                             if os.path.exists(mdns_running_file):
                                 cmd(mdns_update_command)
+                            if os.path.exists(dhcp4_relay_running_file):
+                                cmd(dhcp4_relay_update_command)
 
                             tmp = dict_search(f'sync_group.{n_name}.transition_script.{n_state.lower()}', self.vrrp_config_dict)
                             if tmp != None:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add the ability to disable DHCP relay on interfaces not in the VRRP MASTER state.

This feature can be enabled with `set service dhcp-relay vrrp-disable`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5032

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
- dhcp-relay
- vrrp

## Proposed changes
Add the ability to disable DHCP relay on interfaces not in the VRRP MASTER state.

This feature can be enabled with `set service dhcp-relay vrrp-disable`.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
1. Configure VRRP between two routers
2. Configure DHCP relay on one of the VRRP interfaces
3. The router in the BACKUP state should have the `isc-dhcp-relay` service stopped.
4. The router in the MASTER state should have the `isc-dhcp-relay` service running.
5. Test fail over between the routers and check the `isc-dhcp-relay` service state.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
