### PR TITLE
T5065: Add verify for firewall port-group and port

### DIFF
--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -282,6 +282,9 @@ def verify_rule(firewall, rule_conf, ipv6):
                 if rule_conf['protocol'] not in ['tcp', 'udp', 'tcp_udp']:
                     raise ConfigError('Protocol must be tcp, udp, or tcp_udp when specifying a port or port-group')
 
+            if 'port' in side_conf and dict_search_args(side_conf, 'group', 'port_group'):
+                raise ConfigError(f'{side} port-group and port cannot both be defined')
+
     if 'log_options' in rule_conf:
         if 'log' not in rule_conf or 'enable' not in rule_conf['log']:
             raise ConfigError('log-options defined, but log is not enable')


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
We cannot use both 'port' and 'port-group' for the same direction in one rule at the same time
Otherwise, it generates wrong rules that don't block anything
```
  set P_pgrp {
	type inet_service
	flags interval
	auto-merge
	elements = { 101-105 }
  }

  chain NAME_foo {
	tcp dport 22 tcp dport @P_pgrp counter drop comment "foo-10"
	counter return comment "foo default-action accept"
  }
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5065

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set firewall group port-group pgrp port '101-105'
set firewall interface eth0 local name 'foo'
set firewall name foo default-action 'accept'
set firewall name foo description 'foo'
set firewall name foo rule 10 action 'drop'
set firewall name foo rule 10 destination group port-group 'pgrp'
set firewall name foo rule 10 destination port '22'
set firewall name foo rule 10 protocol 'tcp'

```
Expected raise ConfigError message
```
vyos@r14# commit
[ firewall ]
destination port-group and port cannot both be defined

[[firewall]] failed
Commit failed
[edit]
vyos@r14# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
