### PR TITLE
op-mode: T5051: use Literal types to provide op-mode CLI choices and API enums

### DIFF
--- a/op-mode-definitions/openvpn.xml.in
+++ b/op-mode-definitions/openvpn.xml.in
@@ -122,7 +122,7 @@
             <properties>
               <help>Show tunnel status for OpenVPN site-to-site interfaces</help>
             </properties>
-            <command>sudo ${vyos_op_scripts_dir}/openvpn.py show --mode site-to-site</command>
+            <command>sudo ${vyos_op_scripts_dir}/openvpn.py show --mode site_to_site</command>
           </leafNode>
         </children>
       </node>

--- a/src/op_mode/bgp.py
+++ b/src/op_mode/bgp.py
@@ -30,6 +30,7 @@ from vyos.configquery import ConfigTreeQuery
 
 import vyos.opmode
 
+ArgFamily = typing.Literal['inet', 'inet6']
 
 frr_command_template = Template("""
 {% if family %}
@@ -75,7 +76,7 @@ def _verify(func):
 
 @_verify
 def show_neighbors(raw: bool,
-                   family: str,
+                   family: ArgFamily,
                    peer: typing.Optional[str],
                    vrf: typing.Optional[str]):
     kwargs = dict(locals())

--- a/src/op_mode/conntrack.py
+++ b/src/op_mode/conntrack.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+import typing
 import xmltodict
 
 from tabulate import tabulate
@@ -23,6 +24,7 @@ from vyos.util import run
 
 import vyos.opmode
 
+ArgFamily = typing.Literal['inet', 'inet6']
 
 def _get_xml_data(family):
     """
@@ -126,7 +128,7 @@ def get_formatted_output(dict_data):
     return output
 
 
-def show(raw: bool, family: str):
+def show(raw: bool, family: ArgFamily):
     family = 'ipv6' if family == 'inet6' else 'ipv4'
     conntrack_data = _get_raw_data(family)
     if raw:

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -36,6 +36,9 @@ lease_valid_states = ['all', 'active', 'free', 'expired', 'released', 'abandoned
 sort_valid_inet = ['end', 'mac', 'hostname', 'ip', 'pool', 'remaining', 'start', 'state']
 sort_valid_inet6 = ['end', 'iaid_duid', 'ip', 'last_communication', 'pool', 'remaining', 'state', 'type']
 
+ArgFamily = typing.Literal['inet', 'inet6']
+ArgState = typing.Literal['all', 'active', 'free', 'expired', 'released', 'abandoned', 'reset', 'backup']
+
 def _utc_to_local(utc_dt):
     return datetime.fromtimestamp((datetime.fromtimestamp(utc_dt) - datetime(1970, 1, 1)).total_seconds())
 
@@ -248,7 +251,7 @@ def _verify(func):
 
 
 @_verify
-def show_pool_statistics(raw: bool, family: str, pool: typing.Optional[str]):
+def show_pool_statistics(raw: bool, family: ArgFamily, pool: typing.Optional[str]):
     pool_data = _get_raw_pool_statistics(family=family, pool=pool)
     if raw:
         return pool_data
@@ -257,8 +260,8 @@ def show_pool_statistics(raw: bool, family: str, pool: typing.Optional[str]):
 
 
 @_verify
-def show_server_leases(raw: bool, family: str, pool: typing.Optional[str],
-                       sorted: typing.Optional[str], state: typing.Optional[str]):
+def show_server_leases(raw: bool, family: ArgFamily, pool: typing.Optional[str],
+                       sorted: typing.Optional[str], state: typing.Optional[ArgState]):
     # if dhcp server is down, inactive leases may still be shown as active, so warn the user.
     if not is_systemd_service_running('isc-dhcp-server.service'):
         Warning('DHCP server is configured but not started. Data may be stale.')

--- a/src/op_mode/nat.py
+++ b/src/op_mode/nat.py
@@ -31,6 +31,8 @@ from vyos.util import dict_search
 base = 'nat'
 unconf_message = 'NAT is not configured'
 
+ArgDirection = typing.Literal['source', 'destination']
+ArgFamily = typing.Literal['inet', 'inet6']
 
 def _get_xml_translation(direction, family, address=None):
     """
@@ -298,7 +300,7 @@ def _verify(func):
 
 
 @_verify
-def show_rules(raw: bool, direction: str, family: str):
+def show_rules(raw: bool, direction: ArgDirection, family: ArgFamily):
     nat_rules = _get_raw_data_rules(direction, family)
     if raw:
         return nat_rules
@@ -307,7 +309,7 @@ def show_rules(raw: bool, direction: str, family: str):
 
 
 @_verify
-def show_statistics(raw: bool, direction: str, family: str):
+def show_statistics(raw: bool, direction: ArgDirection, family: ArgFamily):
     nat_statistics = _get_raw_data_rules(direction, family)
     if raw:
         return nat_statistics
@@ -316,8 +318,8 @@ def show_statistics(raw: bool, direction: str, family: str):
 
 
 @_verify
-def show_translations(raw: bool, direction:
-                      str, family: str,
+def show_translations(raw: bool, direction: ArgDirection,
+                      family: ArgFamily,
                       address: typing.Optional[str],
                       verbose: typing.Optional[bool]):
     family = 'ipv6' if family == 'inet6' else 'ipv4'

--- a/src/op_mode/neighbor.py
+++ b/src/op_mode/neighbor.py
@@ -32,6 +32,9 @@ import typing
 
 import vyos.opmode
 
+ArgFamily = typing.Literal['inet', 'inet6']
+ArgState = typing.Literal['reachable', 'stale', 'failed', 'permanent']
+
 def interface_exists(interface):
     import os
     return os.path.exists(f'/sys/class/net/{interface}')
@@ -88,7 +91,8 @@ def format_neighbors(neighs, interface=None):
     headers = ["Address", "Interface", "Link layer address",  "State"]
     return tabulate(neighs, headers)
 
-def show(raw: bool, family: str, interface: typing.Optional[str], state: typing.Optional[str]):
+def show(raw: bool, family: ArgFamily, interface: typing.Optional[str],
+         state: typing.Optional[ArgState]):
     """ Display neighbor table contents """
     data = get_raw_data(family, interface, state=state)
 
@@ -97,7 +101,7 @@ def show(raw: bool, family: str, interface: typing.Optional[str], state: typing.
     else:
         return format_neighbors(data, interface)
 
-def reset(family: str, interface: typing.Optional[str], address: typing.Optional[str]):
+def reset(family: ArgFamily, interface: typing.Optional[str], address: typing.Optional[str]):
     from vyos.util import run
 
     if address and interface:

--- a/src/op_mode/openvpn.py
+++ b/src/op_mode/openvpn.py
@@ -18,6 +18,7 @@
 
 import os
 import sys
+import typing
 from tabulate import tabulate
 
 import vyos.opmode
@@ -25,6 +26,8 @@ from vyos.util import bytes_to_human
 from vyos.util import commit_in_progress
 from vyos.util import call
 from vyos.config import Config
+
+ArgMode = typing.Literal['client', 'server', 'site_to_site']
 
 def _get_tunnel_address(peer_host, peer_port, status_file):
     peer = peer_host + ':' + peer_port
@@ -155,7 +158,7 @@ def _get_raw_data(mode: str) -> dict:
         d['local_port'] = conf_dict[intf].get('local-port', '')
         if conf.exists(f'interfaces openvpn {intf} server client'):
             d['configured_clients'] = conf.list_nodes(f'interfaces openvpn {intf} server client')
-        if mode in ['client', 'site-to-site']:
+        if mode in ['client', 'site_to_site']:
             for client in d['clients']:
                 if 'shared-secret-key-file' in list(conf_dict[intf]):
                     client['name'] = 'None (PSK)'
@@ -198,7 +201,7 @@ def _format_openvpn(data: dict) -> str:
 
     return out
 
-def show(raw: bool, mode: str) -> str:
+def show(raw: bool, mode: ArgMode) -> str:
     openvpn_data = _get_raw_data(mode)
 
     if raw:

--- a/src/op_mode/route.py
+++ b/src/op_mode/route.py
@@ -54,7 +54,9 @@ frr_command_template = Template("""
 {% endif %}
 """)
 
-def show_summary(raw: bool, family: str, table: typing.Optional[int], vrf: typing.Optional[str]):
+ArgFamily = typing.Literal['inet', 'inet6']
+
+def show_summary(raw: bool, family: ArgFamily, table: typing.Optional[int], vrf: typing.Optional[str]):
     from vyos.util import cmd
 
     if family == 'inet':
@@ -94,7 +96,7 @@ def show_summary(raw: bool, family: str, table: typing.Optional[int], vrf: typin
         return output
 
 def show(raw: bool,
-         family: str,
+         family: ArgFamily,
          net: typing.Optional[str],
          table: typing.Optional[int],
          protocol: typing.Optional[str],


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Use of typing.Literal in standardized op-mode scripts provides arpgparse 'choices' for the CLI script and enum types for the API.

For example, adding:

```
ArgFamily = typing.Literal["inet", "inet6"]
...
def show(raw: bool,
         family: ArgFamily,
...
```

to op-mode/route.py, may be used by opmode.py, respectively, schema_from_op_mode.py to provide:

```
root@vyos:/usr/libexec/vyos/op_mode# ./route.py show -h
usage: route.py show [-h] [--raw] --family  {inet,inet6} ...
```

respectively:

```
enum FamilyRoute {
    inet
    inet6
}

input ShowRouteInput {
    key: String
    family: FamilyRoute!
    net: String = null
    table: Int = null
    protocol: String = null
    vrf: String = null
    tag: String = null
...

```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5051

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
