### PR TITLE
wifi: T5491: allow white-/blacklisting station MAC addresses for security

### DIFF
--- a/data/templates/wifi/hostapd.conf.j2
+++ b/data/templates/wifi/hostapd.conf.j2
@@ -430,14 +430,22 @@ ieee80211n={{ '1' if 'n' in mode or 'ac' in mode else '0' }}
 ignore_broadcast_ssid=1
 {% endif %}
 
-# Station MAC address -based authentication
+{% if type is vyos_defined('access-point') %}
+# Station MAC address-based authentication
 # Please note that this kind of access control requires a driver that uses
 # hostapd to take care of management frame processing and as such, this can be
 # used with driver=hostap or driver=nl80211, but not with driver=atheros.
 # 0 = accept unless in deny list
 # 1 = deny unless in accept list
 # 2 = use external RADIUS server (accept/deny lists are searched first)
-macaddr_acl=0
+macaddr_acl={{ '0' if security.station_address.mode is vyos_defined('accept') else '1' }}
+
+# Accept/deny lists are read from separate files (containing list of
+# MAC addresses, one per line). Use absolute path name to make sure that the
+# files can be read on SIGHUP configuration reloads.
+accept_mac_file={{ hostapd_accept_station_conf }}
+deny_mac_file={{ hostapd_deny_station_conf }}
+{% endif %}
 
 {% if max_stations is vyos_defined %}
 # Maximum number of stations allowed in station table. New stations will be

--- a/data/templates/wifi/hostapd_accept_station.conf.j2
+++ b/data/templates/wifi/hostapd_accept_station.conf.j2
@@ -1,0 +1,7 @@
+# List of MAC addresses that are allowed to authenticate (IEEE 802.11)
+# with the AP
+{% if security.station_address.accept.mac is vyos_defined %}
+{%     for mac in security.station_address.accept.mac %}
+{{ mac | lower }}
+{%     endfor %}
+{% endif %}

--- a/data/templates/wifi/hostapd_deny_station.conf.j2
+++ b/data/templates/wifi/hostapd_deny_station.conf.j2
@@ -1,0 +1,7 @@
+# List of MAC addresses that are not allowed to authenticate
+# (IEEE 802.11) with the access point
+{% if security.station_address.deny.mac is vyos_defined %}
+{%     for mac in security.station_address.deny.mac %}
+{{ mac | lower }}
+{%     endfor %}
+{% endif %}

--- a/interface-definitions/include/interface/mac-multi.xml.i
+++ b/interface-definitions/include/interface/mac-multi.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from interface/mac-multi.xml.i -->
+<leafNode name="mac">
+  <properties>
+    <help>Media Access Control (MAC) address</help>
+    <valueHelp>
+      <format>macaddr</format>
+      <description>Hardware (MAC) address</description>
+    </valueHelp>
+    <constraint>
+      <validator name="mac-address"/>
+    </constraint>
+    <multi/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/interfaces-wireless.xml.in
+++ b/interface-definitions/interfaces-wireless.xml.in
@@ -595,6 +595,49 @@
               <help>Wireless security settings</help>
             </properties>
             <children>
+              <node name="station-address">
+                <properties>
+                  <help>Station MAC address based authentication</help>
+                </properties>
+                <children>
+                  <leafNode name="mode">
+                    <properties>
+                      <help>Select security operation mode</help>
+                      <completionHelp>
+                        <list>accept deny</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>accept</format>
+                        <description>Accept all clients unless found in deny list</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>deny</format>
+                        <description>Deny all clients unless found in accept list</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>(accept|deny)</regex>
+                      </constraint>
+                    </properties>
+                    <defaultValue>accept</defaultValue>
+                  </leafNode>
+                  <node name="accept">
+                    <properties>
+                      <help>Accept station MAC address</help>
+                    </properties>
+                    <children>
+                      #include <include/interface/mac-multi.xml.i>
+                    </children>
+                  </node>
+                  <node name="deny">
+                    <properties>
+                      <help>Deny station MAC address</help>
+                    </properties>
+                    <children>
+                      #include <include/interface/mac-multi.xml.i>
+                    </children>
+                  </node>
+                </children>
+              </node>
               <node name="wep">
                 <properties>
                   <help>Wired Equivalent Privacy (WEP) parameters</help>

--- a/src/conf_mode/interfaces-wireless.py
+++ b/src/conf_mode/interfaces-wireless.py
@@ -25,8 +25,6 @@ from vyos.configdict import get_interface_dict
 from vyos.configdict import dict_merge
 from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
-from vyos.configverify import verify_dhcpv6
-from vyos.configverify import verify_source_interface
 from vyos.configverify import verify_mirror_redirect
 from vyos.configverify import verify_vlan_config
 from vyos.configverify import verify_vrf

