### PR TITLE
gre tunnel: T5223 :clear key id after deletion

### DIFF
--- a/src/conf_mode/interfaces-tunnel.py
+++ b/src/conf_mode/interfaces-tunnel.py
@@ -55,6 +55,9 @@ def get_config(config=None):
         tmp = is_node_changed(conf, base + [ifname, 'encapsulation'])
         if tmp: tunnel.update({'encapsulation_changed': {}})
 
+        tmp = is_node_changed(conf, base + [ifname, 'parameters', 'ip', 'key'])
+        if tmp: tunnel.update({'key_changed': {}})
+
         # We also need to inspect other configured tunnels as there are Kernel
         # restrictions where we need to comply. E.g. GRE tunnel key can't be used
         # twice, or with multiple GRE tunnels to the same location we must specify
@@ -197,7 +200,8 @@ def apply(tunnel):
         remote = dict_search('linkinfo.info_data.remote', tmp)
 
     if ('deleted' in tunnel or 'encapsulation_changed' in tunnel or encap in
-        ['gretap', 'ip6gretap', 'erspan', 'ip6erspan'] or remote in ['any']):
+        ['gretap', 'ip6gretap', 'erspan', 'ip6erspan'] or remote in ['any'] or
+        'key_changed' in tunnel):
         if interface in interfaces():
             tmp = Interface(interface)
             tmp.remove()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
key parameter doesn't  clear after deletion, its value is still sent in gre header. Its removed after reboot or tunnel recreation. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5223

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
tunnel (gre)
## Proposed changes
<!--- Describe your changes in detail -->

To recreate the tunnel when the key parameter is deleted from the configuration.


## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Before fix:

```
set interfaces tunnel tunx address 'x.x.x.x/x'
set interfaces tunnel tunx encapsulation 'gre'
set interfaces tunnel tunx remote 'x.x.x.x'
set interfaces tunnel tunx source-address 'x.x.x.x'
set interfaces tunnel tunx parameters ip key x

#del interfaces tunnel tunx parameters ip key x

vyos@vyos# sudo ip tun sh
gre0: gre/ip remote any local any ttl inherit nopmtudisc
tun0: gre/ip remote x.x.x.x local x.x.x.x ttl 64 tos inherit key xx

```
After fix:

key gets deleted:

```
vyos@vyos# sudo ip tun sh
gre0: gre/ip remote any local any ttl inherit nopmtudisc
tun0: gre/ip remote x.x.x.x local x.x.x.x ttl 64 tos inherit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
