### PR TITLE
T5447: Initial support for MACsec static keys

### DIFF
--- a/interface-definitions/include/interface/macsec-key.xml.i
+++ b/interface-definitions/include/interface/macsec-key.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from interface/macsec-key.xml.i -->
+<leafNode name="key">
+  <properties>
+    <help>MACsec static key</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>16-byte (128-bit) hex-string (32 hex-digits) for gcm-aes-128 or 32-byte (256-bit) hex-string (64 hex-digits) for gcm-aes-256</description>
+    </valueHelp>
+    <constraint>
+      <regex>[A-Fa-f0-9]{32}</regex>
+      <regex>[A-Fa-f0-9]{64}</regex>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/interfaces-macsec.xml.in
+++ b/interface-definitions/interfaces-macsec.xml.in
@@ -54,46 +54,22 @@
               </leafNode>
               <node name="static">
                 <properties>
-                  <help>Assign static MACSec keys instead of using MKA</help>
+                  <help>Use static keys for MACsec [static Secure Authentication Key (SAK) mode]</help>
                 </properties>
                 <children>
-                  <leafNode name="tx-key">
-                    <properties>
-                      <help>Set the static transmit key</help>
-                      <valueHelp>
-                        <format>txt</format>
-                        <description>16-byte (128-bit) hex-string (32 hex-digits) for gcm-aes-128 or 32-byte (256-bit) hex-string (64 hex-digits) for gcm-aes-256</description>
-                      </valueHelp>
-                      <constraint>
-                        <regex>[A-Fa-f0-9]{32}</regex>
-                        <regex>[A-Fa-f0-9]{64}</regex>
-                      </constraint>
-                    </properties>
-                  </leafNode>
+                  #include <include/interface/macsec-key.xml.i>
                   <tagNode name="peer">
                     <properties>
-                      <help>peer alias</help>
+                      <help>MACsec peer name</help>
                       <constraint>
                         <regex>[^ ]{1,100}</regex>
                       </constraint>
-                      <constraintErrorMessage>peer alias too long (limit 100 characters)</constraintErrorMessage>
+                      <constraintErrorMessage>MACsec peer name exceeds limit of 100 characters</constraintErrorMessage>
                     </properties>
                     <children>
                       #include <include/generic-disable-node.xml.i>
                       #include <include/interface/mac.xml.i>
-                      <leafNode name="rx-key">
-                        <properties>
-                          <help>Set the static receive key for peer</help>
-                          <valueHelp>
-                            <format>txt</format>
-                            <description>16-byte (128-bit) hex-string (32 hex-digits) for gcm-aes-128 or 32-byte (256-bit) hex-string (64 hex-digits) for gcm-aes-256</description>
-                          </valueHelp>
-                          <constraint>
-                            <regex>[A-Fa-f0-9]{32}</regex>
-                            <regex>[A-Fa-f0-9]{64}</regex>
-                          </constraint>
-                        </properties>
-                      </leafNode>
+                      #include <include/interface/macsec-key.xml.i>
                     </children>
                   </tagNode>
                 </children>

--- a/interface-definitions/interfaces-macsec.xml.in
+++ b/interface-definitions/interfaces-macsec.xml.in
@@ -52,6 +52,52 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <node name="static">
+                <properties>
+                  <help>Assign static MACSec keys instead of using MKA</help>
+                </properties>
+                <children>
+                  <leafNode name="tx-key">
+                    <properties>
+                      <help>Set the static transmit key</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>16-byte (128-bit) hex-string (32 hex-digits) for gcm-aes-128 or 32-byte (256-bit) hex-string (64 hex-digits) for gcm-aes-256</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>[A-Fa-f0-9]{32}</regex>
+                        <regex>[A-Fa-f0-9]{64}</regex>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <tagNode name="peer">
+                    <properties>
+                      <help>peer alias</help>
+                      <constraint>
+                        <regex>[^ ]{1,100}</regex>
+                      </constraint>
+                      <constraintErrorMessage>peer alias too long (limit 100 characters)</constraintErrorMessage>
+                    </properties>
+                    <children>
+                      #include <include/generic-disable-node.xml.i>
+                      #include <include/interface/mac.xml.i>
+                      <leafNode name="rx-key">
+                        <properties>
+                          <help>Set the static receive key for peer</help>
+                          <valueHelp>
+                            <format>txt</format>
+                            <description>16-byte (128-bit) hex-string (32 hex-digits) for gcm-aes-128 or 32-byte (256-bit) hex-string (64 hex-digits) for gcm-aes-256</description>
+                          </valueHelp>
+                          <constraint>
+                            <regex>[A-Fa-f0-9]{32}</regex>
+                            <regex>[A-Fa-f0-9]{64}</regex>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </tagNode>
+                </children>
+              </node>
               <node name="mka">
                 <properties>
                   <help>MACsec Key Agreement protocol (MKA)</help>

