### PR TITLE
T5373: LLDP is running even with disable option bug

### DIFF
--- a/data/templates/lldp/vyos.conf.j2
+++ b/data/templates/lldp/vyos.conf.j2
@@ -4,7 +4,7 @@ configure system platform VyOS
 configure system description "VyOS {{ version }}"
 {% if interface is vyos_defined %}
 {%     set tmp = [] %}
-{%     for iface, iface_options in interface.items() if not iface_options.disable %}
+{%     for iface, iface_options in interface.items() if iface_options.disable is not vyos_defined %}
 {%         if iface == 'all' %}
 {%             set iface = '*' %}
 {%         endif %}


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix the template. Do not add interfaces with the `disable` option to the `lldp.conf`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5373

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
lldp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS config:
```
set service lldp interface eth1 disable
set service lldp interface eth2
```
before the fix (only eth2 interface expected):
```
vyos@r14# cat /etc/lldpd.d/01-vyos.conf
### Autogenerated by lldp.py ###

configure system platform VyOS
configure system description "VyOS 1.4-rolling-202307090317"
configure system interface pattern "eth1,eth2"
[edit]
vyos@r14# 

```
After the fix (only eth2 interface expected):
```
vyos@r14# cat /etc/lldpd.d/01-vyos.conf
### Autogenerated by lldp.py ###

configure system platform VyOS
configure system description "VyOS 1.4-rolling-202307090317"
configure system interface pattern "eth2"
[edit]
vyos@r14# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
