### PR TITLE
graphql: T5106: extend generation of API client requests to configsession and composite requests

### DIFF
--- a/src/services/api/graphql/generate/config_session_function.py
+++ b/src/services/api/graphql/generate/config_session_function.py
@@ -28,5 +28,3 @@ mutations = {'save_config_file': save_config_file,
              'load_config_file': load_config_file,
              'add_system_image': add_system_image,
              'delete_system_image': delete_system_image}
-
-

--- a/src/services/api/graphql/generate/schema_from_config_session.py
+++ b/src/services/api/graphql/generate/schema_from_config_session.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022 VyOS maintainers and contributors
+# Copyright (C) 2022-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -20,8 +20,7 @@
 
 import os
 import sys
-import json
-from inspect import signature, getmembers, isfunction, isclass, getmro
+from inspect import signature
 from jinja2 import Template
 
 from vyos.defaults import directories
@@ -32,9 +31,9 @@ if __package__ is None or __package__ == '':
 else:
     from .. libs.op_mode import snake_to_pascal_case, map_type_name
     from . config_session_function import queries, mutations
-    from .. import state
 
 SCHEMA_PATH = directories['api_schema']
+CLIENT_OP_PATH = directories['api_client_op']
 
 schema_data: dict = {'schema_name': '',
                      'schema_fields': []}
@@ -85,6 +84,30 @@ extend type Mutation {
 }
 """
 
+op_query_template = """
+query {{ op_name }} ({{ op_sig }}) {
+  {{ op_name }} (data: { {{ op_arg }} }) {
+    success
+    errors
+    data {
+      result
+    }
+  }
+}
+"""
+
+op_mutation_template = """
+mutation {{ op_name }} ({{ op_sig }}) {
+  {{ op_name }} (data: { {{ op_arg }} }) {
+    success
+    errors
+    data {
+      result
+    }
+  }
+}
+"""
+
 def create_schema(func_name: str, func: callable, template: str) -> str:
     sig = signature(func)
 
@@ -104,18 +127,51 @@ def create_schema(func_name: str, func: callable, template: str) -> str:
 
     return res
 
+def create_client_op(func_name: str, func: callable, template: str) -> str:
+    sig = signature(func)
+
+    field_dict = {}
+    for k in sig.parameters:
+        field_dict[sig.parameters[k].name] = map_type_name(sig.parameters[k].annotation)
+
+    op_sig = ['$key: String']
+    op_arg = ['key: $key']
+    for k,v in field_dict.items():
+        op_sig.append('$'+k+': '+v)
+        op_arg.append(k+': $'+k)
+
+    op_data = {}
+    op_data['op_name'] = snake_to_pascal_case(func_name)
+    op_data['op_sig'] = ', '.join(op_sig)
+    op_data['op_arg'] = ', '.join(op_arg)
+
+    j2_template = Template(template)
+
+    res = j2_template.render(op_data)
+
+    return res
+
 def generate_config_session_definitions():
-    results = []
+    schema = []
+    client_op = []
     for name,func in queries.items():
         res = create_schema(name, func, query_template)
-        results.append(res)
+        schema.append(res)
+        res = create_client_op(name, func, op_query_template)
+        client_op.append(res)
 
     for name,func in mutations.items():
         res = create_schema(name, func, mutation_template)
-        results.append(res)
+        schema.append(res)
+        res = create_client_op(name, func, op_mutation_template)
+        client_op.append(res)
 
-    out = '\n'.join(results)
+    out = '\n'.join(schema)
     with open(f'{SCHEMA_PATH}/configsession.graphql', 'w') as f:
+        f.write(out)
+
+    out = '\n'.join(client_op)
+    with open(f'{CLIENT_OP_PATH}/configsession.graphql', 'w') as f:
         f.write(out)
 
 if __name__ == '__main__':

--- a/src/services/api/graphql/generate/schema_from_op_mode.py
+++ b/src/services/api/graphql/generate/schema_from_op_mode.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022 VyOS maintainers and contributors
+# Copyright (C) 2022-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -35,7 +35,6 @@ if __package__ is None or __package__ == '':
 else:
     from .. libs.op_mode import is_show_function_name
     from .. libs.op_mode import snake_to_pascal_case, map_type_name
-    from .. import state
 
 OP_MODE_PATH = directories['op_mode']
 SCHEMA_PATH = directories['api_schema']

--- a/src/services/api/graphql/graphql/client_op/auth_token.graphql
+++ b/src/services/api/graphql/graphql/client_op/auth_token.graphql
@@ -1,0 +1,10 @@
+
+mutation AuthToken ($username: String!, $password: String!) {
+  AuthToken (data: { username: $username, password: $password }) {
+    success
+    errors
+    data {
+      result
+    }
+  }
+}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This completes the client hints code generation of T5068 for use with the 'codegen' tools. T5068 addressed the case of op-mode requests; this PR extends the same practice to configsession native functions and composite requests.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5106

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

http-api

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
