### PR TITLE
debian packaging: T5172: set minimum Python version to 3.10

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Build-Depends:
   build-essential,
   libvyosconfig0 (>= 0.0.7),
   libzmq3-dev,
-  python3,
+  python3 (>= 3.10),
   python3-coverage,
   python3-lxml,
   python3-netifaces,
@@ -33,7 +33,7 @@ Standards-Version: 3.9.6
 Package: vyos-1x
 Architecture: amd64 arm64
 Depends:
-  ${python3:Depends},
+  ${python3:Depends} (>= 3.10),
   aardvark-dns,
   accel-ppp,
   auditd,


### PR DESCRIPTION
It's required for match statements and for op mode introspection. Trying to build vyos-1x on a Debian system with outdated package will also cause syntax errors, it's better to specify it explicitly.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe): internal change.

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5172

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
Debian packaging.

## Proposed changes
<!--- Describe your changes in detail -->
Set build and package dependencies to Python >=3.10


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
