### PR TITLE
T5058: Fix range_to_regex list argument

### DIFF
--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -675,7 +675,10 @@ def range_to_regex(num_range):
     if isinstance(num_range, list):
         data = []
         for entry in num_range:
-            data.append(range_to_regex(entry))
+            if '-' not in entry:
+                data.append(entry)
+            else:
+                data.append(range_to_regex(entry))
         return f'({"|".join(data)})'
 
     if '-' not in num_range:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Values of the list for the 'range_to_regex' could be not only range values as ['10-20', '22-30'] but also not range 
values like ['10-20', '30', '80']
Fix if we args is a list and non-range values exist in this list

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5058

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
template, range_to_regex
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Before fix:
```
>>> from vyos.template import range_to_regex
>>> 
>>> range_to_regex(['10-20'])
'(1\\d|20)'
>>> 
>>> 
>>> range_to_regex(['10-20', '80'])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/vyos/template.py", line 679, in range_to_regex
    return f'({"|".join(data)})'
               ^^^^^^^^^^^^^^
TypeError: sequence item 1: expected str instance, NoneType found
>>> 
>>> 
```
After the fix:
```
>>> range_to_regex(['10-20', '80'])
'(1\\d|20|80)'
>>> 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
