### PR TITLE
T5096: firewall: Change 'accept' rule action from 'return' to 'accept'

### DIFF
--- a/data/templates/firewall/nftables-zone.j2
+++ b/data/templates/firewall/nftables-zone.j2
@@ -38,21 +38,19 @@
 {% for zone_name, zone_conf in zone.items() %}
 {%     if zone_conf.local_zone is vyos_defined %}
     chain VZONE_{{ zone_name }}_IN {
-        iifname lo counter return
+        iifname lo counter accept
 {%         if zone_conf.from is vyos_defined %}
 {%             for from_zone, from_conf in zone_conf.from.items() if from_conf.firewall[fw_name] is vyos_defined %}
         iifname { {{ zone[from_zone].interface | join(",") }} } counter jump NAME{{ suffix }}_{{ from_conf.firewall[fw_name] }}
-        iifname { {{ zone[from_zone].interface | join(",") }} } counter return
 {%             endfor %}
 {%         endif %}
         {{ zone_conf | nft_default_rule('zone_' + zone_name) }}
     }
     chain VZONE_{{ zone_name }}_OUT {
-        oifname lo counter return
+        oifname lo counter accept
 {%         if zone_conf.from_local is vyos_defined %}
 {%             for from_zone, from_conf in zone_conf.from_local.items() if from_conf.firewall[fw_name] is vyos_defined %}
         oifname { {{ zone[from_zone].interface | join(",") }} } counter jump NAME{{ suffix }}_{{ from_conf.firewall[fw_name] }}
-        oifname { {{ zone[from_zone].interface | join(",") }} } counter return
 {%             endfor %}
 {%         endif %}
         {{ zone_conf | nft_default_rule('zone_' + zone_name) }}
@@ -60,14 +58,10 @@
 {%     else %}
     chain VZONE_{{ zone_name }} {
         iifname { {{ zone_conf.interface | join(",") }} } counter {{ zone_conf | nft_intra_zone_action(ipv6) }}
-{%         if zone_conf.intra_zone_filtering is vyos_defined %}
-        iifname { {{ zone_conf.interface | join(",") }} } counter return
-{%         endif %}
 {%         if zone_conf.from is vyos_defined %}
 {%             for from_zone, from_conf in zone_conf.from.items() if from_conf.firewall[fw_name] is vyos_defined %}
 {%                 if zone[from_zone].local_zone is not defined %}
         iifname { {{ zone[from_zone].interface | join(",") }} } counter jump NAME{{ suffix }}_{{ from_conf.firewall[fw_name] }}
-        iifname { {{ zone[from_zone].interface | join(",") }} } counter return
 {%                 endif %}
 {%             endfor %}
 {%         endif %}

--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -22,7 +22,6 @@ table ip vyos_filter {
 {%         endif %}
 {%     endfor %}
 {% endif %}
-        jump VYOS_POST_FW
     }
     chain VYOS_FW_LOCAL {
         type filter hook input priority 0; policy accept;
@@ -36,17 +35,12 @@ table ip vyos_filter {
 {%         endif %}
 {%     endfor %}
 {% endif %}
-        jump VYOS_POST_FW
     }
     chain VYOS_FW_OUTPUT {
         type filter hook output priority 0; policy accept;
 {% if state_policy is vyos_defined %}
         jump VYOS_STATE_POLICY
 {% endif %}
-        jump VYOS_POST_FW
-    }
-    chain VYOS_POST_FW {
-        return
     }
     chain VYOS_FRAG_MARK {
         type filter hook prerouting priority -450; policy accept;
@@ -131,7 +125,6 @@ table ip6 vyos_filter {
 {%         endif %}
 {%     endfor %}
 {% endif %}
-        jump VYOS_POST_FW6
     }
     chain VYOS_FW6_LOCAL {
         type filter hook input priority 0; policy accept;
@@ -145,17 +138,12 @@ table ip6 vyos_filter {
 {%         endif %}
 {%     endfor %}
 {% endif %}
-        jump VYOS_POST_FW6
     }
     chain VYOS_FW6_OUTPUT {
         type filter hook output priority 0; policy accept;
 {% if state_policy is vyos_defined %}
         jump VYOS_STATE_POLICY6
 {% endif %}
-        jump VYOS_POST_FW6
-    }
-    chain VYOS_POST_FW6 {
-        return
     }
     chain VYOS_FRAG6_MARK {
         type filter hook prerouting priority -450; policy accept;

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -45,7 +45,7 @@ def fqdn_config_parse(firewall):
         rule = path[3] # rule id
         suffix = path[4][0] # source/destination (1 char)
         set_name = f'{fw_name}_{rule}_{suffix}'
-            
+
         if path[0] == 'name':
             firewall['ip_fqdn'][set_name] = domain
         elif path[0] == 'ipv6_name':
@@ -76,8 +76,6 @@ def remove_nftables_rule(table, chain, handle):
 # Functions below used by template generation
 
 def nft_action(vyos_action):
-    if vyos_action == 'accept':
-        return 'return'
     return vyos_action
 
 def parse_rule(rule_conf, fw_name, rule_id, ip_name):

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -569,8 +569,6 @@ def snmp_auth_oid(type):
 
 @register_filter('nft_action')
 def nft_action(vyos_action):
-    if vyos_action == 'accept':
-        return 'return'
     return vyos_action
 
 @register_filter('nft_rule')
@@ -624,13 +622,11 @@ def nft_intra_zone_action(zone_conf, ipv6=False):
         name_prefix = 'NAME6_' if ipv6 else 'NAME_'
 
         if 'action' in intra_zone:
-            if intra_zone['action'] == 'accept':
-                return 'return'
             return intra_zone['action']
         elif dict_search_args(intra_zone, 'firewall', fw_name):
             name = dict_search_args(intra_zone, 'firewall', fw_name)
             return f'jump {name_prefix}{name}'
-    return 'return'
+    return 'accept'
 
 @register_filter('nft_nested_group')
 def nft_nested_group(out_list, includes, groups, key):

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -102,7 +102,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         nftables_search = [
             ['ip saddr @GEOIP_CC_smoketest_1', 'drop'],
-            ['ip saddr != @GEOIP_CC_smoketest_2', 'return']
+            ['ip saddr != @GEOIP_CC_smoketest_2', 'accept']
         ]
 
         # -t prevents 1000+ GeoIP elements being returned
@@ -147,16 +147,16 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         nftables_search = [
             ['iifname "eth0"', 'jump NAME_smoketest'],
-            ['ip saddr @N_smoketest_network', 'ip daddr 172.16.10.10', 'th dport @P_smoketest_port', 'return'],
+            ['ip saddr @N_smoketest_network', 'ip daddr 172.16.10.10', 'th dport @P_smoketest_port', 'accept'],
             ['elements = { 172.16.99.0/24 }'],
             ['elements = { 53, 123 }'],
-            ['ether saddr @M_smoketest_mac', 'return'],
+            ['ether saddr @M_smoketest_mac', 'accept'],
             ['elements = { 00:01:02:03:04:05 }'],
             ['set D_smoketest_domain'],
             ['elements = { 192.0.2.5, 192.0.2.8,'],
             ['192.0.2.10, 192.0.2.11 }'],
-            ['ip saddr @D_smoketest_domain', 'return'],
-            ['oifname @I_smoketest_interface', 'return']
+            ['ip saddr @D_smoketest_domain', 'accept'],
+            ['oifname @I_smoketest_interface', 'accept']
         ]
         self.verify_nftables(nftables_search, 'ip vyos_filter')
 
@@ -188,7 +188,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         nftables_search = [
             ['iifname "eth0"', 'jump NAME_smoketest'],
-            ['ip saddr @N_smoketest_network1', 'th dport @P_smoketest_port1', 'return'],
+            ['ip saddr @N_smoketest_network1', 'th dport @P_smoketest_port1', 'accept'],
             ['elements = { 172.16.99.0/24, 172.16.101.0/24 }'],
             ['elements = { 53, 123 }']
         ]
@@ -250,9 +250,9 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         nftables_search = [
             [f'iifname "{interface}"', f'jump NAME_{name}'],
             [f'iifname "{interface_wc}"', f'jump NAME_{name}'],
-            ['saddr 172.16.20.10', 'daddr 172.16.10.10', 'log prefix "[smoketest-1-A]" log level debug', 'ip ttl 15', 'return'],
+            ['saddr 172.16.20.10', 'daddr 172.16.10.10', 'log prefix "[smoketest-1-A]" log level debug', 'ip ttl 15', 'accept'],
             ['tcp flags syn / syn,ack', 'tcp dport 8888', 'log prefix "[smoketest-2-R]" log level err', 'ip ttl > 102', 'reject'],
-            ['tcp dport 22', 'limit rate 5/minute', 'return'],
+            ['tcp dport 22', 'limit rate 5/minute', 'accept'],
             ['log prefix "[smoketest-default-D]"','smoketest default-action', 'drop'],
             ['tcp dport 22', 'add @RECENT_smoketest_4 { ip saddr limit rate over 10/minute burst 10 packets }', 'meta pkttype host', 'drop'],
             ['tcp flags & syn == syn', f'tcp option maxseg size {mss_range}', f'iifname "{interface}"', 'meta pkttype broadcast'],
@@ -308,8 +308,8 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         nftables_search = [
             [f'iifname "{interface}"', f'jump NAME_{name}'],
-            ['ip length { 64, 512, 1024 }', 'ip dscp { 0x11, 0x34 }', f'log prefix "[{name}-6-A]" log group 66 snaplen 6666 queue-threshold 32000', 'return'],
-            ['ip length 1-30000', 'ip length != 60000-65535', 'ip dscp 0x03-0x0b', 'ip dscp != 0x15-0x19', 'return'],
+            ['ip length { 64, 512, 1024 }', 'ip dscp { 0x11, 0x34 }', f'log prefix "[{name}-6-A]" log group 66 snaplen 6666 queue-threshold 32000', 'accept'],
+            ['ip length 1-30000', 'ip length != 60000-65535', 'ip dscp 0x03-0x0b', 'ip dscp != 0x15-0x19', 'accept'],
             [f'log prefix "[{name}-default-D]"', 'drop'],
             ['ip saddr 198.51.100.1', f'jump NAME_{name}'],
             [f'log prefix "[{name2}-default-J]"', f'jump NAME_{name}'],
@@ -381,7 +381,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         nftables_search = [
             [f'iifname "{interface}"', f'jump NAME6_{name}'],
-            ['saddr 2002::1', 'daddr 2002::1:1', 'log prefix "[v6-smoketest-1-A]" log level crit', 'return'],
+            ['saddr 2002::1', 'daddr 2002::1:1', 'log prefix "[v6-smoketest-1-A]" log level crit', 'accept'],
             ['meta l4proto { tcp, udp }', 'th dport 8888', f'iifname "{interface}"', 'reject'],
             ['meta l4proto gre', f'oifname "{interface}"', 'return'],
             ['smoketest default-action', f'log prefix "[{name}-default-D]"', 'drop']


### PR DESCRIPTION
I encountered the same issue as https://vyos.dev/T5096, which I was expecting a `jump` action was designed to use with a chain with `return` default action to create reusable rule sets.

e.g.

```
interface eth8 {
     in {
         name stdnt-in
     }
 }
 name floating {
     default-action return
     enable-default-log
     rule 1 {
         action accept
         destination {
             address 10.236.253.11
         }
         log enable
         protocol icmp
     }
 }
 name stdnt-in {
     default-action drop
     enable-default-log
     rule 1 {
         action jump
         jump-target floating
         log enable
     }
 }
```

With the above configuration, it should accept ingress ICMP packets to destination 10.236.253.11. However this doesn't work. Those ICMP packets will be dropped because Vyos converts `accept` action to `return` action for nftables. The rendered nftables rules look like:

```
        chain NAME_floating {
                meta l4proto icmp ip daddr 10.236.253.11 log prefix "[floating-1-A]" counter packets 0 bytes 0 return comment "floating-1"
                counter packets 0 bytes 0 log prefix "[floating-default-R]" return comment "floating default-action return"
        }

        chain NAME_stdnt-in {
                log prefix "[stdnt-in-1-J]" counter packets 0 bytes 0 jump NAME_floating comment "stdnt-in-1"
                counter packets 0 bytes 0 log prefix "[stdnt-in-default-D]" drop comment "stdnt-in default-action drop"
        }

        chain VYOS_FW_FORWARD {
        	type filter hook forward priority 0; policy accept;
 		iifname eth8 counter jump NAME_stdnt
                # here we have rules for other interfaces
                jump VYOS_POST_FW
        }

```

Maybe I have missed something, but it doesn't seem to have a good reason to replace the `accept` action with `return` action. This replacement actually makes the `jump` action useless because you can't actually accept a rule in a sub-chain.

Also because of the `return` action, the `VYOS_POST_FW` chain is always be run. However, that chain is hardcoded to be empty so it does nothing.

So I would like to change it. In order there is a good reason to do further processing after a rule is accepted, we have have other workarounds.

Let me know if this change makes sense.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/Txxxx

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
