### PR TITLE
dns: T5144: Refactor smoke tests for dynamic dns operation

### DIFF
--- a/smoketest/scripts/cli/test_service_dns_dynamic.py
+++ b/smoketest/scripts/cli/test_service_dns_dynamic.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2020 VyOS maintainers and contributors
+# Copyright (C) 2019-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -30,13 +30,16 @@ DDCLIENT_PID = '/run/ddclient/ddclient.pid'
 
 base_path = ['service', 'dns', 'dynamic']
 hostname = 'test.ddns.vyos.io'
+zone = 'vyos.io'
+password = 'paSS_@4ord'
 interface = 'eth0'
+
 
 def get_config_value(key):
     tmp = cmd(f'sudo cat {DDCLIENT_CONF}')
-    tmp = re.findall(r'\n?{}=+(.*)'.format(key), tmp)
-    tmp = tmp[0].rstrip(', \\')
-    return tmp
+    vals = re.findall(r'\n?{}=([.-@_A-Za-z0-9]+),? \\'.format(key), tmp)
+    return vals[0] if vals else ''
+
 
 class TestServiceDDNS(VyOSUnitTestSHIM.TestCase):
     def tearDown(self):
@@ -50,13 +53,12 @@ class TestServiceDDNS(VyOSUnitTestSHIM.TestCase):
         # PID file must no londer exist after process exited
         self.assertFalse(os.path.exists(DDCLIENT_PID))
 
-    def test_dyndns_service(self):
+    # IPv4 standard DDNS service configuration
+    def test_dyndns_service_standard(self):
         ddns = ['address', interface, 'service']
