### PR TITLE
system-ip: T5449: add TCP MSS probing options

### DIFF
--- a/interface-definitions/system-ip.xml.in
+++ b/interface-definitions/system-ip.xml.in
@@ -48,6 +48,64 @@
               </leafNode>
             </children>
           </node>
+          <node name="tcp">
+            <properties>
+              <help>IPv4 TCP parameters</help>
+            </properties>
+            <children>
+              <node name="mss">
+                <properties>
+                  <help>IPv4 TCP MSS probing options</help>
+                </properties>
+                <children>
+                  <leafNode name="probing">
+                    <properties>
+                      <help>Attempt to lower the MSS if TCP connections fail to establish</help>
+                      <completionHelp>
+                        <list>on-icmp-black-hole force</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>on-icmp-black-hole</format>
+                        <description>Attempt TCP MSS probing when an ICMP black hole is detected</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>force</format>
+                      <description>Attempt TCP MSS probing by default</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>(on-icmp-black-hole|force)</regex>
+                      </constraint>
+                      <constraintErrorMessage>Must be on-icmp-black-hole or force</constraintErrorMessage>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="base">
+                    <properties>
+                      <help>Base MSS to start probing from (applicable to "probing force")</help>
+                      <valueHelp>
+                        <format>u32:48-1460</format>
+                        <description>Base MSS value for probing (default: 1024)</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 48-1460"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="floor">
+                    <properties>
+                      <help>Minimum MSS to stop probing at (default: 48)</help>
+                      <valueHelp>
+                        <format>u32:48-1460</format>
+                        <description>Minimum MSS value to probe</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 48-1460"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+            </children>
+          </node>
           #include <include/system-ip-protocol.xml.i>
         </children>
       </node>

--- a/src/conf_mode/system-ip.py
+++ b/src/conf_mode/system-ip.py
@@ -98,6 +98,27 @@ def apply(opt):
     value = '1' if (tmp != None) else '0'
     sysctl_write('net.ipv4.fib_multipath_hash_policy', value)
 
+    # configure TCP options (defaults as of Linux 6.4)
+    tmp = dict_search('tcp.mss.probing', opt)
+    if tmp is None:
+        value = 0
+    elif tmp == 'on-icmp-black-hole':
+        value = 1
+    elif tmp == 'force':
+        value = 2
+    else:
+        # Shouldn't happen
+        raise ValueError("TCP MSS probing is neither 'on-icmp-black-hole' nor 'force'!")
+    sysctl_write('net.ipv4.tcp_mtu_probing', value)
+
+    tmp = dict_search('tcp.mss.base', opt)
+    value = '1024' if (tmp is None) else tmp
+    sysctl_write('net.ipv4.tcp_base_mss', value)
+
+    tmp = dict_search('tcp.mss.floor', opt)
+    value = '48' if (tmp is None) else tmp
+    sysctl_write('net.ipv4.tcp_mtu_probe_floor', value)
+
     if 'protocol' in opt:
         zebra_daemon = 'zebra'
         # Save original configuration prior to starting any commit actions


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5449

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

`system ip` commands.

## Proposed changes
<!--- Describe your changes in detail -->

New commands:

```
set system ip tcp mss probing <enable|force>
set system ip tcp mss base
set system ip tcp mss floor
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
