### PR TITLE
dhcp-server: T5414: improve bootfile-name constraint pattern

### DIFF
--- a/interface-definitions/dhcp-server.xml.in
+++ b/interface-definitions/dhcp-server.xml.in
@@ -129,7 +129,7 @@
                     <properties>
                       <help>Bootstrap file name</help>
                       <constraint>
-                        <regex>[-_a-zA-Z0-9./]+</regex>
+                        <regex>[-_a-zA-Z0-9.:/~#@!$&*+,;=~%\\\\]+</regex>
                       </constraint>
                     </properties>
                   </leafNode>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This pull request expands the accepted character set for the bootfile-name option in the DHCP server configuration of VyOS. The original pattern `[-_a-zA-Z0-9./]+` has been updated to `[-_a-zA-Z0-9.:/~#@!$&*+,;=~%\\\\]+` to accommodate a broader range of input, including full URLs, file paths, bare filenames, and a subset of [RFC 3886](https://www.rfc-editor.org/rfc/rfc3986) reserved characters (excluding `[]` `'` `()`). This change allows DHCP server configurations in VyOS to support functions like zero-touch provisioning of network devices, which rely on the `bootfile-name` (`Option 67`) for fetching boot instructions. The new pattern also adds simple handling of "[% encoding](https://www.rfc-editor.org/rfc/rfc3986#section-2.1)", and supports Windows paths used for services like [Windows Deployment Services](https://web.archive.org/web/20160910100740/https://technet.microsoft.com/en-us/library/cc766320.aspx). This adjustment addresses the limitation that was preventing the system from accepting valid configurations and hindering the migration of existing (legacy) configurations during a VyOS upgrade.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5414

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-server

## Proposed changes
<!--- Describe your changes in detail -->

Change the constraint regex pattern to: `[-_a-zA-Z0-9.:/~#@!$&*+,;=~%\\\\]+`

This adjustment expands the existing pattern to accommodate full URLs, file paths, and bare filenames. It also adds a subset of [RFC 3886](https://www.rfc-editor.org/rfc/rfc3986) "[reserved](https://www.rfc-editor.org/rfc/rfc3986#section-2.2)" characters (gen-delims and sub-delims), excluding `[]` `'` `()` , due to their rarity and negative interactions with the command line. Additionally, it adds simple handling of "[% encoding](https://www.rfc-editor.org/rfc/rfc3986#section-2.1)".

Finally, the double-escaped `\` enables support for Windows paths like those used for [Windows Deployment Services](https://web.archive.org/web/20160910100740/https://technet.microsoft.com/en-us/library/cc766320.aspx) (ex: `boot\x64\wdsnbp.com`). These land in `dhcpd.conf` as `boot\\x64\\wdsnbp.com`, which passes `dhcpd -t`. An explanation of `string` handling in ISC DHCP's [documentation](https://kb.isc.org/v1/docs/isc-dhcp-44-manual-pages-dhcp-eval) suggests that this is the correct format. See also: [PXE Boot from WDS using ISC DHCPd (r/networking)](https://old.reddit.com/r/networking/comments/3f4z6u/pxe_boot_from_wds_using_isc_dhcpd/).

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

The following commands test the proposed pattern against input validation and against `dhcpd -t` upon commit:

```
configure

cp /opt/vyatta/share/vyatta-cfg/templates/service/dhcp-server/shared-network-name/node.tag/subnet/node.tag/bootfile-name/node.def /tmp/bootfile-name-node.def.bak

# manually edit the regex in node.def to [-_a-zA-Z0-9./:?#@!$&*+,;=~%\\\\]+
sudo vi /opt/vyatta/share/vyatta-cfg/templates/service/dhcp-server/shared-network-name/node.tag/subnet/node.tag/bootfile-name/node.def

sudo systemctl restart vyos-configd

set service dhcp-server shared-network-name TESTNET subnet 203.0.113.0/24 range 0 start 203.0.113.2
set service dhcp-server shared-network-name TESTNET subnet 203.0.113.0/24 range 0 stop 203.0.113.254

set service dhcp-server shared-network-name TESTNET subnet 203.0.113.0/24 bootfile-name "http://example.com/path/to/file.py"
commit
grep "shared-network TESTNET" -A9 /run/dhcp-server/dhcpd.conf

set service dhcp-server shared-network-name TESTNET subnet 203.0.113.0/24 bootfile-name "https://192.0.2.1/path/to/file.py"
commit
grep "shared-network TESTNET" -A9 /run/dhcp-server/dhcpd.conf

set service dhcp-server shared-network-name TESTNET subnet 203.0.113.0/24 bootfile-name "/pxelinux.0"
commit
grep "shared-network TESTNET" -A9 /run/dhcp-server/dhcpd.conf

set service dhcp-server shared-network-name TESTNET subnet 203.0.113.0/24 bootfile-name "boot\x64\wdsnbp.com"
commit
grep "shared-network TESTNET" -A9 /run/dhcp-server/dhcpd.conf

delete service dhcp-server shared-network-name TESTNET
commit

sudo mv /tmp/bootfile-name-node.def.bak /opt/vyatta/share/vyatta-cfg/templates/service/dhcp-server/shared-network-name/node.tag/subnet/node.tag/bootfile-name/node.def
sudo systemctl restart vyos-configd

exit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
