### PR TITLE
T5108: Add option rate-limit for l2tp pptp sstp ipoe raw format

### DIFF
--- a/src/op_mode/accelppp.py
+++ b/src/op_mode/accelppp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022 VyOS maintainers and contributors
+# Copyright (C) 2022-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -75,8 +75,8 @@ def _get_raw_statistics(accel_output, pattern, protocol):
 
 
 def _get_raw_sessions(port):
-    cmd_options = 'show sessions ifname,username,ip,ip6,ip6-dp,type,state,' \
-                  'uptime-raw,calling-sid,called-sid,sid,comp,rx-bytes-raw,' \
+    cmd_options = 'show sessions ifname,username,ip,ip6,ip6-dp,type,rate-limit,' \
+                  'state,uptime-raw,calling-sid,called-sid,sid,comp,rx-bytes-raw,' \
                   'tx-bytes-raw,rx-pkts,tx-pkts'
     output = vyos.accel_ppp.accel_cmd(port, cmd_options)
     parsed_data: list[dict[str, str]] = vyos.accel_ppp.accel_out_parse(


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
There is a missing useful option `rate-limit` for L2TP/PPTP/SSTP/IPoE raw output format, `op-mode`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Extend exists accel-ppp options

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5108

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
accel-ppp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Before fix no expected option `rate_limit` for `raw`:
```
# /usr/libexec/vyos/op_mode/accelppp.py show_sessions --protocol pppoe
ifname | username |      ip      | ip6 | ip6-dp |    calling-sid    | rate-limit  | state  |  uptime  | rx-bytes | tx-bytes 
--------+----------+--------------+-----+--------+-------------------+-------------+--------+----------+----------+----------
 ppp1   | user1    | 100.64.202.2 |     |        | 56:ac:80:ed:69:63 | 10000/10000 | active | 00:01:10 | 832 B    | 198 B
# 
# /usr/libexec/vyos/op_mode/accelppp.py show_sessions --protocol pppoe --raw
[
    {
        "ifname": "ppp1",
        "username": "user1",
        "ip": "100.64.202.2",
        "ip6": "",
        "ip6_dp": "",
        "type": "pppoe",
        "state": "active",
        "uptime_raw": "76",
        "calling_sid": "56:ac:80:ed:69:63",
        "called_sid": "c2:ab:18:fc:82:a0",
        "sid": "9620a0d7914d7e7f",
        "comp": "",
        "rx_bytes_raw": "832",
        "tx_bytes_raw": "198",
        "rx_pkts": "14",
        "tx_pkts": "6"
    }
]

```
After fix (added option `rate_limit`):
```
# /usr/libexec/vyos/op_mode/accelppp.py show_sessions --protocol pppoe --raw
[
    {
        "ifname": "ppp1",
        "username": "user1",
        "ip": "100.64.202.2",
        "ip6": "",
        "ip6_dp": "",
        "type": "pppoe",
        "rate_limit": "10000/10000",
        "state": "active",
        "uptime_raw": "253",
        "calling_sid": "56:ac:80:ed:69:63",
        "called_sid": "c2:ab:18:fc:82:a0",
        "sid": "9620a0d7914d7e7f",
        "comp": "",
        "rx_bytes_raw": "832",
        "tx_bytes_raw": "198",
        "rx_pkts": "14",
        "tx_pkts": "6"
    }
]

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
