### PR TITLE
conntrack: T4309: T4903: Refactor `system conntrack ignore`, add IPv6 support and firewall groups

### DIFF
--- a/data/config-mode-dependencies.json
+++ b/data/config-mode-dependencies.json
@@ -1,5 +1,5 @@
 {
-  "firewall": {"group_resync": ["nat", "policy-route"]},
+  "firewall": {"group_resync": ["conntrack", "nat", "policy-route"]},
   "http_api": {"https": ["https"]},
   "pki": {
            "ethernet": ["interfaces-ethernet"],

--- a/data/templates/conntrack/nftables-ct.j2
+++ b/data/templates/conntrack/nftables-ct.j2
@@ -1,5 +1,7 @@
 #!/usr/sbin/nft -f
 
+{% import 'firewall/nftables-defines.j2' as group_tmpl %}
+
 {% set nft_ct_ignore_name = 'VYOS_CT_IGNORE' %}
 {% set nft_ct_timeout_name = 'VYOS_CT_TIMEOUT' %}
 
@@ -10,29 +12,10 @@ flush chain raw {{ nft_ct_timeout_name }}
 
 table raw {
     chain {{ nft_ct_ignore_name }} {
-{% if ignore.rule is vyos_defined %}
-{%     for rule, rule_config in ignore.rule.items() %}
+{% if ignore.ipv4.rule is vyos_defined %}
+{%     for rule, rule_config in ignore.ipv4.rule.items() %}
         # rule-{{ rule }} {{ '- ' ~ rule_config.description if rule_config.description is vyos_defined }}
-{%         set nft_command = '' %}
-{%         if rule_config.inbound_interface is vyos_defined %}
-{%             set nft_command = nft_command ~ ' iifname ' ~ rule_config.inbound_interface %}
-{%         endif %}
-{%         if rule_config.protocol is vyos_defined %}
-{%             set nft_command = nft_command ~ ' ip protocol ' ~ rule_config.protocol %}
-{%         endif %}
-{%         if rule_config.destination.address is vyos_defined %}
-{%             set nft_command = nft_command ~ ' ip daddr ' ~ rule_config.destination.address %}
-{%         endif %}
-{%         if rule_config.destination.port is vyos_defined %}
-{%             set nft_command = nft_command ~ ' ' ~ rule_config.protocol ~ ' dport { ' ~ rule_config.destination.port ~ ' }' %}
-{%         endif %}
-{%         if rule_config.source.address is vyos_defined %}
-{%             set nft_command = nft_command ~ ' ip saddr ' ~ rule_config.source.address %}
-{%         endif %}
-{%         if rule_config.source.port is vyos_defined %}
-{%             set nft_command = nft_command ~ ' ' ~ rule_config.protocol ~ ' sport { ' ~ rule_config.source.port ~ ' }' %}
-{%         endif %}
-       {{ nft_command }} counter notrack comment ignore-{{ rule }}
+       {{ rule_config | conntrack_ignore_rule(rule, ipv6=False) }}
 {%     endfor %}
 {% endif %}
         return
@@ -45,4 +28,31 @@ table raw {
 {% endif %}
         return
     }
+
+{{ group_tmpl.groups(firewall_group, False) }}
+}
+
+flush chain ip6 raw {{ nft_ct_ignore_name }}
+flush chain ip6 raw {{ nft_ct_timeout_name }}
+
+table ip6 raw {
+    chain {{ nft_ct_ignore_name }} {
+{% if ignore.ipv6.rule is vyos_defined %}
+{%     for rule, rule_config in ignore.ipv6.rule.items() %}
+        # rule-{{ rule }} {{ '- ' ~ rule_config.description if rule_config.description is vyos_defined }}
+       {{ rule_config | conntrack_ignore_rule(rule, ipv6=True) }}
+{%     endfor %}
+{% endif %}
+        return
+    }
+    chain {{ nft_ct_timeout_name }} {
+{% if timeout.custom.rule is vyos_defined %}
+{%     for rule, rule_config in timeout.custom.rule.items() %}
+        # rule-{{ rule }} {{ '- ' ~ rule_config.description if rule_config.description is vyos_defined }}
+{%     endfor %}
+{% endif %}
+        return
+    }
+
+{{ group_tmpl.groups(firewall_group, True) }}
 }

--- a/data/vyos-firewall-init.conf
+++ b/data/vyos-firewall-init.conf
@@ -88,6 +88,8 @@ table ip6 raw {
 
     chain PREROUTING {
         type filter hook prerouting priority -300; policy accept;
+        counter jump VYOS_CT_IGNORE
+        counter jump VYOS_CT_TIMEOUT
         counter jump VYOS_CT_PREROUTING_HOOK
         counter jump FW_CONNTRACK
         notrack
@@ -95,9 +97,38 @@ table ip6 raw {
 
     chain OUTPUT {
         type filter hook output priority -300; policy accept;
+        counter jump VYOS_CT_IGNORE
+        counter jump VYOS_CT_TIMEOUT
         counter jump VYOS_CT_OUTPUT_HOOK
         counter jump FW_CONNTRACK
         notrack
+    }
+
+    ct helper rpc_tcp {
+        type "rpc" protocol tcp;
+    }
+
+    ct helper rpc_udp {
+        type "rpc" protocol udp;
+    }
+
+    ct helper tns_tcp {
+        type "tns" protocol tcp;
+    }
+
+    chain VYOS_CT_HELPER {
+        ct helper set "rpc_tcp" tcp dport {111} return
+        ct helper set "rpc_udp" udp dport {111} return
+        ct helper set "tns_tcp" tcp dport {1521,1525,1536} return
+        return
+    }
+
+    chain VYOS_CT_IGNORE {
+        return
+    }
+
+    chain VYOS_CT_TIMEOUT {
+        return
     }
 
     chain VYOS_CT_PREROUTING_HOOK {

--- a/interface-definitions/include/firewall/source-destination-group-ipv4.xml.i
+++ b/interface-definitions/include/firewall/source-destination-group-ipv4.xml.i
@@ -1,0 +1,41 @@
+<!-- include start from firewall/source-destination-group-ipv4.xml.i -->
+<node name="group">
+  <properties>
+    <help>Group</help>
+  </properties>
+  <children>
+    <leafNode name="address-group">
+      <properties>
+        <help>Group of addresses</help>
+        <completionHelp>
+          <path>firewall group address-group</path>
+        </completionHelp>
+      </properties>
+    </leafNode>
+    <leafNode name="domain-group">
+      <properties>
+        <help>Group of domains</help>
+        <completionHelp>
+          <path>firewall group domain-group</path>
+        </completionHelp>
+      </properties>
+    </leafNode>
+    <leafNode name="network-group">
+      <properties>
+        <help>Group of networks</help>
+        <completionHelp>
+          <path>firewall group network-group</path>
+        </completionHelp>
+      </properties>
+    </leafNode>
+    <leafNode name="port-group">
+      <properties>
+        <help>Group of ports</help>
+        <completionHelp>
+          <path>firewall group port-group</path>
+        </completionHelp>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/version/conntrack-version.xml.i
+++ b/interface-definitions/include/version/conntrack-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/conntrack-version.xml.i -->
-<syntaxVersion component='conntrack' version='3'></syntaxVersion>
+<syntaxVersion component='conntrack' version='4'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/system-conntrack.xml.in
+++ b/interface-definitions/system-conntrack.xml.in
@@ -40,82 +40,177 @@
               <help>Customized rules to ignore selective connection tracking</help>
             </properties>
             <children>
-              <tagNode name="rule">
+              <node name="ipv4">
                 <properties>
-                  <help>Rule number</help>
-                  <valueHelp>
-                    <format>u32:1-999999</format>
-                    <description>Number of conntrack ignore rule</description>
-                  </valueHelp>
-                  <constraint>
-                    <validator name="numeric" argument="--range 1-999999"/>
-                  </constraint>
-                  <constraintErrorMessage>Ignore rule number must be between 1 and 999999</constraintErrorMessage>
+                  <help>IPv4 rules</help>
                 </properties>
                 <children>
-                  #include <include/generic-description.xml.i>
-                  <node name="destination">
+                  <tagNode name="rule">
                     <properties>
-                      <help>Destination parameters</help>
-                    </properties>
-                    <children>
-                      #include <include/nat-address.xml.i>
-                      #include <include/nat-port.xml.i>
-                    </children>
-                  </node>
-                  <leafNode name="inbound-interface">
-                    <properties>
-                      <help>Interface to ignore connections tracking on</help>
-                      <completionHelp>
-                        <list>any</list>
-                        <script>${vyos_completion_dir}/list_interfaces</script>
-                      </completionHelp>
-                    </properties>
-                  </leafNode>
-                  #include <include/ip-protocol.xml.i>
-                  <leafNode name="protocol">
-                    <properties>
-                      <help>Protocol to match (protocol name, number, or "all")</help>
-                      <completionHelp>
-                        <script>${vyos_completion_dir}/list_protocols.sh</script>
-                        <list>all tcp_udp</list>
-                      </completionHelp>
+                      <help>Rule number</help>
                       <valueHelp>
-                        <format>all</format>
-                        <description>All IP protocols</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>tcp_udp</format>
-                        <description>Both TCP and UDP</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>u32:0-255</format>
-                        <description>IP protocol number</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>&lt;protocol&gt;</format>
-                        <description>IP protocol name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>!&lt;protocol&gt;</format>
-                        <description>IP protocol name</description>
+                        <format>u32:1-999999</format>
+                        <description>Number of conntrack ignore rule</description>
                       </valueHelp>
                       <constraint>
-                        <validator name="ip-protocol"/>
+                        <validator name="numeric" argument="--range 1-999999"/>
                       </constraint>
-                    </properties>
-                  </leafNode>
-                  <node name="source">
-                    <properties>
-                      <help>Source parameters</help>
+                      <constraintErrorMessage>Ignore rule number must be between 1 and 999999</constraintErrorMessage>
                     </properties>
                     <children>
-                      #include <include/nat-address.xml.i>
-                      #include <include/nat-port.xml.i>
+                      #include <include/generic-description.xml.i>
+                      <node name="destination">
+                        <properties>
+                          <help>Destination parameters</help>
+                        </properties>
+                        <children>
+                          #include <include/firewall/source-destination-group-ipv4.xml.i>
+                          #include <include/nat-address.xml.i>
+                          #include <include/nat-port.xml.i>
+                        </children>
+                      </node>
+                      <leafNode name="inbound-interface">
+                        <properties>
+                          <help>Interface to ignore connections tracking on</help>
+                          <completionHelp>
+                            <list>any</list>
+                            <script>${vyos_completion_dir}/list_interfaces</script>
+                          </completionHelp>
+                        </properties>
+                      </leafNode>
+                      #include <include/ip-protocol.xml.i>
+                      <leafNode name="protocol">
+                        <properties>
+                          <help>Protocol to match (protocol name, number, or "all")</help>
+                          <completionHelp>
+                            <script>${vyos_completion_dir}/list_protocols.sh</script>
+                            <list>all tcp_udp</list>
+                          </completionHelp>
+                          <valueHelp>
+                            <format>all</format>
+                            <description>All IP protocols</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>tcp_udp</format>
+                            <description>Both TCP and UDP</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>u32:0-255</format>
+                            <description>IP protocol number</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>&lt;protocol&gt;</format>
+                            <description>IP protocol name</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>!&lt;protocol&gt;</format>
+                            <description>IP protocol name</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="ip-protocol"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                      <node name="source">
+                        <properties>
+                          <help>Source parameters</help>
+                        </properties>
+                        <children>
+                          #include <include/firewall/source-destination-group-ipv4.xml.i>
+                          #include <include/nat-address.xml.i>
+                          #include <include/nat-port.xml.i>
+                        </children>
+                      </node>
                     </children>
-                  </node>
+                  </tagNode>
                 </children>
-              </tagNode>
+              </node>
+              <node name="ipv6">
+                <properties>
+                  <help>IPv6 rules</help>
+                </properties>
+                <children>
+                  <tagNode name="rule">
+                    <properties>
+                      <help>Rule number</help>
+                      <valueHelp>
+                        <format>u32:1-999999</format>
+                        <description>Number of conntrack ignore rule</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-999999"/>
+                      </constraint>
+                      <constraintErrorMessage>Ignore rule number must be between 1 and 999999</constraintErrorMessage>
+                    </properties>
+                    <children>
+                      #include <include/generic-description.xml.i>
+                      <node name="destination">
+                        <properties>
+                          <help>Destination parameters</help>
+                        </properties>
+                        <children>
+                          #include <include/firewall/address-ipv6.xml.i>
+                          #include <include/firewall/source-destination-group-ipv6.xml.i>
+                          #include <include/nat-port.xml.i>
+                        </children>
+                      </node>
+                      <leafNode name="inbound-interface">
+                        <properties>
+                          <help>Interface to ignore connections tracking on</help>
+                          <completionHelp>
+                            <list>any</list>
+                            <script>${vyos_completion_dir}/list_interfaces</script>
+                          </completionHelp>
+                        </properties>
+                      </leafNode>
+                      #include <include/ip-protocol.xml.i>
+                      <leafNode name="protocol">
+                        <properties>
+                          <help>Protocol to match (protocol name, number, or "all")</help>
+                          <completionHelp>
+                            <script>${vyos_completion_dir}/list_protocols.sh</script>
+                            <list>all tcp_udp</list>
+                          </completionHelp>
+                          <valueHelp>
+                            <format>all</format>
+                            <description>All IP protocols</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>tcp_udp</format>
+                            <description>Both TCP and UDP</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>u32:0-255</format>
+                            <description>IP protocol number</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>&lt;protocol&gt;</format>
+                            <description>IP protocol name</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>!&lt;protocol&gt;</format>
+                            <description>IP protocol name</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="ip-protocol"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                      <node name="source">
+                        <properties>
+                          <help>Source parameters</help>
+                        </properties>
+                        <children>
+                          #include <include/firewall/address-ipv6.xml.i>
+                          #include <include/firewall/source-destination-group-ipv6.xml.i>
+                          #include <include/nat-port.xml.i>
+                        </children>
+                      </node>
+                    </children>
+                  </tagNode>
+                </children>
+              </node>
+              
             </children>
           </node>
           <node name="log">

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -663,6 +663,84 @@ def nat_static_rule(rule_conf, rule_id, nat_type):
     from vyos.nat import parse_nat_static_rule
     return parse_nat_static_rule(rule_conf, rule_id, nat_type)
 
+@register_filter('conntrack_ignore_rule')
+def conntrack_ignore_rule(rule_conf, rule_id, ipv6=False):
+    ip_prefix = 'ip6' if ipv6 else 'ip'
+    def_suffix = '6' if ipv6 else ''
+    output = []
+
+    if 'inbound_interface' in rule_conf:
+        ifname = rule_conf['inbound_interface']
+        output.append(f'iifname {ifname}')
+
+    if 'protocol' in rule_conf:
+        proto = rule_conf['protocol']
+        output.append(f'meta l4proto {proto}')
+
+    for side in ['source', 'destination']:
+        if side in rule_conf:
+            side_conf = rule_conf[side]
+            prefix = side[0]
+
+            if 'address' in side_conf:
+                address = side_conf['address']
+                operator = ''
+                if address[0] == '!':
+                    operator = '!='
+                    address = address[1:]
+                output.append(f'{ip_prefix} {prefix}addr {operator} {address}')
+
+            if 'port' in side_conf:
+                port = side_conf['port']
+                operator = ''
+                if port[0] == '!':
+                    operator = '!='
+                    port = port[1:]
+                output.append(f'th {prefix}port {operator} {port}')
+
+            if 'group' in side_conf:
+                group = side_conf['group']
+
+                if 'address_group' in group:
+                    group_name = group['address_group']
+                    operator = ''
+                    if group_name[0] == '!':
+                        operator = '!='
+                        group_name = group_name[1:]
+                    output.append(f'{ip_prefix} {prefix}addr {operator} @A{def_suffix}_{group_name}')
+                # Generate firewall group domain-group
+                elif 'domain_group' in group:
+                    group_name = group['domain_group']
+                    operator = ''
+                    if group_name[0] == '!':
+                        operator = '!='
+                        group_name = group_name[1:]
+                    output.append(f'{ip_prefix} {prefix}addr {operator} @D_{group_name}')
+                elif 'network_group' in group:
+                    group_name = group['network_group']
+                    operator = ''
+                    if group_name[0] == '!':
+                        operator = '!='
+                        group_name = group_name[1:]
+                    output.append(f'{ip_prefix} {prefix}addr {operator} @N{def_suffix}_{group_name}')
+                if 'port_group' in group:
+                    group_name = group['port_group']
+
+                    if proto == 'tcp_udp':
+                        proto = 'th'
+
+                    operator = ''
+                    if group_name[0] == '!':
+                        operator = '!='
+                        group_name = group_name[1:]
+
+                    output.append(f'{proto} {prefix}port {operator} @P_{group_name}')
+
+    output.append('counter notrack')
+    output.append(f'comment "ignore-{rule_id}"')
+
+    return " ".join(output)
+
 @register_filter('range_to_regex')
 def range_to_regex(num_range):
     """Convert range of numbers or list of ranges

--- a/smoketest/configs/basic-vyos
+++ b/smoketest/configs/basic-vyos
@@ -116,6 +116,18 @@ system {
             speed 115200
         }
     }
+    conntrack {
+        ignore {
+            rule 1 {
+                destination {
+                    address 192.0.2.2
+                }
+                source {
+                    address 192.0.2.1
+                }
+            }
+        }
+    }
     host-name vyos
     login {
         user vyos {

--- a/src/conf_mode/nat.py
+++ b/src/conf_mode/nat.py
@@ -112,7 +112,7 @@ def verify_rule(config, err_msg, groups_dict):
                         group_obj = dict_search_args(groups_dict, group, group_name)
 
                         if group_obj is None:
-                            raise ConfigError(f'Invalid {error_group} "{group_name}" on firewall rule')
+                            raise ConfigError(f'Invalid {error_group} "{group_name}" on nat rule')
 
                         if not group_obj:
                             Warning(f'{error_group} "{group_name}" has no members!')

--- a/src/helpers/vyos-domain-resolver.py
+++ b/src/helpers/vyos-domain-resolver.py
@@ -37,12 +37,14 @@ domain_state = {}
 ipv4_tables = {
     'ip vyos_mangle',
     'ip vyos_filter',
-    'ip vyos_nat'
+    'ip vyos_nat',
+    'ip raw'
 }
 
 ipv6_tables = {
     'ip6 vyos_mangle',
-    'ip6 vyos_filter'
+    'ip6 vyos_filter',
+    'ip6 raw'
 }
 
 def get_config(conf):

--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -335,6 +335,9 @@ start ()
     nfct helper add rpc inet tcp
     nfct helper add rpc inet udp
     nfct helper add tns inet tcp
+    nfct helper add rpc inet6 tcp
+    nfct helper add rpc inet6 udp
+    nfct helper add tns inet6 tcp
     nft -f /usr/share/vyos/vyos-firewall-init.conf || log_failure_msg "could not initiate firewall rules"
 
     rm -f /etc/hostname

--- a/src/migration-scripts/conntrack/3-to-4
+++ b/src/migration-scripts/conntrack/3-to-4
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Add support for IPv6 conntrack ignore, move existing nodes to `system conntrack ignore ipv4`
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['system', 'conntrack']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+
+if config.exists(base + ['ignore', 'rule']):
+    config.set(base + ['ignore', 'ipv4'])
+    config.copy(base + ['ignore', 'rule'], base + ['ignore', 'ipv4', 'rule'])
+    config.delete(base + ['ignore', 'rule'])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
- Refactors `system conntrack ignore` rule generation
- Add IPv6 `system conntrack ignore` support
- Adds firewall groups for both IPv4 and IPv6 on conntrack ignore
- Fix typo in NAT conf script

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4309
* https://vyos.dev/T4903
* https://vyos.dev/T1877

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
conntrack, nat

## Proposed changes
<!--- Describe your changes in detail -->
- Migrate `system conntrack ignore rule N` to `system conntrack ignore [ipv4|ipv6] rule N`
- Move `conntrack ignore` rule generation to `vyos.template` (A PR will follow to consolidate and de-dupe common rule logic used by all `firewall`, `nat`, `policy route` and `conntrack ignore` conf scripts)
- Add migration test to `basic-vyos` and add smoketest for `conntrack ignore`

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
`load /usr/libexec/vyos/tests/config/basic-vyos`:
```
Loading configuration from '/usr/libexec/vyos/tests/config/basic-vyos'
Load complete. Use 'commit' to make changes effective.
[edit]
vyos@vyos# compare
...
[system conntrack]
+ ignore {
+     ipv4 {
+         rule 1 {
+             destination {
+                 address "192.0.2.2"
+             }
+             source {
+                 address "192.0.2.1"
+             }
+         }
+     }
+ }
```

Smoketest:
```
test_conntrack_hash_size (__main__.TestSystemConntrack.test_conntrack_hash_size) ... ok
test_conntrack_ignore (__main__.TestSystemConntrack.test_conntrack_ignore) ... ok
test_conntrack_module_enable (__main__.TestSystemConntrack.test_conntrack_module_enable) ... ok
test_conntrack_options (__main__.TestSystemConntrack.test_conntrack_options) ... ok

----------------------------------------------------------------------
Ran 4 tests in 43.582s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
