### PR TITLE
opmode: T5191: replace underscores with hyphens in generated options

### DIFF
--- a/op-mode-definitions/counters.xml.in
+++ b/op-mode-definitions/counters.xml.in
@@ -19,7 +19,7 @@
                 <properties>
                   <help>Clear all bonding interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -35,7 +35,7 @@
                 <properties>
                   <help>Clear interface counters for a given bonding interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -48,7 +48,7 @@
                 <properties>
                   <help>Clear all bridge interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -64,7 +64,7 @@
                 <properties>
                   <help>Clear interface counters for a given bridge interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -77,7 +77,7 @@
                 <properties>
                   <help>Clear all dummy interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -93,7 +93,7 @@
                 <properties>
                   <help>Clear interface counters for a given dummy interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -106,7 +106,7 @@
                 <properties>
                   <help>Clear all ethernet interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -122,7 +122,7 @@
                 <properties>
                   <help>Clear interface counters for a given ethernet interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -135,7 +135,7 @@
                 <properties>
                   <help>Clear all GENEVE interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -151,7 +151,7 @@
                 <properties>
                   <help>Clear interface counters for a given GENEVE interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -164,7 +164,7 @@
                 <properties>
                   <help>Clear all Input interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -180,7 +180,7 @@
                 <properties>
                   <help>Clear interface counters for a given Input interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -193,7 +193,7 @@
                 <properties>
                   <help>Clear all L2TPv3 interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -209,7 +209,7 @@
                 <properties>
                   <help>Clear interface counters for a given L2TPv3 interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -222,7 +222,7 @@
                 <properties>
                   <help>Clear all loopback interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -238,7 +238,7 @@
                 <properties>
                   <help>Clear interface counters for a given loopback interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -251,7 +251,7 @@
                 <properties>
                   <help>Clear all MACsec interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -267,7 +267,7 @@
                 <properties>
                   <help>Clear interface counters for a given MACsec interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -280,7 +280,7 @@
                 <properties>
                   <help>Clear all OpenVPN interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -296,7 +296,7 @@
                 <properties>
                   <help>Clear interface counters for a given OpenVPN interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -309,7 +309,7 @@
                 <properties>
                   <help>Clear all PPPoE interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -325,7 +325,7 @@
                 <properties>
                   <help>Clear interface counters for a given PPPoE interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -338,7 +338,7 @@
                 <properties>
                   <help>Clear all Pseudo-Ethernet interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -354,7 +354,7 @@
                 <properties>
                   <help>Clear interface counters for a given Pseudo-Ethernet interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -367,7 +367,7 @@
                 <properties>
                   <help>Clear all SSTP interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -383,7 +383,7 @@
                 <properties>
                   <help>Clear interface counters for a given SSTP interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -396,7 +396,7 @@
                 <properties>
                   <help>Clear all tunnel interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -412,7 +412,7 @@
                 <properties>
                   <help>Clear interface counters for a given tunnel interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -425,7 +425,7 @@
                 <properties>
                   <help>Clear all virtual-ethernet interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -441,7 +441,7 @@
                 <properties>
                   <help>Clear interface counters for a given virtual-ethernet interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -454,7 +454,7 @@
                 <properties>
                   <help>Clear all VTI interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -470,7 +470,7 @@
                 <properties>
                   <help>Clear interface counters for a given VTI interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -483,7 +483,7 @@
                 <properties>
                   <help>Clear all VXLAN interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -499,7 +499,7 @@
                 <properties>
                   <help>Clear interface counters for a given VXLAN interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -512,7 +512,7 @@
                 <properties>
                   <help>Clear all Wireguard interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </node>
             </children>
           </node>
@@ -528,7 +528,7 @@
                 <properties>
                   <help>Clear interface counters for a given Wireguard interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -541,7 +541,7 @@
                 <properties>
                   <help>Clear all wireless interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </leafNode>
             </children>
           </node>
