### PR TITLE
T5303: Rsyslog.service is not working

### DIFF
--- a/src/etc/rsyslog.conf
+++ b/src/etc/rsyslog.conf
@@ -52,8 +52,8 @@ $Umask 0022
 #
 # Stop excessive logging of sudo
 #
-:msg, contains, " pam_unix(sudo:session): session opened for user root(uid=0) by" ~
-:msg, contains, "pam_unix(sudo:session): session closed for user root" ~
+:msg, contains, " pam_unix(sudo:session): session opened for user root(uid=0) by" stop
+:msg, contains, "pam_unix(sudo:session): session closed for user root" stop
 
 #
 # Include all config files in /etc/rsyslog.d/


### PR DESCRIPTION
warning: ~ action is deprecated, consider using the 'stop' statement instead [v8.24.0 try http://www.rsyslog.com/e/2307 ]

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5303

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes

## How to test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
