### PR TITLE
configdiff: T5089: add unit test of config_diff

### DIFF
--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -352,6 +352,27 @@ def show_diff(left, right, path=[], commands=False, libpath=LIBPATH):
 
     return res
 
+def union(left, right, libpath=LIBPATH):
+    if left is None:
+        left = ConfigTree(config_string='\n')
+    if right is None:
+        right = ConfigTree(config_string='\n')
+    if not (isinstance(left, ConfigTree) and isinstance(right, ConfigTree)):
+        raise TypeError("Arguments must be instances of ConfigTree")
+
+    __lib = cdll.LoadLibrary(libpath)
+    __tree_union = __lib.tree_union
+    __tree_union.argtypes = [c_void_p, c_void_p]
+    __tree_union.restype = c_void_p
+    __get_error = __lib.get_error
+    __get_error.argtypes = []
+    __get_error.restype = c_char_p
+
+    res = __tree_union( left._get_config(), right._get_config())
+    tree = ConfigTree(address=res)
+
+    return tree
+
 class DiffTree:
     def __init__(self, left, right, path=[], libpath=LIBPATH):
         if left is None:

--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -60,7 +60,7 @@ class ConfigTree(object):
         self.__get_error.restype = c_char_p
 
         self.__to_string = self.__lib.to_string
-        self.__to_string.argtypes = [c_void_p]
+        self.__to_string.argtypes = [c_void_p, c_bool]
         self.__to_string.restype = c_char_p
 
         self.__to_commands = self.__lib.to_commands
@@ -160,8 +160,8 @@ class ConfigTree(object):
     def _get_config(self):
         return self.__config
 
-    def to_string(self):
-        config_string = self.__to_string(self.__config).decode()
+    def to_string(self, ordered_values=False):
+        config_string = self.__to_string(self.__config, ordered_values).decode()
         config_string = "{0}\n{1}".format(config_string, self.__version)
         return config_string
 

--- a/src/tests/test_config_diff.py
+++ b/src/tests/test_config_diff.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import vyos.configtree
+
+from unittest import TestCase
+
+class TestConfigDiff(TestCase):
+    def setUp(self):
+        with open('tests/data/config.left', 'r') as f:
+            config_string = f.read()
+            self.config_left = vyos.configtree.ConfigTree(config_string)
+
+        with open('tests/data/config.right', 'r') as f:
+            config_string = f.read()
+            self.config_right = vyos.configtree.ConfigTree(config_string)
+
+        self.config_null = vyos.configtree.ConfigTree('')
+
+    def test_unit(self):
+        diff = vyos.configtree.DiffTree(self.config_left, self.config_null)
+        sub = diff.sub
+        self.assertEqual(sub.to_string(), self.config_left.to_string())
+
+        diff = vyos.configtree.DiffTree(self.config_null, self.config_left)
+        add = diff.add
+        self.assertEqual(add.to_string(), self.config_left.to_string())
+
+    def test_symmetry(self):
+        lr_diff = vyos.configtree.DiffTree(self.config_left,
+                                           self.config_right)
+        rl_diff = vyos.configtree.DiffTree(self.config_right,
+                                           self.config_left)
+
+        sub = lr_diff.sub
+        add = rl_diff.add
+        self.assertEqual(sub.to_string(), add.to_string())
+        add = lr_diff.add
+        sub = rl_diff.sub
+        self.assertEqual(add.to_string(), sub.to_string())
+
+    def test_identity(self):
+        lr_diff = vyos.configtree.DiffTree(self.config_left,
+                                           self.config_right)
+
+        sub = lr_diff.sub
+        inter = lr_diff.inter
+        add = lr_diff.add
+
+        r_union = vyos.configtree.union(add, inter)
+        l_union = vyos.configtree.union(sub, inter)
+
+        self.assertEqual(r_union.to_string(),
+                         self.config_right.to_string(ordered_values=True))
+        self.assertEqual(l_union.to_string(),
+                         self.config_left.to_string(ordered_values=True))

--- a/tests/data/config.left
+++ b/tests/data/config.left
@@ -1,0 +1,36 @@
+node1 {
+    tag_node foo {
+        valueless
+        multi_node 'v2'
+        multi_node 'v1'
+        single 'left_val'
+    }
+    tag_node bar {
+        node {
+            single 'v0'
+        }
+    }
+    tag_node other {
+        leaf 'leaf_l'
+    }
+}
+
+node3 {
+}
+
+node2 {
+    sub_node_other {
+        single 'val'
+    }
+    sub_node {
+        tag_node other {
+            single 'val'
+        }
+        tag_node bob {
+            valued 'baz'
+        }
+        tag_node duff {
+            valued 'buz'
+        }
+    }
+}

--- a/tests/data/config.right
+++ b/tests/data/config.right
@@ -1,0 +1,25 @@
+node1 {
+    tag_node baz {
+        other_node {
+            multi_node 'some_val'
+            multe_node 'other_val'
+        }
+    }
+    tag_node foo {
+        valueless
+        multi_node 'v3'
+        multi_node 'v1'
+        single 'right_val'
+    }
+    tag_node other {
+        leaf 'leaf_r'
+    }
+}
+
+node2 {
+    sub_node {
+        tag_node other {
+            multi 'mv'
+        }
+    }
+}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Dependencies merged; rebased over current in order to pull in a commit necessary for the update of vyos1x-config/libvyosconfig:
https://github.com/vyos/vyos-1x/commit/c57494027bd3b5865634c62ccd97f44e1d75c546
so ignore 'compare'.

Add support for unit test of configtree diff function, by adding a union operation for configtrees and an optional argument for ordering values on rendering to_string(). These are used only in internal tests.

The commit to vyos1x-config
https://github.com/vyos/vyos1x-config/commit/0d45764873c0a2ec345b14c3bf750ff1fccb74a9
implements a general ordering of _nodes_ consistent with that of the legacy backend. No change will be apparent in CLI use, but it provides standard ordering for mock configs (unit tests) and will provide a future replacement for the legacy ordering.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5089
* https://vyos.dev/T5088
* https://vyos.dev/T5087

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
