### PR TITLE
T5086: Add sFlow feature based on hsflowd

### DIFF
--- a/data/configd-include.json
+++ b/data/configd-include.json
@@ -74,6 +74,7 @@
 "system-logs.py",
 "system-option.py",
 "system-proxy.py",
+"system_sflow.py",
 "system_sysctl.py",
 "system-syslog.py",
 "system-timezone.py",

--- a/data/templates/sflow/hsflowd.conf.j2
+++ b/data/templates/sflow/hsflowd.conf.j2
@@ -1,0 +1,28 @@
+# Genereated by /usr/libexec/vyos/conf_mode/system_sflow.py
+# Parameters http://sflow.net/host-sflow-linux-config.php
+
+sflow {
+{% if polling is vyos_defined %}
+  polling={{ polling }}
+{% endif %}
+{% if sampling_rate is vyos_defined %}
+  sampling={{ sampling_rate }}
+  sampling.bps_ratio=0
+{% endif %}
+{% if agent_address is vyos_defined %}
+  agentIP={{ agent_address }}
+{% endif %}
+{% if agent_interface is vyos_defined %}
+  agent={{ agent_interface }}
+{% endif %}
+{% if server is vyos_defined %}
+{%     for server, server_config in server.items() %}
+  collector { ip = {{ server }} udpport = {{ server_config.port }} }
+{%     endfor %}
+{% endif %}
+{% if interface is vyos_defined %}
+{%     for iface in interface %}
+  pcap { dev={{ iface }} }
+{%     endfor %}
+{% endif %}
+}

--- a/data/templates/sflow/override.conf.j2
+++ b/data/templates/sflow/override.conf.j2
@@ -1,0 +1,16 @@
+[Unit]
+After=
+After=vyos-router.service
+ConditionPathExists=
+ConditionPathExists=/run/sflow/hsflowd.conf
+
+[Service]
+EnvironmentFile=
+ExecStart=
+ExecStart=/usr/sbin/hsflowd -m %m -d -f /run/sflow/hsflowd.conf
+WorkingDirectory=
+WorkingDirectory=/run/sflow
+PIDFile=
+PIDFile=/run/sflow/hsflowd.pid
+Restart=always
+RestartSec=10

--- a/debian/control
+++ b/debian/control
@@ -64,6 +64,7 @@ Depends:
   libpam-google-authenticator,
   grc,
   hostapd,
+  hsflowd,
   hvinfo,
   igmpproxy,
   ipaddrcheck,

