### PR TITLE
T738: add CLI option for PowerDNS local-port

### DIFF
--- a/data/templates/dns-forwarding/recursor.conf.tmpl
+++ b/data/templates/dns-forwarding/recursor.conf.tmpl
@@ -25,6 +25,11 @@ export-etc-hosts={{ 'no' if ignore_hosts_file is defined else 'yes' }}
 # listen-address
 local-address={{ listen_address | join(',') }}
 
+{% if port is defined and port is not none %}
+# listen-port
+local-port={{ port }}
+{% endif %}
+
 # dnssec
 dnssec={{ dnssec }}
 

--- a/interface-definitions/dns-forwarding.xml.in
+++ b/interface-definitions/dns-forwarding.xml.in
@@ -147,6 +147,10 @@
                 </properties>
               </leafNode>
               #include <include/listen-address.xml.i>
+              #include <include/port-number.xml.i>
+              <leafNode name="port">
+                <defaultValue>53</defaultValue>
+              </leafNode>
               <leafNode name="negative-ttl">
                 <properties>
                   <help>Maximum amount of time negative entries are cached (default: 3600)</help>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
add CLI option for PowerDNS local-port
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Add port option

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T738

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration
```
set service dns forwarding allow-from '192.168.122.0/24'
set service dns forwarding listen-address '192.168.122.11'
set service dns forwarding port '5353'
```
Config
```
vyos@r1# cat /run/powerdns/recursor.conf
### Autogenerated by dns_forwarding.py ###

# XXX: pdns recursor doesn't like whitespace near entry separators,
# especially in the semicolon-separated lists of name servers.
# Please be careful if you edit the template.

# Non-configurable defaults
daemon=yes
threads=1
allow-from=192.168.122.0/24
log-common-errors=yes
non-local-bind=yes
query-local-address=0.0.0.0,::
lua-config-file=recursor.conf.lua

# cache-size
max-cache-entries=10000

# negative TTL for NXDOMAIN
max-negative-ttl=3600

# ignore-hosts-file
export-etc-hosts=yes

# listen-address
local-address=192.168.122.11

# listen-port
local-port=5353

# dnsse
```
Listen ports:
```
vyos@r1# sudo netstat -tulpn | grep 5353
tcp        0      0 192.168.122.11:5353     0.0.0.0:*               LISTEN      5083/pdns_recursor  
udp        0      0 192.168.122.11:5353     0.0.0.0:*                           5083/pdns_recursor  
[edit]
vyos@r1# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
