### PR TITLE
T5237: Add support VLANs and QinQ for virtual-ethernet interfaces

### DIFF
--- a/interface-definitions/interfaces-virtual-ethernet.xml.in
+++ b/interface-definitions/interfaces-virtual-ethernet.xml.in
@@ -21,6 +21,8 @@
           #include <include/interface/dhcp-options.xml.i>
           #include <include/interface/dhcpv6-options.xml.i>
           #include <include/interface/disable.xml.i>
+          #include <include/interface/vif-s.xml.i>
+          #include <include/interface/vif.xml.i>
           #include <include/interface/vrf.xml.i>
           <leafNode name="peer-name">
             <properties>


### PR DESCRIPTION



<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to use `vif`` and `vif-s` for virtual-ethernet `vethX` interfaces

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5237

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
virtual-ethernet, veth
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces virtual-ethernet veth10 peer-name 'veth100'
set interfaces virtual-ethernet veth10 vif 50 address '10.0.50.0/31'
set interfaces virtual-ethernet veth100 peer-name 'veth10'
set interfaces virtual-ethernet veth100 vif 50 address '10.0.50.1/31'
```
Check:
```
vyos@r14# run show interfaces virtual-ethernet 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
veth10           -                                 u/u  
veth10.50        10.0.50.0/31                      u/u  
veth100          -                                 u/u  
veth100.50       10.0.50.1/31                      u/u  
[edit]
vyos@r14# 


vyos@r14# run ping 10.0.50.1 source-address 10.0.50.0
PING 10.0.50.1 (10.0.50.1) from 10.0.50.0 : 56(84) bytes of data.
64 bytes from 10.0.50.1: icmp_seq=1 ttl=64 time=0.109 ms
64 bytes from 10.0.50.1: icmp_seq=2 ttl=64 time=0.075 ms
64 bytes from 10.0.50.1: icmp_seq=3 ttl=64 time=0.064 ms
^C
--- 10.0.50.1 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2076ms
rtt min/avg/max/mdev = 0.064/0.082/0.109/0.019 ms
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
