### PR TITLE
 T4939: backport VRRP startup delay

### DIFF
--- a/data/templates/vrrp/keepalived.conf.tmpl
+++ b/data/templates/vrrp/keepalived.conf.tmpl
@@ -5,8 +5,10 @@
 global_defs {
     dynamic_interfaces
     script_user root
-{% if vrrp.global_parameters.startup_delay is vyos_defined %}
-    vrrp_startup_delay {{ vrrp.global_parameters.startup_delay }}
+{% if global_parameters is defined and global_parameters is not none %}
+{%     if global_parameters.startup_delay is defined %}
+    vrrp_startup_delay {{ global_parameters.startup_delay }}
+{%     endif %}
 {% endif %}
     notify_fifo /run/keepalived/keepalived_notify_fifo
     notify_fifo_script /usr/libexec/vyos/system/keepalived-fifo.py

--- a/data/templates/vrrp/keepalived.conf.tmpl
+++ b/data/templates/vrrp/keepalived.conf.tmpl
@@ -5,6 +5,9 @@
 global_defs {
     dynamic_interfaces
     script_user root
+{% if vrrp.global_parameters.startup_delay is vyos_defined %}
+    vrrp_startup_delay {{ vrrp.global_parameters.startup_delay }}
+{% endif %}
     notify_fifo /run/keepalived/keepalived_notify_fifo
     notify_fifo_script /usr/libexec/vyos/system/keepalived-fifo.py
 }

--- a/interface-definitions/vrrp.xml.in
+++ b/interface-definitions/vrrp.xml.in
@@ -11,6 +11,25 @@
           <help>Virtual Router Redundancy Protocol settings</help>
         </properties>
         <children>
+          <node name="global-parameters">
+            <properties>
+              <help>VRRP global parameters</help>
+            </properties>
+            <children>
+              <leafNode name="startup-delay">
+                <properties>
+                  <help>Time VRRP startup process (in seconds)</help>
+                  <valueHelp>
+                    <format>u32:1-600</format>
+                    <description>Interval in seconds</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 1-600"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+            </children>
+          </node>
           <tagNode name="group">
             <properties>
               <help>VRRP group</help>

--- a/smoketest/scripts/cli/test_ha_vrrp.py
+++ b/smoketest/scripts/cli/test_ha_vrrp.py
@@ -87,11 +87,13 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
         advertise_interval = '77'
         priority = '123'
         preempt_delay = '400'
+        startup_delay = '120'
 
         for group in groups:
             vlan_id = group.lstrip('VLAN')
             vip = f'100.64.{vlan_id}.1/24'
             group_base = base_path + ['group', group]
+            global_param_base = base_path + ['global-parameters']
 
             self.cli_set(['interfaces', 'ethernet', vrrp_interface, 'vif', vlan_id, 'address', inc_ip(vip, 1) + '/' + vip.split('/')[-1]])
 
@@ -110,8 +112,15 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
             self.cli_set(group_base + ['authentication', 'type', 'plaintext-password'])
             self.cli_set(group_base + ['authentication', 'password', f'{group}'])
 
+            # Global parameters
+            self.cli_set(global_param_base + ['startup-delay', f'{startup_delay}'])
+
         # commit changes
         self.cli_commit()
+
+        # Check Global parameters
+        config = getConfig(f'global_defs')
+        self.assertIn(f'vrrp_startup_delay {startup_delay}', config)
 
         for group in groups:
             vlan_id = group.lstrip('VLAN')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
this is a backport feature 1.4.X to VRRP , it would give more time/delay to start the process

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4939

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrrp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
we would see this change in global_defs : 
```
global_defs {
    dynamic_interfaces
    script_user root
    vrrp_startup_delay 60
    notify_fifo /run/keepalived/keepalived_notify_fifo
    notify_fifo_script /usr/libexec/vyos/system/keepalived-fifo.py
}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
