### PR TITLE
T5222: Refactoring load-balancing reverse-proxy

### DIFF
--- a/data/templates/load-balancing/haproxy.cfg.j2
+++ b/data/templates/load-balancing/haproxy.cfg.j2
@@ -19,12 +19,12 @@ global
     ca-base /etc/ssl/certs
     crt-base /etc/ssl/private
 
-{%     if global_parameters.tls.ssl_bind_ciphers is vyos_defined %}
+{%     if global_parameters.ssl_bind_ciphers is vyos_defined %}
     # https://ssl-config.mozilla.org/#server=haproxy&version=2.6.12-1&config=intermediate&openssl=3.0.8-1&guideline=5.6
-    ssl-default-bind-ciphers {{ global_parameters.tls.ssl_bind_ciphers | join(':') | upper }}
+    ssl-default-bind-ciphers {{ global_parameters.ssl_bind_ciphers | join(':') | upper }}
 {%     endif %}
     ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
-{%     if global_parameters.tls.tls_version_min is vyos_defined('1.3') %}
+{%     if global_parameters.tls_version_min is vyos_defined('1.3') %}
     ssl-default-bind-options force-tlsv13
 {%     else %}
     ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets
@@ -47,8 +47,8 @@ defaults
     errorfile 504 /etc/haproxy/errors/504.http
 
 # Frontend
-{% if server is vyos_defined %}
-{%     for front, front_config in server.items() %}
+{% if service is vyos_defined %}
+{%     for front, front_config in service.items() %}
 frontend {{ front }}
 {%         set ssl_front =  'ssl crt /run/haproxy/' ~ front_config.ssl.certificate ~ '.pem' if front_config.ssl.certificate is vyos_defined else '' %}
     bind {{ front_config.listen_address if front_config.listen_address if vyos_defined else '*' }}:{{ front_config.port }} {{ ssl_front }}
@@ -61,14 +61,16 @@ frontend {{ front }}
 {%         if front_config.rule is vyos_defined %}
 {%             for rule, rule_config in front_config.rule.items() %}
     # rule {{ rule }}
-{%                 if rule_config.domain_name is vyos_defined and rule_config.set.server is vyos_defined %}
+{%                 if rule_config.domain_name is vyos_defined and rule_config.set.backend is vyos_defined %}
 {%                     set rule_options = 'hdr(host)' %}
 {%                     if rule_config.ssl is vyos_defined %}
 {%                         set ssl_rule_translate = {'req-ssl-sni': 'req_ssl_sni', 'ssl-fc-sni': 'ssl_fc_sni', 'ssl-fc-sni-end': 'ssl_fc_sni_end'} %}
 {%                         set rule_options = ssl_rule_translate[rule_config.ssl] %}
 {%                     endif %}
