### PR TITLE
BFD : T5161: add feature bfd static monitoring

### DIFF
--- a/data/templates/frr/static_routes_macro.j2
+++ b/data/templates/frr/static_routes_macro.j2
@@ -18,7 +18,12 @@
 {% endif %}
 {% if prefix_config.next_hop is vyos_defined and prefix_config.next_hop is not none %}
 {%     for next_hop, next_hop_config in prefix_config.next_hop.items() if next_hop_config.disable is not defined %}
-{{ ip_ipv6 }} route {{ prefix }} {{ next_hop }} {{ next_hop_config.interface if next_hop_config.interface is vyos_defined }} {{ next_hop_config.distance if next_hop_config.distance is vyos_defined }} {{ 'nexthop-vrf ' ~ next_hop_config.vrf if next_hop_config.vrf is vyos_defined }} {{ 'table ' ~ table if table is vyos_defined }}
+{{ ip_ipv6 }} route {{ prefix }} {{ next_hop }} {{ next_hop_config.interface if next_hop_config.interface is vyos_defined }} {{ next_hop_config.distance if next_hop_config.distance is vyos_defined }} {{ 'nexthop-vrf ' ~ next_hop_config.vrf if next_hop_config.vrf is vyos_defined }} {{ 'bfd profile ' ~ next_hop_config.bfd.profile if next_hop_config.bfd.profile is vyos_defined }} {{ 'table ' ~ table if table is vyos_defined }} 
+{%         if next_hop_config.bfd.multi_hop.source is vyos_defined %}
+{%             for source, source_config in next_hop_config.bfd.multi_hop.source.items() %}
+{{ ip_ipv6 }} route {{ prefix }} {{ next_hop }} bfd multi-hop source {{ source }} profile {{ source_config.profile }}
+{%             endfor %}
+{%         endif %} 
 {%     endfor %}
 {% endif %}
 {% endmacro %}

--- a/interface-definitions/include/static/static-route-bfd.xml.i
+++ b/interface-definitions/include/static/static-route-bfd.xml.i
@@ -13,12 +13,17 @@
        <tagNode name="source">
          <properties>
            <help>Use source for BFD session</help>
-           <valueHelp>
+          <valueHelp>
              <format>ipv4</format>
-             <description>IPv4 source</description>
+             <description>IPv4 source address</description>
+           </valueHelp>
+           <valueHelp>
+             <format>ipv6</format>
+             <description>IPv6 source address</description>
            </valueHelp>
            <constraint>
              <validator name="ipv4-address"/>
+             <validator name="ipv6-address"/>
            </constraint>
          </properties>
          <children>

--- a/interface-definitions/include/static/static-route-bfd.xml.i
+++ b/interface-definitions/include/static/static-route-bfd.xml.i
@@ -1,0 +1,32 @@
+<!-- include start from static/static-route-bfd.xml.i -->
+<node name="bfd">
+  <properties>
+    <help>BFD monitoring</help>
+  </properties>
+  <children>
+    #include <include/bfd/profile.xml.i>
+    <node name="multi-hop">
+      <properties>
+        <help>Use BFD multi hop session</help>
+      </properties>
+      <children>
+       <tagNode name="source">
+         <properties>
+           <help>Use source for BFD session</help>
+           <valueHelp>
+             <format>ipv4</format>
+             <description>IPv4 source</description>
+           </valueHelp>
+           <constraint>
+             <validator name="ipv4-address"/>
+           </constraint>
+         </properties>
+         <children>
+           #include <include/bfd/profile.xml.i>
+         </children>
+       </tagNode>
+      </children>
+    </node>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/static/static-route.xml.i
+++ b/interface-definitions/include/static/static-route.xml.i
@@ -51,6 +51,7 @@
         #include <include/static/static-route-distance.xml.i>
         #include <include/static/static-route-interface.xml.i>
         #include <include/static/static-route-vrf.xml.i>
+        #include <include/static/static-route-bfd.xml.i>
       </children>
     </tagNode>
   </children>

--- a/interface-definitions/include/static/static-route6.xml.i
+++ b/interface-definitions/include/static/static-route6.xml.i
@@ -50,6 +50,7 @@
         #include <include/static/static-route-distance.xml.i>
         #include <include/static/static-route-interface.xml.i>
         #include <include/static/static-route-vrf.xml.i>
+        #include <include/static/static-route-bfd.xml.i>
       </children>
     </tagNode>
   </children>

--- a/op-mode-definitions/show-bfd.xml.in
+++ b/op-mode-definitions/show-bfd.xml.in
@@ -49,6 +49,19 @@
               </leafNode>
             </children>
           </node>
+          <node name="static">
+            <properties>
+              <help>Show route Routing Table</help>
+            </properties>
+            <children>
+              <leafNode name="routes">
+                <properties>
+                  <help>Showing BFD monitored static routes</help>
+                </properties>
+                <command>vtysh -c "show bfd static route"</command>
+              </leafNode>
+            </children>
+          </node>
         </children>
       </node>
     </children>

--- a/smoketest/scripts/cli/test_protocols_static.py
+++ b/smoketest/scripts/cli/test_protocols_static.py
@@ -139,7 +139,7 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
                     if 'bfd' in next_hop_config:
                         self.cli_set(base + ['next-hop', next_hop, 'bfd', 'profile', bfd_profile ])
                     if 'bfd_source' in next_hop_config:
