### PR TITLE
T5427: Fix migration script arguments len expects 2 args

### DIFF
--- a/src/migration-scripts/bgp/0-to-1
+++ b/src/migration-scripts/bgp/0-to-1
@@ -21,7 +21,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/bgp/1-to-2
+++ b/src/migration-scripts/bgp/1-to-2
@@ -21,7 +21,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/bgp/2-to-3
+++ b/src/migration-scripts/bgp/2-to-3
@@ -21,7 +21,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/bgp/3-to-4
+++ b/src/migration-scripts/bgp/3-to-4
@@ -22,7 +22,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/config-management/0-to-1
+++ b/src/migration-scripts/config-management/0-to-1
@@ -6,7 +6,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/conntrack-sync/1-to-2
+++ b/src/migration-scripts/conntrack-sync/1-to-2
@@ -23,7 +23,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/conntrack/1-to-2
+++ b/src/migration-scripts/conntrack/1-to-2
@@ -6,7 +6,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/conntrack/2-to-3
+++ b/src/migration-scripts/conntrack/2-to-3
@@ -8,7 +8,7 @@ import sys
 from vyos.configtree import ConfigTree
 from vyos.version import get_version
 
-if len(sys.argv) < 1:
+if len(sys.argv) < 2:
     print('Must specify file name!')
     sys.exit(1)
 

--- a/src/migration-scripts/container/0-to-1
+++ b/src/migration-scripts/container/0-to-1
@@ -23,7 +23,7 @@ import sys
 from vyos.configtree import ConfigTree
 from vyos.utils.process import call
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/dhcp-relay/1-to-2
+++ b/src/migration-scripts/dhcp-relay/1-to-2
@@ -7,7 +7,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/dhcp-server/4-to-5
+++ b/src/migration-scripts/dhcp-server/4-to-5
@@ -9,7 +9,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/dhcp-server/5-to-6
+++ b/src/migration-scripts/dhcp-server/5-to-6
@@ -20,7 +20,7 @@
 import sys
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/dhcpv6-server/0-to-1
+++ b/src/migration-scripts/dhcpv6-server/0-to-1
@@ -19,7 +19,7 @@
 from sys import argv, exit
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/dns-dynamic/0-to-1
+++ b/src/migration-scripts/dns-dynamic/0-to-1
@@ -43,7 +43,7 @@ service_protocol_mapping = {
     'zoneedit': 'zoneedit1'
 }
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/dns-forwarding/0-to-1
+++ b/src/migration-scripts/dns-forwarding/0-to-1
@@ -22,7 +22,7 @@
 import sys
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/dns-forwarding/1-to-2
+++ b/src/migration-scripts/dns-forwarding/1-to-2
@@ -25,7 +25,7 @@ from sys import argv, exit
 from vyos.ifconfig import Interface
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/dns-forwarding/2-to-3
+++ b/src/migration-scripts/dns-forwarding/2-to-3
@@ -21,7 +21,7 @@
 import sys
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/dns-forwarding/3-to-4
+++ b/src/migration-scripts/dns-forwarding/3-to-4
@@ -20,7 +20,7 @@
 import sys
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/firewall/5-to-6
+++ b/src/migration-scripts/firewall/5-to-6
@@ -23,7 +23,7 @@ from sys import exit
 from vyos.configtree import ConfigTree
 from vyos.ifconfig import Section
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/firewall/6-to-7
+++ b/src/migration-scripts/firewall/6-to-7
@@ -28,7 +28,7 @@ from sys import exit
 from vyos.configtree import ConfigTree
 from vyos.ifconfig import Section
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/firewall/7-to-8
+++ b/src/migration-scripts/firewall/7-to-8
@@ -25,7 +25,7 @@ from sys import exit
 from vyos.configtree import ConfigTree
 from vyos.ifconfig import Section
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/firewall/8-to-9
+++ b/src/migration-scripts/firewall/8-to-9
@@ -28,7 +28,7 @@ from sys import exit
 from vyos.configtree import ConfigTree
 from vyos.ifconfig import Section
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/firewall/9-to-10
+++ b/src/migration-scripts/firewall/9-to-10
@@ -28,7 +28,7 @@ from sys import exit
 from vyos.configtree import ConfigTree
 from vyos.ifconfig import Section
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/flow-accounting/0-to-1
+++ b/src/migration-scripts/flow-accounting/0-to-1
@@ -21,7 +21,7 @@
 from sys import argv
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/https/2-to-3
+++ b/src/migration-scripts/https/2-to-3
@@ -25,7 +25,7 @@ from vyos.pki import create_private_key
 from vyos.pki import encode_certificate
 from vyos.pki import encode_private_key
 
