### PR TITLE
T5055: Firewall: add packet-type matcher in firewall and route policy

### DIFF
--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -459,7 +459,7 @@
               </node>
               #include <include/firewall/common-rule.xml.i>
               #include <include/firewall/dscp.xml.i>
-              #include <include/firewall/packet-length.xml.i>
+              #include <include/firewall/packet-options.xml.i>
               #include <include/firewall/hop-limit.xml.i>
               #include <include/firewall/connection-mark.xml.i>
               <node name="icmpv6">
@@ -629,7 +629,7 @@
               </node>
               #include <include/firewall/common-rule.xml.i>
               #include <include/firewall/dscp.xml.i>
-              #include <include/firewall/packet-length.xml.i>
+              #include <include/firewall/packet-options.xml.i>
               #include <include/firewall/connection-mark.xml.i>
               <node name="icmp">
                 <properties>

--- a/interface-definitions/include/firewall/packet-options.xml.i
+++ b/interface-definitions/include/firewall/packet-options.xml.i
@@ -1,4 +1,4 @@
-<!-- include start from firewall/packet-length.xml.i -->
+<!-- include start from firewall/packet-options.xml.i -->
 <leafNode name="packet-length">
   <properties>
     <help>Payload size in bytes, including header and data to match</help>
@@ -31,6 +31,33 @@
       <validator name="numeric" argument="--allow-range --range 1-65535"/>
     </constraint>
     <multi/>
+  </properties>
+</leafNode>
+<leafNode name="packet-type">
+  <properties>
+    <help>Packet type</help>
+    <completionHelp>
+      <list>broadcast host multicast other</list>
+    </completionHelp>
+    <valueHelp>
+      <format>broadcast</format>
+      <description>Match broadcast packet type</description>
+    </valueHelp>
+    <valueHelp>
+      <format>host</format>
+      <description>Match host packet type, addressed to local host</description>
+    </valueHelp>
+    <valueHelp>
+      <format>multicast</format>
+      <description>Match multicast packet type</description>
+    </valueHelp>
+    <valueHelp>
+      <format>other</format>
+      <description>Match packet addressed to another host</description>
+    </valueHelp>
+    <constraint>
+      <regex>(broadcast|host|multicast|other)</regex>
+    </constraint>
   </properties>
 </leafNode>
 <!-- include end -->

--- a/interface-definitions/policy-route.xml.in
+++ b/interface-definitions/policy-route.xml.in
@@ -50,7 +50,7 @@
               #include <include/policy/route-common.xml.i>
               #include <include/policy/route-ipv6.xml.i>
               #include <include/firewall/dscp.xml.i>
-              #include <include/firewall/packet-length.xml.i>
+              #include <include/firewall/packet-options.xml.i>
               #include <include/firewall/hop-limit.xml.i>
               #include <include/firewall/connection-mark.xml.i>
             </children>
@@ -105,7 +105,7 @@
               #include <include/policy/route-common.xml.i>
               #include <include/policy/route-ipv4.xml.i>
               #include <include/firewall/dscp.xml.i>
-              #include <include/firewall/packet-length.xml.i>
+              #include <include/firewall/packet-options.xml.i>
               #include <include/firewall/ttl.xml.i>
               #include <include/firewall/connection-mark.xml.i>
             </children>

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -277,6 +277,9 @@ def parse_rule(rule_conf, fw_name, rule_id, ip_name):
         negated_lengths_str = ','.join(rule_conf['packet_length_exclude'])
         output.append(f'ip{def_suffix} length != {{{negated_lengths_str}}}')
 
+    if 'packet_type' in rule_conf:
+        output.append(f'pkttype ' + rule_conf['packet_type'])
+
     if 'dscp' in rule_conf:
         dscp_str = ','.join(rule_conf['dscp'])
         output.append(f'ip{def_suffix} dscp {{{dscp_str}}}')

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -227,10 +227,12 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['firewall', 'name', name, 'rule', '4', 'destination', 'port', '22'])
         self.cli_set(['firewall', 'name', name, 'rule', '4', 'recent', 'count', '10'])
         self.cli_set(['firewall', 'name', name, 'rule', '4', 'recent', 'time', 'minute'])
+        self.cli_set(['firewall', 'name', name, 'rule', '4', 'packet-type', 'host'])
         self.cli_set(['firewall', 'name', name, 'rule', '5', 'action', 'accept'])
         self.cli_set(['firewall', 'name', name, 'rule', '5', 'protocol', 'tcp'])
         self.cli_set(['firewall', 'name', name, 'rule', '5', 'tcp', 'flags', 'syn'])
         self.cli_set(['firewall', 'name', name, 'rule', '5', 'tcp', 'mss', mss_range])
+        self.cli_set(['firewall', 'name', name, 'rule', '5', 'packet-type', 'broadcast'])
         self.cli_set(['firewall', 'name', name, 'rule', '5', 'inbound-interface', 'interface-name', interface])
         self.cli_set(['firewall', 'name', name, 'rule', '6', 'action', 'return'])
         self.cli_set(['firewall', 'name', name, 'rule', '6', 'protocol', 'gre'])
@@ -249,8 +251,8 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['tcp flags syn / syn,ack', 'tcp dport 8888', 'log prefix "[smoketest-2-R]" level err', 'ip ttl > 102', 'reject'],
             ['tcp dport 22', 'limit rate 5/minute', 'return'],
             ['log prefix "[smoketest-default-D]"','smoketest default-action', 'drop'],
