### PR TITLE
T5037: Firewall: Add queue action and options to firewall

### DIFF
--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -502,6 +502,7 @@
                   </completionHelp>
                 </properties>
               </leafNode>
+              #include <include/firewall/nft-queue.xml.i>
             </children>
           </tagNode>
         </children>
@@ -671,6 +672,7 @@
                 </properties>
               </leafNode>
               #include <include/firewall/ttl.xml.i>
+              #include <include/firewall/nft-queue.xml.i>
             </children>
           </tagNode>
         </children>

--- a/interface-definitions/include/firewall/action.xml.i
+++ b/interface-definitions/include/firewall/action.xml.i
@@ -3,7 +3,7 @@
   <properties>
     <help>Rule action</help>
     <completionHelp>
-      <list>accept jump reject return drop</list>
+      <list>accept jump reject return drop queue</list>
     </completionHelp>
     <valueHelp>
       <format>accept</format>
@@ -25,8 +25,12 @@
       <format>drop</format>
       <description>Drop matching entries</description>
     </valueHelp>
+    <valueHelp>
+      <format>queue</format>
+      <description>Enqueue packet to userspace</description>
+    </valueHelp>
     <constraint>
-      <regex>(accept|jump|reject|return|drop)</regex>
+      <regex>(accept|jump|reject|return|drop|queue)</regex>
     </constraint>
   </properties>
 </leafNode>

--- a/interface-definitions/include/firewall/nft-queue.xml.i
+++ b/interface-definitions/include/firewall/nft-queue.xml.i
@@ -1,0 +1,34 @@
+<!-- include start from firewall/nft-queue.xml.i -->
+<leafNode name="queue">
+  <properties>
+    <help>Queue target to use. Action queue must be defined to use this setting</help>
+    <valueHelp>
+      <format>u32:0-65535</format>
+      <description>Queue target</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--allow-range --range 0-65535"/>
+    </constraint>
+  </properties>
+</leafNode>
+<leafNode name="queue-options">
+  <properties>
+    <help>Options used for queue target. Action queue must be defined to use this setting</help>
+    <completionHelp>
+      <list>bypass fanout</list>
+    </completionHelp>
+    <valueHelp>
+      <format>bypass</format>
+      <description>Let packets go through if userspace application cannot back off</description>
+    </valueHelp>
+    <valueHelp>
+      <format>fanout</format>
+      <description>Distribute packets between several queues</description>
+    </valueHelp>
+    <constraint>
+      <regex>(bypass|fanout)</regex>
+    </constraint>
+    <multi/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -337,6 +337,15 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
             target = rule_conf['jump_target']
             output.append(f'NAME{def_suffix}_{target}')
 
+        if 'queue' in rule_conf['action']:
+            if 'queue' in rule_conf:
+                target = rule_conf['queue']
+                output.append(f'num {target}')
+
+            if 'queue_options' in rule_conf:
+                queue_opts = ','.join(rule_conf['queue_options'])
+                output.append(f'{queue_opts}')
+
     else:
         output.append('return')
 

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -284,6 +284,15 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['firewall', 'name', name2, 'rule', '1', 'action', 'jump'])
         self.cli_set(['firewall', 'name', name2, 'rule', '1', 'jump-target', name])
 
+        self.cli_set(['firewall', 'name', name2, 'rule', '2', 'protocol', 'tcp'])
+        self.cli_set(['firewall', 'name', name2, 'rule', '2', 'action', 'queue'])
+        self.cli_set(['firewall', 'name', name2, 'rule', '2', 'queue', '3'])
+        self.cli_set(['firewall', 'name', name2, 'rule', '3', 'protocol', 'udp'])
+        self.cli_set(['firewall', 'name', name2, 'rule', '3', 'action', 'queue'])
+        self.cli_set(['firewall', 'name', name2, 'rule', '3', 'queue-options', 'fanout'])
+        self.cli_set(['firewall', 'name', name2, 'rule', '3', 'queue-options', 'bypass'])
+        self.cli_set(['firewall', 'name', name2, 'rule', '3', 'queue', '0-15'])
+
         self.cli_set(['firewall', 'interface', interface, 'in', 'name', name])
 
         self.cli_commit()