--- a/python/vyos/ifconfig/macsec.py
+++ b/python/vyos/ifconfig/macsec.py
@@ -51,7 +51,7 @@ class MACsecIf(Interface):
         if 'static' in self.config["security"]:
             # Set static TX key
             cmd = 'ip macsec add {ifname} tx sa 0 pn 1 on key 00'.format(**self.config)
-            cmd += f' {self.config["security"]["static"]["tx_key"]}'
+            cmd += f' {self.config["security"]["static"]["key"]}'
             self._cmd(cmd)
 
             for peer, peer_config in self.config["security"]["static"]["peer"].items():
@@ -63,11 +63,11 @@ class MACsecIf(Interface):
                 cmd += f' {peer_config["mac"]}'
                 self._cmd(cmd)
                 # Add the rx-key to the address
-                cmd += f' sa 0 pn 1 on key 01 {peer_config["rx_key"]}'
+                cmd += f' sa 0 pn 1 on key 01 {peer_config["key"]}'
                 self._cmd(cmd)
 
             # Set admin state to up
-            self.set_admin_state('up')
+            self.set_admin_state('down')
 
         else:
             # interface is always A/D down. It needs to be enabled explicitly

--- a/python/vyos/ifconfig/macsec.py
+++ b/python/vyos/ifconfig/macsec.py
@@ -66,7 +66,7 @@ class MACsecIf(Interface):
                 cmd += f' sa 0 pn 1 on key 01 {peer_config["key"]}'
                 self._cmd(cmd)
 
-            # Set admin state to up
+            # interface is always A/D down. It needs to be enabled explicitly
             self.set_admin_state('down')
 
         else:

--- a/python/vyos/ifconfig/macsec.py
+++ b/python/vyos/ifconfig/macsec.py
@@ -39,7 +39,7 @@ class MACsecIf(Interface):
     def _create(self):
         """
         Create MACsec interface in OS kernel. Interface is administrative
-        down by default when not using static keys.
+        down by default.
         """
 
         # create tunnel interface

--- a/python/vyos/ifconfig/macsec.py
+++ b/python/vyos/ifconfig/macsec.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2020-2023 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/python/vyos/ifconfig/macsec.py
+++ b/python/vyos/ifconfig/macsec.py
@@ -66,9 +66,5 @@ class MACsecIf(Interface):
                 cmd += f' sa 0 pn 1 on key 01 {peer_config["key"]}'
                 self._cmd(cmd)
 
-            # interface is always A/D down. It needs to be enabled explicitly
-            self.set_admin_state('down')
-
-        else:
-            # interface is always A/D down. It needs to be enabled explicitly
-            self.set_admin_state('down')
+        # interface is always A/D down. It needs to be enabled explicitly
+        self.set_admin_state('down')

--- a/smoketest/scripts/cli/test_interfaces_macsec.py
+++ b/smoketest/scripts/cli/test_interfaces_macsec.py
@@ -208,5 +208,78 @@ class MACsecInterfaceTest(BasicInterfaceTest.TestCase):
         # Check for running process
         self.assertTrue(process_named_running(PROCESS_NAME))
 
