### PR TITLE
config-mgmt: T5297: add check for changes under node between revisions

### DIFF
--- a/python/vyos/config_mgmt.py
+++ b/python/vyos/config_mgmt.py
@@ -72,6 +72,29 @@ def unsaved_commits() -> bool:
     os.unlink(tmp_save)
     return ret
 
+def get_file_revision(rev: int):
+    revision = os.path.join(archive_dir, f'config.boot.{rev}.gz')
+    try:
+        with gzip.open(revision) as f:
+            r = f.read().decode()
+    except FileNotFoundError:
+        logger.warning(f'commit revision {rev} not available')
+        return ''
+    return r
+
+def get_config_tree_revision(rev: int):
+    c = get_file_revision(rev)
+    return ConfigTree(c)
+
+def is_node_revised(path: list = [], rev1: int = 1, rev2: int = 0) -> bool:
+    from vyos.configtree import DiffTree
+    left = get_config_tree_revision(rev1)
+    right = get_config_tree_revision(rev2)
+    diff_tree = DiffTree(left, right)
+    if diff_tree.add.exists(path) or diff_tree.sub.exists(path):
+        return True
+    return False
+
 class ConfigMgmtError(Exception):
     pass
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add a utility function to check for changes under node between revisions. Analogous to is_node_changed for recursively checking changes under node between working and active config, the function would be useful for testing if an action is necessary in a post-commit hook.

Discussed with @sever-sever regarding config-sync, one could use the following:

```
diff --git a/src/helpers/vyos_config_sync.py b/src/helpers/vyos_config_sync.py
index b7ed8f265..237e431ef 100755
--- a/src/helpers/vyos_config_sync.py
+++ b/src/helpers/vyos_config_sync.py
@@ -139,6 +139,9 @@ def set_remote_config(
         logger.error(f"An error occurred: {e}")
         return None

+def is_section_revised(section: str) -> bool:
+    from vyos.config_mgmt import is_node_revised
+    return is_node_revised([section])

 def config_sync(primary_address: str, primary_key: str, secondary_address: str,
                 secondary_key: str, sections: List[str], mode: str):
@@ -146,6 +149,9 @@ def config_sync(primary_address: str, primary_key: str, secondary_address: str,
        secondary router
     """

+    if not any(map(is_section_revised, sections)):
+        return
+
     logger.info(
         f"Config synchronization: Mode={mode}, Primary={primary_address}, Secondary={secondary_address}"
     )
-- 
```


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5297

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
