### PR TITLE
T5320: warn on entering config mode if boot config errors present

### DIFF
--- a/op-mode-definitions/configure.xml.in
+++ b/op-mode-definitions/configure.xml.in
@@ -11,7 +11,12 @@
         echo "Please do it as an administrator level VyOS user instead."
     else
         if grep -q -e '^overlay.*/filesystem.squashfs' /proc/mounts; then
-            echo "WARNING: You are currently configuring a live-ISO environment, changes will not persist until installed"
+        echo "WARNING: You are currently configuring a live-ISO environment, changes will not persist until installed"
+        else
+            if grep -q -s '1' /tmp/vyos-config-status; then
+            echo "WARNING: There was a config error on boot: saving the configuration now could overwrite data."
+            echo "You may want to check and reload the boot config"
+            fi
         fi
         history -w
         export _OFR_CONFIGURE=ok

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -1139,6 +1139,19 @@ def boot_configuration_complete() -> bool:
         return True
     return False
 
+def boot_configuration_success() -> bool:
+    from vyos.defaults import config_status
+
+    try:
+        with open(config_status) as f:
+            res = f.read().strip()
+    except FileNotFoundError:
+        return False
+
+    if int(res) == 0:
+        return True
+    return False
+
 def sysctl_read(name):
     """ Read and return current value of sysctl() option """
     tmp = cmd(f'sysctl {name}')

--- a/src/op_mode/powerctrl.py
+++ b/src/op_mode/powerctrl.py
@@ -104,8 +104,9 @@ def cancel_shutdown():
 
 def check_unsaved_config():
     from vyos.config_mgmt import unsaved_commits
+    from vyos.util import boot_configuration_success
 
-    if unsaved_commits():
+    if unsaved_commits() and boot_configuration_success():
         print("Warning: there are unsaved configuration changes!")
         print("Run 'save' command if you do not want to lose those changes after reboot/shutdown.")
     else:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

In the unlikely case of a boot config error of a verified config (for example, T5300), the user may miss the error message on boot, and then go on to config/commit/save, overwriting the failed config section. Add a warning on entering config mode in case of boot config error.

Also, a boot config error, if not overwritten, will present a 'unsaved commit' warning on reboot: this is misleading (cf. comment in T5262), so modify the check (since the reboot will restore/re-error the section, as in the case above for an intermittent error due to race condition).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe):
        Warn user in config mode if necessary; modify warning on reboot.

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5320

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
