### PR TITLE
bgp: T5328: Fixed verifying peer without AFI.

### DIFF
--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -203,14 +203,21 @@ def verify_remote_as(peer_config, bgp_config):
     return None
 
 def verify_afi(peer_config, bgp_config):
+    # If address_family configured under neighboor
     if 'address_family' in peer_config:
         return True
 
+    # If address_family configured under peer-group
+    # if neighbor interface configured
+    peer_group_name = ''
+    if dict_search('interface.peer_group', peer_config):
+        peer_group_name = peer_config['interface']['peer_group']
+    # if neighbor IP configured.
     if 'peer_group' in peer_config:
         peer_group_name = peer_config['peer_group']
+    if peer_group_name:
         tmp = dict_search(f'peer_group.{peer_group_name}.address_family', bgp_config)
         if tmp: return True
-
     return False
 
 def verify(bgp):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed verifying peer without AFI, if the peer is interface.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5328

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp

## Proposed changes
<!--- Describe your changes in detail -->
Fixed verifying peer without AFI, if the peer is interface.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configuration:
```
set protocols bgp neighbor eth0 interface peer-group 'peer1'
set protocols bgp peer-group peer1 address-family ipv4-unicast
set protocols bgp peer-group peer1 remote-as '65535'
set protocols bgp peer-group peer1 update-source 'eth0'
set protocols bgp system-as '65534'
```

Before:
```
vyos@vyos# commit

WARNING: BGP neighbor "eth0" requires address-family!
```

After:
No warning messages

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