--- a/src/conf_mode/interfaces-wireless.py
+++ b/src/conf_mode/interfaces-wireless.py
@@ -42,6 +42,8 @@ airbag.enable()
 # XXX: wpa_supplicant works on the source interface
 wpa_suppl_conf = '/run/wpa_supplicant/{ifname}.conf'
 hostapd_conf = '/run/hostapd/{ifname}.conf'
+hostapd_accept_station_conf = '/run/hostapd/{ifname}_station_accept.conf'
+hostapd_deny_station_conf = '/run/hostapd/{ifname}_station_deny.conf'
 
 def find_other_stations(conf, base, ifname):
     """
@@ -81,10 +83,12 @@ def get_config(config=None):
 
     if 'deleted' not in wifi:
         # then get_interface_dict provides default keys
-        if wifi.from_defaults(['security']): # if not set by user
-            del wifi['security']
+        if wifi.from_defaults(['security', 'wep']): # if not set by user
+            del wifi['security']['wep']
+        if wifi.from_defaults(['security', 'wpa']): # if not set by user
+            del wifi['security']['wpa']
 
-    if 'security' in wifi and 'wpa' in wifi['security']:
+    if dict_search('security.wpa', wifi) != None:
         wpa_cipher = wifi['security']['wpa'].get('cipher')
         wpa_mode = wifi['security']['wpa'].get('mode')
         if not wpa_cipher:
@@ -101,6 +105,10 @@ def get_config(config=None):
     # Only one wireless interface per phy can be in station mode
     tmp = find_other_stations(conf, base, wifi['ifname'])
     if tmp: wifi['station_interfaces'] = tmp
+
+    # used in hostapt.conf.j2
+    wifi['hostapd_accept_station_conf'] = hostapd_accept_station_conf.format(**wifi)
+    wifi['hostapd_deny_station_conf'] = hostapd_deny_station_conf.format(**wifi)
 
     return wifi
 
@@ -189,7 +197,10 @@ def generate(wifi):
     if 'deleted' in wifi:
         if os.path.isfile(hostapd_conf.format(**wifi)):
             os.unlink(hostapd_conf.format(**wifi))
-
+        if os.path.isfile(hostapd_accept_station_conf.format(**wifi)):
+            os.unlink(hostapd_accept_station_conf.format(**wifi))
+        if os.path.isfile(hostapd_deny_station_conf.format(**wifi)):
+            os.unlink(hostapd_deny_station_conf.format(**wifi))
         if os.path.isfile(wpa_suppl_conf.format(**wifi)):
             os.unlink(wpa_suppl_conf.format(**wifi))
 
@@ -224,12 +235,12 @@ def generate(wifi):
 
     # render appropriate new config files depending on access-point or station mode
     if wifi['type'] == 'access-point':
-        render(hostapd_conf.format(**wifi), 'wifi/hostapd.conf.j2',
-               wifi)
+        render(hostapd_conf.format(**wifi), 'wifi/hostapd.conf.j2', wifi)
+        render(hostapd_accept_station_conf.format(**wifi), 'wifi/hostapd_accept_station.conf.j2', wifi)
+        render(hostapd_deny_station_conf.format(**wifi), 'wifi/hostapd_deny_station.conf.j2', wifi)
 
     elif wifi['type'] == 'station':
-        render(wpa_suppl_conf.format(**wifi), 'wifi/wpa_supplicant.conf.j2',
-               wifi)
+        render(wpa_suppl_conf.format(**wifi), 'wifi/wpa_supplicant.conf.j2', wifi)
 
     return None
 

--- a/src/etc/netplug/netplugd.conf
+++ b/src/etc/netplug/netplugd.conf
@@ -1,3 +1,4 @@
 eth*
 br*
 bond*
+wlan*


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Station MAC address-based authentication means:

* `allow` accept all clients except the one on the deny list
* `deny` accept only clients listed on the accept list

New CLI commands:

* `set interfaces wireless wlan0 security station-address mode <accept|deny>`
* `set interfaces wireless wlan0 security station-address accept mac <mac>`
* `set interfaces wireless wlan0 security station-address deny mac <mac>`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5491

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wifi

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests

or

```
set interfaces wireless wlan0 ssid VyOS-ACL
set interfaces wireless wlan0 country-code se
set interfaces wireless wlan0 type access-point
set interfaces wireless wlan0 security station-address mode accept
set interfaces wireless wlan0 security station-address accept mac 00:00:00:00:ac:01
set interfaces wireless wlan0 security station-address accept mac 00:00:00:00:ac:02
set interfaces wireless wlan0 security station-address accept mac 00:00:00:00:ac:03
set interfaces wireless wlan0 security station-address accept mac 00:00:00:00:ac:04
set interfaces wireless wlan0 security station-address deny mac 00:00:00:00:de:01
set interfaces wireless wlan0 security station-address deny mac 00:00:00:00:de:02
set interfaces wireless wlan0 security station-address deny mac 00:00:00:00:de:03
set interfaces wireless wlan0 security station-address deny mac 00:00:00:00:de:04
set interfaces wireless wlan0 security station-address mode deny
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
