### PR TITLE
T5434: remove reamining calls to incorrect defaults

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -32,9 +32,6 @@ override_dh_auto_build:
 override_dh_auto_install:
 	dh_auto_install
 
-	# convert the XML to dictionaries
-	env PYTHONPATH=python python3 python/vyos/xml/generate.py
-
 	cd python; python3 setup.py install --install-layout=deb --root ../$(DIR); cd ..
 
 	# Install scripts

--- a/python/vyos/component_version.py
+++ b/python/vyos/component_version.py
@@ -37,7 +37,7 @@ import re
 import sys
 import fileinput
 
-from vyos.xml import component_version
+from vyos.xml_ref import component_version
 from vyos.version import get_version
 from vyos.defaults import directories
 

--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -20,7 +20,6 @@ import os
 import json
 
 from vyos.utils.dict import dict_search
-from vyos.xml import defaults
 from vyos.utils.process import cmd
 
 def retrieve_config(path_hash, base_path, config):

--- a/python/vyos/configdiff.py
+++ b/python/vyos/configdiff.py
@@ -22,7 +22,7 @@ from vyos.configdict import list_diff
 from vyos.utils.dict import get_sub_dict
 from vyos.utils.dict import mangle_dict_keys
 from vyos.utils.dict import dict_search_args
-from vyos.xml import defaults
+from vyos.xml_ref import get_defaults
 
 class ConfigDiffError(Exception):
     """
@@ -240,7 +240,9 @@ class ConfigDiff(object):
                         if self._key_mangling:
                             ret[k] = self._mangle_dict_keys(ret[k])
                         if k in target_defaults and not no_defaults:
-                            default_values = defaults(self._make_path(path))
+                            default_values = get_defaults(self._make_path(path),
+                                                          get_first_key=True,
+                                                          recursive=True)
                             ret[k] = dict_merge(default_values, ret[k])
                 return ret
 
@@ -264,7 +266,9 @@ class ConfigDiff(object):
                     ret[k] = self._mangle_dict_keys(ret[k])
 
                 if k in target_defaults and not no_defaults:
-                    default_values = defaults(self._make_path(path))
+                    default_values = get_defaults(self._make_path(path),
+                                                  get_first_key=True,
+                                                  recursive=True)
                     ret[k] = dict_merge(default_values, ret[k])
 
         return ret
@@ -312,7 +316,9 @@ class ConfigDiff(object):
                         if self._key_mangling:
                             ret[k] = self._mangle_dict_keys(ret[k])
                         if k in target_defaults and not no_defaults:
-                            default_values = defaults(self._make_path(path))
+                            default_values = get_defaults(self._make_path(path),
+                                                          get_first_key=True,
+                                                          recursive=True)
                             ret[k] = dict_merge(default_values, ret[k])
                 return ret
 
@@ -335,7 +341,9 @@ class ConfigDiff(object):
                     ret[k] = self._mangle_dict_keys(ret[k])
 
                 if k in target_defaults and not no_defaults:
-                    default_values = defaults(self._make_path(path))
+                    default_values = get_defaults(self._make_path(path),
+                                                  get_first_key=True,
+                                                  recursive=True)
                     ret[k] = dict_merge(default_values, ret[k])
 
         return ret

--- a/python/vyos/xml_ref/definition.py
+++ b/python/vyos/xml_ref/definition.py
@@ -162,7 +162,7 @@ class Xml:
 
     def component_version(self) -> dict:
         d = {}
-        for k, v in self.ref['component_version']:
+        for k, v in self.ref['component_version'].items():
             d[k] = int(v)
         return d
 

--- a/src/helpers/vyos-domain-resolver.py
+++ b/src/helpers/vyos-domain-resolver.py
@@ -26,7 +26,7 @@ from vyos.utils.commit import commit_in_progress
 from vyos.utils.dict import dict_search_args
 from vyos.utils.process import cmd
 from vyos.utils.process import run
-from vyos.xml import defaults
+from vyos.xml_ref import get_defaults
 
 base = ['firewall']
 timeout = 300
@@ -49,13 +49,7 @@ def get_config(conf):
     firewall = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True,
                                     no_tag_node_value_mangle=True)
 
-    default_values = defaults(base)
-    for tmp in ['name', 'ipv6_name']:
-        if tmp in default_values:
-            del default_values[tmp]
-
-    if 'zone' in default_values:
-        del default_values['zone']
+    default_values = get_defaults(base, get_first_key=True)
 
     firewall = dict_merge(default_values, firewall)
 

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -26,7 +26,6 @@ from cryptography.x509.oid import ExtendedKeyUsageOID
 
 from vyos.config import Config
 from vyos.configquery import ConfigTreeQuery
-from vyos.configdict import dict_merge
 from vyos.pki import encode_certificate, encode_public_key, encode_private_key, encode_dh_parameters
 from vyos.pki import get_certificate_fingerprint
 from vyos.pki import create_certificate, create_certificate_request, create_certificate_revocation_list
@@ -39,7 +38,6 @@ from vyos.utils.io import ask_input
 from vyos.utils.io import ask_yes_no
 from vyos.utils.misc import install_into_config
 from vyos.utils.process import cmd
-from vyos.xml import defaults
 
 CERT_REQ_END = '-----END CERTIFICATE REQUEST-----'
 auth_dir = '/config/auth'
@@ -50,10 +48,9 @@ def get_default_values():
     # Fetch default x509 values
     base = ['pki', 'x509', 'default']
     x509_defaults = conf.get_config_dict(base, key_mangling=('-', '_'),
+                                     no_tag_node_value_mangle=True,
                                      get_first_key=True,
-                                     no_tag_node_value_mangle=True)
-    default_values = defaults(base)
-    x509_defaults = dict_merge(default_values, x509_defaults)
+                                     with_recursive_defaults=True)
 
     return x509_defaults
 

--- a/src/tests/test_initial_setup.py
+++ b/src/tests/test_initial_setup.py
@@ -21,14 +21,16 @@ import vyos.configtree
 import vyos.initialsetup as vis
 
 from unittest import TestCase
-from vyos import xml
+from vyos.xml_ref import definition
+from vyos.xml_ref.pkg_cache.vyos_1x_cache import reference
 
 class TestInitialSetup(TestCase):
     def setUp(self):
         with open('tests/data/config.boot.default', 'r') as f:
             config_string = f.read()
             self.config = vyos.configtree.ConfigTree(config_string)
-            self.xml = xml.load_configuration()
+            self.xml = definition.Xml()
+            self.xml.define(reference)
 
     def test_set_user_password(self):
         vis.set_user_password(self.config, 'vyos', 'vyosvyos')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

PR #2136 removed all workarounds and calls to the old defaults function in config_mode scripts; this PR removes all remaining references to vyos.xml, in favor of the revised vyos.xml_ref.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5434
* https://vyos.dev/T5319
* https://vyos.dev/T5218 (for typo fix)

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
