### PR TITLE
T5314: Fix default QOS classes not getting qdisc

### DIFF
--- a/python/vyos/qos/base.py
+++ b/python/vyos/qos/base.py
@@ -331,13 +331,15 @@ class QoSBase:
                 #     burst = cls_config['burst']
                 #     filter_cmd += f' burst {burst}'
 
+        if 'default' in config:
+            default_cls_id = 1
+            if 'class' in config:
+                class_id_max = self._get_class_max_id(config)
+                default_cls_id = int(class_id_max) +1
+            self._build_base_qdisc(config['default'], default_cls_id)
+
         if self.qostype == 'limiter':
             if 'default' in config:
-                if 'class' in config:
-                    class_id_max = self._get_class_max_id(config)
-                    default_cls_id = int(class_id_max) + 1
-                    self._build_base_qdisc(config['default'], default_cls_id)
-
                 filter_cmd = f'tc filter replace dev {self._interface} parent {self._parent:x}: '
                 filter_cmd += 'prio 255 protocol all basic'
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix default QOS classes not getting setup with their configured queuing disciplines.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5314

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
qos

## Proposed changes
<!--- Describe your changes in detail -->
Revert the sections of T5295 that prevent default classes from ever getting assigned their qdisc. 
Additionally, ensure the _build_base_qdisc function is called even when a non default class is configured.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics -->

Configure simple shaper policy with and without classes.
Then perform sanity check to verify configured queue-type was applied.
Verified against fq-codel, fair-queue, and drop-tail.

With no other classes:
```
vyos@vyos# commit
DEBUG/QoS: tc qdisc replace dev eth1 root handle 1: htb r2q 555 default 1
DEBUG/QoS: tc class replace dev eth1 parent 1: classid 1:1 htb rate 888000000
DEBUG/QoS: tc class replace dev eth1 parent 1:1 classid 1:1 htb rate 123000000 burst 15k quantum 1514 prio 20
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:1 sfq
{'bandwidth': '888mbit',
 'default': {'bandwidth': '123mbit',
             'burst': '15k',
             'codel_quantum': '1514',
             'flows': '1024',
             'interval': '100',
             'priority': '20',
             'queue_type': 'fq-codel',
             'target': '5'}}
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:1 fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5
[edit]
vyos@vyos# tc qdisc show dev eth1
qdisc htb 1: root refcnt 2 r2q 555 default 0x1 direct_packets_stat 0 direct_qlen 1000
qdisc fq_codel 8002: parent 1:1 limit 10240p flows 1024 quantum 1514 target 4us interval 99us memory_limit 32Mb ecn drop_batch 64
[edit]
```
With class configured:
```
vyos@vyos# set qos policy shaper TEST class 3 bandwidth 30mbit
[edit]
vyos@vyos# commit
DEBUG/QoS: tc qdisc replace dev eth1 root handle 1: htb r2q 555 default 4
DEBUG/QoS: tc class replace dev eth1 parent 1: classid 1:1 htb rate 888000000
DEBUG/QoS: tc class replace dev eth1 parent 1:1 classid 1:3 htb rate 30000000 burst 15k quantum 1514
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:3 sfq
DEBUG/QoS: tc class replace dev eth1 parent 1:1 classid 1:4 htb rate 123000000 burst 15k quantum 1514 prio 20
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:4 sfq
{'bandwidth': '888mbit',
 'class': {'3': {'bandwidth': '30mbit',
                 'burst': '15k',
                 'codel_quantum': '1514',
                 'flows': '1024',
                 'interval': '100',
                 'queue_type': 'fq-codel',
                 'target': '5'}},
 'default': {'bandwidth': '123mbit',
             'burst': '15k',
             'codel_quantum': '1514',
             'flows': '1024',
             'interval': '100',
             'priority': '20',
             'queue_type': 'fq-codel',
             'target': '5'}}
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:3 fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5
DEBUG/QoS: tc filter replace dev eth1 parent 1: protocol all basic flowid 1:3
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:4 fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5
[edit]
vyos@vyos# tc qdisc show dev eth1
qdisc htb 1: root refcnt 2 r2q 555 default 0x4 direct_packets_stat 0 direct_qlen 1000
qdisc fq_codel 8005: parent 1:3 limit 10240p flows 1024 quantum 1514 target 4us interval 99us memory_limit 32Mb ecn drop_batch 64
qdisc fq_codel 8006: parent 1:4 limit 10240p flows 1024 quantum 1514 target 4us interval 99us memory_limit 32Mb ecn drop_batch 64
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
