### PR TITLE
util: T5074: Fixed decoding of certificate value to UTF-8 string

### DIFF
--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -874,12 +874,16 @@ def convert_data(data):
     Returns:
         str | list | dict: converted data
     """
+    from base64 import b64encode
     from collections import OrderedDict
 
     if isinstance(data, str):
         return data
     if isinstance(data, bytes):
-        return data.decode()
+        try:
+            return data.decode()
+        except UnicodeDecodeError:
+            return b64encode(data).decode()
     if isinstance(data, list):
         list_tmp = []
         for item in data:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed decoding of certificate value returned by vici to UTF-8 string.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5074

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
util

## Proposed changes
<!--- Describe your changes in detail -->
Fixed decoding of certificate value returned by vici to UTF-8 string.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
According to the task returned certificate value by vici is
```
                             b'0\x82\x03\xb50\x82\x02\x9d\xa0\x03\x02\x01'
                             b'\x02\x02\x14fM\x9cE0\xf2\x8be\x89'
                             b'\xb9\xdf\xb3\x97#=\xae\x8d\xd5\xf7\x820\r\x06\t*'
                             b'\x86H\x86\xf7\r\x01\x01\x0b\x05\x000W1\x0b0\t'
                             b'\x06\x03U\x04\x06\x13\x02GB1\x130\x11\x06\x03U'
                             b'\x04\x08\x0c\nSome-State1\x120\x10\x06\x03'
                             b'U\x04\x07\x0c\tSome-City1\r0\x0b\x06\x03'
                             b'U\x04\n\x0c\x04VyOS1\x100\x0e\x06\x03U'
                             b'\x04\x03\x0c\x07vyos.io0\x1e\x17\r230301110602Z'
                             b'\x17\r240229110602Z0[1\x0b0\t\x06\x03U'
                             b'\x04\x06\x13\x02GB1\x130\x11\x06\x03'
                             b'U\x04\x08\x0c\nSome-State1\x120\x10\x06'
                             b'\x03U\x04\x07\x0c\tSome-City1\r0\x0b\x06'
                             b'\x03U\x04\n\x0c\x04VyOS1\x140\x12\x06\x03'
                             b'U\x04\x03\x0c\x0bvpn.vyos.io0\x82\x01"0\r\x06\t'
                             b'*\x86H\x86\xf7\r\x01\x01\x01\x05\x00\x03'
                             b'\x82\x01\x0f\x000\x82\x01\n\x02\x82\x01\x01'
                             b'\x00\xcc\xdd\xfeT\x7f\xb9\x1f\xa9-\xe0\x8f'
                             b'\xcd\x81\xab:\xf1\x85tTS\xca\xc5P'
                             b'\x9e\xd9\x96\xe2\xdb9\xf7j\xd8\xfd\xa4\x9b'
                             b'5\xa8\xf1z\xc2\xe5\xdb\x13\x04>4\xf1x\xa7`\xbc'
                             b'\xc5\xf90$\xee\x18\x12\x83\x84\x84o\xde'
                             b'5\xe7E\x94,\xbb\xe5\xdb\x9e\xd8\xd4\xad'
                             b'\n\x0e\x1f\x0c\nh\xca\x9c\x97:\xeb\xc1'
                             b'\x8c\xfa\x96g\xbcP\x9fC\xc4m\xb7\xa6'
                             b'\xcd1\x83\x03\xb5\x939\r\x17\xf8\x136'
                             b'\xed\x0b&\xa8\xc2<\xe6\x1f; \x83\xb3'
                             b'\x19\x0c\xf8\xe0\x93\xba\x9d"d\xc0.\x06'
                             b'|\x16\xd5\x80KQ\xce~\xec\xa48U\xb6]\xb3:'
                             b'\x8d\xb1i\x18\xc3p\xf9\x19\x04\xab\xfap'
                             b'\xf8\xa2\xcc7\xed\\\xa5;\xc4\xc7\x9a\x89'
                             b'\x0c3\x99\x81\xa2\x97:\xc68\x0b\xf3Loe\xc6v'
                             b'\xe2\xe5`Bo\xaf)d/\x91\x8d\x02i\xa8\xf4\xbe'
                             b'U\\\x80\x01\xc1\xee\x1d\x1e|\x8bb{tY\xa6j'
                             b'\xc4<\x0f\xcek\x82\x99~/]\xbc0\xbb\xf3\xc8\xa5'
                             b'@\x182\x1a,_r\xae\xa6\xc2,y\x99\xf5\xb3}'
                             b'M\x02\x03\x01\x00\x01\xa3u0s0\x0c\x06\x03U\x1d'
                             b'\x13\x01\x01\xff\x04\x020\x000\x0e\x06\x03'
                             b'U\x1d\x0f\x01\x01\xff\x04\x04\x03\x02\x07\x80'
                             b'0\x13\x06\x03U\x1d%\x04\x0c0\n\x06\x08+\x06\x01'
                             b'\x05\x05\x07\x03\x010\x1d\x06\x03U\x1d\x0e'
                             b'\x04\x16\x04\x14\xfcGLQ\xf8\x17[\xb4\x88a\x95z'
                             b'rV\xcc\x8c\x88\xf8\xa2p0\x1f\x06\x03U\x1d#\x04'
                             b'\x180\x16\x80\x14I\xe2\x10\xe4\xd3\x16$'
                             b'\xd1\xb88\xea\xe5\x91\x0fR\xbe\xc11\x1dx0\r\x06'
                             b'\t*\x86H\x86\xf7\r\x01\x01\x0b\x05\x00'
                             b'\x03\x82\x01\x01\x00-9\x0b\x9b\x9f\xb9\x9a'
                             b')U_\x0b\xf2\xa7\xfdt\xc8\xddW\xc3g)\x10O'
                             b'\x9b+\xf5\xa1\xe6\x1d\x88\xb2\x88^SL'
                             b'\x0e\x15T\xfb\xfb\xd9lOFb@BF\xa7:v'
                             b'\xc0\xa6\xd0\xbf\xa7+\x9b0\xa7\xddR\xec'
                             b'\x8c\x95\xd9\xb0\x18G\x7f \xcd\xf8\xd7\xba'
                             b'73\x1d\xc5\xd5YD\xe0\xeb\x12\x1e\xce'
                             b'-\xc4\x9b\x15Y\xc2D \xe3J&\xdc\xa3`\x94;'
                             b'\x93+k\xcc\x16Fl\t]\x8fh\x8c\xc8\xb6\x9am'
                             b'\x04>\xce\xcc\xbb\x8e\xa2+w\x19y\xf3'
                             b'\xa2L\x87\xeeAW\xb3\xab\xebD\xb4\xf3'
                             b"\x1a(\xd6\x99\xd7\xa3'L\x81'\x14\xe0\x08\xb0Xs"
                             b'\xf8\x91\xd2JZ\xc5\\\x99\xf0\x9c\xfbO$\xf9)\xb8'
                             b'!)+;f\xbe\xcbc\x8aH+\xfb\xd5\xbd\xe2\xbb'
                             b'\xabu\xb5c\xe1W\x11^5\x06\xd4K}\n\x8aW'
                             b"\xe7\xd0\xdf\xf6\xf9\xaf\x05t'\x7f%]97\xef\x15"
                             b'\xc9r\xe5TA\xdb\xf9\x1f\x90\xb5\xb0\xcb'
                             b'J\xc4\x8a\xac\xea\xb8\x82d\r\x14\xdb\xb0'
                             b"\xaa%\x11\x80y'$\x8dw"
```
Before fix decode function returns an exception:
`'utf-8' codec can't decode byte 0x82 in position 1: invalid start byte`

After fix value is: 
```
MIIDtTCCAp2gAwIBAgIUZk2cRTDyi2WJud+zlyM9ro3V94IwDQYJKoZIhvcNAQELBQAwVzELMAkGA1UEBhMCR0IxEzARBgNVBAgMClNvbWUtU3RhdGUxEjAQBgNVBAcMCVNvbWUtQ2l0eTENMAsGA1UECgwEVnlPUzEQMA4GA1UEAwwHdnlvcy5pbzAeFw0yMzAzMDExMTA2MDJaFw0yNDAyMjkxMTA2MDJaMFsxCzAJBgNVBAYTAkdCMRMwEQYDVQQIDApTb21lLVN0YXRlMRIwEAYDVQQHDAlTb21lLUNpdHkxDTALBgNVBAoMBFZ5T1MxFDASBgNVBAMMC3Zwbi52eW9zLmlvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzN3+VH+5H6kt4I/Ngas68YV0VFPKxVCe2Zbi2zn3atj9pJs1qPF6wuXbEwQ+NPF4p2C8xfkwJO4YEoOEhG/eNedFlCy75due2NStCg4fDApoypyXOuvBjPqWZ7xQn0PEbbemzTGDA7WTOQ0X+BM27QsmqMI85h87IIOzGQz44JO6nSJkwC4GfBbVgEtRzn7spDhVtl2zOo2xaRjDcPkZBKv6cPiizDftXKU7xMeaiQwzmYGilzrGOAvzTG9lxnbi5WBCb68pZC+RjQJpqPS+VVyAAcHuHR58i2J7dFmmasQ8D85rgpl+L128MLvzyKVAGDIaLF9yrqbCLHmZ9bN9TQIDAQABo3UwczAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDATAdBgNVHQ4EFgQU/EdMUfgXW7SIYZV6clbMjIj4onAwHwYDVR0jBBgwFoAUSeIQ5NMWJNG4OOrlkQ9SvsExHXgwDQYJKoZIhvcNAQELBQADggEBAC05C5ufuZopVV8L8qf9dMjdV8NnKRBPmyv1oeYdiLKIXlNMDhVU+/vZbE9GYkBCRqc6dsCm0L+nK5swp91S7IyV2bAYR38gzfjXujczHcXVWUTg6xIezi3EmxVZwkQg40om3KNglDuTK2vMFkZsCV2PaIzItpptBD7OzLuOoit3GXnzokyH7kFXs6vrRLTzGijWmdejJ0yBJxTgCLBYc/iR0kpaxVyZ8Jz7TyT5KbghKSs7Zr7LY4pIK/vVveK7q3W1Y+FXEV41BtRLfQqKV+fQ3/b5rwV0J38lXTk37xXJcuVUQdv5H5C1sMtKxIqs6riCZA0U27CqJRGAeSckjXc=
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
