### PR TITLE
VPP: T1797: Added interfaces reinitialization

### DIFF
--- a/data/config-mode-dependencies.json
+++ b/data/config-mode-dependencies.json
@@ -28,5 +28,8 @@
            "wireguard": ["interfaces-wireguard"],
            "wireless": ["interfaces-wireless"],
            "wwan": ["interfaces-wwan"]
+         },
+  "vpp": {
+           "ethernet": ["interfaces-ethernet"]
          }
 }

--- a/interface-definitions/netns.xml.in
+++ b/interface-definitions/netns.xml.in
@@ -3,7 +3,7 @@
   <node name="netns" owner="${vyos_conf_scripts_dir}/netns.py">
     <properties>
       <help>Network namespace</help>
-      <priority>299</priority>
+      <priority>291</priority>
     </properties>
     <children>
       <tagNode name="name">

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -3,7 +3,7 @@
   <node name="vpp" owner="${vyos_conf_scripts_dir}/vpp.py">
     <properties>
       <help>Accelerated data-plane</help>
-      <priority>1280</priority>
+      <priority>295</priority>
     </properties>
     <children>
       <node name="cpu">


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added interfaces reinitialization for VPP

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T1797

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
VPP

## Proposed changes
<!--- Describe your changes in detail -->
After an interface is added/removed from VPP, it will be reinitialized, which allows reconfiguring IP addresses on it.

Also modified VPP load priority to start before interfaces, and avoid reconfiguration during boot.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Add/delete interfaces to VPP. During this process they are destroyed and created again in the system, therefore config is always empty. With this change, they will be reinitialized according to CLI configuration:

```
set interfaces ethernet eth0 address '192.0.2.1/24'
set vpp interface eth0
commit
```

```
set interfaces ethernet eth0 address '192.0.2.1/24'
delete vpp interface eth0
commit
```

```
vyos@vyos# run show interfaces 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
eth0             192.0.2.1/24                      u/u  
lo               127.0.0.1/8                       u/u  
                 ::1/128                                
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
