### PR TITLE
dhclient: T5358: Use return in 99-ipsec-dhclient-hook

### DIFF
--- a/src/etc/dhcp/dhclient-exit-hooks.d/99-ipsec-dhclient-hook
+++ b/src/etc/dhcp/dhclient-exit-hooks.d/99-ipsec-dhclient-hook
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 if [ "$reason" == "REBOOT" ] || [ "$reason" == "EXPIRE" ]; then
-    exit 0
+    return 0
 fi
 
 DHCP_HOOK_IFLIST="/tmp/ipsec_dhcp_waiting"
@@ -24,12 +24,12 @@ if [ -f $DHCP_HOOK_IFLIST ] && [ "$reason" == "BOUND" ]; then
     if grep -qw $interface $DHCP_HOOK_IFLIST; then
         sudo rm $DHCP_HOOK_IFLIST
         sudo /usr/libexec/vyos/conf_mode/vpn_ipsec.py
-        exit 0
+        return 0
     fi
 fi
 
 if [ "$old_ip_address" == "$new_ip_address" ] && [ "$reason" == "BOUND" ]; then
-    exit 0
+    return 0
 fi
 
 python3 - <<PYEND


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Use return instead of exit in 99-dhclient-exit-hook to allow subsequent unnumbered hooks to run (like rfc3442-classless-routes). Hooks are sourced, not executed.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5358

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* dhclient

## Proposed changes
<!--- Describe your changes in detail -->
Replace exit with return in `99-ipsec-dhclient-hook` since exit hook scripts are sourced, not executed. This allows the subsequent unnumbered scripts such as `rfc3442-classless-routes` and fixes the bug where classless routes were not being installed.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
1. Configure a vyos router as a dhcp server with classless static routes:
```
configure
set interface ethernet eth0 address '192.168.1.1/24'
set service dhcp-server shared-network TEST subnet 192.168.1.0/16 default-router '192.168.1.1'
set service dhcp-server shared-network TEST subnet 192.168.1.0/24 lease '300'
set service dhcp-server shared-network TEST subnet 192.168.1.0/24 range 0 start '192.168.1.64'
set service dhcp-server shared-network TEST subnet 192.168.1.0/24 range 0 stop '192.168.1.250'
set service dhcp-server shared-network TEST subnet 192.168.1.0/24 subnet-parameters 'option rfc3442-static-route 0, 192, 168, 1, 1, 24, 192, 168, 116, 192, 168, 20, 1;'
commit
save
exit
```
2. Connect a vyos router as a dhcp client with vrfs:
```
configure
set interfaces ethernet eth0 address 'dhcp'
set interfaces ethernet eth0 vrf vrf_eth0
set vrf name vrf_eth0 table 200
save
exit
```
3. Run `show ip route vrf vrf_eth0` on the client to verify the routes are installed.
```
vyos@vyos:~$ show ip route vrf vrf_eth0 
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

VRF vrf_eth0:
S>* 0.0.0.0/0 [210/0] via 192.168.1.1, eth0, weight 1, 00:02:57
C>* 192.168.1.0/24 is directly connected, eth0, 00:03:06
S   192.168.116.0/24 [210/0] via 192.168.20.1, eth0 inactive, weight 1, 00:02:57
```
5. Disconnect the link and check that the routes are removed with `show ip route vrf vrf_eth0`.
6. Reconnect the link and check the routes are installed with `show ip route vrf vrf_eth0`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly