### PR TITLE
T5463: Container allow publish listen-addresses

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -213,6 +213,7 @@
               <help>Publish port to the container</help>
             </properties>
             <children>
+              #include <include/listen-address.xml.i>
               <leafNode name="source">
                 <properties>
                   <help>Source host port</help>

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -33,6 +33,7 @@ from vyos.utils.process import call
 from vyos.utils.process import cmd
 from vyos.utils.process import run
 from vyos.utils.process import rc_cmd
+from vyos.template import bracketize_ipv6
 from vyos.template import inc_ip
 from vyos.template import is_ipv4
 from vyos.template import is_ipv6
@@ -280,6 +281,14 @@ def generate_run_arguments(name, container_config):
             protocol = container_config['port'][portmap]['protocol']
             sport = container_config['port'][portmap]['source']
             dport = container_config['port'][portmap]['destination']
+            listen_addresses = container_config['port'][portmap].get('listen_address', [])
+
+        # If listen_addresses is not empty, include them in the publish command
+        if listen_addresses:
+            for listen_address in listen_addresses:
+                port += f' --publish {bracketize_ipv6(listen_address)}:{sport}:{dport}/{protocol}'
+        else:
+            # If listen_addresses is empty, just include the standard publish command
             port += f' --publish {sport}:{dport}/{protocol}'
 
     # Bind volume


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to publish multiple IP/IPv6 addresses for container

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Add ability to publish IP/IPv6 address

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5463

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
containers
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration
```
set container name c1 description 'Busybox'
set container name c1 image 'busybox'
set container name c1 network NET01
set container name c1 port web destination '80'
set container name c1 port web listen-address '192.0.2.1'
set container name c1 port web listen-address '2001:db8:1111::1'
set container name c1 port web source '8080'
set container network NET01 prefix '10.0.0.0/24'
```
Generated options args
```
--detach --interactive --tty --replace  --memory 512m --shm-size 64m --memory-swap 0 --restart on-failure --name c1    --publish 192.0.2.1:8080:80/tcp --publish [2001:db8:1111::1]:8080:80/tcp   --net NET01   busybox
```
Check address/ports:
```
vyos@r14# run show container 
CONTAINER ID  IMAGE                             COMMAND     CREATED        STATUS            PORTS                                                  NAMES
3cb3728bfa0b  docker.io/library/busybox:latest  sh          3 seconds ago  Up 3 seconds ago  192.0.2.1:8080->80/tcp, 2001:db8:1111::1:8080->80/tcp  c1
[edit]
vyos@r14# 
[edit]
vyos@r14# sudo podman port c1
80/tcp -> 192.0.2.1:8080
80/tcp -> 2001:db8:1111::1:8080
[edit]
vyos@r14# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
