### PR TITLE
T5148: Fix OpenVPN plugin dir variable

### DIFF
--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2022 VyOS maintainers and contributors
+# Copyright (C) 2019-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -597,7 +597,7 @@ def generate_pki_files(openvpn):
 def generate(openvpn):
     interface = openvpn['ifname']
     directory = os.path.dirname(cfg_file.format(**openvpn))
-    plugin_dir = '/usr/lib/openvpn'
+    openvpn['plugin_dir'] = '/usr/lib/openvpn'
     # create base config directory on demand
     makedir(directory, user, group)
     # enforce proper permissions on /run/openvpn


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Jinja2 template uses `{{ plugin_dir }}` that it gets from the interface-openvpn.py variable `plugin_dir` but the correct var should be as part of 'openvpn' dictionary i.e. `openvpn['plugin_dir']`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5148

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
OpenVPN configuration:
```
set interfaces openvpn vtun10 description 'Server foo'
set interfaces openvpn vtun10 encryption cipher 'aes256'
set interfaces openvpn vtun10 hash 'sha512'
set interfaces openvpn vtun10 local-host '203.0.113.1'
set interfaces openvpn vtun10 local-port '1194'
set interfaces openvpn vtun10 mode 'server'
set interfaces openvpn vtun10 persistent-tunnel
set interfaces openvpn vtun10 protocol 'udp'
set interfaces openvpn vtun10 server client client1 ip '10.10.0.10'
set interfaces openvpn vtun10 server domain-name 'vyos.net'
set interfaces openvpn vtun10 server max-connections '250'
set interfaces openvpn vtun10 server mfa totp
set interfaces openvpn vtun10 server name-server '172.16.254.30'
set interfaces openvpn vtun10 server subnet '10.10.0.0/24'
set interfaces openvpn vtun10 server topology 'subnet'
set interfaces openvpn vtun10 tls ca-certificate 'ca'
set interfaces openvpn vtun10 tls certificate 'cert'
set interfaces openvpn vtun10 tls dh-params 'dh'
set interfaces openvpn vtun10 tls tls-version-min '1.0'
```
Before fix we get incorrect `plugin_path`
```
plugin "/openvpn-otp.so" "otp_secrets=/config/auth/openvpn/vtun10-otp-secrets otp_slop=180 totp_t0=0 totp_step=30 totp_digits=6 password_is_cr=1"
```
And OpenVPN cannot start:
```
Apr 10 13:17:38 r14 openvpn-vtun10[13114]: PLUGIN_INIT: could not load plugin shared object /openvpn-otp.so: /openvpn-otp.so: cannot open shared object file: No such file or directory: No such file or directory (errno=2)
Apr 10 13:17:38 r14 openvpn-vtun10[13114]: Exiting due to fatal error
Apr 10 13:17:38 r14 systemd[1]: openvpn@vtun10.service: Main process exited, code=exited, status=1/FAILURE
Apr 10 13:17:38 r14 systemd[1]: openvpn@vtun10.service: Failed with result 'exit-code'.
Apr 10 13:17:38 r14 systemd[1]: Failed to start openvpn@vtun10.service - OpenVPN connection to vtun10
```

After fix:
```
plugin "/usr/lib/openvpn/openvpn-otp.so" "otp_secrets=/config/auth/openvpn/vtun10-otp-secrets otp_slop=180 totp_t0=0 totp_step=30 totp_digits=6 password_is_cr=1"
```
Show interfaces
```
vyos@r14# run show interfaces openvpn 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
vtun10           10.10.0.1/24                      u/u  Server foo

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
