### PR TITLE
T5154: NTP: allow maximum of one ipv4 and one ipv6 address on paramet…

### DIFF
--- a/data/templates/chrony/chrony.conf.j2
+++ b/data/templates/chrony/chrony.conf.j2
@@ -53,8 +53,6 @@ bindaddress {{ address }}
 {%         endfor %}
 {%     endif %}
 {%     if interface is vyos_defined %}
-{%         for ifname in interface %}
-binddevice {{ ifname }}
-{%         endfor %}
+binddevice {{ interface }}
 {%     endif %}
 {% endif %}

--- a/interface-definitions/include/version/ntp-version.xml.i
+++ b/interface-definitions/include/version/ntp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/ntp-version.xml.i -->
-<syntaxVersion component='ntp' version='2'></syntaxVersion>
+<syntaxVersion component='ntp' version='3'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/ntp.xml.in
+++ b/interface-definitions/ntp.xml.in
@@ -57,7 +57,7 @@
             </children>
           </tagNode>
           #include <include/allow-client.xml.i>
-          #include <include/generic-interface-multi.xml.i>
+          #include <include/generic-interface.xml.i>
           #include <include/listen-address.xml.i>
           #include <include/interface/vrf.xml.i>
         </children>

--- a/smoketest/scripts/cli/test_service_ntp.py
+++ b/smoketest/scripts/cli/test_service_ntp.py
@@ -108,7 +108,7 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f'bindaddress {listen}', config)
 
     def test_03_ntp_interface(self):
-        interfaces = ['eth0', 'eth1']
+        interfaces = ['eth0']
         for interface in interfaces:
             self.cli_set(base_path + ['interface', interface])
 

--- a/src/conf_mode/ntp.py
+++ b/src/conf_mode/ntp.py
@@ -24,6 +24,7 @@ from vyos.util import call
 from vyos.util import chmod_750
 from vyos.util import get_interface_config
 from vyos.template import render
+from vyos.template import is_ipv4
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -62,16 +63,29 @@ def verify(ntp):
 
     if 'interface' in ntp:
         # If ntpd should listen on a given interface, ensure it exists
-        for interface in ntp['interface']:
-            verify_interface_exists(interface)
+        interface = ntp['interface']
+        verify_interface_exists(interface)
 
-            # If we run in a VRF, our interface must belong to this VRF, too
-            if 'vrf' in ntp:
-                tmp = get_interface_config(interface)
-                vrf_name = ntp['vrf']
-                if 'master' not in tmp or tmp['master'] != vrf_name:
-                    raise ConfigError(f'NTP runs in VRF "{vrf_name}" - "{interface}" '\
-                                      f'does not belong to this VRF!')
+        # If we run in a VRF, our interface must belong to this VRF, too
+        if 'vrf' in ntp:
+            tmp = get_interface_config(interface)
+            vrf_name = ntp['vrf']
+            if 'master' not in tmp or tmp['master'] != vrf_name:
+                raise ConfigError(f'NTP runs in VRF "{vrf_name}" - "{interface}" '\
+                                  f'does not belong to this VRF!')
+
+    if 'listen_address' in ntp:
+        ipv4_addresses = 0
+        ipv6_addresses = 0
+        for address in ntp['listen_address']:
+            if is_ipv4(address):
+                ipv4_addresses += 1
+            else:
+                ipv6_addresses += 1
+        if ipv4_addresses > 1:
+            raise ConfigError(f'NTP Only admits one ipv4 value for listen-address parameter ')
+        if ipv6_addresses > 1:
+            raise ConfigError(f'NTP Only admits one ipv6 value for listen-address parameter ')
 
     return None
 

--- a/src/migration-scripts/ntp/2-to-3
+++ b/src/migration-scripts/ntp/2-to-3
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T5154: allow only one ip address per family for parameter 'listen-address'
+# Allow only one interface for parameter 'interface'
+# If more than one are specified, remove such entries
+
+import sys
+
+from vyos.configtree import ConfigTree
+from vyos.template import is_ipv4
+from vyos.template import is_ipv6
+
+if (len(sys.argv) < 1):
+    print("Must specify file name!")
+    sys.exit(1)
+
+file_name = sys.argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+
+base_path = ['service', 'ntp']
+if not config.exists(base_path):
+    # Nothing to do
+    sys.exit(0)
+
+if config.exists(base_path + ['listen-address']) and (len([addr for addr in config.return_values(base_path + ['listen-address']) if is_ipv4(addr)]) > 1):
+    for addr in config.return_values(base_path + ['listen-address']):
+        if is_ipv4(addr):
+            config.delete_value(base_path + ['listen-address'], addr)
+
+if config.exists(base_path + ['listen-address']) and (len([addr for addr in config.return_values(base_path + ['listen-address']) if is_ipv6(addr)]) > 1):
+    for addr in config.return_values(base_path + ['listen-address']):
+        if is_ipv6(addr):
+            config.delete_value(base_path + ['listen-address'], addr)
+
+if config.exists(base_path + ['interface']):
+    if len(config.return_values(base_path + ['interface'])) > 1:
+        config.delete(base_path + ['interface'])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    sys.exit(1)


### PR DESCRIPTION
…er <listen-address>. Also allow only one single value <interface>.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow maximum of one ipv4 and one ipv6 address on <listen-aaddress>.
Also allow one interface on <interface>

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T154

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ntp

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Allow only one ip per family:
```
vyos@NTP# set service ntp listen-address 192.168.0.164 
[edit]
vyos@NTP# set service ntp listen-address 10.20.20.1 
[edit]
vyos@NTP# commit

NTP Only admits one ipv4 value for listen-address parameter

[[service ntp]] failed
Commit failed
[edit]
vyos@NTP# discard

  Changes have been discarded

[edit]
vyos@NTP# set service ntp listen-address ::1
[edit]
vyos@NTP# set service ntp listen-address ::99
[edit]
vyos@NTP# commit

NTP Only admits one ipv6 value for listen-address parameter

[[service ntp]] failed
Commit failed
[edit]
```

Valid configuration:
```
vyos@NTP# run show config comm | grep ntp
set service ntp allow-client address '0.0.0.0/0'
set service ntp allow-client address '::/0'
set service ntp interface 'eth0'
set service ntp listen-address '10.20.20.1'
set service ntp listen-address '::99'
set service ntp server time1.vyos.net
set service ntp server time2.vyos.net
set service ntp server time3.vyos.net
[edit]
vyos@NTP# sudo netstat -putane | grep 123
udp        0      0 10.20.20.1:123          0.0.0.0:*                           0          17043      3119/chronyd        
udp6       0      0 ::99:123                :::*                                0          17044      3119/chronyd        
[edit]

vyos@NTP# sudo cat /run/chrony/chrony.conf | tail -3
bindaddress 10.20.20.1
bindaddress ::99
binddevice eth0
[edit]
vyos@NTP# 

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
