### PR TITLE
T5213: Add accounting-interim-interval option for PPPoE IPoE SSTP

### DIFF
--- a/data/templates/accel-ppp/config_chap_secrets_radius.j2
+++ b/data/templates/accel-ppp/config_chap_secrets_radius.j2
@@ -7,6 +7,9 @@ verbose=1
 {%     for server, options in authentication.radius.server.items() if not options.disable is vyos_defined %}
 server={{ server }},{{ options.key }},auth-port={{ options.port }},acct-port={{ options.acct_port }},req-limit=0,fail-time={{ options.fail_time }}
 {%     endfor %}
+{%     if authentication.radius.accounting_interim_interval is vyos_defined %}
+acct-interim-interval={{ authentication.radius.accounting_interim_interval }}
+{%     endif %}
 {%     if authentication.radius.acct_interim_jitter is vyos_defined %}
 acct-interim-jitter={{ authentication.radius.acct_interim_jitter }}
 {%     endif %}

--- a/interface-definitions/include/accel-ppp/radius-additions.xml.i
+++ b/interface-definitions/include/accel-ppp/radius-additions.xml.i
@@ -1,6 +1,19 @@
 <!-- include start from accel-ppp/radius-additions.xml.i -->
 <node name="radius">
   <children>
+    <leafNode name="accounting-interim-interval">
+      <properties>
+        <help>Interval in seconds to send accounting information</help>
+        <valueHelp>
+          <format>u32:1-3600</format>
+          <description>Interval in seconds to send accounting information</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-3600"/>
+        </constraint>
+        <constraintErrorMessage>Interval value must be between 1 and 3600 seconds</constraintErrorMessage>
+      </properties>
+    </leafNode>
     <leafNode name="acct-interim-jitter">
       <properties>
         <help>Maximum jitter value in seconds to be applied to accounting information interval</help>

--- a/smoketest/scripts/cli/test_service_pppoe-server.py
+++ b/smoketest/scripts/cli/test_service_pppoe-server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022 VyOS maintainers and contributors
+# Copyright (C) 2022-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -243,9 +243,11 @@ class TestServicePPPoEServer(BasicAccelPPPTest.TestCase):
     def test_accel_radius_authentication(self):
         radius_called_sid = 'ifname:mac'
         radius_acct_interim_jitter = '9'
+        radius_acct_interim_interval = '60'
 
         self.set(['authentication', 'radius', 'called-sid-format', radius_called_sid])
         self.set(['authentication', 'radius', 'acct-interim-jitter', radius_acct_interim_jitter])
+        self.set(['authentication', 'radius', 'accounting-interim-interval', radius_acct_interim_interval])
 
         # run common tests
         super().test_accel_radius_authentication()
@@ -257,6 +259,7 @@ class TestServicePPPoEServer(BasicAccelPPPTest.TestCase):
         # Validate configuration
         self.assertEqual(conf['pppoe']['called-sid'], radius_called_sid)
         self.assertEqual(conf['radius']['acct-interim-jitter'], radius_acct_interim_jitter)
+        self.assertEqual(conf['radius']['acct-interim-interval'], radius_acct_interim_interval)
 
 
     def test_pppoe_server_vlan(self):

--- a/src/conf_mode/service_pppoe-server.py
+++ b/src/conf_mode/service_pppoe-server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2022 VyOS maintainers and contributors
+# Copyright (C) 2018-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -71,8 +71,9 @@ def verify(pppoe):
 
     # local ippool and gateway settings config checks
     if not (dict_search('client_ip_pool.subnet', pppoe) or
+           (dict_search('client_ip_pool.name', pppoe) or
            (dict_search('client_ip_pool.start', pppoe) and
-            dict_search('client_ip_pool.stop', pppoe))):
+            dict_search('client_ip_pool.stop', pppoe)))):
         print('Warning: No PPPoE client pool defined')
 
     if dict_search('authentication.radius.dynamic_author.server', pppoe):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add accounting-interim-interval option for PPPoE IPoE SSTP
Fix warning if a named pool is defined for PPPoE-server

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5213
* https://vyos.dev/T5214

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set service pppoe-server authentication mode 'radius'
set service pppoe-server authentication radius accounting-interim-interval '60'
set service pppoe-server authentication radius server 203.0.113.1 key '123'
set service pppoe-server client-ip-pool name POOL-01 gateway-address '192.0.2.1'
set service pppoe-server client-ip-pool name POOL-01 subnet '192.0.2.0/24'
set service pppoe-server interface eth1
```
pppoe.conf
```
vyos@r14# cat /run/accel-pppd/pppoe.conf | grep "\[radius" -A 3
[radius]
verbose=1
server=203.0.113.1,123,auth-port=1812,acct-port=1813,req-limit=0,fail-time=0
acct-interim-interval=60
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
