### PR TITLE
T5128: Policy Route: allow wildcard on interface

### DIFF
--- a/data/templates/firewall/nftables-policy.j2
+++ b/data/templates/firewall/nftables-policy.j2
@@ -11,7 +11,7 @@ table ip vyos_mangle {
         type filter hook prerouting priority -150; policy accept;
 {% if route is vyos_defined %}
 {%     for route_text, conf in route.items() if conf.interface is vyos_defined %}
-        iifname { {{ ",".join(conf.interface) }} } counter jump VYOS_PBR_{{ route_text }}
+        iifname { {{ conf.interface | join(",") }} } counter jump VYOS_PBR_{{ route_text }}
 {%     endfor %}
 {% endif %}
     }

--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -349,6 +349,9 @@
           <completionHelp>
             <script>${vyos_completion_dir}/list_interfaces</script>
           </completionHelp>
+          <constraint>
+            #include <include/constraint/interface-name-with-wildcard.xml.in>
+          </constraint>
         </properties>
         <children>
           <node name="in">

--- a/interface-definitions/include/constraint/interface-name-with-wildcard.xml.in
+++ b/interface-definitions/include/constraint/interface-name-with-wildcard.xml.in
@@ -1,0 +1,4 @@
+<!-- include start from constraint/interface-name-with-wildcard.xml.in -->
+<regex>(bond|br|dum|en|ersp|eth|gnv|ifb|lan|l2tp|l2tpeth|macsec|peth|ppp|pppoe|pptp|sstp|tun|veth|vti|vtun|vxlan|wg|wlan|wwan)([0-9]?)(\*?)(.+)?|lo</regex>
+<validator name="file-path --lookup-path /sys/class/net --directory"/>
+<!-- include end -->

--- a/interface-definitions/include/generic-interface-multi-wildcard.xml.i
+++ b/interface-definitions/include/generic-interface-multi-wildcard.xml.i
@@ -1,0 +1,19 @@
+
+<!-- include start from generic-interface-multi-wildcard.xml.i -->
+<leafNode name="interface">
+  <properties>
+    <help>Interface name to apply policy route configuration</help>
+    <completionHelp>
+      <script>${vyos_completion_dir}/list_interfaces</script>
+    </completionHelp>
+    <valueHelp>
+      <format>txt</format>
+      <description>Interface name</description>
+    </valueHelp>
+    <constraint>
+      #include <include/constraint/interface-name-with-wildcard.xml.in>
+    </constraint>
+    <multi/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/policy-route.xml.in
+++ b/interface-definitions/policy-route.xml.in
@@ -12,8 +12,8 @@
         </properties>
         <children>
           #include <include/generic-description.xml.i>
-          #include <include/generic-interface-multi.xml.i>
           #include <include/firewall/enable-default-log.xml.i>
+          #include <include/generic-interface-multi-wildcard.xml.i>
           <tagNode name="rule">
             <properties>
               <help>Policy rule number</help>
@@ -67,8 +67,8 @@
         </properties>
         <children>
           #include <include/generic-description.xml.i>
-          #include <include/generic-interface-multi.xml.i>
           #include <include/firewall/enable-default-log.xml.i>
+          #include <include/generic-interface-multi-wildcard.xml.i>
           <tagNode name="rule">
             <properties>
               <help>Policy rule number</help>

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -198,6 +198,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
     def test_ipv4_basic_rules(self):
         name = 'smoketest'
         interface = 'eth0'
+        interface_wc = 'l2tp*'
         mss_range = '501-1460'
         conn_mark = '555'
 
@@ -240,6 +241,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['firewall', 'name', name, 'rule', '6', 'connection-mark', conn_mark])
 
         self.cli_set(['firewall', 'interface', interface, 'in', 'name', name])
+        self.cli_set(['firewall', 'interface', interface_wc, 'in', 'name', name])
 
         self.cli_commit()
 
@@ -247,6 +249,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         nftables_search = [
             [f'iifname "{interface}"', f'jump NAME_{name}'],
+            [f'iifname "{interface_wc}"', f'jump NAME_{name}'],
             ['saddr 172.16.20.10', 'daddr 172.16.10.10', 'log prefix "[smoketest-1-A]" log level debug', 'ip ttl 15', 'return'],
             ['tcp flags syn / syn,ack', 'tcp dport 8888', 'log prefix "[smoketest-2-R]" log level err', 'ip ttl > 102', 'reject'],
             ['tcp dport 22', 'limit rate 5/minute', 'return'],

--- a/smoketest/scripts/cli/test_policy_route.py
+++ b/smoketest/scripts/cli/test_policy_route.py
@@ -26,6 +26,7 @@ conn_mark_set = '111'
 table_mark_offset = 0x7fffffff
 table_id = '101'
 interface = 'eth0'
+interface_wc = 'ppp*'
 interface_ip = '172.16.10.1/24'
 
 class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
@@ -236,7 +237,8 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '5', 'set', 'table', table_id])
 
         self.cli_set(['policy', 'route', 'smoketest', 'interface', interface])
