### PR TITLE
T5125: Add op-mode for sFlow based on hsflowd

### DIFF
--- a/data/templates/sflow/hsflowd.conf.j2
+++ b/data/templates/sflow/hsflowd.conf.j2
@@ -28,4 +28,5 @@ sflow {
 {% if drop_monitor_limit is vyos_defined %}
   dropmon { limit={{ drop_monitor_limit }} start=on sw=on hw=off }
 {% endif %}
+  dbus { }
 }

--- a/op-mode-definitions/sflow.xml.in
+++ b/op-mode-definitions/sflow.xml.in
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- sflow op mode commands -->
+<interfaceDefinition>
+  <node name="show">
+    <children>
+      <node name="sflow">
+        <properties>
+          <help>Show sFlow statistics</help>
+        </properties>
+        <!-- requires sudo, do not remove it -->
+        <command>sudo ${vyos_op_scripts_dir}/sflow.py show</command>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/smoketest/scripts/cli/test_system_sflow.py
+++ b/smoketest/scripts/cli/test_system_sflow.py
@@ -91,6 +91,7 @@ class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'collector {{ ip = {server} udpport = {port} }}', hsflowd)
         self.assertIn(f'collector {{ ip = {local_server} udpport = {default_port} }}', hsflowd)
         self.assertIn(f'dropmon {{ limit={mon_limit} start=on sw=on hw=off }}', hsflowd)
+        self.assertIn('dbus { }', hsflowd)
 
         for interface in Section.interfaces('ethernet'):
             self.assertIn(f'pcap {{ dev={interface} }}', hsflowd)

--- a/src/op_mode/sflow.py
+++ b/src/op_mode/sflow.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import dbus
+import sys
+
+from tabulate import tabulate
+
+from vyos.configquery import ConfigTreeQuery
+from vyos.util import cmd
+
+import vyos.opmode
+
+
+def _get_raw_sflow():
+    bus = dbus.SystemBus()
+    config = ConfigTreeQuery()
+
+    interfaces = config.values('system sflow interface')
+    servers = config.list_nodes('system sflow server')
+
+    sflow = bus.get_object('net.sflow.hsflowd', '/net/sflow/hsflowd')
+    sflow_telemetry = dbus.Interface(
+        sflow, dbus_interface='net.sflow.hsflowd.telemetry')
+    agent_address = sflow_telemetry.GetAgent()
+    samples_dropped = int(sflow_telemetry.Get('dropped_samples'))
+    samples_packet_sent = int(sflow_telemetry.Get('flow_samples'))
+    samples_counter_sent = int(sflow_telemetry.Get('counter_samples'))
+    datagrams_sent = int(sflow_telemetry.Get('datagrams'))
+    rtmetric_samples = int(sflow_telemetry.Get('rtmetric_samples'))
+    samples_suppressed = int(sflow_telemetry.Get('flow_samples_suppressed'))
+    counter_samples_suppressed = int(
+        sflow_telemetry.Get("counter_samples_suppressed"))
+    version = sflow_telemetry.GetVersion()
+
+    sflow_dict = {
+        'agent_address': agent_address,
+        'sflow_interfaces': interfaces,
+        'sflow_servers': servers,
+        'counter_samples_sent': samples_counter_sent,
+        'datagrams_sent': datagrams_sent,
+        'packet_samples_dropped': samples_dropped,
+        'packet_samples_sent': samples_packet_sent,
+        'rtmetric_samples': rtmetric_samples,
+        'flow_samples_suppressed': samples_suppressed,
+        'counter_samples_suppressed': counter_samples_suppressed,
+        'hsflowd_version': version
+    }
+    return sflow_dict
+
+
+def _get_formatted_sflow(data):
+    table = [
+        ['Agent address', f'{data.get("agent_address")}'],
+        ['sFlow interfaces', f'{data.get("sflow_interfaces", "n/a")}'],
+        ['sFlow servers', f'{data.get("sflow_servers", "n/a")}'],
+        ['Datagrams sent', f'{data.get("datagrams_sent")}'],
+        ['Packet samples sent', f'{data.get("packet_samples_sent")}'],
+        ['Packet samples dropped', f'{data.get("packet_samples_dropped")}'],
+        ['Counter samples sent', f'{data.get("counter_samples_sent")}'],
+        ['Flow samples suppressed', f'{data.get("flow_samples_suppressed")}'],
+        ['Counter samples suppressed', f'{data.get("counter_samples_suppressed")}']
+    ]
+
+    return tabulate(table)
+
+
+def show(raw: bool):
+
+    config = ConfigTreeQuery()
+    if not config.exists('system sflow'):
+        raise vyos.opmode.UnconfiguredSubsystem(
+            '"system sflow" is not configured!')
+
+    sflow_data = _get_raw_sflow()
+    if raw:
+        return sflow_data
+    else:
+        return _get_formatted_sflow(sflow_data)
+
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except (ValueError, vyos.opmode.Error) as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add op-mode for sFlow based on hsflowd `show sflow`
Add machine-readable format `--raw` and formatted output
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5125

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
sflow
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Example of configuration:
```
set system sflow agent-address '192.168.122.14'
set system sflow drop-monitor-limit '50'
set system sflow interface 'eth0'
set system sflow interface 'eth1'
set system sflow polling '30'
set system sflow sampling-rate '100'
set system sflow server 192.168.122.1 port '6343'
set system sflow server 192.168.122.11 port '6343'

```
Op-mode formatted output:
```
vyos@r14:~$ show sflow 
--------------------------  -----------------------------------
Agent address               192.168.122.14
sFlow interfaces            ['eth0', 'eth1']
sFlow servers               ['192.168.122.1', '192.168.122.11']
Datagrams sent              164
Packet samples sent         9
Packet samples dropped      0
Counter samples sent        493
Flow samples suppressed     0
Counter samples suppressed  0
--------------------------  -----------------------------------
vyos@r14:~$ 
```
Raw format:
```
vyos@r14:~$ sudo /usr/libexec/vyos/op_mode/sflow.py show --raw
{
    "agent_address": "192.168.122.14",
    "sflow_interfaces": [
        "eth0",
        "eth1"
    ],
    "sflow_servers": [
        "192.168.122.1",
        "192.168.122.11"
    ],
    "counter_samples_sent": 652,
    "datagrams_sent": 218,
    "packet_samples_dropped": 0,
    "packet_samples_sent": 14,
    "rtmetric_samples": 0,
    "flow_samples_suppressed": 0,
    "counter_samples_suppressed": 0,
    "hsflowd_version": "2.0.50"
}
vyos@r14:~$ 
```
Smoketest:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_sflow.py
test_sflow (__main__.TestSystemFlowAccounting.test_sflow) ... ok

----------------------------------------------------------------------
Ran 1 test in 6.435s

OK
vyos@r14:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
