### PR TITLE
T5332: Fix show policy route without attahed interface

### DIFF
--- a/src/op_mode/policy_route.py
+++ b/src/op_mode/policy_route.py
@@ -61,8 +61,10 @@ def output_policy_route(name, route_conf, ipv6=False, single_rule_id=None):
     ip_str = 'IPv6' if ipv6 else 'IPv4'
     print(f'\n---------------------------------\n{ip_str} Policy Route "{name}"\n')
 
-    if route_conf['interface']:
+    if route_conf.get('interface'):
         print('Active on: {0}\n'.format(" ".join(route_conf['interface'])))
+    else:
+        print('Inactive - Not applied to any interfaces\n')
 
     details = get_nftables_details(name, ipv6)
     rows = []


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Interface may not be present in the op-mode dictionary, it cause `KeyError: 'interface'` for policy route
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5332

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
policy-route, op-mode
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set policy route FOO rule 1000 protocol 'tcp'
set policy route FOO rule 1000 set table '100'
set policy route FOO rule 1000 source port '22'
```
Before fix:
```
vyos@r14:~$ show policy route 
Ruleset Information

---------------------------------
IPv4 Policy Route "FOO"
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/policy_route.py", line 149, in <module>
    show_policy(args.ipv6)
  File "/usr/libexec/vyos/op_mode/policy_route.py", line 112, in show_policy
    output_policy_route(route, route_conf, ipv6=False)
  File "/usr/libexec/vyos/op_mode/policy_route.py", line 64, in output_policy_route
    if route_conf['interface']:
       ~~~~~~~~~~^^^^^^^^^^^^^
KeyError: 'interface'

vyos@r14:~$ 
```

After fix:
```
vyos@r14:~$ show policy route
Ruleset Information

---------------------------------
IPv4 Policy Route "FOO"

Inactive - Not applied to any interfaces

  Rule  Action    Protocol
------  --------  ----------
  1000  set       tcp

vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
