### PR TITLE
Conditional was always True resulting in failed migration on my config

### DIFF
--- a/python/vyos/ethtool.py
+++ b/python/vyos/ethtool.py
@@ -81,7 +81,7 @@ class Ethtool:
                             self._speed_duplex.update({ speed : {}})
                         if duplex not in self._speed_duplex[speed]:
                             self._speed_duplex[speed].update({ duplex : ''})
-            if 'Supports auto-negotiation:':
+            if 'Supports auto-negotiation:' in line: 
                 # Split the following string: Auto-negotiation: off
                 # we are only interested in off or on
                 tmp = line.split()[-1]


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Conditional was always True resulting in failed migration on my config

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/Txxxx
Waiting approval on Phabricator...

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ethtool

## Proposed changes
<!--- Describe your changes in detail -->
This conditional is always true

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Attempt to apply vif interface
    + eth6 {
    +     description "HOME"
    +     vif 20 {
    +         address "10.0.20.26/23"
    +         description "TRUSTED"
    +     }
    +     vif 24 {
    +         address "10.0.24.26/23"
    +         description "UNTRUSTED"
    +     }
    + }

Before change results in Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/interfaces-ethernet.py", line 218, in <module>
    verify(c)
  File "/usr/libexec/vyos/conf_mode/interfaces-ethernet.py", line 91, in verify
    ethtool = Ethtool(ifname)
              ^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/ethtool.py", line 87, in __init__
    tmp = line.split()[-1]
          ~~~~~~~~~~~~^^^^

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s) -- Phabricator approval pending
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id -- Phabricator approval pending
- [ ] My change requires a change to the documentation -- N/A
- [ ] I have updated the documentation accordingly -- N/A
