### PR TITLE
T5319: remove workarounds for incorrect defaults in config-mode scripts

### DIFF
--- a/python/vyos/xml_ref/__init__.py
+++ b/python/vyos/xml_ref/__init__.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Optional, Union
 from vyos.xml_ref import definition
 
 def load_reference(cache=[]):
@@ -53,6 +54,9 @@ def from_source(d: dict, path: list) -> bool:
 
 def component_version() -> dict:
     return load_reference().component_version()
+
+def default_value(path: list) -> Optional[Union[str, list]]:
+    return load_reference().default_value(path)
 
 def multi_to_list(rpath: list, conf: dict) -> dict:
     return load_reference().multi_to_list(rpath, conf)

--- a/python/vyos/xml_ref/__init__.py
+++ b/python/vyos/xml_ref/__init__.py
@@ -13,8 +13,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from typing import Optional, Union, TYPE_CHECKING
 from vyos.xml_ref import definition
+
+if TYPE_CHECKING:
+    from vyos.config import ConfigDict
 
 def load_reference(cache=[]):
     if cache:
@@ -49,9 +52,6 @@ def is_leaf(path: list) -> bool:
 def cli_defined(path: list, node: str, non_local=False) -> bool:
     return load_reference().cli_defined(path, node, non_local=non_local)
 
-def from_source(d: dict, path: list) -> bool:
-    return load_reference().from_source(d, path)
-
 def component_version() -> dict:
     return load_reference().component_version()
 
@@ -72,8 +72,8 @@ def relative_defaults(rpath: list, conf: dict, get_first_key=False,
                                               get_first_key=get_first_key,
                                               recursive=recursive)
 
-def merge_defaults(path: list, conf: dict, get_first_key=False,
-                   recursive=False) -> dict:
-    return load_reference().merge_defaults(path, conf,
-                                           get_first_key=get_first_key,
-                                           recursive=recursive)
+def from_source(d: dict, path: list) -> bool:
+    return definition.from_source(d, path)
+
+def ext_dict_merge(source: dict, destination: Union[dict, 'ConfigDict']):
+    return definition.ext_dict_merge(source, destination)

--- a/python/vyos/xml_ref/definition.py
+++ b/python/vyos/xml_ref/definition.py
@@ -153,6 +153,15 @@ class Xml:
             return default.split()
         return default
 
