### PR TITLE
mpls: T5346: Set priority 490 for MPLS config after all interfaces

### DIFF
--- a/interface-definitions/protocols-mpls.xml.in
+++ b/interface-definitions/protocols-mpls.xml.in
@@ -6,7 +6,7 @@
       <node name="mpls" owner="${vyos_conf_scripts_dir}/protocols_mpls.py">
         <properties>
           <help>Multiprotocol Label Switching (MPLS)</help>
-          <priority>400</priority>
+          <priority>490</priority>
         </properties>
         <children>
           <node name="ldp">


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Update the MPLS configuration priority to `490` to allow all other interfaces to be present and configured before attempting MPLS configuration.

This is similar to [T4489](https://vyos.dev/T4489) in which GRE interfaces were not present at the time of MPLS configuration. This same issue is now experienced with L2TP interfaces (priority 485).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5346

## Component(s) name
* MPLS

## Proposed changes
This PR increases the priority for MPLS configuration 490. This ensures all other interfaces are configured prior to applying MPLS configuration. 

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configure a set of L2TP interfaces and then configure protocol MPLS for them. At run time this seems to work, however after a restart the configuration order attempts MPLS configuration prior to the L2TP interfaces being available. 

This results in non-functioning MPLS interfaces and the following error entering configuration mode:

```
jvoss@test-R1:~$ config
WARNING: There was a config error on boot: saving the configuration now could overwrite data.
You may want to check and reload the boot config
[edit]
```

After this proposed change the errors are no longer present, the interfaces and MPLS are configured appropriately and the network functions as expected.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
