### PR TITLE
T1237: Failover route add policy for targets checking

### DIFF
--- a/interface-definitions/protocols-failover.xml.in
+++ b/interface-definitions/protocols-failover.xml.in
@@ -37,6 +37,26 @@
                       <help>Check target options</help>
                     </properties>
                     <children>
+                      <leafNode name="policy">
+                        <properties>
+                          <help>Policy for check targets</help>
+                          <completionHelp>
+                            <list>any-available all-available</list>
+                          </completionHelp>
+                          <valueHelp>
+                            <format>all-available</format>
+                            <description>All targets must be alive</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>any-available</format>
+                            <description>Any target must be alive</description>
+                          </valueHelp>
+                          <constraint>
+                            <regex>(all-available|any-available)</regex>
+                          </constraint>
+                        </properties>
+                        <defaultValue>any-available</defaultValue>
+                      </leafNode>
                       #include <include/port-number.xml.i>
                       <leafNode name="target">
                         <properties>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add policy (any-available|all-available) for target checking for failover route
It depends if we need that all targets must be alive or just one target.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T1237

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
failover
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set protocols failover route 192.0.2.55/32 next-hop 192.168.122.1 check policy 'any-available'
set protocols failover route 192.0.2.55/32 next-hop 192.168.122.1 check target '192.168.122.1'
set protocols failover route 192.0.2.55/32 next-hop 192.168.122.1 check target '192.168.122.11'
set protocols failover route 192.0.2.55/32 next-hop 192.168.122.1 check timeout '3'
set protocols failover route 192.0.2.55/32 next-hop 192.168.122.1 interface 'eth0'
```
If any of those targets are available, the route should exist in the routing table
```
vyos@r14# run show ip route 192.0.2.55
Routing entry for 192.0.2.55/32
  Known via "kernel", distance 0, metric 1, best
  Last update 00:24:13 ago
  * 192.168.122.1, via eth0

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
