### PR TITLE
T2102: Add interface to PPPoE-server without restarting sessions

### DIFF
--- a/op-mode-definitions/force-pppoe-server.xml.in
+++ b/op-mode-definitions/force-pppoe-server.xml.in
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="force">
+    <children>
+      <node name="pppoe-server">
+        <properties>
+          <help>Set PPPoE-server oprions</help>
+        </properties>
+        <children>
+          <tagNode name="interface">
+            <properties>
+              <help>Set listen interface</help>
+              <completionHelp>
+                <script>${vyos_completion_dir}/list_interfaces.py</script>
+              </completionHelp>
+            </properties>
+            <command>/usr/bin/accel-cmd -p 2001 pppoe interface add $4</command>
+          </tagNode>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Sometimes, it is required to temporarily add new listen interfaces for the PPPoE-server without restarting current sessions/accel-ppp daemon. It is possible from op-mode:
```
/usr/bin/accel-cmd -p 2001 pppoe interface add "xxx"
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T2102

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set service pppoe-server authentication local-users username user1 password 'user1'
set service pppoe-server authentication local-users username user2 password 'user2'
set service pppoe-server authentication mode 'local'
set service pppoe-server client-ip-pool name POOL gateway-address '100.64.0.1'
set service pppoe-server client-ip-pool name POOL subnet '100.64.0.0/24'
set service pppoe-server interface eth0
```
Add temporary listen interface eth1:
```
vyos@r1:~$ show pppoe-server interfaces 
interface:   connections:    state:
-----------------------------------
     eth0              1    active
vyos@r1:~$ 


vyos@r1:~$ force pppoe-server interface eth1
vyos@r1:~$ 
vyos@r1:~$ show pppoe-server interfaces 
interface:   connections:    state:
-----------------------------------
     eth0              1    active
     eth1              0    active
vyos@r1:~$ 

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
