### PR TITLE
T5253: commit priority: commit error received when mpls config executed with WG

### DIFF
--- a/interface-definitions/interfaces-wireguard.xml.in
+++ b/interface-definitions/interfaces-wireguard.xml.in
@@ -5,7 +5,7 @@
       <tagNode name="wireguard" owner="${vyos_conf_scripts_dir}/interfaces-wireguard.py">
         <properties>
           <help>WireGuard Interface</help>
-          <priority>459</priority>
+          <priority>381</priority>
           <constraint>
             <regex>wg[0-9]+</regex>
           </constraint>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
MPLS configuration part when included with a wireguard interface is executed for first time(adding the interface config in the same commit), an error is received because of the priority preference. Rebooting the device removes the mpls configuration. Increased the priority of the wireguard node compared to mpls.  
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5253

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireguard
## Proposed changes
<!--- Describe your changes in detail -->

**Existing code**:

      <tagNode name="wireguard" owner="${vyos_conf_scripts_dir}/interfaces-wireguard.py">
        <properties>
          <help>WireGuard Interface</help>
          <priority>459</priority>
          <constraint>

**New change**:

      <tagNode name="wireguard" owner="${vyos_conf_scripts_dir}/interfaces-wireguard.py">
        <properties>
          <help>WireGuard Interface</help>
          <priority>381</priority>
          <constraint>

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set interfaces wireguard wg0 address '100.120.0.2/30'
set interfaces wireguard wg0 peer PE2 address '192.168.11.1'
set interfaces wireguard wg0 peer PE2 allowed-ips '0.0.0.0/0'
set interfaces wireguard wg0 peer PE2 port '51820'
set interfaces wireguard wg0 peer PE2 public-key <key>
set interfaces wireguard wg0 port '51820'
set interfaces wireguard wg0 private-key <key>
set protocols mpls interface 'wg0'
set protocols mpls ldp interface 'wg0'

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
