### PR TITLE
T5219: ddclient: Allow not set login for Cloudflare API token

### DIFF
--- a/data/templates/dynamic-dns/ddclient.conf.j2
+++ b/data/templates/dynamic-dns/ddclient.conf.j2
@@ -34,7 +34,9 @@ zone={{ config.zone }}
 # DynDNS provider configuration for {{ service }}, {{ dns_record }}
 protocol={{ config.protocol }},
 max-interval=28d,
+{%                     if config.login is vyos_defined %}
 login={{ config.login }},
+{%                     endif %}
 password='{{ config.password }}',
 {%                     if config.server is vyos_defined %}
 server={{ config.server }},

--- a/src/conf_mode/dynamic_dns.py
+++ b/src/conf_mode/dynamic_dns.py
@@ -108,7 +108,8 @@ def verify(dyndns):
                     raise ConfigError(f'"host-name" {error_msg}')
 
                 if 'login' not in config:
-                    raise ConfigError(f'"login" (username) {error_msg}')
+                    if service != 'cloudflare' and ('protocol' not in config or config['protocol'] != 'cloudflare'):
+                        raise ConfigError(f'"login" (username) {error_msg}, unless using CloudFlare')
 
                 if 'password' not in config:
                     raise ConfigError(f'"password" {error_msg}')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow not set login for Cloudflare API token.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5219

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ddclient

## Proposed changes
<!--- Describe your changes in detail -->
- Change login to not mandatory for Cloudflare
- Remove it from template generation if not set for Cloudflare

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
I have updated and run smoketest for this.
```shell
set service dns dynamic interface pppoe999 service cloudflare host-name 'example.com'
set service dns dynamic interface pppoe999 service cloudflare password 'ExAmPlEpAsSwOrD'
set service dns dynamic interface pppoe999 service cloudflare protocol 'cloudflare'
set service dns dynamic interface pppoe999 service cloudflare zone 'example.com'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
