### PR TITLE
T5230: Added missing enforce-first-as option to bgp protocol common c…

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -86,6 +86,9 @@
 {% if config.solo is vyos_defined %}
  neighbor {{ neighbor }} solo
 {% endif %}
+{% if config.enforce_first_as is vyos_defined %}	
+ neighbor {{ neighbor }} enforce-first-as	
+{% endif %}
 {% if config.strict_capability_match is vyos_defined %}
  neighbor {{ neighbor }} strict-capability-match
 {% endif %}

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -1016,6 +1016,12 @@
         <valueless/>
       </properties>
     </leafNode>
+    <leafNode name="enforce-first-as">
+      <properties>
+        <help>Ensure the first AS in the AS path matches the peer AS</help>
+        <valueless/>
+      </properties>
+    </leafNode>
     <leafNode name="strict-capability-match">
       <properties>
         <help>Enable strict capability negotiation</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added missing enforce-first-as option to bgp protocol common config and frr bgp jinja template

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5230

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
FRR BGP

## Proposed changes
<!--- Describe your changes in detail -->
Added enforce-first-as option to cli/jinja template for frr bgp. 

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Build image or use https://repo.serverforge.org/vyos/dev/sagitta/vyos-1.4-rolling-202305191659-amd64.iso
Configure ebgp with a neigbor that is advertising routes with the peer in the path. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
