### PR TITLE
configdiff: T4900: cache diff_tree and diff_dict in Config instance

### DIFF
--- a/python/vyos/configdiff.py
+++ b/python/vyos/configdiff.py
@@ -76,23 +76,34 @@ def get_config_diff(config, key_mangling=None):
             isinstance(key_mangling[1], str)):
         raise ValueError("key_mangling must be a tuple of two strings")
 
-    diff_t = DiffTree(config._running_config, config._session_config)
+    if hasattr(config, 'cached_diff_tree'):
+        diff_t = getattr(config, 'cached_diff_tree')
+    else:
+        diff_t = DiffTree(config._running_config, config._session_config)
+        setattr(config, 'cached_diff_tree', diff_t)
 
-    return ConfigDiff(config, key_mangling, diff_tree=diff_t)
+    if hasattr(config, 'cached_diff_dict'):
+        diff_d = getattr(config, 'cached_diff_dict')
+    else:
+        diff_d = diff_t.dict
+        setattr(config, 'cached_diff_dict', diff_d)
+
+    return ConfigDiff(config, key_mangling, diff_tree=diff_t,
+                                            diff_dict=diff_d)
 
 class ConfigDiff(object):
     """
     The class of config changes as represented by comparison between the
     session config dict and the effective config dict.
     """
-    def __init__(self, config, key_mangling=None, diff_tree=None):
+    def __init__(self, config, key_mangling=None, diff_tree=None, diff_dict=None):
         self._level = config.get_level()
         self._session_config_dict = config.get_cached_root_dict(effective=False)
         self._effective_config_dict = config.get_cached_root_dict(effective=True)
         self._key_mangling = key_mangling
 
         self._diff_tree = diff_tree
-        self._diff_dict = diff_tree.dict if diff_tree else {}
+        self._diff_dict = diff_dict
 
     # mirrored from Config; allow path arguments relative to level
     def _make_path(self, path):
@@ -179,9 +190,9 @@ class ConfigDiff(object):
             if self._diff_tree is None:
                 raise NotImplementedError("diff_tree class not available")
             else:
-                add = get_sub_dict(self._diff_tree.dict, ['add'], get_first_key=True)
-                sub = get_sub_dict(self._diff_tree.dict, ['sub'], get_first_key=True)
-                inter = get_sub_dict(self._diff_tree.dict, ['inter'], get_first_key=True)
+                add = get_sub_dict(self._diff_dict, ['add'], get_first_key=True)
+                sub = get_sub_dict(self._diff_dict, ['sub'], get_first_key=True)
+                inter = get_sub_dict(self._diff_dict, ['inter'], get_first_key=True)
                 ret = {}
                 ret[enum_to_key(Diff.MERGE)] = session_dict
                 ret[enum_to_key(Diff.DELETE)] = get_sub_dict(sub, self._make_path(path),
@@ -254,9 +265,9 @@ class ConfigDiff(object):
             if self._diff_tree is None:
                 raise NotImplementedError("diff_tree class not available")
             else:
-                add = get_sub_dict(self._diff_tree.dict, ['add'], get_first_key=True)
-                sub = get_sub_dict(self._diff_tree.dict, ['sub'], get_first_key=True)
-                inter = get_sub_dict(self._diff_tree.dict, ['inter'], get_first_key=True)
+                add = get_sub_dict(self._diff_dict, ['add'], get_first_key=True)
+                sub = get_sub_dict(self._diff_dict, ['sub'], get_first_key=True)
+                inter = get_sub_dict(self._diff_dict, ['inter'], get_first_key=True)
                 ret = {}
                 ret[enum_to_key(Diff.MERGE)] = session_dict
                 ret[enum_to_key(Diff.DELETE)] = get_sub_dict(sub, self._make_path(path))


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Backport for Equuleus.
(cherry picked from commit d2330b00f109a9c837fc8ae6971e2f6bfa7eb372)


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe):
       Performance optimization.

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4900

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
