### PR TITLE
T160: nat64: Implement Jool-based NAT64 translator

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -78,6 +78,7 @@ Depends:
   isc-dhcp-relay,
   isc-dhcp-server,
   iw,
+  jool,
   keepalived (>=2.0.5),
   lcdproc,
   lcdproc-extra-drivers,

--- a/interface-definitions/include/nat64-protocol.xml.i
+++ b/interface-definitions/include/nat64-protocol.xml.i
@@ -1,0 +1,27 @@
+<!-- include start from nat64-protocol.xml.i -->
+<node name="protocol">
+  <properties>
+    <help>Apply translation address to a specfic protocol</help>
+  </properties>
+  <children>
+    <leafNode name="tcp">
+      <properties>
+        <help>Transmission Control Protocol</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+    <leafNode name="udp">
+      <properties>
+        <help>User Datagram Protocol</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+    <leafNode name="icmp">
+      <properties>
+        <help>Internet Control Message Protocol</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/nat64.xml.in
+++ b/interface-definitions/nat64.xml.in
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="nat64" owner="${vyos_conf_scripts_dir}/nat64.py">
+    <properties>
+      <help>IPv6-to-IPv4 Network Address Translation (NAT64) Settings</help>
+      <priority>501</priority>
+    </properties>
+    <children>
+      <node name="source">
+        <properties>
+          <help>IPv6 source to IPv4 destination address translation</help>
+        </properties>
+        <children>
+          <tagNode name="rule">
+            <properties>
+              <help>Source NAT64 rule number</help>
+              <valueHelp>
+                <format>u32:1-999999</format>
+                <description>Number for this rule</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 1-999999"/>
+              </constraint>
+              <constraintErrorMessage>NAT64 rule number must be between 1 and 999999</constraintErrorMessage>
+            </properties>
+            <children>
+              #include <include/generic-description.xml.i>
+              #include <include/generic-disable-node.xml.i>
+              <node name="source">
+                <properties>
+                  <help>IPv6 source prefix options</help>
+                </properties>
+                <children>
+                  <leafNode name="prefix">
+                    <properties>
+                      <help>IPv6 prefix to be translated</help>
+                      <valueHelp>
+                        <format>ipv6net</format>
+                        <description>IPv6 prefix</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="ipv6-prefix"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+              <node name="translation">
+                <properties>
+                  <help>Translated IPv4 address options</help>
+                </properties>
+                <children>
+                  <tagNode name="pool">
+                    <properties>
+                      <help>Translation IPv4 pool number</help>
+                      <valueHelp>
+                        <format>u32:1-999999</format>
+                        <description>Number for this rule</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-999999"/>
+                      </constraint>
+                      <constraintErrorMessage>NAT64 pool number must be between 1 and 999999</constraintErrorMessage>
+                    </properties>
+                    <children>
+                      #include <include/generic-description.xml.i>
+                      #include <include/generic-disable-node.xml.i>
+                      #include <include/nat-translation-port.xml.i>
+                      #include <include/nat64-protocol.xml.i>
+                      <leafNode name="address">
+                        <properties>
+                          <help>IPv4 address or prefix to translate to</help>
+                          <valueHelp>
+                            <format>ipv4</format>
+                            <description>IPv4 address</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>ipv4net</format>
+                            <description>IPv4 prefix</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="ipv4-address"/>
+                            <validator name="ipv4-prefix"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </tagNode>
+                </children>
+              </node>
+            </children>
+          </tagNode>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/python/vyos/utils/file.py
+++ b/python/vyos/utils/file.py
@@ -83,6 +83,20 @@ def read_json(fname, defaultonfailure=None):
             return defaultonfailure
         raise e
 
+def write_json(fname, data, indent=2, defaultonfailure=None):
+    """
+    encode data to json and write to a file
+    should defaultonfailure be not None, it is returned on failure to write
+    """
+    import json
+    try:
+        with open(fname, 'w') as f:
+            json.dump(data, f, indent=indent)
+    except Exception as e:
+        if defaultonfailure is not None:
+            return defaultonfailure
+        raise e
+
 def chown(path, user, group):
     """ change file/directory owner """
     from pwd import getpwnam

