### PR TITLE
T5450: allow inverted matcher for interface and interface-group

### DIFF
--- a/interface-definitions/include/constraint/interface-name-with-wildcard-and-inverted.xml.i
+++ b/interface-definitions/include/constraint/interface-name-with-wildcard-and-inverted.xml.i
@@ -1,0 +1,4 @@
+<!-- include start from constraint/interface-name-with-wildcard-and-inverted.xml.i -->
+<regex>(\!?)(bond|br|dum|en|ersp|eth|gnv|ifb|lan|l2tp|l2tpeth|macsec|peth|ppp|pppoe|pptp|sstp|tun|veth|vti|vtun|vxlan|wg|wlan|wwan)([0-9]?)(\*?)(.+)?|(\!?)lo</regex>
+<validator name="file-path --lookup-path /sys/class/net --directory"/>
+<!-- include end -->

--- a/interface-definitions/include/firewall/match-interface.xml.i
+++ b/interface-definitions/include/firewall/match-interface.xml.i
@@ -7,10 +7,18 @@
     </completionHelp>
     <valueHelp>
       <format>txt</format>
-      <description>Interface name, wildcard (*) supported</description>
+      <description>Interface name</description>
+    </valueHelp>
+    <valueHelp>
+      <format>txt*</format>
+      <description>Interface name with wildcard</description>
+    </valueHelp>
+    <valueHelp>
+      <format>!txt</format>
+      <description>Inverted interface name to match</description>
     </valueHelp>
     <constraint>
-      #include <include/constraint/interface-name-with-wildcard.xml.i>
+      #include <include/constraint/interface-name-with-wildcard-and-inverted.xml.i>
     </constraint>
   </properties>
 </leafNode>
@@ -20,6 +28,14 @@
     <completionHelp>
       <path>firewall group interface-group</path>
     </completionHelp>
+    <valueHelp>
+      <format>txt</format>
+      <description>Interface-group name to match</description>
+    </valueHelp>
+    <valueHelp>
+      <format>!txt</format>
+      <description>Inverted interface-group name to match</description>
+    </valueHelp>
   </properties>
 </leafNode>
 <!-- include end -->

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -272,20 +272,34 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
                 output.append(f'ip6 hoplimit {operator} {value}')
 
     if 'inbound_interface' in rule_conf:
+        operator = ''
         if 'interface_name' in rule_conf['inbound_interface']:
             iiface = rule_conf['inbound_interface']['interface_name']
-            output.append(f'iifname {{{iiface}}}')
+            if iiface[0] == '!':
+                operator = '!='
+                iiface = iiface[1:]
+            output.append(f'iifname {operator} {{{iiface}}}')
         else:
             iiface = rule_conf['inbound_interface']['interface_group']
-            output.append(f'iifname @I_{iiface}')
+            if iiface[0] == '!':
+                operator = '!='
+                iiface = iiface[1:]
+            output.append(f'iifname {operator} @I_{iiface}')
 
     if 'outbound_interface' in rule_conf:
+        operator = ''
         if 'interface_name' in rule_conf['outbound_interface']:
             oiface = rule_conf['outbound_interface']['interface_name']
-            output.append(f'oifname {{{oiface}}}')
+            if oiface[0] == '!':
+                operator = '!='
+                oiface = oiface[1:]
+            output.append(f'oifname {operator} {{{oiface}}}')
         else:
             oiface = rule_conf['outbound_interface']['interface_group']
-            output.append(f'oifname @I_{oiface}')
+            if oiface[0] == '!':
+                operator = '!='
+                oiface = oiface[1:]
+            output.append(f'oifname {operator} @I_{oiface}')
 
     if 'ttl' in rule_conf:
         operators = {'eq': '==', 'gt': '>', 'lt': '<'}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow inverted matcher for interface and interface-group

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5450

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->
Allow inverted matcher for interface and interface-group
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@HASH:~$ show config comm | grep firewall
set firewall group interface-group TEST-GROUP interface 'eth1'
set firewall group interface-group TEST-GROUP interface 'vtun*'
set firewall group interface-group TEST-GROUP interface 'bond0.55'
set firewall name FOO rule 10 action 'accept'
set firewall name FOO rule 10 inbound-interface interface-name 'l2tp*'
set firewall name FOO rule 10 outbound-interface interface-group 'TEST-GROUP'
set firewall name FOO rule 20 action 'drop'
set firewall name FOO rule 20 inbound-interface interface-name 'br13'
set firewall name FOO rule 20 outbound-interface interface-group '!TEST-GROUP'
vyos@HASH:~$ sudo nft list chain ip vyos_filter NAME_FOO
table ip vyos_filter {
        chain NAME_FOO {
                iifname "l2tp*" oifname @I_TEST-GROUP counter packets 0 bytes 0 return comment "FOO-10"
                iifname "br13" oifname != @I_TEST-GROUP counter packets 0 bytes 0 drop comment "FOO-20"
                counter packets 0 bytes 0 drop comment "FOO default-action drop"
        }
}

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