@@ -294,7 +303,9 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['ip length 1-30000', 'ip length != 60000-65535', 'ip dscp 0x03-0x0b', 'ip dscp != 0x15-0x19', 'return'],
             [f'log prefix "[{name}-default-D]"', 'drop'],
             ['ip saddr 198.51.100.1', f'jump NAME_{name}'],
-            [f'log prefix "[{name2}-default-J]"', f'jump NAME_{name}']
+            [f'log prefix "[{name2}-default-J]"', f'jump NAME_{name}'],
+            [f'meta l4proto tcp','queue to 3'],
+            [f'meta l4proto udp','queue flags bypass,fanout to 0-15']
         ]
 
         self.verify_nftables(nftables_search, 'ip vyos_filter')

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -197,6 +197,15 @@ def verify_rule(firewall, rule_conf, ipv6):
             if target not in dict_search_args(firewall, 'ipv6_name'):
                 raise ConfigError(f'Invalid jump-target. Firewall ipv6-name {target} does not exist on the system')
 
+    if 'queue_options' in rule_conf:
+        if 'queue' not in rule_conf['action']:
+            raise ConfigError('queue-options defined, but action queue needed and it is not defined')
+        if 'fanout' in rule_conf['queue_options'] and ('queue' not in rule_conf or '-' not in rule_conf['queue']):
+            raise ConfigError('queue-options fanout defined, then queue needs to be defined as a range')
+
+    if 'queue' in rule_conf and 'queue' not in rule_conf['action']:
+        raise ConfigError('queue defined, but action queue needed and it is not defined')
+
     if 'fragment' in rule_conf:
         if {'match_frag', 'match_non_frag'} <= set(rule_conf['fragment']):
             raise ConfigError('Cannot specify both "match-frag" and "match-non-frag"')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add queue action and options in firewall

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5037

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@nfq-queue:~$ show config comm | grep fire
set firewall name FOO rule 2 action 'queue'
set firewall name FOO rule 2 protocol 'tcp'
set firewall name FOO rule 2 queue '3'
set firewall name FOO rule 3 action 'queue'
set firewall name FOO rule 3 protocol 'udp'
set firewall name FOO rule 3 queue-options 'fanout'
set firewall name FOO rule 3 queue-options 'bypass'
set firewall name FOO rule 3 queue '0-15'
set firewall name FOO rule 10 action 'queue'
set firewall name FOO rule 10 protocol 'tcp'
set firewall name FOO rule 20 action 'queue'
set firewall name FOO rule 20 protocol 'udp'
set firewall name FOO rule 20 queue-options 'bypass'
set firewall name FOO rule 20 queue-options 'fanout'
set firewall name FOO rule 20 queue '112-7777'
set firewall name FOO rule 30 action 'queue'
set firewall name FOO rule 30 queue-options 'fanout'
set firewall name FOO rule 30 queue '12-22'

yos@nfq-queue:~$ sudo nft -S list chain ip vyos_filter NAME_FOO
table ip vyos_filter {
	chain NAME_FOO {
		meta l4proto tcp counter packets 0 bytes 0 queue to 3 comment "FOO-2"
		meta l4proto udp counter packets 0 bytes 0 queue flags bypass,fanout to 0-15 comment "FOO-3"
		meta l4proto tcp counter packets 0 bytes 0 queue to 0 comment "FOO-10"
		meta l4proto udp counter packets 0 bytes 0 queue flags bypass,fanout to 112-7777 comment "FOO-20"
		counter packets 0 bytes 0 queue flags fanout to 12-22 comment "FOO-30"
		counter packets 0 bytes 0 drop comment "FOO default-action drop"
	}
}
vyos@nfq-queue:~$ 
```



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
