### PR TITLE
T5057: Fix IPoE regex Jinja2 for interface

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.j2
+++ b/data/templates/accel-ppp/ipoe.config.j2
@@ -25,7 +25,7 @@ verbose=1
 {%     for iface, iface_config in interface.items() %}
 {%         set tmp = 'interface=' %}
 {%         if iface_config.vlan is vyos_defined %}
-{%             set tmp = tmp ~ 're:' ~ iface ~ '\.\d+' %}
+{%             set tmp = tmp ~ 're:^' ~ iface ~ '\.' ~ iface_config.vlan | range_to_regex ~ '$' %}
 {%         else %}
 {%             set tmp = tmp ~ iface %}
 {%         endif %}
@@ -36,6 +36,9 @@ verbose=1
 {%             set shared = 'shared=0,' %}
 {%         endif %}
 {{ tmp }},{{ shared }}mode={{ iface_config.mode | upper }},ifcfg=1,range={{ iface_config.client_subnet }},start=dhcpv4,ipv6=1
+{%         if iface_config.vlan is vyos_defined %}
+vlan-mon={{ iface }},{{ iface_config.vlan | join(',') }}
+{%         endif %}
 {%     endfor %}
 {% endif %}
 {% if authentication.mode is vyos_defined('noauth') %}
@@ -53,12 +56,6 @@ username=ifname
 password=csid
 {% endif %}
 proxy-arp=1
-
-{% for iface, iface_options in interface.items() %}
-{%     if iface_options.network is vyos_defined('vlan') %}
-vlan-mon={{ iface }},{{ iface_options.vlan | join(',') }}
-{%     endif %}
-{% endfor %}
 
 {% if client_ip_pool.name is vyos_defined %}
 [ip-pool]


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix incorrect regex `'\d+'` when used vlan ranges
For example 'ipoe-server interface eth1 vlan 2000-3000'
```
  - replace 'interface=re:eth1\.\d+' 
    => 'interface=re:^eth1\.(200\d|20[1-9]\d|2[1-9]\d{2}|3000)$'
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related PR
Vlan-range regex requires to merge this https://github.com/vyos/vyos-1x/pull/1870

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5057

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service ipoe-server authentication mode 'noauth'
set service ipoe-server interface eth1 client-subnet '100.64.24.0/24'
set service ipoe-server interface eth1 network 'shared'
set service ipoe-server interface eth1 vlan '2000-3000'
```
check regex:
```
vyos@r14# cat /run/accel-pppd/ipoe.conf | grep "\[ipoe" -A 10
[ipoe]
verbose=1
interface=re:^eth1\.(200\d|20[1-9]\d|2[1-9]\d{2}|3000)$,shared=1,mode=L2,ifcfg=1,range=100.64.24.0/24,start=dhcpv4,ipv6=1
vlan-mon=eth1,2000-3000
noauth=1
proxy-arp=1
```
Check the client from any vlan in range can get address via DHCP
```
vyos@r14# run show ipoe-server sessions 
ifname | username |    calling-sid    |     ip      | rate-limit | type | comp | state  |  uptime  
--------+----------+-------------------+-------------+------------+------+------+--------+----------
 ipoe0  |          | 52:54:00:38:cc:4f | 100.64.24.2 |            | ipoe |      | active | 00:04:07
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
