### PR TITLE
router-advert: T5240: verify() that no more then 3 IPv6 name-servers configured

### DIFF
--- a/src/conf_mode/service_router-advert.py
+++ b/src/conf_mode/service_router-advert.py
@@ -95,6 +95,10 @@ def verify(rtradv):
                 if not (int(valid_lifetime) >= int(preferred_lifetime)):
                     raise ConfigError('Prefix valid-lifetime must be greater then or equal to preferred-lifetime')
 
+        if 'name_server' in interface:
+            if len(interface['name_server']) > 3:
+                raise ConfigError('No more then 3 IPv6 name-servers supported!')
+
     return None
 
 def generate(rtradv):

--- a/src/etc/systemd/system/radvd.service.d/override.conf
+++ b/src/etc/systemd/system/radvd.service.d/override.conf
@@ -15,3 +15,4 @@ ExecReload=/usr/sbin/radvd --logmethod stderr_clean --configtest --config /run/r
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=
 PIDFile=/run/radvd/radvd.pid
+Restart=always


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This is a radvd limitation.

(cherry picked from commit 8ef017a3496467433c311af63116af7657c58037)


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5240

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
IPv6 router advertisements

## Proposed changes
<!--- Describe your changes in detail -->
Add check to `verify()` section

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set service router-advert interface eth1 default-preference 'high'
set service router-advert interface eth1 hop-limit '64'
set service router-advert interface eth1 name-server '2001:db8:1111::1'
set service router-advert interface eth1 name-server '2001:db8:1111::2'
set service router-advert interface eth1 name-server '2001:db8:1111::3'
set service router-advert interface eth1 name-server '2001:db8:1111::4'
set service router-advert interface eth1 no-send-advert
set service router-advert interface eth1 prefix 2001:db8::/64
commit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
