### PR TITLE
T5340: snmp: add checks while configuring snmp listen-address with an…

### DIFF
--- a/src/conf_mode/snmp.py
+++ b/src/conf_mode/snmp.py
@@ -161,8 +161,12 @@ def verify(snmp):
         for address in snmp['listen_address']:
             # We only wan't to configure addresses that exist on the system.
             # Hint the user if they don't exist
-            if not is_addr_assigned(address):
-                Warning(f'SNMP listen address "{address}" not configured!')
+            if 'vrf' in snmp:
+                vrf_name = snmp['vrf']
+                if not is_addr_assigned(address, vrf_name) and address not in ['::1','127.0.0.1']:
+                    raise ConfigError(f'SNMP listen address "{address}" not configured in vrf "{vrf_name}"!')
+            elif not is_addr_assigned(address):
+                raise ConfigError(f'SNMP listen address "{address}" not configured in default vrf!')
 
     if 'trap_target' in snmp:
         for trap, trap_config in snmp['trap_target'].items():


### PR DESCRIPTION
…d without vrf

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add checks for snmp configuration commands.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5340

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
snmp

## Proposed changes
<!--- Describe your changes in detail -->
Check listen-address parameter and vrf configuration, to avoid wrong configuration
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Example 1
```
vyos@SNMP# run show config comm | grep "address\|snmp\|vrf"
set interfaces ethernet eth0 address 'dhcp'
set interfaces ethernet eth1 address '198.51.100.1/24'
set interfaces ethernet eth1 vrf 'MGMT'
set interfaces ethernet eth2 address '192.0.2.1/24'
set service ntp allow-client address '0.0.0.0/0'
set service ntp allow-client address '::/0'
set vrf name MGMT table '101'
[edit]
vyos@SNMP# set service snmp listen-address 198.51.100.1 
[edit]
vyos@SNMP# commit
[ service snmp ]
SNMP listen address "198.51.100.1" not configured in default vrf!

[[service snmp]] failed
Commit failed
[edit]
vyos@SNMP# set service snmp vrf MGMT 
[edit]
vyos@SNMP# commit
[edit]
vyos@SNMP# sudo netstat -putane | grep 161
udp        0      0 127.0.0.1:161           0.0.0.0:*                           0          16584      3039/snmpd          
udp        0      0 198.51.100.1:161        0.0.0.0:*                           0          16583      3039/snmpd          
udp6       0      0 ::1:161                 :::*                                0          16585      3039/snmpd          
[edit]
vyos@SNMP# 
```

Example2:
```
vyos@SNMP# run show config comm | grep "address\|snmp\|vrf"
set interfaces ethernet eth0 address 'dhcp'
set interfaces ethernet eth1 address '198.51.100.1/24'
set interfaces ethernet eth1 vrf 'MGMT'
set interfaces ethernet eth2 address '192.0.2.1/24'
set service ntp allow-client address '0.0.0.0/0'
set service ntp allow-client address '::/0'
set vrf name MGMT table '101'
[edit]
vyos@SNMP# set service snmp vrf MGMT 
[edit]
vyos@SNMP# set service snmp listen-address 192.0.2.1 
[edit]
vyos@SNMP# commit
[ service snmp ]
SNMP listen address "192.0.2.1" not configured in vrf "MGMT"!

[[service snmp]] failed
Commit failed
[edit]
vyos@SNMP# del service snmp vrf 
[edit]
vyos@SNMP# commit
[edit]
vyos@SNMP# sudo netstat -putane | grep 161
udp        0      0 127.0.0.1:161           0.0.0.0:*                           0          26344      3719/snmpd          
udp        0      0 192.0.2.1:161           0.0.0.0:*                           0          26343      3719/snmpd          
udp6       0      0 ::1:161                 :::*                                0          26345      3719/snmpd          
[edit]
vyos@SNMP# 
```

Example 3:
```
vyos@SNMP# run show config comm | grep "address\|snmp\|vrf"
set interfaces ethernet eth0 address 'dhcp'
set interfaces ethernet eth1 address '198.51.100.1/24'
set interfaces ethernet eth1 vrf 'MGMT'
set interfaces ethernet eth2 address '192.0.2.1/24'
set service ntp allow-client address '0.0.0.0/0'
set service ntp allow-client address '::/0'
set vrf name MGMT table '101'
[edit]
vyos@SNMP# set service snmp listen-address 198.51.100.1 
[edit]
vyos@SNMP# set service snmp listen-address 192.0.2.1 
[edit]
vyos@SNMP# commit
[ service snmp ]
SNMP listen address "198.51.100.1" not configured in default vrf!

[[service snmp]] failed
Commit failed
[edit]
vyos@SNMP# 
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
