### PR TITLE
T5056: Fix IPoE server template for vlan-mon

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.j2
+++ b/data/templates/accel-ppp/ipoe.config.j2
@@ -54,9 +54,9 @@ password=csid
 {% endif %}
 proxy-arp=1
 
-{% for interface in interfaces %}
-{%     if (interface.shared == '0') and (interface.vlan_mon) %}
-vlan-mon={{ interface.name }},{{ interface.vlan_mon | join(',') }}
+{% for iface, iface_options in interface.items() %}
+{%     if iface_options.network is vyos_defined('vlan') %}
+vlan-mon={{ iface }},{{ iface_options.vlan | join(',') }}
 {%     endif %}
 {% endfor %}
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
After rewriting IPoE server for config.dict the ipoe.config.j2 template wasn't changed for 'vlan-mon' section
Fix it

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5056

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service ipoe-server authentication mode 'noauth'
set service ipoe-server interface eth1 client-subnet '100.64.24.0/24'
set service ipoe-server interface eth1 network 'vlan'
set service ipoe-server interface eth1 vlan '2000-3000'
set service ipoe-server interface eth1 vlan '3001-3005'
```
Before fix (no **vlan-mon section**):
```
vyos@r14# cat /run/accel-pppd/ipoe.conf  | grep "\[ipoe" -A 7
[ipoe]
verbose=1
interface=re:eth1\.\d+,shared=0,mode=L2,ifcfg=1,range=100.64.24.0/24,start=dhcpv4,ipv6=1
noauth=1
proxy-arp=1


```
After fix:
```
vyos@r14# cat /run/accel-pppd/ipoe.conf  | grep "\[ipoe" -A 7
[ipoe]
verbose=1
interface=re:eth1\.\d+,shared=0,mode=L2,ifcfg=1,range=100.64.24.0/24,start=dhcpv4,ipv6=1
noauth=1
proxy-arp=1

vlan-mon=eth1,2000-3000,3001-3005

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
