### PR TITLE
openconnect: T5259: fix migration logic in delete_value radius|local

### DIFF
--- a/src/migration-scripts/openconnect/1-to-2
+++ b/src/migration-scripts/openconnect/1-to-2
@@ -39,13 +39,13 @@ if not config.exists(cfg_base):
 else:
     if config.exists(cfg_base + ['authentication', 'mode']):
         if config.return_value(cfg_base + ['authentication', 'mode']) == 'radius':
-            # if "mode value radius", change to "tag node mode + valueless node radius"
-            config.delete(cfg_base + ['authentication','mode', 'radius'])
-            config.set(cfg_base + ['authentication', 'mode', 'radius'], value=None, replace=True)
-        elif not config.exists(cfg_base + ['authentication', 'mode', 'local']):
-            # if "mode local", change to "tag node mode + node local value password"
-            config.delete(cfg_base + ['authentication', 'mode', 'local'])
-            config.set(cfg_base + ['authentication', 'mode', 'local'], value='password', replace=True)
+            # if "mode value radius", change to "mode + valueless node radius"
+            config.delete_value(cfg_base + ['authentication','mode'], 'radius')
+            config.set(cfg_base + ['authentication', 'mode', 'radius'], value=None)
+        elif config.return_value(cfg_base + ['authentication', 'mode']) == 'local':
+            # if "mode local", change to "mode + node local value password"
+            config.delete_value(cfg_base + ['authentication', 'mode'], 'local')
+            config.set(cfg_base + ['authentication', 'mode', 'local'], value='password')
     try:
         with open(file_name, 'w') as f:
             f.write(config.to_string())


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Incorrect logic of node deletion now raises error, after T5251. Fixed.
config-tests now pass.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5259

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

openconnect

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
