### PR TITLE
interfaces: T5254: Disable interface changes in bond members

### DIFF
--- a/interface-definitions/include/version/interfaces-version.xml.i
+++ b/interface-definitions/include/version/interfaces-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/interfaces-version.xml.i -->
-<syntaxVersion component='interfaces' version='29'></syntaxVersion>
+<syntaxVersion component='interfaces' version='30'></syntaxVersion>
 <!-- include end -->

--- a/python/vyos/validate.py
+++ b/python/vyos/validate.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2018-2023 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -302,3 +302,32 @@ def has_vrf_configured(conf, intf):
 
     conf.set_level(old_level)
     return ret
+
+
+def is_bond_member_allowed_option(option: str) -> bool:
+    """
+    Check if ethernet interface option is allowed for changes
+    when interface is a bond member
+    :param option: ethernet interface option
+    :type option: str
+    :return: If option allowed to changes return True else False
+    :rtype: bool
+    """
+    bond_allowed_options = [
+        'description',
+        'disable',
+        'disable_flow_control',
+        'disable_link_detect',
+        'duplex',
+        'eapol',
+        'mirror',
+        'offload',
+        'redirect',
+        'ring-buffer',
+        'speed',
+        'hw_id'
+    ]
+    if option in bond_allowed_options:
+        return True
+    else:
+        return False

--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2021 VyOS maintainers and contributors
+# Copyright (C) 2019-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -19,7 +19,6 @@ import os
 from glob import glob
 from sys import exit
 
-from vyos.base import Warning
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
@@ -33,6 +32,7 @@ from vyos.configverify import verify_mtu_ipv6
 from vyos.configverify import verify_vlan_config
 from vyos.configverify import verify_vrf
 from vyos.configverify import verify_bond_bridge_member
+from vyos.validate import is_bond_member_allowed_option
 from vyos.ethtool import Ethtool
 from vyos.ifconfig import EthernetIf
 from vyos.pki import find_chain
@@ -45,11 +45,50 @@ from vyos.utils.dict import dict_search
 from vyos.utils.file import write_file
 from vyos import ConfigError
 from vyos import airbag
+
+
 airbag.enable()
 
 # XXX: wpa_supplicant works on the source interface
 cfg_dir = '/run/wpa_supplicant'
 wpa_suppl_conf = '/run/wpa_supplicant/{ifname}.conf'
