### PR TITLE
dns: T5113: Support custom port for name-server forwarders

### DIFF
--- a/interface-definitions/dns-forwarding.xml.in
+++ b/interface-definitions/dns-forwarding.xml.in
@@ -635,7 +635,7 @@
                 </properties>
                 <defaultValue>1500</defaultValue>
               </leafNode>
-              #include <include/name-server-ipv4-ipv6.xml.i>
+              #include <include/name-server-ipv4-ipv6-port.xml.i>
               <leafNode name="source-address">
                 <properties>
                   <help>Local addresses from which to send DNS queries</help>

--- a/interface-definitions/include/name-server-ipv4-ipv6-port.xml.i
+++ b/interface-definitions/include/name-server-ipv4-ipv6-port.xml.i
@@ -1,0 +1,25 @@
+<!-- include start from name-server-ipv4-ipv6-port.xml.i -->
+<tagNode name="name-server">
+  <properties>
+    <help>Domain Name Servers (DNS) addresses</help>
+    <valueHelp>
+      <format>ipv4</format>
+      <description>Domain Name Server (DNS) IPv4 address</description>
+    </valueHelp>
+    <valueHelp>
+      <format>ipv6</format>
+      <description>Domain Name Server (DNS) IPv6 address</description>
+    </valueHelp>
+    <constraint>
+      <validator name="ipv4-address"/>
+      <validator name="ipv6-address"/>
+    </constraint>
+  </properties>
+  <children>
+    #include <include/port-number.xml.i>
+    <leafNode name="port">
+      <defaultValue>53</defaultValue>
+    </leafNode>
+  </children>
+</tagNode>
+<!-- include end -->


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Support custom port for name-server forwarders that would allow using custom ports in name server forwarders to enable forwarding to alternative name servers (unbound, stubby, dnscrypt-proxy etc.) operating on non-default port.

This would also allow using DNS Over TLS in PowerDNS Recursor 4.6 onwards (pdns doesn't support certificate check for validity yet) by enabling `dot-to-port-853`. This is set by default if compiled in with DoT support.
See: https://doc.powerdns.com/recursor/settings.html#dot-to-port-853
 
This also partially implements T921, T2195 (DoT without certificate check).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5113
* https://vyos.dev/T921
* https://vyos.dev/T2195

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dns forwarding

## Implementation details
<!--- Describe your changes in detail -->
- In 'dns/forwarding' configuration, 'name-server' now allows optional `port` (defaults to 53).
- Instead of modifying `name-server-ipv4-ipv6.xml.i` to add optional `port`, a new file `name-server-ipv4-ipv6-port.xml.i` has been used to avoid impacting other places where it is reused because not all of them honor ports (mostly VPN related).
- The `host:port` entries to be used by PowerDNS recursor config are normalized eagerly at the point of loading VyOS `Config` instead of doing them lazily while rendering the Jinja2 template to keep the implementation less intrusive. The alternative would entail making quite a bit of change in how `vyos-hostsd` processes `static` `name_servers` entries or persists their runtime states. (_I am open to suggestion/recommendation with the approach here._)
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
- Add forwarding name-servers as so:
```
set service dns forwarding name-server 1.1.1.1                     # default port 53
set service dns forwarding name-server 1.0.0.1 port 853            # custom port 853
set service dns forwarding name-server 2606:4700::1111 port 853    # custom port 853
```
- Look for static entries in `/run/powerdns/recursor.forward-zones.conf` like so:
  - `1.1.1.1`
  - `1.0.0.1:853`
  - `[2606:4700::1111]:853`


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
