### PR TITLE
T4983: Add ping check for wwan

### DIFF
--- a/interface-definitions/interfaces-wwan.xml.in
+++ b/interface-definitions/interfaces-wwan.xml.in
@@ -36,6 +36,67 @@
           <leafNode name="mtu">
             <defaultValue>1430</defaultValue>
           </leafNode>
+          <node name="ping-check">
+            <properties>
+              <help>Use ping check rather than interface state check for automatic re-dial</help>
+            </properties>
+            <children>
+              <leafNode name="enable">
+                <properties>
+                  <help>Enable ping check instead of interface state check</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="address">
+                <properties>
+                  <help>Ping target</help>
+                  <constraint>
+                    <validator name="ipv4-address"/>
+                    <validator name="ipv6-address"/>
+                    <validator name="fqdn"/>
+                  </constraint>
+                  <valueHelp>
+                    <format>ipv4</format>
+                    <description>IP address of ping target</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ipv6</format>
+                    <description>IPv6 address of ping target</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>hostname</format>
+                    <description>Fully qualified domain name of ping target</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
+              <leafNode name="count">
+                <properties>
+                  <help>Number of requests to send</help>
+                  <valueHelp>
+                    <format>u32:1-655340</format>
+                    <description>Amount</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 1-655340"/>
+                  </constraint>
+                </properties>
+                <defaultValue>4</defaultValue>
+              </leafNode>
+              <leafNode name="deadline">
+                <properties>
+                  <help>Number of seconds before ping exits</help>
+                  <valueHelp>
+                    <format>u32:1-655340</format>
+                    <description>Seconds</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 1-655340"/>
+                  </constraint>
+                </properties>
+                <defaultValue>30</defaultValue>
+              </leafNode>
+            </children>
+          </node>
           #include <include/interface/ipv4-options.xml.i>
           #include <include/interface/ipv6-options.xml.i>
           #include <include/interface/dial-on-demand.xml.i>

--- a/src/conf_mode/interfaces-wwan.py
+++ b/src/conf_mode/interfaces-wwan.py
@@ -101,6 +101,9 @@ def verify(wwan):
     verify_vrf(wwan)
     verify_mirror_redirect(wwan)
 
+    if ('ping-check' in wwan) and ('enable' in wwan['ping-check']) and ('address' not in wwan['ping-check']):
+        raise ConfigError(f'An address is required with ping-check for "{ifname}"')
+
     return None
 
 def generate(wwan):
@@ -127,7 +130,7 @@ def apply(wwan):
     if not is_systemd_service_active(service_name):
         cmd(f'systemctl start {service_name}')
 
-        counter = 100
+        counter = 200
         # Wait until a modem is detected and then we can continue
         while counter > 0:
             counter -= 1

--- a/src/helpers/vyos-check-wwan.py
+++ b/src/helpers/vyos-check-wwan.py
@@ -17,6 +17,7 @@
 from vyos.configquery import VbashOpRun
 from vyos.configquery import ConfigTreeQuery
 
+from vyos.utils.process import rc_cmd
 from vyos.utils.network import is_wwan_connected
 
 conf = ConfigTreeQuery()
@@ -28,6 +29,13 @@ for interface, interface_config in dict.items():
         if 'disable' in interface_config:
             # do not restart this interface as it's disabled by the user
             continue
+
+        # user wish to use ping to validate interface
+        if 'enable' in interface_config.get("ping-check"):
+            rc, output = rc_cmd(["/bin/ping", "-c", interface_config.get("count"), "-w", interface_config.get("deadline"), interface_config.get("address")])
+            if rc != 0:
+                op = VbashOpRun()
+                op.run(['disconnect', 'interface', interface])
 
         op = VbashOpRun()
         op.run(['connect', 'interface', interface])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
During the periodically run of `src/helpers/vyos-check-wwan.py` rather than using just run command to connect the interface, it first ping to a target, if the ping are unsuccessful, it will disconnect the interface first before connect the interface.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4983

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wwan

## Proposed changes
<!--- Describe your changes in detail -->
- Add configuration option to set ping check parameters.
- Update `counter = 200` to extend the time it wait for the modem to be detected. (This was needed in some wwan modem that I tested)
- Add ping check which will disconnect the interface if failed first before attempt to re-connect at `src/helpers/vyos-check-wwan.py`

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

1. Configure a normal wwan interface

```bash
set interfaces wwan wwan0 address 'dhcp'
set interfaces wwan wwan0 apn 'internet'
set interfaces wwan wwan0 description 'WWAN0 4G'
```

2. Then observe the behavior, within 2 week, the router interface wwan0 will no longer be able to connect to the internet.

3. Update wwan interface with ping-check

```bash
set interfaces wwan wwan0 address 'dhcp'
set interfaces wwan wwan0 apn 'internet'
set interfaces wwan wwan0 description 'WWAN0 4G'
set interfaces wwan wwan0 ping-check address '1.1.1.1'
set interfaces wwan wwan0 ping-check deadline '30'
set interfaces wwan wwan0 ping-check enable
```

4. Observe that when the disconnect appear, it will reconnect itself.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
