### PR TITLE
op-mode: T5159: dhcpv6 incorrect warning message

### DIFF
--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -264,8 +264,10 @@ def show_pool_statistics(raw: bool, family: ArgFamily, pool: typing.Optional[str
 def show_server_leases(raw: bool, family: ArgFamily, pool: typing.Optional[str],
                        sorted: typing.Optional[str], state: typing.Optional[ArgState]):
     # if dhcp server is down, inactive leases may still be shown as active, so warn the user.
-    if not is_systemd_service_running('isc-dhcp-server.service'):
-        Warning('DHCP server is configured but not started. Data may be stale.')
+    v = '6' if family == 'inet6' else ''
+    service_name = 'DHCPv6' if family == 'inet6' else 'DHCP'
+    if not is_systemd_service_running(f'isc-dhcp-server{v}.service'):
+        Warning(f'{service_name} server is configured but not started. Data may be stale.')
 
     v = 'v6' if family == 'inet6' else ''
     if pool and pool not in _get_dhcp_pools(family=family):


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The operational command "show dhcpv6 server leases" shows a warning message even if dhcpv6 setting are configured
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5159

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcpv6
## Proposed changes
<!--- Describe your changes in detail -->
Modified the dhcp.py script to show the output like this:

```
vyos@server# run sh dhcpv6 server leases
IPv6 address              State    Last communication    Lease expiration     Remaining                Type               Pool    IAID_DUID
------------------------  -------  --------------------  -------------------  -----------------------  -----------------  ------  -----------------------------------------------------------------
2001:cafe:1111:1::100     active   2023/04/14 09:01:11   2023/04/14 11:01:11  -1 day, 21:53:10.491725  non-temporary      prefix  00:00:00:00:00:04:b0:34:25:53:1d:f8:49:0d:af:87:04:b0:ad:ed:60:20
2001:cafe:1111:1::95      active   2023/04/14 13:00:11   2023/04/14 15:00:11  1:52:10                  non-temporary      prefix  00:00:00:00:00:04:5f:a2:74:eb:08:be:43:6c:96:8b:19:ac:08:0d:7b:cc
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
-->

Configure the dhcpv6 server settings and execute the operational command  "show dhcpv6 server leases" to see the output result

```
set service dhcpv6-server shared-network-name prefix subnet 2001:cafe:1111::/48 address-range start 2001:cafe:1111:1::1 stop '2001:cafe:1111:1::100'
set service dhcpv6-server shared-network-name prefix subnet 2001:cafe:1111::/48 lease-time default '7200'
set service dhcpv6-server shared-network-name prefix subnet 2001:cafe:1111::/48 name-server 2001:cafe:1111::ffff
```  

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
