### PR TITLE
interface: T5550: Interface source-validation priority over global value 

### DIFF
--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -29,9 +29,9 @@ table ip6 raw {
     }
 
     chain vyos_global_rpfilter {
-{% if global_options.source_validation is vyos_defined('loose') %}
+{% if global_options.ipv6_source_validation is vyos_defined('loose') %}
         fib saddr oif 0 counter drop
-{% elif global_options.source_validation is vyos_defined('strict') %}
+{% elif global_options.ipv6_source_validation is vyos_defined('strict') %}
         fib saddr . iif oif 0 counter drop
 {% endif %}
         return

--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -5,9 +5,21 @@
 flush chain raw FW_CONNTRACK
 flush chain ip6 raw FW_CONNTRACK
 
+flush chain raw vyos_global_rpfilter
+flush chain ip6 raw vyos_global_rpfilter
+
 table raw {
     chain FW_CONNTRACK {
         {{ ipv4_conntrack_action }}
+    }
+
+    chain vyos_global_rpfilter {
+{% if global_options.source_validation is vyos_defined('loose') %}
+        fib saddr oif 0 counter drop
+{% elif global_options.source_validation is vyos_defined('strict') %}
+        fib saddr . iif oif 0 counter drop
+{% endif %}
+        return
     }
 }
 
@@ -15,19 +27,14 @@ table ip6 raw {
     chain FW_CONNTRACK {
         {{ ipv6_conntrack_action }}
     }
-}
 
-{% if first_install is not vyos_defined %}
-delete table inet vyos_global_rpfilter
-{% endif %}
-table inet vyos_global_rpfilter {
-    chain PREROUTING {
-        type filter hook prerouting priority -300; policy accept;
+    chain vyos_global_rpfilter {
 {% if global_options.source_validation is vyos_defined('loose') %}
         fib saddr oif 0 counter drop
 {% elif global_options.source_validation is vyos_defined('strict') %}
         fib saddr . iif oif 0 counter drop
 {% endif %}
+        return
     }
 }
 

--- a/data/vyos-firewall-init.conf
+++ b/data/vyos-firewall-init.conf
@@ -19,6 +19,15 @@ table raw {
         type filter hook forward priority -300; policy accept;
     }
 
+    chain vyos_global_rpfilter {
+        return
+    }
+
+    chain vyos_rpfilter {
+        type filter hook prerouting priority -300; policy accept;
+        counter jump vyos_global_rpfilter
+    }
+
     chain PREROUTING {
         type filter hook prerouting priority -300; policy accept;
         counter jump VYOS_CT_IGNORE
@@ -82,8 +91,13 @@ table ip6 raw {
         type filter hook forward priority -300; policy accept;
     }
 
+    chain vyos_global_rpfilter {
+        return
+    }
+
     chain vyos_rpfilter {
         type filter hook prerouting priority -300; policy accept;
+        counter jump vyos_global_rpfilter
     }
 
     chain PREROUTING {

--- a/interface-definitions/include/firewall/global-options.xml.i
+++ b/interface-definitions/include/firewall/global-options.xml.i
@@ -145,21 +145,21 @@
     </leafNode>
     <leafNode name="source-validation">
       <properties>
-        <help>Policy for source validation by reversed path, as specified in RFC3704</help>
+        <help>Policy for IPv4 source validation by reversed path, as specified in RFC3704</help>
         <completionHelp>
           <list>strict loose disable</list>
         </completionHelp>
         <valueHelp>
           <format>strict</format>
-          <description>Enable Strict Reverse Path Forwarding as defined in RFC3704</description>
+          <description>Enable IPv4 Strict Reverse Path Forwarding as defined in RFC3704</description>
         </valueHelp>
         <valueHelp>
           <format>loose</format>
-          <description>Enable Loose Reverse Path Forwarding as defined in RFC3704</description>
+          <description>Enable IPv4 Loose Reverse Path Forwarding as defined in RFC3704</description>
         </valueHelp>
         <valueHelp>
           <format>disable</format>
-          <description>No source validation</description>
+          <description>No IPv4 source validation</description>
         </valueHelp>
         <constraint>
           <regex>(strict|loose|disable)</regex>
@@ -223,6 +223,30 @@
         </valueHelp>
         <constraint>
           <regex>(enable|disable)</regex>
+        </constraint>
+      </properties>
+      <defaultValue>disable</defaultValue>
+    </leafNode>
+    <leafNode name="ipv6-source-validation">
+      <properties>
+        <help>Policy for IPv6 source validation by reversed path, as specified in RFC3704</help>
+        <completionHelp>
+          <list>strict loose disable</list>
+        </completionHelp>
+        <valueHelp>
+          <format>strict</format>
+          <description>Enable IPv6 Strict Reverse Path Forwarding as defined in RFC3704</description>
+        </valueHelp>
+        <valueHelp>
+          <format>loose</format>
+          <description>Enable IPv6 Loose Reverse Path Forwarding as defined in RFC3704</description>
+        </valueHelp>
+        <valueHelp>
+          <format>disable</format>
+          <description>No IPv6 source validation</description>
+        </valueHelp>
+        <constraint>
+          <regex>(strict|loose|disable)</regex>
         </constraint>
       </properties>
       <defaultValue>disable</defaultValue>

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -174,10 +174,6 @@ class Interface(Control):
             'validate': assert_boolean,
             'location': '/proc/sys/net/ipv4/conf/{ifname}/bc_forwarding',
         },
-        'rp_filter': {
-            'validate': lambda flt: assert_range(flt,0,3),
-            'location': '/proc/sys/net/ipv4/conf/{ifname}/rp_filter',
-        },
         'ipv6_accept_ra': {
             'validate': lambda ara: assert_range(ara,0,3),
             'location': '/proc/sys/net/ipv6/conf/{ifname}/accept_ra',
@@ -250,9 +246,6 @@ class Interface(Control):
         },
         'ipv4_directed_broadcast': {
             'location': '/proc/sys/net/ipv4/conf/{ifname}/bc_forwarding',
-        },
-        'rp_filter': {
-            'location': '/proc/sys/net/ipv4/conf/{ifname}/rp_filter',
         },
         'ipv6_accept_ra': {
             'location': '/proc/sys/net/ipv6/conf/{ifname}/accept_ra',
@@ -763,44 +756,36 @@ class Interface(Control):
             return None
         return self.set_interface('ipv4_directed_broadcast', forwarding)
 
-    def set_ipv4_source_validation(self, value):
-        """
-        Help prevent attacks used by Spoofing IP Addresses. Reverse path
-        filtering is a Kernel feature that, when enabled, is designed to ensure
-        packets that are not routable to be dropped. The easiest example of this
-        would be and IP Address of the range 10.0.0.0/8, a private IP Address,
-        being received on the Internet facing interface of the router.
+    def _cleanup_ipv4_source_validation_rules(self, ifname):
+        results = self._cmd(f'nft -a list chain ip raw vyos_rpfilter').split("\n")
+        for line in results:
+            if f'iifname "{ifname}"' in line:
+                handle_search = re.search('handle (\d+)', line)
+                if handle_search:
+                    self._cmd(f'nft delete rule ip raw vyos_rpfilter handle {handle_search[1]}')
 
-        As per RFC3074.
+    def set_ipv4_source_validation(self, mode):
+        """
+        Set IPv4 reverse path validation
+
+        Example:
+        >>> from vyos.ifconfig import Interface
+        >>> Interface('eth0').set_ipv4_source_validation('strict')
         """
         # Don't allow for netns yet
         if 'netns' in self.config:
             return None
 
-        if value == 'strict':
-            value = 1
-        elif value == 'loose':
-            value = 2
-        else:
-            value = 0
-
-        all_rp_filter = int(read_file('/proc/sys/net/ipv4/conf/all/rp_filter'))
-        if all_rp_filter > value:
-            global_setting = 'disable'
-            if   all_rp_filter == 1: global_setting = 'strict'
-            elif all_rp_filter == 2: global_setting = 'loose'
-
-            from vyos.base import Warning
-            Warning(f'Global source-validation is set to "{global_setting}", this '\
-                    f'overrides per interface setting on "{self.ifname}"!')
-
-        tmp = self.get_interface('rp_filter')
-        if int(tmp) == value:
-            return None
-        return self.set_interface('rp_filter', value)
+        self._cleanup_ipv4_source_validation_rules(self.ifname)
+        nft_prefix = f'nft insert rule ip raw vyos_rpfilter iifname "{self.ifname}"'
+        if mode in ['strict', 'loose']:
+            self._cmd(f"{nft_prefix} counter return")
+        if mode == 'strict':
+            self._cmd(f"{nft_prefix} fib saddr . iif oif 0 counter drop")
+        elif mode == 'loose':
+            self._cmd(f"{nft_prefix} fib saddr oif 0 counter drop")
 
     def _cleanup_ipv6_source_validation_rules(self, ifname):
-        commands = []
         results = self._cmd(f'nft -a list chain ip6 raw vyos_rpfilter').split("\n")
         for line in results:
             if f'iifname "{ifname}"' in line:
@@ -821,7 +806,9 @@ class Interface(Control):
             return None
 
         self._cleanup_ipv6_source_validation_rules(self.ifname)
-        nft_prefix = f'nft add rule ip6 raw vyos_rpfilter iifname "{self.ifname}"'
+        nft_prefix = f'nft insert rule ip6 raw vyos_rpfilter iifname "{self.ifname}"'
+        if mode in ['strict', 'loose']:
+            self._cmd(f"{nft_prefix} counter return")
         if mode == 'strict':
             self._cmd(f"{nft_prefix} fib saddr . iif oif 0 counter drop")
         elif mode == 'loose':

--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -834,8 +834,12 @@ class BasicInterfaceTest:
                     self.assertEqual('1', tmp)
 
                 if cli_defined(self._base_path + ['ip'], 'source-validation'):
-                    tmp = read_file(f'{proc_base}/rp_filter')
-                    self.assertEqual('2', tmp)
+                    base_options = f'iifname "{interface}"'
+                    out = cmd('sudo nft list chain ip raw vyos_rpfilter')
+                    for line in out.splitlines():
+                        if line.startswith(base_options):
+                            self.assertIn('fib saddr oif 0', line)
+                            self.assertIn('drop', line)
 
         def test_interface_ipv6_options(self):
             if not self._test_ipv6:

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -529,23 +529,27 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
     def test_source_validation(self):
         # Strict
         self.cli_set(['firewall', 'global-options', 'source-validation', 'strict'])
+        self.cli_set(['firewall', 'global-options', 'ipv6-source-validation', 'strict'])
         self.cli_commit()
 
         nftables_strict_search = [
             ['fib saddr . iif oif 0', 'drop']
         ]
 
-        self.verify_nftables(nftables_strict_search, 'inet vyos_global_rpfilter')
+        self.verify_nftables_chain(nftables_strict_search, 'ip raw', 'vyos_global_rpfilter')
+        self.verify_nftables_chain(nftables_strict_search, 'ip6 raw', 'vyos_global_rpfilter')
 
         # Loose
         self.cli_set(['firewall', 'global-options', 'source-validation', 'loose'])
+        self.cli_set(['firewall', 'global-options', 'ipv6-source-validation', 'loose'])
         self.cli_commit()
 
         nftables_loose_search = [
             ['fib saddr oif 0', 'drop']
         ]
 
-        self.verify_nftables(nftables_loose_search, 'inet vyos_global_rpfilter')
+        self.verify_nftables_chain(nftables_loose_search, 'ip raw', 'vyos_global_rpfilter')
+        self.verify_nftables_chain(nftables_loose_search, 'ip6 raw', 'vyos_global_rpfilter')
 
     def test_sysfs(self):
         for name, conf in sysfs_config.items():


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
- Move interface IPv4 `source-validation` to nftables
- Add IPv6 specific firewall global-option `ipv6-source-validation`
- Update logic to ensure per-interface value takes priority over the global-options value when defined

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5550
* https://vyos.dev/T3509

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
interface, firewall

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set firewall global-options source-validation 'loose'
set interfaces ethernet eth0 ip source-validation 'strict'
set interfaces ethernet eth1 ip source-validation 'strict'
...
vyos@vyos# sudo nft list table ip raw
table ip raw {
        chain vyos_rpfilter {
                type filter hook prerouting priority raw; policy accept;
                iifname "eth0" fib saddr . iif oif 0 counter packets 0 bytes 0 drop
                iifname "eth0" counter packets 0 bytes 0 return # <--- ensures a stricter global-option does not take effect for this interface
                iifname "eth1" fib saddr . iif oif 0 counter packets 0 bytes 0 drop
                iifname "eth1" counter packets 0 bytes 0 return
                counter packets 216 bytes 15984 jump vyos_global_rpfilter
        }
        chain vyos_global_rpfilter {
                fib saddr oif 0 counter packets 0 bytes 0 drop
                return
        }
}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
