### PR TITLE
vyos.ifconfig: T2104: support adding and removing VLANs in one call.

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1549,6 +1549,14 @@ class VLANIf(Interface):
         if self.exists(f'{self.ifname}'):
             return
 
+        # If source_interface or vlan_id was not explicitly defined (e.g. when
+        # calling  VLANIf('eth0.1').remove() we can define source_interface and
+        # vlan_id here, as it's quiet obvious that it would be eth0 in that case.
+        if 'source_interface' not in self.config:
+            self.config['source_interface'] = '.'.join(self.ifname.split('.')[:-1])
+        if 'vlan_id' not in self.config:
+            self.config['vlan_id'] = self.ifname.split('.')[-1]
+
         cmd = 'ip link add link {source_interface} name {ifname} type vlan id {vlan_id}'
         if 'protocol' in self.config:
             cmd += ' protocol {protocol}'

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -361,7 +361,7 @@ def generate(container):
                 'name' : network,
                 'plugins' : [{
                     'type': 'bridge',
-                    'bridge': f'cni-{network}',
+                    'bridge': f'pod-{network}',
                     'isGateway': True,
                     'ipMasq': False,
                     'hairpinMode': False,


### PR DESCRIPTION
VLANIf('eth0.10').remove() will create and remove the VLAN in one command. Thus one can ensure when calling remove() on a VLAN it will always succeed.

(cherry picked from commit 7700da10b8d1d1b3d0db914ab48aebf8ff536da1)

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T2104

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
