### PR TITLE
eapol: T5151: Allow TLSv1.0/1.1 for EAP-TLS

### DIFF
--- a/data/templates/ethernet/wpa_supplicant.conf.j2
+++ b/data/templates/ethernet/wpa_supplicant.conf.j2
@@ -67,6 +67,11 @@ network={
     # discards such frames to protect against potential attacks by rogue
     # devices, but this option can be used to disable that protection for cases
     # where the server/authenticator does not need to be authenticated.
-    phase1="allow_canned_success=1"
+    #
+    # "tls_disable_tlsv1_0=0" is used to allow TLSv1 for compatibility with
+    # legacy networks. This follows the behavior of Debian's wpa_supplicant,
+    # which includes a custom patch for allowing TLSv1, but the patch currently
+    # does not work for VyOS' git builds of wpa_supplicant.
+    phase1="allow_canned_success=1 tls_disable_tlsv1_0=0"
 }
 


### PR DESCRIPTION
## Change Summary

The Debian 12 upgrade in T5003 caused a regression for connecting to legacy networks that only support TLSv1.0/1.1 for EAP-TLS. Debian allows this by default in their wpa_supplicant package, but their `allow-tlsv1.patch` patch does not work properly with VyOS' newer wpa_supplicant package, which is based on the latest code in git. As a result, wpa_supplicant always respects the system-wide openssl crypto policy, disallowing TLSv1. The commit uses the documented way of allowing TLSv1, which takes precedence over the system crypto policy.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

https://vyos.dev/T5151

## Component(s) name

ethernet, eapol, wpa_supplicant

## Proposed changes

(Included above)

## How to test

I've tested this personally with my ISP, but I don't know how to set up a legacy auth server to test this in other environments.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
