### PR TITLE
T5086: Add sFlow drop-monitor-limit option

### DIFF
--- a/data/templates/sflow/hsflowd.conf.j2
+++ b/data/templates/sflow/hsflowd.conf.j2
@@ -25,4 +25,7 @@ sflow {
   pcap { dev={{ iface }} }
 {%     endfor %}
 {% endif %}
+{% if drop_monitor_limit is vyos_defined %}
+  dropmon { limit={{ drop_monitor_limit }} start=on sw=on hw=off }
+{% endif %}
 }

--- a/interface-definitions/system-sflow.xml.in
+++ b/interface-definitions/system-sflow.xml.in
@@ -46,6 +46,18 @@
               </constraint>
             </properties>
           </leafNode>
+          <leafNode name="drop-monitor-limit">
+            <properties>
+              <help>Export headers of dropped by kernel packets</help>
+              <valueHelp>
+                <format>u32:1-65535</format>
+                <description>Maximum rate limit of N drops per second send out in the sFlow datagrams</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 1-65535"/>
+              </constraint>
+            </properties>
+          </leafNode>
           #include <include/generic-interface-multi.xml.i>
           <leafNode name="polling">
             <properties>

--- a/smoketest/scripts/cli/test_system_sflow.py
+++ b/smoketest/scripts/cli/test_system_sflow.py
@@ -57,6 +57,7 @@ class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
         sampling_rate = '128'
         server = '192.0.2.254'
         port = '8192'
+        mon_limit = '50'
 
         self.cli_set(
             ['interfaces', 'dummy', 'dum0', 'address', f'{agent_address}/24'])
@@ -72,6 +73,7 @@ class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['polling', polling])
         self.cli_set(base_path + ['sampling-rate', sampling_rate])
         self.cli_set(base_path + ['server', server, 'port', port])
+        self.cli_set(base_path + ['drop-monitor-limit', mon_limit])
 
         # commit changes
         self.cli_commit()
@@ -84,6 +86,7 @@ class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'agentIP={agent_address}', hsflowd)
         self.assertIn(f'agent={agent_interface}', hsflowd)
         self.assertIn(f'collector {{ ip = {server} udpport = {port} }}', hsflowd)
+        self.assertIn(f'dropmon {{ limit={mon_limit} start=on sw=on hw=off }}', hsflowd)
 
         for interface in Section.interfaces('ethernet'):
             self.assertIn(f'pcap {{ dev={interface} }}', hsflowd)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
hsflowd will export the headers of dropped packets (along with the name of the function in the Linux kernel where that skb was dropped) as part of the standard sFlow feed.
This measurement complements the sFlow packet sampling and counter-telemetry well because it provides visibility into the traffic that is not flowing.
Very helpful for troubleshooting.
The limit (a rate limit max of N drops per second sent out in the sFlow datagrams) is the parameter you would set in the CLI.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related PR
https://github.com/vyos/vyos-build/pull/321

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5086

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
sflow
## Proposed changes
<!--- Describe your changes in detail -->
Add  new config option
```
set system sflow drop-monitor-limit 50
```
## How to test
```
set system sflow agent-address '192.168.122.14'
set system sflow drop-monitor-limit '50'
set system sflow interface 'eth0'
set system sflow interface 'eth1'
set system sflow polling '30'
set system sflow sampling-rate '100'
set system sflow server 192.168.122.1 port '6343'
```
Expect **dropmon** option:
```
vyos@r14# cat /run/sflow/hsflowd.conf 
# Genereated by /usr/libexec/vyos/conf_mode/system_sflow.py
# Parameters http://sflow.net/host-sflow-linux-config.php

sflow {
  polling=30
  sampling=100
  sampling.bps_ratio=0
  agentIP=192.168.122.14
  collector { ip = 192.168.122.1 udpport = 6343 }
  pcap { dev=eth0 }
  pcap { dev=eth1 }
  dropmon { limit=50 start=on sw=on hw=off }

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
