### PR TITLE
T5543: IGMP: Fix source address handling in static joins

### DIFF
--- a/data/templates/frr/igmp.frr.j2
+++ b/data/templates/frr/igmp.frr.j2
@@ -27,9 +27,9 @@ interface {{ interface }}
 {%     if interface_config.query_max_resp_time %}
  ip igmp query-max-response-time {{ interface_config.query_max_resp_time }}
 {%     endif %}
-{%     for group in interface_config.gr_join %}
-{%         if ifaces[iface].gr_join[group] %}
-{%             for source in ifaces[iface].gr_join[group] %}
+{%     for group, sources in interface_config.gr_join.items() %}
+{%         if sources is vyos_defined %}
+{%             for source in sources %}
  ip igmp join {{ group }} {{ source }}
 {%             endfor %}
 {%         else %}

--- a/src/conf_mode/protocols_igmp.py
+++ b/src/conf_mode/protocols_igmp.py
@@ -102,7 +102,7 @@ def verify(igmp):
         # Check, is this multicast group
         for intfc in igmp['ifaces']:
             for gr_addr in igmp['ifaces'][intfc]['gr_join']:
-                if IPv4Address(gr_addr) < IPv4Address('224.0.0.0'):
+                if not IPv4Address(gr_addr).is_multicast:
                     raise ConfigError(gr_addr + " not a multicast group")
 
 def generate(igmp):


### PR DESCRIPTION
The following command expects to join source-specific multicast group 239.1.2.3 on interface eth0, where the source address is 192.0.2.1.
```
set protocols igmp interface eth0 join 239.1.2.3 source 192.0.2.1
```

This command should generate FRR config:

```
interface eth0
 ip igmp
 ip igmp join 239.1.2.3 192.0.2.1
exit

```

However, there is a bug in the Jinja template where `if ifaces[iface].gr_join[group]` is mostly evaluated as `false` because `iface` is a loop variable from another loop.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/Txxxx

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
