### PR TITLE
pppoe: T5098: allow user to set pppd holdoff option

### DIFF
--- a/data/templates/pppoe/peer.j2
+++ b/data/templates/pppoe/peer.j2
@@ -65,6 +65,10 @@ mru {{ mtu }}
 noipv6
 {% endif %}
 
+{% if holdoff is vyos_defined %}
+holdoff {{ holdoff }}
+{% endif %}
+
 {% if connect_on_demand is vyos_defined %}
 demand
 # See T2249. PPP default route options should only be set when in on-demand

--- a/interface-definitions/interfaces-pppoe.xml.in
+++ b/interface-definitions/interfaces-pppoe.xml.in
@@ -50,6 +50,20 @@
               <constraintErrorMessage>Host-uniq must be specified as hex-adecimal byte-string (even number of HEX characters)</constraintErrorMessage>
             </properties>
           </leafNode>
+          <leafNode name="holdoff">
+            <properties>
+              <help>Delay before re-dial to the access concentrator when PPP session terminated by peer (in seconds)</help>
+              <valueHelp>
+                <format>u32:0-86400</format>
+                <description>Holdoff time in seconds</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 0-86400"/>
+              </constraint>
+              <constraintErrorMessage>Holdoff must be in range 0 to 86400</constraintErrorMessage>
+            </properties>
+            <defaultValue>30</defaultValue>
+          </leafNode>
           <node name="ip">
             <properties>
               <help>IPv4 routing parameters</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Allow user to set pppd holdoff option, meet some ISP's requirement.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5098

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
-->
```
set int pppoe pppoeN holdoff 5
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
