### PR TITLE
T5073: IPoE-server fix parse empty range option

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.j2
+++ b/data/templates/accel-ppp/ipoe.config.j2
@@ -35,7 +35,8 @@ verbose=1
 {%         elif iface_config.network is vyos_defined('vlan') %}
 {%             set shared = 'shared=0,' %}
 {%         endif %}
-{{ tmp }},{{ shared }}mode={{ iface_config.mode | upper }},ifcfg=1,range={{ iface_config.client_subnet }},start=dhcpv4,ipv6=1
+{%         set range = 'range=' ~ iface_config.client_subnet ~ ',' if iface_config.client_subnet is vyos_defined else '' %}
+{{ tmp }},{{ shared }}mode={{ iface_config.mode | upper }},ifcfg=1,{{ range }}start=dhcpv4,ipv6=1
 {%         if iface_config.vlan is vyos_defined %}
 vlan-mon={{ iface }},{{ iface_config.vlan | join(',') }}
 {%         endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
If the `client-subnet` is not used (`service ipoe-server interface eth1 client-subnet`), we must exclude it from the `ipoe.config.j2` template.
Otherwise, we get the wrong empty parameter `',range=,'`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5073

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service ipoe-server authentication mode 'noauth'
set service ipoe-server client-ip-pool name POOL1 gateway-address '192.0.2.1'
set service ipoe-server client-ip-pool name POOL1 subnet '192.0.2.0/24'
set service ipoe-server interface eth1 vlan '2000-3000'
```
Before the fix:
```
Mar 09 09:27:07 r14 accel-ipoe[5798]: ipoe: failed to parse 're:^eth1\.(200\d|20[1-9]\d|2[1-9]\d{2}|3000)$,shared=1,mode=L2,ifcfg=1,range=,start=dhcpv4,ipv6=1'
Mar 09 09:27:08 r14 accel-ipoe[5798]: vlan-mon: notify 2 2021 0800 14
Mar 09 09:27:08 r14 accel-ipoe[5798]: ipoe: create vlan eth1.2021 parent eth1
Mar 09 09:27:08 r14 accel-ipoe[5798]: ipoe: failed to parse 're:^eth1\.(200\d|20[1-9]\d|2[1-9]\d{2}|3000)$,shared=1,mode=L2,ifcfg=1,range=,start=dhcpv4,ipv6=1'
```
After the fix:
```
Mar 09 10:13:09 r14 accel-ipoe[7986]: vlan-mon: notify 2 2023 0800 0
Mar 09 10:13:09 r14 accel-ipoe[7986]: ipoe: create vlan eth1.2023 parent eth1
Mar 09 10:13:09 r14 accel-ipoe[7986]: ipoe: start interface eth1.2023 (shared=1,mode=L2,ifcfg=1,start=dhcpv4,ipv6=1)
Mar 09 10:13:12 r14 accel-ipoe[7986]: eth1.2023:: recv [DHCPv4 Discover xid=66c05343 chaddr=52:54:00:38:cc:4f <Message-Type Discover> <Host-Name r1> <Request-List Subnet,Broadcast,Router,DNS,Classless-Route,Domain-Name,MTU>]
Mar 09 10:13:12 r14 accel-ipoe[7986]: ipoe0:: create interface ipoe0 parent eth1.2023
Mar 09 10:13:12 r14 accel-ipoe[7986]: ipoe0:: (null): authentication succeeded
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
