### PR TITLE
ipsec: T5003: Resolve issue with IPsec DHCP test

### DIFF
--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -117,6 +117,8 @@ rgiyCHemtMepq57Pl1Nmj49eEA==
 """
 
 class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
+    skip_process_check = False
+
     @classmethod
     def setUpClass(cls):
         super(TestVPNIPsec, cls).setUpClass()
@@ -141,7 +143,10 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
     def tearDown(self):
         # Check for running process
-        self.assertTrue(process_named_running(PROCESS_NAME))
+        if not self.skip_process_check:
+            self.assertTrue(process_named_running(PROCESS_NAME))
+        else:
+            self.skip_process_check = False # Reset
 
         self.cli_delete(base_path)
         self.cli_delete(tunnel_path)
@@ -151,6 +156,9 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         self.assertFalse(process_named_running(PROCESS_NAME))
 
     def test_01_dhcp_fail_handling(self):
+        # Skip process check - connection is not created for this test
+        self.skip_process_check = True
+
         # Interface for dhcp-interface
         self.cli_set(ethernet_path + [interface, 'vif', vif, 'address', 'dhcp']) # Use VLAN to avoid getting IP from qemu dhcp server
 

--- a/src/conf_mode/vpn_ipsec.py
+++ b/src/conf_mode/vpn_ipsec.py
@@ -549,6 +549,8 @@ def generate(ipsec):
     if ipsec['dhcp_no_address']:
         with open(DHCP_HOOK_IFLIST, 'w') as f:
             f.write(" ".join(ipsec['dhcp_no_address'].values()))
+    elif os.path.exists(DHCP_HOOK_IFLIST):
+        os.unlink(DHCP_HOOK_IFLIST)
 
     for path in [swanctl_dir, CERT_PATH, CA_PATH, CRL_PATH, PUBKEY_PATH]:
         if not os.path.exists(path):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Issue caused as the DHCP test does not create any connection and thus no `charon` process is created. `tearDown` by default asserts existence of the process.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5003
* https://vyos.dev/T2816

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec

## Proposed changes
<!--- Describe your changes in detail -->
This PR allows a test to bypass the process check on tearDown by setting a class variable.

Also add a commit to remove the DHCP hook file if present and no longer required.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
test_01_dhcp_fail_handling (__main__.TestVPNIPsec.test_01_dhcp_fail_handling) ... ok
test_02_site_to_site (__main__.TestVPNIPsec.test_02_site_to_site) ... ok
test_03_site_to_site_vti (__main__.TestVPNIPsec.test_03_site_to_site_vti) ... ok
test_04_dmvpn (__main__.TestVPNIPsec.test_04_dmvpn) ... ok
test_05_x509_site2site (__main__.TestVPNIPsec.test_05_x509_site2site) ... ok
test_06_flex_vpn_vips (__main__.TestVPNIPsec.test_06_flex_vpn_vips) ... ok

----------------------------------------------------------------------
Ran 6 tests in 30.563s
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
