### PR TITLE
openvpn: T5271: add peer certificate fingerprint option

### DIFF
--- a/data/templates/openvpn/server.conf.j2
+++ b/data/templates/openvpn/server.conf.j2
@@ -200,6 +200,14 @@ tls-client
 {%     elif tls.role is vyos_defined('passive') %}
 tls-server
 {%     endif %}
+
+{%     if peer_fingerprint is vyos_defined %}
+<peer-fingerprint>
+{%         for fp in peer_fingerprint %}
+{{ fp }}
+{%         endfor %}
+</peer-fingerprint>
+{%     endif %}
 {% endif %}
 
 # Encryption options

--- a/interface-definitions/interfaces-openvpn.xml.in
+++ b/interface-definitions/interfaces-openvpn.xml.in
@@ -752,6 +752,16 @@
                   </completionHelp>
                 </properties>
               </leafNode>
+              <leafNode name="peer-fingerprint">
+                <properties>
+                  <multi/>
+                  <help>Peer certificate SHA256 fingerprint</help>
+                  <constraint>
+                    <regex>[0-9a-fA-F]{2}:([0-9a-fA-F]{2}:){30}[0-9a-fA-F]{2}</regex>
+                  </constraint>
+                  <constraintErrorMessage>Peer certificate fingerprint must be a colon-separated SHA256 hex digest</constraintErrorMessage>
+                </properties>
+              </leafNode>
               <leafNode name="tls-version-min">
                 <properties>
                   <help>Specify the minimum required TLS version</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add support for peer certificate fingerprints. This is required for the future "site-to-site with TLS" mode that relies on self-signed EC certs and uses fingerprints for peer authentication without a CA cert (see https://github.com/OpenVPN/openvpn/blob/master/doc/man-sections/example-fingerprint.rst)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5271

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

OpenVPN.

## Proposed changes
<!--- Describe your changes in detail -->

`set interfaces openvpn vtunX tls peer-fingerprint <fingerprint>` (a multi node)

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Right now, you can set it, but you need a CA and DH to actually commit a configuration. Relaxing those restrictions will be done in subsequent PRs because it's a separate change.

OpenVPN only supports SHA256 fingerprints at the moment.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