-            ['tcp dport 22', 'add @RECENT_smoketest_4 { ip saddr limit rate over 10/minute burst 10 packets }', 'drop'],
-            ['tcp flags & syn == syn', f'tcp option maxseg size {mss_range}', f'iifname "{interface}"'],
+            ['tcp dport 22', 'add @RECENT_smoketest_4 { ip saddr limit rate over 10/minute burst 10 packets }', 'meta pkttype host', 'drop'],
+            ['tcp flags & syn == syn', f'tcp option maxseg size {mss_range}', f'iifname "{interface}"', 'meta pkttype broadcast'],
             ['meta l4proto gre', f'oifname "{interface}"', f'ct mark {mark_hex}', 'return']
         ]
 

--- a/smoketest/scripts/cli/test_policy_route.py
+++ b/smoketest/scripts/cli/test_policy_route.py
@@ -204,6 +204,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'icmp', 'type-name', 'echo-request'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'packet-length', '128'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'packet-length', '1024-2048'])
+        self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'packet-type', 'other'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'log', 'enable'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'set', 'table', table_id])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '5', 'dscp', '41'])
@@ -226,6 +227,8 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '4', 'icmpv6', 'type', 'echo-request'])
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '4', 'packet-length-exclude', '128'])
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '4', 'packet-length-exclude', '1024-2048'])
+        self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '4', 'packet-type', 'multicast'])
+
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '4', 'log', 'enable'])
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '4', 'set', 'table', table_id])
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '5', 'dscp-exclude', '61'])
@@ -245,7 +248,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
             ['meta l4proto udp', 'drop'],
             ['tcp flags syn / syn,ack', 'meta mark set ' + mark_hex],
             ['ct state new', 'tcp dport 22', 'ip saddr 198.51.100.0/24', 'ip ttl > 2', 'meta mark set ' + mark_hex],
-            ['meta l4proto icmp', 'log prefix "[smoketest-4-A]"', 'icmp type echo-request', 'ip length { 128, 1024-2048 }', 'meta mark set ' + mark_hex],
+            ['meta l4proto icmp', 'log prefix "[smoketest-4-A]"', 'icmp type echo-request', 'ip length { 128, 1024-2048 }', 'meta pkttype other', 'meta mark set ' + mark_hex],
             ['ip dscp { 0x29, 0x39-0x3b }', 'meta mark set ' + mark_hex]
         ]
 
@@ -257,7 +260,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
             ['meta l4proto udp', 'drop'],
             ['tcp flags syn / syn,ack', 'meta mark set ' + mark_hex],
             ['ct state new', 'tcp dport 22', 'ip6 saddr 2001:db8::/64', 'ip6 hoplimit > 2', 'meta mark set ' + mark_hex],
-            ['meta l4proto ipv6-icmp', 'log prefix "[smoketest6-4-A]"', 'icmpv6 type echo-request', 'ip6 length != { 128, 1024-2048 }', 'meta mark set ' + mark_hex],
+            ['meta l4proto ipv6-icmp', 'log prefix "[smoketest6-4-A]"', 'icmpv6 type echo-request', 'ip6 length != { 128, 1024-2048 }', 'meta pkttype multicast', 'meta mark set ' + mark_hex],
             ['ip6 dscp != { 0x0e-0x13, 0x3d }', 'meta mark set ' + mark_hex]
         ]
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add pkttype matcher in firewall and route policy

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5055

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Firewall
```
vyos@vyos# run show config comm | grep fire
set firewall interface eth0 in name 'FOO'
set firewall interface eth0 local name 'FOO'
set firewall name FOO default-action 'accept'
set firewall name FOO rule 10 action 'drop'
set firewall name FOO rule 10 source address '7.7.7.7'
set firewall name FOO rule 20 action 'accept'
set firewall name FOO rule 20 packet-type 'host'
set firewall name FOO rule 20 source address '8.8.8.8'
set firewall name FOO rule 40 action 'drop'
set firewall name FOO rule 40 packet-type 'multicast'
set firewall name FOO rule 40 source address '192.168.88.0/24'
set firewall name FOO rule 50 action 'accept'
set firewall name FOO rule 50 packet-type 'broadcast'
set firewall name FOO rule 50 protocol 'icmp'
[edit]
vyos@vyos# sudo nft -S list chain ip vyos_filter NAME_FOO
table ip vyos_filter {
        chain NAME_FOO {
                ip saddr 7.7.7.7 counter packets 0 bytes 0 drop comment "FOO-10"
                ip saddr 8.8.8.8 meta pkttype host counter packets 0 bytes 0 return comment "FOO-20"
                ip saddr 192.168.88.0/24 meta pkttype multicast counter packets 0 bytes 0 drop comment "FOO-40"
                meta l4proto icmp meta pkttype broadcast counter packets 0 bytes 0 return comment "FOO-50"
                counter packets 913 bytes 175118 return comment "FOO default-action accept"
        }
}
[edit]
```
Policy:
```
vyos@vyos# run show config comm | grep route6
set policy route6 FOO6 rule 10 action 'drop'
set policy route6 FOO6 rule 10 packet-type 'multicast'
set policy route6 FOO6 rule 20 action 'accept'
set policy route6 FOO6 rule 20 packet-type 'host'
set policy route6 FOO6 rule 30 action 'accept'
set policy route6 FOO6 rule 30 packet-type 'other'
[edit]
vyos@vyos# sudo nft -S list table ip6 vyos_mangle
table ip6 vyos_mangle {
        chain VYOS_PBR6_PREROUTING {
                type filter hook prerouting priority mangle; policy accept;
        }

        chain VYOS_PBR6_POSTROUTING {
                type filter hook postrouting priority mangle; policy accept;
        }

        chain VYOS_PBR6_FOO6 {
                meta pkttype multicast counter packets 0 bytes 0 drop comment "FOO6-10"
                meta pkttype host counter packets 0 bytes 0 return comment "FOO6-20"
                meta pkttype other counter packets 0 bytes 0 return comment "FOO6-30"
        }
}
[edit]

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
