### PR TITLE
T5271: allow OpenVPN peer-fingerprint to be used instead of a CA in site-to-site mode

### DIFF
--- a/data/templates/openvpn/server.conf.j2
+++ b/data/templates/openvpn/server.conf.j2
@@ -185,7 +185,7 @@ tls-version-min {{ tls.tls_version_min }}
 {%     endif %}
 {%     if tls.dh_params is vyos_defined %}
 dh /run/openvpn/{{ ifname }}_dh.pem
-{%     elif mode is vyos_defined('server') and tls.private_key is vyos_defined %}
+{%     else %}
 dh none
 {%     endif %}
 {%     if tls.auth_key is vyos_defined %}

--- a/data/templates/openvpn/server.conf.j2
+++ b/data/templates/openvpn/server.conf.j2
@@ -201,9 +201,9 @@ tls-client
 tls-server
 {%     endif %}
 
-{%     if peer_fingerprint is vyos_defined %}
+{%     if tls.peer_fingerprint is vyos_defined %}
 <peer-fingerprint>
-{%         for fp in peer_fingerprint %}
+{%         for fp in tls.peer_fingerprint %}
 {{ fp }}
 {%         endfor %}
 </peer-fingerprint>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This is the final set of changes required to support the new fingerprint-based site-to-site OpenVPN.
The new `tls peer-fingerprint` option can now be used _instead of_ the `tls ca-certificate` option in site-to-site mode.

When it's merged, I'll document it and add a deprecation warning with a link to documentation.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5271

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

OpenVPN

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Sample config:

```
vyos@server# show interfaces openvpn 
 openvpn vtun0 {
     local-address 10.20.30.1 {
     }
     local-host 192.168.56.101
     local-port 8000
     mode site-to-site
     protocol tcp-passive
     remote-address 10.20.30.2
     tls {
         certificate vpn-server
         peer-fingerprint 9C:72:67:32:32:34:54:E3:90:EB:06:80:ED:F9:06:CB:29:7A:34:D6:05:E1:A9:97:39:4B:26:95:DF:5A:E7:4A
         role passive
     }
 }

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
