### PR TITLE
T3083: Add service event-handler

### DIFF
--- a/interface-definitions/service-event-handler.xml.in
+++ b/interface-definitions/service-event-handler.xml.in
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interfaceDefinition>
+  <node name="service">
+    <children>
+      <node name="event-handler" owner="${vyos_conf_scripts_dir}/service_event_handler.py">
+        <properties>
+          <help>Service event handler</help>
+        </properties>
+        <children>
+          <tagNode name="event">
+            <properties>
+              <help>Event handler name</help>
+            </properties>
+            <children>
+              <node name="filter">
+                <properties>
+                  <help>Logs filter settings</help>
+                </properties>
+                <children>
+                  <leafNode name="pattern">
+                    <properties>
+                      <help>Match pattern (regex)</help>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="syslog-identifier">
+                    <properties>
+                      <help>Identifier of a process in syslog (string)</help>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+              <node name="script">
+                <properties>
+                  <help>Event handler script file</help>
+                </properties>
+                <children>
+                  <leafNode name="arguments">
+                    <properties>
+                      <help>Script arguments</help>
+                    </properties>
+                  </leafNode>
+                  <tagNode name="environment">
+                    <properties>
+                      <help>Script environment arguments</help>
+                    </properties>
+                    <children>
+                      <leafNode name="value">
+                        <properties>
+                          <help>Environment value</help>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </tagNode>
+                  <leafNode name="path">
+                    <properties>
+                      <help>Path to the script</help>
+                      <constraint>
+                        <validator name="script"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+            </children>
+          </tagNode>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/src/conf_mode/service_event_handler.py
+++ b/src/conf_mode/service_event_handler.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import json
+from pathlib import Path
+
+from vyos.config import Config
+from vyos.util import call, dict_search
+from vyos import ConfigError
+from vyos import airbag
+
+airbag.enable()
+
+service_name = 'vyos-event-handler'
+service_conf = Path(f'/run/{service_name}.conf')
+
+
+def get_config(config=None):
+    if config:
+        conf = config
+    else:
+        conf = Config()
+
+    base = ['service', 'event-handler', 'event']
+    config = conf.get_config_dict(base,
+                                  get_first_key=True,
+                                  no_tag_node_value_mangle=True)
+
+    return config
+
+
+def verify(config):
+    # bail out early - looks like removal from running config
+    if not config:
+        return None
+
+    for name, event_config in config.items():
+        if not dict_search('filter.pattern', event_config) or not dict_search(
+                'script.path', event_config):
+            raise ConfigError(
+                'Event-handler: both pattern and script path items are mandatory'
+            )
+
+        if dict_search('script.environment.message', event_config):
+            raise ConfigError(
+                'Event-handler: "message" environment variable is reserved for log message text'
+            )
+
+
+def generate(config):
+    if not config:
+        # Remove old config and return
+        if os.path.isfile(service_conf):
+            os.unlink(service_conf)
+        return None
+
+    # Write configuration file
+    conf_json = json.dumps(config, indent=4)
+    service_conf.write_text(conf_json)
+
+    return None
+
+
+def apply(config):
+    if config:
+        call(f'systemctl restart {service_name}.service')
+    else:
+        call(f'systemctl stop {service_name}.service')
+
+
+if __name__ == '__main__':
+    try:
+        c = get_config()
+        verify(c)
+        generate(c)
+        apply(c)
+    except ConfigError as e:
+        print(e)
+        exit(1)

