### PR TITLE
T5066: Fix GRE tunnel variable name for verify check keys

### DIFF
--- a/src/conf_mode/interfaces-tunnel.py
+++ b/src/conf_mode/interfaces-tunnel.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2022 yOS maintainers and contributors
+# Copyright (C) 2018-2023 yOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -115,7 +115,7 @@ def verify(tunnel):
             if our_key != None:
                 if their_address == our_address and their_key == our_key:
                     raise ConfigError(f'Key "{our_key}" for source-address "{our_address}" ' \
-                                      f'is already used for tunnel "{tunnel_if}"!')
+                                      f'is already used for tunnel "{o_tunnel}"!')
             else:
                 our_source_if = dict_search('source_interface', tunnel)
                 their_source_if = dict_search('source_interface', o_tunnel_conf)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix GRE tunnel variable name for verify check keys
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5066

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
gre, tunnel
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Use the same key for tunnels
```
set interfaces tunnel tun0 address '192.168.0.15/24'
set interfaces tunnel tun0 encapsulation 'gre'
set interfaces tunnel tun0 parameters ip key '10'
set interfaces tunnel tun0 remote '192.168.0.10'
set interfaces tunnel tun0 source-address '192.168.0.15'

set interfaces tunnel tun1 address '192.168.0.15/24'
set interfaces tunnel tun1 encapsulation 'gre'
set interfaces tunnel tun1 parameters ip key '10'
set interfaces tunnel tun1 remote '192.168.0.10'
set interfaces tunnel tun1 source-address '192.168.0.15'
```
Commit before fix:
```
Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/interfaces-tunnel.py", line 194, in <module>
    verify(c)
  File "/usr/libexec/vyos/conf_mode/interfaces-tunnel.py", line 117, in verify
    raise ConfigError(f'Key "{our_key}" for source-address "{our_address}" ' \
NameError: name 'tunnel_if' is not defined



[[interfaces tunnel tun1]] failed
Commit failed
[edit]
vyos@r1# 

```
Commit after the fix:
```
vyos@r1# commit
[ interfaces tunnel tun0 ]
Key "10" for source-address "192.168.0.15" is already used for tunnel
"tun1"!

[[interfaces tunnel tun0]] failed
[ interfaces tunnel tun1 ]
Key "10" for source-address "192.168.0.15" is already used for tunnel
"tun0"!

[[interfaces tunnel tun1]] failed
Commit failed
[edit]
vyos@r1# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