-        self.cli_set(['policy', 'route6', 'smoketest6', 'interface', interface])
+        self.cli_set(['policy', 'route', 'smoketest', 'interface', interface_wc])
+        self.cli_set(['policy', 'route6', 'smoketest6', 'interface', interface_wc])
 
         self.cli_commit()
 
@@ -244,7 +246,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
 
         # IPv4
         nftables_search = [
-            [f'iifname "{interface}"', 'jump VYOS_PBR_smoketest'],
+            ['iifname { "' + interface + '", "' + interface_wc + '" }', 'jump VYOS_PBR_smoketest'],
             ['meta l4proto udp', 'drop'],
             ['tcp flags syn / syn,ack', 'meta mark set ' + mark_hex],
             ['ct state new', 'tcp dport 22', 'ip saddr 198.51.100.0/24', 'ip ttl > 2', 'meta mark set ' + mark_hex],
@@ -256,7 +258,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
 
         # IPv6
         nftables6_search = [
-            [f'iifname "{interface}"', 'jump VYOS_PBR6_smoketest'],
+            [f'iifname "{interface_wc}"', 'jump VYOS_PBR6_smoketest'],
             ['meta l4proto udp', 'drop'],
             ['tcp flags syn / syn,ack', 'meta mark set ' + mark_hex],
             ['ct state new', 'tcp dport 22', 'ip6 saddr 2001:db8::/64', 'ip6 hoplimit > 2', 'meta mark set ' + mark_hex],


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
allow wildcard on interface

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5128

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
policy route
policy route6

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
vyos@POL-WC# run show config comm | grep policy
set policy route PR-01 interface 'eth1'
set policy route PR-01 interface 'l2tp*'
set policy route PR-01 rule 10 destination address '198.51.100.100'
set policy route PR-01 rule 10 protocol 'tcp'
set policy route PR-01 rule 10 set connection-mark '555'
set policy route PR-02 interface 'eth3'
set policy route PR-02 rule 10 protocol 'icmp'
set policy route PR-02 rule 10 set mark '999'
set policy route PR-02 rule 10 source address '203.0.113.0/24'
set policy route6 PR6 interface 'eth*'
set policy route6 PR6 rule 10 protocol 'icmpv6'
set policy route6 PR6 rule 10 set table '66'
[edit]
vyos@POL-WC# sudo nft list table ip vyos_mangle
table ip vyos_mangle {
        chain VYOS_PBR_PREROUTING {
                type filter hook prerouting priority mangle; policy accept;
                iifname { "eth1", "l2tp*" } counter packets 0 bytes 0 jump VYOS_PBR_PR-01
                iifname "eth3" counter packets 0 bytes 0 jump VYOS_PBR_PR-02
        }

        chain VYOS_PBR_POSTROUTING {
                type filter hook postrouting priority mangle; policy accept;
        }

        chain VYOS_PBR_PR-01 {
                meta l4proto tcp ip daddr 198.51.100.100 counter packets 0 bytes 0 ct mark set 0x0000022b return comment "PR-01-10"
        }

        chain VYOS_PBR_PR-02 {
                meta l4proto icmp ip saddr 203.0.113.0/24 counter packets 0 bytes 0 meta mark set 0x000003e7 return comment "PR-02-10"
        }
}
[edit]
vyos@POL-WC# sudo nft list table ip6 vyos_mangle
table ip6 vyos_mangle {
        chain VYOS_PBR6_PREROUTING {
                type filter hook prerouting priority mangle; policy accept;
                iifname "eth*" counter packets 4 bytes 224 jump VYOS_PBR6_PR6
        }

        chain VYOS_PBR6_POSTROUTING {
                type filter hook postrouting priority mangle; policy accept;
        }

        chain VYOS_PBR6_PR6 {
                meta l4proto ipv6-icmp counter packets 4 bytes 224 meta mark set 0x7fffffbd return comment "PR6-10"
        }
}
[edit]
vyos@POL-WC# 
```
Also, update constraint for firewall interface, and add smoke test for at least one interface using wild-card:
```
root@POL-WC:/usr/libexec/vyos/tests/smoke/cli# ./test_firewall.py
test_geoip (__main__.TestFirewall.test_geoip) ... Updating GeoIP. Please wait...
Updating GeoIP. Please wait...
ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
test_state_policy (__main__.TestFirewall.test_state_policy) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok

----------------------------------------------------------------------
Ran 13 tests in 28.146s
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