@@ -557,7 +557,7 @@
                 <properties>
                   <help>Clear counters for a given wireless interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>
@@ -570,7 +570,7 @@
                 <properties>
                   <help>Clear all WWAN interface counters</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_type "$3"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-type "$3"</command>
               </leafNode>
             </children>
           </node>
@@ -586,7 +586,7 @@
                 <properties>
                   <help>Clear counters for a given WWAN interface</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf_name "$4"</command>
+                <command>sudo ${vyos_op_scripts_dir}/interfaces.py clear_counters --intf-name "$4"</command>
               </leafNode>
             </children>
           </tagNode>

--- a/op-mode-definitions/generate-system-login-user.xml.in
+++ b/op-mode-definitions/generate-system-login-user.xml.in
@@ -35,19 +35,19 @@
                             <properties>
                               <help>Duration of single time interval</help>
                             </properties>
-                            <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate_limit "$9"</command>
+                            <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate-limit "$9"</command>
                             <children>
                               <tagNode name="rate-time">
                                 <properties>
                                   <help>The number of digits in the one-time password</help>
                                 </properties>
-                                <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate_limit "$9" --rate_time "${11}" </command>
+                                <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate-limit "$9" --rate-time "${11}" </command>
                                 <children>
                                   <tagNode name="window-size">
                                     <properties>
                                       <help>The number of digits in the one-time password</help>
                                     </properties>
-                                    <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate_limit "$9" --rate_time "${11}" --window_size "${13}"</command>
+                                    <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate-limit "$9" --rate-time "${11}" --window-size "${13}"</command>
                                   </tagNode>
                                 </children>
                               </tagNode>
@@ -57,19 +57,19 @@
                             <properties>
                               <help>The number of digits in the one-time password</help>
                             </properties>
-                            <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --window_size "${9}"</command>
+                            <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --window-size "${9}"</command>
                             <children>
                               <tagNode name="rate-limit">
                                 <properties>
                                   <help>Duration of single time interval</help>
                                 </properties>
-                                <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate_limit "${11}" --window_size "${9}"</command>
+                                <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate-limit "${11}" --window-size "${9}"</command>
                                 <children>
                                   <tagNode name="rate-time">
                                     <properties>
                                       <help>Duration of single time interval</help>
                                     </properties>
-                                    <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate_limit "${11}" --rate_time "${13}" --window_size "${9}"</command>
+                                    <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate-limit "${11}" --rate-time "${13}" --window-size "${9}"</command>
                                   </tagNode>
                                 </children>
                               </tagNode>

--- a/op-mode-definitions/openvpn.xml.in
+++ b/op-mode-definitions/openvpn.xml.in
@@ -37,13 +37,13 @@
             <properties>
               <help>Show OpenVPN interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=openvpn</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=openvpn</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed OpenVPN interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=openvpn</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=openvpn</command>
               </leafNode>
             </children>
           </node>
@@ -54,7 +54,7 @@
                 <script>sudo ${vyos_completion_dir}/list_interfaces --type openvpn</script>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name=$4</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name=$4</command>
             <children>
               <tagNode name="user">
                 <properties>
@@ -95,7 +95,7 @@
                 <properties>
                   <help>Show summary of specified OpenVPN interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4"</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4"</command>
               </leafNode>
             </children>
           </tagNode>

--- a/op-mode-definitions/reboot.xml.in
+++ b/op-mode-definitions/reboot.xml.in
@@ -25,7 +25,7 @@
             <list>&lt;Minutes&gt;</list>
           </completionHelp>
         </properties>
-        <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --reboot_in $3 $4</command>
+        <command>sudo ${vyos_op_scripts_dir}/powerctrl.py --yes --reboot-in $3 $4</command>
       </tagNode>
       <tagNode name="at">
         <properties>

--- a/op-mode-definitions/show-acceleration.xml.in
+++ b/op-mode-definitions/show-acceleration.xml.in
@@ -21,7 +21,7 @@
                     <properties>
                       <help>Show QAT information for a given acceleration device</help>
                       <completionHelp>
