### PR TITLE
T5368: service ids ddos-protection add support sflow mode

### DIFF
--- a/data/templates/ids/fastnetmon.j2
+++ b/data/templates/ids/fastnetmon.j2
@@ -29,9 +29,18 @@ unban_only_if_attack_finished = on
 # For each subnet, list track speed in bps and pps for both directions
 enable_subnet_counters = off
 
-{% if mode.mirror is vyos_defined %}
+{% if mode is vyos_defined('mirror') %}
 mirror_afpacket = on
+{% elif mode is vyos_defined('sflow') %}
+sflow = on
+{%     if sflow.port is vyos_defined %}
+sflow_port = {{ sflow.port }}
+{%     endif %}
+{%     if sflow.listen_address is vyos_defined %}
+sflow_host = {{ sflow.listen_address }}
+{%     endif %}
 {% endif %}
+
 
 process_incoming_traffic = {{ 'on' if direction is vyos_defined and 'in' in direction else 'off' }}
 process_outgoing_traffic = {{ 'on' if direction is vyos_defined and 'out' in direction else 'off' }}

--- a/data/templates/ids/fastnetmon_networks_list.j2
+++ b/data/templates/ids/fastnetmon_networks_list.j2
@@ -1,4 +1,4 @@
-{% if network is vyos_defined() %}
+{% if network is vyos_defined %}
 {%     for net in network %}
 {{ net }}
 {%     endfor %}

--- a/interface-definitions/service-ids-ddos-protection.xml.in
+++ b/interface-definitions/service-ids-ddos-protection.xml.in
@@ -70,17 +70,34 @@
                   <multi/>
                 </properties>
               </leafNode>
-              <node name="mode">
+              <leafNode name="mode">
                 <properties>
-                  <help>Traffic capture modes</help>
+                  <help>Traffic capture mode</help>
+                  <completionHelp>
+                    <list>mirror sflow</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>mirror</format>
+                    <description>Listen to mirrored traffic</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>sflow</format>
+                    <description>Capture sFlow flows</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(mirror|sflow)</regex>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <node name="sflow">
+                <properties>
+                  <help>Sflow settings</help>
                 </properties>
                 <children>
-                  <!-- Future modes "mirror" "netflow" "combine (both)" -->
-                  <leafNode name="mirror">
-                    <properties>
-                      <help>Listen mirrored traffic mode</help>
-                      <valueless/>
-                    </properties>
+                  #include <include/listen-address-ipv4-single.xml.i>
+                  #include <include/port-number.xml.i>
+                  <leafNode name="port">
+                    <defaultValue>6343</defaultValue>
                   </leafNode>
                 </children>
               </node>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
sFlow mode requires fewer resources then mode `mirror`
Integrate it into configuration mode
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5368

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Get flows from eth0 interface and export them to FastNetmon
```
set system sflow interface 'eth0'
set system sflow interface 'eth1'
set system sflow server 127.0.0.1

set service ids ddos-protection direction 'in'
set service ids ddos-protection mode 'sflow'
set service ids ddos-protection network '192.0.2.0/24'
set service ids ddos-protection sflow listen-address '127.0.0.1'
set service ids ddos-protection sflow port '6343'
set service ids ddos-protection threshold general pps '10000'
```
Send traffic to 192.0.2.1  more than 10Kpps
![fnm](https://github.com/vyos/vyos-1x/assets/12792111/1775a751-2bef-42a7-97b6-81130118f667)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
