### PR TITLE
T5295: Fix QoS shaper rate limit

### DIFF
--- a/python/vyos/qos/base.py
+++ b/python/vyos/qos/base.py
@@ -1,4 +1,4 @@
-# Copyright 2022 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2022-2023 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -243,60 +243,70 @@ class QoSBase:
                 # The police block allows limiting of the byte or packet rate of
                 # traffic matched by the filter it is attached to.
                 # https://man7.org/linux/man-pages/man8/tc-police.8.html
-                if any(tmp in ['exceed', 'bandwidth', 'burst'] for tmp in cls_config):
-                    filter_cmd += f' action police'
 
-                if 'exceed' in cls_config:
-                    action = cls_config['exceed']
-                    filter_cmd += f' conform-exceed {action}'
-                    if 'not_exceed' in cls_config:
-                        action = cls_config['not_exceed']
-                        filter_cmd += f'/{action}'
-
-                if 'bandwidth' in cls_config:
-                    rate = self._rate_convert(cls_config['bandwidth'])
-                    filter_cmd += f' rate {rate}'
-
-                if 'burst' in cls_config:
-                    burst = cls_config['burst']
-                    filter_cmd += f' burst {burst}'
+                # T5295: We do not handle rate via tc filter directly,
+                # but rather set the tc filter to direct traffic to the correct tc class flow.
+                #
+                # if any(tmp in ['exceed', 'bandwidth', 'burst'] for tmp in cls_config):
+                #     filter_cmd += f' action police'
+                #
+                # if 'exceed' in cls_config:
+                #     action = cls_config['exceed']
+                #     filter_cmd += f' conform-exceed {action}'
+                #     if 'not_exceed' in cls_config:
+                #         action = cls_config['not_exceed']
+                #         filter_cmd += f'/{action}'
+                #
+                # if 'bandwidth' in cls_config:
+                #     rate = self._rate_convert(cls_config['bandwidth'])
+                #     filter_cmd += f' rate {rate}'
+                #
+                # if 'burst' in cls_config:
+                #     burst = cls_config['burst']
+                #     filter_cmd += f' burst {burst}'
 
                 cls = int(cls)
                 filter_cmd += f' flowid {self._parent:x}:{cls:x}'
                 self._cmd(filter_cmd)
 
-        if 'default' in config:
-            if 'class' in config:
-                class_id_max = self._get_class_max_id(config)
-                default_cls_id = int(class_id_max) +1
-                self._build_base_qdisc(config['default'], default_cls_id)
-
-            filter_cmd = f'tc filter replace dev {self._interface} parent {self._parent:x}: '
-            filter_cmd += 'prio 255 protocol all basic'
-
-            # The police block allows limiting of the byte or packet rate of
-            # traffic matched by the filter it is attached to.
-            # https://man7.org/linux/man-pages/man8/tc-police.8.html
-            if any(tmp in ['exceed', 'bandwidth', 'burst'] for tmp in config['default']):
-                filter_cmd += f' action police'
-
-            if 'exceed' in config['default']:
-                action = config['default']['exceed']
-                filter_cmd += f' conform-exceed {action}'
-                if 'not_exceed' in config['default']:
-                    action = config['default']['not_exceed']
-                    filter_cmd += f'/{action}'
-
-            if 'bandwidth' in config['default']:
-                rate = self._rate_convert(config['default']['bandwidth'])
-                filter_cmd += f' rate {rate}'
-
-            if 'burst' in config['default']:
-                burst = config['default']['burst']
-                filter_cmd += f' burst {burst}'
-
-            if 'class' in config:
-                filter_cmd += f' flowid {self._parent:x}:{default_cls_id:x}'
-
-            self._cmd(filter_cmd)
-
+        # T5295: Do not do any tc filter action for 'default'
+        # In VyOS 1.4, we have the following configuration:
+        # tc filter replace dev eth0 parent 1: prio 255 protocol all basic action police rate 300000000 burst 15k
+        # However, this caused unexpected random speeds.
+        # In VyOS 1.3, we do not use any 'tc filter' for rate limits,
+        # It gets rate from  tc class classid 1:1
+        #
+        # if 'default' in config:
+        #     if 'class' in config:
+        #         class_id_max = self._get_class_max_id(config)
+        #         default_cls_id = int(class_id_max) +1
+        #         self._build_base_qdisc(config['default'], default_cls_id)
+        #
+        #     filter_cmd = f'tc filter replace dev {self._interface} parent {self._parent:x}: '
+        #     filter_cmd += 'prio 255 protocol all basic'
+        #
+        #     # The police block allows limiting of the byte or packet rate of
+        #     # traffic matched by the filter it is attached to.
+        #     # https://man7.org/linux/man-pages/man8/tc-police.8.html
+        #     if any(tmp in ['exceed', 'bandwidth', 'burst'] for tmp in config['default']):
+        #         filter_cmd += f' action police'
+        #
+        #     if 'exceed' in config['default']:
+        #         action = config['default']['exceed']
+        #         filter_cmd += f' conform-exceed {action}'
+        #         if 'not_exceed' in config['default']:
+        #             action = config['default']['not_exceed']
+        #             filter_cmd += f'/{action}'
+        #
+        #     if 'bandwidth' in config['default']:
+        #         rate = self._rate_convert(config['default']['bandwidth'])
+        #         filter_cmd += f' rate {rate}'
+        #
+        #     if 'burst' in config['default']:
+        #         burst = config['default']['burst']
+        #         filter_cmd += f' burst {burst}'
+        #
+        #     if 'class' in config:
+        #         filter_cmd += f' flowid {self._parent:x}:{default_cls_id:x}'
+        #
+        #     self._cmd(filter_cmd)


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Do not directly handle rate via `tc filter` but rather set the `tc filter` to direct traffic to the correct `tc class` flow.
As it is in 1.3.
It fixes random unexpected shapes when you set, for example 300mbit but get 3-11mbit