+
+
+def remove_blocked_options(conf: Config, ethernet: dict):
+    """
+    Remove unused options if interface is in bonding.
+    If unused option was changed, it is added to ethernet['bond_blocked_changes']
+    as a list for verifying
+    :param conf: Configuration
+    :type conf: Config
+    :param ethernet: dictionary which is received from get_interface_dict
+    :type ethernet:dict
+    """
+    config_with_defaults = conf.get_config_dict(
+        ['interfaces', 'ethernet', ethernet['ifname']],
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+        with_defaults=True,
+        with_recursive_defaults=True)
+    config_without_defaults = conf.get_config_dict(
+        ['interfaces', 'ethernet', ethernet['ifname']],
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+        with_defaults=False,
+        with_recursive_defaults=False)
+
+    list_blocked_changes = []
+    list_keys = list(ethernet.keys())
+    for option in list_keys:
+        if not is_bond_member_allowed_option(option):
+            if option in config_with_defaults:
+                del ethernet[option]
+            if option in config_without_defaults:
+                list_blocked_changes.append(option)
+    ethernet['bond_blocked_changes'] = list_blocked_changes
+
 
 def get_config(config=None):
     """
@@ -64,13 +103,16 @@ def get_config(config=None):
     # This must be called prior to get_interface_dict(), as this function will
     # alter the config level (config.set_level())
     pki = conf.get_config_dict(['pki'], key_mangling=('-', '_'),
-                               get_first_key=True, no_tag_node_value_mangle=True)
+                               get_first_key=True,
+                               no_tag_node_value_mangle=True)
 
     base = ['interfaces', 'ethernet']
     ifname, ethernet = get_interface_dict(conf, base)
 
+    if 'is_bond_member' in ethernet:
+        remove_blocked_options(conf, ethernet)
     if 'deleted' not in ethernet:
-       if pki: ethernet['pki'] = pki
+        if pki: ethernet['pki'] = pki
 
     tmp = is_node_changed(conf, base + [ifname, 'speed'])
     if tmp: ethernet.update({'speed_duplex_changed': {}})
@@ -80,10 +122,140 @@ def get_config(config=None):
 
     return ethernet
 
+
+def verify_speed_duplex(ethernet: dict, ethtool: Ethtool):
+    """
+     Verify speed and duplex
+    :param ethernet: dictionary which is received from get_interface_dict
+    :type ethernet: dict
+    :param ethtool: Ethernet object
+    :type ethtool: Ethtool
+    """
+    if ((ethernet['speed'] == 'auto' and ethernet['duplex'] != 'auto') or
+            (ethernet['speed'] != 'auto' and ethernet['duplex'] == 'auto')):
+        raise ConfigError(
+            'Speed/Duplex missmatch. Must be both auto or manually configured')
+
+    if ethernet['speed'] != 'auto' and ethernet['duplex'] != 'auto':
+        # We need to verify if the requested speed and duplex setting is
+        # supported by the underlaying NIC.
+        speed = ethernet['speed']
+        duplex = ethernet['duplex']
+        if not ethtool.check_speed_duplex(speed, duplex):
+            raise ConfigError(
+                f'Adapter does not support changing speed ' \
+                f'and duplex settings to: {speed}/{duplex}!')
+
+
+def verify_flow_control(ethernet: dict, ethtool: Ethtool):
+    """
+     Verify flow control
+    :param ethernet: dictionary which is received from get_interface_dict
+    :type ethernet: dict
+    :param ethtool: Ethernet object
+    :type ethtool: Ethtool
+    """
+    if 'disable_flow_control' in ethernet:
+        if not ethtool.check_flow_control():
+            raise ConfigError(
+                'Adapter does not support changing flow-control settings!')
+
+
+def verify_ring_buffer(ethernet: dict, ethtool: Ethtool):
+    """
+     Verify ring buffer
+    :param ethernet: dictionary which is received from get_interface_dict
+    :type ethernet: dict
+    :param ethtool: Ethernet object
+    :type ethtool: Ethtool
+    """
+    if 'ring_buffer' in ethernet:
+        max_rx = ethtool.get_ring_buffer_max('rx')
+        if not max_rx:
+            raise ConfigError(
+                'Driver does not support RX ring-buffer configuration!')
+
+        max_tx = ethtool.get_ring_buffer_max('tx')
+        if not max_tx:
+            raise ConfigError(
+                'Driver does not support TX ring-buffer configuration!')
+
+        rx = dict_search('ring_buffer.rx', ethernet)
+        if rx and int(rx) > int(max_rx):
+            raise ConfigError(f'Driver only supports a maximum RX ring-buffer ' \
+                              f'size of "{max_rx}" bytes!')
+
+        tx = dict_search('ring_buffer.tx', ethernet)
+        if tx and int(tx) > int(max_tx):
+            raise ConfigError(f'Driver only supports a maximum TX ring-buffer ' \
+                              f'size of "{max_tx}" bytes!')
+
+
+def verify_offload(ethernet: dict, ethtool: Ethtool):
+    """
+     Verify offloading capabilities
+    :param ethernet: dictionary which is received from get_interface_dict
+    :type ethernet: dict
+    :param ethtool: Ethernet object
+    :type ethtool: Ethtool
+    """
+    if dict_search('offload.rps', ethernet) != None:
+        if not os.path.exists(f'/sys/class/net/{ethernet["ifname"]}/queues/rx-0/rps_cpus'):
+            raise ConfigError('Interface does not suport RPS!')
+    driver = ethtool.get_driver_name()
+    # T3342 - Xen driver requires special treatment
+    if driver == 'vif':
+        if int(ethernet['mtu']) > 1500 and dict_search('offload.sg', ethernet) == None:
+            raise ConfigError('Xen netback drivers requires scatter-gatter offloading '\
+                              'for MTU size larger then 1500 bytes')
+
+
+def verify_allowedbond_changes(ethernet: dict):
+    """
+     Verify changed options if interface is in bonding
+    :param ethernet: dictionary which is received from get_interface_dict
+    :type ethernet: dict
+    """
+    if ethernet['bond_blocked_changes']:
+        for option in ethernet['bond_blocked_changes']:
+            raise ConfigError(f'Cannot configure {option} ' \
+                              f'on interface {ethernet["ifname"]}.' \
+                              f' Interface is a bond member')
+
+
 def verify(ethernet):
     if 'deleted' in ethernet:
         return None
+    if 'is_bond_member' in ethernet:
+        verify_bond_member(ethernet)
+    else:
+        verify_ethernet(ethernet)
 
+
+def verify_bond_member(ethernet):
+    """
+     Verification function for ethernet interface which is in bonding
+    :param ethernet: dictionary which is received from get_interface_dict
+    :type ethernet: dict
+    """
+    ifname = ethernet['ifname']
+    verify_interface_exists(ifname)
+    verify_bond_bridge_member(ethernet)
+    verify_eapol(ethernet)
+    verify_mirror_redirect(ethernet)
+    ethtool = Ethtool(ifname)
+    verify_speed_duplex(ethernet, ethtool)
+    verify_flow_control(ethernet, ethtool)
+    verify_ring_buffer(ethernet, ethtool)
+    verify_offload(ethernet, ethtool)
+    verify_allowedbond_changes(ethernet)
+
+def verify_ethernet(ethernet):
+    """
+     Verification function for simple ethernet interface
+    :param ethernet: dictionary which is received from get_interface_dict
+    :type ethernet: dict
+    """
     ifname = ethernet['ifname']
     verify_interface_exists(ifname)
     verify_mtu(ethernet)
@@ -94,64 +266,16 @@ def verify(ethernet):
     verify_bond_bridge_member(ethernet)
     verify_eapol(ethernet)
     verify_mirror_redirect(ethernet)
-
     ethtool = Ethtool(ifname)
     # No need to check speed and duplex keys as both have default values.
-    if ((ethernet['speed'] == 'auto' and ethernet['duplex'] != 'auto') or
-        (ethernet['speed'] != 'auto' and ethernet['duplex'] == 'auto')):
-            raise ConfigError('Speed/Duplex missmatch. Must be both auto or manually configured')
-
-    if ethernet['speed'] != 'auto' and ethernet['duplex'] != 'auto':
-        # We need to verify if the requested speed and duplex setting is
-        # supported by the underlaying NIC.
-        speed = ethernet['speed']
-        duplex = ethernet['duplex']
-        if not ethtool.check_speed_duplex(speed, duplex):
-            raise ConfigError(f'Adapter does not support changing speed and duplex '\
-                              f'settings to: {speed}/{duplex}!')
-
-    if 'disable_flow_control' in ethernet:
-        if not ethtool.check_flow_control():
-            raise ConfigError('Adapter does not support changing flow-control settings!')
-
-    if 'ring_buffer' in ethernet:
-        max_rx = ethtool.get_ring_buffer_max('rx')
-        if not max_rx:
-            raise ConfigError('Driver does not support RX ring-buffer configuration!')
-
-        max_tx = ethtool.get_ring_buffer_max('tx')
-        if not max_tx:
-            raise ConfigError('Driver does not support TX ring-buffer configuration!')
-
-        rx = dict_search('ring_buffer.rx', ethernet)
-        if rx and int(rx) > int(max_rx):
-            raise ConfigError(f'Driver only supports a maximum RX ring-buffer '\
-                              f'size of "{max_rx}" bytes!')
-
-        tx = dict_search('ring_buffer.tx', ethernet)
-        if tx and int(tx) > int(max_tx):
-            raise ConfigError(f'Driver only supports a maximum TX ring-buffer '\
-                              f'size of "{max_tx}" bytes!')
-
-    # verify offloading capabilities
-    if dict_search('offload.rps', ethernet) != None:
-        if not os.path.exists(f'/sys/class/net/{ifname}/queues/rx-0/rps_cpus'):
-            raise ConfigError('Interface does not suport RPS!')
-
-    driver = ethtool.get_driver_name()
-    # T3342 - Xen driver requires special treatment
-    if driver == 'vif':
-        if int(ethernet['mtu']) > 1500 and dict_search('offload.sg', ethernet) == None:
-            raise ConfigError('Xen netback drivers requires scatter-gatter offloading '\
-                              'for MTU size larger then 1500 bytes')
-
-    if {'is_bond_member', 'mac'} <= set(ethernet):
-        Warning(f'changing mac address "{mac}" will be ignored as "{ifname}" ' \
-                f'is a member of bond "{is_bond_member}"'.format(**ethernet))
-
+    verify_speed_duplex(ethernet, ethtool)
+    verify_flow_control(ethernet, ethtool)
+    verify_ring_buffer(ethernet, ethtool)
+    verify_offload(ethernet, ethtool)
     # use common function to verify VLAN configuration
     verify_vlan_config(ethernet)
     return None
+
 
 def generate(ethernet):
     # render real configuration file once

--- a/src/migration-scripts/interfaces/29-to-30
+++ b/src/migration-scripts/interfaces/29-to-30
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from sys import argv
+from vyos.configtree import ConfigTree
+from vyos.validate import is_bond_member_allowed_option
+
+if (len(argv) < 1):
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+with open(file_name, 'r') as f:
+    config_file = f.read()
+    base = ['interfaces', 'bonding']
+
+config = ConfigTree(config_file)
+
+for bond in config.list_nodes(base):
+    member_base = base + [bond, 'member', 'interface']
+    if config.exists(member_base):
+        for interface in config.return_values(member_base):
+            if_base = ['interfaces', 'ethernet', interface]
+            if config.exists(if_base):
+                for option in config.list_nodes(if_base):
+                    if not is_bond_member_allowed_option(option.replace('-','_')):
+                        config.delete(if_base + [option])
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print(f'Failed to save the modified config: {e}')
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
If an interface is a bond member, disable to change interface options 
which should be changed under the bond interface section.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5254

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
interfaces

## Proposed changes
<!--- Describe your changes in detail -->
If interface is  bond member, disable to change interface options 
which should be changed under bond interface section.

Suggested allowed options for changes :
'description',
'disable',
'disable_flow_control',
'disable_link_detect',
'duplex',
'eapol',
'mirror',
'offload',
'redirect',
'ring-buffer',
'speed',
'hw_id'

All others will be disabled for changes in the interface ethernet section if that interface is a bond member.

For example:
You can not add interface 'eth0' to bond interface 'bond0', if 'mtu' is configured in the interface 'eth0' section.
You can not change 'mtu' in the interface 'eth0' section if interface 'eth0' is a bond member.


## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configuration:
```
set interfaces bonding bond0 member interface 'eth1'

vyos@vyos# set interfaces ethernet eth1 mtu 9000
[edit]
vyos@vyos# commit

Cannot configure mtu on interface eth1. Interface is a bond member

[[interfaces ethernet eth1]] failed
Commit failed
[edit]
vyos@vyos#

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
