### PR TITLE
T5048: QoS index priority should be used only for shaper

### DIFF
--- a/python/vyos/qos/base.py
+++ b/python/vyos/qos/base.py
@@ -217,7 +217,8 @@ class QoSBase:
                 if 'match' in cls_config:
                     for index, (match, match_config) in enumerate(cls_config['match'].items(), start=1):
                         filter_cmd = filter_cmd_base
-                        filter_cmd += f' prio {index}'
+                        if self.qostype == 'shaper':
+                            filter_cmd += f' prio {index}'
                         if 'mark' in match_config:
                             mark = match_config['mark']
                             filter_cmd += f' handle {mark} fw'

--- a/python/vyos/qos/trafficshaper.py
+++ b/python/vyos/qos/trafficshaper.py
@@ -22,6 +22,7 @@ MINQUANTUM = 1000
 
 class TrafficShaper(QoSBase):
     _parent = 1
+    qostype = 'shaper'
 
     # https://man7.org/linux/man-pages/man8/tc-htb.8.html
     def update(self, config, direction):


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
QoS index priority should be used only for qostype 'shaper' otherwise we set priority 2 times, that is incorrect.
```
OSError: [Errno 255] failed to run command:
tc filter add dev eth2 parent 1: prio 5 protocol all prio 1 u32 match ip src 10.1.1.0/24 flowid 1:1e
exit code: 255
```
Fix it
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5048

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
QoS
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Before fix:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_qos.py
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... ERROR
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... ERROR

======================================================================
ERROR: test_05_limiter (__main__.TestQoS.test_05_limiter)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/libexec/vyos/tests/smoke/cli/test_qos.py", line 284, in test_05_limiter
    self.cli_commit()
  File "/usr/libexec/vyos/tests/smoke/cli/base_vyostest_shim.py", line 76, in cli_commit
    self._session.commit()
  File "/usr/lib/python3/dist-packages/vyos/configsession.py", line 183, in commit
    out = self.__run_command([COMMIT])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/configsession.py", line 139, in __run_command
    raise ConfigSessionError(output)
vyos.configsession.ConfigSessionError: [ qos ]
VyOS had an issue completing a command.

Hardware UUID:    166cfd25-7d3a-4eca-9ef6-0b655c9acf0f

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/qos.py", line 271, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/qos.py", line 260, in apply
    tmp.update(shaper_config, direction)
  File "/usr/lib/python3/dist-packages/vyos/qos/limiter.py", line 27, in update
    super().update(config, direction)
  File "/usr/lib/python3/dist-packages/vyos/qos/base.py", line 297, in update
    self._cmd(filter_cmd)
  File "/usr/lib/python3/dist-packages/vyos/qos/base.py", line 74, in _cmd
    return cmd(command)
           ^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/util.py", line 161, in cmd
    raise OSError(code, feedback)
OSError: [Errno 255] failed to run command: tc filter add dev eth0 parent ffff: prio 20 protocol all prio 1 u32 match ip dport 22 0xffff flowid ffff:1
returned: 
exit code: 255




======================================================================
ERROR: test_07_priority_queue (__main__.TestQoS.test_07_priority_queue)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/libexec/vyos/tests/smoke/cli/test_qos.py", line 402, in test_07_priority_queue
    self.cli_commit()
  File "/usr/libexec/vyos/tests/smoke/cli/base_vyostest_shim.py", line 76, in cli_commit
    self._session.commit()
  File "/usr/lib/python3/dist-packages/vyos/configsession.py", line 183, in commit
    out = self.__run_command([COMMIT])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/configsession.py", line 139, in __run_command
    raise ConfigSessionError(output)
