### PR TITLE
T5341: HA migrate virtual-server address tag to section address

### DIFF
--- a/data/templates/high-availability/keepalived.conf.j2
+++ b/data/templates/high-availability/keepalived.conf.j2
@@ -173,7 +173,7 @@ vrrp_sync_group {{ name }} {
 {%     for vserver, vserver_config in virtual_server.items() %}
 # Vserver {{ vserver }}
 {%         if vserver_config.port is vyos_defined %}
-virtual_server {{ vserver }} {{ vserver_config.port }} {
+virtual_server {{ vserver_config.address }} {{ vserver_config.port }} {
 {%         else %}
 virtual_server fwmark {{ vserver_config.fwmark }} {
 {%         endif %}

--- a/interface-definitions/high-availability.xml.in
+++ b/interface-definitions/high-availability.xml.in
@@ -336,9 +336,10 @@
       </node>
       <tagNode name="virtual-server">
         <properties>
-          <help>Load-balancing virtual server address</help>
+          <help>Load-balancing virtual server alias</help>
         </properties>
         <children>
+          #include <include/address-ipv4-ipv6-single.xml.i>
           <leafNode name="algorithm">
             <properties>
               <help>Schedule algorithm (default - least-connection)</help>

--- a/interface-definitions/include/address-ipv4-ipv6-single.xml.i
+++ b/interface-definitions/include/address-ipv4-ipv6-single.xml.i
@@ -1,0 +1,18 @@
+<!-- include start from interface/address-ipv4-ipv6.xml.i -->
+<leafNode name="address">
+  <properties>
+    <help>IP address</help>
+    <valueHelp>
+      <format>ipv4</format>
+      <description>IPv4 address</description>
+    </valueHelp>
+    <valueHelp>
+      <format>ipv6</format>
+      <description>IPv6 address</description>
+    </valueHelp>
+    <constraint>
+      <validator name="ip-address"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/version/vrrp-version.xml.i
+++ b/interface-definitions/include/version/vrrp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/vrrp-version.xml.i -->
-<syntaxVersion component='vrrp' version='3'></syntaxVersion>
+<syntaxVersion component='vrrp' version='4'></syntaxVersion>
 <!-- include end -->

--- a/smoketest/scripts/cli/test_ha_virtual_server.py
+++ b/smoketest/scripts/cli/test_ha_virtual_server.py
@@ -47,6 +47,7 @@ class TestHAVirtualServer(VyOSUnitTestSHIM.TestCase):
         delay = '10'
         method = 'nat'
         persistence_timeout = '600'
+        vs = 'serv-one'
         vip = '203.0.113.111'
         vport = '2222'
         rservers = ['192.0.2.21', '192.0.2.22', '192.0.2.23']
@@ -56,21 +57,23 @@ class TestHAVirtualServer(VyOSUnitTestSHIM.TestCase):
 
         vserver_base = base_path + ['virtual-server']
 
-        self.cli_set(vserver_base + [vip, 'algorithm', algo])
-        self.cli_set(vserver_base + [vip, 'delay-loop', delay])
-        self.cli_set(vserver_base + [vip, 'forward-method', method])
-        self.cli_set(vserver_base + [vip, 'persistence-timeout', persistence_timeout])
-        self.cli_set(vserver_base + [vip, 'port', vport])
-        self.cli_set(vserver_base + [vip, 'protocol', proto])
+        self.cli_set(vserver_base + [vs, 'address', vip])
+        self.cli_set(vserver_base + [vs, 'algorithm', algo])
+        self.cli_set(vserver_base + [vs, 'delay-loop', delay])
+        self.cli_set(vserver_base + [vs, 'forward-method', method])
+        self.cli_set(vserver_base + [vs, 'persistence-timeout', persistence_timeout])
+        self.cli_set(vserver_base + [vs, 'port', vport])
+        self.cli_set(vserver_base + [vs, 'protocol', proto])
         for rs in rservers:
-            self.cli_set(vserver_base + [vip, 'real-server', rs, 'connection-timeout', connection_timeout])
-            self.cli_set(vserver_base + [vip, 'real-server', rs, 'port', rport])
+            self.cli_set(vserver_base + [vs, 'real-server', rs, 'connection-timeout', connection_timeout])
+            self.cli_set(vserver_base + [vs, 'real-server', rs, 'port', rport])
 
         # commit changes
         self.cli_commit()
 
         config = read_file(KEEPALIVED_CONF)
 
+        self.assertIn(f'virtual_server {vip} {vport}', config)
         self.assertIn(f'delay_loop {delay}', config)
         self.assertIn(f'lb_algo lc', config)
         self.assertIn(f'lb_kind {method.upper()}', config)
@@ -86,6 +89,7 @@ class TestHAVirtualServer(VyOSUnitTestSHIM.TestCase):
         delay = '15'
         method = 'nat'
         persistence_timeout = '300'
+        vs = 'serv-two'
         vip = '203.0.113.222'
         vport = '22322'
         rservers = ['192.0.2.11', '192.0.2.12']
@@ -107,15 +111,16 @@ class TestHAVirtualServer(VyOSUnitTestSHIM.TestCase):
         self.cli_set(vrrp_base + [group, 'vrid', vrid])
 
         # Virtual-server config
-        self.cli_set(vserver_base + [vip, 'algorithm', algo])
-        self.cli_set(vserver_base + [vip, 'delay-loop', delay])
-        self.cli_set(vserver_base + [vip, 'forward-method', method])
-        self.cli_set(vserver_base + [vip, 'persistence-timeout', persistence_timeout])
-        self.cli_set(vserver_base + [vip, 'port', vport])
-        self.cli_set(vserver_base + [vip, 'protocol', proto])
+        self.cli_set(vserver_base + [vs, 'address', vip])
+        self.cli_set(vserver_base + [vs, 'algorithm', algo])
+        self.cli_set(vserver_base + [vs, 'delay-loop', delay])
+        self.cli_set(vserver_base + [vs, 'forward-method', method])
+        self.cli_set(vserver_base + [vs, 'persistence-timeout', persistence_timeout])
+        self.cli_set(vserver_base + [vs, 'port', vport])
+        self.cli_set(vserver_base + [vs, 'protocol', proto])
         for rs in rservers:
-            self.cli_set(vserver_base + [vip, 'real-server', rs, 'connection-timeout', connection_timeout])
-            self.cli_set(vserver_base + [vip, 'real-server', rs, 'port', rport])
+            self.cli_set(vserver_base + [vs, 'real-server', rs, 'connection-timeout', connection_timeout])
+            self.cli_set(vserver_base + [vs, 'real-server', rs, 'port', rport])
 
         # commit changes
         self.cli_commit()
@@ -131,6 +136,7 @@ class TestHAVirtualServer(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'preempt_delay 0', config) # default value
 
         # Keepalived virtual-server
+        self.assertIn(f'virtual_server {vip} {vport}', config)
         self.assertIn(f'delay_loop {delay}', config)
         self.assertIn(f'lb_algo lc', config)
         self.assertIn(f'lb_kind {method.upper()}', config)

--- a/src/conf_mode/high-availability.py
+++ b/src/conf_mode/high-availability.py
@@ -175,6 +175,11 @@ def verify(ha):
     # Virtual-server
     if 'virtual_server' in ha:
         for vs, vs_config in ha['virtual_server'].items():
+
+            if 'address' not in vs_config and 'fwmark' not in vs_config:
+                raise ConfigError('Either address or fwmark is required '
+                                  f'but not set for virtual-server "{vs}"')
+
             if 'port' not in vs_config and 'fwmark' not in vs_config:
                 raise ConfigError(f'Port or fwmark is required but not set for virtual-server "{vs}"')
             if 'port' in vs_config and 'fwmark' in vs_config:

--- a/src/migration-scripts/vrrp/3-to-4
+++ b/src/migration-scripts/vrrp/3-to-4
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from sys import argv
+from vyos.configtree import ConfigTree
+
+if (len(argv) < 1):
+    print('Must specify file name!')
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['high-availability', 'virtual-server']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+
+if config.exists(base):
+    for vs in config.list_nodes(base):
+        vs_base = base + [vs]
+
+        # If the fwmark is used, the address is not required
+        if not config.exists(vs_base + ['fwmark']):
+            # add option: 'virtual-server <tag> address x.x.x.x'
+            config.set(vs_base + ['address'], value=vs)
+
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print(f'Failed to save the modified config: {e}')
+    exit(1)


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Migrate:
```
    high-availability virtual-server 203.0.113.1
to: high-availability virtual-server <name> address 203.0.113.1
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5341

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
virtual-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set high-availability virtual-server R1-8881 address '203.0.113.1'
set high-availability virtual-server R1-8881 port '8881'
set high-availability virtual-server R1-8881 real-server 192.0.2.11 port '80'

set high-availability virtual-server R1-8882 address '203.0.113.1'
set high-availability virtual-server R1-8882 port '8882'
set high-availability virtual-server R1-8882 real-server 192.0.2.11 port '80'

```
Keepalived conf:
```
vyos@r14:~$ cat /run/keepalived/keepalived.conf 
# Autogenerated by VyOS
# Do not edit this file, all your changes will be lost
# on next commit or reboot

# Global definitions configuration block
global_defs {
    dynamic_interfaces
    script_user root
    notify_fifo /run/keepalived/keepalived_notify_fifo
    notify_fifo_script /usr/libexec/vyos/system/keepalived-fifo.py
}



# Virtual-server configuration
# Vserver R1-8881
virtual_server 203.0.113.1 8881 {
    delay_loop 10
    lb_algo lc
    lb_kind NAT
    persistence_timeout 300
    protocol TCP
    real_server 192.0.2.11 80 {
        weight 1
        TCP_CHECK {
        }
    }
}
# Vserver R1-8882
virtual_server 203.0.113.1 8882 {
    delay_loop 10
    lb_algo lc
    lb_kind NAT
    persistence_timeout 300
    protocol TCP
    real_server 192.0.2.11 80 {
        weight 1
        TCP_CHECK {
        }
    }
}

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
