### PR TITLE
ospf: T5377: add graceful restart FRR feature (RFC 3623)

### DIFF
--- a/data/templates/frr/ospf6d.frr.j2
+++ b/data/templates/frr/ospf6d.frr.j2
@@ -80,6 +80,27 @@ router ospf6 {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {% if distance.ospfv3 is vyos_defined %}
  distance ospf6 {{ 'intra-area ' ~ distance.ospfv3.intra_area if distance.ospfv3.intra_area is vyos_defined }} {{ 'inter-area ' ~ distance.ospfv3.inter_area if distance.ospfv3.inter_area is vyos_defined }} {{ 'external ' ~ distance.ospfv3.external if distance.ospfv3.external is vyos_defined }}
 {% endif %}
+{% if graceful_restart is vyos_defined %}
+{%     if graceful_restart.grace_period is vyos_defined %}
+ graceful-restart grace-period {{ graceful_restart.grace_period }}
+{%     endif %}
+{%     if graceful_restart.helper.enable.router_id is vyos_defined %}
+{%         for router_id in graceful_restart.helper.enable.router_id %}
+ graceful-restart helper enable {{ router_id }}
+{%         endfor %}
+{%     elif graceful_restart.helper.enable is vyos_defined %}
+ graceful-restart helper enable
+{%     endif %}
+{%     if graceful_restart.helper.planned_only is vyos_defined %}
+ graceful-restart helper planned-only
+{%     endif %}
+{%     if graceful_restart.helper.lsa_check_disable is vyos_defined %}
+ graceful-restart helper lsa-check-disable
+{%     endif %}
+{%     if graceful_restart.helper.supported_grace_time is vyos_defined %}
+ graceful-restart helper supported-grace-time {{ graceful_restart.helper.supported_grace_time }}
+{%     endif %}
+{% endif %}
 {% if log_adjacency_changes is vyos_defined %}
  log-adjacency-changes {{ "detail" if log_adjacency_changes.detail is vyos_defined }}
 {% endif %}

--- a/data/templates/frr/ospfd.frr.j2
+++ b/data/templates/frr/ospfd.frr.j2
@@ -153,6 +153,27 @@ router ospf {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {% if distance.ospf is vyos_defined %}
  distance ospf {{ 'intra-area ' + distance.ospf.intra_area if distance.ospf.intra_area is vyos_defined }} {{ 'inter-area ' + distance.ospf.inter_area if distance.ospf.inter_area is vyos_defined }} {{ 'external ' + distance.ospf.external if distance.ospf.external is vyos_defined }}
 {% endif %}
+{% if graceful_restart is vyos_defined %}
+{%     if graceful_restart.grace_period is vyos_defined %}
+ graceful-restart grace-period {{ graceful_restart.grace_period }}
+{%     endif %}
+{%     if graceful_restart.helper.enable.router_id is vyos_defined %}
+{%         for router_id in graceful_restart.helper.enable.router_id %}
+ graceful-restart helper enable {{ router_id }}
+{%         endfor %}
+{%     elif graceful_restart.helper.enable is vyos_defined %}
+ graceful-restart helper enable
+{%     endif %}
+{%     if graceful_restart.helper.planned_only is vyos_defined %}
+ graceful-restart helper planned-only
+{%     endif %}
+{%     if graceful_restart.helper.no_strict_lsa_checking is vyos_defined %}
+ no graceful-restart helper strict-lsa-checking
+{%     endif %}
+{%     if graceful_restart.helper.supported_grace_time is vyos_defined %}
+ graceful-restart helper supported-grace-time {{ graceful_restart.helper.supported_grace_time }}
+{%     endif %}
+{% endif %}
 {% if log_adjacency_changes is vyos_defined %}
  log-adjacency-changes {{ "detail" if log_adjacency_changes.detail is vyos_defined }}
 {% endif %}

--- a/data/templates/frr/ospfd.frr.j2
+++ b/data/templates/frr/ospfd.frr.j2
@@ -133,6 +133,9 @@ router ospf {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {% if auto_cost.reference_bandwidth is vyos_defined %}
  auto-cost reference-bandwidth {{ auto_cost.reference_bandwidth }}
 {% endif %}
+{% if capability.opaque is vyos_defined %}
+ capability opaque
+{% endif %}
 {% if default_information.originate is vyos_defined %}
  default-information originate {{ 'always' if default_information.originate.always is vyos_defined }} {{ 'metric ' + default_information.originate.metric if default_information.originate.metric is vyos_defined }} {{ 'metric-type ' + default_information.originate.metric_type if default_information.originate.metric_type is vyos_defined }} {{ 'route-map ' + default_information.originate.route_map if default_information.originate.route_map is vyos_defined }}
 {% endif %}

--- a/interface-definitions/include/ospf/graceful-restart.xml.i
+++ b/interface-definitions/include/ospf/graceful-restart.xml.i
@@ -1,0 +1,67 @@
+<!-- include start from ospf/graceful-restart.xml.i -->
+<node name="graceful-restart">
+  <properties>
+    <help>Graceful Restart</help>
+  </properties>
+  <children>
+    <leafNode name="grace-period">
+      <properties>
+        <help>Maximum length of the grace period</help>
+        <valueHelp>
+          <format>u32:1-1800</format>
+          <description>Maximum length of the grace period in seconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 5-1800"/>
+        </constraint>
+      </properties>
+      <defaultValue>120</defaultValue>
+    </leafNode>
+    <node name="helper">
+      <properties>
+        <help>OSPF graceful-restart helpers</help>
+      </properties>
+      <children>
+        <node name="enable">
+          <properties>
+            <help>Enable helper support</help>
+          </properties>
+          <children>
+            <leafNode name="router-id">
+              <properties>
+                <help>Advertising Router-ID</help>
+                <valueHelp>
+                  <format>ipv4</format>
+                  <description>Router-ID in IP address format</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="ipv4-address"/>
+                </constraint>
+                <multi/>
+              </properties>
+            </leafNode>
+          </children>
+        </node>
+        <leafNode name="planned-only">
+          <properties>
+            <help>Supported only planned restart</help>
+            <valueless/>
+          </properties>
+        </leafNode>
+        <leafNode name="supported-grace-time">
+          <properties>
+            <help>Supported grace timer</help>
+            <valueHelp>
+              <format>u32:10-1800</format>
+              <description>Grace interval in seconds</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 10-1800"/>
+            </constraint>
+          </properties>
+        </leafNode>
+      </children>
+    </node>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/ospf/protocol-common-config.xml.i
+++ b/interface-definitions/include/ospf/protocol-common-config.xml.i
@@ -339,6 +339,21 @@
     </constraint>
   </properties>
 </leafNode>
+#include <include/ospf/graceful-restart.xml.i>
+<node name="graceful-restart">
+  <children>
+    <node name="helper">
+      <children>
+        <leafNode name="no-strict-lsa-checking">
+          <properties>
+            <help>Disable strict LSA check</help>
+            <valueless/>
+          </properties>
+        </leafNode>
+      </children>
+    </node>
+  </children>
+</node>
 <leafNode name="maximum-paths">
   <properties>
     <help>Maximum multiple paths (ECMP)</help>

--- a/interface-definitions/include/ospf/protocol-common-config.xml.i
+++ b/interface-definitions/include/ospf/protocol-common-config.xml.i
@@ -326,6 +326,19 @@
   </children>
 </tagNode>
 #include <include/ospf/auto-cost.xml.i>
+<node name="capability">
+  <properties>
+    <help>Enable specific OSPF features</help>
+  </properties>
+  <children>
+    <leafNode name="opaque">
+      <properties>
+        <help>Opaque LSA</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+  </children>
+</node>
 #include <include/ospf/default-information.xml.i>
 <leafNode name="default-metric">
   <properties>

--- a/interface-definitions/include/ospfv3/protocol-common-config.xml.i
+++ b/interface-definitions/include/ospfv3/protocol-common-config.xml.i
@@ -107,6 +107,21 @@
     </node>
   </children>
 </node>
+#include <include/ospf/graceful-restart.xml.i>
+<node name="graceful-restart">
+  <children>
+    <node name="helper">
+      <children>
+        <leafNode name="lsa-check-disable">
+          <properties>
+            <help>Disable strict LSA check</help>
+            <valueless/>
+          </properties>
+        </leafNode>
+      </children>
+    </node>
+  </children>
+</node>
 <tagNode name="interface">
   <properties>
     <help>Enable routing on an IPv6 interface</help>

--- a/op-mode-definitions/include/ospf/common.xml.i
+++ b/op-mode-definitions/include/ospf/common.xml.i
@@ -502,6 +502,7 @@
     </tagNode>
   </children>
 </node>
+#include <include/ospf/graceful-restart.xml.i>
 <node name="interface">
   <properties>
     <help>Show IPv4 OSPF interface information</help>
@@ -556,4 +557,3 @@
   </children>
 </node>
 <!-- included end -->
-

--- a/op-mode-definitions/include/ospf/graceful-restart.xml.i
+++ b/op-mode-definitions/include/ospf/graceful-restart.xml.i
@@ -1,0 +1,13 @@
+<node name="graceful-restart">
+    <properties>
+      <help>Show IPv4 OSPF Graceful Restart</help>
+    </properties>
+    <children>
+      <leafNode name="helper">
+        <properties>
+          <help>OSPF Graceful Restart helper details</help>
+        </properties>
+        <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+      </leafNode>
+    </children>
+  </node>

--- a/op-mode-definitions/show-ip-ospf.xml.in
+++ b/op-mode-definitions/show-ip-ospf.xml.in
@@ -13,7 +13,7 @@
             </properties>
             <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
             <children>
-              #include <include/ospf-common.xml.i>
+              #include <include/ospf/common.xml.i>
               <tagNode name="vrf">
                 <properties>
                   <help>Show OSPF routing protocol for given VRF</help>
@@ -24,7 +24,7 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
                 <children>
-                  #include <include/ospf-common.xml.i>
+                  #include <include/ospf/common.xml.i>
                 </children>
               </tagNode>
             </children>

--- a/op-mode-definitions/show-ipv6-ospfv3.xml.in
+++ b/op-mode-definitions/show-ipv6-ospfv3.xml.in
@@ -41,6 +41,7 @@
               </tagNode>
               #include <include/ospfv3/border-routers.xml.i>
               #include <include/ospfv3/database.xml.i>
+              #include <include/ospf/graceful-restart.xml.i>
               #include <include/ospfv3/interface.xml.i>
               #include <include/ospfv3/linkstate.xml.i>
               #include <include/ospfv3/neighbor.xml.i>
@@ -94,6 +95,7 @@
                   </tagNode>
                   #include <include/ospfv3/border-routers.xml.i>
                   #include <include/ospfv3/database.xml.i>
+                  #include <include/ospf/graceful-restart.xml.i>
                   #include <include/ospfv3/interface.xml.i>
                   #include <include/ospfv3/linkstate.xml.i>
                   #include <include/ospfv3/neighbor.xml.i>

--- a/smoketest/scripts/cli/test_protocols_ospf.py
+++ b/smoketest/scripts/cli/test_protocols_ospf.py
@@ -484,6 +484,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         supported_grace_time = '400'
         router_ids = ['192.0.2.1', '192.0.2.2']
 
+        self.cli_set(base_path + ['capability', 'opaque'])
         self.cli_set(base_path + ['graceful-restart', 'grace-period', period])
         self.cli_set(base_path + ['graceful-restart', 'helper', 'planned-only'])
         self.cli_set(base_path + ['graceful-restart', 'helper', 'no-strict-lsa-checking'])
@@ -497,6 +498,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         # Verify FRR ospfd configuration
         frrconfig = self.getFRRconfig('router ospf')
         self.assertIn(f'router ospf', frrconfig)
+        self.assertIn(f' capability opaque', frrconfig)
         self.assertIn(f' graceful-restart grace-period {period}', frrconfig)
         self.assertIn(f' graceful-restart helper planned-only', frrconfig)
         self.assertIn(f' no graceful-restart helper strict-lsa-checking', frrconfig)

--- a/smoketest/scripts/cli/test_protocols_ospfv3.py
+++ b/smoketest/scripts/cli/test_protocols_ospfv3.py
@@ -281,5 +281,31 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(['vrf', 'name', vrf])
         self.cli_delete(['interfaces', 'ethernet', vrf_iface, 'vrf'])
 
+
+    def test_ospfv3_09_graceful_restart(self):
+        period = '300'
+        supported_grace_time = '400'
+        router_ids = ['192.0.2.1', '192.0.2.2']
+
+        self.cli_set(base_path + ['graceful-restart', 'grace-period', period])
+        self.cli_set(base_path + ['graceful-restart', 'helper', 'planned-only'])
+        self.cli_set(base_path + ['graceful-restart', 'helper', 'lsa-check-disable'])
+        self.cli_set(base_path + ['graceful-restart', 'helper', 'supported-grace-time', supported_grace_time])
+        for router_id in router_ids:
+            self.cli_set(base_path + ['graceful-restart', 'helper', 'enable', 'router-id', router_id])
+
+        # commit changes
+        self.cli_commit()
+
+        # Verify FRR ospfd configuration
+        frrconfig = self.getFRRconfig('router ospf6')
+        self.assertIn(f'router ospf6', frrconfig)
+        self.assertIn(f' graceful-restart grace-period {period}', frrconfig)
+        self.assertIn(f' graceful-restart helper planned-only', frrconfig)
+        self.assertIn(f' graceful-restart helper lsa-check-disable', frrconfig)
+        self.assertIn(f' graceful-restart helper supported-grace-time {supported_grace_time}', frrconfig)
+        for router_id in router_ids:
+            self.assertIn(f' graceful-restart helper enable {router_id}', frrconfig)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/protocols_ospf.py
+++ b/src/conf_mode/protocols_ospf.py
@@ -88,6 +88,8 @@ def get_config(config=None):
         del default_values['area']['area_type']['nssa']
     if 'mpls_te' not in ospf:
         del default_values['mpls_te']
+    if 'graceful_restart' not in ospf:
+        del default_values['graceful_restart']
 
     for protocol in ['babel', 'bgp', 'connected', 'isis', 'kernel', 'rip', 'static', 'table']:
         # table is a tagNode thus we need to clean out all occurances for the

--- a/src/conf_mode/protocols_ospfv3.py
+++ b/src/conf_mode/protocols_ospfv3.py
@@ -83,6 +83,8 @@ def get_config(config=None):
     # need to check this first and probably drop that key.
     if dict_search('default_information.originate', ospfv3) is None:
         del default_values['default_information']
+    if 'graceful_restart' not in ospfv3:
+        del default_values['graceful_restart']
 
     # XXX: T2665: we currently have no nice way for defaults under tag nodes,
     # clean them out and add them manually :(


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5377

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* ospf
* ospfv3

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Either use the embedded smoketests .. or

### OSPFv2

```bash
set protocols ospf graceful-restart grace-period 300
set protocols ospf graceful-restart helper planned-only
set protocols ospf graceful-restart helper no-strict-lsa-checking
set protocols ospf graceful-restart helper supported-grace-time 400
set protocols ospf graceful-restart helper enable router-id 192.0.2.1
set protocols ospf graceful-restart helper enable router-id 192.0.2.2
```

### OSPFv3

```bash
set protocols ospfv3 graceful-restart grace-period 300
set protocols ospfv3 graceful-restart helper planned-only
set protocols ospfv3 graceful-restart helper lsa-check-disable
set protocols ospfv3 graceful-restart helper supported-grace-time 400
set protocols ospfv3 graceful-restart helper enable router-id 192.0.2.1
set protocols ospfv3 graceful-restart helper enable router-id 192.0.2.2
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