-if (len(sys.argv) < 2):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/https/3-to-4
+++ b/src/migration-scripts/https/3-to-4
@@ -20,7 +20,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 2):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/ids/0-to-1
+++ b/src/migration-scripts/ids/0-to-1
@@ -19,7 +19,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/interfaces/0-to-1
+++ b/src/migration-scripts/interfaces/0-to-1
@@ -37,7 +37,7 @@ def migrate_bridge(config, tree, intf):
 
 
 if __name__ == '__main__':
-    if (len(sys.argv) < 1):
+    if len(sys.argv) < 2:
         print("Must specify file name!")
         sys.exit(1)
 

--- a/src/migration-scripts/interfaces/1-to-2
+++ b/src/migration-scripts/interfaces/1-to-2
@@ -7,7 +7,7 @@
 import sys
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/interfaces/10-to-11
+++ b/src/migration-scripts/interfaces/10-to-11
@@ -23,7 +23,7 @@ from sys import exit, argv
 from vyos.configtree import ConfigTree
 
 if __name__ == '__main__':
-    if (len(argv) < 1):
+    if len(argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/interfaces/11-to-12
+++ b/src/migration-scripts/interfaces/11-to-12
@@ -22,7 +22,7 @@ from sys import exit, argv
 from vyos.configtree import ConfigTree
 
 if __name__ == '__main__':
-    if (len(argv) < 1):
+    if len(argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/interfaces/12-to-13
+++ b/src/migration-scripts/interfaces/12-to-13
@@ -24,7 +24,7 @@ from sys import exit, argv
 from vyos.configtree import ConfigTree
 
 if __name__ == '__main__':
-    if (len(argv) < 1):
+    if len(argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/interfaces/13-to-14
+++ b/src/migration-scripts/interfaces/13-to-14
@@ -21,7 +21,7 @@ from sys import exit, argv
 from vyos.configtree import ConfigTree
 
 if __name__ == '__main__':
-    if (len(argv) < 1):
+    if len(argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/interfaces/14-to-15
+++ b/src/migration-scripts/interfaces/14-to-15
@@ -20,7 +20,7 @@ from sys import exit, argv
 from vyos.configtree import ConfigTree
 
 if __name__ == '__main__':
-    if (len(argv) < 1):
+    if len(argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/interfaces/15-to-16
+++ b/src/migration-scripts/interfaces/15-to-16
@@ -20,7 +20,7 @@ from sys import exit, argv
 from vyos.configtree import ConfigTree
 
 if __name__ == '__main__':
-    if (len(argv) < 1):
+    if len(argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/interfaces/16-to-17
+++ b/src/migration-scripts/interfaces/16-to-17
@@ -21,7 +21,7 @@ import sys
 from vyos.configtree import ConfigTree
 
 if __name__ == '__main__':
-    if (len(sys.argv) < 1):
+    if len(sys.argv) < 2:
         print("Must specify file name!")
         sys.exit(1)
 
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     if not config.exists(base):
         # Nothing to do
         sys.exit(0)
-    
+
     for interface in config.list_nodes(base):
         mirror_old_base = base + [interface, 'mirror']
         if config.exists(mirror_old_base):
@@ -43,7 +43,7 @@ if __name__ == '__main__':
             if config.exists(mirror_old_base):
                 config.delete(mirror_old_base)
                 config.set(mirror_old_base + ['ingress'],intf[0])
-    
+
     try:
         with open(file_name, 'w') as f:
             f.write(config.to_string())

--- a/src/migration-scripts/interfaces/17-to-18
+++ b/src/migration-scripts/interfaces/17-to-18
@@ -22,7 +22,7 @@ from sys import exit, argv
 from vyos.configtree import ConfigTree
 
 if __name__ == '__main__':
-    if (len(argv) < 1):
+    if len(argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/interfaces/18-to-19
+++ b/src/migration-scripts/interfaces/18-to-19
@@ -41,7 +41,7 @@ def replace_nat_interfaces(config, old, new):
 
 
 if __name__ == '__main__':
-    if (len(argv) < 1):
+    if len(argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/interfaces/19-to-20
+++ b/src/migration-scripts/interfaces/19-to-20
@@ -19,7 +19,7 @@ from sys import exit
 from vyos.configtree import ConfigTree
 
 if __name__ == '__main__':
-    if (len(argv) < 1):
+    if len(argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/interfaces/2-to-3
+++ b/src/migration-scripts/interfaces/2-to-3
@@ -7,7 +7,7 @@
 import sys
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/interfaces/20-to-21
+++ b/src/migration-scripts/interfaces/20-to-21
@@ -23,7 +23,7 @@ from sys import argv
 from vyos.ethtool import Ethtool
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/interfaces/21-to-22
+++ b/src/migration-scripts/interfaces/21-to-22
@@ -17,7 +17,7 @@
 from sys import argv
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/interfaces/22-to-23
+++ b/src/migration-scripts/interfaces/22-to-23
@@ -75,7 +75,7 @@ def migrate_ripng(config, path, interface):
             config.delete(path[:-1])
 
 if __name__ == '__main__':
-    if (len(argv) < 1):
+    if len(argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/interfaces/23-to-24
+++ b/src/migration-scripts/interfaces/23-to-24
@@ -22,7 +22,7 @@ import sys
 from vyos.configtree import ConfigTree
 
 if __name__ == '__main__':
-    if (len(sys.argv) < 1):
+    if len(sys.argv) < 2:
         print("Must specify file name!")
         sys.exit(1)
 

--- a/src/migration-scripts/interfaces/24-to-25
+++ b/src/migration-scripts/interfaces/24-to-25
@@ -53,7 +53,7 @@ def read_file_for_pki(config_auth_path):
 
     return output
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/interfaces/25-to-26
+++ b/src/migration-scripts/interfaces/25-to-26
@@ -22,7 +22,7 @@ from sys import argv
 from vyos.ethtool import Ethtool
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/interfaces/26-to-27
+++ b/src/migration-scripts/interfaces/26-to-27
@@ -22,7 +22,7 @@ from sys import argv
 from vyos.ethtool import Ethtool
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/interfaces/27-to-28
+++ b/src/migration-scripts/interfaces/27-to-28
@@ -22,7 +22,7 @@ from sys import argv
 from vyos.ethtool import Ethtool
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/interfaces/28-to-29
+++ b/src/migration-scripts/interfaces/28-to-29
@@ -21,7 +21,7 @@ from sys import argv
 from vyos.ethtool import Ethtool
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/interfaces/3-to-4
+++ b/src/migration-scripts/interfaces/3-to-4
@@ -6,7 +6,7 @@
 import sys
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/interfaces/4-to-5
+++ b/src/migration-scripts/interfaces/4-to-5
@@ -57,7 +57,7 @@ def migrate_dialer(config, tree, intf):
 
 
 if __name__ == '__main__':
-    if (len(sys.argv) < 1):
+    if len(sys.argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/interfaces/5-to-6
+++ b/src/migration-scripts/interfaces/5-to-6
@@ -98,7 +98,7 @@ def copy_rtradv(c, old_base, interface):
                 c.delete(new_base + ['link-mtu'])
 
 if __name__ == '__main__':
-    if (len(sys.argv) < 1):
+    if len(sys.argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/interfaces/6-to-7
+++ b/src/migration-scripts/interfaces/6-to-7
@@ -20,7 +20,7 @@ import sys
 from vyos.configtree import ConfigTree
 
 if __name__ == '__main__':
-    if (len(sys.argv) < 1):
+    if len(sys.argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/interfaces/7-to-8
+++ b/src/migration-scripts/interfaces/7-to-8
@@ -37,7 +37,7 @@ def migrate_default_keys():
         os.rename(f'{kdir}/public.key', f'{location}/public.key')
 
 if __name__ == '__main__':
-    if (len(argv) < 1):
+    if len(argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/interfaces/8-to-9
+++ b/src/migration-scripts/interfaces/8-to-9
@@ -22,7 +22,7 @@ from sys import exit, argv
 from vyos.configtree import ConfigTree
 
 if __name__ == '__main__':
-    if (len(argv) < 1):
+    if len(argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/interfaces/9-to-10
+++ b/src/migration-scripts/interfaces/9-to-10
@@ -23,7 +23,7 @@ from sys import exit, argv
 from vyos.configtree import ConfigTree
 
 if __name__ == '__main__':
-    if (len(argv) < 1):
+    if len(argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/ipoe-server/0-to-1
+++ b/src/migration-scripts/ipoe-server/0-to-1
@@ -26,7 +26,7 @@ import sys
 from sys import argv, exit
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/ipsec/10-to-11
+++ b/src/migration-scripts/ipsec/10-to-11
@@ -20,7 +20,7 @@ from sys import exit
 from vyos.configtree import ConfigTree
 
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/ipsec/11-to-12
+++ b/src/migration-scripts/ipsec/11-to-12
@@ -23,7 +23,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/ipsec/4-to-5
+++ b/src/migration-scripts/ipsec/4-to-5
@@ -20,7 +20,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/ipsec/5-to-6
+++ b/src/migration-scripts/ipsec/5-to-6
@@ -23,7 +23,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/ipsec/6-to-7
+++ b/src/migration-scripts/ipsec/6-to-7
@@ -29,7 +29,7 @@ from vyos.pki import encode_certificate
 from vyos.pki import encode_private_key
 from vyos.utils.process import run
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/ipsec/7-to-8
+++ b/src/migration-scripts/ipsec/7-to-8
@@ -31,7 +31,7 @@ from vyos.pki import load_private_key
 from vyos.pki import encode_public_key
 from vyos.pki import encode_private_key
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/ipsec/8-to-9
+++ b/src/migration-scripts/ipsec/8-to-9
@@ -19,7 +19,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/ipsec/9-to-10
+++ b/src/migration-scripts/ipsec/9-to-10
@@ -24,7 +24,7 @@ from vyos.template import is_ipv4
 from vyos.template import is_ipv6
 
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/isis/0-to-1
+++ b/src/migration-scripts/isis/0-to-1
@@ -21,7 +21,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/isis/1-to-2
+++ b/src/migration-scripts/isis/1-to-2
@@ -21,7 +21,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/isis/2-to-3
+++ b/src/migration-scripts/isis/2-to-3
@@ -22,7 +22,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/l2tp/0-to-1
+++ b/src/migration-scripts/l2tp/0-to-1
@@ -8,7 +8,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/l2tp/1-to-2
+++ b/src/migration-scripts/l2tp/1-to-2
@@ -6,7 +6,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/l2tp/2-to-3
+++ b/src/migration-scripts/l2tp/2-to-3
@@ -23,7 +23,7 @@ import sys
 from sys import argv, exit
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/l2tp/3-to-4
+++ b/src/migration-scripts/l2tp/3-to-4
@@ -29,7 +29,7 @@ from vyos.pki import encode_certificate
 from vyos.pki import encode_private_key
 from vyos.utils.process import run
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/lldp/0-to-1
+++ b/src/migration-scripts/lldp/0-to-1
@@ -7,7 +7,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/monitoring/0-to-1
+++ b/src/migration-scripts/monitoring/0-to-1
@@ -21,7 +21,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/nat/4-to-5
+++ b/src/migration-scripts/nat/4-to-5
@@ -20,7 +20,7 @@
 from sys import argv,exit
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/nat66/0-to-1
+++ b/src/migration-scripts/nat66/0-to-1
@@ -17,7 +17,7 @@
 from sys import argv,exit
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/ntp/0-to-1
+++ b/src/migration-scripts/ntp/0-to-1
@@ -6,7 +6,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/ntp/1-to-2
+++ b/src/migration-scripts/ntp/1-to-2
@@ -20,7 +20,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/ntp/2-to-3
+++ b/src/migration-scripts/ntp/2-to-3
@@ -24,7 +24,7 @@ from vyos.configtree import ConfigTree
 from vyos.template import is_ipv4
 from vyos.template import is_ipv6
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/openconnect/0-to-1
+++ b/src/migration-scripts/openconnect/0-to-1
@@ -28,7 +28,7 @@ from vyos.pki import encode_certificate
 from vyos.pki import encode_private_key
 from vyos.utils.process import run
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/openconnect/1-to-2
+++ b/src/migration-scripts/openconnect/1-to-2
@@ -20,7 +20,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/ospf/0-to-1
+++ b/src/migration-scripts/ospf/0-to-1
@@ -37,7 +37,7 @@ def ospf_passive_migration(config, ospf_base):
                 config.set(ospf_base + ['interface', interface, 'passive', 'disable'])
             config.delete(ospf_base + ['passive-interface-exclude'])
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/ospf/1-to-2
+++ b/src/migration-scripts/ospf/1-to-2
@@ -22,7 +22,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/policy/0-to-1
+++ b/src/migration-scripts/policy/0-to-1
@@ -23,7 +23,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/policy/1-to-2
+++ b/src/migration-scripts/policy/1-to-2
@@ -23,7 +23,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/policy/2-to-3
+++ b/src/migration-scripts/policy/2-to-3
@@ -23,7 +23,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/policy/3-to-4
+++ b/src/migration-scripts/policy/3-to-4
@@ -98,7 +98,7 @@ def extcommunity_migrate(config: ConfigTree, rule: list[str]) -> None:
             config.set(rule + ['soo'], value=community, replace=False)
 
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/policy/4-to-5
+++ b/src/migration-scripts/policy/4-to-5
@@ -24,7 +24,7 @@ from sys import exit
 from vyos.configtree import ConfigTree
 from vyos.ifconfig import Section
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/pppoe-server/0-to-1
+++ b/src/migration-scripts/pppoe-server/0-to-1
@@ -20,7 +20,7 @@
 from sys import argv, exit
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/pppoe-server/1-to-2
+++ b/src/migration-scripts/pppoe-server/1-to-2
@@ -21,7 +21,7 @@ import os
 from sys import argv, exit
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/pppoe-server/2-to-3
+++ b/src/migration-scripts/pppoe-server/2-to-3
@@ -19,7 +19,7 @@
 from sys import argv, exit
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/pppoe-server/3-to-4
+++ b/src/migration-scripts/pppoe-server/3-to-4
@@ -21,7 +21,7 @@ import os
 from sys import argv, exit
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/pppoe-server/4-to-5
+++ b/src/migration-scripts/pppoe-server/4-to-5
@@ -20,7 +20,7 @@ from vyos.configtree import ConfigTree
 from sys import argv
 from sys import exit
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/pppoe-server/5-to-6
+++ b/src/migration-scripts/pppoe-server/5-to-6
@@ -20,7 +20,7 @@ from vyos.configtree import ConfigTree
 from sys import argv
 from sys import exit
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/pptp/0-to-1
+++ b/src/migration-scripts/pptp/0-to-1
@@ -8,7 +8,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/pptp/1-to-2
+++ b/src/migration-scripts/pptp/1-to-2
@@ -21,7 +21,7 @@ from sys import argv, exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/qos/1-to-2
+++ b/src/migration-scripts/qos/1-to-2
@@ -28,7 +28,7 @@ def bandwidth_percent_to_val(interface, percent) -> int:
     speed = int(speed) *1000000 # convert to MBit/s
     return speed * int(percent) // 100 # integer division
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/quagga/10-to-11
+++ b/src/migration-scripts/quagga/10-to-11
@@ -22,7 +22,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/quagga/2-to-3
+++ b/src/migration-scripts/quagga/2-to-3
@@ -21,7 +21,7 @@ import sys
 from vyos.configtree import ConfigTree
 
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/quagga/3-to-4
+++ b/src/migration-scripts/quagga/3-to-4
@@ -28,7 +28,7 @@ import sys
 from vyos.configtree import ConfigTree
 
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/quagga/4-to-5
+++ b/src/migration-scripts/quagga/4-to-5
@@ -21,7 +21,7 @@ import sys
 from vyos.configtree import ConfigTree
 
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/quagga/5-to-6
+++ b/src/migration-scripts/quagga/5-to-6
@@ -22,7 +22,7 @@ import sys
 from vyos.configtree import ConfigTree
 
 
-if (len(sys.argv) < 2):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/quagga/6-to-7
+++ b/src/migration-scripts/quagga/6-to-7
@@ -23,7 +23,7 @@ from vyos.configtree import ConfigTree
 from vyos.template import is_ipv4
 from vyos.template import is_ipv6
 
-if (len(argv) < 2):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/quagga/7-to-8
+++ b/src/migration-scripts/quagga/7-to-8
@@ -22,7 +22,7 @@ from sys import argv
 from sys import exit
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 2):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/quagga/8-to-9
+++ b/src/migration-scripts/quagga/8-to-9
@@ -84,7 +84,7 @@ def migrate_route(config, base, path, route_route6):
                         config.rename(vrf_path, 'vrf')
 
 
-if (len(argv) < 2):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/quagga/9-to-10
+++ b/src/migration-scripts/quagga/9-to-10
@@ -21,7 +21,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 2):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/rip/0-to-1
+++ b/src/migration-scripts/rip/0-to-1
@@ -22,7 +22,7 @@ from sys import exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/rpki/0-to-1
+++ b/src/migration-scripts/rpki/0-to-1
@@ -18,7 +18,7 @@ from sys import exit
 from sys import argv
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/salt/0-to-1
+++ b/src/migration-scripts/salt/0-to-1
@@ -22,7 +22,7 @@ from sys import argv,exit
 
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/snmp/0-to-1
+++ b/src/migration-scripts/snmp/0-to-1
@@ -17,7 +17,7 @@
 import sys
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/snmp/1-to-2
+++ b/src/migration-scripts/snmp/1-to-2
@@ -43,7 +43,7 @@ def migrate_keys(config, path):
             config.set(config_path_priv, value=tmp)
 
 if __name__ == '__main__':
-    if (len(argv) < 1):
+    if len(argv) < 2:
         print("Must specify file name!")
         exit(1)
 

--- a/src/migration-scripts/snmp/2-to-3
+++ b/src/migration-scripts/snmp/2-to-3
@@ -28,7 +28,7 @@ from sys import exit
 from vyos.configtree import ConfigTree
 from vyos.ifconfig import Section
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/ssh/0-to-1
+++ b/src/migration-scripts/ssh/0-to-1
@@ -6,7 +6,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/ssh/1-to-2
+++ b/src/migration-scripts/ssh/1-to-2
@@ -21,7 +21,7 @@
 from sys import argv,exit
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/sstp/0-to-1
+++ b/src/migration-scripts/sstp/0-to-1
@@ -28,7 +28,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/sstp/1-to-2
+++ b/src/migration-scripts/sstp/1-to-2
@@ -25,7 +25,7 @@ from shutil import copy2
 from stat import S_IRUSR, S_IWUSR, S_IRGRP, S_IROTH
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/sstp/2-to-3
+++ b/src/migration-scripts/sstp/2-to-3
@@ -21,7 +21,7 @@ from vyos.configtree import ConfigTree
 from sys import argv
 from sys import exit
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/sstp/3-to-4
+++ b/src/migration-scripts/sstp/3-to-4
@@ -28,7 +28,7 @@ from vyos.pki import encode_certificate
 from vyos.pki import encode_private_key
 from vyos.utils.process import run
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/system/10-to-11
+++ b/src/migration-scripts/system/10-to-11
@@ -6,7 +6,7 @@
 import sys
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/system/11-to-12
+++ b/src/migration-scripts/system/11-to-12
@@ -8,7 +8,7 @@
 import sys
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/system/12-to-13
+++ b/src/migration-scripts/system/12-to-13
@@ -8,7 +8,7 @@ import re
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
   print("Must specify file name!")
   sys.exit(1)
 

--- a/src/migration-scripts/system/13-to-14
+++ b/src/migration-scripts/system/13-to-14
@@ -15,7 +15,7 @@ from vyos.configtree import ConfigTree
 from vyos.utils.process import cmd
 
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/system/14-to-15
+++ b/src/migration-scripts/system/14-to-15
@@ -11,7 +11,7 @@ ipv6_blacklist_file = '/etc/modprobe.d/vyatta_blacklist_ipv6.conf'
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/system/15-to-16
+++ b/src/migration-scripts/system/15-to-16
@@ -7,7 +7,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/system/16-to-17
+++ b/src/migration-scripts/system/16-to-17
@@ -25,7 +25,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/system/17-to-18
+++ b/src/migration-scripts/system/17-to-18
@@ -22,7 +22,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/system/18-to-19
+++ b/src/migration-scripts/system/18-to-19
@@ -24,7 +24,7 @@ from sys import argv, exit
 from vyos.ifconfig import Interface
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/system/19-to-20
+++ b/src/migration-scripts/system/19-to-20
@@ -21,7 +21,7 @@ import os
 from sys import exit, argv
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/system/20-to-21
+++ b/src/migration-scripts/system/20-to-21
@@ -21,7 +21,7 @@ import os
 from sys import argv
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/system/21-to-22
+++ b/src/migration-scripts/system/21-to-22
@@ -19,7 +19,7 @@ import os
 from sys import exit, argv
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/system/22-to-23
+++ b/src/migration-scripts/system/22-to-23
@@ -19,7 +19,7 @@ import os
 from sys import exit, argv
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/system/23-to-24
+++ b/src/migration-scripts/system/23-to-24
@@ -22,7 +22,7 @@ from sys import exit, argv
 from vyos.configtree import ConfigTree
 from vyos.template import is_ipv4
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/system/24-to-25
+++ b/src/migration-scripts/system/24-to-25
@@ -19,7 +19,7 @@
 from sys import exit, argv
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/system/25-to-26
+++ b/src/migration-scripts/system/25-to-26
@@ -21,7 +21,7 @@
 from sys import exit, argv
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/system/6-to-7
+++ b/src/migration-scripts/system/6-to-7
@@ -6,7 +6,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/system/7-to-8
+++ b/src/migration-scripts/system/7-to-8
@@ -6,7 +6,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/system/8-to-9
+++ b/src/migration-scripts/system/8-to-9
@@ -6,7 +6,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/vrf/0-to-1
+++ b/src/migration-scripts/vrf/0-to-1
@@ -20,7 +20,7 @@ from sys import argv
 from sys import exit
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 2):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/vrf/1-to-2
+++ b/src/migration-scripts/vrf/1-to-2
@@ -20,7 +20,7 @@ from sys import argv
 from sys import exit
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 2):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/vrf/2-to-3
+++ b/src/migration-scripts/vrf/2-to-3
@@ -69,7 +69,7 @@ def _search_tables(config_commands, table_num):
     return table_items
 
 
-if (len(argv) < 2):
+if len(argv) < 2:
     print("Must specify file name!")
     exit(1)
 

--- a/src/migration-scripts/vrrp/1-to-2
+++ b/src/migration-scripts/vrrp/1-to-2
@@ -21,7 +21,7 @@ import sys
 from vyos.configtree import ConfigTree
 
 
-if (len(sys.argv) < 1):
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 

--- a/src/migration-scripts/vrrp/2-to-3
+++ b/src/migration-scripts/vrrp/2-to-3
@@ -19,7 +19,7 @@
 from sys import argv
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print('Must specify file name!')
     exit(1)
 

--- a/src/migration-scripts/vrrp/3-to-4
+++ b/src/migration-scripts/vrrp/3-to-4
@@ -17,7 +17,7 @@
 from sys import argv
 from vyos.configtree import ConfigTree
 
-if (len(argv) < 1):
+if len(argv) < 2:
     print('Must specify file name!')
     exit(1)
 

--- a/src/migration-scripts/webproxy/1-to-2
+++ b/src/migration-scripts/webproxy/1-to-2
@@ -7,7 +7,7 @@ import sys
 
 from vyos.configtree import ConfigTree
 
-if len(sys.argv) < 1:
+if len(sys.argv) < 2:
     print("Must specify file name!")
     sys.exit(1)
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The script's name is always provided as the first argument `sys.argv[0]`
The expected length for argv is 2 (script itself + config file)

Change: `if (len(argv) < 1)` to `if len(argv) < 2`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Trivial fix without change functionality

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5427

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
migration-scripts
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
