### PR TITLE
wireguard: T5409: Added 'set interfaces wireguard wgX threaded'

### DIFF
--- a/interface-definitions/include/interface/per-client-thread.xml.i
+++ b/interface-definitions/include/interface/per-client-thread.xml.i
@@ -1,0 +1,8 @@
+<!-- include start from interface/per-client-thread.xml.i -->
+<leafNode name="per-client-thread">
+  <properties>
+    <help>Process traffic from each client in a dedicated thread</help>
+    <valueless/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/interfaces-wireguard.xml.in
+++ b/interface-definitions/interfaces-wireguard.xml.in
@@ -119,6 +119,12 @@
             </children>
           </tagNode>
           #include <include/interface/redirect.xml.i>
+          <leafNode name="threaded">
+            <properties>
+              <help>Process traffic from each peer in a dedicated thread</help>
+              <valueless/>
+            </properties>
+          </leafNode>
           #include <include/interface/vrf.xml.i>
         </children>
       </tagNode>

--- a/interface-definitions/interfaces-wireguard.xml.in
+++ b/interface-definitions/interfaces-wireguard.xml.in
@@ -119,12 +119,7 @@
             </children>
           </tagNode>
           #include <include/interface/redirect.xml.i>
-          <leafNode name="threaded">
-            <properties>
-              <help>Process traffic from each peer in a dedicated thread</help>
-              <valueless/>
-            </properties>
-          </leafNode>
+          #include <include/interface/per-client-thread.xml.i>
           #include <include/interface/vrf.xml.i>
         </children>
       </tagNode>

--- a/interface-definitions/interfaces-wireless.xml.in
+++ b/interface-definitions/interfaces-wireless.xml.in
@@ -778,6 +778,7 @@
             </properties>
             <defaultValue>monitor</defaultValue>
           </leafNode>
+          #include <include/interface/per-client-thread.xml.i>
           #include <include/interface/redirect.xml.i>
           #include <include/interface/vif.xml.i>
           #include <include/interface/vif-s.xml.i>

--- a/python/vyos/ifconfig/wireguard.py
+++ b/python/vyos/ifconfig/wireguard.py
@@ -27,7 +27,6 @@ from vyos.ifconfig import Operational
 from vyos.template import is_ipv6
 from vyos.base import Warning
 
-
 class WireGuardOperational(Operational):
     def _dump(self):
         """Dump wireguard data in a python friendly way."""
@@ -229,13 +228,6 @@ class WireGuardIf(Interface):
                 # PSK key file is not required to be stored persistently as its backed by CLI
                 if psk_file != no_psk_file and os.path.exists(psk_file):
                     os.remove(psk_file)
-
-        try:
-            self._write_sysfs(f'/sys/devices/virtual/net/{self.ifname}/threaded',
-                          '1' if 'threaded' in config else '0')
-        except Exception:
-            Warning(f'Update threaded status on interface "{config["ifname"]}" FAILED.\n'
-                    f'An unexpected error occurred.')
 
         # call base class
         super().update(config)

--- a/smoketest/scripts/cli/test_interfaces_wireguard.py
+++ b/smoketest/scripts/cli/test_interfaces_wireguard.py
@@ -145,18 +145,11 @@ class WireGuardInterfaceTest(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + [interface, 'peer', 'PEER01', 'public-key', pubkey])
         self.cli_set(base_path + [interface, 'peer', 'PEER01', 'allowed-ips', '10.205.212.10/32'])
         self.cli_set(base_path + [interface, 'peer', 'PEER01', 'address', '192.0.2.1'])
-        self.cli_set(base_path + [interface, 'peer', 'PEER01', 'disable'])
-        self.cli_set(base_path + [interface, 'threaded'])
-
-        # Threaded is set and no enabled peer is configured
-        with self.assertRaises(ConfigSessionError):
-            self.cli_commit()
-
-        self.cli_delete(base_path + [interface, 'peer', 'PEER01', 'disable'])
+        self.cli_set(base_path + [interface, 'per-client-thread'])
 
         # Commit peers
         self.cli_commit()
-        tmp = read_file(f'/sys/devices/virtual/net/{interface}/threaded')
+        tmp = read_file(f'/sys/class/net/{interface}/threaded')
         self.assertTrue(tmp, "1")
 
 if __name__ == '__main__':

--- a/smoketest/scripts/cli/test_interfaces_wireguard.py
+++ b/smoketest/scripts/cli/test_interfaces_wireguard.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020-2021 VyOS maintainers and contributors
+# Copyright (C) 2020-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -19,6 +19,7 @@ import unittest
 
 from base_vyostest_shim import VyOSUnitTestSHIM
 from vyos.configsession import ConfigSessionError
+from vyos.utils.file import read_file
 
 base_path = ['interfaces', 'wireguard']
 
