### PR TITLE
firewall: T5080: Disable conntrack unless required by rules

### DIFF
--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -2,6 +2,21 @@
 
 {% import 'firewall/nftables-defines.j2' as group_tmpl %}
 
+flush chain raw FW_CONNTRACK
+flush chain ip6 raw FW_CONNTRACK
+
+table raw {
+    chain FW_CONNTRACK {
+        {{ ipv4_conntrack_action }}
+    }
+}
+
+table ip6 raw {
+    chain FW_CONNTRACK {
+        {{ ipv6_conntrack_action }}
+    }
+}
+
 {% if first_install is not vyos_defined %}
 delete table inet vyos_global_rpfilter
 {% endif %}

--- a/data/vyos-firewall-init.conf
+++ b/data/vyos-firewall-init.conf
@@ -73,7 +73,7 @@ table raw {
     }
 
     chain FW_CONNTRACK {
-        accept
+        return
     }
 }
 
@@ -109,6 +109,6 @@ table ip6 raw {
     }
 
     chain FW_CONNTRACK {
-        accept
+        return
     }
 }

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -333,6 +333,17 @@ def generate(firewall):
     if not os.path.exists(nftables_conf):
         firewall['first_install'] = True
 
+    # Determine if conntrack is needed
+    firewall['ipv4_conntrack_action'] = 'return'
+    firewall['ipv6_conntrack_action'] = 'return'
+
+    for rules, path in dict_search_recursive(firewall, 'rule'):
+        if any(('state' in rule_conf or 'connection_status' in rule_conf) for rule_conf in rules.values()):
+            if path[0] == 'ipv4':
+                firewall['ipv4_conntrack_action'] = 'accept'
+            elif path[0] == 'ipv6':
+                firewall['ipv6_conntrack_action'] = 'accept'
+
     render(nftables_conf, 'firewall/nftables.j2', firewall)
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes conntrack being enabled by default, it is only enabled when rules exist with `state` or `connection-status`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5080

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->
- Conntrack is disabled by default
- Iterates IPv4/IPv6 rules and only enables conntrack where required
- Smoketest added to verify correct behaviour

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
With no rules checking state or connection-status, `FW_CONNTRACK` chain will `return` and fallback to `notrack` (except where NAT is configured)

With rules checking state or connection-status, `FW_CONNTRACK` chain will `accept` and conntrack is enabled

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
