### PR TITLE
eapol: T4782: Support multiple CA chains

### DIFF
--- a/interface-definitions/include/interface/eapol.xml.i
+++ b/interface-definitions/include/interface/eapol.xml.i
@@ -4,7 +4,7 @@
      <help>Extensible Authentication Protocol over Local Area Network</help>
   </properties>
   <children>
-    #include <include/pki/ca-certificate.xml.i>
+    #include <include/pki/ca-certificate-multi.xml.i>
     #include <include/pki/certificate-key.xml.i>
   </children>
 </node>

--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -187,15 +187,14 @@ def verify_eapol(config):
             if 'ca' not in config['pki']:
                 raise ConfigError('Invalid CA certificate specified for EAPoL')
 
-            ca_cert_name = config['eapol']['ca_certificate']
+            for ca_cert_name in config['eapol']['ca_certificate']:
+                if ca_cert_name not in config['pki']['ca']:
+                    raise ConfigError('Invalid CA certificate specified for EAPoL')
 
-            if ca_cert_name not in config['pki']['ca']:
-                raise ConfigError('Invalid CA certificate specified for EAPoL')
+                ca_cert = config['pki']['ca'][ca_cert_name]
 
-            ca_cert = config['pki']['ca'][ca_cert_name]
-
-            if 'certificate' not in ca_cert:
-                raise ConfigError('Invalid CA certificate specified for EAPoL')
+                if 'certificate' not in ca_cert:
+                    raise ConfigError('Invalid CA certificate specified for EAPoL')
 
 def verify_mirror_redirect(config):
     """

--- a/smoketest/scripts/cli/test_interfaces_ethernet.py
+++ b/smoketest/scripts/cli/test_interfaces_ethernet.py
@@ -250,7 +250,16 @@ class EthernetInterfaceTest(BasicInterfaceTest.TestCase):
         for interface in self._interfaces:
             # Enable EAPoL
             self.cli_set(self._base_path + [interface, 'eapol', 'ca-certificate', 'eapol-server-ca-intermediate'])
+            self.cli_set(self._base_path + [interface, 'eapol', 'ca-certificate', 'eapol-client-ca-intermediate'])
             self.cli_set(self._base_path + [interface, 'eapol', 'certificate', cert_name])
+
+        self.cli_commit()
+
+        # Test multiple CA chains
+        self.assertEqual(get_certificate_count(interface, 'ca'), 4)
+
+        for interface in self._interfaces:
+            self.cli_delete(self._base_path + [interface, 'eapol', 'ca-certificate', 'eapol-client-ca-intermediate'])
 
         self.cli_commit()
 

--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -186,14 +186,15 @@ def generate(ethernet):
 
         if 'ca_certificate' in ethernet['eapol']:
             ca_cert_file_path = os.path.join(cfg_dir, f'{ifname}_ca.pem')
-            ca_cert_name = ethernet['eapol']['ca_certificate']
-            pki_ca_cert = ethernet['pki']['ca'][ca_cert_name]
+            ca_chains = []
 
-            loaded_ca_cert = load_certificate(pki_ca_cert['certificate'])
-            ca_full_chain = find_chain(loaded_ca_cert, loaded_ca_certs)
+            for ca_cert_name in ethernet['eapol']['ca_certificate']:
+                pki_ca_cert = ethernet['pki']['ca'][ca_cert_name]
+                loaded_ca_cert = load_certificate(pki_ca_cert['certificate'])
+                ca_full_chain = find_chain(loaded_ca_cert, loaded_ca_certs)
+                ca_chains.append('\n'.join(encode_certificate(c) for c in ca_full_chain))
 
-            write_file(ca_cert_file_path,
-                       '\n'.join(encode_certificate(c) for c in ca_full_chain))
+            write_file(ca_cert_file_path, '\n'.join(ca_chains))
 
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Updates eapol with support for multiple CA chains 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4782

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
eapol

## Proposed changes
<!--- Describe your changes in detail -->
- Changes `ca-certificate` node to multi node
- Updated smoketest to verify

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Updated smoketest passes:
```
test_eapol_support (__main__.EthernetInterfaceTest.test_eapol_support) ... ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
