### PR TITLE
T5055: NAT: extend packet-type to NAT 

### DIFF
--- a/interface-definitions/include/nat-rule.xml.i
+++ b/interface-definitions/include/nat-rule.xml.i
@@ -31,6 +31,33 @@
         <valueless/>
       </properties>
     </leafNode>
+    <leafNode name="packet-type">
+      <properties>
+        <help>Packet type</help>
+        <completionHelp>
+          <list>broadcast host multicast other</list>
+        </completionHelp>
+        <valueHelp>
+          <format>broadcast</format>
+          <description>Match broadcast packet type</description>
+        </valueHelp>
+        <valueHelp>
+          <format>host</format>
+          <description>Match host packet type, addressed to local host</description>
+        </valueHelp>
+        <valueHelp>
+          <format>multicast</format>
+          <description>Match multicast packet type</description>
+        </valueHelp>
+        <valueHelp>
+          <format>other</format>
+          <description>Match packet addressed to another host</description>
+        </valueHelp>
+        <constraint>
+          <regex>(broadcast|host|multicast|other)</regex>
+        </constraint>
+      </properties>
+    </leafNode>
     <leafNode name="protocol">
       <properties>
         <help>Protocol to NAT</help>

--- a/python/vyos/nat.py
+++ b/python/vyos/nat.py
@@ -47,6 +47,9 @@ def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
             protocol = '{ tcp, udp }'
         output.append(f'meta l4proto {protocol}')
 
+    if 'packet_type' in rule_conf:
+        output.append(f'pkttype ' + rule_conf['packet_type'])
+
     if 'exclude' in rule_conf:
         translation_str = 'return'
         log_suffix = '-EXCL'

--- a/smoketest/scripts/cli/test_nat.py
+++ b/smoketest/scripts/cli/test_nat.py
@@ -194,12 +194,13 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
         self.cli_set(dst_path + ['rule', '1', 'inbound-interface', 'eth1'])
         self.cli_set(dst_path + ['rule', '1', 'destination', 'port', '443'])
         self.cli_set(dst_path + ['rule', '1', 'protocol', 'tcp'])
+        self.cli_set(dst_path + ['rule', '1', 'packet-type', 'host'])
         self.cli_set(dst_path + ['rule', '1', 'translation', 'port', '443'])
 
         self.cli_commit()
 
         nftables_search = [
-            ['iifname "eth1"', 'tcp dport 443', 'dnat to :443']
+            ['iifname "eth1"', 'tcp dport 443', 'pkttype host', 'dnat to :443']
         ]
 
         self.verify_nftables(nftables_search, 'ip vyos_nat')


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5055

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
NAT

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos# run show config comm | grep nat
set nat destination rule 10 destination port '5122'
set nat destination rule 10 inbound-interface 'eth0'
set nat destination rule 10 packet-type 'host'
set nat destination rule 10 protocol 'tcp'
set nat destination rule 10 translation address '198.51.100.77'
set nat destination rule 10 translation port '22'
set nat destination rule 20 inbound-interface 'eth1'
set nat destination rule 20 packet-type 'broadcast'
set nat destination rule 20 translation address '1.2.3.4'
set nat source rule 10 exclude
set nat source rule 10 outbound-interface 'eth1'
set nat source rule 10 packet-type 'other'
set nat source rule 10 source address '203.0.113.25'
[edit]
vyos@vyos# sudo nft -s list table ip vyos_nat
table ip vyos_nat {
        chain PREROUTING {
                type nat hook prerouting priority dstnat; policy accept;
                counter jump VYOS_PRE_DNAT_HOOK
                iifname "eth0" meta pkttype host tcp dport 5122 counter dnat to 198.51.100.77:22 comment "DST-NAT-10"
                iifname "eth1" meta pkttype broadcast counter dnat to 1.2.3.4 comment "DST-NAT-20"
        }

        chain POSTROUTING {
                type nat hook postrouting priority srcnat; policy accept;
                counter jump VYOS_PRE_SNAT_HOOK
                oifname "eth1" meta pkttype other ip saddr 203.0.113.25 counter return comment "SRC-NAT-10"
        }


```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
