### PR TITLE
T5486: smoketest: adjust to new process_named_running() implementation

### DIFF
--- a/smoketest/scripts/cli/test_service_dns_dynamic.py
+++ b/smoketest/scripts/cli/test_service_dns_dynamic.py
@@ -22,10 +22,11 @@ from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.configsession import ConfigSessionError
 from vyos.util import cmd
-from vyos.util import process_named_running
+from vyos.util import process_running
 
 PROCESS_NAME = 'ddclient'
 DDCLIENT_CONF = '/run/ddclient/ddclient.conf'
+DDCLIENT_PID = '/run/ddclient/ddclient.pid'
 base_path = ['service', 'dns', 'dynamic']
 
 def get_config_value(key):
@@ -89,7 +90,7 @@ class TestServiceDDNS(VyOSUnitTestSHIM.TestCase):
             self.assertTrue(pwd == "'" + password + "'")
 
             # Check for running process
-            self.assertTrue(process_named_running(PROCESS_NAME))
+            self.assertTrue(process_running(DDCLIENT_PID))
 
     def test_dyndns_rfc2136(self):
         # Check if DDNS service can be configured and runs
@@ -119,7 +120,7 @@ class TestServiceDDNS(VyOSUnitTestSHIM.TestCase):
         # TODO: inspect generated configuration file
 
         # Check for running process
-        self.assertTrue(process_named_running(PROCESS_NAME))
+        self.assertTrue(process_running(DDCLIENT_PID))
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
After commit 9c677c8 ("vyos.util: extend process_named_running() signature with cmdline") we need an exact match for the process name. In the past we used a in b and now we test for a == b.

Process name doesn't march 'ddclient'
```
psutil.Process(pid=10987, name='ddclient - sleeping for 20 seconds', started='13:12:47' It cause smoketest fail
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5486

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
smoketest
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
vyos@r1:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_dns_dynamic.py
test_dyndns_rfc2136 (__main__.TestServiceDDNS) ... ok
test_dyndns_service (__main__.TestServiceDDNS) ... ok

----------------------------------------------------------------------
Ran 2 tests in 12.908s

OK
vyos@r1:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
