### PR TITLE
static: T5398: do not mangle interface names in FRR

### DIFF
--- a/src/conf_mode/protocols_static.py
+++ b/src/conf_mode/protocols_static.py
@@ -47,7 +47,7 @@ def get_config(config=None):
     base_path = ['protocols', 'static']
     # eqivalent of the C foo ? 'a' : 'b' statement
     base = vrf and ['vrf', 'name', vrf, 'protocols', 'static'] or base_path
-    static = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
+    static = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True, no_tag_node_value_mangle=True)
 
     # Assign the name of our VRF context
     if vrf: static['vrf'] = vrf


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
This PR resolves an issue when configuring static routes involving interfaces containing a `-` in the name. When rendered to FRR, the interface is mangled to an underscore `_`. This is most noticeable when creating static VRF-leaked routes for container networks:

`pod-TEST` becomes `pod_TEST`

```
# VyOS
container {
  name TEST {
     image ubuntu:20.04
     network TEST {
     }
  }
  network TEST {
     prefix 192.168.1.0/24
  }
}
vrf {
  name TEST {
    protocols {
        static {
             route 192.168.1.0/24 {
                 interface pod-TEST {
                     vrf default
                 }
             }
         }
    }
  }

}
```

```
# FRR rendered configuration
!
vrf TEST
 ip route 192.168.1.0/24 pod_TEST nexthop-vrf default
exit-vrf
!
```

No static route is installed into the table due to the mismatching interface name:
```
jvoss@test-R1:~$ show ip route vrf TEST static
jvoss@test-R1:~$ 
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5398

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* protocols static

## Proposed changes
<!--- Describe your changes in detail -->
Update the static configuration retrieval in `protocols_static.py` to not mangle node values by adding the `no_tag_node_value_mangle=True` option.

## How to test
Perform the configuration changes as documented in the change summary. However after this change is applied and `vyos-configd` is restarted the interface name is no longer mangled:

```
# FRR rendered configuration
!
vrf TEST
 ip route 192.168.1.0/24 pod-TEST nexthop-vrf default
exit-vrf
!
```

The route is also installed into the routing table:
```
jvoss@test-R1:~$ show ip route vrf TEST static
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

VRF TEST:
S>* 192.168.1.0/24 [1/0] is directly connected, pod-TEST (vrf default), weight 1, 00:00:45
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
