### PR TITLE
T5257: Fix netflow VRF and bracketize v6 source addresses for netflow…

### DIFF
--- a/data/templates/pmacct/uacctd.conf.j2
+++ b/data/templates/pmacct/uacctd.conf.j2
@@ -53,7 +53,7 @@ nfprobe_maxflows[{{ nf_server_key }}]: {{ netflow.max_flows }}
 sampling_rate[{{ nf_server_key }}]: {{ netflow.sampling_rate }}
 {%         endif %}
 {%         if netflow.source_address is vyos_defined %}
-nfprobe_source_ip[{{ nf_server_key }}]: {{ netflow.source_address }}
+nfprobe_source_ip[{{ nf_server_key }}]: {{ netflow.source_address | bracketize_ipv6 }}
 {%         endif %}
 {%         if netflow.timeout is vyos_defined %}
 nfprobe_timeouts[{{ nf_server_key }}]: expint={{ netflow.timeout.expiry_interval }}:general={{ netflow.timeout.flow_generic }}:icmp={{ netflow.timeout.icmp }}:maxlife={{ netflow.timeout.max_active_life }}:tcp.fin={{ netflow.timeout.tcp_fin }}:tcp={{ netflow.timeout.tcp_generic }}:tcp.rst={{ netflow.timeout.tcp_rst }}:udp={{ netflow.timeout.udp }}
@@ -73,7 +73,7 @@ sfprobe_agentip[{{ sf_server_key }}]: {{ sflow.agent_address }}
 sampling_rate[{{ sf_server_key }}]: {{ sflow.sampling_rate }}
 {%         endif %}
 {%         if sflow.source_address is vyos_defined %}
-sfprobe_source_ip[{{ sf_server_key }}]: {{ sflow.source_address }}
+sfprobe_source_ip[{{ sf_server_key }}]: {{ sflow.source_address | bracketize_ipv6 }}
 {%         endif %}
 
 {%     endfor %}

--- a/src/conf_mode/flow_accounting_conf.py
+++ b/src/conf_mode/flow_accounting_conf.py
@@ -211,7 +211,7 @@ def verify(flow_config):
             if not is_addr_assigned(tmp, sflow_vrf):
                 raise ConfigError(f'Configured "sflow agent-address {tmp}" does not exist in the system!')
 
-        # Check if configured netflow source-address exist in the system
+        # Check if configured sflow source-address exist in the system
         if 'source_address' in flow_config['sflow']:
             if not is_addr_assigned(flow_config['sflow']['source_address'], sflow_vrf):
                 tmp = flow_config['sflow']['source_address']
@@ -219,13 +219,18 @@ def verify(flow_config):
 
     # check NetFlow configuration
     if 'netflow' in flow_config:
+        # check if vrf is defined for netflow
+        netflow_vrf = None
+        if 'vrf' in flow_config:
+            netflow_vrf = flow_config['vrf']
+            
         # check if at least one NetFlow collector is configured if NetFlow configuration is presented
         if 'server' not in flow_config['netflow']:
             raise ConfigError('You need to configure at least one NetFlow server!')
 
         # Check if configured netflow source-address exist in the system
         if 'source_address' in flow_config['netflow']:
-            if not is_addr_assigned(flow_config['netflow']['source_address']):
+            if not is_addr_assigned(flow_config['netflow']['source_address'], netflow_vrf):
                 tmp = flow_config['netflow']['source_address']
                 raise ConfigError(f'Configured "netflow source-address {tmp}" does not exist on the system!')
 


### PR DESCRIPTION
…/sflow

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added changes to flow_accounting_conf.py to allow addresses in the non default VRF to work.
Added changes to uacctd.conf.j2 to bracketize v6 source ips.
Fixed typo in comment in flow_accounting_conf.py that labeled the vrf check part in the sflow section as for netflow. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://vyos.dev/T5257

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pmacctd

## Proposed changes
<!--- Describe your changes in detail -->
Added changes to flow_accounting_conf.py to allow addresses in the non default VRF to work.
Added changes to uacctd.conf.j2 to bracketize v6 source ips.
Fixed typo in comment in flow_accounting_conf.py that labeled the vrf check part in the sflow section as for netflow.
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Build image with changes.
Configure netflow with v6/v4 address in non default vrf. 
Configure sflow/netflow with v6 source ip. 

prebuilt image available at the link below.
https://repo.serverforge.org/vyos/dev/sagitta/vyos-1.4-rolling-202306022302-amd64.iso

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
