### PR TITLE
vyos.configdict: T5308: Remove workarounds for incorrect defaults in get_interface_dict

### DIFF
--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -389,7 +389,7 @@ def get_pppoe_interfaces(conf, vrf=None):
 
     return pppoe_interfaces
 
-def get_interface_dict(config, base, ifname=''):
+def get_interface_dict(config, base, ifname='', recursive_defaults=True):
     """
     Common utility function to retrieve and mangle the interfaces configuration
     from the CLI input nodes. All interfaces have a common base where value
@@ -405,46 +405,23 @@ def get_interface_dict(config, base, ifname=''):
             raise ConfigError('Interface (VYOS_TAGNODE_VALUE) not specified')
         ifname = os.environ['VYOS_TAGNODE_VALUE']
 
-    # retrieve interface default values
-    default_values = defaults(base)
-
-    # We take care about VLAN (vif, vif-s, vif-c) default values later on when
-    # parsing vlans in default dict and merge the "proper" values in correctly,
-    # see T2665.
-    for vif in ['vif', 'vif_s']:
-        if vif in default_values: del default_values[vif]
-
-    dict = config.get_config_dict(base + [ifname], key_mangling=('-', '_'),
-                                  get_first_key=True,
-                                  no_tag_node_value_mangle=True)
-
     # Check if interface has been removed. We must use exists() as
     # get_config_dict() will always return {} - even when an empty interface
     # node like the following exists.
     # +macsec macsec1 {
     # +}
     if not config.exists(base + [ifname]):
+        dict = config.get_config_dict(base + [ifname], key_mangling=('-', '_'),
+                                      get_first_key=True,
+                                      no_tag_node_value_mangle=True)
         dict.update({'deleted' : {}})
-
-    # Add interface instance name into dictionary
-    dict.update({'ifname': ifname})
-
-    # Check if QoS policy applied on this interface - See ifconfig.interface.set_mirror_redirect()
-    if config.exists(['qos', 'interface', ifname]):
-        dict.update({'traffic_policy': {}})
-
-    # XXX: T2665: When there is no DHCPv6-PD configuration given, we can safely
-    # remove the default values from the dict.
-    if 'dhcpv6_options' not in dict:
-        if 'dhcpv6_options' in default_values:
-            del default_values['dhcpv6_options']
-
-    # We have gathered the dict representation of the CLI, but there are
-    # default options which we need to update into the dictionary retrived.
-    # But we should only add them when interface is not deleted - as this might
-    # confuse parsers
-    if 'deleted' not in dict:
-        dict = dict_merge(default_values, dict)
+    else:
+        # Get config_dict with default values
+        dict = config.get_config_dict(base + [ifname], key_mangling=('-', '_'),
+                                      get_first_key=True,
+                                      no_tag_node_value_mangle=True,
+                                      with_defaults=True,
+                                      with_recursive_defaults=recursive_defaults)
 
         # If interface does not request an IPv4 DHCP address there is no need
         # to keep the dhcp-options key
@@ -452,8 +429,12 @@ def get_interface_dict(config, base, ifname=''):
             if 'dhcp_options' in dict:
                 del dict['dhcp_options']
 
-    # XXX: T2665: blend in proper DHCPv6-PD default values
-    dict = T2665_set_dhcpv6pd_defaults(dict)
+    # Add interface instance name into dictionary
+    dict.update({'ifname': ifname})
+
+    # Check if QoS policy applied on this interface - See ifconfig.interface.set_mirror_redirect()
+    if config.exists(['qos', 'interface', ifname]):
+        dict.update({'traffic_policy': {}})
 
     address = leaf_node_changed(config, base + [ifname, 'address'])
     if address: dict.update({'address_old' : address})
@@ -497,9 +478,6 @@ def get_interface_dict(config, base, ifname=''):
         else:
             dict['ipv6']['address'].update({'eui64_old': eui64})
 
-    # Implant default dictionary in vif/vif-s VLAN interfaces. Values are
-    # identical for all types of VLAN interfaces as they all include the same
-    # XML definitions which hold the defaults.
     for vif, vif_config in dict.get('vif', {}).items():
         # Add subinterface name to dictionary
         dict['vif'][vif].update({'ifname' : f'{ifname}.{vif}'})
@@ -507,21 +485,9 @@ def get_interface_dict(config, base, ifname=''):
         if config.exists(['qos', 'interface', f'{ifname}.{vif}']):
             dict['vif'][vif].update({'traffic_policy': {}})
 
-        default_vif_values = defaults(base + ['vif'])
-        # XXX: T2665: When there is no DHCPv6-PD configuration given, we can safely
-        # remove the default values from the dict.
-        if not 'dhcpv6_options' in vif_config:
-            del default_vif_values['dhcpv6_options']
-
-        # Only add defaults if interface is not about to be deleted - this is
-        # to keep a cleaner config dict.
         if 'deleted' not in dict:
             address = leaf_node_changed(config, base + [ifname, 'vif', vif, 'address'])
             if address: dict['vif'][vif].update({'address_old' : address})
-
-            dict['vif'][vif] = dict_merge(default_vif_values, dict['vif'][vif])
-            # XXX: T2665: blend in proper DHCPv6-PD default values
-            dict['vif'][vif] = T2665_set_dhcpv6pd_defaults(dict['vif'][vif])
 
             # If interface does not request an IPv4 DHCP address there is no need
             # to keep the dhcp-options key
@@ -544,25 +510,9 @@ def get_interface_dict(config, base, ifname=''):
         if config.exists(['qos', 'interface', f'{ifname}.{vif_s}']):
             dict['vif_s'][vif_s].update({'traffic_policy': {}})
 
-        default_vif_s_values = defaults(base + ['vif-s'])
-        # XXX: T2665: we only wan't the vif-s defaults - do not care about vif-c
-        if 'vif_c' in default_vif_s_values: del default_vif_s_values['vif_c']
-
-        # XXX: T2665: When there is no DHCPv6-PD configuration given, we can safely
-        # remove the default values from the dict.
-        if not 'dhcpv6_options' in vif_s_config:
-            del default_vif_s_values['dhcpv6_options']
-
-        # Only add defaults if interface is not about to be deleted - this is
-        # to keep a cleaner config dict.
         if 'deleted' not in dict:
             address = leaf_node_changed(config, base + [ifname, 'vif-s', vif_s, 'address'])
             if address: dict['vif_s'][vif_s].update({'address_old' : address})
-
-            dict['vif_s'][vif_s] = dict_merge(default_vif_s_values,
-                    dict['vif_s'][vif_s])
-            # XXX: T2665: blend in proper DHCPv6-PD default values
-            dict['vif_s'][vif_s] = T2665_set_dhcpv6pd_defaults(dict['vif_s'][vif_s])
 
             # If interface does not request an IPv4 DHCP address there is no need
             # to keep the dhcp-options key
@@ -586,25 +536,10 @@ def get_interface_dict(config, base, ifname=''):
             if config.exists(['qos', 'interface', f'{ifname}.{vif_s}.{vif_c}']):
                 dict['vif_s'][vif_s]['vif_c'][vif_c].update({'traffic_policy': {}})
 
-            default_vif_c_values = defaults(base + ['vif-s', 'vif-c'])
-
-            # XXX: T2665: When there is no DHCPv6-PD configuration given, we can safely
-            # remove the default values from the dict.
-            if not 'dhcpv6_options' in vif_c_config:
-                del default_vif_c_values['dhcpv6_options']
-
-            # Only add defaults if interface is not about to be deleted - this is
-            # to keep a cleaner config dict.
             if 'deleted' not in dict:
                 address = leaf_node_changed(config, base + [ifname, 'vif-s', vif_s, 'vif-c', vif_c, 'address'])
                 if address: dict['vif_s'][vif_s]['vif_c'][vif_c].update(
                         {'address_old' : address})
-
-                dict['vif_s'][vif_s]['vif_c'][vif_c] = dict_merge(
-                    default_vif_c_values, dict['vif_s'][vif_s]['vif_c'][vif_c])
-                # XXX: T2665: blend in proper DHCPv6-PD default values
-                dict['vif_s'][vif_s]['vif_c'][vif_c] = T2665_set_dhcpv6pd_defaults(
-                    dict['vif_s'][vif_s]['vif_c'][vif_c])
 
                 # If interface does not request an IPv4 DHCP address there is no need
                 # to keep the dhcp-options key

--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -322,7 +322,7 @@ def verify_dhcpv6(config):
 
         # It is not allowed to have duplicate SLA-IDs as those identify an
         # assigned IPv6 subnet from a delegated prefix
-        for pd in dict_search('dhcpv6_options.pd', config):
+        for pd in (dict_search('dhcpv6_options.pd', config) or []):
             sla_ids = []
             interfaces = dict_search(f'dhcpv6_options.pd.{pd}.interface', config)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Note: this depends on PR:
https://github.com/vyos/vyos-1x/pull/2010

Applying the revised vyos.xml lib (T5218) to `get_config_dict`, one can remove the workarounds needed in `get_interface_dict` due to incorrect defaults on tag nodes (bug T2665).

The original implementation of the vyos.xml lib adds defaults below a tag node name, irrespective of the existence of a corresponding tag node value, and at the wrong level; this required workarounds to delete and/or shift defaults before merging dicts.

That bug is corrected in the revision of the vyos.xml lib, merged in T5218.

As a first step, we remove the workarounds in` vyos.configdict.get_interface_dict`; this provides the same results without the workaround overhead, passes all smoketests and config tests. As get_interface_dict is a critical part of the vyos lib infrastructure, it is addressed first and as a separate task. Removing all other cases of T2665 workarounds will follow directly.

Note that for compatibility this maintains the practice of merging 'recursive' defaults in `get_interface_dict` --- namely, those leaf nodes with default values that have an _ancestor_ node in the config are merged into the result. The revisions to the xml lib and `get_config_dict` also support providing 'non-recursive' defaults: those that have a _parent_ in the config; cf. the discussion of invariants in PR https://github.com/vyos/vyos-1x/pull/2010, above. We can consider maintaining this invariant going forward.

Example, exhibiting the bug corrected in the second commit, below:

```
vyos@vyos# show interfaces ethernet eth1
+address dhcpv6
+dhcpv6-options {
+    parameters-only
+}
 hw-id 52:54:00:7b:3e:08
>>> from vyos.config import Config
>>> from vyos.orig_configdict import get_interface_dict as orig_get_interface_dict
>>> from vyos.configdict import get_interface_dict
>>> from pprint import pprint
>>> conf = Config()
>>> base = ['interfaces', 'ethernet']
>>> _, orig = orig_get_interface_dict(conf, base, ifname='eth1')
>>> _, rev = get_interface_dict(conf, base, ifname='eth1')
>>> _, rev_local = get_interface_dict(conf, base, ifname='eth1', recursive_defaults=False)
>>> pprint(dict(sorted(orig.items())))
{'address': ['dhcpv6'],
 'dhcpv6_options': {'parameters_only': {}, 'pd': {}},
 'duplex': 'auto',
 'hw_id': '52:54:00:7b:3e:08',
 'ifname': 'eth1',
 'ip': {'arp_cache_timeout': '30'},
 'mtu': '1500',
 'speed': 'auto'}
>>> pprint(dict(sorted(rev.items())))
{'address': ['dhcpv6'],
 'dhcpv6_options': {'parameters_only': {}},
 'duplex': 'auto',
 'hw_id': '52:54:00:7b:3e:08',
 'ifname': 'eth1',
 'ip': {'arp_cache_timeout': '30'},
 'mtu': '1500',
 'speed': 'auto'}
>>> pprint(dict(sorted(rev_local.items())))
{'address': ['dhcpv6'],
 'dhcpv6_options': {'parameters_only': {}},
 'duplex': 'auto',
 'hw_id': '52:54:00:7b:3e:08',
 'ifname': 'eth1',
 'mtu': '1500',
 'speed': 'auto'}
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5308
* https://vyos.dev/T5228

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
