### PR TITLE
container: T5407: increase priority before protocol static

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -3,7 +3,7 @@
   <node name="container" owner="${vyos_conf_scripts_dir}/container.py">
     <properties>
       <help>Container applications</help>
-      <priority>1280</priority>
+      <priority>450</priority>
     </properties>
     <children>
       <tagNode name="name">


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Increase the priority of container configuration to `450` to before protocols/static (`480`).

This is necessary when static routes are pointed at container networks (`pod-<NETWORK_NAME>`). Otherwise configuration validation fails on boot and the entire static route stanza is dropped from the configuration.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5407

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* container

## Proposed changes
This PR updates the priority of container configuration to come before protocol/static. This ensures that any container networks are created prior to any potential static route pointed at a container network.

Prior to this change, after reboot, any static route configured using an interface `pod-<NETWORK-NAME>` fails validation and static routes are rejected from the configuration. This presents a configuration error message to users when entering configuration mode. Additionally no static routes are installed.

## How to test
1. Configure a container network and container as well as a static route:

```
container {
  name test {
     image ubuntu:20.04
     network TEST {
     }
  }
  network TEST {
     prefix 192.168.0.0/24
  }
}
[...]
protocols {
     static {
         route 192.168.0.0/24 {
             interface pod-TEST {
             }
         }
     }
}
```

2. Validate the route was installed:

```
jvoss@test-R1:~$ show ip route static
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

S>* 192.168.1.0/24 [1/0] is directly connected, pod-TEST, weight 1, 00:00:45
```

3. Reboot

4. Validate the static route persisted in the configuration (prior to this change it is missing)

```
jvoss@test-R1# show protocols static 
 route 192.168.1.0/24 {
     interface pod-TEST {
     }
 }
[edit]
```

6. Validate the route was installed:

```
jvoss@test-R1:~$ show ip route static
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

S>* 192.168.1.0/24 [1/0] is directly connected, pod-TEST, weight 1, 00:00:57
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
