### PR TITLE
T5181: Fix for correct deleting vni under vrf

### DIFF
--- a/src/conf_mode/vrf_vni.py
+++ b/src/conf_mode/vrf_vni.py
@@ -33,12 +33,13 @@ def get_config(config=None):
     vrf_name = None
     if len(argv) > 1:
         vrf_name = argv[1]
+    else:
+        return None
 
     base = ['vrf', 'name', vrf_name]
     tmp = conf.get_config_dict(base, key_mangling=('-', '_'),
                                no_tag_node_value_mangle=True, get_first_key=True)
-    if not tmp:
-        return None
+
     vrf = {'name': {vrf_name: tmp}}
     return vrf
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix for correct deleting vni under vrf
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5181

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrf, vni
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set interfaces vxlan vxlan3000 mtu '1500'
set interfaces vxlan vxlan3000 parameters nolearning
set interfaces vxlan vxlan3000 port '4789'
set interfaces vxlan vxlan3000 source-address '172.29.255.1'
set interfaces vxlan vxlan3000 vni '3000'

set interfaces bridge br3000 address '10.2.1.1/24'
set interfaces bridge br3000 description 'customer red'
set interfaces bridge br3000 member interface eth5
set interfaces bridge br3000 member interface vxlan3000
set interfaces bridge br3000 vrf 'red'

set protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
set protocols bgp address-family l2vpn-evpn advertise-all-vni
set protocols bgp system-as '65001'

set vrf name red protocols bgp address-family ipv4-unicast redistribute connected
set vrf name red protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
set vrf name red protocols bgp system-as '65001'
set vrf name red table '3000'
set vrf name red vni '3000'

commit
```
Before fix:
```
delete interfaces bridge 
delete interfaces vxlan 
delete vrf 
commit

Traceback:

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/protocols_bgp.py", line 515, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/protocols_bgp.py", line 506, in apply
    frr_cfg.commit_configuration(bgp_daemon)
  File "/usr/lib/python3/dist-packages/vyos/frr.py", line 480, in commit_configuration
    raise ConfigurationNotValid(f'Config commit retry counter ({count_max}) exceeded for {daemon} dameon!')
vyos.frr.ConfigurationNotValid: Config commit retry counter (5) exceeded for bgpd dameon!


FRR debug:

vyos@r14# commit
[ vrf name red vni 3000 ]
load_configuration: Configuration loaded from FRR daemon zebra
load_configuration:  loaded      0 !
load_configuration:  loaded      1 frr version 8.5
load_configuration:  loaded      2 frr defaults traditional
load_configuration:  loaded      3 hostname debian
load_configuration:  loaded      4 log syslog
load_configuration:  loaded      5 log facility local7
load_configuration:  loaded      6 hostname r14
load_configuration:  loaded      7 service integrated-vtysh-config
load_configuration:  loaded      8 !
load_configuration:  loaded      9 vrf red
load_configuration:  loaded     10  vni 3000
load_configuration:  loaded     11 exit-vrf
load_configuration:  loaded     12 !
load_configuration:  loaded     13 end
commit_configuration:  Commiting configuration
commit_configuration: new_config   0 !
commit_configuration: new_config   1 frr version 8.5
commit_configuration: new_config   2 frr defaults traditional
commit_configuration: new_config   3 hostname debian
commit_configuration: new_config   4 log syslog
commit_configuration: new_config   5 log facility local7
commit_configuration: new_config   6 hostname r14
commit_configuration: new_config   7 service integrated-vtysh-config
commit_configuration: new_config   8 !
commit_configuration: new_config   9 vrf red
commit_configuration: new_config  10  vni 3000
commit_configuration: new_config  11 exit-vrf
commit_configuration: new_config  12 !
commit_configuration: new_config  13 end
reload_configuration: Reloading config using temporary file: /tmp/tmp947i2_kj
reload_configuration: Executing command against frr-reload: "/usr/lib/frr/frr-reload.py --reload --daemon zebra --debug --stdout /tmp/tmp947i2_kj"
frr-reload output:   0 2023-04-26 10:33:09,248  INFO: Called via "Namespace(input=None, reload=True, test=False, debug=True, log_level='info', stdout=True, pathspace=None, filename='/tmp/tmp947i2_kj', overwrite=False, bindir='/usr/bin', confdir='/etc/frr', rundir='/var/run/frr', vty_socket=None, daemon='zebra', test_reset=False)"
frr-reload output:   1 2023-04-26 10:33:09,248  INFO: Loading Config object from file /tmp/tmp947i2_kj
frr-reload output:   2 2023-04-26 10:33:09,277 DEBUG: LINE frr version 8.5                                   : single-line context
frr-reload output:   3 2023-04-26 10:33:09,277 DEBUG: LINE frr defaults traditional                          : single-line context
frr-reload output:   4 2023-04-26 10:33:09,277 DEBUG: LINE hostname debian                                   : single-line context
frr-reload output:   5 2023-04-26 10:33:09,277 DEBUG: LINE log syslog                                        : single-line context
frr-reload output:   6 2023-04-26 10:33:09,277 DEBUG: LINE log facility local7                               : single-line context
frr-reload output:   7 2023-04-26 10:33:09,278 DEBUG: LINE hostname r14                                      : single-line context
frr-reload output:   8 2023-04-26 10:33:09,278 DEBUG: LINE service integrated-vtysh-config                   : single-line context
frr-reload output:   9 2023-04-26 10:33:09,278 DEBUG: LINE vrf red                                           : enter context ['vrf red']                                       
frr-reload output:  10 2023-04-26 10:33:09,278 DEBUG: LINE vni 3000                                          : add to current context ['vrf red']                                       
frr-reload output:  11 2023-04-26 10:33:09,278 DEBUG: LINE exit-vrf                                          : exit context ['vrf red']                                       
frr-reload output:  12 2023-04-26 10:33:09,309 DEBUG: New Frr Config
frr-reload output:  13 !
```
After fix:
```
vyos@r14# delete interfaces bridge 
[edit]
vyos@r14# delete interfaces vxlan 
[edit]
vyos@r14# delete vrf 
[edit]
vyos@r14# commit
[edit]
vyos@r14# 
[edit]
vyos@r14# vtysh -c "show run zebra"
Building configuration...

Current configuration:
!
frr version 8.5
frr defaults traditional
hostname debian
log syslog
log facility local7
hostname r14
service integrated-vtysh-config
!
end
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
