### PR TITLE
T5213: Add accounting-interim-interval option for L2TP/PPTP servers

### DIFF
--- a/data/templates/accel-ppp/l2tp.config.j2
+++ b/data/templates/accel-ppp/l2tp.config.j2
@@ -91,6 +91,9 @@ server={{ r.server }},{{ r.key }},auth-port={{ r.port }},acct-port={{ r.acct_por
 {%     if radius_dynamic_author.server is vyos_defined %}
 dae-server={{ radius_dynamic_author.server }}:{{ radius_dynamic_author.port }},{{ radius_dynamic_author.key }}
 {%     endif %}
+{%     if radius_acct_interim_interval is vyos_defined %}
+acct-interim-interval={{ radius_acct_interim_interval }}
+{%     endif %}
 {%     if radius_acct_inter_jitter %}
 acct-interim-jitter={{ radius_acct_inter_jitter }}
 {%     endif %}

--- a/data/templates/accel-ppp/pptp.config.j2
+++ b/data/templates/accel-ppp/pptp.config.j2
@@ -70,6 +70,9 @@ verbose=1
 server={{ r.server }},{{ r.key }},auth-port={{ r.port }},acct-port={{ r.acct_port }},req-limit=0,fail-time={{ r.fail_time }}
 {%     endfor %}
 
+{%     if radius_acct_interim_interval is vyos_defined %}
+acct-interim-interval={{ radius_acct_interim_interval }}
+{%     endif %}
 {%     if radius_acct_inter_jitter %}
 acct-interim-jitter={{ radius_acct_inter_jitter }}
 {%     endif %}

--- a/interface-definitions/include/accel-ppp/radius-accounting-interim-interval.xml.i
+++ b/interface-definitions/include/accel-ppp/radius-accounting-interim-interval.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from accel-ppp/radius-accounting-interim-interval.xml.i -->
+<leafNode name="accounting-interim-interval">
+  <properties>
+    <help>Interval in seconds to send accounting information</help>
+    <valueHelp>
+      <format>u32:1-3600</format>
+      <description>Interval in seconds to send accounting information</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-3600"/>
+    </constraint>
+    <constraintErrorMessage>Interval value must be between 1 and 3600 seconds</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/vpn-l2tp.xml.in
+++ b/interface-definitions/vpn-l2tp.xml.in
@@ -177,6 +177,7 @@
                   #include <include/radius-auth-server-ipv4.xml.i>
                   <node name="radius">
                     <children>
+                      #include <include/accel-ppp/radius-accounting-interim-interval.xml.i>
                       <tagNode name="server">
                         <children>
                           #include <include/accel-ppp/radius-additions-disable-accounting.xml.i>

--- a/src/conf_mode/vpn_l2tp.py
+++ b/src/conf_mode/vpn_l2tp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2020 VyOS maintainers and contributors
+# Copyright (C) 2019-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -63,6 +63,7 @@ default_config_data = {
     'ppp_ipv6_peer_intf_id': None,
     'radius_server': [],
     'radius_acct_inter_jitter': '',
+    'radius_acct_interim_interval': None,
     'radius_acct_tmo': '3',
     'radius_max_try': '3',
     'radius_timeout': '3',
@@ -189,6 +190,9 @@ def get_config(config=None):
         #
         # advanced radius-setting
         conf.set_level(base_path + ['authentication', 'radius'])
+
+        if conf.exists(['accounting-interim-interval']):
+            l2tp['radius_acct_interim_interval'] = conf.return_value(['accounting-interim-interval'])
 
         if conf.exists(['acct-interim-jitter']):
             l2tp['radius_acct_inter_jitter'] = conf.return_value(['acct-interim-jitter'])

--- a/src/conf_mode/vpn_pptp.py
+++ b/src/conf_mode/vpn_pptp.py
@@ -37,6 +37,7 @@ default_pptp = {
     'local_users' : [],
     'radius_server' : [],
     'radius_acct_inter_jitter': '',
+    'radius_acct_interim_interval': None,
     'radius_acct_tmo' : '30',
     'radius_max_try' : '3',
     'radius_timeout' : '30',
@@ -144,6 +145,9 @@ def get_config(config=None):
         #
         # advanced radius-setting
         conf.set_level(base_path + ['authentication', 'radius'])
+
+        if conf.exists(['accounting-interim-interval']):
+            pptp['radius_acct_interim_interval'] = conf.return_value(['accounting-interim-interval'])
 
         if conf.exists(['acct-interim-jitter']):
             pptp['radius_acct_inter_jitter'] = conf.return_value(['acct-interim-jitter'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add accounting-interim-interval option for L2TP/PPTP servers

    Add RADIUS accounting-interim-interval option for L2TP-server
    Specifies interval in seconds to send accounting information
    (may be overridden by radius Acct-Interim-Interval attribute)
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5213

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
l2tp-server, pptp-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set vpn l2tp remote-access authentication mode 'radius'
set vpn l2tp remote-access authentication radius accounting-interim-interval '23'
set vpn l2tp remote-access authentication radius server 203.0.113.10 key '123'
set vpn l2tp remote-access client-ip-pool subnet '192.0.2.0/24'
set vpn l2tp remote-access outside-address '203.0.113.1'
```
l2tp configuration:
```
vyos@r14# cat /run/accel-pppd/l2tp.conf | grep "\[radius" -A 3
[radius]
verbose=1
server=203.0.113.10,123,auth-port=1812,acct-port=1813,req-limit=0,fail-time=0
acct-interim-interval=23
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