-        services = {'cloudflare': {'protocol': 'cloudflare', 'zone': 'vyos.io'},
+        services = {'cloudflare': {'protocol': 'cloudflare'},
                     'freedns': {'protocol': 'freedns', 'username': 'vyos_user'},
                     'zoneedit': {'protocol': 'zoneedit1', 'username': 'vyos_user'}}
-        password = 'vyos_pass'
-        zone = 'vyos.io'
 
         for svc, details in services.items():
             self.cli_delete(base_path)
@@ -78,44 +80,46 @@ class TestServiceDDNS(VyOSUnitTestSHIM.TestCase):
                 # commit changes again - now it should work
                 self.cli_commit()
 
-            for opt in details.keys():
-                if opt == 'username':
-                    self.assertTrue(get_config_value('login') == details[opt])
-                else:
-                    self.assertTrue(get_config_value(opt) == details[opt])
-
-            self.assertTrue(get_config_value('use') == 'if')
-            self.assertTrue(get_config_value('if') == interface)
-
-    def test_dyndns_rfc2136(self):
-        # Check if DDNS service can be configured and runs
-        ddns = ['address', interface, 'rfc2136', 'vyos']
-        srv = 'ns1.vyos.io'
-        zone = 'vyos.io'
-        ttl = '300'
-
-        with tempfile.NamedTemporaryFile(prefix='/config/auth/') as key_file:
-            key_file.write(b'S3cretKey')
-
-            self.cli_set(base_path + ddns + ['key', key_file.name])
-            self.cli_set(base_path + ddns + ['host-name', hostname])
-            self.cli_set(base_path + ddns + ['server', srv])
-            self.cli_set(base_path + ddns + ['ttl', ttl])
-            self.cli_set(base_path + ddns + ['zone', zone])
-
-            # commit changes
-            self.cli_commit()
-
-            # Check some generating config parameters
-            self.assertEqual(get_config_value('protocol'), 'nsupdate')
-            self.assertTrue(get_config_value('password') == key_file.name)
-            self.assertTrue(get_config_value('server') == srv)
-            self.assertTrue(get_config_value('zone') == zone)
-            self.assertTrue(get_config_value('ttl') == ttl)
+            # Check the generating config parameters
             self.assertEqual(get_config_value('use'), 'if')
             self.assertEqual(get_config_value('if'), interface)
+            self.assertEqual(get_config_value('password'), password)
 
-    def test_dyndns_dual(self):
+            for opt in details.keys():
+                if opt == 'username':
+                    self.assertEqual(get_config_value('login'), details[opt])
+                else:
+                    self.assertEqual(get_config_value(opt), details[opt])
+
+    # IPv6 only DDNS service configuration
+    def test_dyndns_service_ipv6(self):
+        ddns = ['address', interface, 'service', 'dynv6']
+        proto = 'dyndns2'
+        user = 'none'
+        password = 'paSS_4ord'
+        srv = 'ddns.vyos.io'
+        ip_version = 'ipv6'
+
+        self.cli_set(base_path + ddns + ['ip-version', ip_version])
+        self.cli_set(base_path + ddns + ['protocol', proto])
+        self.cli_set(base_path + ddns + ['server', srv])
+        self.cli_set(base_path + ddns + ['username', user])
+        self.cli_set(base_path + ddns + ['password', password])
+        self.cli_set(base_path + ddns + ['host-name', hostname])
+
+        # commit changes
+        self.cli_commit()
+
+        # Check the generating config parameters
+        self.assertEqual(get_config_value('usev6'), 'ifv6')
+        self.assertEqual(get_config_value('ifv6'), interface)
+        self.assertEqual(get_config_value('protocol'), proto)
+        self.assertEqual(get_config_value('server'), srv)
+        self.assertEqual(get_config_value('login'), user)
+        self.assertEqual(get_config_value('password'), password)
+
+    # IPv4+IPv6 dual DDNS service configuration
+    def test_dyndns_service_dual_stack(self):
         ddns = ['address', interface, 'service']
         services = {'cloudflare': {'protocol': 'cloudflare', 'zone': 'vyos.io'},
                     'freedns': {'protocol': 'freedns', 'username': 'vyos_user'}}
@@ -133,43 +137,47 @@ class TestServiceDDNS(VyOSUnitTestSHIM.TestCase):
             # commit changes
             self.cli_commit()
 
-            # Check some generating config parameters
+            # Check the generating config parameters
+            self.assertEqual(get_config_value('usev4'), 'ifv4')
+            self.assertEqual(get_config_value('usev6'), 'ifv6')
+            self.assertEqual(get_config_value('ifv4'), interface)
+            self.assertEqual(get_config_value('ifv6'), interface)
+            self.assertEqual(get_config_value('password'), password)
+
             for opt in details.keys():
                 if opt == 'username':
-                    self.assertTrue(get_config_value('login') == details[opt])
+                    self.assertEqual(get_config_value('login'), details[opt])
                 else:
-                    self.assertTrue(get_config_value(opt) == details[opt])
+                    self.assertEqual(get_config_value(opt), details[opt])
 
-            self.assertTrue(get_config_value('usev4') == 'ifv4')
-            self.assertTrue(get_config_value('usev6') == 'ifv6')
-            self.assertTrue(get_config_value('ifv4') == interface)
-            self.assertTrue(get_config_value('ifv6') == interface)
+    def test_dyndns_rfc2136(self):
+        # Check if DDNS service can be configured and runs
+        ddns = ['address', interface, 'rfc2136', 'vyos']
+        srv = 'ns1.vyos.io'
+        zone = 'vyos.io'
+        ttl = '300'
 
-    def test_dyndns_ipv6(self):
-        ddns = ['address', interface, 'service', 'dynv6']
-        proto = 'dyndns2'
-        user = 'none'
-        password = 'paSS_4ord'
-        srv = 'ddns.vyos.io'
-        ip_version = 'ipv6'
+        with tempfile.NamedTemporaryFile(prefix='/config/auth/') as key_file:
+            key_file.write(b'S3cretKey')
 
-        self.cli_set(base_path + ddns + ['host-name', hostname])
-        self.cli_set(base_path + ddns + ['username', user])
-        self.cli_set(base_path + ddns + ['password', password])
-        self.cli_set(base_path + ddns + ['protocol', proto])
-        self.cli_set(base_path + ddns + ['server', srv])
-        self.cli_set(base_path + ddns + ['ip-version', ip_version])
+            self.cli_set(base_path + ddns + ['server', srv])
+            self.cli_set(base_path + ddns + ['zone', zone])
+            self.cli_set(base_path + ddns + ['key', key_file.name])
+            self.cli_set(base_path + ddns + ['ttl', ttl])
+            self.cli_set(base_path + ddns + ['host-name', hostname])
 
-        # commit changes
-        self.cli_commit()
+            # commit changes
+            self.cli_commit()
 
-        # Check some generating config parameters
-        self.assertEqual(get_config_value('protocol'), proto)
-        self.assertEqual(get_config_value('login'), user)
-        self.assertEqual(get_config_value('password'), password)
-        self.assertEqual(get_config_value('server'), srv)
-        self.assertEqual(get_config_value('usev6'), 'ifv6')
-        self.assertEqual(get_config_value('ifv6'), interface)
+            # Check some generating config parameters
+            self.assertEqual(get_config_value('use'), 'if')
+            self.assertEqual(get_config_value('if'), interface)
+            self.assertEqual(get_config_value('protocol'), 'nsupdate')
+            self.assertEqual(get_config_value('server'), srv)
+            self.assertEqual(get_config_value('zone'), zone)
+            self.assertEqual(get_config_value('password'), key_file.name)
+            self.assertEqual(get_config_value('ttl'), ttl)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/op_mode/dns_dynamic.py
+++ b/src/op_mode/dns_dynamic.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2020 VyOS maintainers and contributors
+# Copyright (C) 2018-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
- Smoke tests for dynamic DNS operation have been refactored
- Add guard for case when the user enters a partial CLI command without any `address` specified.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5144

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dns dynamic

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