+    def default_value(self, path: list) -> Optional[Union[str, list]]:
+        d = self._get_ref_path(path)
+        default = self._get_default_value(d)
+        if default is None:
+            return None
+        if self._is_multi_node(d) or self._is_tag_node(d):
+            return default.split()
+        return default
+
     def get_defaults(self, path: list, get_first_key=False, recursive=False) -> dict:
         """Return dict containing default values below path
 

--- a/src/conf_mode/conntrack.py
+++ b/src/conf_mode/conntrack.py
@@ -20,7 +20,6 @@ import re
 from sys import exit
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.firewall import find_nftables_rule
 from vyos.firewall import remove_nftables_rule
 from vyos.utils.process import process_named_running
@@ -28,7 +27,6 @@ from vyos.utils.dict import dict_search
 from vyos.utils.process import cmd
 from vyos.utils.process import run
 from vyos.template import render
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -77,16 +75,8 @@ def get_config(config=None):
     base = ['system', 'conntrack']
 
     conntrack = conf.get_config_dict(base, key_mangling=('-', '_'),
-                                     get_first_key=True)
-
-    # We have gathered the dict representation of the CLI, but there are default
-    # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    # XXX: T2665: we can not safely rely on the defaults() when there are
-    # tagNodes in place, it is better to blend in the defaults manually.
-    if 'timeout' in default_values and 'custom' in default_values['timeout']:
-        del default_values['timeout']['custom']
-    conntrack = dict_merge(default_values, conntrack)
+                                     get_first_key=True,
+                                     with_recursive_defaults=True)
 
     return conntrack
 

--- a/src/conf_mode/conntrack_sync.py
+++ b/src/conf_mode/conntrack_sync.py
@@ -18,7 +18,6 @@ import os
 
 from sys import exit
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.configverify import verify_interface_exists
 from vyos.utils.dict import dict_search
 from vyos.utils.process import process_named_running
@@ -28,7 +27,6 @@ from vyos.utils.process import run
 from vyos.template import render
 from vyos.template import get_ipv4
 from vyos.utils.network import is_addr_assigned
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -50,11 +48,7 @@ def get_config(config=None):
         return None
 
     conntrack = conf.get_config_dict(base, key_mangling=('-', '_'),
-                                     get_first_key=True)
-    # We have gathered the dict representation of the CLI, but there are default
-    # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    conntrack = dict_merge(default_values, conntrack)
+                                     get_first_key=True, with_defaults=True)
 
     conntrack['hash_size'] = read_file('/sys/module/nf_conntrack/parameters/hashsize')
     conntrack['table_size'] = read_file('/proc/sys/net/netfilter/nf_conntrack_max')

--- a/src/conf_mode/dhcp_relay.py
+++ b/src/conf_mode/dhcp_relay.py
@@ -20,12 +20,10 @@ from sys import exit
 
 from vyos.base import Warning
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.template import render
 from vyos.base import Warning
 from vyos.utils.process import call
 from vyos.utils.dict import dict_search
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -41,11 +39,9 @@ def get_config(config=None):
     if not conf.exists(base):
         return None
 
-    relay = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
-    # We have gathered the dict representation of the CLI, but there are default
-    # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    relay = dict_merge(default_values, relay)
+    relay = conf.get_config_dict(base, key_mangling=('-', '_'),
+                                 get_first_key=True,
+                                 with_recursive_defaults=True)
 
     return relay
 

--- a/src/conf_mode/dhcpv6_relay.py
+++ b/src/conf_mode/dhcpv6_relay.py
@@ -19,14 +19,11 @@ import os
 from sys import exit
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.ifconfig import Interface
 from vyos.template import render
 from vyos.template import is_ipv6
 from vyos.utils.process import call
-from vyos.utils.dict import dict_search
 from vyos.utils.network import is_ipv6_link_local
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -42,11 +39,9 @@ def get_config(config=None):
     if not conf.exists(base):
         return None
 
-    relay = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
-    # We have gathered the dict representation of the CLI, but there are default
-    # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    relay = dict_merge(default_values, relay)
+    relay = conf.get_config_dict(base, key_mangling=('-', '_'),
+                                 get_first_key=True,
+                                 with_recursive_defaults=True)
 
     return relay
 

--- a/src/conf_mode/dns_dynamic.py
+++ b/src/conf_mode/dns_dynamic.py
@@ -19,10 +19,8 @@ import os
 from sys import exit
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.template import render
 from vyos.utils.process import call
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -50,8 +48,9 @@ def get_config(config=None):
         return None
 
     dyndns = conf.get_config_dict(base_level, key_mangling=('-', '_'),
-                                  get_first_key=True, no_tag_node_value_mangle=True,
-                                  with_defaults=True, with_recursive_defaults=True)
+                                  no_tag_node_value_mangle=True,
+                                  get_first_key=True,
+                                  with_recursive_defaults=True)
 
     dyndns['config_file'] = config_file
     return dyndns

--- a/src/conf_mode/http-api.py
+++ b/src/conf_mode/http-api.py
@@ -24,12 +24,9 @@ from copy import deepcopy
 import vyos.defaults
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.configdep import set_dependents, call_dependents
 from vyos.template import render
-from vyos.utils.process import cmd
 from vyos.utils.process import call
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -72,8 +69,9 @@ def get_config(config=None):
         return None
 
     api_dict = conf.get_config_dict(base, key_mangling=('-', '_'),
-                                          no_tag_node_value_mangle=True,
-                                          get_first_key=True)
+                                    no_tag_node_value_mangle=True,
+                                    get_first_key=True,
+                                    with_recursive_defaults=True)
 
     # One needs to 'flatten' the keys dict from the config into the
     # http-api.conf format for api_keys:
@@ -93,8 +91,8 @@ def get_config(config=None):
     if 'api_keys' in api_dict:
         keys_added = True
 
-    if 'graphql' in api_dict:
-        api_dict = dict_merge(defaults(base), api_dict)
+    if api_dict.from_defaults(['graphql']):
+        del api_dict['graphql']
 
     http_api.update(api_dict)
 

--- a/src/conf_mode/igmp_proxy.py
+++ b/src/conf_mode/igmp_proxy.py
@@ -21,11 +21,9 @@ from netifaces import interfaces
 
 from vyos.base import Warning
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.template import render
 from vyos.utils.process import call
 from vyos.utils.dict import dict_search
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -39,16 +37,9 @@ def get_config(config=None):
         conf = Config()
 
     base = ['protocols', 'igmp-proxy']
-    igmp_proxy = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
-
-    if 'interface' in igmp_proxy:
-        # T2665: we must add the tagNode defaults individually until this is
-        # moved to the base class
-        default_values = defaults(base + ['interface'])
-        for interface in igmp_proxy['interface']:
-            igmp_proxy['interface'][interface] = dict_merge(default_values,
-                igmp_proxy['interface'][interface])
-
+    igmp_proxy = conf.get_config_dict(base, key_mangling=('-', '_'),
+                                      get_first_key=True,
+                                      with_defaults=True)
 
     if conf.exists(['protocols', 'igmp']):
         igmp_proxy.update({'igmp_configured': ''})

--- a/src/conf_mode/load-balancing-haproxy.py
+++ b/src/conf_mode/load-balancing-haproxy.py
@@ -20,14 +20,12 @@ from sys import exit
 from shutil import rmtree
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.utils.process import call
 from vyos.utils.network import check_port_availability
 from vyos.utils.network import is_listen_port_bind_service
 from vyos.pki import wrap_certificate
 from vyos.pki import wrap_private_key
 from vyos.template import render
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -54,18 +52,8 @@ def get_config(config=None):
         lb['pki'] = conf.get_config_dict(['pki'], key_mangling=('-', '_'),
                                     get_first_key=True, no_tag_node_value_mangle=True)
 
-    # We have gathered the dict representation of the CLI, but there are default
-    # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    if 'backend' in default_values:
-        del default_values['backend']
     if lb:
-        lb = dict_merge(default_values, lb)
-
-    if 'backend' in lb:
-        for backend in lb['backend']:
-            default_balues_backend = defaults(base + ['backend'])
-            lb['backend'][backend] = dict_merge(default_balues_backend, lb['backend'][backend])
+        lb = conf.merge_defaults(lb, recursive=True)
 
     return lb
 

--- a/src/conf_mode/nat66.py
+++ b/src/conf_mode/nat66.py
@@ -23,13 +23,11 @@ from netifaces import interfaces
 
 from vyos.base import Warning
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.template import render
 from vyos.utils.process import cmd
 from vyos.utils.kernel import check_kmod
 from vyos.utils.dict import dict_search
 from vyos.template import is_ipv6
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -59,16 +57,6 @@ def get_config(config=None):
 
     base = ['nat66']
     nat = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
-
-    # T2665: we must add the tagNode defaults individually until this is
-    # moved to the base class
-    for direction in ['source', 'destination']:
-        if direction in nat:
-            default_values = defaults(base + [direction, 'rule'])
-            if 'rule' in nat[direction]:
-                for rule in nat[direction]['rule']:
-                    nat[direction]['rule'][rule] = dict_merge(default_values,
-                        nat[direction]['rule'][rule])
 
     # read in current nftable (once) for further processing
     tmp = cmd('nft -j list table ip6 raw')

--- a/src/conf_mode/pki.py
+++ b/src/conf_mode/pki.py
@@ -18,7 +18,6 @@ from sys import exit
 
 from vyos.config import Config
 from vyos.configdep import set_dependents, call_dependents
-from vyos.configdict import dict_merge
 from vyos.configdict import node_changed
 from vyos.pki import is_ca_certificate
 from vyos.pki import load_certificate
@@ -28,7 +27,6 @@ from vyos.pki import load_crl
 from vyos.pki import load_dh_parameters
 from vyos.utils.dict import dict_search_args
 from vyos.utils.dict import dict_search_recursive
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -113,8 +111,7 @@ def get_config(config=None):
 
     # We only merge on the defaults of there is a configuration at all
     if conf.exists(base):
-        default_values = defaults(base)
-        pki = dict_merge(default_values, pki)
+        pki = conf.merge_defaults(pki, recursive=True)
 
     # We need to get the entire system configuration to verify that we are not
     # deleting a certificate that is still referenced somewhere!

--- a/src/conf_mode/protocols_bfd.py
+++ b/src/conf_mode/protocols_bfd.py
@@ -17,12 +17,10 @@
 import os
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.configverify import verify_vrf
 from vyos.template import is_ipv6
 from vyos.template import render_to_string
 from vyos.utils.network import is_ipv6_link_local
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import frr
 from vyos import airbag
@@ -41,18 +39,7 @@ def get_config(config=None):
     if not conf.exists(base):
         return bfd
 
-    # We have gathered the dict representation of the CLI, but there are
-    # default options which we need to update into the dictionary retrived.
-    # XXX: T2665: we currently have no nice way for defaults under tag
-    # nodes, thus we load the defaults "by hand"
-    default_values = defaults(base + ['peer'])
-    if 'peer' in bfd:
-        for peer in bfd['peer']:
-            bfd['peer'][peer] = dict_merge(default_values, bfd['peer'][peer])
-
-    if 'profile' in bfd:
-        for profile in bfd['profile']:
-            bfd['profile'][profile] = dict_merge(default_values, bfd['profile'][profile])
+    bfd = conf.merge_defaults(bfd, recursive=True)
 
     return bfd
 

--- a/src/conf_mode/protocols_failover.py
+++ b/src/conf_mode/protocols_failover.py
@@ -19,10 +19,8 @@ import json
 from pathlib import Path
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.template import render
 from vyos.utils.process import call
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 
@@ -42,15 +40,12 @@ def get_config(config=None):
         conf = Config()
 
     base = ['protocols', 'failover']
-    failover = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
+    failover = conf.get_config_dict(base, key_mangling=('-', '_'),
+                                    get_first_key=True)
 
     # Set default values only if we set config
-    if failover.get('route'):
-        for route, route_config in failover.get('route').items():
-            for next_hop, next_hop_config in route_config.get('next_hop').items():
-                default_values = defaults(base + ['route'])
-                failover['route'][route]['next_hop'][next_hop] = dict_merge(
-                    default_values['next_hop'], failover['route'][route]['next_hop'][next_hop])
+    if failover.get('route') is not None:
+        failover = conf.merge_defaults(failover, recursive=True)
 
     return failover
 

--- a/src/conf_mode/protocols_isis.py
+++ b/src/conf_mode/protocols_isis.py
@@ -28,7 +28,6 @@ from vyos.ifconfig import Interface
 from vyos.utils.dict import dict_search
 from vyos.utils.network import get_interface_config
 from vyos.template import render_to_string
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import frr
 from vyos import airbag
@@ -69,14 +68,8 @@ def get_config(config=None):
         isis.update({'deleted' : ''})
         return isis
 
-    # We have gathered the dict representation of the CLI, but there are default
-    # options which we need to update into the dictionary retrived.
-    # XXX: Note that we can not call defaults(base), as defaults does not work
-    # on an instance of a tag node. As we use the exact same CLI definition for
-    # both the non-vrf and vrf version this is absolutely safe!
-    default_values = defaults(base_path)
     # merge in default values
-    isis = dict_merge(default_values, isis)
+    isis = conf.merge_defaults(isis, recursive=True)
 
     # We also need some additional information from the config, prefix-lists
     # and route-maps for instance. They will be used in verify().

--- a/src/conf_mode/protocols_rip.py
+++ b/src/conf_mode/protocols_rip.py
@@ -25,7 +25,6 @@ from vyos.configverify import verify_common_route_maps
 from vyos.configverify import verify_access_list
 from vyos.configverify import verify_prefix_list
 from vyos.utils.dict import dict_search
-from vyos.xml import defaults
 from vyos.template import render_to_string
 from vyos import ConfigError
 from vyos import frr
@@ -55,9 +54,7 @@ def get_config(config=None):
 
     # We have gathered the dict representation of the CLI, but there are default
     # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    # merge in remaining default values
-    rip = dict_merge(default_values, rip)
+    rip = conf.merge_defaults(rip, recursive=True)
 
     # We also need some additional information from the config, prefix-lists
     # and route-maps for instance. They will be used in verify().

--- a/src/conf_mode/protocols_ripng.py
+++ b/src/conf_mode/protocols_ripng.py
@@ -24,7 +24,6 @@ from vyos.configverify import verify_common_route_maps
 from vyos.configverify import verify_access_list
 from vyos.configverify import verify_prefix_list
 from vyos.utils.dict import dict_search
-from vyos.xml import defaults
 from vyos.template import render_to_string
 from vyos import ConfigError
 from vyos import frr
@@ -45,9 +44,7 @@ def get_config(config=None):
 
     # We have gathered the dict representation of the CLI, but there are default
     # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    # merge in remaining default values
-    ripng = dict_merge(default_values, ripng)
+    ripng = conf.merge_defaults(ripng, recursive=True)
 
     # We also need some additional information from the config, prefix-lists
     # and route-maps for instance. They will be used in verify().

--- a/src/conf_mode/protocols_rpki.py
+++ b/src/conf_mode/protocols_rpki.py
@@ -19,10 +19,8 @@ import os
 from sys import exit
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.template import render_to_string
 from vyos.utils.dict import dict_search
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import frr
 from vyos import airbag
@@ -43,8 +41,7 @@ def get_config(config=None):
 
     # We have gathered the dict representation of the CLI, but there are default
     # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    rpki = dict_merge(default_values, rpki)
+    rpki = conf.merge_defaults(rpki, recursive=True)
 
     return rpki
 

--- a/src/conf_mode/salt-minion.py
+++ b/src/conf_mode/salt-minion.py
@@ -22,12 +22,10 @@ from urllib3 import PoolManager
 
 from vyos.base import Warning
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.configverify import verify_interface_exists
 from vyos.template import render
 from vyos.utils.process import call
 from vyos.utils.permission import chown
-from vyos.xml import defaults
 from vyos import ConfigError
 
 from vyos import airbag
@@ -55,8 +53,7 @@ def get_config(config=None):
         salt['id'] = gethostname()
     # We have gathered the dict representation of the CLI, but there are default
     # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    salt = dict_merge(default_values, salt)
+    salt = conf.merge_defaults(salt, recursive=True)
 
     if not conf.exists(base):
         return None

--- a/src/conf_mode/service_config_sync.py
+++ b/src/conf_mode/service_config_sync.py
@@ -19,8 +19,6 @@ import json
 from pathlib import Path
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 
@@ -42,12 +40,8 @@ def get_config(config=None):
     base = ['service', 'config-sync']
     if not conf.exists(base):
         return None
-    config = conf.get_config_dict(base,
-                                  get_first_key=True,
-                                  no_tag_node_value_mangle=True)
-
-    default_values = defaults(base)
-    config = dict_merge(default_values, config)
+    config = conf.get_config_dict(base, get_first_key=True,
+                                  with_recursive_defaults=True)
 
     return config
 

--- a/src/conf_mode/service_console-server.py
+++ b/src/conf_mode/service_console-server.py
@@ -20,10 +20,8 @@ from sys import exit
 from psutil import process_iter
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.template import render
 from vyos.utils.process import call
-from vyos.xml import defaults
 from vyos import ConfigError
 
 config_file = '/run/conserver/conserver.cf'
@@ -49,11 +47,7 @@ def get_config(config=None):
 
     # We have gathered the dict representation of the CLI, but there are default
     # options which we need to update into the dictionary retrived.
-    default_values = defaults(base + ['device'])
-    if 'device' in proxy:
-        for device in proxy['device']:
-            tmp = dict_merge(default_values, proxy['device'][device])
-            proxy['device'][device] = tmp
+    proxy = conf.merge_defaults(proxy, recursive=True)
 
     return proxy
 

--- a/src/conf_mode/service_ids_fastnetmon.py
+++ b/src/conf_mode/service_ids_fastnetmon.py
@@ -19,10 +19,8 @@ import os
 from sys import exit
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.template import render
 from vyos.utils.process import call
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -41,11 +39,9 @@ def get_config(config=None):
     if not conf.exists(base):
         return None
 
-    fastnetmon = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
-    # We have gathered the dict representation of the CLI, but there are default
-    # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    fastnetmon = dict_merge(default_values, fastnetmon)
+    fastnetmon = conf.get_config_dict(base, key_mangling=('-', '_'),
+                                      get_first_key=True,
+                                      with_recursive_defaults=True)
 
     return fastnetmon
 

--- a/src/conf_mode/service_monitoring_telegraf.py
+++ b/src/conf_mode/service_monitoring_telegraf.py
@@ -22,7 +22,6 @@ from sys import exit
 from shutil import rmtree
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.configdict import is_node_changed
 from vyos.configverify import verify_vrf
 from vyos.ifconfig import Section
@@ -30,7 +29,6 @@ from vyos.template import render
 from vyos.utils.process import call
 from vyos.utils.permission import chown
 from vyos.utils.process import cmd
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -83,8 +81,7 @@ def get_config(config=None):
 
     # We have gathered the dict representation of the CLI, but there are default
     # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    monitoring = dict_merge(default_values, monitoring)
+    monitoring = conf.merge_defaults(monitoring, recursive=True)
 
     monitoring['custom_scripts_dir'] = custom_scripts_dir
     monitoring['hostname'] = get_hostname()

--- a/src/conf_mode/service_sla.py
+++ b/src/conf_mode/service_sla.py
@@ -19,10 +19,8 @@ import os
 from sys import exit
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.template import render
 from vyos.utils.process import call
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -44,11 +42,9 @@ def get_config(config=None):
     if not conf.exists(base):
         return None
 
-    sla = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
-    # We have gathered the dict representation of the CLI, but there are default
-    # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    sla = dict_merge(default_values, sla)
+    sla = conf.get_config_dict(base, key_mangling=('-', '_'),
+                               get_first_key=True,
+                               with_recursive_defaults=True)
 
     # Ignore default XML values if config doesn't exists
     # Delete key from dict

--- a/src/conf_mode/service_upnp.py
+++ b/src/conf_mode/service_upnp.py
@@ -23,12 +23,10 @@ from ipaddress import IPv4Network
 from ipaddress import IPv6Network
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.utils.process import call
 from vyos.template import render
 from vyos.template import is_ipv4
 from vyos.template import is_ipv6
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -47,10 +45,7 @@ def get_config(config=None):
     if not upnpd:
         return None
 
-    if 'rule' in upnpd:
-        default_member_values = defaults(base + ['rule'])
-        for rule,rule_config in upnpd['rule'].items():
-            upnpd['rule'][rule] = dict_merge(default_member_values, upnpd['rule'][rule])
+    upnpd = conf.merge_defaults(upnpd, recursive=True)
 
     uuidgen = uuid.uuid1()
     upnpd.update({'uuid': uuidgen})

--- a/src/conf_mode/ssh.py
+++ b/src/conf_mode/ssh.py
@@ -21,12 +21,10 @@ from syslog import syslog
 from syslog import LOG_INFO
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.configdict import is_node_changed
 from vyos.configverify import verify_vrf
 from vyos.utils.process import call
 from vyos.template import render
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -57,8 +55,8 @@ def get_config(config=None):
 
     # We have gathered the dict representation of the CLI, but there are default
     # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    ssh = dict_merge(default_values, ssh)
+    ssh = conf.merge_defaults(ssh, recursive=True)
+
     # pass config file path - used in override template
     ssh['config_file'] = config_file
 

--- a/src/conf_mode/system-ip.py
+++ b/src/conf_mode/system-ip.py
@@ -24,7 +24,6 @@ from vyos.utils.process import call
 from vyos.utils.dict import dict_search
 from vyos.utils.file import write_file
 from vyos.utils.system import sysctl_write
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import frr
 from vyos import airbag
@@ -37,11 +36,9 @@ def get_config(config=None):
         conf = Config()
     base = ['system', 'ip']
 
-    opt = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
-    # We have gathered the dict representation of the CLI, but there are default
-    # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    opt = dict_merge(default_values, opt)
+    opt = conf.get_config_dict(base, key_mangling=('-', '_'),
+                               get_first_key=True,
+                               with_recursive_defaults=True)
 
     # When working with FRR we need to know the corresponding address-family
     opt['afi'] = 'ip'

--- a/src/conf_mode/system-ipv6.py
+++ b/src/conf_mode/system-ipv6.py
@@ -24,7 +24,6 @@ from vyos.template import render_to_string
 from vyos.utils.dict import dict_search
 from vyos.utils.system import sysctl_write
 from vyos.utils.file import write_file
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import frr
 from vyos import airbag
@@ -37,12 +36,9 @@ def get_config(config=None):
         conf = Config()
     base = ['system', 'ipv6']
 
-    opt = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
-
-    # We have gathered the dict representation of the CLI, but there are default
-    # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    opt = dict_merge(default_values, opt)
+    opt = conf.get_config_dict(base, key_mangling=('-', '_'),
+                               get_first_key=True,
+                               with_recursive_defaults=True)
 
     # When working with FRR we need to know the corresponding address-family
     opt['afi'] = 'ipv6'

--- a/src/conf_mode/system-logs.py
+++ b/src/conf_mode/system-logs.py
@@ -19,11 +19,9 @@ from sys import exit
 from vyos import ConfigError
 from vyos import airbag
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.logger import syslog
 from vyos.template import render
 from vyos.utils.dict import dict_search
-from vyos.xml import defaults
 airbag.enable()
 
 # path to logrotate configs
@@ -38,11 +36,9 @@ def get_config(config=None):
         conf = Config()
 
     base = ['system', 'logs']
-    default_values = defaults(base)
-    logs_config = conf.get_config_dict(base,
-                                       key_mangling=('-', '_'),
-                                       get_first_key=True)
-    logs_config = dict_merge(default_values, logs_config)
+    logs_config = conf.get_config_dict(base, key_mangling=('-', '_'),
+                                       get_first_key=True,
+                                       with_recursive_defaults=True)
 
     return logs_config
 

--- a/src/conf_mode/system-option.py
+++ b/src/conf_mode/system-option.py
@@ -21,14 +21,12 @@ from sys import exit
 from time import sleep
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.configverify import verify_source_interface
 from vyos.template import render
 from vyos.utils.process import cmd
 from vyos.utils.process import is_systemd_service_running
 from vyos.utils.network import is_addr_assigned
 from vyos.utils.network import is_intf_addr_assigned
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -48,12 +46,9 @@ def get_config(config=None):
     else:
         conf = Config()
     base = ['system', 'option']
-    options = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
-
-    # We have gathered the dict representation of the CLI, but there are default
-    # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    options = dict_merge(default_values, options)
+    options = conf.get_config_dict(base, key_mangling=('-', '_'),
+                                   get_first_key=True,
+                                   with_recursive_defaults=True)
 
     return options
 

--- a/src/conf_mode/system_console.py
+++ b/src/conf_mode/system_console.py
@@ -19,12 +19,10 @@ import re
 from pathlib import Path
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.utils.process import call
 from vyos.utils.file import read_file
 from vyos.utils.file import write_file
 from vyos.template import render
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -45,16 +43,12 @@ def get_config(config=None):
     if 'device' not in console:
         return console
 
-    # convert CLI values to system values
-    default_values = defaults(base + ['device'])
     for device, device_config in console['device'].items():
         if 'speed' not in device_config and device.startswith('hvc'):
             # XEN console has a different default console speed
             console['device'][device]['speed'] = 38400
-        else:
-            # Merge in XML defaults - the proper way to do it
-            console['device'][device] = dict_merge(default_values,
-                                                   console['device'][device])
+
+    console = conf.merge_defaults(console, recursive=True)
 
     return console
 

--- a/src/conf_mode/system_sflow.py
+++ b/src/conf_mode/system_sflow.py
@@ -19,11 +19,9 @@ import os
 from sys import exit
 
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.template import render
 from vyos.utils.process import call
 from vyos.utils.network import is_addr_assigned
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -42,26 +40,9 @@ def get_config(config=None):
     if not conf.exists(base):
         return None
 
-    sflow = conf.get_config_dict(base,
-                                 key_mangling=('-', '_'),
-                                 get_first_key=True)
-
-    # We have gathered the dict representation of the CLI, but there are default
-    # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-
-    sflow = dict_merge(default_values, sflow)
-
-    # Ignore default XML values if config doesn't exists
-    # Delete key from dict
-    if 'port' in sflow['server']:
-        del sflow['server']['port']
-
-    # Set default values per server
-    if 'server' in sflow:
-        for server in sflow['server']:
-            default_values = defaults(base + ['server'])
-            sflow['server'][server] = dict_merge(default_values, sflow['server'][server])
+    sflow = conf.get_config_dict(base, key_mangling=('-', '_'),
+                                 get_first_key=True,
+                                 with_recursive_defaults=True)
 
     return sflow
 

--- a/src/conf_mode/tftp_server.py
+++ b/src/conf_mode/tftp_server.py
@@ -24,14 +24,12 @@ from sys import exit
 
 from vyos.base import Warning
 from vyos.config import Config
-from vyos.configdict import dict_merge
 from vyos.configverify import verify_vrf
 from vyos.template import render
 from vyos.template import is_ipv4
 from vyos.utils.process import call
 from vyos.utils.permission import chmod_755
 from vyos.utils.network import is_addr_assigned
-from vyos.xml import defaults
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -48,11 +46,9 @@ def get_config(config=None):
     if not conf.exists(base):
         return None
 
-    tftpd = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
-    # We have gathered the dict representation of the CLI, but there are default
-    # options which we need to update into the dictionary retrived.
-    default_values = defaults(base)
-    tftpd = dict_merge(default_values, tftpd)
+    tftpd = conf.get_config_dict(base, key_mangling=('-', '_'),
+                                 get_first_key=True,
+                                 with_recursive_defaults=True)
     return tftpd
 
 def verify(tftpd):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This updates all conf_mode scripts to remove the workarounds for incorrect defaults, and replace any other calls of `defaults` with reliable patterns of merging default values in the config_dict.

Note this was tested without commit 710dac55, pending a fix for the revised smoketests, although it has been rebased over current as is.

In the course of converting conf_mode scripts, another pattern for merging defaults was introduced in T5443, as intermediary between the coarse-grained control of automatic merging of defaults in `get_config_dict` and the fine-grained control of `get_config_defaults/config_dict_merge`; the available patterns are summarized in that task, and examples of each are in the conf_mode script translations. That method is included in this PR.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5319
* https://vyos.dev/T5443
* https://vyos.dev/T5434
* https://vyos.dev/T5435

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
