### PR TITLE
config-mgmt: T5347: set logrotate conf permissions correctly for system update

### DIFF
--- a/python/vyos/config_mgmt.py
+++ b/python/vyos/config_mgmt.py
@@ -21,6 +21,8 @@ import logging
 from typing import Optional, Tuple, Union
 from filecmp import cmp
 from datetime import datetime
+from textwrap import dedent
+from pathlib import Path
 from tabulate import tabulate
 
 from vyos.config import Config
@@ -456,19 +458,18 @@ Proceed ?'''
         return ConfigTree(c)
 
     def _add_logrotate_conf(self):
-        conf = f"""{archive_config_file} {{
-    su root vyattacfg
-    rotate {self.max_revisions}
-    start 0
-    compress
-    copy
-}}"""
-        mask = os.umask(0o133)
-
-        with open(logrotate_conf, 'w') as f:
-            f.write(conf)
-
-        os.umask(mask)
+        conf: str = dedent(f"""\
+        {archive_config_file} {{
+            su root vyattacfg
+            rotate {self.max_revisions}
+            start 0
+            compress
+            copy
+        }}
+        """)
+        conf_file = Path(logrotate_conf)
+        conf_file.write_text(conf)
+        conf_file.chmod(0o644)
 
     def _archive_active_config(self) -> bool:
         mask = os.umask(0o113)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Diagnosis and implementation by @zdc : the logrotate permissions are incorrect following a system update, and consequently the config commit archiving is not updated. Fix as suggested.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5347

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
