### PR TITLE
T2508: PowerDNS enable user to configure own LUA scripts

### DIFF
--- a/data/templates/dns-forwarding/recursor.conf.j2
+++ b/data/templates/dns-forwarding/recursor.conf.j2
@@ -32,6 +32,11 @@ local-address={{ listen_address | join(',') }}
 # listen-port
 local-port={{ port }}
 
+{% if lua_dns_script is vyos_defined %}
+# lua dns script
+lua-dns-script={{ lua_dns_script }}
+{% endif %}
+
 # dnssec
 dnssec={{ dnssec }}
 

--- a/interface-definitions/dns-forwarding.xml.in
+++ b/interface-definitions/dns-forwarding.xml.in
@@ -602,7 +602,7 @@
               <leafNode name="no-serve-rfc1918">
                 <properties>
                   <help>Makes the server authoritatively not aware of RFC1918 addresses</help>
-		          <valueless/>
+                  <valueless/>
                 </properties>
               </leafNode>
               <leafNode name="allow-from">
@@ -623,6 +623,18 @@
                 </properties>
               </leafNode>
               #include <include/listen-address.xml.i>
+              <leafNode name="lua-dns-script">
+                <properties>
+                  <help>PowerDNS recursor LUA dns-script file</help>
+                  <valueHelp>
+                    <format>file</format>
+                    <description>Path to file in the /config directory</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="file-path"/>
+                  </constraint>
+                </properties>
+              </leafNode>
               #include <include/port-number.xml.i>
               <leafNode name="port">
                 <defaultValue>53</defaultValue>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
PowerDNS has a feature that lets the user configure a LUA script that modifies the behavior during resolution

https://github.com/PowerDNS/pdns/tree/master/pdns/recursordist/examples
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T2508

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dns
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service dns forwarding allow-from '192.168.122.0/24'
set service dns forwarding listen-address '192.168.122.14'
set service dns forwarding lua-dns-script '/config/scripts/tmp.lua'

```
Recursor configuration:
```
vyos@r14# cat /run/powerdns/recursor.conf
### Autogenerated by dns_forwarding.py ###

# XXX: pdns recursor doesn't like whitespace near entry separators,
# especially in the semicolon-separated lists of name servers.
# Please be careful if you edit the template.

...

# listen-address
local-address=192.168.122.14

# listen-port
local-port=53

# lua dns script
lua-dns-script=/config/scripts/tmp.lua


```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
