### PR TITLE
T5091: IPoE-server verify RADIUS settings

### DIFF
--- a/src/conf_mode/service_ipoe-server.py
+++ b/src/conf_mode/service_ipoe-server.py
@@ -60,6 +60,17 @@ def verify(ipoe):
                               'Use "ipoe client-ip-pool" instead.')
 
     #verify_accel_ppp_base_service(ipoe, local_users=False)
+    # IPoE server does not have 'gateway' option in the CLI
+    # we cannot use configverify.py verify_accel_ppp_base_service for ipoe-server
+
+    if dict_search('authentication.mode', ipoe) == 'radius':
+        if not dict_search('authentication.radius.server', ipoe):
+            raise ConfigError('RADIUS authentication requires at least one server')
+
+        for server in dict_search('authentication.radius.server', ipoe):
+            radius_config = ipoe['authentication']['radius']['server'][server]
+            if 'key' not in radius_config:
+                raise ConfigError(f'Missing RADIUS secret key for server "{server}"')
 
     if 'client_ipv6_pool' in ipoe:
         if 'delegate' in ipoe['client_ipv6_pool'] and 'prefix' not in ipoe['client_ipv6_pool']:


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
We don't have the global option `gateway-address` for ipoe-server we cannot use the general `configverify.verify_accel_ppp_base_service` https://github.com/vyos/vyos-1x/blob/7f0eb0b029c927e4b7b0003c934f682be9b36380/python/vyos/configverify.py#L391
Add verify radius setting for configuration mode `radius Radius authentication required at least one RADIUS server
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5091

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set service ipoe-server authentication mode 'radius'
set service ipoe-server client-ip-pool name POOL1 gateway-address '192.0.2.1'
set service ipoe-server client-ip-pool name POOL1 subnet '192.0.2.0/24'
set service ipoe-server interface eth1 vlan '2000-3000'
```
Before the fix:
```
Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/service_ipoe-server.py", line 99, in <module>
    generate(c)
  File "/usr/libexec/vyos/conf_mode/service_ipoe-server.py", line 75, in generate
    render(ipoe_conf, 'accel-ppp/ipoe.config.j2', ipoe)
  File "/usr/lib/python3/dist-packages/vyos/template.py", line 141, in render
    rendered = render_to_string(template, content, formater, location)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/template.py", line 110, in render_to_string
    rendered = template.render(content)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "/usr/lib/python3/dist-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/usr/share/vyos/templates/accel-ppp/ipoe.config.j2", line 78, in top-level template code
    {% include 'accel-ppp/config_chap_secrets_radius.j2' %}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/vyos/templates/accel-ppp/config_chap_secrets_radius.j2", line 7, in top-level template code
    {%     for server, options in authentication.radius.server.items() if not options.disable is vyos_defined %}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'server'



[[service ipoe-server]] failed
Commit failed
[edit]
vyos@r14#
```
After the fix:
```
vyos@r14# commit
[ service ipoe-server ]
RADIUS authentication requires at least one server

[[service ipoe-server]] failed
Commit failed
[edit]
vyos@r14# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