-    acl {{ rule }} {{ rule_options }} -i {{ rule_config.domain_name }}
-    use_backend {{ rule_config.set.server }} if {{ rule }}
+{%                     for domain in rule_config.domain_name %}
+    acl {{ rule }} {{ rule_options }} -i {{ domain }}
+{%                     endfor %}
+    use_backend {{ rule_config.set.backend }} if {{ rule }}
 {%                 endif %}
 {# path url #}
 {%                 if rule_config.url_path is vyos_defined and rule_config.set.redirect_location is vyos_defined %}
@@ -117,7 +119,9 @@ backend {{ back }}
 {%                         set ssl_rule_translate = {'req-ssl-sni': 'req_ssl_sni', 'ssl-fc-sni': 'ssl_fc_sni', 'ssl-fc-sni-end': 'ssl_fc_sni_end'} %}
 {%                         set rule_options = ssl_rule_translate[rule_config.ssl] %}
 {%                     endif %}
-    acl {{ rule }} {{ rule_options }} -i {{ rule_config.domain_name }}
+{%                     for domain in rule_config.domain_name %}
+    acl {{ rule }} {{ rule_options }} -i {{ domain }}
+{%                     endfor %}
     use-server {{ rule_config.set.server }} if {{ rule }}
 {%                 endif %}
 {# path url #}

--- a/interface-definitions/include/haproxy/rule-backend.xml.i
+++ b/interface-definitions/include/haproxy/rule-backend.xml.i
@@ -1,0 +1,131 @@
+<!-- include start from haproxy/rule.xml.i -->
+<tagNode name="rule">
+  <properties>
+    <help>Proxy rule number</help>
+    <valueHelp>
+      <format>u32:1-10000</format>
+      <description>Number for this proxy rule</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-10000"/>
+    </constraint>
+    <constraintErrorMessage>Proxy rule number must be between 1 and 10000</constraintErrorMessage>
+  </properties>
+  <children>
+    <leafNode name="domain-name">
+      <properties>
+        <help>Domain name to match</help>
+        <valueHelp>
+          <format>txt</format>
+          <description>Domain address to match</description>
+        </valueHelp>
+        <constraint>
+          <validator name="fqdn"/>
+        </constraint>
+        <multi/>
+      </properties>
+    </leafNode>
+    <node name="set">
+      <properties>
+        <help>Proxy modifications</help>
+      </properties>
+      <children>
+        <leafNode name="redirect-location">
+          <properties>
+            <help>Set URL location</help>
+            <valueHelp>
+              <format>url</format>
+              <description>Set URL location</description>
+            </valueHelp>
+            <constraint>
+              <regex>^\/[\w\-.\/]+$</regex>
+            </constraint>
+            <constraintErrorMessage>Incorrect URL format</constraintErrorMessage>
+          </properties>
+        </leafNode>
+        <leafNode name="server">
+          <properties>
+            <help>Server name</help>
+            <constraint>
+              <regex>[-_a-zA-Z0-9]+</regex>
+            </constraint>
+            <constraintErrorMessage>Server name must be alphanumeric and can contain hyphen and underscores</constraintErrorMessage>
+          </properties>
+        </leafNode>
+      </children>
+    </node>
+    <leafNode name="ssl">
+      <properties>
+        <help>SSL match options</help>
+        <completionHelp>
+          <list>req-ssl-sni ssl-fc-sni</list>
+        </completionHelp>
+        <valueHelp>
+          <format>req-ssl-sni</format>
+          <description>SSL Server Name Indication (SNI) request match</description>
+        </valueHelp>
+        <valueHelp>
+          <format>ssl-fc-sni</format>
+          <description>SSL frontend connection Server Name Indication match</description>
+        </valueHelp>
+        <valueHelp>
+          <format>ssl-fc-sni-end</format>
+          <description>SSL frontend match end of connection Server Name Indication</description>
+        </valueHelp>
+        <constraint>
+          <regex>(req-ssl-sni|ssl-fc-sni|ssl-fc-sni-end)</regex>
+        </constraint>
+      </properties>
+    </leafNode>
+    <node name="url-path">
+      <properties>
+        <help>URL path match</help>
+      </properties>
+      <children>
+        <leafNode name="begin">
+          <properties>
+            <help>Begin URL match</help>
+            <valueHelp>
+              <format>url</format>
+              <description>Begin URL</description>
+            </valueHelp>
+            <constraint>
+              <regex>^\/[\w\-.\/]+$</regex>
+            </constraint>
+            <constraintErrorMessage>Incorrect URL format</constraintErrorMessage>
+            <multi/>
+          </properties>
+        </leafNode>
+        <leafNode name="end">
+          <properties>
+            <help>End URL match</help>
+            <valueHelp>
+              <format>url</format>
+              <description>End URL</description>
+            </valueHelp>
+            <constraint>
+              <regex>^\/[\w\-.\/]+$</regex>
+            </constraint>
+            <constraintErrorMessage>Incorrect URL format</constraintErrorMessage>
+            <multi/>
+          </properties>
+        </leafNode>
+        <leafNode name="exact">
+          <properties>
+            <help>Exactly URL match</help>
+            <valueHelp>
+              <format>url</format>
+              <description>Exactly URL</description>
+            </valueHelp>
+            <constraint>
+              <regex>^\/[\w\-.\/]+$</regex>
+            </constraint>
+            <constraintErrorMessage>Incorrect URL format</constraintErrorMessage>
+            <multi/>
+          </properties>
+        </leafNode>
+      </children>
+    </node>
+  </children>
+</tagNode>
+<!-- include end -->

--- a/interface-definitions/include/haproxy/rule-frontend.xml.i
+++ b/interface-definitions/include/haproxy/rule-frontend.xml.i
@@ -22,6 +22,7 @@
         <constraint>
           <validator name="fqdn"/>
         </constraint>
+        <multi/>
       </properties>
     </leafNode>
     <node name="set">
@@ -42,9 +43,9 @@
             <constraintErrorMessage>Incorrect URL format</constraintErrorMessage>
           </properties>
         </leafNode>
-        <leafNode name="server">
+        <leafNode name="backend">
           <properties>
-            <help>Server name</help>
+            <help>Backend name</help>
             <constraint>
               <regex>[-_a-zA-Z0-9]+</regex>
             </constraint>

--- a/interface-definitions/load-balancing-haproxy.xml.in
+++ b/interface-definitions/load-balancing-haproxy.xml.in
@@ -7,9 +7,9 @@
           <help>Configure reverse-proxy</help>
         </properties>
         <children>
-          <tagNode name="server">
+          <tagNode name="service">
             <properties>
-              <help>Frontend server name</help>
+              <help>Frontend service name</help>
               <constraint>
                 #include <include/constraint/alpha-numeric-hyphen-underscore.xml.i>
               </constraint>
@@ -37,7 +37,7 @@
               #include <include/listen-address.xml.i>
               #include <include/haproxy/mode.xml.i>
               #include <include/port-number.xml.i>
-              #include <include/haproxy/rule.xml.i>
+              #include <include/haproxy/rule-frontend.xml.i>
               <leafNode name="redirect-http-to-https">
                 <properties>
                   <help>Redirect HTTP to HTTPS</help>
@@ -102,7 +102,7 @@
                   </leafNode>
                 </children>
               </node>
-              #include <include/haproxy/rule.xml.i>
+              #include <include/haproxy/rule-backend.xml.i>
               <tagNode name="server">
                 <properties>
                   <help>Backend server name</help>
@@ -161,78 +161,71 @@
                   </constraint>
                 </properties>
               </leafNode>
-              <node name="tls">
+              <leafNode name="ssl-bind-ciphers">
                 <properties>
-                  <help>Transport Layer Security (TLS) options</help>
+                  <help>Cipher algorithms ("cipher suite") used during SSL/TLS handshake for all frontend servers</help>
+                  <completionHelp>
+                    <list>ecdhe-ecdsa-aes128-gcm-sha256 ecdhe-rsa-aes128-gcm-sha256 ecdhe-ecdsa-aes256-gcm-sha384 ecdhe-rsa-aes256-gcm-sha384 ecdhe-ecdsa-chacha20-poly1305 ecdhe-rsa-chacha20-poly1305 dhe-rsa-aes128-gcm-sha256 dhe-rsa-aes256-gcm-sha384</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>ecdhe-ecdsa-aes128-gcm-sha256</format>
+                    <description>ecdhe-ecdsa-aes128-gcm-sha256</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ecdhe-rsa-aes128-gcm-sha256</format>
+                    <description>ecdhe-rsa-aes128-gcm-sha256</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ecdhe-ecdsa-aes256-gcm-sha384</format>
+                    <description>ecdhe-ecdsa-aes256-gcm-sha384</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ecdhe-rsa-aes256-gcm-sha384</format>
+                    <description>ecdhe-rsa-aes256-gcm-sha384</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ecdhe-ecdsa-chacha20-poly1305</format>
+                    <description>ecdhe-ecdsa-chacha20-poly1305</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ecdhe-rsa-chacha20-poly1305</format>
+                    <description>ecdhe-rsa-chacha20-poly1305</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>dhe-rsa-aes128-gcm-sha256</format>
+                    <description>dhe-rsa-aes128-gcm-sha256</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>dhe-rsa-aes256-gcm-sha384</format>
+                    <description>dhe-rsa-aes256-gcm-sha384</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(ecdhe-ecdsa-aes128-gcm-sha256|ecdhe-rsa-aes128-gcm-sha256|ecdhe-ecdsa-aes256-gcm-sha384|ecdhe-rsa-aes256-gcm-sha384|ecdhe-ecdsa-chacha20-poly1305|ecdhe-rsa-chacha20-poly1305|dhe-rsa-aes128-gcm-sha256|dhe-rsa-aes256-gcm-sha384)</regex>
+                  </constraint>
+                  <multi/>
                 </properties>
-                <children>
-                  <leafNode name="ssl-bind-ciphers">
-                    <properties>
-                      <help>Cipher algorithms ("cipher suite") used during SSL/TLS handshake for all frontend servers</help>
-                      <completionHelp>
-                        <list>ecdhe-ecdsa-aes128-gcm-sha256 ecdhe-rsa-aes128-gcm-sha256 ecdhe-ecdsa-aes256-gcm-sha384 ecdhe-rsa-aes256-gcm-sha384 ecdhe-ecdsa-chacha20-poly1305 ecdhe-rsa-chacha20-poly1305 dhe-rsa-aes128-gcm-sha256 dhe-rsa-aes256-gcm-sha384</list>
-                      </completionHelp>
-                      <valueHelp>
-                        <format>ecdhe-ecdsa-aes128-gcm-sha256</format>
-                        <description>ecdhe-ecdsa-aes128-gcm-sha256</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>ecdhe-rsa-aes128-gcm-sha256</format>
-                        <description>ecdhe-rsa-aes128-gcm-sha256</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>ecdhe-ecdsa-aes256-gcm-sha384</format>
-                        <description>ecdhe-ecdsa-aes256-gcm-sha384</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>ecdhe-rsa-aes256-gcm-sha384</format>
-                        <description>ecdhe-rsa-aes256-gcm-sha384</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>ecdhe-ecdsa-chacha20-poly1305</format>
-                        <description>ecdhe-ecdsa-chacha20-poly1305</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>ecdhe-rsa-chacha20-poly1305</format>
-                        <description>ecdhe-rsa-chacha20-poly1305</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>dhe-rsa-aes128-gcm-sha256</format>
-                        <description>dhe-rsa-aes128-gcm-sha256</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>dhe-rsa-aes256-gcm-sha384</format>
-                        <description>dhe-rsa-aes256-gcm-sha384</description>
-                      </valueHelp>
-                      <constraint>
-                        <regex>(ecdhe-ecdsa-aes128-gcm-sha256|ecdhe-rsa-aes128-gcm-sha256|ecdhe-ecdsa-aes256-gcm-sha384|ecdhe-rsa-aes256-gcm-sha384|ecdhe-ecdsa-chacha20-poly1305|ecdhe-rsa-chacha20-poly1305|dhe-rsa-aes128-gcm-sha256|dhe-rsa-aes256-gcm-sha384)</regex>
-                      </constraint>
-                      <multi/>
-                    </properties>
-                    <defaultValue>ecdhe-ecdsa-aes128-gcm-sha256 ecdhe-rsa-aes128-gcm-sha256 ecdhe-ecdsa-aes256-gcm-sha384 ecdhe-rsa-aes256-gcm-sha384 ecdhe-ecdsa-chacha20-poly1305 ecdhe-rsa-chacha20-poly1305 dhe-rsa-aes128-gcm-sha256 dhe-rsa-aes256-gcm-sha384</defaultValue>
-                  </leafNode>
-                  <leafNode name="tls-version-min">
-                    <properties>
-                      <help>Specify the minimum required TLS version</help>
-                      <completionHelp>
-                        <list>1.2 1.3</list>
-                      </completionHelp>
-                      <valueHelp>
-                        <format>1.2</format>
-                        <description>TLS v1.2</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>1.3</format>
-                        <description>TLS v1.3</description>
-                      </valueHelp>
-                      <constraint>
-                        <regex>(1.2|1.3)</regex>
-                      </constraint>
-                    </properties>
-                    <defaultValue>1.3</defaultValue>
-                  </leafNode>
-                </children>
-              </node>
+                <defaultValue>ecdhe-ecdsa-aes128-gcm-sha256 ecdhe-rsa-aes128-gcm-sha256 ecdhe-ecdsa-aes256-gcm-sha384 ecdhe-rsa-aes256-gcm-sha384 ecdhe-ecdsa-chacha20-poly1305 ecdhe-rsa-chacha20-poly1305 dhe-rsa-aes128-gcm-sha256 dhe-rsa-aes256-gcm-sha384</defaultValue>
+              </leafNode>
+              <leafNode name="tls-version-min">
+                <properties>
+                  <help>Specify the minimum required TLS version</help>
+                  <completionHelp>
+                    <list>1.2 1.3</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>1.2</format>
+                    <description>TLS v1.2</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>1.3</format>
+                    <description>TLS v1.3</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(1.2|1.3)</regex>
+                  </constraint>
+                </properties>
+                <defaultValue>1.3</defaultValue>
+              </leafNode>
             </children>
           </node>
           #include <include/interface/vrf.xml.i>

--- a/src/conf_mode/load-balancing-haproxy.py
+++ b/src/conf_mode/load-balancing-haproxy.py
@@ -74,15 +74,12 @@ def verify(lb):
     if not lb:
         return None
 
-    if 'backend' not in lb or 'server' not in lb:
-        raise ConfigError(f'"server" and "backend" must be configured!')
+    if 'backend' not in lb or 'service' not in lb:
+        raise ConfigError(f'"service" and "backend" must be configured!')
 
-    for front, front_config in lb['server'].items():
+    for front, front_config in lb['service'].items():
         if 'port' not in front_config:
-            raise ConfigError(f'"{front} server port" must be configured!')
-        # We can use redirect to HTTPS without backend section
-        if 'backend' not in front_config and 'redirect_http_to_https' not in front_config:
-           raise ConfigError(f'"{front} backend" must be configured!')
+            raise ConfigError(f'"{front} service port" must be configured!')
 
         # Check if bind address:port are used by another service
         tmp_address = front_config.get('address', '0.0.0.0')
@@ -117,7 +114,7 @@ def generate(lb):
         os.mkdir(load_balancing_dir)
 
     # SSL Certificates for frontend
-    for front, front_config in lb['server'].items():
+    for front, front_config in lb['service'].items():
         if 'ssl' in front_config:
             cert_file_path = os.path.join(load_balancing_dir, 'cert.pem')
             cert_key_path = os.path.join(load_balancing_dir, 'cert.pem.key')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Improve and refactoring "load-balancing reverse-proxy"

```
 - replace 'reverse-proxy server <tag>' 
        => 'reverse-proxy service <tag>'

 - replace 'reverse-proxy global-parameters tls <xxx>' 
        => 'reverse-proxy global-parameters tls-version-min xxx' 
        => 'reverse-proxy global-parameters ssl-bind-ciphers xxx'

 - replace 'reverse-proxy service https rule <tag> set server 'xxx' 
        => 'reverse-proxy service https rule <tag> set backend 'xxx'

  'service https rule <tag> domain-name xxx' set as multinode

```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5222

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
load-balancing, reverse-proxy
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set load-balancing reverse-proxy service http description 'bind port 80 and redirect to 443'
set load-balancing reverse-proxy service http mode 'http'
set load-balancing reverse-proxy service http port '80'
set load-balancing reverse-proxy service http redirect-http-to-https

set load-balancing reverse-proxy service https description 'bind port 80'
set load-balancing reverse-proxy service https mode 'http'
set load-balancing reverse-proxy service https port '443'

set load-balancing reverse-proxy service https rule 10 domain-name 'r11.example.com'
set load-balancing reverse-proxy service https rule 10 domain-name 'r12.example.com'
set load-balancing reverse-proxy service https rule 10 domain-name 'r13.example.com'
set load-balancing reverse-proxy service https rule 10 set backend 'bk-01'
set load-balancing reverse-proxy service https rule 20 domain-name 'r22.example.com'
set load-balancing reverse-proxy service https rule 20 set backend 'bk-02'

set load-balancing reverse-proxy backend bk-01 description 'My API-1'
set load-balancing reverse-proxy backend bk-01 mode 'http'
set load-balancing reverse-proxy backend bk-01 server srv-01 address '192.168.122.11'
set load-balancing reverse-proxy backend bk-01 server srv-01 port '5000'
set load-balancing reverse-proxy backend bk-02 description 'My API-2'
set load-balancing reverse-proxy backend bk-02 mode 'http'
set load-balancing reverse-proxy backend bk-02 server srv-01 address '192.168.122.12'
set load-balancing reverse-proxy backend bk-02 server srv-01 port '5000'

set load-balancing reverse-proxy global-parameters max-connections '1100'
set load-balancing reverse-proxy global-parameters tls-version-min 1.2
```

Validate and show configuration
```
vyos@r14# sudo haproxy -c -f /run/haproxy/haproxy.cfg 
Configuration file is valid
[edit]
vyos@r14# 
[edit]
vyos@r14# sudo cat /run/haproxy/haproxy.cfg 
# Generated by ${vyos_conf_scripts_dir}/load-balancing-haproxy.py

global
    log /dev/log local0
    log /dev/log local1 notice
    chroot /var/lib/haproxy
    stats socket /run/haproxy/admin.sock mode 660 level admin
    stats timeout 30s
    user haproxy
    group haproxy
    daemon

    maxconn 1100

    # Default SSL material locations
    ca-base /etc/ssl/certs
    crt-base /etc/ssl/private

    # https://ssl-config.mozilla.org/#server=haproxy&version=2.6.12-1&config=intermediate&openssl=3.0.8-1&guideline=5.6
    ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
    ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
    ssl-default-bind-options ssl-min-ver TLSv1.2 no-tls-tickets

defaults
    log     global
    mode    http
    option  dontlognull
    timeout connect 10s
    timeout client  50s
    timeout server  50s
    errorfile 400 /etc/haproxy/errors/400.http
    errorfile 403 /etc/haproxy/errors/403.http
    errorfile 408 /etc/haproxy/errors/408.http
    errorfile 500 /etc/haproxy/errors/500.http
    errorfile 502 /etc/haproxy/errors/502.http
    errorfile 503 /etc/haproxy/errors/503.http
    errorfile 504 /etc/haproxy/errors/504.http

# Frontend
frontend http
    bind *:80 
    http-request redirect scheme https unless { ssl_fc }
    mode http

frontend https
    bind *:443 
    mode http
    # rule 10
    acl 10 hdr(host) -i r11.example.com
    acl 10 hdr(host) -i r12.example.com
    acl 10 hdr(host) -i r13.example.com
    use_backend bk-01 if 10
    # rule 20
    acl 20 hdr(host) -i r22.example.com
    use_backend bk-02 if 20


# Backend
backend bk-01
    balance roundrobin
    option forwardfor
    http-request set-header X-Forwarded-Port %[dst_port]
    http-request add-header X-Forwarded-Proto https if { ssl_fc }
    mode http
    server srv-01 192.168.122.11:5000  

backend bk-02
    balance roundrobin
    option forwardfor
    http-request set-header X-Forwarded-Port %[dst_port]
    http-request add-header X-Forwarded-Proto https if { ssl_fc }
    mode http
    server srv-01 192.168.122.12:5000  


```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
