### PR TITLE
T5086: Fix sflow fix default values for server

### DIFF
--- a/smoketest/scripts/cli/test_system_sflow.py
+++ b/smoketest/scripts/cli/test_system_sflow.py
@@ -56,7 +56,9 @@ class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
         polling = '24'
         sampling_rate = '128'
         server = '192.0.2.254'
+        local_server = '127.0.0.1'
         port = '8192'
+        default_port = '6343'
         mon_limit = '50'
 
         self.cli_set(
@@ -73,6 +75,7 @@ class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['polling', polling])
         self.cli_set(base_path + ['sampling-rate', sampling_rate])
         self.cli_set(base_path + ['server', server, 'port', port])
+        self.cli_set(base_path + ['server', local_server])
         self.cli_set(base_path + ['drop-monitor-limit', mon_limit])
 
         # commit changes
@@ -86,6 +89,7 @@ class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'agentIP={agent_address}', hsflowd)
         self.assertIn(f'agent={agent_interface}', hsflowd)
         self.assertIn(f'collector {{ ip = {server} udpport = {port} }}', hsflowd)
+        self.assertIn(f'collector {{ ip = {local_server} udpport = {default_port} }}', hsflowd)
         self.assertIn(f'dropmon {{ limit={mon_limit} start=on sw=on hw=off }}', hsflowd)
 
         for interface in Section.interfaces('ethernet'):

--- a/src/conf_mode/system_sflow.py
+++ b/src/conf_mode/system_sflow.py
@@ -57,6 +57,12 @@ def get_config(config=None):
     if 'port' in sflow['server']:
         del sflow['server']['port']
 
+    # Set default values per server
+    if 'server' in sflow:
+        for server in sflow['server']:
+            default_values = defaults(base + ['server'])
+            sflow['server'][server] = dict_merge(default_values, sflow['server'][server])
+
     return sflow
 
 


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
We drop default values 'port' but don't set it again per server 
Fix it
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5086

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
sflow
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Set sflow servers without port
```
set system sflow agent-address '192.168.122.14'
set system sflow drop-monitor-limit '50'
set system sflow interface 'eth0'
set system sflow interface 'eth1'
set system sflow polling '30'
set system sflow sampling-rate '100'
set system sflow server 127.0.0.1 port '6555'
set system sflow server 192.168.122.1
set system sflow server 192.0.2.5
```
Expected default port 6343
```
vyos@r14# cat /run/sflow/hsflowd.conf 
# Genereated by /usr/libexec/vyos/conf_mode/system_sflow.py
# Parameters http://sflow.net/host-sflow-linux-config.php

sflow {
  polling=30
  sampling=100
  sampling.bps_ratio=0
  agentIP=192.168.122.14
  collector { ip = 127.0.0.1 udpport = 6555 }
  collector { ip = 192.0.2.5 udpport = 6343 }
  collector { ip = 192.168.122.1 udpport = 6343 }
  pcap { dev=eth0 }
  pcap { dev=eth1 }
  dropmon { limit=50 start=on sw=on hw=off }
}
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ x I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