@@ -35,7 +36,7 @@ class WireGuardInterfaceTest(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(base_path)
         self.cli_commit()
 
-    def test_wireguard_peer(self):
+    def test_01_wireguard_peer(self):
         # Create WireGuard interfaces with associated peers
         for intf in self._interfaces:
             peer = 'foo-' + intf
@@ -62,7 +63,7 @@ class WireGuardInterfaceTest(VyOSUnitTestSHIM.TestCase):
 
             self.assertTrue(os.path.isdir(f'/sys/class/net/{intf}'))
 
-    def test_wireguard_add_remove_peer(self):
+    def test_02_wireguard_add_remove_peer(self):
         # T2939: Create WireGuard interfaces with associated peers.
         # Remove one of the configured peers.
         # T4774: Test prevention of duplicate peer public keys
@@ -100,10 +101,9 @@ class WireGuardInterfaceTest(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(base_path + [interface, 'peer', 'PEER01'])
         self.cli_commit()
 
-    def test_wireguard_same_public_key(self):
-        # T2939: Create WireGuard interfaces with associated peers.
-        # Remove one of the configured peers.
-        # T4774: Test prevention of duplicate peer public keys
+    def test_03_wireguard_same_public_key(self):
+        # T5413: Test prevention of equality interface public key and peer's
+        #        public key
         interface = 'wg0'
         port = '12345'
         privkey = 'OOjcXGfgQlAuM6q8Z9aAYduCua7pxf7UKYvIqoUPoGQ='
@@ -128,6 +128,36 @@ class WireGuardInterfaceTest(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         self.assertTrue(os.path.isdir(f'/sys/class/net/{interface}'))
+
+    def test_04_wireguard_threaded(self):
+        # T5409: Test adding threaded option on interface.
+        #        Test prevention for adding threaded
+        #        if no enabled peer is configured.
+        interface = 'wg0'
+        port = '12345'
+        privkey = 'OOjcXGfgQlAuM6q8Z9aAYduCua7pxf7UKYvIqoUPoGQ='
+        pubkey = 'ebFx/1G0ti8tvuZd94sEIosAZZIznX+dBAKG/8DFm0I='
+
+        self.cli_set(base_path + [interface, 'address', '172.16.0.1/24'])
+        self.cli_set(base_path + [interface, 'private-key', privkey])
+
+        self.cli_set(base_path + [interface, 'peer', 'PEER01', 'port', port])
+        self.cli_set(base_path + [interface, 'peer', 'PEER01', 'public-key', pubkey])
+        self.cli_set(base_path + [interface, 'peer', 'PEER01', 'allowed-ips', '10.205.212.10/32'])
+        self.cli_set(base_path + [interface, 'peer', 'PEER01', 'address', '192.0.2.1'])
+        self.cli_set(base_path + [interface, 'peer', 'PEER01', 'disable'])
+        self.cli_set(base_path + [interface, 'threaded'])
+
+        # Threaded is set and no enabled peer is configured
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_delete(base_path + [interface, 'peer', 'PEER01', 'disable'])
+
+        # Commit peers
+        self.cli_commit()
+        tmp = read_file(f'/sys/devices/virtual/net/{interface}/threaded')
+        self.assertTrue(tmp, "1")
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/interfaces-wireguard.py
+++ b/src/conf_mode/interfaces-wireguard.py
@@ -90,7 +90,7 @@ def verify(wireguard):
 
     # run checks on individual configured WireGuard peer
     public_keys = []
-
+    peer_enabled = False
     for tmp in wireguard['peer']:
         peer = wireguard['peer'][tmp]
 
@@ -110,7 +110,14 @@ def verify(wireguard):
         if 'disable' not in peer and is_wireguard_key_pair(wireguard['private_key'], peer['public_key']):
             raise ConfigError(f'Peer "{tmp}" has the same public key as the interface "{wireguard["ifname"]}"')
 
+        if 'disable' not in peer:
+            peer_enabled = True
+
         public_keys.append(peer['public_key'])
+
+    #Threaded can be enabled only if one enabled peer exists.
+    if not peer_enabled and 'threaded' in wireguard:
+        raise ConfigError(f'Set threaded on interface "{wireguard["ifname"]}" FAILED.\nNo enabled peers are configured')
 
 def apply(wireguard):
     tmp = WireGuardIf(wireguard['ifname'])

--- a/src/conf_mode/interfaces-wireguard.py
+++ b/src/conf_mode/interfaces-wireguard.py
@@ -90,7 +90,6 @@ def verify(wireguard):
 
     # run checks on individual configured WireGuard peer
     public_keys = []
-    peer_enabled = False
     for tmp in wireguard['peer']:
         peer = wireguard['peer'][tmp]
 
@@ -107,17 +106,11 @@ def verify(wireguard):
         if peer['public_key'] in public_keys:
             raise ConfigError(f'Duplicate public-key defined on peer "{tmp}"')
 
-        if 'disable' not in peer and is_wireguard_key_pair(wireguard['private_key'], peer['public_key']):
-            raise ConfigError(f'Peer "{tmp}" has the same public key as the interface "{wireguard["ifname"]}"')
-
         if 'disable' not in peer:
-            peer_enabled = True
+            if is_wireguard_key_pair(wireguard['private_key'], peer['public_key']):
+                raise ConfigError(f'Peer "{tmp}" has the same public key as the interface "{wireguard["ifname"]}"')
 
         public_keys.append(peer['public_key'])
-
-    #Threaded can be enabled only if one enabled peer exists.
-    if not peer_enabled and 'threaded' in wireguard:
-        raise ConfigError(f'Set threaded on interface "{wireguard["ifname"]}" FAILED.\nNo enabled peers are configured')
 
 def apply(wireguard):
     tmp = WireGuardIf(wireguard['ifname'])


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added 'set interfaces wireguard wgX threaded' command. 
Process traffic from each peer in a dedicated thread.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5409

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireguard
## Proposed changes
<!--- Describe your changes in detail -->
Added 'set interfaces wireguard wgX threaded' command. 
Process traffic from each peer in a dedicated thread.
This command is allowed only if one enabled peer exists

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
