### PR TITLE
T5446: BGP: change <bgp paramater bestpath med> from node to leafNode

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -481,7 +481,7 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
  bgp bestpath compare-routerid
 {% endif %}
 {% if parameters.bestpath.med is vyos_defined %}
- bgp bestpath med {{ 'confed' if parameters.bestpath.med.confed is vyos_defined }} {{ 'missing-as-worst' if parameters.bestpath.med.missing_as_worst is vyos_defined }}
+ bgp bestpath med {{ parameters.bestpath.med | join(' ') | replace('_', '-') }}
 {% endif %}
 {% if parameters.bestpath.peer_type is vyos_defined %}
  bgp bestpath peer-type {{ 'multipath-relax' if parameters.bestpath.peer_type.multipath_relax is vyos_defined }}

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -1123,25 +1123,26 @@
             <valueless/>
           </properties>
         </leafNode>
-        <node name="med">
+        <leafNode name="med">
           <properties>
             <help>MED attribute comparison parameters</help>
+            <completionHelp>
+              <list>confed missing-as-worst</list>
+            </completionHelp>
+            <valueHelp>
+              <format>confed</format>
+              <description>Compare MEDs among confederation paths</description>
+            </valueHelp>
+            <valueHelp>
+              <format>missing-as-worst</format>
+              <description>Treat missing route as a MED as the least preferred one</description>
+            </valueHelp>
+            <constraint>
+              <regex>(confed|missing-as-worst)</regex>
+            </constraint>
+            <multi/>
           </properties>
-          <children>
-            <leafNode name="confed">
-              <properties>
-                <help>Compare MEDs among confederation paths</help>
-                <valueless/>
-              </properties>
-            </leafNode>
-            <leafNode name="missing-as-worst">
-              <properties>
-                <help>Treat missing route as a MED as the least preferred one</help>
-                <valueless/>
-              </properties>
-            </leafNode>
-          </children>
-        </node>
+        </leafNode>
         <node name="peer-type">
           <properties>
             <help>Peer type</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Change `set protocols bgp paramater bestpath med` from `node` to `leafNode`, in order to avoid empty value and problems when removing such parameters

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5446

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
vyos@LEFT# run show config comm | grep bgp
set protocols bgp address-family ipv4-unicast network 192.0.2.0/24
set protocols bgp neighbor 198.51.100.2 address-family ipv4-unicast soft-reconfiguration inbound
set protocols bgp neighbor 198.51.100.2 remote-as 'external'
set protocols bgp neighbor 198.51.100.2 update-source '198.51.100.1'
set protocols bgp parameters bestpath med 'missing-as-worst'
set protocols bgp parameters bestpath med 'confed'
set protocols bgp parameters router-id '198.51.100.1'
set protocols bgp system-as '65545'
[edit]
vyos@LEFT# sudo vtysh -c "show run" | grep med
 bgp bestpath med confed missing-as-worst
[edit]
vyos@LEFT# del protocols bgp parameters bestpath med confed 
[edit]
vyos@LEFT# commit
[edit]
vyos@LEFT# sudo vtysh -c "show run" | grep med
 bgp bestpath med missing-as-worst
[edit]
vyos@LEFT# del protocols bgp parameters bestpath med 
[edit]
vyos@LEFT# compare
[protocols bgp parameters bestpath]
- med "missing-as-worst"

[edit]
vyos@LEFT# commit
[edit]
vyos@LEFT# sudo vtysh -c "show run" | grep med
[edit]
vyos@LEFT# run show config comm | grep bgp
set protocols bgp address-family ipv4-unicast network 192.0.2.0/24
set protocols bgp neighbor 198.51.100.2 address-family ipv4-unicast soft-reconfiguration inbound
set protocols bgp neighbor 198.51.100.2 remote-as 'external'
set protocols bgp neighbor 198.51.100.2 update-source '198.51.100.1'
set protocols bgp parameters bestpath
set protocols bgp parameters router-id '198.51.100.1'
set protocols bgp system-as '65545'
[edit]
vyos@LEFT# 
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
