### PR TITLE
T5295: QoS fix policy limiter tc filter rate limit

### DIFF
--- a/python/vyos/qos/limiter.py
+++ b/python/vyos/qos/limiter.py
@@ -17,6 +17,7 @@ from vyos.qos.base import QoSBase
 
 class Limiter(QoSBase):
     _direction = ['ingress']
+    qostype = 'limiter'
 
     def update(self, config, direction):
         tmp = f'tc qdisc add dev {self._interface} handle {self._parent:x}: {direction}'


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
1. tc filter rate limit should be used only if qostype is `limiter` and not `shaper`
2. Fix QoS tc class with multiple matches generates one rule but expects multiple filter rules:
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5295
* https://vyos.dev/T5302

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
qos, limiter
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set qos interface eth0 ingress '300m-in'
set qos policy limiter 300m-in default bandwidth '300mbit'
set qos policy limiter 300m-in default burst '125000000b'
commit
```
Before fix
```
vyos@r14# commit
[ qos ]
DEBUG/QoS: tc qdisc add dev eth0 handle ffff: ingress
{'default': {'bandwidth': '300mbit',
             'burst': '125000000b',
             'exceed': 'drop',
             'not_exceed': 'ok'}}

[edit]
vyos@r14# 

```

After fix:
```
vyos@r14# commit
[ qos ]
DEBUG/QoS: tc qdisc add dev eth0 handle ffff: ingress
{'default': {'bandwidth': '300mbit',
             'burst': '125000000b',
             'exceed': 'drop',
             'not_exceed': 'ok'}}
DEBUG/QoS: tc filter replace dev eth0 parent ffff: prio 255 protocol all basic action police conform-exceed drop/ok rate 300000000 burst 125000000b

[edit]
vyos@r14# 
```
Expected 300 mbit
```
vyos@r14# sudo iperf3 -c 192.168.122.11 -R 
Connecting to host 192.168.122.11, port 5201
Reverse mode, remote host 192.168.122.11 is sending
[  5] local 192.168.122.14 port 45878 connected to 192.168.122.11 port 5201
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec   150 MBytes  1.26 Gbits/sec                  
[  5]   1.00-2.00   sec  34.5 MBytes   290 Mbits/sec                  
[  5]   2.00-3.00   sec  34.3 MBytes   288 Mbits/sec                  
[  5]   3.00-4.00   sec  34.7 MBytes   291 Mbits/sec                  
[  5]   4.00-5.00   sec  34.5 MBytes   290 Mbits/sec                  
[  5]   5.00-6.00   sec  34.5 MBytes   290 Mbits/sec                  
[  5]   6.00-7.00   sec  34.5 MBytes   290 Mbits/sec                  
[  5]   7.00-8.00   sec  34.5 MBytes   290 Mbits/sec                  
[  5]   8.00-9.00   sec  34.5 MBytes   289 Mbits/sec                  
[  5]   9.00-10.00  sec  34.6 MBytes   290 Mbits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.04  sec   465 MBytes   389 Mbits/sec  46377             sender
[  5]   0.00-10.00  sec   460 MBytes   386 Mbits/sec                  receiver

iperf Done.
[edit]
vyos@r14# 
```


the second fix for multiple matches:
VyOS config
```
set qos interface eth0 egress 'test'
set qos policy shaper test bandwidth '300mbit'
set qos policy shaper test class 23 bandwidth '150mbit'
set qos policy shaper test class 23 match one ip protocol 'tcp'
set qos policy shaper test class 23 match two ip protocol 'udp'
set qos policy shaper test default bandwidth '20mbit'
set qos policy shaper test default queue-type 'fair-queue'
commit
```
Before fix generates `filter` rules in one line that is incorrect:
```
DEBUG/QoS: tc qdisc replace dev eth0 root handle 1: htb r2q 187 default 18
DEBUG/QoS: tc class replace dev eth0 parent 1: classid 1:1 htb rate 300000000
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:17 htb rate 150000000 burst 15k quantum 1514
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:17 sfq
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:18 htb rate 20000000 burst 15k quantum 1514 prio 20
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:18 sfq
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:17 fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5 noecn
DEBUG/QoS: tc filter replace dev eth0 parent 1: protocol all u32 match ip protocol 6 0xff u32 match ip protocol 17 0xff flowid 1:17

  File "/usr/lib/python3/dist-packages/vyos/util.py", line 161, in cmd
    raise OSError(code, feedback)
PermissionError: [Errno 1] failed to run command: tc filter replace dev eth0 parent 1: protocol all u32 match ip protocol 6 0xff u32 match ip protocol 17 0xff flowid 1:17
returned: 
exit code: 1

```

After fix:
```
DEBUG/QoS: tc qdisc replace dev eth0 root handle 1: htb r2q 187 default 18
DEBUG/QoS: tc class replace dev eth0 parent 1: classid 1:1 htb rate 300000000
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:17 htb rate 150000000 burst 15k quantum 1514
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:17 sfq
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:18 htb rate 20000000 burst 15k quantum 1514 prio 20
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:18 sfq
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:17 fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5 noecn
DEBUG/QoS: tc filter add dev eth0 parent 1: protocol all prio 1 u32 match ip protocol 6 0xff flowid 1:17
DEBUG/QoS: tc filter add dev eth0 parent 1: protocol all prio 2 u32 match ip protocol 17 0xff flowid 1:17

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