-                        <script>${vyos_op_scripts_dir}/show_acceleration.py --dev_list</script>
+                        <script>${vyos_op_scripts_dir}/show_acceleration.py --dev-list</script>
                       </completionHelp>
                     </properties>
                     <children>

--- a/op-mode-definitions/show-interfaces-bonding.xml.in
+++ b/op-mode-definitions/show-interfaces-bonding.xml.in
@@ -11,13 +11,13 @@
                 <path>interfaces bonding</path>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=bonding</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=bonding</command>
             <children>
               <leafNode name="brief">
                 <properties>
                   <help>Show summary of the specified bonding interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4" --intf_type=bonding</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=bonding</command>
               </leafNode>
               <leafNode name="detail">
                 <properties>
@@ -38,13 +38,13 @@
                     <path>interfaces bonding ${COMP_WORDS[3]} vif</path>
                   </completionHelp>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4.$6" --intf_type=bonding</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4.$6" --intf-type=bonding</command>
                 <children>
                   <leafNode name="brief">
                     <properties>
                       <help>Show summary of specified virtual network interface (vif) information</help>
                     </properties>
-                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4.$6" --intf_type=bonding</command>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4.$6" --intf-type=bonding</command>
                   </leafNode>
                 </children>
               </tagNode>
@@ -60,13 +60,13 @@
             <properties>
               <help>Show Bonding interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=bonding</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=bonding</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed bonding interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=bonding</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=bonding</command>
               </leafNode>
               <leafNode name="slaves">
                 <properties>

--- a/op-mode-definitions/show-interfaces-bridge.xml.in
+++ b/op-mode-definitions/show-interfaces-bridge.xml.in
@@ -11,13 +11,13 @@
                 <path>interfaces bridge</path>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=bridge</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=bridge</command>
             <children>
               <leafNode name="brief">
                 <properties>
                   <help>Show summary of the specified bridge interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4" --intf_type=bridge</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=bridge</command>
               </leafNode>
             </children>
           </tagNode>
@@ -25,13 +25,13 @@
             <properties>
               <help>Show Bridge interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=bridge</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=bridge</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed bridge interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=bridge</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=bridge</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/show-interfaces-dummy.xml.in
+++ b/op-mode-definitions/show-interfaces-dummy.xml.in
@@ -11,13 +11,13 @@
                 <path>interfaces dummy</path>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=dummy</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=dummy</command>
             <children>
               <leafNode name="brief">
                 <properties>
                   <help>Show summary of the specified dummy interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4" --intf_type=dummy</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=dummy</command>
               </leafNode>
             </children>
           </tagNode>
@@ -25,13 +25,13 @@
             <properties>
               <help>Show Dummy interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=dummy</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=dummy</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed dummy interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=dummy</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=dummy</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/show-interfaces-ethernet.xml.in
+++ b/op-mode-definitions/show-interfaces-ethernet.xml.in
@@ -11,13 +11,13 @@
                 <path>interfaces ethernet</path>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=ethernet</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=ethernet</command>
             <children>
               <leafNode name="brief">
                 <properties>
                   <help>Show summary of the specified ethernet interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4" --intf_type=ethernet</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=ethernet</command>
               </leafNode>
               <leafNode name="identify">
                 <properties>
@@ -58,13 +58,13 @@
                     <path>interfaces ethernet ${COMP_WORDS[3]} vif</path>
                   </completionHelp>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4.$6" --intf_type=ethernet</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4.$6" --intf-type=ethernet</command>
                 <children>
                   <leafNode name="brief">
                     <properties>
                       <help>Show summary of specified virtual network interface (vif) information</help>
                     </properties>
-                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4.$6" --intf_type=ethernet</command>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4.$6" --intf-type=ethernet</command>
                   </leafNode>
                 </children>
               </tagNode>
