### PR TITLE
T5423: Fix for op-mode show vpn ike secrets

### DIFF
--- a/op-mode-definitions/vpn-ipsec.xml.in
+++ b/op-mode-definitions/vpn-ipsec.xml.in
@@ -177,7 +177,7 @@
                 <properties>
                   <help>Show all the pre-shared key secrets</help>
                 </properties>
-                <command>sudo cat /etc/ipsec.secrets | sed 's/#.*//'</command>
+                <command>${vyos_op_scripts_dir}/ipsec.py show_psk</command>
               </node>
               <node name="status">
                 <properties>

--- a/src/op_mode/ipsec.py
+++ b/src/op_mode/ipsec.py
@@ -779,6 +779,45 @@ def show_ra_summary(raw: bool):
     return _get_formatted_output_ra_summary(list_sa)
 
 
+# PSK block
+def _get_raw_psk():
+    conf: ConfigTreeQuery = ConfigTreeQuery()
+    config_path = ['vpn', 'ipsec', 'authentication', 'psk']
+    psk_config = conf.get_config_dict(config_path, key_mangling=('-', '_'),
+                                       get_first_key=True,
+                                       no_tag_node_value_mangle=True)
+
+    psk_list = []
+    for psk, psk_data in psk_config.items():
+        psk_data['psk'] = psk
+        psk_list.append(psk_data)
+
+    return psk_list
+
+
+def _get_formatted_psk(psk_list):
+    headers = ["PSK", "Id", "Secret"]
+    formatted_data = []
+
+    for psk_data in psk_list:
+        formatted_data.append([psk_data["psk"], "\n".join(psk_data["id"]), psk_data["secret"]])
+
+    return tabulate(formatted_data, headers=headers)
+
+
+def show_psk(raw: bool):
+    config = ConfigTreeQuery()
+    if not config.exists('vpn ipsec authentication psk'):
+        raise vyos.opmode.UnconfiguredSubsystem('VPN ipsec psk authentication is not configured')
+
+    psk = _get_raw_psk()
+    if raw:
+        return psk
+    return _get_formatted_psk(psk)
+
+# PSK block end
+
+
 if __name__ == '__main__':
     try:
         res = vyos.opmode.run(sys.modules[__name__])


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
We don't use `ipsec.secrets` anymore.
Fix op-mode for `show vpn ike secrets`.
Ability to get `RAW` format
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5423

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set vpn ipsec authentication psk one id '192.0.2.1'
set vpn ipsec authentication psk one id '192.0.2.2'
set vpn ipsec authentication psk one secret 'SSSeeccRetT'
set vpn ipsec authentication psk two id '192.0.2.22'
set vpn ipsec authentication psk two secret 'se123cret'
```
Before the fix:
```
vyos@r14:~$ show vpn ike secrets 
cat: /etc/ipsec.secrets: No such file or directory
vyos@r14:~$
```
After the fix:
```
vyos@r14:~$ show vpn ike secrets 
PSK    Id          Secret
-----  ----------  -----------
one    192.0.2.1   SSSeeccRetT
       192.0.2.2
two    192.0.2.22  se123cret
vyos@r14:~$ 

```
RAW:
```
vyos@r14:~$ /usr/libexec/vyos/op_mode/ipsec.py show_psk --raw
[
    {
        "id": [
            "192.0.2.1",
            "192.0.2.2"
        ],
        "secret": "SSSeeccRetT",
        "psk": "one"
    },
    {
        "id": [
            "192.0.2.22"
        ],
        "secret": "se123cret",
        "psk": "two"
    }
]
vyos@r14:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