--- a/src/system/vyos-event-handler.py
+++ b/src/system/vyos-event-handler.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import json
+import re
+import select
+from copy import deepcopy
+from os import getpid, environ
+from pathlib import Path
+from signal import signal, SIGTERM, SIGINT
+from sys import exit
+from systemd import journal
+
+from vyos.util import run, dict_search
+
+# Identify this script
+my_pid = getpid()
+my_name = Path(__file__).stem
+
+
+# handle termination signal
+def handle_signal(signal_type, frame):
+    if signal_type == SIGTERM:
+        journal.send('Received SIGTERM signal, stopping normally',
+                     SYSLOG_IDENTIFIER=my_name)
+    if signal_type == SIGINT:
+        journal.send('Received SIGINT signal, stopping normally',
+                     SYSLOG_IDENTIFIER=my_name)
+    exit(0)
+
+
+# Class for analyzing and process messages
+class Analyzer:
+    # Initialize settings
+    def __init__(self, config: dict) -> None:
+        self.config = {}
+        # Prepare compiled regex objects
+        for event_id, event_config in config.items():
+            script = dict_search('script.path', event_config)
+            # Check for arguments
+            if dict_search('script.arguments', event_config):
+                script_arguments = dict_search('script.arguments', event_config)
+                script = f'{script} {script_arguments}'
+            # Prepare environment
+            environment = deepcopy(environ)
+            # Check for additional environment options
+            if dict_search('script.environment', event_config):
+                for env_variable, env_value in dict_search(
+                        'script.environment', event_config).items():
+                    environment[env_variable] = env_value.get('value')
+            # Create final config dictionary
+            pattern_raw = event_config['filter']['pattern']
+            pattern_compiled = re.compile(
+                rf'{event_config["filter"]["pattern"]}')
+            pattern_config = {
+                pattern_compiled: {
+                    'pattern_raw':
+                        pattern_raw,
+                    'syslog_id':
+                        dict_search('filter.syslog-identifier', event_config),
+                    'pattern_script': {
+                        'path': script,
+                        'environment': environment
+                    }
+                }
+            }
+            self.config.update(pattern_config)
+
+    # Execute script safely
+    def script_run(self, pattern: str, script_path: str,
+                   script_env: dict) -> None:
+        try:
+            run(script_path, env=script_env)
+            journal.send(
+                f'Pattern found: "{pattern}", script executed: "{script_path}"',
+                SYSLOG_IDENTIFIER=my_name)
+        except Exception as err:
+            journal.send(
+                f'Pattern found: "{pattern}", failed to execute script "{script_path}": {err}',
+                SYSLOG_IDENTIFIER=my_name)
+
+    # Analyze a message
+    def process_message(self, message: dict) -> None:
+        for pattern_compiled, pattern_config in self.config.items():
+            # Check if syslog id is presented in config and matches
+            syslog_id = pattern_config.get('syslog_id')
+            if syslog_id and message['SYSLOG_IDENTIFIER'] != syslog_id:
+                continue
+            if pattern_compiled.fullmatch(message['MESSAGE']):
+                # Add message to environment variables
+                pattern_config['pattern_script']['environment'][
+                    'message'] = message['MESSAGE']
+                # Run script
+                self.script_run(
+                    pattern=pattern_config['pattern_raw'],
+                    script_path=pattern_config['pattern_script']['path'],
+                    script_env=pattern_config['pattern_script']['environment'])
+
+
+if __name__ == '__main__':
+    # Parse command arguments and get config
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c',
+                        '--config',
+                        action='store',
+                        help='Path to even-handler configuration',
+                        required=True,
+                        type=Path)
+
+    args = parser.parse_args()
+    try:
+        config_path = Path(args.config)
+        config = json.loads(config_path.read_text())
+        # Create an object for analazyng messages
+        analyzer = Analyzer(config)
+    except Exception as err:
+        print(
+            f'Configuration file "{config_path}" does not exist or malformed: {err}'
+        )
+        exit(1)
+
+    # Prepare for proper exitting
+    signal(SIGTERM, handle_signal)
+    signal(SIGINT, handle_signal)
+
+    # Set up journal connection
+    data = journal.Reader()
+    data.seek_tail()
+    data.get_previous()
+    p = select.poll()
+    p.register(data, data.get_events())
+
+    journal.send(f'Started with configuration: {config}',
+                 SYSLOG_IDENTIFIER=my_name)
+
+    while p.poll():
+        if data.process() != journal.APPEND:
+            continue
+        for entry in data:
+            message = entry['MESSAGE']
+            pid = entry['_PID']
+            # Skip empty messages and messages from this process
+            if message and pid != my_pid:
+                try:
+                    analyzer.process_message(entry)
+                except Exception as err:
+                    journal.send(f'Unable to process message: {err}',
+                                 SYSLOG_IDENTIFIER=my_name)

--- a/src/systemd/vyos-event-handler.service
+++ b/src/systemd/vyos-event-handler.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=VyOS event handler
+After=network.target vyos-router.service
+
+[Service]
+Type=simple
+Restart=always
+ExecStart=/usr/bin/python3 /usr/libexec/vyos/system/vyos-event-handler.py --config /run/vyos-event-handler.conf
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Event-handler allows executing a custom script when detects some configured "pattern regex"
It is the backport from 1.4
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3083

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
event-handler
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service event-handler event first filter pattern '.*ssh2.*'
set service event-handler event first script arguments '192.0.2.5'
set service event-handler event first script environment interface value 'eth0'
set service event-handler event first script path '/config/scripts/hello.sh'
```
cat hello.sh:
```
#!/usr/bin/env bash

echo "$(date) Hello world! From script, first arg ${1}" >> /tmp/hello.txt
```
Expect `vyos-event-handle.service`
```
vyos@r1# systemctl status vyos-event-handler.service
● vyos-event-handler.service - VyOS event handler
   Loaded: loaded (/lib/systemd/system/vyos-event-handler.service; disabled; vendor preset: enabled)
   Active: active (running) since Wed 2023-03-15 17:05:14 EET; 34s ago
 Main PID: 8087 (python3)
    Tasks: 1 (limit: 1149)
   Memory: 6.4M
   CGroup: /system.slice/vyos-event-handler.service
           └─8087 /usr/bin/python3 /usr/libexec/vyos/system/vyos-event-handler.py --config /run/vyos-event-handler.conf

Mar 15 17:05:14 r1 systemd[1]: Started VyOS event handler.
Mar 15 17:05:14 r1 vyos-event-handler[8087]: Started with configuration: {'first': {'filter': {'pattern': '.*ssh2.*'}, 'script': {'arguments': '192.0.2.5', 'environment': {'interface': {'value': 'eth0'}}, 'path': '/config/scripts/hello.sh'}}}
[edit]
vyos@r1# 
```
Connect via ssh and check journalctl:
```
...
Mar 15 17:06:45 r1 vyos-event-handler[8087]: Pattern found: ".*ssh2.*", script executed: "/config/scripts/hello.sh 192.0.2.5"
...
```
check cat /tmp/hello.txt
```
vyos@r1# cat /tmp/hello.txt
Wed 15 Mar 2023 04:50:04 PM EET Hello world! From script, first arg 192.0.2.5
Wed 15 Mar 2023 05:06:45 PM EET Hello world! From script, first arg 192.0.2.5
[edit]
vyos@r1# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
