### PR TITLE
wireguard: T5413: Blocked adding the peer with the router's public key

### DIFF
--- a/interface-definitions/include/version/interfaces-version.xml.i
+++ b/interface-definitions/include/version/interfaces-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/interfaces-version.xml.i -->
-<syntaxVersion component='interfaces' version='29'></syntaxVersion>
+<syntaxVersion component='interfaces' version='30'></syntaxVersion>
 <!-- include end -->

--- a/python/vyos/validate.py
+++ b/python/vyos/validate.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2018-2023 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -302,3 +302,20 @@ def has_vrf_configured(conf, intf):
 
     conf.set_level(old_level)
     return ret
+
+def is_wireguard_key_pair(private_key: str, public_key:str) -> bool:
+    """
+     Checks if public/private keys are keypair
+    :param private_key: Wireguard private key
+    :type private_key: str
+    :param public_key: Wireguard public key
+    :type public_key: str
+    :return: If public/private keys are keypair returns True else False
+    :rtype: bool
+    """
+    from vyos.utils.process import cmd
+    gen_public_key = cmd('wg pubkey', input=private_key)
+    if gen_public_key == public_key:
+        return True
+    else:
+        return False

--- a/src/conf_mode/interfaces-wireguard.py
+++ b/src/conf_mode/interfaces-wireguard.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2022 VyOS maintainers and contributors
+# Copyright (C) 2018-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -29,9 +29,11 @@ from vyos.configverify import verify_bond_bridge_member
 from vyos.ifconfig import WireGuardIf
 from vyos.utils.kernel import check_kmod
 from vyos.utils.network import check_port_availability
+from vyos.validate import is_wireguard_key_pair
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
+
 
 def get_config(config=None):
     """
@@ -104,6 +106,9 @@ def verify(wireguard):
 
         if peer['public_key'] in public_keys:
             raise ConfigError(f'Duplicate public-key defined on peer "{tmp}"')
+
+        if 'disable' not in peer and is_wireguard_key_pair(wireguard['private_key'], peer['public_key']):
+            raise ConfigError(f'Peer "{tmp}" has the same public key as the interface "{wireguard["ifname"]}"')
 
         public_keys.append(peer['public_key'])
 

--- a/src/migration-scripts/interfaces/29-to-30
+++ b/src/migration-scripts/interfaces/29-to-30
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021-2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Deletes Wireguard peers if they have the same public key as the router has.
+import sys
+from vyos.configtree import ConfigTree
+from vyos.validate import is_wireguard_key_pair
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("Must specify file name!")
+        sys.exit(1)
+
+    file_name = sys.argv[1]
+
+    with open(file_name, 'r') as f:
+        config_file = f.read()
+
+    config = ConfigTree(config_file)
+    base = ['interfaces', 'wireguard']
+    if not config.exists(base):
+        # Nothing to do
+        sys.exit(0)
+    for interface in config.list_nodes(base):
+        private_key = config.return_value(base + [interface, 'private-key'])
+        interface_base = base + [interface]
+        if config.exists(interface_base + ['peer']):
+            for peer in config.list_nodes(interface_base + ['peer']):
+                peer_base = interface_base + ['peer', peer]
+                peer_public_key = config.return_value(peer_base + ['public-key'])
+                if config.exists(peer_base + ['public-key']):
+                    if not config.exists(peer_base + ['disable']) \
+                            and is_wireguard_key_pair(private_key, peer_public_key):
+                        config.set(peer_base + ['disable'])
+
+    try:
+        with open(file_name, 'w') as f:
+            f.write(config.to_string())
+    except OSError as e:
+        print("Failed to save the modified config: {}".format(e))
+        sys.exit(1)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Disabeled adding the peer with the same public key as the router has.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5413

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireguard

## Proposed changes
<!--- Describe your changes in detail -->
Disabeled adding the peer with the same public key as the router has.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Key pair generation

```
vyos@vyos:~$ generate pki wireguard key-pair
Private key: oA2mjnxYxccfIFxnNfOZSrcJJiRl7kr9Qee999qywnY=
Public key: vu1n32sZC39x97i5wXRWb62KBCsj+UGVigwdmr4uhzg=
```
Configuration:

```
set interfaces wireguard wg1 address '10.0.0.1/24'
set interfaces wireguard wg1 peer TEST address '192.168.139.20'
set interfaces wireguard wg1 peer TEST allowed-ips '10.0.1.0/24'
set interfaces wireguard wg1 peer TEST port '51569'
set interfaces wireguard wg1 peer TEST public-key 'vu1n32sZC39x97i5wXRWb62KBCsj+UGVigwdmr4uhzg='
set interfaces wireguard wg1 private-key 'oA2mjnxYxccfIFxnNfOZSrcJJiRl7kr9Qee999qywnY='
```

Before changes:
```
vyos@vyos# commit
vyos@vyos:~$ sudo wg show

interface: wg1
  public key: vu1n32sZC39x97i5wXRWb62KBCsj+UGVigwdmr4uhzg=
  private key: (hidden)
  listening port: 57089
```

After changes:
```
vyos@vyos# commit

Peer "TEST" has the same public key as the router"

[[interfaces wireguard wg1]] failed
Commit failed
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
