### PR TITLE
T5210:VPN:Fix typo in Warning

### DIFF
--- a/src/conf_mode/vpn_ipsec.py
+++ b/src/conf_mode/vpn_ipsec.py
@@ -455,7 +455,7 @@ def verify(ipsec):
 
                 if dict_search('options.disable_route_autoinstall',
                                ipsec) == None:
-                    Warning('It\'s recommended to use ipsec vty with the next command\n[set vpn ipsec option disable-route-autoinstall]')
+                    Warning('It\'s recommended to use ipsec vti with the next command\n[set vpn ipsec option disable-route-autoinstall]')
 
                 if 'bind' in peer_conf['vti']:
                     vti_interface = peer_conf['vti']['bind']


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Fix typo in warning vti interface

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5210

## Component(s) name
vpn

## Proposed changes
Edited line 458 in the vpn_ipsec.py file to fix the typo

## How to test
```
set interfaces vti vti1 address '10.2.2.1/30'
set vpn ipsec authentication psk PSK id '192.168.100.184'
set vpn ipsec authentication psk PSK id '192.168.100.254'
set vpn ipsec authentication psk PSK secret 'SSSeeccRetT'
set vpn ipsec esp-group ESP-group lifetime '1800'
set vpn ipsec esp-group ESP-group mode 'tunnel'
set vpn ipsec esp-group ESP-group pfs 'enable'
set vpn ipsec esp-group ESP-group proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-group proposal 1 hash 'sha256'
set vpn ipsec ike-group IKE-group key-exchange 'ikev1'
set vpn ipsec ike-group IKE-group lifetime '3600'
set vpn ipsec ike-group IKE-group proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE-group proposal 1 hash 'sha256'
set vpn ipsec interface 'eth1'
set vpn ipsec site-to-site peer OFFICE-B authentication local-id '192.168.100.254'
set vpn ipsec site-to-site peer OFFICE-B authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer OFFICE-B authentication remote-id '192.168.100.184'
set vpn ipsec site-to-site peer OFFICE-B connection-type 'initiate'
set vpn ipsec site-to-site peer OFFICE-B dhcp-interface 'eth0'
set vpn ipsec site-to-site peer OFFICE-B ike-group 'IKE-group'
set vpn ipsec site-to-site peer OFFICE-B remote-address '192.168.100.184'
set vpn ipsec site-to-site peer OFFICE-B vti bind 'vti1'
set vpn ipsec site-to-site peer OFFICE-B vti esp-group 'ESP-group'
vyos@vyos# commit
[ vpn ipsec ]

WARNING: It's recommended to use ipsec vti with the next command
[set vpn ipsec option disable-route-autoinstall]
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