--- a/interface-definitions/system-sflow.xml.in
+++ b/interface-definitions/system-sflow.xml.in
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- sflow configuration -->
+<interfaceDefinition>
+  <node name="system">
+    <children>
+      <node name="sflow" owner="${vyos_conf_scripts_dir}/system_sflow.py">
+        <properties>
+          <help>sFlow settings</help>
+          <priority>990</priority>
+        </properties>
+        <children>
+          <leafNode name="agent-address">
+            <properties>
+              <help>sFlow agent IPv4 or IPv6 address</help>
+              <completionHelp>
+                <list>auto</list>
+                <script>${vyos_completion_dir}/list_local_ips.sh --both</script>
+              </completionHelp>
+              <valueHelp>
+                <format>ipv4</format>
+                <description>sFlow IPv4 agent address</description>
+              </valueHelp>
+              <valueHelp>
+                <format>ipv6</format>
+                <description>sFlow IPv6 agent address</description>
+              </valueHelp>
+              <constraint>
+                <validator name="ipv4-address"/>
+                <validator name="ipv6-address"/>
+                <validator name="ipv6-link-local"/>
+              </constraint>
+            </properties>
+          </leafNode>
+          <leafNode name="agent-interface">
+            <properties>
+              <help>IP address associated with this interface</help>
+              <completionHelp>
+                <script>${vyos_completion_dir}/list_interfaces</script>
+              </completionHelp>
+              <valueHelp>
+                <format>txt</format>
+                <description>Interface name</description>
+              </valueHelp>
+              <constraint>
+                #include <include/constraint/interface-name.xml.in>
+              </constraint>
+            </properties>
+          </leafNode>
+          #include <include/generic-interface-multi.xml.i>
+          <leafNode name="polling">
+            <properties>
+              <help>Schedule counter-polling in seconds</help>
+              <valueHelp>
+                <format>u32:1-600</format>
+                <description>Polling rate in seconds</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 1-600"/>
+              </constraint>
+            </properties>
+            <defaultValue>30</defaultValue>
+          </leafNode>
+          <leafNode name="sampling-rate">
+            <properties>
+              <help>sFlow sampling-rate</help>
+              <valueHelp>
+                <format>u32:1-65535</format>
+                <description>Sampling rate (1 in N packets)</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 1-65535"/>
+              </constraint>
+            </properties>
+            <defaultValue>1000</defaultValue>
+          </leafNode>
+          <tagNode name="server">
+            <properties>
+              <help>sFlow destination server</help>
+              <valueHelp>
+                <format>ipv4</format>
+                <description>IPv4 server to export sFlow</description>
+              </valueHelp>
+              <valueHelp>
+                <format>ipv6</format>
+                <description>IPv6 server to export sFlow</description>
+              </valueHelp>
+              <constraint>
+                <validator name="ipv4-address"/>
+                <validator name="ipv6-address"/>
+              </constraint>
+            </properties>
+            <children>
+              #include <include/port-number.xml.i>
+              <leafNode name="port">
+                <defaultValue>6343</defaultValue>
+              </leafNode>
+            </children>
+          </tagNode>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/smoketest/scripts/cli/test_system_sflow.py
+++ b/smoketest/scripts/cli/test_system_sflow.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from base_vyostest_shim import VyOSUnitTestSHIM
+
+from vyos.configsession import ConfigSessionError
+from vyos.ifconfig import Section
+from vyos.util import cmd
+from vyos.util import process_named_running
+from vyos.util import read_file
+
+PROCESS_NAME = 'hsflowd'
+base_path = ['system', 'sflow']
+
+hsflowd_conf = '/run/sflow/hsflowd.conf'
+
+
+class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestSystemFlowAccounting, cls).setUpClass()
+
+        # ensure we can also run this test on a live system - so lets clean
+        # out the current configuration :)
+        cls.cli_delete(cls, base_path)
+
+    def tearDown(self):
+        # after service removal process must no longer run
+        self.assertTrue(process_named_running(PROCESS_NAME))
+
+        self.cli_delete(base_path)
+        self.cli_commit()
+
+        # after service removal process must no longer run
+        self.assertFalse(process_named_running(PROCESS_NAME))
+
+    def test_sflow(self):
+        agent_address = '192.0.2.5'
+        agent_interface = 'eth0'
+        polling = '24'
+        sampling_rate = '128'
+        server = '192.0.2.254'
+        port = '8192'
+
+        self.cli_set(
+            ['interfaces', 'dummy', 'dum0', 'address', f'{agent_address}/24'])
+        self.cli_set(base_path + ['agent-address', agent_address])
+        self.cli_set(base_path + ['agent-interface', agent_interface])
+
+        # You need to configure at least one interface for sflow
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        for interface in Section.interfaces('ethernet'):
+            self.cli_set(base_path + ['interface', interface])
+
+        self.cli_set(base_path + ['polling', polling])
+        self.cli_set(base_path + ['sampling-rate', sampling_rate])
+        self.cli_set(base_path + ['server', server, 'port', port])
+
+        # commit changes
+        self.cli_commit()
+
+        # verify configuration
+        hsflowd = read_file(hsflowd_conf)
+
+        self.assertIn(f'polling={polling}', hsflowd)
+        self.assertIn(f'sampling={sampling_rate}', hsflowd)
+        self.assertIn(f'agentIP={agent_address}', hsflowd)
+        self.assertIn(f'agent={agent_interface}', hsflowd)
+        self.assertIn(f'collector {{ ip = {server} udpport = {port} }}', hsflowd)
+
+        for interface in Section.interfaces('ethernet'):
+            self.assertIn(f'pcap {{ dev={interface} }}', hsflowd)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/src/conf_mode/system_sflow.py
+++ b/src/conf_mode/system_sflow.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from sys import exit
+
+from vyos.config import Config
+from vyos.configdict import dict_merge
+from vyos.template import render
+from vyos.util import call
+from vyos.validate import is_addr_assigned
+from vyos.xml import defaults
+from vyos import ConfigError
+from vyos import airbag
+airbag.enable()
+
+hsflowd_conf_path = '/run/sflow/hsflowd.conf'
+systemd_service = 'hsflowd.service'
+systemd_override = f'/run/systemd/system/{systemd_service}.d/override.conf'
+
+
+def get_config(config=None):
+    if config:
+        conf = config
+    else:
+        conf = Config()
+    base = ['system', 'sflow']
+    if not conf.exists(base):
+        return None
+
+    sflow = conf.get_config_dict(base,
+                                 key_mangling=('-', '_'),
+                                 get_first_key=True)
+
+    # We have gathered the dict representation of the CLI, but there are default
+    # options which we need to update into the dictionary retrived.
+    default_values = defaults(base)
+
+    sflow = dict_merge(default_values, sflow)
+
+    # Ignore default XML values if config doesn't exists
+    # Delete key from dict
+    if 'port' in sflow['server']:
+        del sflow['server']['port']
+
+    return sflow
+
+
+def verify(sflow):
+    if not sflow:
+        return None
+
+    # Check if configured sflow agent-address exist in the system
+    if 'agent_address' in sflow:
+        tmp = sflow['agent_address']
+        if not is_addr_assigned(tmp):
+            raise ConfigError(
+                f'Configured "sflow agent-address {tmp}" does not exist in the system!'
+            )
+
+    # Check if at least one interface is configured
+    if 'interface' not in sflow:
+        raise ConfigError(
+            'sFlow requires at least one interface to be configured!')
+
+    # Check if at least one server is configured
+    if 'server' not in sflow:
+        raise ConfigError('You need to configure at least one sFlow server!')
+
+    # return True if all checks were passed
+    return True
+
+
+def generate(sflow):
+    if not sflow:
+        return None
+
+    render(hsflowd_conf_path, 'sflow/hsflowd.conf.j2', sflow)
+    render(systemd_override, 'sflow/override.conf.j2', sflow)
+    # Reload systemd manager configuration
+    call('systemctl daemon-reload')
+
+
+def apply(sflow):
+    if not sflow:
+        # Stop flow-accounting daemon and remove configuration file
+        call(f'systemctl stop {systemd_service}')
+        if os.path.exists(hsflowd_conf_path):
+            os.unlink(hsflowd_conf_path)
+        return
+
+    # Start/reload flow-accounting daemon
+    call(f'systemctl restart {systemd_service}')
+
+
+if __name__ == '__main__':
+    try:
+        config = get_config()
+        verify(config)
+        generate(config)
+        apply(config)
+    except ConfigError as e:
+        print(e)
+        exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add sFlow feature based on [hsflowd](https://github.com/sflow/host-sflow)
According to user reviews, it works more stable and more productive than pmacct
I haven't deleted 'pmacct' 'system flow-accounting sflow' yet It could be migrated or deprecated later

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related PR
https://github.com/vyos/vyos-build/pull/320

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5086

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
sflow
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set system sflow agent-address 'fe80::5054:ff:fef2:cace'
set system sflow agent-interface 'eth0'
set system sflow interface 'eth0'
set system sflow interface 'eth1'
set system sflow polling '30'
set system sflow sampling-rate '100'
set system sflow server 192.168.122.1 port '6343'
set system sflow server 192.168.122.11 port '6343'

```

check service
```
vyos@r14# sudo systemctl status hsflowd
● hsflowd.service - Host sFlow
     Loaded: loaded (/lib/systemd/system/hsflowd.service; disabled; preset: enabled)
    Drop-In: /run/systemd/system/hsflowd.service.d
             └─override.conf
     Active: active (running) since Tue 2023-03-14 20:58:28 EET; 3s ago
   Main PID: 13144 (hsflowd)
      Tasks: 2 (limit: 9400)
     Memory: 716.0K
        CPU: 10ms
     CGroup: /system.slice/hsflowd.service
             └─13144 /usr/sbin/hsflowd -m 4d6f4d291ae8446f8d2b3decd9da64c7 -d -f /run/sflow/hsflowd.conf

Mar 14 20:58:28 r14 systemd[1]: Started hsflowd.service - Host sFlow.
[edit]
vyos@r14# 

```
config:
```
vyos@r14# cat /run/sflow/hsflowd.conf
# Genereated by /usr/libexec/vyos/conf_mode/system_sflow.py
# Parameters http://sflow.net/host-sflow-linux-config.php

sflow {
  polling=30
  sampling=100
  sampling.bps_ratio=0
  agentIP=192.168.122.14
  agent=eth0
  collector { ip = 192.168.122.1 udpport = 6343 }
  collector { ip = 192.168.122.11 udpport = 6343 }
  pcap { dev=eth0 }
  pcap { dev=eth1 }
}
```
Dump:
```
vyos@r14# sudo tcpdump -ntvi eth0 port 6343
tcpdump: listening on eth0, link-type EN10MB (Ethernet), snapshot length 262144 bytes

IP (tos 0x0, ttl 64, id 63082, offset 0, flags [DF], proto UDP (17), length 200)
    192.168.122.14.55255 > 192.168.122.11.6343: sFlowv5, IPv6 agent fe80::5054:ff:fef2:cace, agent-id 100000, seqnum 10, uptime 84849, samples 1, length 172
	counter sample (2), length 124, seqnum 3, type 0, idx 2, records 2
	    enterprise 0, Unknown (1005) length 8
		0x0000:  0000 0004 6574 6830
	    enterprise 0, Generic counter (1) length 88
	      ifindex 2, iftype 6, ifspeed 0, ifdirection 1 (full-duplex)
	      ifstatus 3, adminstatus: up, operstatus: up
	      In octets 19986, unicast pkts 200, multicast pkts 4294967295, broadcast pkts 4294967295, discards 0
	      In errors 0, unknown protos 4294967295
	      Out octets 22174, unicast pkts 105, multicast pkts 4294967295, broadcast pkts 4294967295, discards 0
	      Out errors 0, promisc mode 0
IP (tos 0x0, ttl 64, id 45823, offset 0, flags [DF], proto UDP (17), length 200)
    192.168.122.14.43119 > 192.168.122.1.6343: sFlowv5, IPv6 agent fe80::5054:ff:fef2:cace, agent-id 100000, seqnum 10, uptime 84849, samples 1, length 172
	counter sample (2), length 124, seqnum 3, type 0, idx 2, records 2
	    enterprise 0, Unknown (1005) length 8
		0x0000:  0000 0004 6574 6830
	    enterprise 0, Generic counter (1) length 88
	      ifindex 2, iftype 6, ifspeed 0, ifdirection 1 (full-duplex)
	      ifstatus 3, adminstatus: up, operstatus: up
	      In octets 19986, unicast pkts 200, multicast pkts 4294967295, broadcast pkts 4294967295, discards 0
	      In errors 0, unknown protos 4294967295
	      Out octets 22174, unicast pkts 105, multicast pkts 4294967295, broadcast pkts 4294967295, discards 0
	      Out errors 0, promisc mode 0
^C
2 packets captured
2 packets received by filter
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