--- a/src/conf_mode/nat64.py
+++ b/src/conf_mode/nat64.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=empty-docstring,missing-module-docstring
+
+import csv
+import os
+import re
+
+from ipaddress import IPv6Network
+
+from vyos import ConfigError
+from vyos import airbag
+from vyos.config import Config
+from vyos.configdict import dict_merge
+from vyos.configdict import is_node_changed
+from vyos.utils.dict import dict_search
+from vyos.utils.file import write_json
+from vyos.utils.kernel import check_kmod
+from vyos.utils.process import cmd
+from vyos.utils.process import run
+
+airbag.enable()
+
+INSTANCE_REGEX = re.compile(r"instance-(\d+)")
+JOOL_CONFIG_DIR = "/run/jool"
+
+
+def get_config(config: Config | None = None) -> None:
+    """ """
+    if config is None:
+        config = Config()
+
+    base = ["nat64"]
+    nat64 = config.get_config_dict(base, key_mangling=("-", "_"), get_first_key=True)
+
+    # T2665: we must add the tagNode defaults individually until this is
+    # moved to the base class
+    for direction in ["source"]:
+        if direction in nat64:
+            default_values = defaults(base + [direction, "rule"])
+            if "rule" in nat64[direction]:
+                for rule in nat64[direction]["rule"]:
+                    nat64[direction]["rule"][rule] = dict_merge(
+                        default_values, nat64[direction]["rule"][rule]
+                    )
+
+                    # Only support netfilter for now
+                    nat64[direction]["rule"][rule]["mode"] = "netfilter"
+
+    base_src = base + ["source", "rule"]
+
+    # Load in existing instances so we can destroy any unknown
+    lines = cmd("jool instance display --csv").splitlines()
+    for _, instance, _ in csv.reader(lines):
+        match = INSTANCE_REGEX.fullmatch(instance)
+        if not match:
+            # FIXME: Instances that don't match should be ignored but WARN'ed to the user
+            continue
+        num = match.group(1)
+
+        rules = nat64.setdefault("source", {}).setdefault("rule", {})
+        # Mark it for deletion
+        if num not in rules:
+            rules[num] = {"deleted": True}
+            continue
+
+        # If the user changes the mode, recreate the instance else Jool fails with:
+        # Jool error: Sorry; you can't change an instance's framework for now.
+        if is_node_changed(config, base_src + [f"instance-{num}", "mode"]):
+            rules[num]["recreate"] = True
+
+        # If the user changes the pool6, recreate the instance else Jool fails with:
+        # Jool error: Sorry; you can't change a NAT64 instance's pool6 for now.
+        if dict_search("source.prefix", rules[num]) and is_node_changed(
+            config,
+            base_src + [num, "source", "prefix"],
+        ):
+            rules[num]["recreate"] = True
+
+    return nat64
+
+
+def verify(nat64) -> None:
+    """ """
+    if not nat64:
+        # no need to verify the CLI as nat64 is going to be deactivated
+        return
+
+    if dict_search("source.rule", nat64):
+        # Ensure only 1 netfilter instance per namespace
+        nf_rules = filter(
+            lambda i: "deleted" not in i and i["mode"] == "netfilter",
+            nat64["source"]["rule"].values(),
+        )
+        next(nf_rules, None)  # Discard the first element
+        if next(nf_rules, None) is not None:
+            raise ConfigError(
+                "Jool permits only 1 NAT64 netfilter instance (per network namespace)"
+            )
+
+        for rule, instance in nat64["source"]["rule"].items():
+            if "deleted" in instance:
+                continue
+
+            # Verify that source.prefix is set and is a /96
+            if not dict_search("source.prefix", instance):
+                raise ConfigError(f"Source NAT64 rule {rule} missing source prefix")
+            if IPv6Network(instance["source"]["prefix"]).prefixlen != 96:
+                raise ConfigError(f"Source NAT64 rule {rule} source prefix must be /96")
+
+            pools = dict_search("translation.pool", instance)
+            if pools:
+                for num, pool in pools.items():
+                    if "address" not in pool:
+                        raise ConfigError(
+                            f"Source NAT64 rule {rule} translation pool "
+                            f"{num} missing address/prefix"
+                        )
+                    if "port" not in pool:
+                        raise ConfigError(
+                            f"Source NAT64 rule {rule} translation pool "
+                            f"{num} missing port(-range)"
+                        )
+
+
+def generate(nat64) -> None:
+    """ """
+    os.makedirs(JOOL_CONFIG_DIR, exist_ok=True)
+
+    if dict_search("source.rule", nat64):
+        for rule, instance in nat64["source"]["rule"].items():
+            if "deleted" in instance:
+                # Delete the unused instance file
+                os.unlink(os.path.join(JOOL_CONFIG_DIR, f"instance-{rule}.json"))
+                continue
+
+            name = f"instance-{rule}"
+            config = {
+                "instance": name,
+                "framework": "netfilter",
+                "global": {
+                    "pool6": instance["source"]["prefix"],
+                    "manually-enabled": "disable" not in instance,
+                },
+                # "bib": [],
+            }
+
+            if "description" in instance:
+                config["comment"] = instance["description"]
+
+            if dict_search("translation.pool", instance):
+                pool4 = []
+                for pool in instance["translation"]["pool"].values():
+                    if "disable" in pool:
+                        continue
+
+                    protos = pool.get("protocol", {}).keys() or ("tcp", "udp", "icmp")
+                    for proto in protos:
+                        obj = {
+                            "protocol": proto.upper(),
+                            "prefix": pool["address"],
+                            "port range": pool["port"],
+                        }
+                        if "description" in pool:
+                            obj["comment"] = pool["description"]
+
+                        pool4.append(obj)
+
+                if pool4:
+                    config["pool4"] = pool4
+
+            write_json(f"{JOOL_CONFIG_DIR}/{name}.json", config)
+
+
+def apply(nat64) -> None:
+    """ """
+    if not nat64:
+        return
+
+    if dict_search("source.rule", nat64):
+        # Deletions first to avoid conflicts
+        for rule, instance in nat64["source"]["rule"].items():
+            if not any(k in instance for k in ("deleted", "recreate")):
+                continue
+
+            ret = run(f"jool instance remove instance-{rule}")
+            if ret != 0:
+                raise ConfigError(
+                    f"Failed to remove nat64 source rule {rule} (jool instance instance-{rule})"
+                )
+
+        # Now creations
+        for rule, instance in nat64["source"]["rule"].items():
+            if "deleted" in instance:
+                continue
+
+            name = f"instance-{rule}"
+            ret = run(f"jool -i {name} file handle {JOOL_CONFIG_DIR}/{name}.json")
+            if ret != 0:
+                raise ConfigError(f"Failed to set jool instance {name}")
+
+
+if __name__ == "__main__":
+    try:
+        check_kmod(["jool"])
+        c = get_config()
+        verify(c)
+        generate(c)
+        apply(c)
+    except ConfigError as e:
+        print(e)
+        exit(1)


### PR DESCRIPTION
## Change Summary
Implement NAT64 using jool following existing nat44 syntax

```
# https://nicmx.github.io/Jool/en/config-atomic.html#nat64 minimal example
set nat64 source rule 10 description "blah blah"
set nat64 source rule 10 source prefix '64:ffb9::/96'
# TODO global options are not implemented yet
set nat64 source rule 10 option lowest-mtu 1500
# https://nicmx.github.io/Jool/en/usr-flags-pool4.html#options
set nat64 source rule 10 translation pool 1 address '192.168.0.0/24'
set nat64 source rule 10 translation pool 1 port '1-65535'
set nat64 source rule 10 translation pool 1 protocol tcp
set nat64 source rule 10 translation pool 1 protocol udp
set nat64 source rule 10 translation pool 1 protocol icmp
# bib (4->6 DNAT mapping)
# TODO decide config structure
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T160

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat64

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
