### PR TITLE
configtree: T5251: catch/raise errors in functions delete and delete_value

### DIFF
--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -201,7 +201,9 @@ class ConfigTree(object):
         check_path(path)
         path_str = " ".join(map(str, path)).encode()
 
-        self.__delete(self.__config, path_str)
+        res = self.__delete(self.__config, path_str)
+        if (res != 0):
+            raise ConfigTreeError(f"Path doesn't exist: {path}")
 
         if self.__migration:
             print(f"- op: delete path: {path}")
@@ -210,7 +212,14 @@ class ConfigTree(object):
         check_path(path)
         path_str = " ".join(map(str, path)).encode()
 
-        self.__delete_value(self.__config, path_str, value.encode())
+        res = self.__delete_value(self.__config, path_str, value.encode())
+        if (res != 0):
+            if res == 1:
+                raise ConfigTreeError(f"Path doesn't exist: {path}")
+            elif res == 2:
+                raise ConfigTreeError(f"Value doesn't exist: '{value}'")
+            else:
+                raise ConfigTreeError()
 
         if self.__migration:
             print(f"- op: delete_value path: {path} value: {value}")

--- a/src/migration-scripts/system/18-to-19
+++ b/src/migration-scripts/system/18-to-19
@@ -92,9 +92,6 @@ else:
     for intf in dhcp_interfaces:
         config.set(base + ['name-servers-dhcp'], value=intf, replace=False)
 
-    # delete old node
-    config.delete(base + ['disable-dhcp-nameservers'])
-
 try:
     with open(file_name, 'w') as f:
         f.write(config.to_string())


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The functions `delete` and `delete_value` should raise `ConfigTreeError` on a non-zero return value from the respective libvyosconfig functions.

This was a missing case in the implementation; all other functions raise error when appropriate.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5251

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
>>> from vyos.configtree import ConfigTree, ConfigTreeError
>>> with open('/config/config.boot') as f:
...     config_file = f.read()
... 
>>> config = ConfigTree(config_file)
>>> try:
...     config.delete(['interfaces', 'ethernet', 'eth999', 'address'])
... except ConfigTreeError as e:
...     print(e)
... 
Path doesn't exist: ['interfaces', 'ethernet', 'eth999', 'address']
>>> try:
...     config.delete_value(['interfaces', 'ethernet', 'eth0', 'address'], 'foo')
... except ConfigTreeError as e:
...     print(e)
... 
Value doesn't exist: 'foo'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
