### PR TITLE
T4727: Add RADIUS rate-limit attribute for vpn pptp

### DIFF
--- a/data/templates/accel-ppp/pptp.config.tmpl
+++ b/data/templates/accel-ppp/pptp.config.tmpl
@@ -93,6 +93,20 @@ bind={{ radius_source_address }}
 gw-ip-address={{ gw_ip }}
 {% endif %}
 
+{% if radius_shaper_enable %}
+[shaper]
+verbose=1
+{%     if radius_shaper_attr %}
+attr={{ radius_shaper_attr }}
+{%     endif %}
+{%     if radius_shaper_multiplier %}
+rate-multiplier={{ radius_shaper_multiplier }}
+{%     endif %}
+{%     if radius_shaper_vendor %}
+vendor={{ radius_shaper_vendor }}
+{%     endif %}
+{% endif %}
+
 [cli]
 tcp=127.0.0.1:2003
 

--- a/interface-definitions/vpn_pptp.xml.in
+++ b/interface-definitions/vpn_pptp.xml.in
@@ -107,6 +107,11 @@
                       </tagNode>
                     </children>
                   </node>
+                  <node name="radius">
+                    <children>
+                      #include <include/accel-ppp/radius-additions-rate-limit.xml.i>
+                    </children>
+                  </node>
                   #include <include/radius-server-ipv4.xml.i>
                   #include <include/accel-ppp/radius-additions.xml.i>
                 </children>

--- a/src/conf_mode/vpn_pptp.py
+++ b/src/conf_mode/vpn_pptp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2020 VyOS maintainers and contributors
+# Copyright (C) 2018-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -44,6 +44,8 @@ default_pptp = {
     'radius_nas_ip' : '',
     'radius_source_address' : '',
     'radius_shaper_attr' : '',
+    'radius_shaper_enable': False,
+    'radius_shaper_multiplier': '',
     'radius_shaper_vendor': '',
     'radius_dynamic_author' : '',
     'chap_secrets_file': pptp_chap_secrets, # used in Jinja2 template
@@ -183,15 +185,18 @@ def get_config(config=None):
 
             pptp['radius_dynamic_author'] = dae
 
-        if conf.exists(['rate-limit', 'enable']):
-            pptp['radius_shaper_attr'] = 'Filter-Id'
-            c_attr = ['rate-limit', 'enable', 'attribute']
-            if conf.exists(c_attr):
-                pptp['radius_shaper_attr'] = conf.return_value(c_attr)
+        # Rate limit
+        if conf.exists(['rate-limit', 'attribute']):
+            pptp['radius_shaper_attr'] = conf.return_value(['rate-limit', 'attribute'])
 
-            c_vendor = ['rate-limit', 'enable', 'vendor']
-            if conf.exists(c_vendor):
-                pptp['radius_shaper_vendor'] = conf.return_value(c_vendor)
+        if conf.exists(['rate-limit', 'enable']):
+            pptp['radius_shaper_enable'] = True
+
+        if conf.exists(['rate-limit', 'multiplier']):
+            pptp['radius_shaper_multiplier'] = conf.return_value(['rate-limit', 'multiplier'])
+
+        if conf.exists(['rate-limit', 'vendor']):
+            pptp['radius_shaper_vendor'] = conf.return_value(['rate-limit', 'vendor'])
 
     conf.set_level(base_path)
     if conf.exists(['client-ip-pool']):


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add rate-limit attribute, multiplier, vendor-specific attribute for the `[shaper]` section
VyOS 1.3
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4727

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pptp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set vpn pptp remote-access authentication mode 'radius'
set vpn pptp remote-access authentication radius rate-limit attribute 'Mikrotik-Rate-Limit'
set vpn pptp remote-access authentication radius rate-limit enable
set vpn pptp remote-access authentication radius rate-limit multiplier '0.001'
set vpn pptp remote-access authentication radius rate-limit vendor 'mikrotik'
set vpn pptp remote-access authentication radius server 192.0.2.5 key '123'
set vpn pptp remote-access client-ip-pool start '192.0.2.10'
set vpn pptp remote-access client-ip-pool stop '192.0.2.50'
set vpn pptp remote-access gateway-address '192.0.2.1'

```
Expected:
```
vyos@r1# cat /run/accel-pppd/pptp.conf | grep "\[shaper" -A 5
[shaper]
verbose=1
attr=Mikrotik-Rate-Limit
rate-multiplier=0.001
vendor=mikrotik
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
