### PR TITLE
T5063: IPoE-server ethX vlan must not be used with client-subnet

### DIFF
--- a/src/conf_mode/service_ipoe-server.py
+++ b/src/conf_mode/service_ipoe-server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2022 VyOS maintainers and contributors
+# Copyright (C) 2018-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -53,8 +53,11 @@ def verify(ipoe):
     if 'interface' not in ipoe:
         raise ConfigError('No IPoE interface configured')
 
-    for interface in ipoe['interface']:
+    for interface, iface_config in ipoe['interface'].items():
         verify_interface_exists(interface)
+        if 'client_subnet' in iface_config and 'vlan' in iface_config:
+            raise ConfigError('Option "client-subnet" incompatible with "vlan"!'
+                              'Use "ipoe client-ip-pool" instead.')
 
     #verify_accel_ppp_base_service(ipoe, local_users=False)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
IPoE-server 'interface ethX vlan xxx' (aka vlan-mon) must not be used with 'interface ethX client-subnet'
So instead of a shared pool accel-ppp uses the same pool for each dynamically added VLAN

  eth1 client-subnet '192.0.2.0/24'
  eth1 vlan '2000-2021'

It cause this issue:
eth1.2000 range 192.0.2.0/24 (the first client gets address from 192.0.2.2) 
eth2.2001 range 192.0.2.0/24 (the first client gets address from 192.0.2.2)
...

Only named pools with vlan option must be used.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5063

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
