### PR TITLE
hostapd: T5151: Override ConditionFileNotEmpty

### DIFF
--- a/src/etc/systemd/system/hostapd@.service.d/override.conf
+++ b/src/etc/systemd/system/hostapd@.service.d/override.conf
@@ -1,6 +1,8 @@
 [Unit]
 After=
 After=vyos-router.service
+ConditionFileNotEmpty=
+ConditionFileNotEmpty=/run/hostapd/%i.conf
 
 [Service]
 WorkingDirectory=/run/hostapd


### PR DESCRIPTION
## Change Summary

Debian's `debian/2%2.10-12` update of the hostap packaging added a `ConditionFileNotEmpty` directive for `/etc/hostapd/<...>` paths, which doesn't match the `/run/hostapd/<...>` paths that VyOS uses. This commit updates the override file to use the proper VyOS paths.

https://salsa.debian.org/debian/wpa/-/commit/d204ceb5a2dc33db888eb55b5fee542a1005e69c

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

https://vyos.dev/T5151

## Component(s) name

hostapd, wireless

## Proposed changes

(Included above)

## How to test

Tested with `test_interfaces_wireless.py` smoke test, which was broken by the hostap upgrade in https://github.com/vyos/vyos-build/pull/334, but is now fixed by this commit.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
