### PR TITLE
T5472: nat redirect: allow redirection without defining redirected port

### DIFF
--- a/python/vyos/nat.py
+++ b/python/vyos/nat.py
@@ -56,10 +56,13 @@ def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
     elif 'translation' in rule_conf:
         addr = dict_search_args(rule_conf, 'translation', 'address')
         port = dict_search_args(rule_conf, 'translation', 'port')
-        redirect_port = dict_search_args(rule_conf, 'translation', 'redirect', 'port')
-        if redirect_port:
-            translation_output = [f'redirect to {redirect_port}']
+        if 'redirect' in rule_conf['translation']:
+            translation_output = [f'redirect']
+            redirect_port = dict_search_args(rule_conf, 'translation', 'redirect', 'port')
+            if redirect_port:
+                translation_output.append(f'to {redirect_port}')
         else:
+
             translation_prefix = nat_type[:1]
             translation_output = [f'{translation_prefix}nat']
 

--- a/smoketest/scripts/cli/test_nat.py
+++ b/smoketest/scripts/cli/test_nat.py
@@ -244,10 +244,17 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
         self.cli_set(dst_path + ['rule', '10', 'inbound-interface', ifname])
         self.cli_set(dst_path + ['rule', '10', 'translation', 'redirect', 'port', redirected_port])
 
+        self.cli_set(dst_path + ['rule', '20', 'destination', 'address', dst_addr_1])
+        self.cli_set(dst_path + ['rule', '20', 'destination', 'port', dest_port])
+        self.cli_set(dst_path + ['rule', '20', 'protocol', protocol])
+        self.cli_set(dst_path + ['rule', '20', 'inbound-interface', ifname])
+        self.cli_set(dst_path + ['rule', '20', 'translation', 'redirect'])
+
         self.cli_commit()
 
         nftables_search = [
-            [f'iifname "{ifname}"', f'ip daddr {dst_addr_1}', f'{protocol} dport {dest_port}', f'redirect to :{redirected_port}']
+            [f'iifname "{ifname}"', f'ip daddr {dst_addr_1}', f'{protocol} dport {dest_port}', f'redirect to :{redirected_port}'],
+            [f'iifname "{ifname}"', f'ip daddr {dst_addr_1}', f'{protocol} dport {dest_port}', f'redirect']
         ]
 
         self.verify_nftables(nftables_search, 'ip vyos_nat')

--- a/src/conf_mode/nat.py
+++ b/src/conf_mode/nat.py
@@ -224,7 +224,7 @@ def verify(nat):
             elif config['inbound_interface'] not in 'any' and config['inbound_interface'] not in interfaces():
                 Warning(f'rule "{rule}" interface "{config["inbound_interface"]}" does not exist on this system')
 
-            if not dict_search('translation.address', config) and not dict_search('translation.port', config) and not dict_search('translation.redirect.port', config):
+            if not dict_search('translation.address', config) and not dict_search('translation.port', config) and 'redirect' not in config['translation']:
                 if 'exclude' not in config and 'backend' not in config['load_balance']:
                     raise ConfigError(f'{err_msg} translation requires address and/or port')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow redirection without defining redirected port

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5472

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat
## Proposed changes
<!--- Describe your changes in detail -->
Allow redirection without defining redirected port

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@redirect# run show config comm | grep nat
set nat destination rule 10 destination port '53'
set nat destination rule 10 inbound-interface 'eth4'
set nat destination rule 10 protocol 'udp'
set nat destination rule 10 translation redirect
set nat destination rule 20 destination port '21'
set nat destination rule 20 inbound-interface 'pppoe0'
set nat destination rule 20 protocol 'tcp'
set nat destination rule 20 translation redirect port '1021'
set nat destination rule 30 destination port '1001'
set nat destination rule 30 inbound-interface 'eth2'
set nat destination rule 30 protocol 'tcp'
set nat destination rule 30 translation address '198.51.100.100'
set nat destination rule 30 translation port '5555'
[edit]
vyos@redirect# sudo nft -s list table ip vyos_nat
table ip vyos_nat {
        chain PREROUTING {
                type nat hook prerouting priority dstnat; policy accept;
                counter jump VYOS_PRE_DNAT_HOOK
                iifname "eth4" udp dport 53 counter redirect comment "DST-NAT-10"
                iifname "pppoe0" tcp dport 21 counter redirect to :1021 comment "DST-NAT-20"
                iifname "eth2" tcp dport 1001 counter dnat to 198.51.100.100:5555 comment "DST-NAT-30"
        }

        chain POSTROUTING {
                type nat hook postrouting priority srcnat; policy accept;
                counter jump VYOS_PRE_SNAT_HOOK
        }

        chain VYOS_PRE_DNAT_HOOK {
                return
        }

        chain VYOS_PRE_SNAT_HOOK {
                return
        }
}
[edit]
vyos@redirect# 

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
