### PR TITLE
T5033: Ability to generate muliple keys from a file or link

### DIFF
--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2019-2023 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -160,6 +160,16 @@ def dot_colon_to_dash(text):
     text = text.replace(":", "-")
     text = text.replace(".", "-")
     return text
+
+@register_filter('generate_uuid4')
+def generate_uuid4(text):
+    """ Generate random unique ID
+    Example:
+      % uuid4()
+      UUID('958ddf6a-ef14-4e81-8cfb-afb12456d1c5')
+    """
+    from uuid import uuid4
+    return uuid4()
 
 @register_filter('netmask_from_cidr')
 def netmask_from_cidr(prefix):

--- a/src/op_mode/generate_public_key_command.py
+++ b/src/op_mode/generate_public_key_command.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022 VyOS maintainers and contributors
+# Copyright (C) 2022-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -19,28 +19,51 @@ import sys
 import urllib.parse
 
 import vyos.remote
+from vyos.template import generate_uuid4
 
-def get_key(path):
+
+def get_key(path) -> list:
+    """Get public keys from a local file or remote URL
+
+    Args:
+        path: Path to the public keys file
+
+    Returns: list of public keys split by new line
+
+    """
     url = urllib.parse.urlparse(path)
     if url.scheme == 'file' or url.scheme == '':
         with open(os.path.expanduser(path), 'r') as f:
             key_string = f.read()
     else:
         key_string = vyos.remote.get_remote_config(path)
-    return key_string.split()
+    return key_string.split('\n')
 
-try:
-    username = sys.argv[1]
-    algorithm, key, identifier = get_key(sys.argv[2])
-except Exception as e:
-    print("Failed to retrieve the public key: {}".format(e))
-    sys.exit(1)
 
-print('# To add this key as an embedded key, run the following commands:')
-print('configure')
-print(f'set system login user {username} authentication public-keys {identifier} key {key}')
-print(f'set system login user {username} authentication public-keys {identifier} type {algorithm}')
-print('commit')
-print('save')
-print('exit')
+if __name__ == "__main__":
+    first_loop = True
 
+    for k in get_key(sys.argv[2]):
+        k = k.split()
+        # Skip empty list entry
+        if k == []:
+            continue
+
+        try:
+            username = sys.argv[1]
+            # Github keys don't have identifier for example 'vyos@localhost'
+            # 'ssh-rsa AAAA... vyos@localhost'
+            # Generate uuid4 identifier
+            identifier = f'github@{generate_uuid4("")}' if sys.argv[2].startswith('https://github.com') else k[2]
+            algorithm, key = k[0], k[1]
+        except Exception as e:
+            print("Failed to retrieve the public key: {}".format(e))
+            sys.exit(1)
+
+        if first_loop:
+            print('# To add this key as an embedded key, run the following commands:')
+            print('configure')
+        print(f'set system login user {username} authentication public-keys {identifier} key {key}')
+        print(f'set system login user {username} authentication public-keys {identifier} type {algorithm}')
+
+        first_loop = False


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
We generate only one public key (string) from a file xxx.pub op-mode with `generate public-key-command user vyos link_to_key_file`
 Add the ability to generate configuration (from op-mode) for multiple keys

As github keys don't use identifiers, generate uuid4 id for them
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5033

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
generate public-key-command
## Proposed changes
<!--- Describe your changes in detail -->

## How to test

Before fix:
```
vyos@r1:~$ generate public-key-command user vyos path https://github.com/xxx.keys
Failed to retrieve the public key: too many values to unpack (expected 3)
vyos@r1:~$
```
After fix:
```
vyos@r1:~$ generate public-key-command user foo path /etc/ssh/ssh_host_rsa_key.pub
# To add this key as an embedded key, run the following commands:
configure
set system login user foo authentication public-keys root@debian key AAAAB
set system login user foo authentication public-keys root@debian type ssh-rsa
vyos@r1:~$ 
vyos@r1:~$ 
vyos@r1:~$ generate public-key-command user foo path https://github.com/xxx.keys
# To add this key as an embedded key, run the following commands:
configure
set system login user foo authentication public-keys github@91ab41fd-2aa6-46e6-8428-639e6cfd34a0 key xxxxx
set system login user foo authentication public-keys github@91ab41fd-2aa6-46e6-8428-639e6cfd34a0 type ssh-rsa
set system login user foo authentication public-keys github@74d69f15-9fca-4edf-b49b-07371b163ed8 key xxxxx
set system login user foo authentication public-keys github@74d69f15-9fca-4edf-b49b-07371b163ed8 type ssh-rsa
set system login user foo authentication public-keys github@9fb921aa-90c5-4ee8-b5f2-c1f251d918cb key xxxxx
set system login user foo authentication public-keys github@9fb921aa-90c5-4ee8-b5f2-c1f251d918cb type ssh-rs
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
