### PR TITLE
 T5339: GENEVE add option to use ipv4 instead of ethernet

### DIFF
--- a/interface-definitions/include/interface/parameters-innerproto.xml.i
+++ b/interface-definitions/include/interface/parameters-innerproto.xml.i
@@ -1,7 +1,7 @@
 <!-- include start from interface/parameters-innerproto.xml.i -->
 <leafNode name="innerproto">
   <properties>
-    <help> use IPv4 as inner protocol instead of Ethernet</help>
+    <help>Use IPv4 as inner protocol instead of Ethernet</help>
     <valueless/>
   </properties>
 </leafNode>

--- a/interface-definitions/include/interface/parameters-innerproto.xml.i
+++ b/interface-definitions/include/interface/parameters-innerproto.xml.i
@@ -1,0 +1,8 @@
+<!-- include start from interface/parameters-innerproto.xml.i -->
+<leafNode name="innerproto">
+  <properties>
+    <help> use IPv4 as inner protocol instead of Ethernet</help>
+    <valueless/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/interfaces-geneve.xml.in
+++ b/interface-definitions/interfaces-geneve.xml.in
@@ -36,6 +36,7 @@
                   #include <include/interface/parameters-df.xml.i>
                   #include <include/interface/parameters-tos.xml.i>
                   #include <include/interface/parameters-ttl.xml.i>
+                  #include <include/interface/parameters-innerproto.xml.i>
                 </children>
               </node>
               <node name="ipv6">

--- a/python/vyos/ifconfig/geneve.py
+++ b/python/vyos/ifconfig/geneve.py
@@ -45,6 +45,7 @@ class GeneveIf(Interface):
             'parameters.ip.df'           : 'df',
             'parameters.ip.tos'          : 'tos',
             'parameters.ip.ttl'          : 'ttl',
+            'parameters.ip.innerproto'   : 'innerprotoinherit',
             'parameters.ipv6.flowlabel'  : 'flowlabel',
         }
 

--- a/smoketest/scripts/cli/test_interfaces_geneve.py
+++ b/smoketest/scripts/cli/test_interfaces_geneve.py
@@ -43,6 +43,7 @@ class GeneveInterfaceTest(BasicInterfaceTest.TestCase):
 
             self.cli_set(self._base_path + [intf, 'parameters', 'ip', 'df', 'set'])
             self.cli_set(self._base_path + [intf, 'parameters', 'ip', 'tos', tos])
+            self.cli_set(self._base_path + [intf, 'parameters', 'ip', 'innerproto'])
             self.cli_set(self._base_path + [intf, 'parameters', 'ip', 'ttl', str(ttl)])
             ttl += 10
 
@@ -66,6 +67,11 @@ class GeneveInterfaceTest(BasicInterfaceTest.TestCase):
             if any('flowlabel' in s for s in self._options[interface]):
                 label = options['linkinfo']['info_data']['label']
                 self.assertIn(f'parameters ipv6 flowlabel {label}', self._options[interface])
+
+            if any('innerproto' in s for s in self._options[interface]):
+                inner = options['linkinfo']['info_data']['innerproto']
+                self.assertIn(f'parameters ip {inner}', self._options[interface])
+
 
             self.assertEqual('geneve',        options['linkinfo']['info_kind'])
             self.assertEqual('set',      options['linkinfo']['info_data']['df'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->
by default GENEVE interfaces are type Ethernet, this option allows to switch to IP header

https://manpages.debian.org/testing/iproute2/ip-link.8.en.html

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5330

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
geneve
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```

```
-->

using vyos-cli to configure geneve interfaces : 
```
vyos@vyos# run show configuration commands | match geneve
set interfaces geneve gnv1 parameters ip innerproto
set interfaces geneve gnv1 remote '172.16.50.1'
set interfaces geneve gnv1 vni '10'
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
