### PR TITLE
dhcp: pppoe: T5104: fix VRF comparisons

### DIFF
--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -333,8 +333,9 @@ def get_dhcp_interfaces(conf, vrf=None):
             if dict_search('dhcp_options.default_route_distance', config) != None:
                 options.update({'dhcp_options' : config['dhcp_options']})
             if 'vrf' in config:
-                if vrf is config['vrf']: tmp.update({ifname : options})
-            else: tmp.update({ifname : options})
+                if vrf == config['vrf']: tmp.update({ifname : options})
+            else:
+                if vrf is None: tmp.update({ifname : options})
 
         return tmp
 
@@ -382,8 +383,9 @@ def get_pppoe_interfaces(conf, vrf=None):
         if 'no_default_route' in ifconfig:
             options.update({'no_default_route' : {}})
         if 'vrf' in ifconfig:
-            if vrf is ifconfig['vrf']: pppoe_interfaces.update({ifname : options})
-        else: pppoe_interfaces.update({ifname : options})
+            if vrf == ifconfig['vrf']: pppoe_interfaces.update({ifname : options})
+        else:
+            if vrf is None: pppoe_interfaces.update({ifname : options})
 
     return pppoe_interfaces
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Fix DHCP default route issues with static routes in VRFs.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5104

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* dhcp
* pppoe
* vrf

## Proposed changes
<!--- Describe your changes in detail -->
Fix VRF comparisons in `get_dhcp_interfaces()` and `get_pppoe_interfaces()`.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set vrf name MGMT table 100
set interfaces ethernet eth0 vrf MGMT
set interfaces ethernet eth0 address dhcp
commit
sleep 10
vtysh -c 'show running-config'

set vrf name MGMT protocols static route 1.1.1.1/32 dhcp-interface eth0
commit
vtysh -c 'show running-config'

delete interfaces ethernet eth0 address
delete vrf name MGMT protocols
commit
delete interfaces ethernet eth0 vrf
commit
set interfaces ethernet eth0 address dhcp
commit
sleep 10
vtysh -c 'show running-config'

set vrf name MGMT protocols static route 1.1.1.1/32 dhcp-interface eth0
commit
vtysh -c 'show running-config'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
