### PR TITLE
T5355:IPSec:op cmd:"sh vpn ike status" not working

### DIFF
--- a/src/op_mode/vpn_ike_sa.py
+++ b/src/op_mode/vpn_ike_sa.py
@@ -39,8 +39,6 @@ def ike_sa(peer, nat):
     peers = []
     for conn in sas:
         for name, sa in conn.items():
-            if peer and not name.startswith('peer_' + peer):
-                continue
             if name.startswith('peer_') and name in peers:
                 continue
             if nat and 'nat-local' not in sa:
@@ -70,7 +68,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    if not process_named_running('charon'):
+    if not process_named_running('charon-systemd'):
         print("IPsec Process NOT Running")
         sys.exit(0)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
"show vpn ike sa" shows as "IPsec Process NOT Running" even though the process is running.
Same output show for the sub command as well "sh vpn ike sa peer <name>"

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5355

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec
## Proposed changes
<!--- Describe your changes in detail -->
The strongswan service is changed from charon to charon-systemd that's why the process is not running error
is received, so updated the service.

```
vyos@vyos# run sh vpn ike status
● strongswan.service - strongSwan IPsec IKEv1/IKEv2 daemon using swanctl
     Loaded: loaded (/lib/systemd/system/strongswan.service; disabled; preset: )
     Active: active (running) since Thu 2023-07-13 08:02:48 UTC; 12min ago
    Process: 2739 ExecReload=/usr/sbin/swanctl --reload (code=exited, status=0/)
    Process: 2744 ExecReload=/usr/sbin/swanctl --load-all --noprompt (code=exit)
   Main PID: 1903 (charon-systemd)
     Status: "charon-systemd running, strongSwan 5.9.8, Linux 6.1.38-amd64-vyos"
```
   
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configure the ipsec setting on both peers:
set vpn ipsec authentication psk test id 'x.x.x.x'
set vpn ipsec authentication psk test secret 'vyos'
set vpn ipsec esp-group ESP-GROUP lifetime '1800'
set vpn ipsec esp-group ESP-GROUP mode 'tunnel'
set vpn ipsec esp-group ESP-GROUP proposal 1 encryption 'aes128'
set vpn ipsec esp-group ESP-GROUP proposal 1 hash 'sha1'
set vpn ipsec ike-group IKE-GROUP key-exchange 'ikev1'
set vpn ipsec ike-group IKE-GROUP lifetime '3600'
set vpn ipsec ike-group IKE-GROUP proposal 1 dh-group '14'
set vpn ipsec ike-group IKE-GROUP proposal 1 encryption 'aes128'
set vpn ipsec ike-group IKE-GROUP proposal 1 hash 'sha1'
set vpn ipsec interface 'x'
set vpn ipsec site-to-site peer test authentication local-id 'x.x.x.x'
set vpn ipsec site-to-site peer test authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer test authentication remote-id 'x.x.x.x'
set vpn ipsec site-to-site peer test connection-type 'initiate'
set vpn ipsec site-to-site peer test default-esp-group 'ESP-GROUP'
set vpn ipsec site-to-site peer test ike-group 'IKE-GROUP'
set vpn ipsec site-to-site peer test local-address 'x.x.x.x'
set vpn ipsec site-to-site peer test remote-address 'x.x.x.x'
set vpn ipsec site-to-site peer test vti bind 'vti0'
set interfaces vti vti0 address 'x.x.x.x'

Once committed, run the command "show vp ike status" to check the status
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
