### PR TITLE
ipsec: T5093: Fixed 'reset vpn ipsec profile' command

### DIFF
--- a/op-mode-definitions/vpn-ipsec.xml.in
+++ b/op-mode-definitions/vpn-ipsec.xml.in
@@ -14,7 +14,7 @@
             <children>
               <tagNode name="profile">
                 <properties>
-                  <help>Reset all tunnels for given DMVPN profile</help>
+                  <help>Reset a specific tunnel for given DMVPN profile</help>
                   <completionHelp>
                     <path>vpn ipsec profile</path>
                   </completionHelp>
@@ -23,11 +23,24 @@
                   <tagNode name="tunnel">
                     <properties>
                       <help>Reset a specific tunnel for given DMVPN profile</help>
+                      <completionHelp>
+                        <script>sudo ${vyos_completion_dir}/list_ipsec_profile_tunnels.py --profile ${COMP_WORDS[4]}</script>
+                      </completionHelp>
                     </properties>
-                    <command>sudo ${vyos_op_scripts_dir}/vpn_ipsec.py --action="reset-profile" --name="$6" --tunnel="$8"</command>
+                    <children>
+                      <tagNode name="remote-host">
+                        <properties>
+                          <help>Reset a specific tunnel for given DMVPN NBMA</help>
+                          <completionHelp>
+                            <list>&lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
+                          </completionHelp>
+                        </properties>
+                        <command>sudo ${vyos_op_scripts_dir}/ipsec.py reset_profile_dst --profile="$5" --tunnel="$7" --nbma_dst="$9"</command>
+                      </tagNode>
+                    </children>
+                    <command>sudo ${vyos_op_scripts_dir}/ipsec.py reset_profile_all --profile="$5" --tunnel="$7"</command>
                   </tagNode>
                 </children>
-                <command>sudo ${vyos_op_scripts_dir}/vpn_ipsec.py --action="reset-profile" --name="$6" --tunnel="all"</command>
               </tagNode>
               <node name="remote-access">
                 <properties>

--- a/python/vyos/ipsec.py
+++ b/python/vyos/ipsec.py
@@ -139,3 +139,41 @@ def terminate_vici_by_name(ike_name: str, child_name: str) -> None:
         else:
             raise ViciCommandError(
                 f'Failed to terminate SA for IKE {ike_name}')
+
+
+def vici_initiate(ike_sa_name: str, child_sa_name: str, src_addr: str,
+                  dst_addr: str) -> bool:
+    """Initiate IKE SA connection with specific peer
+
+    Args:
+        ike_sa_name (str): an IKE SA connection name
+        child_sa_name (str): a child SA profile name
+        src_addr (str): source address
+        dst_addr (str): remote address
+
+    Returns:
+        bool: a result of initiation command
+    """
+    from vici import Session as vici_session
+
+    try:
+        session = vici_session()
+    except Exception:
+        raise ViciInitiateError("IPsec not initialized")
+
+    try:
+        session_generator = session.initiate({
+            'ike': ike_sa_name,
+            'child': child_sa_name,
+            'timeout': '-1',
+            'my-host': src_addr,
+            'other-host': dst_addr
+        })
+        # a dummy `for` loop is required because of requirements
+        # from vici. Without a full iteration on the output, the
+        # command to vici may not be executed completely
+        for _ in session_generator:
+            pass
+        return True
+    except Exception:
+        raise ViciCommandError(f'Failed to initiate SA for IKE {ike_sa_name}')

--- a/src/completion/list_ipsec_profile_tunnels.py
+++ b/src/completion/list_ipsec_profile_tunnels.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2019-2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import argparse
+
+from vyos.config import Config
+from vyos.util import dict_search
+
+def get_tunnels_from_ipsecprofile(profile):
+    config = Config()
+    base = ['vpn', 'ipsec', 'profile', profile, 'bind']
+    profile_conf = config.get_config_dict(base, effective=True, key_mangling=('-', '_'))
+    tunnels = []
+
+    try:
+        for tunnel in (dict_search('bind.tunnel', profile_conf) or []):
+            tunnels.append(tunnel)
+    except:
+        pass
+
+    return tunnels
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--profile", type=str, help="List tunnels per profile")
+    args = parser.parse_args()
+
+    tunnels = []
+
+    tunnels = get_tunnels_from_ipsecprofile(args.profile)
+
+    print(" ".join(tunnels))
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed 'reset vpn ipsec profile' command
using vici library and new op-mode style.
Added ability to use 'reset vpn ipsec profile' command with 'remote-host' option.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5093

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec

