### PR TITLE
policy: T5357: only delete migrated BGP community rules

### DIFF
--- a/src/migration-scripts/policy/3-to-4
+++ b/src/migration-scripts/policy/3-to-4
@@ -51,7 +51,7 @@ def community_migrate(config: ConfigTree, rule: list[str]) -> bool:
     :rtype: bool
     """
     community_list = list((config.return_value(rule)).split(" "))
-    config.delete(rule)
+
     if 'none' in community_list:
         config.set(rule + ['none'])
         return False
@@ -61,8 +61,10 @@ def community_migrate(config: ConfigTree, rule: list[str]) -> bool:
             community_action = 'add'
             community_list.remove('additive')
         for community in community_list:
-            config.set(rule + [community_action], value=community,
-                       replace=False)
+            if len(community):
+                config.set(rule + [community_action], value=community,
+                        replace=False)
+                config.delete(rule)
         if community_action == 'replace':
             return False
         else:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix issue loading configuration from a file containing route-maps with BGP communities. Currently they get mangled and updated with "replace":

```
# test.config

interfaces {
   ethernet eth0 {
     address "dhcp"
     ipv6 {
         address {
             autoconf 
         }
      }
   }
}
policy {
    route-map TEST {
        rule 10 {
            action "permit"
            set {
                community {
                    add 65000:1
                }
                large-community {
                    add 4200000000:100:1
                }
            }
        }
    }
}
```

```
jvoss@test# compare
+ TEST {
+     rule 10 {
+         action "permit"
+         set {
+             community {
+                 replace ""
+             }
+             large-community {
+                 replace ""
+             }
+         }
+     }
+ }
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5357

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* policy (set BGP community and large-community)

## Proposed changes
Refactor the migration script from deleting every configuration line despite migration status:
https://github.com/vyos/vyos-1x/blob/ac60fe7d1840b8768542ee4b3f28f46544c290f2/src/migration-scripts/policy/3-to-4#L53-L54

This PR updates the migration to only delete the original line if a migration is needed.

## How to test
1) Create a configuration file to load as shown in the change summary above
2) Load the configuration: `load ~/test.conf`
3) Check the pending configuration (`compare`) for correct behavior (i.e. is not overwritten with `replace ""`):

Expected behavior:
```
jvoss@test# compare
+ TEST {
+     rule 10 {
+         action "permit"
+         set {
+             community {
+                 add "65000:1"
+             }
+             large-community {
+                 add "4200000000:100:1"
+             }
+         }
+     }
+ }
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
