### PR TITLE
wireless: T5540: vyos-1x: Fix VHT capability settings for 802.11ac

### DIFF
--- a/data/templates/wifi/hostapd.conf.j2
+++ b/data/templates/wifi/hostapd.conf.j2
@@ -340,6 +340,12 @@ vht_oper_chwidth={{ capabilities.vht.channel_set_width }}
 {%     endif %}
 
 {%     set output = namespace(value='')  %}
+{%     if capabilities.vht.channel_set_width is vyos_defined('2') %}
+{%         set output.value = output.value ~ '[VHT160]' %}
+{%     endif %}
+{%     if capabilities.vht.channel_set_width is vyos_defined('3') %}
+{%         set output.value = output.value ~ '[VHT160-80PLUS80]' %}
+{%     endif %}
 {%     if capabilities.vht.stbc.tx is vyos_defined %}
 {%         set output.value = output.value ~ '[TX-STBC-2BY1]' %}
 {%     endif %}
@@ -363,30 +369,21 @@ vht_oper_chwidth={{ capabilities.vht.channel_set_width }}
 {%     endif %}
 {%     if capabilities.vht.max_mpdu_exp is vyos_defined %}
 {%         set output.value = output.value ~ '[MAX-A-MPDU-LEN-EXP-' ~ capabilities.vht.max_mpdu_exp ~ ']' %}
-{%         if capabilities.vht.max_mpdu_exp is vyos_defined('2') %}
-{%             set output.value = output.value ~ '[VHT160]' %}
-{%         endif %}
-{%         if capabilities.vht.max_mpdu_exp is vyos_defined('3') %}
-{%             set output.value = output.value ~ '[VHT160-80PLUS80]' %}
-{%         endif %}
 {%     endif %}
 {%     if capabilities.vht.link_adaptation is vyos_defined('unsolicited') %}
 {%         set output.value = output.value ~ '[VHT-LINK-ADAPT2]' %}
 {%     elif capabilities.vht.link_adaptation is vyos_defined('both') %}
 {%         set output.value = output.value ~ '[VHT-LINK-ADAPT3]' %}
 {%     endif %}
-
 {%     for short_gi in capabilities.vht.short_gi if capabilities.vht.short_gi is vyos_defined %}
 {%         set output.value = output.value ~ '[SHORT-GI-' ~ short_gi | upper ~ ']'  %}
 {%     endfor %}
-
 {%     for beamform in capabilities.vht.beamform if capabilities.vht.beamform is vyos_defined %}
 {%         set output.value = output.value ~ '[SU-BEAMFORMER]' if beamform is vyos_defined('single-user-beamformer') else '' %}
 {%         set output.value = output.value ~ '[SU-BEAMFORMEE]' if beamform is vyos_defined('single-user-beamformee') else '' %}
 {%         set output.value = output.value ~ '[MU-BEAMFORMER]' if beamform is vyos_defined('multi-user-beamformer')  else '' %}
 {%         set output.value = output.value ~ '[MU-BEAMFORMEE]' if beamform is vyos_defined('multi-user-beamformee')  else '' %}
 {%     endfor %}
-
 {%     if capabilities.vht.antenna_count is vyos_defined and capabilities.vht.antenna_count | int > 1  %}
 {%         if capabilities.vht.beamform is vyos_defined %}
 {%             if capabilities.vht.beamform == 'single-user-beamformer' %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
BUGFIX for WiFi configuration when operating in 802.11ac mode. The VHT capability flags [VHT160] and [VHT160-80PLUS80] were not set correctly. Fixed with this PR.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5540

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireless, hostapd, vyos-1x

## Proposed changes
<!--- Describe your changes in detail -->
* Updates to the Jinja template which is used to generate hostapd config files

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
### Test setup:

#### Real-World setup:

A PC-Engines APU2 with 2x Compex WLE600VX which support 80MHz channel width, but neither 160MHz nor 80+80MHz.

VHT Capabilities as taken from `/config/config.boot` -- WiFi interface was configured for 80MHz channel width (`channel-set-width 1`):

```
vht {
    antenna-count 2
    antenna-pattern-fixed
    center-channel-freq {
        freq-1 42
    }
    channel-set-width 1
    ldpc
    link-adaptation both
    max-mpdu 11454
    max-mpdu-exp 3
    short-gi 80
    stbc {
        rx 1
        tx
    }
}
```

#### Virtual Machine setup:

To verify the correct generation of hostapd config files, you may run simulated WiFi interfaces as follows:

* Set up a VyOS within a VM.
* Add a file `/etc/modprobe.d/mac80211_hwsim.conf` containing the line `options mac80211_hwsim radios=2` which will cause 2 WiFi interfaces to appear when the module `mac80211_hwsim` is loaded.
* Auto-load the module `mac80211_hwsim` by adding it to `/etc/modules`.
* Reboot.

You are now set to test the correct generation of hostapd config files within /run/hostapd/wlanX.conf.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
