### PR TITLE
T5171: Set default value ping for load-balancing test check

### DIFF
--- a/interface-definitions/load-balancing-wan.xml.in
+++ b/interface-definitions/load-balancing-wan.xml.in
@@ -179,6 +179,7 @@
                         <regex>(ping|ttl|user-defined)</regex>
                       </constraint>
                     </properties>
+                    <defaultValue>ping</defaultValue>
                   </leafNode>
                 </children>
               </tagNode>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Use `ping` type check as the default for load-balancing 
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Set default value for 

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5171

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
load-balancing
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
vyos@r14# set load-balancing wan interface-health eth1 nexthop 'dhcp'
[edit]
vyos@r14# set load-balancing wan interface-health eth1 test 10 target '192.168.122.1'
[edit]
vyos@r14# commit
[ load-balancing wan ]
{'interface_health': {'eth1': {'failure_count': '1',
                               'nexthop': 'dhcp',
                               'success_count': '1',
                               'test': {'10': {'resp_time': '5',
                                               'target': '192.168.122.1',
                                               'ttl_limit': '1',
                                               'type': 'ping'}}}}}

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