The current implementation seems not correct as it uses rate limits two times (in class and in filter):
```
  tc class replace dev eth0 parent 1:1 classid 1:17 htb rate 250000000 \
      burst 15k quantum 1514
  tc filter replace dev eth0 parent 1: protocol all u32 match \
      ip dst 192.168.122.11 action police rate 250000000 burst 15k flowid 1:17
```
The correct way after fix:
```
  tc class replace dev eth0 parent 1:1 classid 1:17 htb rate 250000000 \
      burst 15k quantum 1514
  tc filter replace dev eth0 parent 1: protocol all u32 match \
      ip dst 192.168.122.11 flowid 1:17
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5295

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
qos, shaper
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Tested configuration:
```
set qos interface eth0 egress 'test'
set qos policy shaper test bandwidth '330mbit'
set qos policy shaper test class 23 bandwidth '250mbit'
set qos policy shaper test class 23 match 10 ip destination address '192.168.122.11'
set qos policy shaper test default bandwidth '300mbit'
set qos policy shaper test default queue-type 'fair-queue'
```
debug before fix:
```
DEBUG/QoS: tc qdisc replace dev eth0 root handle 1: htb r2q 206 default 18
DEBUG/QoS: tc class replace dev eth0 parent 1: classid 1:1 htb rate 330000000
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:17 htb rate 250000000 burst 15k quantum 1514
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:17 sfq
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:18 htb rate 300000000 burst 15k quantum 1514 prio 20
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:18 sfq
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:17 fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5 noecn
DEBUG/QoS: tc filter replace dev eth0 parent 1: protocol all u32 match ip dst 192.168.122.11 action police rate 250000000 burst 15k flowid 1:17
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:18 sfq
DEBUG/QoS: tc filter replace dev eth0 parent 1: prio 255 protocol all basic action police rate 300000000 burst 15k flowid 1:18

