### PR TITLE
broadcast T5313: UDP Broadcast Broken

### DIFF
--- a/src/conf_mode/bcast_relay.py
+++ b/src/conf_mode/bcast_relay.py
@@ -56,8 +56,8 @@ def verify(relay):
         if isinstance(config.get('interface', []), str):
             config['interface'] = [ config['interface'] ]
         # Relaying data without two interface is kinda senseless ...
-        if len(config.get('interface', [])) < 2:
-            raise ConfigError('At least two interfaces are required for udp broadcast relay "{instance}"')
+        if len(config.get('interface', [])) < 2 or len(config.get('interface', [])) > 2:
+            raise ConfigError('Only two interfaces are required for udp broadcast relay "{instance}"')
 
         for interface in config.get('interface', []):
             if interface not in interfaces():


### PR DESCRIPTION
In Example:

To forward all broadcast packets received on UDP port 1900 on eth3, eth4 or eth5 to all other interfaces in this configuration.

set service broadcast-relay id 1 description 'SONOS'
set service broadcast-relay id 1 interface 'eth3'
set service broadcast-relay id 1 interface 'eth4'
set service broadcast-relay id 1 interface 'eth5'
set service broadcast-relay id 1 port '1900'

When set more 2 interface, service udp broadcast not running and have error:

https://vyos.dev/file/data/sq7wcmruqazef5ld7shq/PHID-FILE-ot4zaecftehga4izek5s/image.png

and Remove interfaces:

https://vyos.dev/file/data/hgoibpsakrelap4dapmq/PHID-FILE-j464jvsnvypv76lrpm32/image.png

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5313

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Result tested in here:
https://vyos.dev/T5313
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
