### PR TITLE
T5536: Fix show dhcp client leases

### DIFF
--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -338,10 +338,12 @@ def _get_formatted_client_leases(lease_data, family):
     from time import localtime
     from time import strftime
 
-    from vyos.validate import is_intf_addr_assigned
+    from vyos.utils.network import is_intf_addr_assigned
 
     data_entries = []
     for lease in lease_data:
+        if not lease.get('new_ip_address'):
+            continue
         data_entries.append(["Interface", lease['interface']])
         if 'new_ip_address' in lease:
             tmp = '[Active]' if is_intf_addr_assigned(lease['interface'], lease['new_ip_address']) else '[Inactive]'


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix helpers was moved to vyos.utils package
Fix empty new address from the lease file causes
```
OSError: illegal IP address string passed to inet_pton
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5536

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Get address by DHCP on one or several interfaces:
Before the fix:
1 Issue
```
vyos@r14:~$ show dhcp client leases 
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/dhcp.py", line 386, in <module>
    res = vyos.opmode.run(sys.modules[__name__])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/opmode.py", line 263, in run
    res = func(**args)
          ^^^^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/dhcp.py", line 382, in show_client_leases
    return _get_formatted_client_leases(lease_data, family=family)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/dhcp.py", line 341, in _get_formatted_client_leases
    from vyos.validate import is_intf_addr_assigned
ModuleNotFoundError: No module named 'vyos.validate'
vyos@r14:~$
``` 
2 Issue:
```
vyos@r14:~$ show dhcp client leases 
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/dhcp.py", line 386, in <module>
    res = vyos.opmode.run(sys.modules[__name__])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/opmode.py", line 263, in run
    res = func(**args)
          ^^^^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/dhcp.py", line 382, in show_client_leases
    return _get_formatted_client_leases(lease_data, family=family)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/dhcp.py", line 347, in _get_formatted_client_leases
    tmp = '[Active]' if is_intf_addr_assigned(lease['interface'], lease['new_ip_address']) else '[Inactive]'
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/utils/network.py", line 313, in is_intf_addr_assigned
    if not _are_same_ip(address, ip_addr):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/utils/network.py", line 24, in _are_same_ip
    return inet_pton(f_one, one) == inet_pton(f_one, two)
           ^^^^^^^^^^^^^^^^^^^^^
OSError: illegal IP address string passed to inet_pton
vyos@r14:~$ 

```
After the fix:
```
vyos@r14:~$ show dhcp client leases 
Interface    eth3
IP address   192.168.122.4                  [Active]
Subnet Mask  255.255.255.0
Domain Name
Router       192.168.122.1
Name Server  192.168.122.1
DHCP Server  192.168.122.1
DHCP Server  3600
VRF          default
Last Update  Fri Sep 01 14:33:50 EEST 2023
Expiry       Fri Sep 01 15:33:49 EEST 2023

Interface    eth2
IP address   192.168.100.197                [Active]
Subnet Mask  255.255.255.0
Domain Name  net-v6
Router       192.168.100.1
Name Server  192.168.100.1
DHCP Server  192.168.100.1
DHCP Server  3600
VRF          default
Last Update  Fri Sep 01 14:34:02 EEST 2023
Expiry       Fri Sep 01 15:34:02 EEST 2023

vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
