### PR TITLE
T2516: Exclude veth interfaces from duplex and speed check

### DIFF
--- a/python/vyos/ethtool.py
+++ b/python/vyos/ethtool.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2022 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2021-2023 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -21,7 +21,7 @@ from vyos.util import popen
 # These drivers do not support using ethtool to change the speed, duplex, or
 # flow control settings
 _drivers_without_speed_duplex_flow = ['vmxnet3', 'virtio_net', 'xen_netfront',
-                                      'iavf', 'ice', 'i40e', 'hv_netvsc']
+                                      'iavf', 'ice', 'i40e', 'hv_netvsc', 'veth']
 
 class Ethtool:
     """


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Exclude interfaces with **veth** driver from duplex and speed check
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T2516

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
veth, duplex
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Deploy VyOS in container and attach veth interface to container
Change any ethernet settings
Before fix
```
vyos@91800359325b# compare 
[interfaces ethernet eth0]
- description "fof"
+ description "WAN"

[edit]
vyos@91800359325b# 
[edit]
vyos@91800359325b# commit
[ interfaces ethernet eth0 ]
sudo: unable to resolve host 91800359325b: System error
VyOS had an issue completing a command.

We are sorry that you encountered a problem while using VyOS.
There are a few things you can do to help us (and yourself):
- Contact us using the online help desk if you have a subscription:
  https://support.vyos.io/
- Make sure you are running the latest version of VyOS available at:
  https://vyos.net/get/
- Consult the community forum to see how to handle this issue:
  https://forum.vyos.io
- Join us on Slack where our users exchange help and advice:
  https://vyos.slack.com

When reporting problems, please include as much information as possible:
- do not obfuscate any data (feel free to contact us privately if your 
  business policy requires it)
- and include all the information presented below

Report time:      2023-03-13 13:30:14
Image version:    VyOS 1.4-rolling-202303120743
Release train:    current

Built by:         autobuild@vyos.net
Built on:         Sun 12 Mar 2023 07:43 UTC
Build UUID:       f0413059-7c5d-4744-a466-367e167102a2
Build commit ID:  fdc0441a77f010

Architecture:     x86_64
Boot via:         installed image
System type:       guest

Hardware vendor:  QEMU
Hardware model:   Standard PC (Q35 + ICH9, 2009)
Hardware S/N:     
Hardware UUID:    4d6f4d29-1ae8-446f-8d2b-3decd9da64c7

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/interfaces-ethernet.py", line 220, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/interfaces-ethernet.py", line 209, in apply
    e.update(ethernet)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/ethernet.py", line 374, in update
    self.set_speed_duplex(speed, duplex)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/ethernet.py", line 172, in set_speed_duplex
    return self._cmd(cmd)
           ^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/control.py", line 52, in _cmd
    return cmd(command, self.debug)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/util.py", line 161, in cmd
    raise OSError(code, feedback)
OSError: [Errno 75] failed to run command: ethtool --change eth0 autoneg on
returned: 
exit code: 75

noteworthy:
cmd 'ethtool --show-ring eth0'
returned (out):

returned (err):
netlink error: Operation not supported
cmd 'ethtool --show-pause eth0'
returned (out):

returned (err):
netlink error: Operation not supported
cmd 'ethtool --show-ring eth0'
returned (out):

returned (err):
netlink error: Operation not supported
cmd 'ethtool --show-pause eth0'
returned (out):

returned (err):
netlink error: Operation not supported
cmd 'ethtool --change eth0 autoneg on'
returned (out):

returned (err):
netlink error: Operation not supported

[[interfaces ethernet eth0]] failed
Commit failed
[edit]
vyos@91800359325b# 
```
After fix:
```
vyos@91800359325b# set interfaces ethernet eth0 address 192.0.2.5/24
[edit]
vyos@91800359325b# commit
[ interfaces ethernet eth0 ]
sudo: unable to resolve host 91800359325b: System error

[edit]
vyos@91800359325b# run show int
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
eth0             192.0.2.5/24                      u/u  WAN
lo               127.0.0.1/8                       u/u  
                 ::1/128                                
[edit]
vyos@91800359325b# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
