### PR TITLE
T5344: container: Add auto-pull option for container image

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -21,6 +21,12 @@
               <valueless/>
             </properties>
           </leafNode>
+          <leafNode name="auto-pull">
+            <properties>
+              <help>Container image will automatically be pulled</help>
+              <valueless/>
+            </properties>
+          </leafNode>
           <leafNode name="cap-add">
             <properties>
               <help>Container capabilities/permissions</help>

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -153,10 +153,11 @@ def verify(container):
             # on upgrade. This is the "cheapest" and fastest solution in terms
             # of image upgrade and deletion.
             image = container_config['image']
-            if run(f'podman image exists {image}') != 0:
+            if run(f'podman image exists {image}') != 0 and 'auto_pull' not in container_config:
                 Warning(f'Image "{image}" used in container "{name}" does not exist '\
                         f'locally. Please use "add container image {image}" to add it '\
-                        f'to the system! Container "{name}" will not be started!')
+                        f'to the system or add auto-pull in container "{name}"! '\
+                        f'Container "{name}" will not be started!')
 
             if 'network' in container_config:
                 if len(container_config['network']) > 1:
@@ -452,9 +453,9 @@ def apply(container):
         for name, container_config in container['name'].items():
             image = container_config['image']
 
-            if run(f'podman image exists {image}') != 0:
+            if run(f'podman image exists {image}') != 0 and 'auto_pull' not in container_config:
                 # container image does not exist locally - user already got
-                # informed by a WARNING in verfiy() - bail out early
+                # informed by a WARNING in verify() - bail out early
                 continue
 
             if 'disable' in container_config:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Add `auto-pull` option to `container` to allow the image to be automatically pulled if it doesn't exist when it's started. This allows a user to not have to separately run `add container image` to pull the image first then commit their configuration.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5344

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
container, podman

## Proposed changes
<!--- Describe your changes in detail -->

Check if user has set `auto-pull` for their container and if so skip any checks to see if the image already exists on the system. This will make it so that when the service is started via `podman run` it will automatically be pulled as is expected behavior and commonly used.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics -->
```
yzguy@vyos# run show container image 
REPOSITORY  TAG         IMAGE ID    CREATED     SIZE
[edit]
yzguy@vyos# compare
[container]
+ name gortr {
+     allow-host-networks { }
+     arguments "-cache https://dn42.burble.com/roa/dn42_roa_46.json -verify=false -checktime=false -bind :8082"
+     image "cloudflare/gortr"
+     port http {
+         destination "8082"
+         source "8082"
+     }
+ }

[edit]
yzguy@vyos# commit

WARNING: Image "cloudflare/gortr" used in container "gortr" does not
exist locally. Please use "add container image cloudflare/gortr" to
add it to the system! Container "gortr" will not be started!

[edit]
yzguy@vyos# set container name gortr auto-pull 
[edit]
yzguy@vyos# commit
[edit]
yzguy@vyos# run show container image 
REPOSITORY                  TAG         IMAGE ID      CREATED      SIZE
docker.io/cloudflare/gortr  latest      eb47db32cd58  2 years ago  19.6 MB
[edit]
yzguy@vyos# run show container 
CONTAINER ID  IMAGE                              COMMAND               CREATED         STATUS             PORTS       NAMES
364b6d5dde6b  docker.io/cloudflare/gortr:latest  -cache https://dn...  17 seconds ago  Up 17 seconds ago              gortr
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

---

This works as it sits, but I have some reservations as how it's implemented, as it essentially relies on the behavior of podman to naturally pull an image if it doesn't exist locally (which arguably most people expect as behavior and is what I expected to happen). When you use an image that doesn't exist and commit, you get a somewhat unfriendly error (see below) which does at least fail the commit, but could be an area of improvement if we can verify if the image exists and could be pulled. However `podman search` does not really adequately provide that as even doing `podman search debian:12` it returns a bunch of results and does not even include the right one.

```
yzguy@vyos# commit
[ container ]
VyOS had an issue completing a command.

We are sorry that you encountered a problem while using VyOS.
There are a few things you can do to help us (and yourself):
- Contact us using the online help desk if you have a subscription:
  https://support.vyos.io/
