### PR TITLE
veth: T3829: Allow moving veth into netns

### DIFF
--- a/interface-definitions/interfaces-virtual-ethernet.xml.in
+++ b/interface-definitions/interfaces-virtual-ethernet.xml.in
@@ -22,6 +22,7 @@
           #include <include/interface/dhcpv6-options.xml.i>
           #include <include/interface/disable.xml.i>
           #include <include/interface/vrf.xml.i>
+          #include <include/interface/netns.xml.i>
           <leafNode name="peer-name">
             <properties>
               <help>Virtual ethernet peer interface name</help>

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -532,7 +532,7 @@ class Interface(Control):
             return None
 
         # As a PoC we only allow 'dummy' interfaces
-        if 'dum' not in self.ifname:
+        if not ('dum' in self.ifname or 'veth' in self.ifname):
             return None
 
         # Check if interface realy exists in namespace


### PR DESCRIPTION
This makes netns infinitely more useful as they can be chained together in many ways to build complex network structures all on the host.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow placing veth devices into an netns

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3829

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
veth, netns

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
frebib@vyos# show interfaces virtual-ethernet
 virtual-ethernet veth0 {
     peer-name veth1
 }
 virtual-ethernet veth1 {
     peer-name veth0
 }
[edit]
frebib@vyos# show netns
 name test {
 }
[edit]

frebib@vyos# ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
    link/ether 52:54:00:90:72:74 brd ff:ff:ff:ff:ff:ff
3: veth1@veth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 8a:1b:42:94:d8:c1 brd ff:ff:ff:ff:ff:ff
4: veth0@veth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 9e:ca:d6:35:e0:a2 brd ff:ff:ff:ff:ff:ff

frebib@vyos# sudo ip netns exec test ip link
1: lo: <LOOPBACK> mtu 65536 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
5: dum0: <BROADCAST,NOARP> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ether 96:0f:9e:1d:14:38 brd ff:ff:ff:ff:ff:ff

frebib@vyos# set interfaces virtual-ethernet veth1 netns test
[edit]
frebib@vyos# compare
[interfaces virtual-ethernet veth1]
+ netns "test"

[edit]
frebib@vyos# commit
[edit]

frebib@vyos# ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
    link/ether 52:54:00:90:72:74 brd ff:ff:ff:ff:ff:ff
4: veth0@if3: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state LOWERLAYERDOWN mode DEFAULT group default qlen 1000
    link/ether 9e:ca:d6:35:e0:a2 brd ff:ff:ff:ff:ff:ff link-netns test

frebib@vyos# sudo ip netns exec test ip link
1: lo: <LOOPBACK> mtu 65536 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
3: veth1@if4: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ether 8a:1b:42:94:d8:c1 brd ff:ff:ff:ff:ff:ff link-netnsid 0
5: dum0: <BROADCAST,NOARP> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ether 96:0f:9e:1d:14:38 brd ff:ff:ff:ff:ff:ff
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
