### PR TITLE
ipsec: T4916: Fixed migrations script

### DIFF
--- a/src/migration-scripts/ipsec/10-to-11
+++ b/src/migration-scripts/ipsec/10-to-11
@@ -14,8 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import re
-
 from sys import argv
 from sys import exit
 
@@ -64,7 +62,7 @@ if config.exists(base + ['site-to-site', 'peer']):
                 tmp = config.return_value(peer_base + ['local-address'])
                 config.set(base + ['authentication', 'psk', peer, 'id'], value=tmp, replace=False)
             if config.exists(peer_base + ['remote-address']):
-                tmp = config.return_value(peer_base + ['remote-address'])
+                tmp = config.return_values(peer_base + ['remote-address'])
                 if tmp:
                     for remote_addr in tmp:
                         if remote_addr == 'any':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed migrations script

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4916

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec

## Proposed changes
<!--- Describe your changes in detail -->
* removed unused `re` from imports
* replaced `return_value()` to `return_values()` for `remote-address` because this is a multi-value configuration node

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
In order to test this config you need to do the following:

1. Configure S2S Peer with multiple addresses

    ```
    set vpn ipsec site-to-site peer OFFICE-B authentication mode 'pre-shared-secret'
    set vpn ipsec site-to-site peer OFFICE-B authentication pre-shared-secret '$ecret'
    set vpn ipsec site-to-site peer OFFICE-B ike-group 'MyIKEGroup'
    set vpn ipsec site-to-site peer OFFICE-B local-address '192.168.1.1'
    set vpn ipsec site-to-site peer OFFICE-B remote-address '192.0.2.2'
    set vpn ipsec site-to-site peer OFFICE-B remote-address '192.0.2.3'
    set vpn ipsec site-to-site peer OFFICE-B remote-address '192.0.2.4'
    set vpn ipsec site-to-site peer OFFICE-B vti bind 'vti10'
    ```

2. Reboot the router to migrate the syntax from old to the new one
3. After migration we will see multiple extra ID's in the configuration  

    ```
   set vpn ipsec authentication psk OFFICE-B id '192.168.1.1'
   set vpn ipsec authentication psk OFFICE-B id '1'
   set vpn ipsec authentication psk OFFICE-B id '9'
   set vpn ipsec authentication psk OFFICE-B id '2'
   set vpn ipsec authentication psk OFFICE-B secret '$ecret'
   ```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
