### PR TITLE
T5092: IPoE-server named pool must not rely on auth type

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.j2
+++ b/data/templates/accel-ppp/ipoe.config.j2
@@ -44,17 +44,17 @@ vlan-mon={{ iface }},{{ iface_config.vlan | join(',') }}
 {% endif %}
 {% if authentication.mode is vyos_defined('noauth') %}
 noauth=1
-{%     if client_ip_pool.name is vyos_defined %}
-{%         for pool, pool_options in client_ip_pool.name.items() %}
-{%             if pool_options.subnet is vyos_defined and pool_options.gateway_address is vyos_defined %}
-ip-pool={{ pool }}
-gw-ip-address={{ pool_options.gateway_address }}/{{ pool_options.subnet.split('/')[1] }}
-{%             endif %}
-{%         endfor %}
-{%     endif %}
 {% elif authentication.mode is vyos_defined('local') %}
 username=ifname
 password=csid
+{% endif %}
+{% if client_ip_pool.name is vyos_defined %}
+{%     for pool, pool_options in client_ip_pool.name.items() %}
+{%         if pool_options.subnet is vyos_defined and pool_options.gateway_address is vyos_defined %}
+ip-pool={{ pool }}
+gw-ip-address={{ pool_options.gateway_address }}/{{ pool_options.subnet.split('/')[1] }}
+{%         endif %}
+{%     endfor %}
 {% endif %}
 proxy-arp=1
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Named pools for ipoe-server must not rely on authentication type 
It is a separate global option for `[ipoe]` and `[ip-pool]` sections
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5092

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service ipoe-server authentication mode 'radius'
set service ipoe-server authentication radius server 192.168.122.14 key 'vyos-secret'
set service ipoe-server client-ip-pool name POOL1 gateway-address '192.0.2.1'
set service ipoe-server client-ip-pool name POOL1 subnet '192.0.2.0/24'
set service ipoe-server interface eth1 vlan '2000-3000'
```
Before the fix (lacks of **ip-pool** settings/**gw-ip-address** for **[ipoe]** section):
```
[ipoe]
verbose=1
interface=re:^eth1\.(200\d|20[1-9]\d|2[1-9]\d{2}|3000)$,shared=1,mode=L2,ifcfg=1,start=dhcpv4,ipv6=1
vlan-mon=eth1,2000-3000
proxy-arp=1

[ip-pool]
192.0.2.0/24,name=POOL1
gw-ip-address=192.0.2.1/24

```
After the fix:
```
[ipoe]
verbose=1
interface=re:^eth1\.(200\d|20[1-9]\d|2[1-9]\d{2}|3000)$,shared=1,mode=L2,ifcfg=1,start=dhcpv4,ipv6=1
vlan-mon=eth1,2000-3000
ip-pool=POOL1
gw-ip-address=192.0.2.1/24
proxy-arp=1

[ip-pool]
192.0.2.0/24,name=POOL1
gw-ip-address=192.0.2.1/24

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
