### PR TITLE
T5215: add a built-in ping check for VRRP groups

### DIFF
--- a/data/templates/high-availability/keepalived.conf.j2
+++ b/data/templates/high-availability/keepalived.conf.j2
@@ -32,9 +32,13 @@ global_defs {
 
 {% if vrrp.group is vyos_defined %}
 {%     for name, group_config in vrrp.group.items() if group_config.disable is not vyos_defined %}
-{%         if group_config.health_check.script is vyos_defined %}
+{%         if group_config.health_check is vyos_defined %}
 vrrp_script healthcheck_{{ name }} {
+{%             if group_config.health_check.script is vyos_defined %}
     script "{{ group_config.health_check.script }}"
+{%             elif group_config.health_check.ping is vyos_defined %}
+    script "/usr/bin/ping -c1 {{ group_config.health_check.ping }}"
+{%             endif %}
     interval {{ group_config.health_check.interval }}
     fall {{ group_config.health_check.failure_count }}
     rise 1
@@ -121,7 +125,7 @@ vrrp_instance {{ name }} {
 {%             endfor %}
     }
 {%         endif %}
-{%         if group_config.health_check.script is vyos_defined %}
+{%         if group_config.health_check is vyos_defined %}
     track_script {
         healthcheck_{{ name }}
     }

--- a/interface-definitions/high-availability.xml.in
+++ b/interface-definitions/high-availability.xml.in
@@ -96,7 +96,7 @@
               #include <include/generic-disable-node.xml.i>
               <node name="health-check">
                 <properties>
-                  <help>Health check script</help>
+                  <help>Health check</help>
                 </properties>
                 <children>
                   <leafNode name="failure-count">
@@ -116,6 +116,23 @@
                       </constraint>
                     </properties>
                     <defaultValue>60</defaultValue>
+                  </leafNode>
+                  <leafNode name="ping">
+                    <properties>
+                      <help>ICMP ping health check</help>
+                      <valueHelp>
+                        <format>ipv4</format>
+                        <description>IPv4 ping target address</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>ipv6</format>
+                        <description>IPv6 ping target address</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="ipv4-address"/>
+                        <validator name="ipv6-address"/>
+                      </constraint>
+                    </properties>
                   </leafNode>
                   <leafNode name="script">
                     <properties>

--- a/python/vyos/utils/dict.py
+++ b/python/vyos/utils/dict.py
@@ -233,3 +233,24 @@ def dict_to_list(d, save_key_to=None):
             collect.append(item)
 
     return collect
+
+def check_mutually_exclusive_options(d, keys, required=False):
+    """ Checks if a dict has at most one or only one of
+    mutually exclusive keys.
+    """
+    present_keys = []
+
+    for k in d:
+        if k in keys:
+            present_keys.append(k)
+
+    # Un-mangle the keys to make them match CLI option syntax
+    from re import sub
+    orig_keys = list(map(lambda s: sub(r'_', '-', s), keys))
+    orig_present_keys = list(map(lambda s: sub(r'_', '-', s), present_keys))
+
+    if len(present_keys) > 1:
+        raise ValueError(f"Options {orig_keys} are mutually-exclusive but more than one of them is present: {orig_present_keys}")
+
+    if required and (len(present_keys) < 1):
+        raise ValueError(f"At least one of the following options is required: {orig_present_keys}")

--- a/src/conf_mode/high-availability.py
+++ b/src/conf_mode/high-availability.py
@@ -106,6 +106,13 @@ def verify(ha):
                 if not {'password', 'type'} <= set(group_config['authentication']):
                     raise ConfigError(f'Authentication requires both type and passwortd to be set in VRRP group "{group}"')
 
+            if 'health_check' in group_config:
+                from vyos.utils.dict import check_mutually_exclusive_options
+                try:
+                    check_mutually_exclusive_options(group_config["health_check"], ["script", "ping"], required=True)
+                except ValueError as e:
+                    raise ConfigError(f'Health check config is incorrect in VRRP group "{group}": {e}')
+
             # Keepalived doesn't allow mixing IPv4 and IPv6 in one group, so we mirror that restriction
             # We also need to make sure VRID is not used twice on the same interface with the
             # same address family.


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add a new `health-check ping` option in addition to `health-check script`. Example:

```
vyos@vyos# show high-availability 
 vrrp {
     group Foo {
         address 192.168.56.200/24 {
         }
         health-check {
             failure-count 3
             interval 5
             ping 192.168.56.1
         }
         interface eth0
         vrid 30
     }
 }
```

One question is whether we should make `ping` a non-leaf node so that we can add options like `count` and `source-address`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5215

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

VRRP

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
