### PR TITLE
 T4974:add/fixed enable ovpn-dco by default

### DIFF
--- a/data/templates/openvpn/server.conf.j2
+++ b/data/templates/openvpn/server.conf.j2
@@ -48,6 +48,10 @@ push "redirect-gateway def1"
 {% if use_lzo_compression is vyos_defined %}
 compress lzo
 {% endif %}
+{% if enable_dco is not vyos_defined %}
+disable-dco
+{% endif %}
+
 
 {% if mode is vyos_defined('client') %}
 #

--- a/interface-definitions/interfaces-openvpn.xml.in
+++ b/interface-definitions/interfaces-openvpn.xml.in
@@ -793,6 +793,12 @@
               <valueless/>
             </properties>
           </leafNode>
+          <leafNode name="enable-dco">
+            <properties>
+              <help>Use to enable OpenVPN data channel offload on this TUN interface</help>
+              <valueless/>
+            </properties>
+          </leafNode>
           #include <include/interface/redirect.xml.i>
           #include <include/interface/vrf.xml.i>
         </children>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->
By default is enabled ovpn-dco when the kernel is loaded ,this option disable by default and allows the user to enable it when is needed , it avoid problem  based on limitation dco. 
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4974

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openvpn
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

this options is added on the openvpn interfaces : 
```
when the command is present on vyos-cli : 

set interfaces openvpn vtun10 enable-dco

7: vtun10: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/none  promiscuity 0  allmulti 0 minmtu 68 maxmtu 65463
    ovpn-dco addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536

when the command is not present : 

: OpenVPN 2.6.3 x86_64-pc-linux-gnu [SSL (OpenSSL)] [LZO] [LZ4] [EPOLL] [PKCS11] [MH/PKTINFO] [AEAD] [DCO]
Jul 21 21:43:36 dco1 openvpn-vtun10[2301]: library versions: OpenSSL 3.0.9 30 May 2023, LZO 2.10
Jul 21 21:43:36 dco1 openvpn-vtun10[2301]: DCO version: N/A
Jul 21 21:43:36 dco1 openvpn-vtun10[2301]: MANAGEMENT: unix domain socket listening on /run/openvpn/openvpn-mgmt-intf
Jul 21 21:43:36 dco1 systemd[1]: Started openvpn@vtun10.service - OpenVPN connection to vtun10.


6: vtun10: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 500
    link/none  promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535
    tun type tun pi off vnet_hdr off persist on addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 6553

````


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
