### PR TITLE
openvpn: T5270: do not require classic DH params in any mode

### DIFF
--- a/src/conf_mode/interfaces-openvpn.py
+++ b/src/conf_mode/interfaces-openvpn.py
@@ -189,16 +189,7 @@ def verify_pki(openvpn):
             if dict_search_args(pki, 'certificate', tls['certificate'], 'private', 'password_protected') is not None:
                 raise ConfigError(f'Cannot use encrypted private key on openvpn interface {interface}')
 
-            if mode == 'server' and 'dh_params' not in tls and not is_ec_private_key(pki, tls['certificate']):
-                raise ConfigError('Must specify "tls dh-params" when not using EC keys in server mode')
-
         if 'dh_params' in tls:
-            if 'dh' not in pki:
-                raise ConfigError('There are no DH parameters in PKI configuration')
-
-            if tls['dh_params'] not in pki['dh']:
-                raise ConfigError(f'Invalid dh-params on openvpn interface {interface}')
-
             pki_dh = pki['dh'][tls['dh_params']]
             dh_params = load_dh_parameters(pki_dh['parameters'])
             dh_numbers = dh_params.parameter_numbers()
@@ -206,6 +197,7 @@ def verify_pki(openvpn):
 
             if dh_bits < 2048:
                 raise ConfigError(f'Minimum DH key-size is 2048 bits')
+
 
         if 'auth_key' in tls or 'crypt_key' in tls:
             if not dict_search_args(pki, 'openvpn', 'shared_secret'):
@@ -494,9 +486,6 @@ def verify(openvpn):
             elif tmp == 'passive':
                 if openvpn['protocol'] == 'tcp-active':
                     raise ConfigError('Cannot specify "tcp-active" when "tls role" is "passive"')
-
-                if not dict_search('tls.dh_params', openvpn):
-                    raise ConfigError('Must specify "tls dh-params" when "tls role" is "passive"')
 
         if 'certificate' in openvpn['tls'] and is_ec_private_key(openvpn['pki'], openvpn['tls']['certificate']):
             if 'dh_params' in openvpn['tls']:


### PR DESCRIPTION
Generate 'dh none' instead and let OpenVPN use ECDH

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Do not require classic rational number based DH at all.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5270

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

OpenVPN

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
