### PR TITLE
config: T5330: add boolean check for additions by default in config dict

### DIFF
--- a/python/vyos/utils/dict.py
+++ b/python/vyos/utils/dict.py
@@ -87,7 +87,7 @@ def mangle_dict_keys(data, regex, replacement, abs_path=None, no_tag_node_value_
     if abs_path is None:
         abs_path = []
 
-    new_dict = {}
+    new_dict = type(data)()
 
     for k in data.keys():
         if no_tag_node_value_mangle and is_tag_value(abs_path + [k]):

--- a/python/vyos/xml_ref/__init__.py
+++ b/python/vyos/xml_ref/__init__.py
@@ -48,6 +48,9 @@ def is_leaf(path: list) -> bool:
 def cli_defined(path: list, node: str, non_local=False) -> bool:
     return load_reference().cli_defined(path, node, non_local=non_local)
 
+def from_source(d: dict, path: list) -> bool:
+    return load_reference().from_source(d, path)
+
 def component_version() -> dict:
     return load_reference().component_version()
 

--- a/python/vyos/xml_ref/definition.py
+++ b/python/vyos/xml_ref/definition.py
@@ -13,7 +13,12 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union, Any
+from typing import Optional, Union, Any, TYPE_CHECKING
+
+# https://peps.python.org/pep-0484/#forward-references
+# for type 'ConfigDict'
+if TYPE_CHECKING:
+    from vyos.config import ConfigDict
 
 class Xml:
     def __init__(self):
@@ -210,19 +215,42 @@ class Xml:
             return False
         return True
 
+    def _set_source_recursive(self, o: Union[dict, str, list], b: bool):
+        d = {}
+        if not isinstance(o, dict):
+            d = {'_source': b}
+        else:
+            for k, v in o.items():
+                d[k] = self._set_source_recursive(v, b)
+            d |= {'_source': b}
+        return d
+
     # use local copy of function in module configdict, to avoid circular
     # import
+    #
+    # extend dict_merge to keep track of keys only in source
     def _dict_merge(self, source, destination):
         from copy import deepcopy
-        tmp = deepcopy(destination)
+        dest = deepcopy(destination)
+        from_source = {}
 
         for key, value in source.items():
-            if key not in tmp:
-                tmp[key] = value
+            if key not in dest:
+                dest[key] = value
+                from_source[key] = self._set_source_recursive(value, True)
             elif isinstance(source[key], dict):
-                tmp[key] = self._dict_merge(source[key], tmp[key])
+                dest[key], f = self._dict_merge(source[key], dest[key])
+                f |= {'_source': False}
+                from_source[key] = f
 
-        return tmp
+        return dest, from_source
+
+    def from_source(self, d: dict, path: list) -> bool:
+        for key in path:
+            d  = d[key] if key in d else {}
+            if not d or not isinstance(d, dict):
+                return False
+        return d.get('_source', False)
 
     def _relative_defaults(self, rpath: list, conf: dict, recursive=False) -> dict:
         res: dict = {}
@@ -264,13 +292,16 @@ class Xml:
 
         return res
 
-    def merge_defaults(self, path: list, conf: dict, get_first_key=False,
-                       recursive=False) -> dict:
+    def merge_defaults(self, path: list, conf: Union[dict, 'ConfigDict'],
+                       get_first_key=False, recursive=False) -> dict:
         """Return config dict with defaults non-destructively merged
 
         This merges non-recursive defaults relative to the config dict.
         """
         d = self.relative_defaults(path, conf, get_first_key=get_first_key,
                                    recursive=recursive)
-        d = self._dict_merge(d, conf)
+        d, f = self._dict_merge(d, conf)
+        d = type(conf)(d)
+        if hasattr(d, '_from_defaults'):
+            setattr(d, '_from_defaults', f)
         return d


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

For a config dict returned with defaults automatically merged (as in the case of `get_interface_dict`; `get_accel_dict`; or `get_config_dict(..., with_defaults=True | with_recursive_defaults=True)` ), it may be useful to know if an entry was set in CLI, or only merged with defaults: retain this information internally and add a configdict method `from_defaults -> bool`.

Simple example:

```
>>> conf = Config()
>>> base = ['interfaces', 'ethernet']
>>> # no defaults:
>>> d = conf.get_config_dict(base, get_first_key=True)
>>> pprint(d)
{'eth0': {'address': ['dhcp'],
          'description': 'test',
          'hw-id': '52:54:00:ad:9f:43',
          'ip': {'arp-cache-timeout': '40'}}}
>>> # merged defaults:
>>> _, d = get_interface_dict(conf, base, ifname='eth0')
>>> pprint(d)
{'address': ['dhcp'],
 'description': 'test',
 'dhcp_options': {'default_route_distance': '210'},
 'duplex': 'auto',
 'hw_id': '52:54:00:ad:9f:43',
 'ifname': 'eth0',
 'ip': {'arp_cache_timeout': '40'},
 'mtu': '1500',
 'speed': 'auto'}
>>> d.from_defaults(['mtu'])
True
>>> d.from_defaults(['dhcp_options'])
True
>>> d.from_defaults(['ip'])
False
>>> d.from_defaults(['ip', 'arp_cache_timeout'])
False
```

The method is present in the above cases `get_interface_dict`, `get_accel_dict`, `get_config_dict(..., with_defaults=True | with_recursive_defaults=True)`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5330

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
