### PR TITLE
T5078: Added filtered-routes BGP command

### DIFF
--- a/op-mode-definitions/include/bgp/afi-ipv4-ipv6-common.xml.i
+++ b/op-mode-definitions/include/bgp/afi-ipv4-ipv6-common.xml.i
@@ -195,6 +195,12 @@
         </leafNode>
       </children>
     </node>
+    <leafNode name="filtered-routes">
+      <properties>
+        <help>Show filtered routes from BGP neighbor</help>
+      </properties>
+      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+    </leafNode>
     <leafNode name="received-routes">
       <properties>
         <help>Show received routes from BGP neighbor</help>

--- a/op-mode-definitions/include/bgp/show-ip-bgp-common.xml.i
+++ b/op-mode-definitions/include/bgp/show-ip-bgp-common.xml.i
@@ -93,6 +93,12 @@
               </properties>
               <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
             </leafNode>
+            <leafNode name="filtered-routes">
+              <properties>
+                <help>Show the filtered routes from neighbor</help>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </leafNode>
             <leafNode name="received-routes">
               <properties>
                 <help>Show the received routes from neighbor</help>


### PR DESCRIPTION
## Change Summary
This change adds the command definition to show filtered routes on a bgp neighbor.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T5078

## Component(s) name
bgp

## Proposed changes
<!--- Describe your changes in detail -->
Add command definition to `op-mode-definitions/include/bgp/afi-ipv4-ipv6-common.xml` and `op-mode-definitions/include/bgp/show-ip-bgp-common.xml.i`

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Deploy update, configure BGP peer which sends routes being filtered, do `sh bgp ipv(4|6) neighbors $neighbor filtered-routes`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
