### PR TITLE
updating network name due to change to aardvark networking

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -343,9 +343,9 @@
         <properties>
           <help>Network name</help>
           <constraint>
-            <regex>[-_a-zA-Z0-9]{1,11}</regex>
+            <regex>[-_a-zA-Z0-9]{1,9}</regex>
           </constraint>
-          <constraintErrorMessage>Network name cannot be longer than 11 characters</constraintErrorMessage>
+          <constraintErrorMessage>Network name cannot be longer than 9 characters</constraintErrorMessage>
         </properties>
         <children>
           #include <include/generic-description.xml.i>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
When following the [documentation for container's example configuration](https://docs.vyos.io/en/latest/configuration/container/index.html#example-configuration) it is clear that something isn't working with the network name 'zabbix-net'.

After reducing the **network_interface** of the network in the file located at _/etc/containers/networks/zabbix-net.json_ to a length of 15 or less I am able to commit my configuration.  With a network name greater than 15 I receive a failure in systemd.

>Error: netavark: get bridge interface: Netlink error: Numerical result out of range (os error 34)


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/Txxxx

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->
Either use the change as suggested in the commit to further limit network name from 11 to 9.

Or rewrite the python code that generates the template to a different **network_interface** scheme.  It used to be "cni" which if we continued this it is a misnomer and could generate misleading information (interface called cni using ardvark).  I am for leaving the interfaces named "podman-" as a transition from "cni-" but it restricts the user names from 11 to 9.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
### some bad config
```bash
set container network zabbix-net prefix 172.20.0.0/16
```
creates a file that looks similar to this, where **len(network_interface) == 17**
```json
{
  "name": "zabbix_net",
  "id": "f39303dff1194a6c063abcb21c5a6ba858268dbcdcb5ce1812274efac54820bc",
  "driver": "bridge",
  "network_interface": "podman-zabbix_net",
  "subnets": [
    {
      "subnet": "172.20.0.0/16",
      "gateway": "172.20.0.1"
    }
  ],
  "ipv6_enabled": false,
  "internal": false,
  "dns_enabled": false,
  "ipam_options": {
    "driver": "host-local"
  }
}
```
### some good config
```bash
set container network zabbix-n prefix 172.20.0.0/16
```
creates a file that looks similar to this, where **len(network_interface) == 15**
```json
{
  "name": "zabbix_net",
  "id": "f39303dff1194a6c063abcb21c5a6ba858268dbcdcb5ce1812274efac54820bc",
  "driver": "bridge",
  "network_interface": "podman-zabbix_n",
  "subnets": [
    {
      "subnet": "172.20.0.0/16",
      "gateway": "172.20.0.1"
    }
  ],
  "ipv6_enabled": false,
  "internal": false,
  "dns_enabled": false,
  "ipam_options": {
    "driver": "host-local"
  }
}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
  - **I am waiting on an account to submit a bug report** 
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
