### PR TITLE
T5440: Restore pre/postconfig scripts if user deleted them

### DIFF
--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -104,10 +104,10 @@ load_bootfile ()
 # restore if missing pre-config script
 restore_if_missing_preconfig_script ()
 {
-    if [ ! -x $vyatta_sysconfdir/config/scripts/vyos-preconfig-bootup.script ]; then
-        cp /usr/lib/live/mount/rootfs/${vyos_rootfs_dir}/opt/vyatta/etc/config/scripts/vyos-preconfig-bootup.script $vyatta_sysconfdir/config/scripts/
-        chgrp ${GROUP} $vyatta_sysconfdir/config/scripts/vyos-preconfig-bootup.script
-        chmod 750 $vyatta_sysconfdir/config/scripts/vyos-preconfig-bootup.script
+    if [ ! -x ${vyatta_sysconfdir}/config/scripts/vyos-preconfig-bootup.script ]; then
+        cp ${vyos_rootfs_dir}/opt/vyatta/etc/config/scripts/vyos-preconfig-bootup.script ${vyatta_sysconfdir}/config/scripts/
+        chgrp ${GROUP} ${vyatta_sysconfdir}/config/scripts/vyos-preconfig-bootup.script
+        chmod 750 ${vyatta_sysconfdir}/config/scripts/vyos-preconfig-bootup.script
     fi
 }
 
@@ -122,10 +122,10 @@ run_preconfig_script ()
 # restore if missing post-config script
 restore_if_missing_postconfig_script ()
 {
-    if [ ! -x $vyatta_sysconfdir/config/scripts/vyos-postconfig-bootup.script ]; then
-        cp /usr/lib/live/mount/rootfs/${vyos_rootfs_dir}/opt/vyatta/etc/config/scripts/vyos-postconfig-bootup.script $vyatta_sysconfdir/config/scripts/
-        chgrp ${GROUP} $vyatta_sysconfdir/config/scripts/vyos-postconfig-bootup.script
-        chmod 750 $vyatta_sysconfdir/config/scripts/vyos-postconfig-bootup.script
+    if [ ! -x ${vyatta_sysconfdir}/config/scripts/vyos-postconfig-bootup.script ]; then
+        cp ${vyos_rootfs_dir}/opt/vyatta/etc/config/scripts/vyos-postconfig-bootup.script ${vyatta_sysconfdir}/config/scripts/
+        chgrp ${GROUP} ${vyatta_sysconfdir}/config/scripts/vyos-postconfig-bootup.script
+        chmod 750 ${vyatta_sysconfdir}/config/scripts/vyos-postconfig-bootup.script
     fi
 }
 

--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -105,9 +105,9 @@ load_bootfile ()
 restore_if_missing_preconfig_script ()
 {
     if [ ! -x $vyatta_sysconfdir/config/scripts/vyos-preconfig-bootup.script ]; then
-        cp /usr/lib/live/mount/rootfs/*/opt/vyatta/etc/config/scripts/vyos-preconfig-bootup.script $vyatta_sysconfdir/config/scripts/
+        cp /usr/lib/live/mount/rootfs/${vyos_rootfs_dir}/opt/vyatta/etc/config/scripts/vyos-preconfig-bootup.script $vyatta_sysconfdir/config/scripts/
         chgrp ${GROUP} $vyatta_sysconfdir/config/scripts/vyos-preconfig-bootup.script
-        chmod 755 $vyatta_sysconfdir/config/scripts/vyos-preconfig-bootup.script
+        chmod 750 $vyatta_sysconfdir/config/scripts/vyos-preconfig-bootup.script
     fi
 }
 
@@ -123,9 +123,9 @@ run_preconfig_script ()
 restore_if_missing_postconfig_script ()
 {
     if [ ! -x $vyatta_sysconfdir/config/scripts/vyos-postconfig-bootup.script ]; then
-        cp /usr/lib/live/mount/rootfs/*/opt/vyatta/etc/config/scripts/vyos-postconfig-bootup.script $vyatta_sysconfdir/config/scripts/
+        cp /usr/lib/live/mount/rootfs/${vyos_rootfs_dir}/opt/vyatta/etc/config/scripts/vyos-postconfig-bootup.script $vyatta_sysconfdir/config/scripts/
         chgrp ${GROUP} $vyatta_sysconfdir/config/scripts/vyos-postconfig-bootup.script
-        chmod 755 $vyatta_sysconfdir/config/scripts/vyos-postconfig-bootup.script
+        chmod 750 $vyatta_sysconfdir/config/scripts/vyos-postconfig-bootup.script
     fi
 }
 

