### PR TITLE
bgp: T5338: Added 'protocols bgp interface <int> mpls forwarding' feature

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -565,3 +565,13 @@ bgp route-reflector allow-outbound-policy
  timers bgp {{ timers.keepalive }} {{ timers.holdtime }}
 {% endif %}
 exit
+{% if interface is vyos_defined %}
+{%     for iface, iface_config in interface.items() %}
+ interface {{ iface }}
+{%         if iface_config.mpls.forwarding is vyos_defined %}
+ mpls bgp forwarding
+{%         endif %}
+ exit
+ !
+{%     endfor %}
+{% endif %}

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -873,6 +873,36 @@
     </node>
   </children>
 </node>
+<tagNode name="interface">
+  <properties>
+    <help>Enable MPLS on Interface</help>
+    <completionHelp>
+      <script>${vyos_completion_dir}/list_interfaces</script>
+    </completionHelp>
+    <valueHelp>
+      <format>txt</format>
+      <description>Interface name</description>
+    </valueHelp>
+    <constraint>
+      #include <include/constraint/interface-name.xml.i>
+    </constraint>
+  </properties>
+  <children>
+    <node name="mpls">
+      <properties>
+        <help> MPLS options</help>
+      </properties>
+      <children>
+        <leafNode name="forwarding">
+          <properties>
+            <help> Enable MPLS forwarding for eBGP directly connected peers</help>
+            <valueless/>
+          </properties>
+        </leafNode>
+      </children>
+    </node>
+  </children>
+</tagNode>
 <node name="listen">
   <properties>
     <help>Listen for and accept BGP dynamic neighbors from range</help>


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added 'protocols bgp interface <int> mpls forwarding' feature. 
It is possible to permit BGP install VPN prefixes without transport labels. 
This configuration will install VPN prefixes originated from an e-bgp session, 
and with the next-hop directly connected.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5338

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp
## Proposed changes
<!--- Describe your changes in detail -->
Added 'protocols bgp interface <int> mpls forwarding' feature. 
It is possible to permit BGP install VPN prefixes without transport labels. 
This configuration will install VPN prefixes originated from an e-bgp session, 
and with the next-hop directly connected.

[https://docs.frrouting.org/en/latest/bgp.html#clicmd-mpls-bgp-forwarding](https://docs.frrouting.org/en/latest/bgp.html#clicmd-mpls-bgp-forwarding)

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
`set protocols bgp interface eth0 mpls forwarding`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