@@ -80,13 +80,13 @@
             <properties>
               <help>Show Ethernet interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=ethernet</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=ethernet</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed ethernet interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=ethernet</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=ethernet</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/show-interfaces-geneve.xml.in
+++ b/op-mode-definitions/show-interfaces-geneve.xml.in
@@ -11,13 +11,13 @@
                 <path>interfaces geneve</path>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=geneve</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=geneve</command>
             <children>
               <leafNode name="brief">
                 <properties>
                   <help>Show summary of the specified GENEVE interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4" --intf_type=geneve</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=geneve</command>
               </leafNode>
             </children>
           </tagNode>
@@ -25,13 +25,13 @@
             <properties>
               <help>Show GENEVE interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=geneve</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=geneve</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed GENEVE interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=geneve</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=geneve</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/show-interfaces-input.xml.in
+++ b/op-mode-definitions/show-interfaces-input.xml.in
@@ -11,13 +11,13 @@
                 <path>interfaces input</path>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=input</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=input</command>
             <children>
               <leafNode name="brief">
                 <properties>
                   <help>Show summary of the specified input interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4" --intf_type=input</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=input</command>
               </leafNode>
             </children>
           </tagNode>
@@ -25,13 +25,13 @@
             <properties>
               <help>Show Input (ifb) interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=input</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=input</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed input interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=input</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=input</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/show-interfaces-l2tpv3.xml.in
+++ b/op-mode-definitions/show-interfaces-l2tpv3.xml.in
@@ -11,13 +11,13 @@
                 <path>interfaces l2tpv3</path>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=l2tpv3</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=l2tpv3</command>
             <children>
               <leafNode name="brief">
                 <properties>
                   <help>Show summary of the specified L2TPv3 interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4" --intf_type=l2tpv3</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=l2tpv3</command>
               </leafNode>
             </children>
           </tagNode>
@@ -25,13 +25,13 @@
             <properties>
               <help>Show L2TPv3 interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=l2tpv3</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=l2tpv3</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed L2TPv3 interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=l2tpv3</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=l2tpv3</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/show-interfaces-loopback.xml.in
+++ b/op-mode-definitions/show-interfaces-loopback.xml.in
@@ -11,13 +11,13 @@
                 <path>interfaces loopback</path>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=loopback</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=loopback</command>
             <children>
               <leafNode name="brief">
                 <properties>
                   <help>Show summary of the specified Loopback interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4" --intf_type=loopback</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=loopback</command>
               </leafNode>
             </children>
           </tagNode>
@@ -25,13 +25,13 @@
             <properties>
               <help>Show Loopback interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=loopback</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=loopback</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed Loopback interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=loopback</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=loopback</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/show-interfaces-pppoe.xml.in
+++ b/op-mode-definitions/show-interfaces-pppoe.xml.in
@@ -11,7 +11,7 @@
                 <path>interfaces pppoe</path>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=pppoe</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=pppoe</command>
             <children>
               <leafNode name="log">
                 <properties>
@@ -34,13 +34,13 @@
             <properties>
               <help>Show PPPoE interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=pppoe</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=pppoe</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed PPPoE interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=pppoe</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=pppoe</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/show-interfaces-pseudo-ethernet.xml.in
+++ b/op-mode-definitions/show-interfaces-pseudo-ethernet.xml.in
@@ -11,13 +11,13 @@
                 <path>interfaces pseudo-ethernet</path>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=pseudo-ethernet</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=pseudo-ethernet</command>
             <children>
               <leafNode name="brief">
                 <properties>
                   <help>Show summary of the specified pseudo-ethernet/MACvlan interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4" --intf_type=pseudo-ethernet</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=pseudo-ethernet</command>
               </leafNode>
             </children>
           </tagNode>
@@ -25,13 +25,13 @@
             <properties>
               <help>Show Pseudo-Ethernet/MACvlan interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=pseudo-ethernet</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=pseudo-ethernet</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed pseudo-ethernet/MACvlan interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=pseudo-ethernet</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=pseudo-ethernet</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/show-interfaces-sstpc.xml.in
