### PR TITLE
T5058: Fix IPoE regex Jinja2 for interface 

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.tmpl
+++ b/data/templates/accel-ppp/ipoe.config.tmpl
@@ -26,7 +26,7 @@ verbose=1
 {% for interface in interfaces %}
 {%   set ifname = interface.name %}
 {%   if interface.vlan_mon %}
-{%     set ifname = 're:' ~ interface.name ~ '\.\d+' %}
+{%     set ifname = 're:^' ~ interface.name ~ '\.' ~ interface.vlan_mon | range_to_regex ~ '$' %}
 {%   endif %}
 interface={{ ifname }},shared={{ interface.shared }},mode={{ interface.mode }},ifcfg={{ interface.ifcfg }}{{ ',range=' ~ interface.range if interface.range is defined and interface.range is not none }},start={{ interface.sess_start }},ipv6=1
 {% endfor %}

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -362,3 +362,28 @@ def get_ipv4(interface):
     """ Get interface IPv4 addresses"""
     from vyos.ifconfig import Interface
     return Interface(interface).get_addr_v4()
+
+@register_filter('range_to_regex')
+def range_to_regex(num_range):
+    """Convert range of numbers or list of ranges
+       to regex
+       % range_to_regex('11-12')
+       '(1[1-2])'
+       % range_to_regex(['11-12', '14-15'])
+       '(1[1-2]|1[4-5])'
+    """
+    from vyos.range_regex import range_to_regex
+    if isinstance(num_range, list):
+        data = []
+        for entry in num_range:
+            if '-' not in entry:
+                data.append(entry)
+            else:
+                data.append(range_to_regex(entry))
+        return f'({"|".join(data)})'
+
+    if '-' not in num_range:
+        return num_range
+
+    regex = range_to_regex(num_range)
+    return f'({regex})'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add template filter `range_to_regex`
Fix IPoE regex Jinja2 for **interface**
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5058
* https://vyos.dev/T5057

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set service ipoe-server authentication mode 'noauth'
set service ipoe-server interface eth1 client-subnet '100.64.24.0/24'
set service ipoe-server interface eth1 network 'vlan'
set service ipoe-server interface eth1 vlan-range '2000-3000'
```
Before fixing incorrect regex **re:eth1\.\d+**
```
[ipoe]
verbose=1
interface=re:eth1\.\d+,shared=0,mode=L2,ifcfg=1,range=100.64.24.0/24,start=dhcpv4,ipv6=1
```
After fix:
```
[ipoe]
verbose=1
interface=re:^eth1\.(200\d|20[1-9]\d|2[1-9]\d{2}|3000)$,shared=0,mode=L2,ifcfg=1,range=100.64.24.0/24,start=dhcpv4,ipv6=1
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