vyos.configsession.ConfigSessionError: [ qos ]
DEBUG/QoS: tc qdisc add dev eth0 root handle 1: prio bands 6 priomap 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 
DEBUG/QoS: tc qdisc add dev eth0 parent 1:1 pfifo
DEBUG/QoS: tc qdisc add dev eth0 parent 1:2 pfifo
DEBUG/QoS: tc qdisc add dev eth0 parent 1:3 pfifo
DEBUG/QoS: tc qdisc add dev eth0 parent 1:4 pfifo
DEBUG/QoS: tc qdisc add dev eth0 parent 1:5 pfifo
{'class': {'1': {'codel_quantum': '1514',
                 'flows': '1024',
                 'interval': '100',
                 'match': {'prio-1': {'ip': {'destination': {'port': '1001'}}}},
                 'queue_type': 'drop-tail',
                 'target': '5'},
           '2': {'codel_quantum': '1514',
                 'flows': '1024',
                 'interval': '100',
                 'match': {'prio-2': {'ip': {'destination': {'port': '1002'}}}},
                 'queue_type': 'drop-tail',
                 'target': '5'},
           '3': {'codel_quantum': '1514',
                 'flows': '1024',
                 'interval': '100',
                 'match': {'prio-3': {'ip': {'destination': {'port': '1003'}}}},
                 'queue_type': 'drop-tail',
                 'target': '5'},
           '4': {'codel_quantum': '1514',
                 'flows': '1024',
                 'interval': '100',
                 'match': {'prio-4': {'ip': {'destination': {'port': '1004'}}}},
                 'queue_type': 'drop-tail',
                 'target': '5'},
           '5': {'codel_quantum': '1514',
                 'flows': '1024',
                 'interval': '100',
                 'match': {'prio-5': {'ip': {'destination': {'port': '1005'}}}},
                 'queue_type': 'drop-tail',
                 'target': '5'}},
 'default': {'codel_quantum': '1514',
             'flows': '1024',
             'interval': '100',
             'queue_limit': '10',
             'queue_type': 'drop-tail',
             'target': '5'}}
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:1 pfifo
DEBUG/QoS: tc filter add dev eth0 parent 1: prio 1 protocol all prio 1 u32 match ip dport 1001 0xffff flowid 1:1
VyOS had an issue completing a command.


```
After fix:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_qos.py
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... skipped 'tc returns invalid JSON here - needs iproute2 fix'
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... ok

----------------------------------------------------------------------
Ran 10 tests in 39.713s

OK (skipped=1)
vyos@r14:~$ 

```
Tested config after fix:
```
set qos interface eth0 egress 'test'
set qos policy priority-queue test class 1 match prio-1 ip destination port '10001'
set qos policy priority-queue test class 2 match prio-1 ip destination port '10002'
set qos policy priority-queue test class 3 match prio-1 ip destination port '10003'
set qos policy priority-queue test default queue-limit '10'


vyos@r14# commit
[ qos ]
DEBUG/QoS: tc qdisc add dev eth0 root handle 1: prio bands 4 priomap 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 
DEBUG/QoS: tc qdisc add dev eth0 parent 1:1 pfifo
DEBUG/QoS: tc qdisc add dev eth0 parent 1:2 pfifo
DEBUG/QoS: tc qdisc add dev eth0 parent 1:3 pfifo
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:1 pfifo
DEBUG/QoS: tc filter add dev eth0 parent 1: prio 1 protocol all u32 match ip dport 10001 0xffff flowid 1:1
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:2 pfifo
DEBUG/QoS: tc filter add dev eth0 parent 1: prio 2 protocol all u32 match ip dport 10002 0xffff flowid 1:2
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:3 pfifo
DEBUG/QoS: tc filter add dev eth0 parent 1: prio 3 protocol all u32 match ip dport 10003 0xffff flowid 1:3

```
Second config:
```
set qos interface eth0 egress 'test'
set qos policy shaper test bandwidth '300mbit'
set qos policy shaper test class 23 bandwidth '150mbit'
set qos policy shaper test class 23 match one ip protocol 'tcp'
set qos policy shaper test class 23 match two ip protocol 'udp'
set qos policy shaper test default bandwidth '20mbit'
set qos policy shaper test default queue-type 'fair-queue'


vyos@r14# commit
[ qos ]
DEBUG/QoS: tc qdisc replace dev eth0 root handle 1: htb r2q 187 default 18
DEBUG/QoS: tc class replace dev eth0 parent 1: classid 1:1 htb rate 300000000
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:17 htb rate 150000000 burst 15k quantum 1514
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:17 sfq
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:18 htb rate 20000000 burst 15k quantum 1514 prio 20
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:18 sfq
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:17 fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5 noecn
DEBUG/QoS: tc filter add dev eth0 parent 1: protocol all prio 1 u32 match ip protocol 6 0xff flowid 1:17
DEBUG/QoS: tc filter add dev eth0 parent 1: protocol all prio 2 u32 match ip protocol 17 0xff flowid 1:17

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
