### PR TITLE
T5296: Fix QoS class bandwidth calculation for auto and percent

### DIFF
--- a/python/vyos/qos/trafficshaper.py
+++ b/python/vyos/qos/trafficshaper.py
@@ -70,7 +70,17 @@ class TrafficShaper(QoSBase):
                 cls = int(cls)
 
                 # bandwidth is a mandatory CLI node
-                rate = self._rate_convert(cls_config['bandwidth'])
+                # T5296 if bandwidth 'auto' or 'xx%' get value from config shaper total "bandwidth"
+                # i.e from  set shaper test bandwidth '300mbit'
+                # without it, it tries to get value from qos.base /sys/class/net/{self._interface}/speed
+                if cls_config['bandwidth'] == 'auto':
+                    rate = self._rate_convert(config['bandwidth'])
+                elif cls_config['bandwidth'].endswith('%'):
+                    percent = cls_config['bandwidth'].rstrip('%')
+                    rate = self._rate_convert(config['bandwidth']) * int(percent) // 100
+                else:
+                    rate = self._rate_convert(cls_config['bandwidth'])
+
                 burst = cls_config['burst']
                 quantum = cls_config['codel_quantum']
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
There are wrong bandwidth calculations for the class 
We shouldn't rely on interface speed, but we should get this value from `shaper <tag> bandwidth xxx` if configured `auto` or bandwidth with`%` like `50%`

Otherwise, we can get an unexpected rate for the class
```
  % sudo cat /sys/class/net/eth0/speed
  % -1
```
generated rate:
`  classid 1:17 htb rate -1000000`

Fix this
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5296

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
qos, shaper
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set qos interface eth0 egress 'test'
set qos policy shaper test bandwidth '300mbit'
set qos policy shaper test class 23 bandwidth '50%'
set qos policy shaper test class 23 match 10 ip destination address '192.168.122.11'
set qos policy shaper test default bandwidth '50mbit'
set qos policy shaper test default queue-type 'fair-queue'
```

debug before fix
```
DEBUG/QoS: tc qdisc replace dev eth0 root handle 1: htb r2q 187 default 18
DEBUG/QoS: tc class replace dev eth0 parent 1: classid 1:1 htb rate 300000000
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:17 htb rate -1000000 burst 15k quantum 1514
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:17 sfq
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:18 htb rate 50000000 burst 15k quantum 1514 prio 20
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:18 sfq
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:17 fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5 noecn
DEBUG/QoS: tc filter replace dev eth0 parent 1: protocol all u32 match ip dst 192.168.122.11 flowid 1:17

```

debug after fix
```
DEBUG/QoS: tc qdisc replace dev eth0 root handle 1: htb r2q 187 default 18
DEBUG/QoS: tc class replace dev eth0 parent 1: classid 1:1 htb rate 300000000
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:17 htb rate 150000000 burst 15k quantum 1514
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:17 sfq
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:18 htb rate 50000000 burst 15k quantum 1514 prio 20
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:18 sfq
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:17 fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5 noecn
DEBUG/QoS: tc filter replace dev eth0 parent 1: protocol all u32 match ip dst 192.168.122.11 flowid 1:17

```

Expected speed `default 50mbit`:
```
vyos@r14# sudo iperf3 -c 192.168.122.1 -t 5
Connecting to host 192.168.122.1, port 5201
[  5] local 192.168.122.14 port 31680 connected to 192.168.122.1 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  7.02 MBytes  58.8 Mbits/sec    0   60.8 KBytes       
[  5]   1.00-2.00   sec  6.21 MBytes  52.1 Mbits/sec    0   53.7 KBytes       
[  5]   2.00-3.00   sec  5.65 MBytes  47.4 Mbits/sec    0   56.6 KBytes       
[  5]   3.00-4.00   sec  5.16 MBytes  43.3 Mbits/sec    0   62.2 KBytes       
[  5]   4.00-5.00   sec  6.28 MBytes  52.7 Mbits/sec    0   56.6 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-5.00   sec  30.3 MBytes  50.9 Mbits/sec    0             sender
[  5]   0.00-5.04   sec  28.5 MBytes  47.4 Mbits/sec                  receiver

iperf Done.
[edit]

```
Expected speed `50%` of total bandwidth, i.e. 150 Mbit
```
vyos@r14# sudo iperf3 -c 192.168.122.11 -t 5
Connecting to host 192.168.122.11, port 5201
[  5] local 192.168.122.14 port 8248 connected to 192.168.122.11 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  18.6 MBytes   156 Mbits/sec  1990    102 KBytes       
[  5]   1.00-2.00   sec  16.8 MBytes   141 Mbits/sec  2017    102 KBytes       
[  5]   2.00-3.00   sec  16.9 MBytes   142 Mbits/sec  2000    116 KBytes       
[  5]   3.00-4.00   sec  16.8 MBytes   141 Mbits/sec  1048   90.5 KBytes       
[  5]   4.00-5.00   sec  16.9 MBytes   142 Mbits/sec  1332   99.0 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-5.00   sec  86.0 MBytes   144 Mbits/sec  8387             sender
[  5]   0.00-5.04   sec  84.2 MBytes   140 Mbits/sec                  receiver

iperf Done.
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
