### PR TITLE
vrrp: T5315: add support to explicitly specify version (backport)

### DIFF
--- a/data/templates/vrrp/keepalived.conf.tmpl
+++ b/data/templates/vrrp/keepalived.conf.tmpl
@@ -9,6 +9,9 @@ global_defs {
 {%     if global_parameters.startup_delay is defined %}
     vrrp_startup_delay {{ global_parameters.startup_delay }}
 {%     endif %}
+{%     if global_parameters.version is defined %}
+    vrrp_version {{ global_parameters.version }}
+{%     endif %}
 {% endif %}
     notify_fifo /run/keepalived/keepalived_notify_fifo
     notify_fifo_script /usr/libexec/vyos/system/keepalived-fifo.py

--- a/interface-definitions/vrrp.xml.in
+++ b/interface-definitions/vrrp.xml.in
@@ -31,15 +31,12 @@
               <leafNode name="version">
                 <properties>
                   <help>Default VRRP version to use, IPv6 always uses VRRP version 3</help>
-                  <completionHelp>
-                    <list>2 3</list>
-                  </completionHelp>
                   <valueHelp>
-                    <format>u32:2</format>
+                    <format>2</format>
                     <description>VRRP version 2</description>
                   </valueHelp>
                   <valueHelp>
-                    <format>u32:3</format>
+                    <format>3</format>
                     <description>VRRP version 3</description>
                   </valueHelp>
                   <constraint>

--- a/interface-definitions/vrrp.xml.in
+++ b/interface-definitions/vrrp.xml.in
@@ -28,6 +28,25 @@
                   </constraint>
                 </properties>
               </leafNode>
+              <leafNode name="version">
+                <properties>
+                  <help>Default VRRP version to use, IPv6 always uses VRRP version 3</help>
+                  <completionHelp>
+                    <list>2 3</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>u32:2</format>
+                    <description>VRRP version 2</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>u32:3</format>
+                    <description>VRRP version 3</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 2-3"/>
+                  </constraint>
+                </properties>
+              </leafNode>
             </children>
           </node>
           <tagNode name="group">

--- a/smoketest/scripts/cli/test_ha_vrrp.py
+++ b/smoketest/scripts/cli/test_ha_vrrp.py
@@ -88,6 +88,7 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
         priority = '123'
         preempt_delay = '400'
         startup_delay = '120'
+        vrrp_version = '3'
 
         for group in groups:
             vlan_id = group.lstrip('VLAN')
@@ -114,6 +115,7 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
 
             # Global parameters
             self.cli_set(global_param_base + ['startup-delay', f'{startup_delay}'])
+            self.cli_set(global_param_base + ['version', vrrp_version])
 
         # commit changes
         self.cli_commit()
@@ -121,6 +123,7 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
         # Check Global parameters
         config = getConfig(f'global_defs')
         self.assertIn(f'vrrp_startup_delay {startup_delay}', config)
+        self.assertIn(f'vrrp_version {vrrp_version}', config)
 
         for group in groups:
             vlan_id = group.lstrip('VLAN')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

(cherry picked from commit 6ca308182a7891e600a2e8749f7b12b566005576)
(cherry picked from commit 90c0c2c4c81cdbf2ec3f928499f3e1719bfd6f9a)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5315

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
VRRP, keepalived

## Proposed changes
<!--- Describe your changes in detail -->

`set high-availability vrrp global-parameters version 2|3`

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