+++ b/op-mode-definitions/show-interfaces-sstpc.xml.in
@@ -11,7 +11,7 @@
                 <path>interfaces sstpc</path>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=sstpc</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=sstpc</command>
             <children>
               <leafNode name="log">
                 <properties>
@@ -34,13 +34,13 @@
             <properties>
               <help>Show SSTP client interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=sstpc</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=sstpc</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed SSTP client interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=sstpc</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=sstpc</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/show-interfaces-tunnel.xml.in
+++ b/op-mode-definitions/show-interfaces-tunnel.xml.in
@@ -11,13 +11,13 @@
                 <path>interfaces tunnel</path>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=tunnel</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=tunnel</command>
             <children>
               <leafNode name="brief">
                 <properties>
                   <help>Show summary of the specified tunnel interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4" --intf_type=tunnel</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=tunnel</command>
               </leafNode>
             </children>
           </tagNode>
@@ -25,13 +25,13 @@
             <properties>
               <help>Show Tunnel interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=tunnel</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=tunnel</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed tunnel interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=tunnel</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=tunnel</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/show-interfaces-virtual-ethernet.xml.in
+++ b/op-mode-definitions/show-interfaces-virtual-ethernet.xml.in
@@ -11,13 +11,13 @@
                 <path>interfaces virtual-ethernet</path>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=virtual-ethernet</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=virtual-ethernet</command>
             <children>
               <leafNode name="brief">
                 <properties>
                   <help>Show summary of the specified virtual-ethernet interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4" --intf_type=virtual-ethernet</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=virtual-ethernet</command>
               </leafNode>
             </children>
           </tagNode>
@@ -25,13 +25,13 @@
             <properties>
               <help>Show virtual-ethernet interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=virtual-ethernet</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=virtual-ethernet</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed virtual-ethernet interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=virtual-ethernet</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=virtual-ethernet</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/show-interfaces-vti.xml.in
+++ b/op-mode-definitions/show-interfaces-vti.xml.in
@@ -11,13 +11,13 @@
                 <path>interfaces vti</path>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=vti</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=vti</command>
             <children>
               <leafNode name="brief">
                 <properties>
                   <help>Show summary of the specified vti interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4" --intf_type=vti</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=vti</command>
               </leafNode>
             </children>
           </tagNode>
@@ -25,13 +25,13 @@
             <properties>
               <help>Show VTI interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=vti</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=vti</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed vti interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=vti</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=vti</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/show-interfaces-vxlan.xml.in
+++ b/op-mode-definitions/show-interfaces-vxlan.xml.in
@@ -11,13 +11,13 @@
                 <path>interfaces vxlan</path>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=vxlan</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=vxlan</command>
             <children>
               <leafNode name="brief">
                 <properties>
                   <help>Show summary of the specified VXLAN interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4" --intf_type=vxlan</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=vxlan</command>
               </leafNode>
             </children>
           </tagNode>
@@ -25,13 +25,13 @@
             <properties>
               <help>Show VXLAN interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=vxlan</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=vxlan</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed VXLAN interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=vxlan</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=vxlan</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/show-interfaces-wireguard.xml.in
+++ b/op-mode-definitions/show-interfaces-wireguard.xml.in
@@ -11,7 +11,7 @@
                 <script>${vyos_completion_dir}/list_interfaces --type wireguard</script>
               </completionHelp>
             </properties>
-	        <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=wireguard</command>
+	        <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=wireguard</command>
             <children>
               <leafNode name="allowed-ips">
                 <properties>
@@ -49,13 +49,13 @@
             <properties>
               <help>Show WireGuard interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=wireguard</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=wireguard</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed Wireguard interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=wireguard</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=wireguard</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/show-interfaces-wireless.xml.in
