### PR TITLE
T5181: Fix condition to detect correct vrf name for vrf-vni

### DIFF
--- a/src/conf_mode/vrf_vni.py
+++ b/src/conf_mode/vrf_vni.py
@@ -84,7 +84,7 @@ def apply(vrf):
     frr_cfg = frr.FRRConfig()
     frr_cfg.load_configuration(frr_daemon)
     # There is only one VRF inside the dict as we read only one in get_config()
-    if vrf and 'name' in vrf:
+    if vrf and 'only_vrf' in vrf:
         vrf_name = vrf['only_vrf']
         frr_cfg.modify_section(f'^vrf {vrf_name}', stop_pattern='^exit-vrf', remove_stop_mark=True)
     if vrf and 'new_frr_config' in vrf:


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
When we delete vrf vni there is a dictionary
```{'only_vrf': 'red', 'new_frr_config': '!\n'}```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5181

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrf, vni
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```

set interfaces vxlan vxlan3000 mtu '1500'
set interfaces vxlan vxlan3000 parameters nolearning
set interfaces vxlan vxlan3000 port '4789'
set interfaces vxlan vxlan3000 source-address '172.29.255.1'
set interfaces vxlan vxlan3000 vni '3000'

set interfaces bridge br3000 address '10.2.1.1/24'
set interfaces bridge br3000 description 'customer red'
set interfaces bridge br3000 member interface eth5
set interfaces bridge br3000 member interface vxlan3000
set interfaces bridge br3000 vrf 'red'

set protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
set protocols bgp address-family l2vpn-evpn advertise-all-vni
set protocols bgp system-as '65001'

set vrf name red protocols bgp address-family ipv4-unicast redistribute connected
set vrf name red protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
set vrf name red protocols bgp system-as '65001'
set vrf name red table '3000'
set vrf name red vni '3000'

commit


delete interfaces bridge 
delete interfaces vxlan 
delete vrf 
commit

```
After deleting we shouldn't see vrf-vni in zebra configuration
Before fix:
```
Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/protocols_bgp.py", line 527, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/protocols_bgp.py", line 518, in apply
    frr_cfg.commit_configuration(bgp_daemon)
  File "/usr/lib/python3/dist-packages/vyos/frr.py", line 480, in commit_configuration
    raise ConfigurationNotValid(f'Config commit retry counter ({count_max}) exceeded for {daemon} dameon!')
vyos.frr.ConfigurationNotValid: Config commit retry counter (5) exceeded for bgpd dameon!


```
After fix:
```
vyos@r14# delete interfaces bridge 
[edit]
vyos@r14# delete interfaces vxlan 
[edit]
vyos@r14# delete vrf 
[edit]
vyos@r14# commit
[edit]
vyos@r14# 
[edit]
vyos@r14# vtysh -c "show run zebra"
Building configuration...

Current configuration:
!
frr version 8.5
frr defaults traditional
hostname debian
log syslog
log facility local7
hostname r14
service integrated-vtysh-config
!
end
[edit]
vyos@r14# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
