### PR TITLE
T5266: QoS limit could be not configured for queue-type priority

### DIFF
--- a/python/vyos/qos/base.py
+++ b/python/vyos/qos/base.py
@@ -107,7 +107,8 @@ class QoSBase:
 
             queue_limit = dict_search('queue_limit', config)
             for ii in range(1, 4):
-                tmp = f'tc qdisc replace dev {self._interface} parent {handle:x}:{ii:x} pfifo limit {queue_limit}'
+                tmp = f'tc qdisc replace dev {self._interface} parent {handle:x}:{ii:x} pfifo'
+                if queue_limit: tmp += f' limit {queue_limit}'
                 self._cmd(tmp)
 
         elif queue_type == 'fair-queue':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix tc qdisc command that use 'limit None' if limit is not in config
Limit xx should be used only if it exists in the config

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5266

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
qos
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration
```
set qos interface eth0 egress 'VyOS-HTB'
set qos policy shaper VyOS-HTB bandwidth '100mbit'
set qos policy shaper VyOS-HTB class 10 bandwidth '40%'
set qos policy shaper VyOS-HTB class 10 description 'dscp_EF_ipprec_5_GETS'
set qos policy shaper VyOS-HTB class 10 match cs5 ip dscp 'CS5'
set qos policy shaper VyOS-HTB class 10 priority '1'
set qos policy shaper VyOS-HTB class 10 queue-type 'priority'
set qos policy shaper VyOS-HTB class 20 bandwidth '30%'
set qos policy shaper VyOS-HTB class 20 description 'dscp_AF4x_ipprec_4'
set qos policy shaper VyOS-HTB class 20 match af41 ip dscp 'AF41'
set qos policy shaper VyOS-HTB class 20 priority '2'
set qos policy shaper VyOS-HTB class 20 queue-type 'priority'
set qos policy shaper VyOS-HTB default bandwidth '20%'
set qos policy shaper VyOS-HTB default priority '3'
set qos policy shaper VyOS-HTB default queue-type 'priority'
```
Before the fix unexpected `limit None`
```

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/qos.py", line 273, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/qos.py", line 262, in apply
    tmp.update(shaper_config, direction)
  File "/usr/lib/python3/dist-packages/vyos/qos/trafficshaper.py", line 111, in update
    super().update(config, direction)
  File "/usr/lib/python3/dist-packages/vyos/qos/base.py", line 208, in update
    self._build_base_qdisc(cls_config, int(cls))
  File "/usr/lib/python3/dist-packages/vyos/qos/base.py", line 115, in _build_base_qdisc
    self._cmd(tmp)
  File "/usr/lib/python3/dist-packages/vyos/qos/base.py", line 74, in _cmd
    return cmd(command)
           ^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/utils/process.py", line 155, in cmd
    raise OSError(code, feedback)
PermissionError: [Errno 1] failed to run command: tc qdisc replace dev eth0 parent 4014:1 pfifo limit None
returned: 
exit code: 1

```
After the fix:
```
vyos@r14# commit
[ qos ]
DEBUG/QoS: tc qdisc replace dev eth0 root handle 1: htb r2q 62 default 15
DEBUG/QoS: tc class replace dev eth0 parent 1: classid 1:1 htb rate 100000000
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:a htb rate 40000000 burst 15k quantum 1514 prio 1
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:a sfq
DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:14 htb rate 30000000 burst 15k quantum 1514 prio 2
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:14 sfq

WARNING: Interface speed cannot be determined (assuming 10 Mbit/s)

DEBUG/QoS: tc class replace dev eth0 parent 1:1 classid 1:15 htb rate -1000000 burst 15k quantum 1514 prio 3
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:15 sfq
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:a handle 400a: prio
DEBUG/QoS: tc qdisc replace dev eth0 parent 400a:1 pfifo
DEBUG/QoS: tc qdisc replace dev eth0 parent 400a:2 pfifo
DEBUG/QoS: tc qdisc replace dev eth0 parent 400a:3 pfifo
DEBUG/QoS: tc filter add dev eth0 parent 1: prio 1 protocol all u32 match ip dsfield 160 0xff flowid 1:a
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:14 handle 4014: prio
DEBUG/QoS: tc qdisc replace dev eth0 parent 4014:1 pfifo
DEBUG/QoS: tc qdisc replace dev eth0 parent 4014:2 pfifo
DEBUG/QoS: tc qdisc replace dev eth0 parent 4014:3 pfifo
DEBUG/QoS: tc filter add dev eth0 parent 1: prio 2 protocol all u32 match ip dsfield 136 0xff flowid 1:14
DEBUG/QoS: tc qdisc replace dev eth0 parent 1:15 handle 4015: prio
DEBUG/QoS: tc qdisc replace dev eth0 parent 4015:1 pfifo
DEBUG/QoS: tc qdisc replace dev eth0 parent 4015:2 pfifo
DEBUG/QoS: tc qdisc replace dev eth0 parent 4015:3 pfifo

[edit]
vyos@r14# 

```
Check tc filter:
```
vyos@r14# sudo tc filter show dev eth0
filter parent 1: protocol all pref 1 u32 chain 0 
filter parent 1: protocol all pref 1 u32 chain 0 fh 800: ht divisor 1 
filter parent 1: protocol all pref 1 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 *flowid 1:a not_in_hw 
  match 00a00000/00ff0000 at 0
filter parent 1: protocol all pref 2 u32 chain 0 
filter parent 1: protocol all pref 2 u32 chain 0 fh 801: ht divisor 1 
filter parent 1: protocol all pref 2 u32 chain 0 fh 801::800 order 2048 key ht 801 bkt 0 *flowid 1:14 not_in_hw 
  match 00880000/00ff0000 at 0
[edit]
vyos@r14# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