--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -101,11 +101,31 @@ load_bootfile ()
     )
 }
 
+# restore if missing pre-config script
+restore_if_missing_preconfig_script ()
+{
+    if [ ! -x $vyatta_sysconfdir/config/scripts/vyos-preconfig-bootup.script ]; then
+        cp /usr/lib/live/mount/rootfs/*/opt/vyatta/etc/config/scripts/vyos-preconfig-bootup.script $vyatta_sysconfdir/config/scripts/
+        chgrp ${GROUP} $vyatta_sysconfdir/config/scripts/vyos-preconfig-bootup.script
+        chmod 755 $vyatta_sysconfdir/config/scripts/vyos-preconfig-bootup.script
+    fi
+}
+
 # execute the pre-config script
 run_preconfig_script ()
 {
     if [ -x $vyatta_sysconfdir/config/scripts/vyos-preconfig-bootup.script ]; then
         $vyatta_sysconfdir/config/scripts/vyos-preconfig-bootup.script
+    fi
+}
+
+# restore if missing post-config script
+restore_if_missing_postconfig_script ()
+{
+    if [ ! -x $vyatta_sysconfdir/config/scripts/vyos-postconfig-bootup.script ]; then
+        cp /usr/lib/live/mount/rootfs/*/opt/vyatta/etc/config/scripts/vyos-postconfig-bootup.script $vyatta_sysconfdir/config/scripts/
+        chgrp ${GROUP} $vyatta_sysconfdir/config/scripts/vyos-postconfig-bootup.script
+        chmod 755 $vyatta_sysconfdir/config/scripts/vyos-postconfig-bootup.script
     fi
 }
 
@@ -360,6 +380,8 @@ start ()
     log_daemon_msg "Starting VyOS router"
     disabled migrate || migrate_bootfile
 
+    restore_if_missing_preconfig_script
+
     run_preconfig_script
 
     run_postupgrade_script
@@ -383,6 +405,8 @@ start ()
 
     telinit q
     chmod g-w,o-w /
+
+    restore_if_missing_postconfig_script
 
     run_postconfig_scripts
 }


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
If user deletes pre/postconfig scripts from directory /config/scripts then its not obvious how to restore the empty editions since they will only show up on a fresh install.

Bugfix is to adjust /usr/libexec/vyos/init/vyos-router so except for copying the empty scripts (if scripts are missing in /config/scripts) it will also set proper group and permission.

This will also fix the issue where preconfig script doesnt show up after an upgrade (add system image) as described in: https://vyos.dev/T5436

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5440

Also fixes:
* https://vyos.dev/T5436

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
boot

## Proposed changes
<!--- Describe your changes in detail -->
1) Edited /usr/libexec/vyos/init/vyos-router.

2) Added functions "restore_if_missing_preconfig_script" and "restore_if_missing_postconfig_script".

3) In start-function made sure that "restore_if_missing_preconfig_script" runs ahead of "run_preconfig_script" as with "restore_if_missing_postconfig_script" runs ahead of "run_postconfig_scripts".

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
1) Delete the files "/config/scripts/vyos-preconfig-bootup.script" and "/config/scripts/vyos-postconfig-bootup.script" and reboot.

2) Verify that the original (empty) files have been recreated in /config/scripts with proper group and permissions after reboot.

3) Edit both script-files and add "touch /config/scripts/test_preconfig.txt" to the preconfig-script and "touch /config/scripts/test_postconfig.txt" to the postconfig-script and reboot.

4) Verify that files "/config/scripts/test_preconfig.txt" and "/config/scripts/test_postconfig.txt" have been created after reboot but also that the content of pre/postconfig-scripts havent been overwritten.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
