### PR TITLE
T5127: vpnv4/v6 : warning for router-id

### DIFF
--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -475,6 +475,8 @@ def verify(bgp):
                     if verify_vrf_as_import(vrf_name, afi, bgp['dependent_vrfs']):
                         raise ConfigError(
                             'Command "import vrf" conflicts with "rd vpn export" command!')
+                    if not dict_search('parameters.router_id', bgp):
+                        Warning(f'BGP "router-id" is required when using "rd" and "route-target"!')
 
                 if dict_search('route_target.vpn.both', afi_config):
                     if verify_vrf_as_import(vrf_name, afi, bgp['dependent_vrfs']):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

To add a warning if router-id option is not configured when rd and route-target settings are used. The warning is needed in order to avoid an automatic assignment of RD after an interface flap. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5127
* https://vyos.dev/T5252

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->
Added a warning message like this:

```
vyos@vyos# commit
[ vrf name blue protocols bgp ]

WARNING: router-id is needed when rd and route-target are configured!
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
set protocols bgp address-family ipv4-unicast rd vpn export '192.168.255.10:200'
set protocols bgp neighbor 192.168.255.12 address-family ipv4-vpn nexthop-self
set protocols bgp neighbor 192.168.255.12 peer-group 'RR'
set protocols bgp peer-group RR remote-as '65002'
set protocols bgp system-as '65002'
set vrf name blue protocols bgp address-family ipv4-unicast export vpn
set vrf name blue protocols bgp address-family ipv4-unicast import vpn
set vrf name blue protocols bgp address-family ipv4-unicast rd vpn export '192.168.255.10:200'
set vrf name blue protocols bgp address-family ipv4-unicast route-target vpn export '65002:200'
set vrf name blue protocols bgp system-as '65002'
set vrf name blue table '200'

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
