### PR TITLE
T5203: Add systemd vyos-wan-load-balance.service

### DIFF
--- a/src/conf_mode/load-balancing-wan.py
+++ b/src/conf_mode/load-balancing-wan.py
@@ -31,6 +31,7 @@ airbag.enable()
 
 load_balancing_dir = '/run/load-balance'
 load_balancing_conf_file = f'{load_balancing_dir}/wlb.conf'
+systemd_service = 'vyos-wan-load-balance.service'
 
 
 def get_config(config=None):
@@ -158,13 +159,13 @@ def generate(lb):
 def apply(lb):
     if not lb:
         try:
-            cmd('sudo /opt/vyatta/sbin/vyatta-wanloadbalance.init stop')
+            cmd(f'systemctl stop {systemd_service}')
         except Exception as e:
             print(f"Error message: {e}")
 
     else:
         cmd('sudo sysctl -w net.netfilter.nf_conntrack_acct=1')
-        cmd(f'sudo /opt/vyatta/sbin/vyatta-wanloadbalance.init restart {load_balancing_conf_file}')
+        cmd(f'systemctl restart {systemd_service}')
 
     return None
 

--- a/src/systemd/vyos-wan-load-balance.service
+++ b/src/systemd/vyos-wan-load-balance.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=VyOS WAN load-balancing service
+After=vyos-router.service
+
+[Service]
+ExecStart=/opt/vyatta/sbin/wan_lb -f /run/load-balance/wlb.conf -d -i /var/run/vyatta/wlb.pid
+ExecReload=/bin/kill -s SIGTERM $MAINPID && sleep 5 && /opt/vyatta/sbin/wan_lb -f /run/load-balance/wlb.conf -d -i /var/run/vyatta/wlb.pid
+ExecStop=/bin/kill -s SIGTERM $MAINPID
+PIDFile=/var/run/vyatta/wlb.pid
+KillMode=process
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add and use systemd unit `vyos-wan-load-balance.service`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related PR
https://github.com/vyos/vyos-build/pull/347

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5203

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
load-balancing
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set load-balancing wan interface-health eth1 nexthop 'dhcp'
```
Check status:
```
vyos@vyos2# sudo systemctl status vyos-wan-load-balance.service
● vyos-wan-load-balance.service - VyOS WAN load-balancing service
     Loaded: loaded (/lib/systemd/system/vyos-wan-load-balance.service; disabled; preset: enabled)
     Active: active (running) since Fri 2023-05-05 11:40:47 UTC; 27s ago
   Main PID: 14626 (wan_lb)
      Tasks: 2 (limit: 538)
     Memory: 5.9M
        CPU: 363ms
     CGroup: /system.slice/vyos-wan-load-balance.service
             ├─14626 /opt/vyatta/sbin/wan_lb -f /run/load-balance/wlb.conf -d -i /var/run/vyatta/wlb.pid
             └─14627 /opt/vyatta/sbin/wan_lb -f /run/load-balance/wlb.conf -d -i /var/run/vyatta/wlb.pid
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
