### PR TITLE
isis: T5335: fix invalid isis config base in migration script

### DIFF
--- a/src/migration-scripts/isis/0-to-1
+++ b/src/migration-scripts/isis/0-to-1
@@ -37,12 +37,9 @@ if not config.exists(base):
     # Nothing to do
     exit(0)
 
-# Only one IS-IS process is supported, thus this operation is save
-isis_base = base + config.list_nodes(base)
-
 # We need a temporary copy of the config
 tmp_base = ['protocols', 'isis2']
-config.copy(isis_base, tmp_base)
+config.copy(base, tmp_base)
 
 # Now it's save to delete the old configuration
 config.delete(base)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
This PR resolves an issue when loading or merging configuration files containing IS-IS configuration items. Before this change an error in the migration script (`/opt/vyatta/etc/config-migrate/migrate/isis/0-to-1`) is experienced:

`/tmp/test_isis.conf`
```
interfaces {
  loopback lo {
  }
}
protocols {
  isis {
    interface lo {
    }
    net 49.0001.0000.0000.0001.00
  }
}
```

```
jvoss@vyos# merge /tmp/test_isis.conf

Migration script error: /opt/vyatta/etc/config-migrate/migrate/isis/0-to-1: [Errno 1] failed to run command: ['/opt/vyatta/etc/config-migrate/migrate/isis/0-to-1', '/tmp/tmpd0jll6fb']
returned: 
exit code: 1.
[edit]
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5335

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* IS-IS

## Proposed changes
<!--- Describe your changes in detail -->
Update the configuration base used in the migration script to start at `protocols isis` instead of considering additional nodes that may be present in the proposed configuration file.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Create configuration file `/tmp/test_isis.conf`: 
```
interfaces {
  loopback lo {
  }
}
protocols {
  isis {
    interface lo {
    }
    net 49.0001.0000.0000.0001.00
  }
}
```

Attempt to load the configuration:
```
jvoss@vyos# merge /tmp/test_isis.conf

Migration script error: /opt/vyatta/etc/config-migrate/migrate/isis/0-to-1: [Errno 1] failed to run command: ['/opt/vyatta/etc/config-migrate/migrate/isis/0-to-1', '/tmp/tmpd0jll6fb']
returned: 
exit code: 1.
[edit]
```

Make the proposed changes in this PR, then attempt to load and again:
```
jvoss@vyos# merge /tmp/test_isis.conf
Merge complete. Use 'commit' to make changes effective.
[edit]

jvoss@vyos# compare
[protocols]
+ isis {
+     interface     lo { }
+     net "49.0001.0000.0000.0001.00"
+ }

[edit]
```

Commit changes:
```
jvoss@vyos# commit
[edit]
```

Validate IS-IS is now running:
```
jvoss@vyos:~$ show isis interface 
Area VyOS:
  Interface   CircId   State    Type     Level
  lo          0x0      Up       loopback L1L2 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
