### PR TITLE
T4889: NAT Redirect: adddestination nat redirection (to local host) feature.

### DIFF
--- a/interface-definitions/nat.xml.in
+++ b/interface-definitions/nat.xml.in
@@ -44,6 +44,14 @@
                   </leafNode>
                   #include <include/nat-translation-port.xml.i>
                   #include <include/nat-translation-options.xml.i>
+                  <node name="redirect">
+                    <properties>
+                      <help>Redirect to local host</help>
+                    </properties>
+                    <children>
+                      #include <include/nat-translation-port.xml.i>
+                    </children>
+                  </node>
                 </children>
               </node>
             </children>

--- a/smoketest/scripts/cli/test_nat.py
+++ b/smoketest/scripts/cli/test_nat.py
@@ -231,5 +231,26 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
 
         self.verify_nftables(nftables_search, 'ip vyos_static_nat')
 
+    def test_dnat_redirect(self):
+        dst_addr_1 = '10.0.1.1'
+        dest_port = '5122'
+        protocol = 'tcp'
+        redirected_port = '22'
+        ifname = 'eth0'
+
+        self.cli_set(dst_path + ['rule', '10', 'destination', 'address', dst_addr_1])
+        self.cli_set(dst_path + ['rule', '10', 'destination', 'port', dest_port])
+        self.cli_set(dst_path + ['rule', '10', 'protocol', protocol])
+        self.cli_set(dst_path + ['rule', '10', 'inbound-interface', ifname])
+        self.cli_set(dst_path + ['rule', '10', 'translation', 'redirect', 'port', redirected_port])
+
+        self.cli_commit()
+
+        nftables_search = [
+            [f'iifname "{ifname}"', f'ip daddr {dst_addr_1}', f'{protocol} dport {dest_port}', f'redirect to :{redirected_port}']
+        ]
+
+        self.verify_nftables(nftables_search, 'ip vyos_nat')
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/nat.py
+++ b/src/conf_mode/nat.py
@@ -72,6 +72,7 @@ def verify_rule(config, err_msg, groups_dict):
     """ Common verify steps used for both source and destination NAT """
 
     if (dict_search('translation.port', config) != None or
+        dict_search('translation.redirect.port', config) != None or
         dict_search('destination.port', config) != None or
         dict_search('source.port', config)):
 
@@ -221,7 +222,7 @@ def verify(nat):
             elif config['inbound_interface'] not in 'any' and config['inbound_interface'] not in interfaces():
                 Warning(f'rule "{rule}" interface "{config["inbound_interface"]}" does not exist on this system')
 
-            if not dict_search('translation.address', config) and not dict_search('translation.port', config):
+            if not dict_search('translation.address', config) and not dict_search('translation.port', config) and not dict_search('translation.redirect.port', config):
                 if 'exclude' not in config:
                     raise ConfigError(f'{err_msg} translation requires address and/or port')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add destination NAT redirection to local-host

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4889

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@redirect# run show config comm | grep nat
set nat destination rule 10 destination port '5121'
set nat destination rule 10 inbound-interface 'eth0'
set nat destination rule 10 protocol 'tcp'
set nat destination rule 10 translation redirect port '21'
set nat destination rule 20 destination address '195.12.12.12'
set nat destination rule 20 inbound-interface 'eth0'
set nat destination rule 20 protocol 'tcp'
set nat destination rule 20 translation redirect port '22'
[edit]
vyos@redirect# sudo nft list table ip vyos_nat
table ip vyos_nat {
        chain PREROUTING {
                type nat hook prerouting priority dstnat; policy accept;
                counter packets 15 bytes 3390 jump VYOS_PRE_DNAT_HOOK
                iifname "eth0" tcp dport 5121 counter packets 0 bytes 0 redirect to :21 comment "DST-NAT-10"
                iifname "eth0" meta l4proto tcp ip daddr 195.12.12.12 counter packets 0 bytes 0 redirect to :22 comment "DST-NAT-20"
        }

        chain POSTROUTING {
                type nat hook postrouting priority srcnat; policy accept;
                counter packets 0 bytes 0 jump VYOS_PRE_SNAT_HOOK
        }

        chain VYOS_PRE_DNAT_HOOK {
                return
        }

        chain VYOS_PRE_SNAT_HOOK {
                return
        }
}
[edit]
vyos@redirect# 
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
