### PR TITLE
T3355: migrate "show dhcp client lease" to new op-mode style

### DIFF
--- a/op-mode-definitions/dhcp.xml.in
+++ b/op-mode-definitions/dhcp.xml.in
@@ -7,6 +7,30 @@
           <help>Show DHCP (Dynamic Host Configuration Protocol) information</help>
         </properties>
         <children>
+          <node name="client">
+            <properties>
+              <help>Show DHCP client information</help>
+            </properties>
+            <children>
+              <node name="leases">
+                <properties>
+                  <help>Show DHCP client leases</help>
+                </properties>
+                <children>
+                  <tagNode name="interface">
+                    <properties>
+                      <help> Show DHCP client information for a given interface</help>
+                      <completionHelp>
+                        <script>${vyos_completion_dir}/list_interfaces --broadcast</script>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/dhcp.py show_client_leases --family inet --interface $6</command>
+                  </tagNode>
+                </children>
+                <command>${vyos_op_scripts_dir}/dhcp.py show_client_leases --family inet</command>
+              </node>
+             </children>
+          </node>
           <node name="server">
             <properties>
               <help>Show DHCP server information</help>

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -14,10 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import sys
 import typing
 
 from datetime import datetime
+from glob import glob
 from ipaddress import ip_address
 from isc_dhcp_leases import IscDhcpLeases
 from tabulate import tabulate
@@ -27,8 +29,9 @@ import vyos.opmode
 from vyos.base import Warning
 from vyos.configquery import ConfigTreeQuery
 
-from vyos.utils.process import cmd
 from vyos.utils.dict import dict_search
+from vyos.utils.file import read_file
+from vyos.utils.process import cmd
 from vyos.utils.process import is_systemd_service_running
 
 config = ConfigTreeQuery()
@@ -286,6 +289,79 @@ def show_server_leases(raw: bool, family: ArgFamily, pool: typing.Optional[str],
     else:
         return _get_formatted_server_leases(lease_data, family=family)
 
+
+def _get_raw_client_leases(family='inet', interface=None):
+    lease_dir = '/var/lib/dhcp'
+    lease_files = []
+    lease_data = []
+
+    if interface:
+        tmp = f'{lease_dir}/dhclient_{interface}.lease'
+        if os.path.exists(tmp):
+            lease_files.append(tmp)
+    else:
+        # All DHCP leases
+        lease_files = glob(f'{lease_dir}/dhclient_*.lease')
+
+    for lease in lease_files:
+        tmp = {}
+        with open(lease, 'r') as f:
+            for line in f.readlines():
+                line = line.rstrip()
+                if 'last_update' not in tmp:
+                    tmp.update({'last_update' : line})
+                    continue
+
+                k, v = line.split('=')
+                tmp.update({k : v.replace("'", "")})
+
+        lease_data.append(tmp)
+
+    return lease_data
+
+def _get_formatted_client_leases(lease_data, family):
+    from time import localtime
+    from time import strftime
+
+    from vyos.validate import is_intf_addr_assigned
+
+    data_entries = []
+    for lease in lease_data:
+        data_entries.append(["Interface", lease['interface']])
+        if 'new_ip_address' in lease:
+            tmp = '[Active]' if is_intf_addr_assigned(lease['interface'], lease['new_ip_address']) else '[Inactive]'
+            data_entries.append(["IP address", lease['new_ip_address'], tmp])
+        if 'new_subnet_mask' in lease:
+            data_entries.append(["Subnet Mask", lease['new_subnet_mask']])
+        if 'new_domain_name' in lease:
+            data_entries.append(["Domain Name", lease['new_domain_name']])
+        if 'new_routers' in lease:
+            data_entries.append(["Router", lease['new_routers']])
+        if 'new_domain_name_servers' in lease:
+            data_entries.append(["Name Server", lease['new_domain_name_servers']])
+        if 'new_dhcp_server_identifier' in lease:
+            data_entries.append(["DHCP Server", lease['new_dhcp_server_identifier']])
+        if 'new_dhcp_lease_time' in lease:
+            data_entries.append(["DHCP Server", lease['new_dhcp_lease_time']])
+        if 'last_update' in lease:
+            data_entries.append(["Last Update", lease['last_update']])
+        if 'new_expiry' in lease:
+            tmp = strftime('%a %b %d %H:%M:%S %Z %Y', localtime(int(lease['new_expiry'])))
+            data_entries.append(["Expiry", tmp])
+
+        # Add empty marker
+        data_entries.append([''])
+
+    output = tabulate(data_entries, tablefmt='plain')
+
+    return output
+
+def show_client_leases(raw: bool, family: ArgFamily, interface: typing.Optional[str]):
+    lease_data = _get_raw_client_leases(family=family, interface=interface)
+    if raw:
+        return lease_data
+    else:
+        return _get_formatted_client_leases(lease_data, family=family)
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3355

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
op-mode DHCP

## Depends On

* https://github.com/vyos/vyatta-op/pull/64

## Proposed changes
<!--- Describe your changes in detail -->

Migrate Perl code to Python

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```bash
vyos@vyos# ${vyos_op_scripts_dir}/dhcp.py show_client_leases --family inet --interface eth0.10
Interface    eth0.10
IP address   172.16.33.123                  [Active]
Subnet Mask  255.255.255.0
Domain Name  vyos.net
Router       172.16.33.254
Name Server  172.16.254.30
DHCP Server  172.16.33.254
DHCP Server  86400
Last Update  Sat Jul 29 21:13:32 CEST 2023
Expiry       Sun Jul 30 21:13:31 CEST 2023
```

```bash
vyos@vyos# ${vyos_op_scripts_dir}/dhcp.py show_client_leases --family inet --interface eth0.10 --raw [
    {
        "last_update": "Sat Jul 29 21:13:32 CEST 2023",
        "reason": "BOUND",
        "interface": "eth0.10",
        "new_expiry": "1690744411",
        "new_dhcp_lease_time": "86400",
        "medium": "",
        "alias_ip_address": "",
        "new_ip_address": "172.16.33.123",
        "new_broadcast_address": "172.16.33.255",
        "new_subnet_mask": "255.255.255.0",
        "new_domain_name": "vyos.net",
        "new_network_number": "172.16.33.0",
        "new_domain_name_servers": "172.16.254.30",
        "new_routers": "172.16.33.254",
        "new_static_routes": "",
        "new_dhcp_server_identifier": "172.16.33.254",
        "new_dhcp_message_type": "5",
        "old_ip_address": "",
        "old_subnet_mask": "",
        "old_domain_name": "",
        "old_domain_name_servers": "",
        "old_routers": "",
        "old_static_routes": ""
    }
]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
