### PR TITLE
T5059: relay: add disable options for dhcp-relay and dhcpv6-relay

### DIFF
--- a/interface-definitions/dhcp-relay.xml.in
+++ b/interface-definitions/dhcp-relay.xml.in
@@ -9,6 +9,7 @@
           <priority>910</priority>
         </properties>
         <children>
+          #include <include/generic-disable-node.xml.i>
           #include <include/generic-interface-multi-broadcast.xml.i>
           <leafNode name="listen-interface">
             <properties>

--- a/interface-definitions/dhcpv6-relay.xml.in
+++ b/interface-definitions/dhcpv6-relay.xml.in
@@ -9,6 +9,7 @@
           <priority>900</priority>
         </properties>
         <children>
+          #include <include/generic-disable-node.xml.i>
           <tagNode name="listen-interface">
             <properties>
               <help>Interface for DHCPv6 Relay Agent to listen for requests</help>

--- a/src/conf_mode/dhcp_relay.py
+++ b/src/conf_mode/dhcp_relay.py
@@ -51,7 +51,7 @@ def get_config(config=None):
 
 def verify(relay):
     # bail out early - looks like removal from running config
-    if not relay:
+    if not relay or 'disable' in relay:
         return None
 
     if 'lo' in (dict_search('interface', relay) or []):
@@ -78,7 +78,7 @@ def verify(relay):
 
 def generate(relay):
     # bail out early - looks like removal from running config
-    if not relay:
+    if not relay or 'disable' in relay:
         return None
 
     render(config_file, 'dhcp-relay/dhcrelay.conf.j2', relay)
@@ -87,7 +87,7 @@ def generate(relay):
 def apply(relay):
     # bail out early - looks like removal from running config
     service_name = 'isc-dhcp-relay.service'
-    if not relay:
+    if not relay or 'disable' in relay:
         call(f'systemctl stop {service_name}')
         if os.path.exists(config_file):
             os.unlink(config_file)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add disable option for relay services.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5059

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-relay
dhcpv6-relay

## Proposed changes
<!--- Describe your changes in detail -->
Add disable options for dhcp-relay and dhcpv6-relai.
Also add validor for dhcpv6-relay which was missing.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
#### Running configuration for relays, status and files:
vyos@RELAY:~$ show config comm | grep "relay\|eth1\|eth2"
set interfaces ethernet eth1 address '198.51.100.1/24'
set interfaces ethernet eth1 address '2001:db8::1/64'
set interfaces ethernet eth1 hw-id '50:00:00:01:00:01'
set interfaces ethernet eth2 address '203.0.113.1/24'
set interfaces ethernet eth2 address '2001:ddd::1/64'
set interfaces ethernet eth2 hw-id '50:00:00:01:00:02'
set service dhcp-relay listen-interface 'eth2'
set service dhcp-relay server '198.51.100.254'
set service dhcp-relay upstream-interface 'eth1'
set service dhcpv6-relay listen-interface eth2
set service dhcpv6-relay upstream-interface eth1 address '2001:db8::55'
vyos@RELAY:~$ sudo ps aux | grep relay
root        1756  0.0  0.3   6180  3900 ?        Ss   11:07   0:00 /usr/sbin/dhcrelay -6 -pf /run/dhcp-relay/dhcrelay6.pid -l eth2 -u 2001:db8::55 eth1 -c 10
root        1828  0.0  0.3   5880  3480 ?        Ss   11:07   0:00 /usr/sbin/dhcrelay -4 -pf /run/dhcp-relay/dhcrelay.pid -c 10 -a -m forward -A 576 -id eth2 -iu eth1 198.51.100.254
vyos        2159  0.0  0.2   6332  2092 ttyS0    S+   11:08   0:00 grep relay
vyos@RELAY:~$ ls /run/dhcp-relay/
dhcrelay6.conf  dhcrelay6.pid  dhcrelay.conf  dhcrelay.pid

## Now disbale both relays
vyos@RELAY:~$ conf
[edit]
vyos@RELAY# set service dhcp-relay disable
[edit]
vyos@RELAY# set service dhcpv6-relay disable
[edit]
vyos@RELAY# commit
[edit]
vyos@RELAY# sudo ps aux | grep relay
vyos        2405  0.0  0.2   6332  2096 ttyS0    S+   11:10   0:00 grep relay
[edit]
vyos@RELAY# ls /run/dhcp-relay/
[edit]
vyos@RELAY# 
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