## Proposed changes
<!--- Describe your changes in detail -->
Fixed 'reset vpn ipsec profile' command
using vici library and new op-mode style.
Added ability to use 'reset vpn ipsec profile' command with 'remote-host' option.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configuration:
DMVPN HUB
```
set interfaces tunnel tun100 address '10.0.0.1/24'
set interfaces tunnel tun100 enable-multicast
set interfaces tunnel tun100 encapsulation 'gre'
set interfaces tunnel tun100 parameters ip key '1'
set interfaces tunnel tun100 source-interface 'eth0'
set protocols nhrp tunnel tun100 cisco-authentication 'test'
set protocols nhrp tunnel tun100 holding-time '30'
set protocols nhrp tunnel tun100 multicast 'dynamic'
set protocols nhrp tunnel tun100 redirect
set protocols nhrp tunnel tun100 shortcut
set vpn ipsec esp-group ESP-HUB lifetime '1800'
set vpn ipsec esp-group ESP-HUB mode 'transport'
set vpn ipsec esp-group ESP-HUB pfs 'dh-group2'
set vpn ipsec esp-group ESP-HUB proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-HUB proposal 1 hash 'sha1'
set vpn ipsec ike-group IKE-HUB close-action 'none'
set vpn ipsec ike-group IKE-HUB dead-peer-detection action 'restart'
set vpn ipsec ike-group IKE-HUB dead-peer-detection interval '3'
set vpn ipsec ike-group IKE-HUB dead-peer-detection timeout '30'
set vpn ipsec ike-group IKE-HUB key-exchange 'ikev1'
set vpn ipsec ike-group IKE-HUB lifetime '3600'
set vpn ipsec ike-group IKE-HUB proposal 1 dh-group '2'
set vpn ipsec ike-group IKE-HUB proposal 1 encryption 'aes128'
set vpn ipsec ike-group IKE-HUB proposal 1 hash 'sha1'
set vpn ipsec interface 'eth0'
set vpn ipsec profile NHRPVPN authentication mode 'pre-shared-secret'
set vpn ipsec profile NHRPVPN authentication pre-shared-secret 'test'
set vpn ipsec profile NHRPVPN bind tunnel 'tun100'
set vpn ipsec profile NHRPVPN esp-group 'ESP-HUB'
set vpn ipsec profile NHRPVPN ike-group 'IKE-HUB'
```


Before changes:
```
vyos@vyos:~$ reset vpn ipsec profile NHRPVPN
Invalid profile, aborting
vyos@vyos:~$ reset vpn ipsec profile NHRPVPN tunnel tun100
Invalid tunnel, aborting
```

'sudo swanctl -l' command does not show any changes. 

After changes:
```
vyos@vyos:~$ reset vpn ipsec profile NHRPVPN tunnel tun100
Profile NHRPVPN tunnel tun100 remote-host 192.168.139.111 reset result: success
Profile NHRPVPN tunnel tun100 remote-host 192.168.139.112 reset result: success
Profile NHRPVPN tunnel tun100 reset result: success

vyos:~$ reset vpn ipsec profile NHRPVPN tunnel tun100 remote-host 192.168.139.111
Profile NHRPVPN tunnel tun100 remote-host 192.168.139.111 reset result: success
```

'sudo swanctl -l' command shows that SAs IDs were changed. 
Before running command:
```
vyos@vyos:~$ sudo swanctl -l
dmvpn-NHRPVPN-tun100: #6, ESTABLISHED, IKEv1, 2ff08e5dc2288849_i* d29faa4353becb1f_r
  local  '192.168.139.101' @ 192.168.139.101[500]
  remote '192.168.139.111' @ 192.168.139.111[500]
  AES_CBC-128/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
  established 832s ago, rekeying in 2451s
  dmvpn: #6, reqid 2, INSTALLED, TRANSPORT, ESP:AES_CBC-256/HMAC_SHA1_96/MODP_1024
    installed 832s ago, rekeying in 474s, expires in 1148s
    in  c1a468fa,   8400 bytes,    75 packets,     6s ago
    out ca00f01f,   9900 bytes,    75 packets,     6s ago
    local  192.168.139.101/32[gre]
    remote 192.168.139.111/32[gre]
dmvpn-NHRPVPN-tun100: #5, ESTABLISHED, IKEv1, ed1649c2c425dbd9_i* 75c5af36b61746b9_r
  local  '192.168.139.101' @ 192.168.139.101[500]
  remote '192.168.139.112' @ 192.168.139.112[500]
  AES_CBC-128/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
  established 883s ago, rekeying in 2394s
  dmvpn: #5, reqid 1, INSTALLED, TRANSPORT, ESP:AES_CBC-256/HMAC_SHA1_96/MODP_1024
    installed 883s ago, rekeying in 562s, expires in 1097s
    in  c70649c9,   8960 bytes,    80 packets,     3s ago
    out c973840e,  10560 bytes,    80 packets,     3s ago
    local  192.168.139.101/32[gre]
    remote 192.168.139.112/32[gre]
```
After running the command
```
vyos@vyos:~$ sudo swanctl -l
dmvpn-NHRPVPN-tun100: #8, ESTABLISHED, IKEv1, 2191bdec00f99fbc_i* 92b417fdd27f0e2a_r
  local  '192.168.139.101' @ 192.168.139.101[500]
  remote '192.168.139.112' @ 192.168.139.112[500]
  AES_CBC-128/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
  established 2s ago, rekeying in 3248s
  dmvpn: #8, reqid 1, INSTALLED, TRANSPORT, ESP:AES_CBC-256/HMAC_SHA1_96/MODP_1024
    installed 2s ago, rekeying in 1468s, expires in 1978s
    in  c22c4ac9,      0 bytes,     0 packets
    out c1533832,      0 bytes,     0 packets
    local  192.168.139.101/32[gre]
    remote 192.168.139.112/32[gre]
dmvpn-NHRPVPN-tun100: #7, ESTABLISHED, IKEv1, 723f60c29c22362d_i* 3c0dac07d613c921_r
  local  '192.168.139.101' @ 192.168.139.101[500]
  remote '192.168.139.111' @ 192.168.139.111[500]
  AES_CBC-128/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
  established 2s ago, rekeying in 3595s
  dmvpn: #7, reqid 2, INSTALLED, TRANSPORT, ESP:AES_CBC-256/HMAC_SHA1_96/MODP_1024
    installed 2s ago, rekeying in 1367s, expires in 1978s
    in  c041d5d7,      0 bytes,     0 packets
    out ce0cdabc,      0 bytes,     0 packets
    local  192.168.139.101/32[gre]
    remote 192.168.139.111/32[gre]
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
