### PR TITLE
T5283: ipoe-server: add more flexibility in subnet parameter.

### DIFF
--- a/interface-definitions/include/accel-ppp/client-ip-pool-subnet-single.xml.i
+++ b/interface-definitions/include/accel-ppp/client-ip-pool-subnet-single.xml.i
@@ -8,8 +8,9 @@
     </valueHelp>
     <constraint>
       <validator name="ipv4-prefix"/>
+      <validator name="ipv4-host"/>
     </constraint>
-    <constraintErrorMessage>Not a valid CIDR formatted prefix</constraintErrorMessage>
+    <constraintErrorMessage>Not a valid IP address or prefix</constraintErrorMessage>
   </properties>
 </leafNode>
 <!-- include end -->


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Extend flexibility on subnet parameter.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5283

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipoe-server

## Proposed changes
<!--- Describe your changes in detail -->
Allow to define ip-address/mask in subnet, in order to be able not to specify a complete network, and just an IP were it should start the pool of addresses used for clients.
This avoids to lease the first address, which is network address, to the client, as described in T5283
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
vyos@ipoe-serv:~$ show config comm | grep ipoe
set service ipoe-server authentication mode 'noauth'
set service ipoe-server client-ip-pool name clients gateway-address '100.64.24.1'
set service ipoe-server client-ip-pool name clients subnet '100.64.24.101/24'
set service ipoe-server interface bond0.100 network 'vlan'
set service ipoe-server interface bond0.100 vlan '2000-3000'
set service ipoe-server name-server '208.67.222.222'
set system host-name 'ipoe-serv'
vyos@ipoe-serv:~$ 
vyos@ipoe-serv:~$ 
vyos@ipoe-serv:~$ show ipoe-server sessions 
ifname     | username |    calling-sid    |      ip       | rate-limit | type | comp | state  |  uptime  
----------------+----------+-------------------+---------------+------------+------+------+--------+----------
 bond0.100.2002 |          | aa:bb:cc:00:b0:00 | 100.64.24.101 |            | ipoe |      | active | 00:00:52 
 bond0.100.2001 |          | 50:00:00:0a:00:00 | 100.64.24.102 |            | ipoe |      | active | 00:00:43 
 bond0.100.2000 |          | 50:00:00:09:00:00 | 100.64.24.103 |            | ipoe |      | active | 00:00:15
vyos@ipoe-serv:~$ 

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
