### PR TITLE
Revert "veth: T3829: Allow moving veth into netns"

### DIFF
--- a/interface-definitions/interfaces-virtual-ethernet.xml.in
+++ b/interface-definitions/interfaces-virtual-ethernet.xml.in
@@ -22,7 +22,6 @@
           #include <include/interface/dhcpv6-options.xml.i>
           #include <include/interface/disable.xml.i>
           #include <include/interface/vrf.xml.i>
-          #include <include/interface/netns.xml.i>
           <leafNode name="peer-name">
             <properties>
               <help>Virtual ethernet peer interface name</help>

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -532,7 +532,7 @@ class Interface(Control):
             return None
 
         # As a PoC we only allow 'dummy' interfaces
-        if not ('dum' in self.ifname or 'veth' in self.ifname):
+        if 'dum' not in self.ifname:
             return None
 
         # Check if interface realy exists in namespace


### PR DESCRIPTION
netns management for any Vyos interfaces doesn't work past the initial creation, because Vyos always tries to recreate it/move it into the netns even though it already exists. Until this is fixed, don't let anyone even attempt to use this:

    set interfaces virtual-ethernet veth10 peer-name 'veth100'
    set interfaces virtual-ethernet veth100 netns 'ns01'
    set interfaces virtual-ethernet veth100 peer-name 'veth10'
    set netns name ns01
    commit

    vyos@r14# sudo ip netns exec ns01 ip link show
    1: lo: <LOOPBACK> mtu 65536 qdisc noop state DOWN mode DEFAULT group default qlen 1000
        link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    12: veth100@if13: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
        link/ether ee:8f:0b:bd:a2:f8 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    [edit]
    vyos@r14#

    set interfaces virtual-ethernet veth100 description MyNetns
    commit

    Traceback (most recent call last):
      File "/usr/libexec/vyos/conf_mode/interfaces-virtual-ethernet.py", line 111, in <module>
        apply(c)
      File "/usr/libexec/vyos/conf_mode/interfaces-virtual-ethernet.py", line 101, in apply
        p.update(veth)
      File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 1413, in update
        self.set_netns(config.get('netns', ''))
      File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 552, in set_netns
        self.set_interface('netns', netns)
      File "/usr/lib/python3/dist-packages/vyos/ifconfig/control.py", line 183, in set_interface
        return self._set_command(self.config, name, value)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/vyos/ifconfig/control.py", line 110, in _set_command
        return self._command_set[name].get('format', lambda _: _)(self._cmd(cmd))
                                                                  ^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/vyos/ifconfig/control.py", line 52, in _cmd
        return cmd(command, self.debug)
               ^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3/dist-packages/vyos/util.py", line 161, in cmd
        raise OSError(code, feedback)
    PermissionError: [Errno 1] failed to run command: ip link set dev veth100 netns ns01
    returned:
    exit code: 1

    noteworthy:
    cmd 'ip link set dev veth100 netns ns01'
    returned (out):

    returned (err):
    Cannot find device "veth100"

This reverts commit f5cc8453860568351cd9b3b7a05d06e1462460e8.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3829

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
