### PR TITLE
T5152: Get default hostname for telegraf from FQDN or hostname

### DIFF
--- a/data/templates/telegraf/telegraf.j2
+++ b/data/templates/telegraf/telegraf.j2
@@ -12,7 +12,7 @@
   debug = false
   quiet = false
   logfile = ""
-  hostname = ""
+  hostname = "{{ hostname }}"
   omit_hostname = false
 {% if azure_data_explorer is vyos_defined %}
 ### Azure Data Explorer ###

--- a/src/conf_mode/service_monitoring_telegraf.py
+++ b/src/conf_mode/service_monitoring_telegraf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2022 VyOS maintainers and contributors
+# Copyright (C) 2021-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import socket
 import json
 
 from sys import exit
@@ -57,6 +58,13 @@ def get_nft_filter_chains():
 
     return chain_list
 
+def get_hostname() -> str:
+    try:
+        hostname = socket.getfqdn()
+    except socket.gaierror:
+        hostname = socket.gethostname()
+    return hostname
+
 def get_config(config=None):
     if config:
         conf = config
@@ -79,6 +87,7 @@ def get_config(config=None):
     monitoring = dict_merge(default_values, monitoring)
 
     monitoring['custom_scripts_dir'] = custom_scripts_dir
+    monitoring['hostname'] = get_hostname()
     monitoring['interfaces_ethernet'] = Section.interfaces('ethernet', vlan=False)
     monitoring['nft_chains'] = get_nft_filter_chains()
 


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix for Telegraf agent hostname isn't qualified
Try to get the hostname from FQDN and then from the hostname
Used for metrics
You may have more than one machine with different domain names
r1 domain-name `foo.local`, hostname `myhost`
r2 domain-name `bar.local`, hostname `myhost`

It helps to detect from which exactly host we get the metric for InfluxDB2

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5152

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
monitoring, telegraf
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set system domain-name 'foo.local'
set system host-name 'r14'
set service monitoring telegraf prometheus-client
```
telegraf config:
```
vyos@r14# cat /run/telegraf/telegraf.conf | grep host
  hostname = "r14.foo.local"
  omit_hostname = false
[edit]
vyos@r14# 
```
check metrics, expected host `r14.foo.local`
```
vyos@r14# curl localhost:9273/metrics | grep chrony_frequency
# TYPE chrony_frequency untyped
chrony_frequency{host="r14.foo.local",leap_status="normal",reference_id="B9F4C39F",stratum="3"} -16.052
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
