### PR TITLE
T5436: Add missing preconfig-script

### DIFF
--- a/debian/vyos-1x.postinst
+++ b/debian/vyos-1x.postinst
@@ -120,8 +120,23 @@ if ! grep -q '^dhcpd' /etc/passwd; then
     adduser --quiet dhcpd hostsd
 fi
 
-# ensure hte proxy user has a proper shell
+# ensure the proxy user has a proper shell
 chsh -s /bin/sh proxy
+
+# create /opt/vyatta/etc/config/scripts/vyos-preconfig-bootup.script
+PRECONFIG_SCRIPT=/opt/vyatta/etc/config/scripts/vyos-preconfig-bootup.script
+if [ ! -x $PRECONFIG_SCRIPT ]; then
+    mkdir -p $(dirname $PRECONFIG_SCRIPT)
+    touch $PRECONFIG_SCRIPT
+    chmod 755 $PRECONFIG_SCRIPT
+    cat <<EOF >>$PRECONFIG_SCRIPT
+#!/bin/sh
+# This script is executed at boot time before VyOS configuration is applied.
+# Any modifications required to work around unfixed bugs or use
+# services not available through the VyOS CLI system can be placed here.
+
+EOF
+fi
 
 # create /opt/vyatta/etc/config/scripts/vyos-postconfig-bootup.script
 POSTCONFIG_SCRIPT=/opt/vyatta/etc/config/scripts/vyos-postconfig-bootup.script

--- a/src/op_mode/show_techsupport_report.py
+++ b/src/op_mode/show_techsupport_report.py
@@ -91,7 +91,8 @@ def show_package_repository_config() -> None:
 
 def show_user_startup_scripts() -> None:
     """Prints the user startup scripts."""
-    execute_command('cat /config/scripts/vyos-postconfig-bootup.script', 'User Startup Scripts')
+    execute_command('cat /config/scripts/vyos-preconfig-bootup.script', 'User Startup Scripts (Preconfig)')
+    execute_command('cat /config/scripts/vyos-postconfig-bootup.script', 'User Startup Scripts (Postconfig)')
 
 
 def show_frr_config() -> None:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add missing preconfig-script to be used on boot as described in https://docs.vyos.io/en/latest/automation/command-scripting.html

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5436

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
boot

## Proposed changes
<!--- Describe your changes in detail -->
Added missing preconfig-script (/config/scripts/vyos-preconfig-bootup.script) to be used during boot as described in https://docs.vyos.io/en/latest/automation/command-scripting.html

It turned out that /src/init/vyos-router already was calling this script but the actual file was missing so that have been fixed in:

- /debian/vyos-1x.postint
- /src/op_mode/show_techsupport_report.py

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
- After boot of VyOS check in /config/scripts/ that file "vyos-preconfig-bootup.script" exists.
- Alter file /config/scripts/vyos-preconfig-bootup.script to verify that the commands in there will actually be runned during boot (for example that this command will be runned during boot: touch /config/test.txt).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
