### PR TITLE
T3546: PPPoE-server add extended scripts for RADIUS attributes

### DIFF
--- a/data/templates/accel-ppp/pppoe.config.tmpl
+++ b/data/templates/accel-ppp/pppoe.config.tmpl
@@ -17,6 +17,10 @@ net-snmp
 {% if limits is defined %}
 connlimit
 {% endif %}
+{% if extended_scripts is defined %}
+sigchld
+pppd_compat
+{% endif %}
 
 [core]
 thread-count={{ thread_count }}
@@ -166,6 +170,16 @@ timeout={{ limits.timeout }}
 
 {# Common RADIUS shaper configuration #}
 {% include 'accel-ppp/config_shaper_radius.j2' %}
+
+{% if extended_scripts is defined %}
+[pppd-compat]
+verbose=1
+radattr-prefix=/run/accel-pppd/radattr
+{% set script_name = {'on_up': 'ip-up', 'on_down': 'ip-down', 'on_change':'ip-change', 'on_pre_up':'ip-pre-up'} %}
+{%   for script in extended_scripts %}
+{{ script_name[script] }}={{ extended_scripts[script] }}
+{%   endfor %}
+{% endif %}
 
 [cli]
 tcp=127.0.0.1:2001

--- a/interface-definitions/service_pppoe-server.xml.in
+++ b/interface-definitions/service_pppoe-server.xml.in
@@ -340,6 +340,45 @@
               </leafNode>
             </children>
           </node>
+          <node name="extended-scripts">
+            <properties>
+              <help>Extended script execution</help>
+            </properties>
+            <children>
+              <leafNode name="on-pre-up">
+                <properties>
+                  <help>Script to run before PPPoE session interface comes up</help>
+                    <constraint>
+                      <validator name="script"/>
+                    </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="on-up">
+                <properties>
+                  <help>Script to run when PPPoE session interface is completely configured and started</help>
+                    <constraint>
+                      <validator name="script"/>
+                    </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="on-down">
+                <properties>
+                  <help>Script to run when PPPoE session interface going to terminate</help>
+                    <constraint>
+                      <validator name="script"/>
+                    </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="on-change">
+                <properties>
+                  <help>Script to run when PPPoE session interface changed by RADIUS CoA handling</help>
+                    <constraint>
+                      <validator name="script"/>
+                    </constraint>
+                </properties>
+              </leafNode>
+            </children>
+          </node>
         </children>
       </node>
     </children>


### PR DESCRIPTION



<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to get and parse RADIUS attributes via a shell script and execute commands (VyOS 1.3).
One use case is creating a custom shaper with some smart.
Already present in 1.4

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3546
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set service pppoe-server authentication mode 'radius'
set service pppoe-server authentication radius server 192.0.2.1 key 'mykey'
set service pppoe-server client-ip-pool name POOL gateway-address '100.64.0.1'
set service pppoe-server client-ip-pool name POOL subnet '100.64.0.0/24'
set service pppoe-server extended-scripts on-change '/config/scripts/tmp.sh'
set service pppoe-server extended-scripts on-down '/config/scripts/tmp.sh'
set service pppoe-server extended-scripts on-up '/config/scripts/tmp.sh'
set service pppoe-server extended-scripts on-pre-up '/config/scripts/tmp.sh'
set service pppoe-server interface eth1

```
Expected configuration:
```
vyos@r1# cat /run/accel-pppd/pppoe.conf 
### generated by accel_pppoe.py ###
[modules]
log_syslog
pppoe
shaper
radius
ippool
auth_pap
auth_chap_md5
auth_mschap_v1
auth_mschap_v2

sigchld
pppd_compat

...
[pppd-compat]
verbose=1
radattr-prefix=/run/accel-pppd/radattr
ip-change=/config/scripts/tmp.sh
ip-down=/config/scripts/tmp.sh
ip-up=/config/scripts/tmp.sh
ip-pre-up=/config/scripts/tmp.sh
```

Extended scripts receive from the PPPoE daemon the following variables:
```
$1 - Interface name
$4 - Tunnel GW IP address
$5 - Delegated IP address to the client
$6 - Calling Station ID (MAC)
```
Use:
```
if [ -f /run/accel-pppd/radattr.$1 ]; then
    true
fi
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
