### PR TITLE
T5533: Fix VRRP IPv6 FAULT state due to IPv6 tentative state

### DIFF
--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -920,6 +920,34 @@ def is_ipv6_enabled() -> bool:
     """ Check if IPv6 support on the system is enabled or not """
     return (sysctl_read('net.ipv6.conf.all.disable_ipv6') == '0')
 
+def is_ipv6_tentative(iface: str, ipv6_address: str) -> bool:
+    """Check if IPv6 address is in tentative state.
+    This function checks if an IPv6 address on a specific network interface is
+    in the tentative state. IPv6 tentative addresses are not fully configured
+    and are undergoing Duplicate Address Detection (DAD) to ensure they are
+    unique on the network.
+    Args:
+        iface (str): The name of the network interface.
+        ipv6_address (str): The IPv6 address to check.
+    Returns:
+        bool: True if the IPv6 address is tentative, False otherwise.
+    """
+    import json
+    from vyos.util import rc_cmd
+
+    rc, out = rc_cmd(f'ip -6 --json address show dev {iface} scope global')
+    if rc:
+        return False
+
+    data = json.loads(out)
+    for addr_info in data[0]['addr_info']:
+        if (
+            addr_info.get('local') == ipv6_address and
+            addr_info.get('tentative', False)
+        ):
+            return True
+    return False
+
 def interface_exists(interface) -> bool:
     import os
     return os.path.exists(f'/sys/class/net/{interface}')


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Check if an IPv6 address on a specific network interface is in the tentative state. IPv6 tentative addresses are not fully configured and are undergoing Duplicate Address Detection (DAD) to ensure they are unique on the network.
```
inet6 2001:db8::3/125 scope global tentative
```
It the tentative state the group enters in FAULT state. Fix it.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5533

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrrp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set interfaces ethernet eth1 address '2001:db8::3/125'
set interfaces ethernet eth1 address '192.0.2.3/24'

set high-availability vrrp group 10 virtual-address 2001:db8::2/125
set high-availability vrrp group 10 description '**IPv6**'
set high-availability vrrp group 10 hello-source-address '2001:db8::3'
set high-availability vrrp group 10 interface 'eth1'
set high-availability vrrp group 10 peer-address '2001:db8::4'
set high-availability vrrp group 10 preempt-delay '5'
set high-availability vrrp group 10 priority '200'
set high-availability vrrp group 10 rfc3768-compatibility
set high-availability vrrp group 10 vrid '10'

set high-availability vrrp group 11 virtual-address 192.0.2.2/24
set high-availability vrrp group 11 description '**IPv4**'
set high-availability vrrp group 11 hello-source-address '192.0.2.3'
set high-availability vrrp group 11 interface 'eth1'
set high-availability vrrp group 11 peer-address '192.0.2.4'
set high-availability vrrp group 11 preempt-delay '5'
set high-availability vrrp group 11 priority '200'
set high-availability vrrp group 11 rfc3768-compatibility
set high-availability vrrp group 11 vrid '11'
```
Before the fix IPv6 group was in the FAULT state due to IPv6 address during this time still being in `tentative` state:
```
vyos@r1# run show vrrp 
  Name  Interface      VRID  State      Priority  Last Transition
------  -----------  ------  -------  ----------  -----------------
    10  eth1v10          10  FAULT           200  18s
    11  eth1v11          11  MASTER          200  15s
[edit]
vyos@r1# 

```
Logs before the fix:
```
Sep 04 18:32:17 r1 Keepalived[3693]: Startup complete
Sep 04 18:32:17 r1 Keepalived_vrrp[3704]: bind unicast_src 2001:db8::3 failed 99 - Cannot assign requested address
Sep 04 18:32:17 r1 Keepalived_vrrp[3704]: (10): entering FAULT state (src address not configured)
Sep 04 18:32:17 r1 Keepalived_vrrp[3704]: (10) Entering FAULT STATE
Sep 04 18:32:17 r1 Keepalived_vrrp[3704]: (11) Entering BACKUP STATE (init)
```
After the fix:
```
Sep 04 18:45:34 r1 Keepalived[6925]: Starting VRRP child process, pid=6926
Sep 04 18:45:34 r1 Keepalived_vrrp[6926]:
Sep 04 18:45:34 r1 Keepalived_vrrp[6926]: use_vmac or no_accept/strict specified, but no firewall configured - using nftables
Sep 04 18:45:34 r1 Keepalived[6925]: Startup complete
Sep 04 18:45:34 r1 Keepalived_vrrp[6926]: (10) Entering BACKUP STATE (init)
Sep 04 18:45:34 r1 Keepalived_vrrp[6926]: (11) Entering BACKUP STATE (init)
...
Sep 04 18:45:37 r1 Keepalived_vrrp[6926]: (10) Entering MASTER STATE
Sep 04 18:45:37 r1 Keepalived_vrrp[6926]: (11) Entering MASTER STATE

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
