### PR TITLE
T775: Config-sync bracketize IPv6 secondary address

### DIFF
--- a/src/helpers/vyos_config_sync.py
+++ b/src/helpers/vyos_config_sync.py
@@ -24,6 +24,7 @@ import logging
 from typing import Optional, List, Union, Dict, Any
 
 from vyos.config import Config
+from vyos.template import bracketize_ipv6
 
 
 CONFIG_FILE = '/run/config_sync_conf.conf'
@@ -175,6 +176,7 @@ if __name__ == '__main__':
 
     mode = config.get('mode')
     secondary_address = config.get('secondary', {}).get('address')
+    secondary_address = bracketize_ipv6(secondary_address)
     secondary_key = config.get('secondary', {}).get('key')
     sections = config.get('section')
     timeout = int(config.get('secondary', {}).get('timeout'))


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
bracketize IPv6 remote address to avoid `Failed to parse: https://2001:db8::2/configure-section`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T775

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
config-sync
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set service config-sync mode 'load'
set service config-sync secondary address '2001:db8::2'
set service config-sync secondary key 'foo'
set service config-sync section 'nat'
set service config-sync section 'firewall'

set nat source rule 100 description '222'
set nat source rule 100 outbound-interface 'eth0'
set nat source rule 100 source address '192.0.2.0/24'
set nat source rule 100 translation address 'masquerade'

```
Commit before the fix:
```
vyos@r14# commit
INFO:vyos_config_sync:Config synchronization: Mode=load, Secondary=2001:db8::2
An error occurred: Failed to parse: https://2001:db8::2/configure-section
ERROR:vyos_config_sync:An error occurred: Failed to parse: https://2001:db8::2/configure-section
An error occurred: Failed to parse: https://2001:db8::2/configure-section
ERROR:vyos_config_sync:An error occurred: Failed to parse: https://2001:db8::2/configure-section
[edit]
vyos@r14# 
```
Commit after the fix:
```
vyos@r14# commit
[ nat ]

INFO:vyos_config_sync:Config synchronization: Mode=load, Secondary=[2001:db8::2]
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
