### PR TITLE
T1981: Fix ipv6 route-map for bgp

### DIFF
--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -486,6 +486,7 @@ def generate(bgp):
 
     bgp['protocol'] = 'bgp' # required for frr/vrf.route-map.frr.j2
     bgp['frr_zebra_config'] = render_to_string('frr/vrf.route-map.frr.j2', bgp)
+    bgp['frr_zebra_config_v6'] = render_to_string('frr/vrf.route-map.v6.frr.j2', bgp)
     bgp['frr_bgpd_config']  = render_to_string('frr/bgpd.frr.j2', bgp)
 
     return None
@@ -499,9 +500,15 @@ def apply(bgp):
 
     # The route-map used for the FIB (zebra) is part of the zebra daemon
     frr_cfg.load_configuration(zebra_daemon)
+
     frr_cfg.modify_section(r'(\s+)?ip protocol bgp route-map [-a-zA-Z0-9.]+', stop_pattern='(\s|!)')
     if 'frr_zebra_config' in bgp:
         frr_cfg.add_before(frr.default_add_before, bgp['frr_zebra_config'])
+
+    frr_cfg.modify_section(r'(\s+)?ipv6 protocol bgp route-map [-a-zA-Z0-9.]+', stop_pattern='(\s|!)')
+    if 'frr_zebra_config_v6' in bgp:
+        frr_cfg.add_before(frr.default_add_before, bgp['frr_zebra_config_v6'])
+
     frr_cfg.commit_configuration(zebra_daemon)
 
     # Generate empty helper string which can be ammended to FRR commands, it


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Add template to generate zebra "ipv6 protocol bgp route-map xxx"

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T1981

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set policy route-map SET-SRC rule 10 action 'permi'
set policy route-map SET-SRC rule 10 set src 2001:db8::1
set protocols bgp route-map 'SET-SRC'
```
Check zebra
```
vyos@r14# vtysh -c "show run zebra"
Building configuration...

Current configuration:
!
frr version 8.4.2
frr defaults traditional
hostname debian
log syslog
log facility local7
hostname r14
service integrated-vtysh-config
!
route-map SET-SRC permit 10
 set src 2001:db8::1
exit
!
ipv6 protocol bgp route-map SET-SRC
!
end
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