```
debug after fix:
```
DEBUG/QoS: tc qdisc replace dev eth0 root handle 1: htb r2q 206 default 18
DEBUG/QoS: tc class replace dev eth0 parent 1: classid 1:1 htb rate 330000000
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:17 htb rate 250000000 burst 15k quantum 1514
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:17 sfq
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:18 htb rate 300000000 burst 15k quantum 1514 prio 20
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:18 sfq
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:17 fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5 noecn
DEBUG/QoS: tc filter replace dev eth0 parent 1: protocol all u32 match ip dst 192.168.122.11 flowid 1:17
```

before fix expected speed 300 mbit (default speed)

```
vyos@r14# sudo iperf3 -c 192.168.122.1 -t 5
Connecting to host 192.168.122.1, port 5201
[  5] local 192.168.122.14 port 44254 connected to 192.168.122.1 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  1.33 MBytes  11.2 Mbits/sec  684   58.0 KBytes       
[  5]   1.00-2.00   sec   445 KBytes  3.65 Mbits/sec  357   32.5 KBytes       
[  5]   2.00-3.00   sec   573 KBytes  4.69 Mbits/sec  352   32.5 KBytes       
[  5]   3.00-4.00   sec   318 KBytes  2.61 Mbits/sec  265   22.6 KBytes       
[  5]   4.00-5.00   sec   382 KBytes  3.13 Mbits/sec  414   25.5 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-5.00   sec  3.01 MBytes  5.05 Mbits/sec  2072             sender
[  5]   0.00-5.04   sec  2.28 MBytes  3.79 Mbits/sec                  receiver

iperf Done.
```

before fix expected speed 250 mbit (class 23)
```

vyos@r14# sudo iperf3 -c 192.168.122.11 -t 5
Connecting to host 192.168.122.11, port 5201
[  5] local 192.168.122.14 port 54474 connected to 192.168.122.11 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  2.08 MBytes  17.4 Mbits/sec  1082   19.8 KBytes       
[  5]   1.00-2.00   sec   318 KBytes  2.60 Mbits/sec  348   12.7 KBytes       
[  5]   2.00-3.00   sec   636 KBytes  5.22 Mbits/sec  373   28.3 KBytes       
[  5]   3.00-4.00   sec   382 KBytes  3.13 Mbits/sec  369   17.0 KBytes       
[  5]   4.00-5.00   sec   764 KBytes  6.26 Mbits/sec  613   14.1 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-5.00   sec  4.13 MBytes  6.93 Mbits/sec  2785             sender
[  5]   0.00-5.04   sec  3.06 MBytes  5.09 Mbits/sec                  receiver

iperf Done.

```

after fix expected speed 300 mbit (default speed)
```

vyos@r14# sudo iperf3 -c 192.168.122.1 -t 5
Connecting to host 192.168.122.1, port 5201
[  5] local 192.168.122.14 port 60154 connected to 192.168.122.1 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  36.6 MBytes   307 Mbits/sec    0    238 KBytes       
[  5]   1.00-2.00   sec  33.9 MBytes   285 Mbits/sec    0    218 KBytes       
[  5]   2.00-3.00   sec  33.9 MBytes   285 Mbits/sec    0    223 KBytes       
[  5]   3.00-4.00   sec  34.8 MBytes   292 Mbits/sec    0    215 KBytes       
[  5]   4.00-5.00   sec  33.9 MBytes   285 Mbits/sec    0    221 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-5.00   sec   173 MBytes   291 Mbits/sec    0             sender
[  5]   0.00-5.04   sec   171 MBytes   285 Mbits/sec                  receiver

iperf Done.
```


after fix expected speed 250 mbit (class 23)

```
vyos@r14# sudo iperf3 -c 192.168.122.11 -t 5
Connecting to host 192.168.122.11, port 5201
[  5] local 192.168.122.14 port 29104 connected to 192.168.122.11 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  30.2 MBytes   254 Mbits/sec  3229    156 KBytes       
[  5]   1.00-2.00   sec  28.7 MBytes   241 Mbits/sec  3254    288 KBytes       
[  5]   2.00-3.00   sec  27.7 MBytes   232 Mbits/sec  3614    127 KBytes       
[  5]   3.00-4.00   sec  28.6 MBytes   240 Mbits/sec  3597    158 KBytes       
[  5]   4.00-5.00   sec  27.8 MBytes   233 Mbits/sec  3753    158 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-5.00   sec   143 MBytes   240 Mbits/sec  17447             sender
[  5]   0.00-5.04   sec   140 MBytes   234 Mbits/sec                  receiver

iperf Done.
[edit]
vyos@r14# 

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
