### PR TITLE
T4825: Add interface type veth

### DIFF
--- a/interface-definitions/interfaces-virtaul-ethernet.xml.in
+++ b/interface-definitions/interfaces-virtaul-ethernet.xml.in
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="interfaces">
+    <children>
+      <tagNode name="virtual-ethernet" owner="${vyos_conf_scripts_dir}/interfaces-virtual-ethernet.py">
+        <properties>
+          <help>Virtual Ethernet (veth) Interface</help>
+          <priority>300</priority>
+          <constraint>
+            <regex>veth[0-9]+</regex>
+          </constraint>
+          <constraintErrorMessage>Virutal Ethernet interface must be named vethN</constraintErrorMessage>
+          <valueHelp>
+            <format>vethN</format>
+            <description>Virtual Ethernet interface name</description>
+          </valueHelp>
+        </properties>
+        <children>
+          #include <include/interface/address-ipv4-ipv6-dhcp.xml.i>
+          #include <include/generic-description.xml.i>
+          #include <include/interface/dhcp-options.xml.i>
+          #include <include/interface/dhcpv6-options.xml.i>
+          #include <include/interface/disable.xml.i>
+          #include <include/interface/vif-s.xml.i>
+          #include <include/interface/vif.xml.i>
+          #include <include/interface/vrf.xml.i>
+          <leafNode name="peer-name">
+            <properties>
+              <help>Virtual ethernet peer interface name</help>
+              <completionHelp>
+                <path>interfaces virtual-ethernet</path>
+              </completionHelp>
+              <valueHelp>
+                <format>txt</format>
+                <description>Name of peer interface</description>
+              </valueHelp>
+              <constraint>
+                <regex>veth[0-9]+</regex>
+              </constraint>
+              <constraintErrorMessage>Virutal Ethernet interface must be named vethN</constraintErrorMessage>
+            </properties>
+          </leafNode>
+        </children>
+      </tagNode>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/python/vyos/ifconfig/__init__.py
+++ b/python/vyos/ifconfig/__init__.py
@@ -36,4 +36,5 @@ from vyos.ifconfig.pppoe import PPPoEIf
 from vyos.ifconfig.wireless import WiFiIf
 from vyos.ifconfig.l2tpv3 import L2TPv3If
 from vyos.ifconfig.macsec import MACsecIf
+from vyos.ifconfig.veth import VethIf
 from vyos.ifconfig.wwan import WWANIf

--- a/python/vyos/ifconfig/veth.py
+++ b/python/vyos/ifconfig/veth.py
@@ -1,0 +1,54 @@
+# Copyright 2022 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+from vyos.ifconfig.interface import Interface
+
+
+@Interface.register
+class VethIf(Interface):
+    """
+    Abstraction of a Linux veth interface
+    """
+    iftype = 'veth'
+    definition = {
+        **Interface.definition,
+        **{
+            'section': 'virtual-ethernet',
+            'prefixes': ['veth', ],
+            'bridgeable': True,
+        },
+    }
+
+    def _create(self):
+        """
+        Create veth interface in OS kernel. Interface is administrative
+        down by default.
+        """
+        # check before create, as we have 2 veth interfaces in our CLI
+        # interface virtual-ethernet veth0 peer-name 'veth1'
+        # interface virtual-ethernet veth1 peer-name 'veth0'
+        #
+        # but iproute2 creates the pair with one command:
+        # ip link add vet0 type veth peer name veth1
+        if self.exists(self.config['peer_name']):
+            return
+
+        # create virtual-ethernet interface
+        cmd = 'ip link add {ifname} type {type}'.format(**self.config)
+        cmd += f' peer name {self.config["peer_name"]}'
+        self._cmd(cmd)
+
+        # interface is always A/D down. It needs to be enabled explicitly
+        self.set_admin_state('down')

