### PR TITLE
T5142: Add audit tool to monitor security-relevant events

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -35,6 +35,7 @@ Architecture: amd64 arm64
 Depends:
   ${python3:Depends},
   accel-ppp,
+  auditd,
   avahi-daemon,
   beep,
   bmon,
@@ -80,6 +81,7 @@ Depends:
   lcdproc,
   lcdproc-extra-drivers,
   libatomic1,
+  libauparse0,
   libbpf1 [amd64],
   libcharon-extra-plugins (>=5.9),
   libcharon-extauth-plugins (>=5.9),

--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -8,6 +8,12 @@
         </properties>
         <command>journalctl --no-hostname --boot</command>
         <children>
+          <leafNode name="audit">
+            <properties>
+              <help>Show audit logs</help>
+            </properties>
+            <command>cat /var/log/audit/audit.log</command>
+          </leafNode>
           <leafNode name="all">
             <properties>
               <help>Show contents of all master log files</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
One of the requirements of a Collaborative Protection Profile cPP for Network Devices is using a system auditing tool to monitor and log all security-relevant events.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related PR's
* https://github.com/vyos/vyos-build/pull/333

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5142
* https://vyos.dev/T4712

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
audit, log
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
vyos@r14:~$ show log audit | tail -n 5
type=USER_LOGIN msg=audit(1680605305.274:946): pid=3991 uid=0 auid=4294967295 ses=4294967295 msg='op=login acct="foo" exe="/usr/sbin/sshd" hostname=? addr=192.168.122.1 terminal=sshd res=failed'UID="root" AUID="unset"
type=USER_AUTH msg=audit(1680605306.452:947): pid=3991 uid=0 auid=4294967295 ses=4294967295 msg='op=PAM:authentication grantors=? acct="foo" exe="/usr/sbin/sshd" hostname=192.168.122.1 addr=192.168.122.1 terminal=ssh res=failed'UID="root" AUID="unset"
type=USER_LOGIN msg=audit(1680605308.416:948): pid=3991 uid=0 auid=4294967295 ses=4294967295 msg='op=login acct="foo" exe="/usr/sbin/sshd" hostname=? addr=192.168.122.1 terminal=sshd res=failed'UID="root" AUID="unset"
type=USER_AUTH msg=audit(1680605309.691:949): pid=3991 uid=0 auid=4294967295 ses=4294967295 msg='op=PAM:authentication grantors=? acct="foo" exe="/usr/sbin/sshd" hostname=192.168.122.1 addr=192.168.122.1 terminal=ssh res=failed'UID="root" AUID="unset"
type=USER_LOGIN msg=audit(1680605312.068:950): pid=3991 uid=0 auid=4294967295 ses=4294967295 msg='op=login acct="foo" exe="/usr/sbin/sshd" hostname=? addr=192.168.122.1 terminal=sshd res=failed'UID="root" AUID="unset"
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
