### PR TITLE
T5110: Fix op-mode FRR vtysh_pam account validation

### DIFF
--- a/debian/vyos-1x.postinst
+++ b/debian/vyos-1x.postinst
@@ -115,5 +115,12 @@ done
 sed -i '/^\/var\/log\/messages$/d' /etc/logrotate.d/rsyslog
 sed -i '/^\/var\/log\/auth.log$/d' /etc/logrotate.d/rsyslog
 
+# Fix FRR pam.d "vtysh_pam" vtysh_pam: Failed in account validation T5110
+if test -f /etc/pam.d/frr; then
+    if grep -q 'pam_rootok.so' /etc/pam.d/frr; then
+        sed -i -re 's/rootok/permit/' /etc/pam.d/frr
+    fi
+fi
+
 # Generate API GraphQL schema
 /usr/libexec/vyos/services/api/graphql/generate/generate_schema.py


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
With FRR 8.5, there exists the file `/etc/pam.d/frr`
With this file, by default, we have cosmetic error for any op-mode command

```
$ show ip bgp
vtysh_pam: Failed in account validation: Success(0)No BGP prefixes displayed, 0 exist
```
Fix it
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5110

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pam.d
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Before fix:
```
vyos@vyos:~$ cat /etc/pam.d/frr
# Any user may call vtysh but only those belonging to the group frrvty can
# actually connect to the socket and use the program.
auth	sufficient	pam_permit.so
account	sufficient	pam_rootok.so
```
FRR any op-mode command:
```
vyos@r14:~$ show ip bgp 
vtysh_pam: Failed in account validation: Success(0)No BGP prefixes displayed, 0 exist
vyos@r14:~$
```

After the fix:
```
vyos@r14:~$ sudo cat /etc/pam.d/frr 
# Any user may call vtysh but only those belonging to the group frrvty can
# actually connect to the socket and use the program.
auth	sufficient	pam_permit.so
account	sufficient	pam_permit.so
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ show ip bgp
No BGP prefixes displayed, 0 exist
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