+++ b/op-mode-definitions/show-interfaces-wireless.xml.in
@@ -8,13 +8,13 @@
             <properties>
               <help>Show Wireless (WLAN) interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=wireless</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=wireless</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed wireless interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=wireless</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=wireless</command>
               </leafNode>
               <leafNode name="info">
                 <properties>
@@ -31,13 +31,13 @@
                 <script>${vyos_completion_dir}/list_interfaces --type wireless</script>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=wireless</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=wireless</command>
             <children>
               <leafNode name="brief">
                 <properties>
                   <help>Show summary of the specified wireless interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4" --intf_type=wireless</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=wireless</command>
               </leafNode>
               <node name="scan">
                 <properties>
@@ -63,13 +63,13 @@
                 <properties>
                   <help>Show specified virtual network interface (vif) information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4.$6" --intf_type=wireless</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4.$6" --intf-type=wireless</command>
                 <children>
                   <leafNode name="brief">
                     <properties>
                       <help>Show summary of specified virtual network interface (vif) information</help>
                     </properties>
-                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_name="$4.$6" --intf_type=wireless</command>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4.$6" --intf-type=wireless</command>
                   </leafNode>
                 </children>
               </tagNode>

--- a/op-mode-definitions/show-interfaces-wwan.xml.in
+++ b/op-mode-definitions/show-interfaces-wwan.xml.in
@@ -12,7 +12,7 @@
                 <script>cd /sys/class/net; ls -d wwan*</script>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf_name="$4" --intf_type=wirelessmodem</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=wirelessmodem</command>
             <children>
               <leafNode name="capabilities">
                 <properties>
@@ -86,13 +86,13 @@
             <properties>
               <help>Show Wireless Modem (WWAN) interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf_type=wirelessmodem</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=wirelessmodem</command>
             <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed Wireless Modem (WWAN( interface information</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf_type=wirelessmodem</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=wirelessmodem</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/vpn-ipsec.xml.in
+++ b/op-mode-definitions/vpn-ipsec.xml.in
@@ -35,7 +35,7 @@
                             <list>&lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
                           </completionHelp>
                         </properties>
-                        <command>sudo ${vyos_op_scripts_dir}/ipsec.py reset_profile_dst --profile="$5" --tunnel="$7" --nbma_dst="$9"</command>
+                        <command>sudo ${vyos_op_scripts_dir}/ipsec.py reset_profile_dst --profile="$5" --tunnel="$7" --nbma-dst="$9"</command>
                       </tagNode>
                     </children>
                     <command>sudo ${vyos_op_scripts_dir}/ipsec.py reset_profile_all --profile="$5" --tunnel="$7"</command>
@@ -219,7 +219,7 @@
                     <properties>
                       <help>Show detail active IKEv2 RA sessions by connection-id</help>
                     </properties>
-                    <command>if systemctl is-active --quiet strongswan ; then sudo ${vyos_op_scripts_dir}/ipsec.py show_ra_detail --conn_id="$6"; else echo "IPsec process not running" ; fi</command>
+                    <command>if systemctl is-active --quiet strongswan ; then sudo ${vyos_op_scripts_dir}/ipsec.py show_ra_detail --conn-id="$6"; else echo "IPsec process not running" ; fi</command>
                   </tagNode>
                   <node name="summary">
                     <properties>

--- a/python/vyos/opmode.py
+++ b/python/vyos/opmode.py
@@ -209,6 +209,11 @@ def run(module):
         for opt in type_hints:
             th = type_hints[opt]
 
+            # Function argument names use underscores as separators
+            # but command-line options should use hyphens
+            # Without this, we'd get options like "--foo_bar"
+            opt = re.sub(r'_', '-', opt)
+
             if _get_arg_type(th) == bool:
                 subparser.add_argument(f"--{opt}", action='store_true')
             else:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): internal change

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5191

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
Op mode.

## Proposed changes
<!--- Describe your changes in detail -->
Replace underscores in CLI options generated by `vyos.opmode.run` with hyphens.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
