### PR TITLE
T5542: ipoe-server: external-dhcp(dhcp-relay) not woking / not implemented

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.j2
+++ b/data/templates/accel-ppp/ipoe.config.j2
@@ -36,7 +36,9 @@ verbose=1
 {%             set shared = 'shared=0,' %}
 {%         endif %}
 {%         set range = 'range=' ~ iface_config.client_subnet ~ ',' if iface_config.client_subnet is vyos_defined else '' %}
-{{ tmp }},{{ shared }}mode={{ iface_config.mode | upper }},ifcfg=1,{{ range }}start=dhcpv4,ipv6=1
+{%         set relay = ',' ~ 'relay=' ~ iface_config.external_dhcp.dhcp_relay  if iface_config.external_dhcp.dhcp_relay is vyos_defined else '' %}
+{%         set giaddr = ',' ~ 'giaddr=' ~ iface_config.external_dhcp.giaddr if iface_config.external_dhcp.giaddr is vyos_defined else '' %}
+{{ tmp }},{{ shared }}mode={{ iface_config.mode | upper }},ifcfg=1,{{ range }}start=dhcpv4,ipv6=1{{ relay }}{{ giaddr }}
 {%         if iface_config.vlan is vyos_defined %}
 vlan-mon={{ iface }},{{ iface_config.vlan | join(',') }}
 {%         endif %}


### PR DESCRIPTION
## Change Summary
Implementation of  ``iface_config.external_dhcp.dhcp_relay`` and ``iface_config.external_dhcp.giaddr`` to the ipoe.conf.j2
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
[T5542](https://vyos.dev/T5542)

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipoe-server

## Proposed changes
<!--- Describe your changes in detail -->
append the relay and giaddr statements after the existing interface-config for the ipoe-server to get the existing cli config commands working

## How to test
After applying my fix as well as utilizing the following ipoe-server config, dhcp gets fowarded to the dhcp server.

```
service {
    ipoe-server {
        authentication {
            mode noauth
        }
        interface eth2 {
            external-dhcp {
                dhcp-relay 12.0.0.1
                giaddr 11.0.0.1
            }
        }
    }
```
resulting config without fix(/run/accel-pppd/ipoe.conf)
```
### generated by ipoe.py ###
(...)
[ipoe]
verbose=1
interface=eth2,shared=1,mode=L2,ifcfg=1,start=dhcpv4,ipv6=1
noauth=1
proxy-arp=1
(...)
```
with fix:
```
### generated by ipoe.py ###
(...)
[ipoe]
verbose=1
interface=eth2,shared=1,mode=L2,ifcfg=1,start=dhcpv4,ipv6=1,relay=12.0.0.1,giaddr=11.0.0.1
noauth=1
proxy-arp=1
(...)
```


```
Sep 03 01:31:19 accel-ipoe[2349]: eth2:: recv [DHCPv4 Discover xid=cefd2142 chaddr=0c:02:b5:e5:00:01 <Message-Type Discover> <Host-Name MT-CLIENT> <Request-List Subnet,Classless-Route,Router,Route,DNS,NTP,138,Vendor-Specific> <Client-ID 010c02b5e50001>]
Sep 03 01:31:19 accel-ipoe[2349]: ipoe0:: create interface ipoe0 parent eth2
Sep 03 01:31:19 accel-ipoe[2349]: ipoe0:: (null): authentication succeeded
Sep 03 01:31:19 accel-ipoe[2349]: ipoe0:: send [DHCPv4 relay Discover xid=cefd2142 giaddr=11.0.0.1 chaddr=0c:02:b5:e5:00:01 <Message-Type Discover> <Host-Name MT-CLIENT> <Request-List Subnet,Classless-Route,Router,Route,DNS,NTP,138,Vendor-Specific> <Client-ID 010c02b5e50001>]
Sep 03 01:31:19 accel-ipoe[2349]: ipoe0:: recv [DHCPv4 relay Offer xid=cefd2142 yiaddr=11.0.0.34 siaddr=12.0.0.1 giaddr=11.0.0.1 chaddr=0c:02:b5:e5:00:01 <Message-Type Offer> <Subnet 255.0.0.0> <Router 11.0.0.1,100.64.0.1> <DNS 192.168.111.1> <Lease-Time 1200> <Server-ID 12.0.0.1>]
Sep 03 01:31:19 accel-ipoe[2349]: ipoe0:: send [DHCPv4 Offer xid=cefd2142 yiaddr=11.0.0.34 chaddr=0c:02:b5:e5:00:01 <Message-Type Offer> <Server-ID 11.0.0.1> <Lease-Time 1200> <T1 300> <T2 525> <Router 11.0.0.1> <Subnet 255.0.0.0> <DNS 192.168.111.1>]
Sep 03 01:31:19 accel-ipoe[2349]: ipoe0:: recv [DHCPv4 Request xid=cefd2142 chaddr=0c:02:b5:e5:00:01 <Message-Type Request> <Host-Name MT-CLIENT> <Request-IP 11.0.0.34> <Server-ID 11.0.0.1> <Request-List Subnet,Classless-Route,Router,Route,DNS,NTP,138,Vendor-Specific> <Client-ID 010c02b5e50001>]
Sep 03 01:31:19 accel-ipoe[2349]: ipoe0:: send [DHCPv4 relay Request xid=cefd2142 giaddr=11.0.0.1 chaddr=0c:02:b5:e5:00:01 <Message-Type Request> <Host-Name MT-CLIENT> <Request-IP 11.0.0.34> <Server-ID 12.0.0.1> <Request-List Subnet,Classless-Route,Router,Route,DNS,NTP,138,Vendor-Specific> <Client-ID 010c02b5e50001>]
Sep 03 01:31:19 accel-ipoe[2349]: ipoe0:: recv [DHCPv4 relay Ack xid=cefd2142 yiaddr=11.0.0.34 siaddr=12.0.0.1 giaddr=11.0.0.1 chaddr=0c:02:b5:e5:00:01 <Message-Type Ack> <Subnet 255.0.0.0> <Router 11.0.0.1,100.64.0.1> <DNS 192.168.111.1> <Lease-Time 1200> <Server-ID 12.0.0.1>]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
