### PR TITLE
T5333: Set prefix UD for PBR generated user-defined chain names

### DIFF
--- a/data/templates/firewall/nftables-policy.j2
+++ b/data/templates/firewall/nftables-policy.j2
@@ -11,7 +11,7 @@ table ip vyos_mangle {
         type filter hook prerouting priority -150; policy accept;
 {% if route is vyos_defined %}
 {%     for route_text, conf in route.items() if conf.interface is vyos_defined %}
-        iifname { {{ conf.interface | join(",") }} } counter jump VYOS_PBR_{{ route_text }}
+        iifname { {{ conf.interface | join(",") }} } counter jump VYOS_PBR_UD_{{ route_text }}
 {%     endfor %}
 {% endif %}
     }
@@ -22,7 +22,7 @@ table ip vyos_mangle {
 
 {% if route is vyos_defined %}
 {%     for route_text, conf in route.items() %}
-    chain VYOS_PBR_{{ route_text }} {
+    chain VYOS_PBR_UD_{{ route_text }} {
 {%         if conf.rule is vyos_defined %}
 {%             for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
         {{ rule_conf | nft_rule(route_text, rule_id, 'ip') }}
@@ -40,7 +40,7 @@ table ip6 vyos_mangle {
         type filter hook prerouting priority -150; policy accept;
 {% if route6 is vyos_defined %}
 {%     for route_text, conf in route6.items() if conf.interface is vyos_defined %}
-        iifname { {{ ",".join(conf.interface) }} } counter jump VYOS_PBR6_{{ route_text }}
+        iifname { {{ ",".join(conf.interface) }} } counter jump VYOS_PBR6_UD_{{ route_text }}
 {%     endfor %}
 {% endif %}
     }
@@ -51,7 +51,7 @@ table ip6 vyos_mangle {
 
 {% if route6 is vyos_defined %}
 {%     for route_text, conf in route6.items() %}
-    chain VYOS_PBR6_{{ route_text }} {
+    chain VYOS_PBR6_UD_{{ route_text }} {
 {%         if conf.rule is vyos_defined %}
 {%             for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
         {{ rule_conf | nft_rule(route_text, rule_id, 'ip6') }}

--- a/smoketest/scripts/cli/test_policy_route.py
+++ b/smoketest/scripts/cli/test_policy_route.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2022 VyOS maintainers and contributors
+# Copyright (C) 2021-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -100,7 +100,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         nftables_search = [
-            [f'iifname "{interface}"','jump VYOS_PBR_smoketest'],
+            [f'iifname "{interface}"','jump VYOS_PBR_UD_smoketest'],
             ['ip daddr @N_smoketest_network1', 'ip saddr @N_smoketest_network'],
         ]
 
@@ -119,7 +119,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
         mark_hex = "{0:#010x}".format(int(mark))
 
         nftables_search = [
-            [f'iifname "{interface}"','jump VYOS_PBR_smoketest'],
+            [f'iifname "{interface}"','jump VYOS_PBR_UD_smoketest'],
             ['ip daddr 172.16.10.10', 'ip saddr 172.16.20.10', 'meta mark set ' + mark_hex],
         ]
 
@@ -138,7 +138,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
         mark_hex_set = "{0:#010x}".format(int(conn_mark_set))
 
         nftables_search = [
-            [f'iifname "{interface}"','jump VYOS_PBR_smoketest'],
+            [f'iifname "{interface}"','jump VYOS_PBR_UD_smoketest'],
             ['ip daddr 172.16.10.10', 'ip saddr 172.16.20.10', 'ct mark ' + mark_hex, 'ct mark set ' + mark_hex_set],
         ]
 
@@ -164,7 +164,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
         # IPv4
 
         nftables_search = [
-            [f'iifname "{interface}"', 'jump VYOS_PBR_smoketest'],
+            [f'iifname "{interface}"', 'jump VYOS_PBR_UD_smoketest'],
             ['tcp flags syn / syn,ack', 'tcp dport 8888', 'meta mark set ' + mark_hex]
         ]
 
@@ -173,7 +173,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
         # IPv6
 
         nftables6_search = [
-            [f'iifname "{interface}"', 'jump VYOS_PBR6_smoketest'],
+            [f'iifname "{interface}"', 'jump VYOS_PBR6_UD_smoketest'],
             ['meta l4proto { tcp, udp }', 'th dport 8888', 'meta mark set ' + mark_hex]
         ]
 
@@ -246,7 +246,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
 
         # IPv4
         nftables_search = [
-            ['iifname { "' + interface + '", "' + interface_wc + '" }', 'jump VYOS_PBR_smoketest'],
+            ['iifname { "' + interface + '", "' + interface_wc + '" }', 'jump VYOS_PBR_UD_smoketest'],
             ['meta l4proto udp', 'drop'],
             ['tcp flags syn / syn,ack', 'meta mark set ' + mark_hex],
             ['ct state new', 'tcp dport 22', 'ip saddr 198.51.100.0/24', 'ip ttl > 2', 'meta mark set ' + mark_hex],
@@ -258,7 +258,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
 
         # IPv6
         nftables6_search = [
-            [f'iifname "{interface_wc}"', 'jump VYOS_PBR6_smoketest'],
+            [f'iifname "{interface_wc}"', 'jump VYOS_PBR6_UD_smoketest'],
             ['meta l4proto udp', 'drop'],
             ['tcp flags syn / syn,ack', 'meta mark set ' + mark_hex],
             ['ct state new', 'tcp dport 22', 'ip6 saddr 2001:db8::/64', 'ip6 hoplimit > 2', 'meta mark set ' + mark_hex],


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
We cannot use some specific names like `POSTROUTING/PREROUTING` as for PBR they overlap with VyOS defined chains
Chains autoconfigured by VyOS itself:
```
  chain VYOS_PBR_PREROUTING
  chain VYOS_PBR_POSTROUTING
```
If we try to use the chain name `POSTROUTING` it generates 2 chains with the same name 
`chain VYOS_PBR_POSTROUTING` one is autoconfigured and the second is defined by the user

  set policy route POSTROUTING rule 100

Add the user-defined (UD) prefix to separate user-defined names That allow to use of any user-defined names
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5333

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pbr
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS config:
```
set policy route POSTROUTING interface "eth1"
set policy route POSTROUTING rule 100 destination address '192.0.2.2'
set policy route POSTROUTING rule 100 set mark '200'
set policy route POSTROUTING rule 201 protocol 'icmp'
set policy route POSTROUTING rule 201 set mark '200'
set policy route POSTROUTING rule 201 source address '192.168.0.0/24'
set policy route POSTROUTING rule 300 destination address '192.0.2.5'
set policy route POSTROUTING rule 300 destination port '8888'
set policy route POSTROUTING rule 300 protocol 'tcp_udp'
set policy route POSTROUTING rule 300 set mark '300'

```
Before fix, chain `VYOS_PBR_POSTROUTING` defined 2 times it causes nft can't apply this rules:
```

vyos@r14# commit
[ policy route POSTROUTING ]
Failed to apply policy based routing

[[policy route POSTROUTING]] failed
Commit failed
[edit]
vyos@r14#
table ip vyos_mangle {
    chain VYOS_PBR_PREROUTING {
        type filter hook prerouting priority -150; policy accept;
        iifname { eth1 } counter jump VYOS_PBR_POSTROUTING
    }

    chain VYOS_PBR_POSTROUTING {
        type filter hook postrouting priority -150; policy accept;
    }

    chain VYOS_PBR_POSTROUTING {
        ip daddr 192.0.2.2 counter meta mark set 200 return comment "POSTROUTING-100"
        meta l4proto  icmp ip saddr 192.168.0.0/24 counter meta mark set 200 return comment "POSTROUTING-201"
        meta l4proto  {tcp, udp} ip daddr 192.0.2.5 th dport {8888} counter meta mark set 300 return comment "POSTROUTING-300"
    }


}


vyos@r14# sudo nft -f /run/nftables_policy.conf 
/run/nftables_policy.conf:9:39-58: Error: Could not process rule: Operation not supported
        iifname { eth1 } counter jump VYOS_PBR_POSTROUTING
                                      ^^^^^^^^^^^^^^^^^^^^
[edit]
vyos@r14#
```
After the fix we have auto-generated `VYOS_PBR_POSTROUTING` and user-defined `VYOS_PBR_UD_POSTROUTING`:
```
vyos@r14# sudo nft list table ip vyos_mangle
table ip vyos_mangle {
	chain VYOS_PBR_PREROUTING {
		type filter hook prerouting priority mangle; policy accept;
		iifname "eth1" counter packets 0 bytes 0 jump VYOS_PBR_UD_POSTROUTING
	}

	chain VYOS_PBR_POSTROUTING {
		type filter hook postrouting priority mangle; policy accept;
	}

	chain VYOS_PBR_UD_POSTROUTING {
		ip daddr 192.0.2.2 counter packets 0 bytes 0 meta mark set 0x000000c8 return comment "POSTROUTING-100"
		meta l4proto icmp ip saddr 192.168.0.0/24 counter packets 0 bytes 0 meta mark set 0x000000c8 return comment "POSTROUTING-201"
		meta l4proto { tcp, udp } ip daddr 192.0.2.5 th dport 8888 counter packets 0 bytes 0 meta mark set 0x0000012c return comment "POSTROUTING-300"
	}
}
```

Smoketest:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_policy_route.py
test_pbr_group (__main__.TestPolicyRoute.test_pbr_group) ... ok
test_pbr_mark (__main__.TestPolicyRoute.test_pbr_mark) ... ok
test_pbr_mark_connection (__main__.TestPolicyRoute.test_pbr_mark_connection) ... ok
test_pbr_matching_criteria (__main__.TestPolicyRoute.test_pbr_matching_criteria) ... ok
test_pbr_table (__main__.TestPolicyRoute.test_pbr_table) ... ok

----------------------------------------------------------------------
Ran 5 tests in 20.666s

OK
vyos@r14:~`
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
