### PR TITLE
container: T5401: only migrate non-overlay images

### DIFF
--- a/src/migration-scripts/container/0-to-1
+++ b/src/migration-scripts/container/0-to-1
@@ -22,6 +22,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 from vyos.utils.process import call
+from vyos.utils.process import rc_cmd
 
 if (len(sys.argv) < 1):
     print("Must specify file name!")
@@ -35,15 +36,21 @@ with open(file_name, 'r') as f:
 base = ['container', 'name']
 config = ConfigTree(config_file)
 
-# Check if containers exist and we need to perform image manipulation
+# Check if non-overlay containers exist and we need to perform image manipulation
 if config.exists(base):
     for container in config.list_nodes(base):
+        image_name = config.return_value(base + [container, 'image'])
+        rc, image_type = rc_cmd(f'sudo podman image inspect --format "{{{{ .GraphDriver.Name }}}}" {image_name}')
+
+        # Skip overlay images
+        if image_type == 'overlay':
+            continue
+
         # Stop any given container first
         call(f'sudo systemctl stop vyos-container-{container}.service')
         # Export container image for later re-import to new filesystem. We store
         # the backup on a real disk as a tmpfs (like /tmp) could probably lack
         # memory if a host has too many containers stored.
-        image_name = config.return_value(base + [container, 'image'])
         call(f'sudo podman image save --quiet --output /root/{container}.tar --format oci-archive {image_name}')
 
 # No need to adjust the strage driver online (this is only used for testing and
@@ -63,15 +70,12 @@ for dir in ['libpod', 'vfs', 'vfs-containers', 'vfs-images', 'vfs-layers']:
 # filesystem mode. Time to re-import the images.
 if config.exists(base):
     for container in config.list_nodes(base):
-        # Export container image for later re-import to new filesystem
-        image_name = config.return_value(base + [container, 'image'])
         image_path = f'/root/{container}.tar'
-        call(f'sudo podman image load --quiet --input {image_path}')
+        if os.path.exists(image_path):
+            call(f'sudo podman image load --quiet --input {image_path}')
+
+            # Delete temporary container image
+            os.unlink(image_path)
 
         # Start any given container first
         call(f'sudo systemctl start vyos-container-{container}.service')
-
-        # Delete temporary container image
-        if os.path.exists(image_path):
-            os.unlink(image_path)
-


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
This PR refactors the container 0-to-1 migration script to only migrate containers that have non-overlay filesystem images instead of all images.

Previously the migration script does this for all containers regardless of type which means each container was stopped, exported, imported, started every time the configuration was changed which is impactful to applications running in the containers (and potentially traffic)

```
yzguy@test-R1# sudo podman ps
CONTAINER ID  IMAGE                              COMMAND               CREATED         STATUS             PORTS       NAMES
3f0e2eea05aa  docker.io/cloudflare/gortr:latest  -cache https://dn...  57 minutes ago  Up 57 minutes ago              gortr
[edit]
yzguy@test-R1# load /var/tmp/config.txt
Loading configuration from '/var/tmp/config.txt'
No configuration changes to commit.
[edit]
yzguy@test-R1# sudo podman ps
CONTAINER ID  IMAGE                              COMMAND               CREATED         STATUS             PORTS       NAMES
6a729c2e5ed8  docker.io/cloudflare/gortr:latest  -cache https://dn...  16 seconds ago  Up 16 seconds ago              gortr
[edit]
yzguy@test-R1# load /var/tmp/config.txt
Loading configuration from '/var/tmp/config.txt'
No configuration changes to commit.
[edit]
yzguy@test-R1# sudo podman ps
CONTAINER ID  IMAGE                              COMMAND               CREATED         STATUS             PORTS       NAMES
f887a92801ee  docker.io/cloudflare/gortr:latest  -cache https://dn...  14 seconds ago  Up 14 seconds ago              gortr
[edit]
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5401

## Component(s) name
container

## Proposed changes
Update container migration script to grab the filesystem type for each image a container uses and only perform the migration when it's not overlay.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

1. Save current configuration (from configure) - `show > /var/tmp/config.txt`
2. Add container to container section if one does not exist

```
container {
    name gortr {
        allow-host-networks { }
        arguments "-cache https://dn42.burble.com/roa/dn42_roa_46.json -verify=false -checktime=false -bind :8082"
        image "cloudflare/gortr"
        port http {
            destination "8082"
            source "8082"
        }
    }
} 
```

3. Load configuration - `load /var/tmp/config.txt`
4. Apply configuration - `commit`
5. View uptime of container(s) - `sudo podman ps`
6. Apply migration script changes
7. Load configuration again `load /var/tmp/config.txt`
8. Verify container uptime has not reset - `sudo podman ps`

```
yzguy@test-R1# sudo podman ps
CONTAINER ID  IMAGE       COMMAND     CREATED     STATUS      PORTS       NAMES
[edit]
yzguy@test-R1# load /var/tmp/config.txt
Loading configuration from '/var/tmp/config.txt'
Load complete. Use 'commit' to make changes effective.
[edit]
yzguy@test-R1# compare
[]
+ container {
+     name gortr {
+         allow-host-networks { }
+         arguments "-cache https://dn42.burble.com/roa/dn42_roa_46.json -verify=false -checktime=false -bind :8082"
+         image "cloudflare/gortr"
+         port http {
+             destination "8082"
+             source "8082"
+         }
+     }
+ }

[edit]
yzguy@test-R1# commit
[edit]
yzguy@test-R1# sudo podman ps
CONTAINER ID  IMAGE                              COMMAND               CREATED             STATUS                 PORTS       NAMES
a171a51fca1e  docker.io/cloudflare/gortr:latest  -cache https://dn...  About a minute ago  Up About a minute ago              gortr
[edit]
yzguy@test-R1# load /var/tmp/config.txt
Loading configuration from '/var/tmp/config.txt'
No configuration changes to commit.
[edit]
yzguy@test-R1# sudo podman ps
CONTAINER ID  IMAGE                              COMMAND               CREATED         STATUS             PORTS       NAMES
5b42500785bc  docker.io/cloudflare/gortr:latest  -cache https://dn...  25 seconds ago  Up 25 seconds ago              gortr
[edit]
yzguy@test-R1# sudo nvim /opt/vyatta/etc/config-migrate/migrate/container/0-to-1
[edit]
yzguy@test-R1# sudo podman ps
CONTAINER ID  IMAGE                              COMMAND               CREATED             STATUS                 PORTS       NAMES
5b42500785bc  docker.io/cloudflare/gortr:latest  -cache https://dn...  About a minute ago  Up About a minute ago              gortr
[edit]
yzguy@test-R1# load /var/tmp/config.txt
Loading configuration from '/var/tmp/config.txt'
No configuration changes to commit.
[edit]
yzguy@test-R1# sudo podman ps
CONTAINER ID  IMAGE                              COMMAND               CREATED             STATUS                 PORTS       NAMES
5b42500785bc  docker.io/cloudflare/gortr:latest  -cache https://dn...  About a minute ago  Up About a minute ago              gortr
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