--- a/smoketest/scripts/cli/test_interfaces_virtual_ethernet.py
+++ b/smoketest/scripts/cli/test_interfaces_virtual_ethernet.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+
+from vyos.ifconfig import Section
+from base_interfaces_test import BasicInterfaceTest
+
+class VEthInterfaceTest(BasicInterfaceTest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._test_dhcp = True
+        cls._base_path = ['interfaces', 'virtual-ethernet']
+
+        cls._options = {
+            'veth0': ['peer-name veth1'],
+            'veth1': ['peer-name veth0'],
+        }
+
+        cls._interfaces = list(cls._options)
+        # call base-classes classmethod
+        super(VEthInterfaceTest, cls).setUpClass()
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/src/conf_mode/interfaces-virtual-ethernet.py
+++ b/src/conf_mode/interfaces-virtual-ethernet.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from sys import exit
+
+from netifaces import interfaces
+from vyos import ConfigError
+from vyos import airbag
+from vyos.config import Config
+from vyos.configdict import get_interface_dict
+from vyos.configverify import verify_address
+from vyos.configverify import verify_bridge_delete
+from vyos.configverify import verify_vrf
+from vyos.ifconfig import VethIf
+
+airbag.enable()
+
+def get_config(config=None):
+    """
+    Retrive CLI config as dictionary. Dictionary can never be empty, as at
+    least the interface name will be added or a deleted flag
+    """
+    if config:
+        conf = config
+    else:
+        conf = Config()
+    base = ['interfaces', 'virtual-ethernet']
+    veth = get_interface_dict(conf, base)
+
+    # We need to know all other veth related interfaces as veth requires a 1:1
+    # mapping for the peer-names. The Linux kernel automatically creates both
+    # interfaces, the local one and the peer-name, but VyOS also needs a peer
+    # interfaces configrued on the CLI so we can assign proper IP addresses etc.
+    conf.set_level(base)
+    veth['other_interfaces'] = conf.get_config_dict([], key_mangling=('-', '_'),
+                                                    get_first_key=True,
+                                                    no_tag_node_value_mangle=True)
+
+    return veth
+
+
+def verify(veth):
+    if 'deleted' in veth:
+        verify_bridge_delete(veth)
+        # Prevent to delete veth interface which used for another "vethX peer-name"
+        for iface, iface_config in veth['other_interfaces'].items():
+            if veth['ifname'] in iface_config['peer_name']:
+                ifname = veth['ifname']
+                raise ConfigError(
+                    f'Cannot delete "{ifname}" used for "interface {iface} peer-name"'
+                )
+        return None
+
+    verify_vrf(veth)
+    verify_address(veth)
+
+    if 'peer_name' not in veth:
+        raise ConfigError(f'Remote peer name must be set for "{veth["ifname"]}"!')
+
+    peer_name = veth['peer_name']
+    ifname = veth['ifname']
+
+    if veth['peer_name'] not in veth['other_interfaces']:
+        raise ConfigError(f'Used peer-name "{peer_name}" on interface "{ifname}" ' \
+                          'is not configured!')
+
+    if veth['other_interfaces'][peer_name]['peer_name'] != ifname:
+        raise ConfigError(
+            f'Configuration mismatch between "{ifname}" and "{peer_name}"!')
+
+    if peer_name == ifname:
+        raise ConfigError(
+            f'Peer-name "{peer_name}" cannot be the same as interface "{ifname}"!')
+
+    return None
+
+
+def generate(peth):
+    return None
+
+
+def apply(veth):
+    # Check if the Veth interface already exists
+    if 'rebuild_required' in veth or 'deleted' in veth:
+        if veth['ifname'] in interfaces():
+            p = VethIf(veth['ifname'])
+            p.remove()
+
+    if 'deleted' not in veth:
+        p = VethIf(**veth)
+        p.update(veth)
+
+    return None
+
+
+if __name__ == '__main__':
+    try:
+        c = get_config()
+        verify(c)
+        generate(c)
+        apply(c)
+    except ConfigError as e:
+        print(e)
+        exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add interface type veth (Virtual ethernet)
One of the usecases it's interconnect different vrf's and default vrf via bridge
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4825

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
veth
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set vrf name foo table '1010'
set interfaces virtual-ethernet veth0 peer-name 'veth1010'
set interfaces virtual-ethernet veth1010 address '10.0.0.10/24'
set interfaces virtual-ethernet veth1010 peer-name 'veth0'
set interfaces virtual-ethernet veth1010 vrf 'foo'
set interfaces bridge br0 address '10.0.0.1/24'
set interfaces bridge br0 member interface veth0
```
Check:
```
vyos@r1# run ping 10.0.0.10 count 1
PING 10.0.0.10 (10.0.0.10) 56(84) bytes of data.
64 bytes from 10.0.0.10: icmp_seq=1 ttl=64 time=0.078 ms

--- 10.0.0.10 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.078/0.078/0.078/0.000 ms
[edit]

vyos@r1# sudo ip link show type veth
41: veth1010@veth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master foo state UP mode DEFAULT group default qlen 1000
    link/ether a2:83:3b:96:75:e3 brd ff:ff:ff:ff:ff:ff
42: veth0@veth1010: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master br0 state UP mode DEFAULT group default qlen 1000
    link/ether de:00:4d:31:b1:ca brd ff:ff:ff:ff:ff:ff
[edit]
vyos@r1# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
