### PR TITLE
T2298: vyos.util: extend process_named_running() signature with cmdline

### DIFF
--- a/interface-definitions/interfaces-wireguard.xml.in
+++ b/interface-definitions/interfaces-wireguard.xml.in
@@ -5,7 +5,7 @@
       <tagNode name="wireguard" owner="${vyos_conf_scripts_dir}/interfaces-wireguard.py">
         <properties>
           <help>WireGuard Interface</help>
-          <priority>459</priority>
+          <priority>379</priority>
           <constraint>
             <regex>^wg[0-9]+$</regex>
           </constraint>

--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -462,15 +462,17 @@ def process_running(pid_file):
         pid = f.read().strip()
     return pid_exists(int(pid))
 
-
-def process_named_running(name):
+def process_named_running(name, cmdline: str=None):
     """ Checks if process with given name is running and returns its PID.
     If Process is not running, return None
     """
     from psutil import process_iter
-    for p in process_iter():
-        if name in p.name():
-            return p.pid
+    for p in process_iter(['name', 'pid', 'cmdline']):
+        if cmdline:
+            if p.info['name'] == name and cmdline in p.info['cmdline']:
+                return p.info['pid']
+        elif p.info['name'] == name:
+            return p.info['pid']
     return None
 
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
```
    vyos.util: extend process_named_running() signature with cmdline
    
    process_named_running() was introduced in commit 16b2fc8fc4ca ("dns-forwarding:
    T2298: fix path to control file") and thus remained more or less unchanged.
    
    Smoketests use process_named_running() heavily and might spawn multiple
    processes with the same name but ifferent options (e.g. dhcp6c or dhclient) and
    it was yet not possible to properly filter on the "real-deal" like the process
    bound to a given interface.
    
    One can now optionally specify a string that is searched inside the command
    line argument list of the process.
    
    Example:
    
    >>> process_named_running('dhcp6c', 'veth0')
    ['/usr/sbin/dhcp6c', '-D', '-k', '/run/dhcp6c/dhcp6c.veth0.sock', '-c',
     '/run/dhcp6c/dhcp6c.veth0.conf', '-p', '/run/dhcp6c/dhcp6c.veth0.pid', 'veth0']
    4215
    
    >>> process_named_running('dhcp6c', 'veth1')
    ['/usr/sbin/dhcp6c', '-D', '-k', '/run/dhcp6c/dhcp6c.veth1.sock', '-c',
     '/run/dhcp6c/dhcp6c.veth1.conf', '-p', '/run/dhcp6c/dhcp6c.veth1.pid', 'veth1']
    4253
    
    Where the debug list returned is the commandline searched.
    
    (cherry picked from commit 9c677c81be6a6e62958c73b038c2a36f1f629108)

```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Cherry-pick 9c677c81be6a6e62958c73b038c2a36f1f629108

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T2298

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
