### PR TITLE
T5070: Added show bgp martian/show bgp nexthop to bgp in vrf

### DIFF
--- a/op-mode-definitions/show-bgp.xml.in
+++ b/op-mode-definitions/show-bgp.xml.in
@@ -100,6 +100,40 @@
             <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
             <children>
               #include <include/bgp/show-bgp-common.xml.i>
+              <node name="martian">
+                <properties>
+                  <help>martian next-hops</help>
+                </properties>
+                <children>
+                  <leafNode name="next-hop">
+                    <properties>
+                      <help>martian next-hop database</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                  </leafNode>
+                </children>
+              </node>
+              <node name="nexthop">
+                <properties>
+                  <help>Show BGP nexthop table</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                <children>
+                  #include <include/vtysh-generic-detail.xml.i>
+                </children>
+              </node>
+              <tagNode name="nexthop">
+                <properties>
+                  <help>IPv4/IPv6 nexthop address</help>
+                  <completionHelp>
+                    <list>&lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                <children>
+                  #include <include/vtysh-generic-detail.xml.i>
+                </children>
+              </tagNode>
             </children>
           </tagNode>
           #include <include/vtysh-generic-wide.xml.i>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Adds nexthop related commands (show bgp nexthop, show bgp martian next-hop) to the CLI for BGP instances running in VRFs.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5070

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp

## Proposed changes
<!--- Describe your changes in detail -->
Adds XML interface definitions.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
After configuring an in-vrf BGP instance, the following commands are now available:

```
$ sh bgp vrf bgp martian next-hop
self nexthop database:
Tunnel-ip database:

$ sh bgp vrf bgp nexthop
...

$ sh bgp vrf bgp nexthop 2001:DB8::1
specified nexthop does not have entry
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
