### PR TITLE
openvpn: T5095: raw output should return list instead of dict

### DIFF
--- a/src/op_mode/openvpn.py
+++ b/src/op_mode/openvpn.py
@@ -53,7 +53,7 @@ def _get_tunnel_address(peer_host, peer_port, status_file):
 def _get_interface_status(mode: str, interface: str) -> dict:
     status_file = f'/run/openvpn/{interface}.status'
 
-    data = {
+    data: dict = {
         'mode': mode,
         'intf': interface,
         'local_host': '',
@@ -142,8 +142,8 @@ def _get_interface_status(mode: str, interface: str) -> dict:
 
     return data
 
-def _get_raw_data(mode: str) -> dict:
-    data = {}
+def _get_raw_data(mode: str) -> list:
+    data: list = []
     conf = Config()
     conf_dict = conf.get_config_dict(['interfaces', 'openvpn'],
                                      get_first_key=True)
@@ -152,8 +152,7 @@ def _get_raw_data(mode: str) -> dict:
 
     interfaces = [x for x in list(conf_dict) if conf_dict[x]['mode'] == mode]
     for intf in interfaces:
-        data[intf] = _get_interface_status(mode, intf)
-        d = data[intf]
+        d = _get_interface_status(mode, intf)
         d['local_host'] = conf_dict[intf].get('local-host', '')
         d['local_port'] = conf_dict[intf].get('local-port', '')
         if conf.exists(f'interfaces openvpn {intf} server client'):
@@ -164,10 +163,11 @@ def _get_raw_data(mode: str) -> dict:
                     client['name'] = 'None (PSK)'
                 client['remote_host'] = conf_dict[intf].get('remote-host', [''])[0]
                 client['remote_port'] = conf_dict[intf].get('remote-port', '1194')
+        data.append(d)
 
     return data
 
-def _format_openvpn(data: dict) -> str:
+def _format_openvpn(data: list) -> str:
     if not data:
         out = 'No OpenVPN interfaces configured'
         return out
@@ -176,11 +176,12 @@ def _format_openvpn(data: dict) -> str:
                'TX bytes', 'RX bytes', 'Connected Since']
 
     out = ''
-    for intf in list(data):
+    for d in data:
         data_out = []
-        l_host = data[intf]['local_host']
-        l_port = data[intf]['local_port']
-        for client in list(data[intf]['clients']):
+        intf = d['intf']
+        l_host = d['local_host']
+        l_port = d['local_port']
+        for client in d['clients']:
             r_host = client['remote_host']
             r_port = client['remote_port']
 
@@ -201,7 +202,7 @@ def _format_openvpn(data: dict) -> str:
 
     return out
 
-def show(raw: bool, mode: ArgMode) -> str:
+def show(raw: bool, mode: ArgMode) -> typing.Union[list,str]:
     openvpn_data = _get_raw_data(mode)
 
     if raw:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

A list is preferred for 'raw' output for use in clients such as the local-UI.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe):
        Change in raw output type.

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5095

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

openvpn

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
