### PR TITLE
T5496: multiple fixes for op-mode command <show firewall>

### DIFF
--- a/src/op_mode/firewall.py
+++ b/src/op_mode/firewall.py
@@ -127,7 +127,13 @@ def output_firewall_name_statistics(hook, prior, prior_conf, ipv6=False, single_
                     if not source_addr:
                         source_addr = dict_search_args(rule_conf, 'source', 'group', 'domain_group')
                         if not source_addr:
-                            source_addr = '::/0' if ipv6 else '0.0.0.0/0'
+                            source_addr = dict_search_args(rule_conf, 'source', 'fqdn')
+                            if not source_addr:
+                                source_addr = dict_search_args(rule_conf, 'source', 'geoip', 'country_code')
+                                if source_addr and 'inverse_match' in dict_search_args(rule_conf, 'source', 'geoip'):
+                                    source_addr = '!' + str(source_addr)
+                                if not source_addr:
+                                    source_addr = '::/0' if ipv6 else '0.0.0.0/0'
 
             # Get destination
             dest_addr = dict_search_args(rule_conf, 'destination', 'address')
@@ -138,7 +144,13 @@ def output_firewall_name_statistics(hook, prior, prior_conf, ipv6=False, single_
                     if not dest_addr:
                         dest_addr = dict_search_args(rule_conf, 'destination', 'group', 'domain_group')
                         if not dest_addr:
-                            dest_addr = '::/0' if ipv6 else '0.0.0.0/0'
+                            dest_addr = dict_search_args(rule_conf, 'destination', 'fqdn')
+                            if not dest_addr:
+                                dest_addr = dict_search_args(rule_conf, 'destination', 'geoip', 'country_code')
+                                if dest_addr and 'inverse_match' in dict_search_args(rule_conf, 'destination', 'geoip'):
+                                    dest_addr = '!' + str(dest_addr)
+                                if not dest_addr:
+                                    dest_addr = '::/0' if ipv6 else '0.0.0.0/0'
 
             # Get inbound interface
             iiface = dict_search_args(rule_conf, 'inbound_interface', 'interface_name')

--- a/src/op_mode/firewall.py
+++ b/src/op_mode/firewall.py
@@ -130,10 +130,12 @@ def output_firewall_name_statistics(hook, prior, prior_conf, ipv6=False, single_
                             source_addr = dict_search_args(rule_conf, 'source', 'fqdn')
                             if not source_addr:
                                 source_addr = dict_search_args(rule_conf, 'source', 'geoip', 'country_code')
-                                if source_addr and 'inverse_match' in dict_search_args(rule_conf, 'source', 'geoip'):
-                                    source_addr = '!' + str(source_addr)
+                                if source_addr:
+                                    source_addr = str(source_addr)[1:-1].replace('\'','')
+                                    if 'inverse_match' in dict_search_args(rule_conf, 'source', 'geoip'):
+                                        source_addr = 'NOT ' + str(source_addr)
                                 if not source_addr:
-                                    source_addr = '::/0' if ipv6 else '0.0.0.0/0'
+                                    source_addr = 'any'
 
             # Get destination
             dest_addr = dict_search_args(rule_conf, 'destination', 'address')
@@ -147,10 +149,12 @@ def output_firewall_name_statistics(hook, prior, prior_conf, ipv6=False, single_
                             dest_addr = dict_search_args(rule_conf, 'destination', 'fqdn')
                             if not dest_addr:
                                 dest_addr = dict_search_args(rule_conf, 'destination', 'geoip', 'country_code')
-                                if dest_addr and 'inverse_match' in dict_search_args(rule_conf, 'destination', 'geoip'):
-                                    dest_addr = '!' + str(dest_addr)
+                                if dest_addr:
+                                    dest_addr = str(dest_addr)[1:-1].replace('\'','')
+                                    if 'inverse_match' in dict_search_args(rule_conf, 'destination', 'geoip'):
+                                        dest_addr = 'NOT ' + str(dest_addr)
                                 if not dest_addr:
-                                    dest_addr = '::/0' if ipv6 else '0.0.0.0/0'
+                                    dest_addr = 'any'
 
             # Get inbound interface
             iiface = dict_search_args(rule_conf, 'inbound_interface', 'interface_name')
@@ -181,7 +185,22 @@ def output_firewall_name_statistics(hook, prior, prior_conf, ipv6=False, single_
             row.append(oiface)
             rows.append(row)
 
-    if 'default_action' in prior_conf and not single_rule_id:
+
+    if hook in ['input', 'forward', 'output']:
+        row = ['default']
+        row.append('N/A')
+        row.append('N/A')
+        if 'default_action' in prior_conf:
+            row.append(prior_conf['default_action'])
+        else:
+            row.append('accept')
+        row.append('any')
+        row.append('any')
+        row.append('any')
+        row.append('any')
+        rows.append(row)
+
+    elif 'default_action' in prior_conf and not single_rule_id:
         row = ['default']
         if 'default-action' in details:
             rule_details = details['default-action']
@@ -191,8 +210,10 @@ def output_firewall_name_statistics(hook, prior, prior_conf, ipv6=False, single_
             row.append('0')
             row.append('0')
         row.append(prior_conf['default_action'])
-        row.append('0.0.0.0/0') # Source
-        row.append('0.0.0.0/0') # Dest
+        row.append('any') # Source
+        row.append('any') # Dest
+        row.append('any')   # inbound-interface
+        row.append('any')   # outbound-interface
         rows.append(row)
 
     if rows:
@@ -315,7 +336,7 @@ def show_firewall_group(name=None):
                 continue
 
             references = find_references(group_type, group_name)
-            row = [group_name, group_type, '\n'.join(references) or 'N/A']
+            row = [group_name, group_type, '\n'.join(references) or 'N/D']
             if 'address' in group_conf:
                 row.append("\n".join(sorted(group_conf['address'])))
             elif 'network' in group_conf:
@@ -327,7 +348,7 @@ def show_firewall_group(name=None):
             elif 'interface' in group_conf:
                 row.append("\n".join(sorted(group_conf['interface'])))
             else:
-                row.append('N/A')
+                row.append('N/D')
             rows.append(row)
 
     if rows:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add fqdn and geo-ip matchers in op-mode command <show firewall statistics>

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5496

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->
Changes that were forgotten on previous PR https://github.com/vyos/vyos-1x/pull/2186, which contained the actual fix and some improvements. 
This PR is just simple improvement.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
vyos@FWALL-SHOW:~$ show firewall group 
Firewall Groups

Name         Type             References               Members
-----------  ---------------  -----------------------  ---------------
EMPTY        address_group    N/D                      N/D
GOOGLE       address_group    ipv4-forward-filter-102  8.8.4.4
                              ipv4-output-filter-91    8.8.8.8
                              ipv4-output-filter-92
TEST-HOST    address_group    ipv4-forward-filter-107  198.51.100.100
VYOS-DOMAIN  domain_group     ipv4-forward-filter-107  vyos.dev
                              ipv4-forward-filter-108
LAN          interface_group  ipv4-forward-filter-101  eth1
                              ipv4-forward-filter-102
                              ipv6-forward-filter-101
                              ipv6-input-filter-10
UN-USED      interface_group  N/D                      bri0.99
                                                       l2tp*
                                                       vtun55
WAN          interface_group  ipv4-forward-filter-101  eth0
                              ipv6-forward-filter-101
ALLOWED      network_group    ipv4-name-FOO-1111       192.168.70.0/24
                              ipv4-input-filter-1      192.168.77.0/24
vyos@FWALL-SHOW:~$ 

```

```
vyos@FWALL-SHOW:~$ show firewall statistics 
Rulesets Statistics

---------------------------------
IPv4 Firewall "forward filter"

Rule     Packets    Bytes    Action    Source     Destination    Inbound-Interface    Outbound-interface
-------  ---------  -------  --------  ---------  -------------  -------------------  --------------------
13       19         1704     accept    any        NOT nz, af     any                  any
28       0          0        accept    any        vyos.dev       any                  any
101      0          0        reject    any        1.1.1.1        LAN                  WAN
102      69         4151     accept    any        GOOGLE         LAN                  any
107      0          0        drop      TEST-HOST  VYOS-DOMAIN    any                  any
108      8          771      drop      any        !VYOS-DOMAIN   any                  any
default  N/A        N/A      accept    any        any            any                  any

---------------------------------
IPv4 Firewall "input filter"

Rule     Packets    Bytes    Action    Source    Destination    Inbound-Interface    Outbound-interface
-------  ---------  -------  --------  --------  -------------  -------------------  --------------------
1        753        51616    accept    ALLOWED   any            any                  any
3        0          0        drop      ag, af    any            any                  any
default  N/A        N/A      accept    any       any            any                  any

---------------------------------
IPv4 Firewall "name FOO"

Rule       Packets    Bytes  Action    Source    Destination    Inbound-Interface    Outbound-interface
-------  ---------  -------  --------  --------  -------------  -------------------  --------------------
1111             0        0  accept    ALLOWED   any            any                  any
default          0        0  return    any       any            any                  any

---------------------------------
IPv4 Firewall "output filter"

Rule     Packets    Bytes    Action    Source    Destination    Inbound-Interface    Outbound-interface
-------  ---------  -------  --------  --------  -------------  -------------------  --------------------
91       0          0        drop      any       GOOGLE         any                  any
92       494        83010    accept    any       !GOOGLE        any                  any
default  N/A        N/A      accept    any       any            any                  any

---------------------------------
IPv6 Firewall "forward filter"

Rule     Packets    Bytes    Action    Source    Destination    Inbound-Interface    Outbound-interface
-------  ---------  -------  --------  --------  -------------  -------------------  --------------------
101      0          0        drop      any       any            LAN                  WAN
default  N/A        N/A      drop      any       any            any                  any

---------------------------------
IPv6 Firewall "input filter"

Rule     Packets    Bytes    Action    Source    Destination    Inbound-Interface    Outbound-interface
-------  ---------  -------  --------  --------  -------------  -------------------  --------------------
10       0          0        drop      any       any            LAN                  any
default  N/A        N/A      accept    any       any            any                  any

---------------------------------
IPv6 Firewall "name V6-test"

Rule       Packets    Bytes  Action    Source        Destination    Inbound-Interface    Outbound-interface
-------  ---------  -------  --------  ------------  -------------  -------------------  --------------------
11               0        0  return    2001:db99::1  any            any                  any
default          0        0  drop      any           any            any                  any

vyos@FWALL-SHOW:~$ 

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