+    def test_macsec_static_keys(self):
+        src_interface = 'eth0'
+        interface = 'macsec5'
+        cipher1 = 'gcm-aes-128'
+        cipher2 = 'gcm-aes-256'
+        tx_key_1 = '71a82a48eddfa12c08a19792ca20c4bb'
+        tx_key_2 = 'dd487b2958e855ea35a5d43a5ecb3dcfbe7889ffcb877770252feb13b734478d'
+        rx_key_1 = '0022d00f57e75241a230cdf7118dfcc5'
+        rx_key_2 = 'b7d6d7ad075e02323fdeb845217b884d3f93ff36b2cdaf6b07eeb189b877245f'
+        peer_mac = '00:11:22:33:44:55'
+        self.cli_set(self._base_path + [interface])
+
+         # Encrypt link
+        self.cli_set(self._base_path + [interface, 'security', 'encrypt'])
+
+        # check validate() - source interface is mandatory
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(self._base_path + [interface, 'source-interface', src_interface])
+
+        # check validate() - cipher is mandatory
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(self._base_path + [interface, 'security', 'cipher', cipher1])
+
+        # check validate() - only static or mka config is allowed
+        self.cli_set(self._base_path + [interface, 'security', 'static'])
+        self.cli_set(self._base_path + [interface, 'security', 'mka', 'cak', tx_key_1])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(self._base_path + [interface, 'security', 'mka'])
+
+        # check validate() - tx-key required
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        # check validate() - tx-key length must match cipher
+        self.cli_set(self._base_path + [interface, 'security', 'static', 'tx-key', tx_key_2])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(self._base_path + [interface, 'security', 'static', 'tx-key', tx_key_1])
+
+        # check validate() - at least one peer must be defined
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        # check validate() - enabled peer must have both rx-key and MAC defined
+        self.cli_set(self._base_path + [interface, 'security', 'static', 'peer', 'TESTPEER'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(self._base_path + [interface, 'security', 'static', 'peer', 'TESTPEER', 'mac', peer_mac])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(self._base_path + [interface, 'security', 'static', 'peer', 'TESTPEER', 'mac'])
+        self.cli_set(self._base_path + [interface, 'security', 'static', 'peer', 'TESTPEER', 'rx-key', rx_key_1])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(self._base_path + [interface, 'security', 'static', 'peer', 'TESTPEER', 'mac', peer_mac])
+
+        # check validate() - peer rx-key length must match cipher
+        self.cli_set(self._base_path + [interface, 'security', 'cipher', cipher2])
+        self.cli_set(self._base_path + [interface, 'security', 'static', 'tx-key', tx_key_2])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(self._base_path + [interface, 'security', 'static', 'peer', 'TESTPEER', 'rx-key', rx_key_2])
+
+        # final commit and verify
+        self.cli_commit()
+        self.assertIn(interface, interfaces())
+        self.assertEqual(cipher2, get_cipher(interface))
+        # Add checks for keys?
+        self.assertTrue(os.path.isdir(f'/sys/class/net/{interface}'))
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/smoketest/scripts/cli/test_interfaces_macsec.py
+++ b/smoketest/scripts/cli/test_interfaces_macsec.py
@@ -245,10 +245,10 @@ class MACsecInterfaceTest(BasicInterfaceTest.TestCase):
             self.cli_commit()
 
         # check validate() - tx-key length must match cipher
-        self.cli_set(self._base_path + [interface, 'security', 'static', 'tx-key', tx_key_2])
+        self.cli_set(self._base_path + [interface, 'security', 'static', 'key', tx_key_2])
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
-        self.cli_set(self._base_path + [interface, 'security', 'static', 'tx-key', tx_key_1])
+        self.cli_set(self._base_path + [interface, 'security', 'static', 'key', tx_key_1])
 
         # check validate() - at least one peer must be defined
         with self.assertRaises(ConfigSessionError):
@@ -262,23 +262,22 @@ class MACsecInterfaceTest(BasicInterfaceTest.TestCase):
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
         self.cli_delete(self._base_path + [interface, 'security', 'static', 'peer', 'TESTPEER', 'mac'])
-        self.cli_set(self._base_path + [interface, 'security', 'static', 'peer', 'TESTPEER', 'rx-key', rx_key_1])
+        self.cli_set(self._base_path + [interface, 'security', 'static', 'peer', 'TESTPEER', 'key', rx_key_1])
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
         self.cli_set(self._base_path + [interface, 'security', 'static', 'peer', 'TESTPEER', 'mac', peer_mac])
 
         # check validate() - peer rx-key length must match cipher
         self.cli_set(self._base_path + [interface, 'security', 'cipher', cipher2])
-        self.cli_set(self._base_path + [interface, 'security', 'static', 'tx-key', tx_key_2])
+        self.cli_set(self._base_path + [interface, 'security', 'static', 'key', tx_key_2])
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
-        self.cli_set(self._base_path + [interface, 'security', 'static', 'peer', 'TESTPEER', 'rx-key', rx_key_2])
+        self.cli_set(self._base_path + [interface, 'security', 'static', 'peer', 'TESTPEER', 'key', rx_key_2])
 
         # final commit and verify
         self.cli_commit()
         self.assertIn(interface, interfaces())
         self.assertEqual(cipher2, get_cipher(interface))
-        # Add checks for keys?
         self.assertTrue(os.path.isdir(f'/sys/class/net/{interface}'))
 
 if __name__ == '__main__':

--- a/src/conf_mode/interfaces-macsec.py
+++ b/src/conf_mode/interfaces-macsec.py
@@ -160,7 +160,7 @@ def verify(macsec):
 
 def generate(macsec):
     # Only generate wpa_supplicant config if using MKA
-    if dict_search('security.static', macsec) == None:
+    if dict_search('security.mka.cak', macsec):
         render(wpa_suppl_conf.format(**macsec), 'macsec/wpa_supplicant.conf.j2', macsec)
     return None
 

--- a/src/conf_mode/interfaces-macsec.py
+++ b/src/conf_mode/interfaces-macsec.py
@@ -95,6 +95,9 @@ def verify(macsec):
 
         # Logic to check static configuration
         if dict_search('security.static', macsec) != None:
+            # tx-key must be defined
+            if dict_search('security.static.tx_key', macsec) == None:
+                raise ConfigError('Static MACsec tx-key must be defined.')
 
             tx_len = len(dict_search('security.static.tx_key', macsec))
 

--- a/src/conf_mode/interfaces-macsec.py
+++ b/src/conf_mode/interfaces-macsec.py
@@ -118,6 +118,17 @@ def verify(macsec):
                 if 'disable' not in peer_config and ('mac' not in peer_config or 'rx_key' not in peer_config):
                     raise ConfigError('Every enabled MACsec static peer must have a MAC address and rx-key defined.')
 
+                # check rx-key length against cipher suite
+                rx_len = len(peer_config['rx_key'])
+
+                if dict_search('security.cipher', macsec) == 'gcm-aes-128' and rx_len != 32:
+                    # gcm-aes-128 requires a 128bit long key - 32 characters (string) = 16byte = 128bit
+                    raise ConfigError('gcm-aes-128 requires a 128bit long key!')
+
+                if dict_search('security.cipher', macsec) == 'gcm-aes-256' and rx_len != 64:
+                    # gcm-aes-256 requires a 256bit long key - 64 characters (string) = 32byte = 256bit
+                    raise ConfigError('gcm-aes-256 requires a 256bit long key!')
+
         # Logic to check MKA configuration
         else:
             if dict_search('security.mka.cak', macsec) == None or dict_search('security.mka.ckn', macsec) == None:

--- a/src/conf_mode/interfaces-macsec.py
+++ b/src/conf_mode/interfaces-macsec.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020-2022 VyOS maintainers and contributors
+# Copyright (C) 2020-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5447

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
MACsec interfaces

## Proposed changes
<!--- Describe your changes in detail -->
This allows for defining static a static MACsec key, and associated MAC address, for environments where EAPOL doesn't work. Error checking that at least one peer is defined, and that each peer that isn't disabled have both a MAC and rx-key set.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
vyos-1x fork was compiled using the docker container for sagitta. The .deb file was copied over to a VM running 1.4 rolling (202308060317) [TEST VM]. A second un-patched VM was deployed on the same VLAN [CONTROL VM]. Testing old configuration using MKA was successful with patch between both VMs. Testing on new changes was then conducted as follows.

Configuration of [TEST VM]:
```
generate macsec mka cak gcm-aes-128 [NOTE: <key_00>]
generate macsec mka mak gcm-aes-128 [NOTE: Used for CONTROL VM <key_01>]
configure
set interfaces ethernet eth0
set interfaces ethernet eth1 address dhcp
set service ssh
commit
sudo su
dpkg -i --ignore-depends=zabbix-agent2 ./vyos-1x_0.0-no.git.tag_amd64.deb
exit
set interfaces macsec macsec0 address 192.168.1.1/30
set interfaces macsec macsec0 source-interface eth0
set interfaces macsec macsec0 security encrypt
set interfaces macsec macsec0 security cipher gcm-aes-128
set interfaces macsec macsec0 security static tx-key <key_00>
set interfaces macsec macsec0 security static peer MACSEC-02 mac <CONTROL VM MAC>
set interfaces macsec macsec0 security static peer MACSEC-02 rx-key <key_01>
commit
ping 192.168.1.2
```

Manual configuration of [CONTROL VM]
```
sudo su
ip link set up dev eth0
ip link add link eth0 macsec0 type macsec encrypt on
ip macsec add macsec0 tx sa 0 pn 1 on key 00 <key_01>
ip macsec add macsec0 rx port 1 address <TEST VM MAC>
ip macsec add macsec0 rx port 1 address <TEST VM MAC> sa 0 pn 1 on key 01 <key_00>
ip addr add 192.168.1.2/30 dev macsec0
ip link set up dev macsec0
ping 192.168.1.1
```

Pings were only successful after keys had been installed on both sides.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