- Make sure you are running the latest version of VyOS available at:
  https://vyos.net/get/
- Consult the community forum to see how to handle this issue:
  https://forum.vyos.io
- Join us on Slack where our users exchange help and advice:
  https://vyos.slack.com

When reporting problems, please include as much information as possible:
- do not obfuscate any data (feel free to contact us privately if your 
  business policy requires it)
- and include all the information presented below

Report time:      2023-07-08 03:16:52
Image version:    VyOS 1.4-rolling-202307022110
Release train:    current

Built by:         autobuild@vyos.net
Built on:         Sun 02 Jul 2023 21:10 UTC
Build UUID:       936e834c-af12-4e77-9c84-293235198d96
Build commit ID:  934bccc686d764

Architecture:     x86_64
Boot via:         installed image
System type:      KVM guest

Hardware vendor:  QEMU
Hardware model:   Standard PC (i440FX + PIIX, 1996)
Hardware S/N:     
Hardware UUID:    63ead957-dd8a-424b-9e14-d6ecc073849a

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/container.py", line 498, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/container.py", line 472, in apply
    cmd(f'systemctl restart vyos-container-{name}.service')
  File "/usr/lib/python3/dist-packages/vyos/util.py", line 161, in cmd
    raise OSError(code, feedback)
PermissionError: [Errno 1] failed to run command: systemctl restart vyos-container-gortr.service
returned: 
exit code: 1

noteworthy:
cmd 'systemctl restart vyos-container-gortr.service'
returned (out):

returned (err):
Job for vyos-container-gortr.service failed because the control process exited with error code.
See "systemctl status vyos-container-gortr.service" and "journalctl -xeu vyos-container-gortr.service" for details.

[[container]] failed
Commit failed
[edit]

yzguy@vyos# journalctl -u vyos-container-gortr.service
Jul 08 03:39:57 vyos systemd[1]: Starting vyos-container-gortr.service - VyOS Container gortr...
Jul 08 03:39:57 vyos podman[4504]: time="2023-07-08T03:39:57Z" level=warning msg="The input device is not a TTY. The --tty and --interactive flags might not work properly"
Jul 08 03:39:57 vyos podman[4504]: Resolving "doesnt/exist" using unqualified-search registries (/etc/containers/registries.conf)
Jul 08 03:39:57 vyos podman[4504]: Trying to pull docker.io/doesnt/exist:latest...
Jul 08 03:39:57 vyos podman[4504]: Trying to pull quay.io/doesnt/exist:latest...
Jul 08 03:39:58 vyos podman[4504]: Error: 2 errors occurred while pulling:
Jul 08 03:39:58 vyos podman[4504]:  * initializing source docker://doesnt/exist:latest: reading manifest latest in docker.io/doesnt/exist: errors:
Jul 08 03:39:58 vyos podman[4504]: denied: requested access to the resource is denied
Jul 08 03:39:58 vyos podman[4504]: unauthorized: authentication required
Jul 08 03:39:58 vyos podman[4504]:  * initializing source docker://quay.io/doesnt/exist:latest: reading manifest latest in quay.io/doesnt/exist: unauthorized: access to the requested resource is not authorized
Jul 08 03:39:58 vyos systemd[1]: vyos-container-gortr.service: Control process exited, code=exited, status=125/n/a
Jul 08 03:39:58 vyos podman[4511]: Error: reading CIDFile: open /run/vyos-container-gortr.service.cid: no such file or directory
Jul 08 03:39:58 vyos systemd[1]: vyos-container-gortr.service: Control process exited, code=exited, status=125/n/a
Jul 08 03:39:58 vyos systemd[1]: vyos-container-gortr.service: Failed with result 'exit-code'.
Jul 08 03:39:58 vyos systemd[1]: Failed to start vyos-container-gortr.service - VyOS Container gortr.
Jul 08 03:39:58 vyos systemd[1]: vyos-container-gortr.service: Scheduled restart job, restart counter is at 5.
Jul 08 03:39:58 vyos systemd[1]: Stopped vyos-container-gortr.service - VyOS Container gortr.
```