-                        self.cli_set(base + ['next-hop', next_hop, 'bfd', 'multi-hop','source', next_hop_config['bfd_source'], 'profile', bfd_profile])
+                        self.cli_set(base + ['next-hop', next_hop, 'bfd', 'multi-hop', 'source', next_hop_config['bfd_source'], 'profile', bfd_profile])
 
 
             if 'interface' in route_config:
@@ -197,7 +197,7 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
                     if 'bfd' in next_hop_config:
                         tmp += ' bfd profile ' + bfd_profile
                     if 'bfd_source' in next_hop_config:
-                        tmp += ' bfd multi-hop source ' + next_hop_config['bfd_source'] + 'profile' + bfd_profile
+                        tmp += ' bfd multi-hop source ' + next_hop_config['bfd_source'] + ' profile ' + bfd_profile
 
                     if 'disable' in next_hop_config:
                         self.assertNotIn(tmp, frrconfig)

--- a/smoketest/scripts/cli/test_protocols_static.py
+++ b/smoketest/scripts/cli/test_protocols_static.py
@@ -31,6 +31,8 @@ routes = {
             '192.0.2.100' : { 'distance' : '100' },
             '192.0.2.110' : { 'distance' : '110', 'interface' : 'eth0' },
             '192.0.2.120' : { 'distance' : '120', 'disable' : '' },
+            '192.0.2.130' : { 'bfd' : '' },
+            '192.0.2.140' : { 'bfd_source' : '192.0.2.10' },
         },
         'interface' : {
             'eth0'  : { 'distance' : '130' },
@@ -117,6 +119,7 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
     def test_01_static(self):
+        bfd_profile = 'vyos-test'
         for route, route_config in routes.items():
             route_type = 'route'
             if is_ipv6(route):
@@ -133,6 +136,10 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
                         self.cli_set(base + ['next-hop', next_hop, 'interface', next_hop_config['interface']])
                     if 'vrf' in next_hop_config:
                         self.cli_set(base + ['next-hop', next_hop, 'vrf', next_hop_config['vrf']])
+                    if 'bfd' in next_hop_config:
+                        self.cli_set(base + ['next-hop', next_hop, 'bfd', 'profile', bfd_profile ])
+                    if 'bfd_source' in next_hop_config:
+                        self.cli_set(base + ['next-hop', next_hop, 'bfd', 'multi-hop','source', next_hop_config['bfd_source'], 'profile', bfd_profile])
 
 
             if 'interface' in route_config:
@@ -187,6 +194,10 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
                         tmp += ' ' + next_hop_config['distance']
                     if 'vrf' in next_hop_config:
                         tmp += ' nexthop-vrf ' + next_hop_config['vrf']
+                    if 'bfd' in next_hop_config:
+                        tmp += ' bfd profile ' + bfd_profile
+                    if 'bfd_source' in next_hop_config:
+                        tmp += ' bfd multi-hop source ' + next_hop_config['bfd_source'] + 'profile' + bfd_profile
 
                     if 'disable' in next_hop_config:
                         self.assertNotIn(tmp, frrconfig)

--- a/smoketest/scripts/cli/test_protocols_static.py
+++ b/smoketest/scripts/cli/test_protocols_static.py
@@ -69,6 +69,8 @@ routes = {
             '2001:db8::1' : { 'distance' : '10' },
             '2001:db8::2' : { 'distance' : '20', 'interface' : 'eth0' },
             '2001:db8::3' : { 'distance' : '30', 'disable' : '' },
+            '2001:db8::4' : { 'bfd' : '' },
+            '2001:db8::5' : { 'bfd_source' : '2001:db8::ffff' },
         },
         'interface' : {
             'eth0'  : { 'distance' : '40', 'vrf' : 'black' },


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->
FRR has introduced the ability to monitor a static route and remove it from RIB , When the BFD session is down it is removed from RIB and propagated , if it's is up the routes are installed :

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5161

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bfd , static 

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

BFD static monitoring works with profile  and  next-hop or multi-hop more profile : 
```
vyos-cli 

set protocols bfd profile static interval multiplier '3'
set protocols bfd profile static interval receive '300'
set protocols bfd profile static interval transmit '300'

set protocols bfd profile static_m interval multiplier '5'
set protocols bfd profile static_m interval receive '800'
set protocols bfd profile static_m interval transmit '800'

set protocols static route 10.10.13.3/32 next-hop 192.168.2.3 bfd profile 'static'

#multi-hop
set protocols static route 172.16.10.3/32 next-hop 192.168.10.1 bfd multi-hop source 192.168.2.1 profile 'static_m'

```

verifications : 

```

vyos@rt-1# run show bfd static routes
Showing BFD monitored static routes:

  Next hops:
    VRF default IPv4 Unicast:
        10.10.13.3/32 peer 192.168.2.3 (status: installed)
        172.16.10.3/32 peer 192.168.10.1 (status: installed)

    VRF default IPv4 Multicast:

vyos@rt-1# run show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

S>* 10.10.13.3/32 [1/0] via 192.168.2.3, eth1, weight 1, 01:15:14
C>* 172.16.2.2/32 is directly connected, dum10, 01w0d04h
S>  172.16.10.3/32 [1/0] via 192.168.10.1 (recursive), weight 1, 00:15:05
  *                        via 192.168.2.3, eth1, weight 1, 00:15:05
C>* 192.168.2.0/24 is directly connected, eth1, 01w0d04h
S>* 192.168.10.0/24 [1/0] via 192.168.2.3, eth1, weight 1, 01w0d03h

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
