### PR TITLE
T5256: T5195: Fix QoS match protocol and add vyos.utils.network

### DIFF
--- a/python/vyos/qos/base.py
+++ b/python/vyos/qos/base.py
@@ -20,6 +20,9 @@ from vyos.util import cmd
 from vyos.util import dict_search
 from vyos.util import read_file
 
+from vyos.utils.network import get_protocol_by_name
+
+
 class QoSBase:
     _debug = False
     _direction = ['egress']
@@ -197,7 +200,9 @@ class QoSBase:
                                 if tmp: filter_cmd += f' match {tc_af} dport {tmp} 0xffff'
 
                                 tmp = dict_search(f'{af}.protocol', match_config)
-                                if tmp: filter_cmd += f' match {tc_af} protocol {tmp} 0xff'
+                                if tmp:
+                                    tmp = get_protocol_by_name(tmp)
+                                    filter_cmd += f' match {tc_af} protocol {tmp} 0xff'
 
                                 # Will match against total length of an IPv4 packet and
                                 # payload length of an IPv6 packet.

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -13,4 +13,18 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-from vyos.utils import network
+import os
+
+
+def get_protocol_by_name(protocol_name):
+    """Get protocol number by protocol name
+
+       % get_protocol_by_name('tcp')
+       % 6
+    """
+    import socket
+    try:
+        protocol_number = socket.getprotobyname(protocol_name)
+        return protocol_number
+    except socket.error:
+        return protocol_name


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
1. Add `vyos.utils.network`

2. tc filter expects protocol number for the match instead of the protocol name
```
vyos@r14# sudo tc filter replace dev eth0 parent 1: protocol all u32 match ip sport 53 0xffff match ip protocol icmp 0xff flowid 1:17
Illegal "match"
[edit]
vyos@r14# 
[edit]
vyos@r14# sudo tc filter replace dev eth0 parent 1: protocol all u32 match ip sport 53 0xffff match ip protocol 1 0xff flowid 1:17
[edit]
vyos@r14# 

```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5256
* https://vyos.dev/T5195

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS config:
```
set qos interface eth0 egress 'test'
set qos policy shaper test bandwidth '330mbit'
set qos policy shaper test class 23 match 10 ip protocol 'icmp'
set qos policy shaper test class 23 match 10 ip source port '53'
set qos policy shaper test default bandwidth '20mbit'
set qos policy shaper test default ceiling '30mbit'
set qos policy shaper test default queue-type 'fair-queue'
```
Before fix:
```
    raise OSError(code, feedback)
PermissionError: [Errno 1] failed to run command: tc filter replace dev eth0 parent 1: protocol all u32 match ip sport 53 0xffff match ip protocol icmp 0xff flowid 1:17
returned: 
exit code: 1
```
After the fix:
```
{'bandwidth': '330mbit',
 'class': {'23': {'bandwidth': 'auto',
                  'burst': '15k',
                  'codel_quantum': '1514',
                  'flows': '1024',
                  'interval': '100',
                  'match': {'10': {'ip': {'protocol': 'icmp',
                                          'source': {'port': '53'}}}},
                  'queue_type': 'fq-codel',
                  'target': '5'}},
 'default': {'bandwidth': '20mbit',
             'burst': '15k',
             'ceiling': '30mbit',
             'codel_quantum': '1514',
             'flows': '1024',
             'interval': '100',
             'priority': '20',
             'queue_type': 'fair-queue',
             'target': '5'}}

DEBUG/QoS: tc qdisc replace dev eth0 root handle 1: htb r2q 206 default 18
DEBUG/QoS: tc class replace dev eth0 parent 1: classid 1:1 htb rate 330000000
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:17 htb rate -1000000 burst 15k quantum 1514
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:17 sfq
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:18 htb rate 20000000 burst 15k quantum 1514 prio 20
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:18 sfq
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:17 fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5 noecn
DEBUG/QoS: tc filter replace dev eth0 parent 1: protocol all u32 match ip sport 53 0xffff match ip protocol 1 0xff flowid 1:17

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
