### PR TITLE
T5241: Support netns for veth and dummy interfaces

### DIFF
--- a/interface-definitions/interfaces-virtual-ethernet.xml.in
+++ b/interface-definitions/interfaces-virtual-ethernet.xml.in
@@ -21,6 +21,7 @@
           #include <include/interface/dhcp-options.xml.i>
           #include <include/interface/dhcpv6-options.xml.i>
           #include <include/interface/disable.xml.i>
+          #include <include/interface/netns.xml.i>
           #include <include/interface/vif-s.xml.i>
           #include <include/interface/vif.xml.i>
           #include <include/interface/vrf.xml.i>

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -903,14 +903,16 @@ def get_bridge_fdb(interface):
     tmp = loads(cmd(f'bridge -j fdb show dev {interface}'))
     return tmp
 
-def get_interface_config(interface):
+def get_interface_config(interface, netns=None):
     """ Returns the used encapsulation protocol for given interface.
         If interface does not exist, None is returned.
     """
-    if not os.path.exists(f'/sys/class/net/{interface}'):
+    from vyos.util import run
+    netns_exec = f'ip netns exec {netns}' if netns else ''
+    if run(f'{netns_exec} test -e /sys/class/net/{interface}') != 0:
         return None
     from json import loads
-    tmp = loads(cmd(f'ip -d -j link show {interface}'))[0]
+    tmp = loads(cmd(f'{netns_exec} ip -d -j link show {interface}'))[0]
     return tmp
 
 def get_interface_address(interface):

--- a/src/conf_mode/interfaces-dummy.py
+++ b/src/conf_mode/interfaces-dummy.py
@@ -55,7 +55,10 @@ def generate(dummy):
     return None
 
 def apply(dummy):
-    d = DummyIf(dummy['ifname'])
+    if 'netns' in dummy:
+        d = DummyIf(ifname=dummy['ifname'], netns=dummy['netns'])
+    else:
+        d = DummyIf(dummy['ifname'])
 
     # Remove dummy interface
     if 'deleted' in dummy:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add netns configuration for dummy and virtual-ethernet interfaces
Change Interface class to get/set data to netns

There is a link to the second version of netns implementation https://github.com/vyos/vyos-1x/pull/2022
Should be used either
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5241

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
netns, veth
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
touch /tmp/vyos.ifconfig.debug
set netns name ns01
set interfaces dummy dum0 description 'dum0_ns01'
set interfaces dummy dum0 netns 'ns01'
set interfaces dummy dum0 mtu 1800
set interfaces dummy dum0 address 192.0.2.55/32

vyos@r14# commit
[ interfaces dummy dum0 ]
DEBUG/IFCONFIG cmd 'ip netns exec ns01 ip link add dev dum0 type dummy'
{'address': ['192.0.2.55/32'],
 'description': 'dum0_ns01',
 'ifname': 'dum0',
 'mtu': '1800',
 'netns': 'ns01'}
DEBUG/IFCONFIG cmd 'ip netns exec ns01 ip link set dev dum0 alias "dum0_ns01"'
DEBUG/IFCONFIG cmd 'ip netns exec ns01 ip addr add 192.0.2.55/32 dev dum0 brd +'
DEBUG/IFCONFIG cmd 'ip netns exec ns01 ip link set dev dum0 mtu 1800'
DEBUG/IFCONFIG cmd 'ip netns exec ns01 ip link set dev dum0 up'

[edit]
vyos@r14# 
```
Check address and description in netnx:
```
vyos@r14# sudo ip netns exec ns01 ip a
1: lo: <LOOPBACK> mtu 65536 qdisc noop state DOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: dum0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1800 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 4a:fb:7e:35:06:04 brd ff:ff:ff:ff:ff:ff
    inet 192.0.2.55/32 scope global dum0
       valid_lft forever preferred_lft forever
    inet6 fe80::48fb:7eff:fe35:604/64 scope link 
       valid_lft forever preferred_lft forever
[edit]
vyos@r14# 
[edit]
vyos@r14# sudo ip netns exec ns01 ip link
1: lo: <LOOPBACK> mtu 65536 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: dum0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1800 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 4a:fb:7e:35:06:04 brd ff:ff:ff:ff:ff:ff
    alias dum0_ns01
[edit]
vyos@r14# 
```
Example with veth interfaces:
```
set interfaces virtual-ethernet veth10 address '10.0.0.1/30'
set interfaces virtual-ethernet veth10 peer-name 'veth20'

set interfaces virtual-ethernet veth20 address '10.0.0.2/30'
set interfaces virtual-ethernet veth20 description 'veth20-in-netns01'
set interfaces virtual-ethernet veth20 netns 'ns01'
set interfaces virtual-ethernet veth20 peer-name 'veth10'
commit

```
Check in netns:
```
vyos@r14# sudo ip netns exec ns01 ip a
1: lo: <LOOPBACK> mtu 65536 qdisc noop state DOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: dum0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1800 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 4a:fb:7e:35:06:04 brd ff:ff:ff:ff:ff:ff
    inet 192.0.2.55/32 scope global dum0
       valid_lft forever preferred_lft forever
    inet6 fe80::48fb:7eff:fe35:604/64 scope link 
       valid_lft forever preferred_lft forever
526: veth20@if527: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 7e:95:0e:7a:b4:e3 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet 10.0.0.2/30 brd 10.0.0.3 scope global veth20
       valid_lft forever preferred_lft forever
    inet6 fe80::7c95:eff:fe7a:b4e3/64 scope link 
       valid_lft forever preferred_lft forever
[edit]
vyos@r14# 
[edit]
vyos@r14# sudo ip netns exec ns01 ip link
1: lo: <LOOPBACK> mtu 65536 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: dum0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1800 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 4a:fb:7e:35:06:04 brd ff:ff:ff:ff:ff:ff
    alias dum0_ns01
526: veth20@if527: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 7e:95:0e:7a:b4:e3 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    alias veth20-in-netns01
[edit]
vyos@r14# 

```
Ping from netns, default stack:
```
vyos@r14# sudo ip netns exec ns01 ping 10.0.0.1
PING 10.0.0.1 (10.0.0.1) 56(84) bytes of data.
64 bytes from 10.0.0.1: icmp_seq=1 ttl=64 time=0.136 ms
64 bytes from 10.0.0.1: icmp_seq=2 ttl=64 time=0.072 ms
^C
--- 10.0.0.1 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1020ms
rtt min/avg/max/mdev = 0.072/0.104/0.136/0.032 ms
[edit]
vyos@r14# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
