### PR TITLE
config-mgmt: T5353: normalize archive updates and commit log entries

### DIFF
--- a/python/vyos/config_mgmt.py
+++ b/python/vyos/config_mgmt.py
@@ -31,6 +31,7 @@ from vyos.configtree import ConfigTree, ConfigTreeError, show_diff
 from vyos.defaults import directories
 from vyos.version import get_full_version_data
 from vyos.utils.io import ask_yes_no
+from vyos.utils.boot import boot_configuration_complete
 from vyos.utils.process import is_systemd_service_active
 from vyos.utils.process import rc_cmd
 
@@ -474,22 +475,26 @@ Proceed ?'''
         conf_file.chmod(0o644)
 
     def _archive_active_config(self) -> bool:
+        use_tmp = (boot_configuration_complete() or not
+                   os.path.isfile(archive_config_file))
         mask = os.umask(0o113)
 
-        ext = os.getpid()
-        tmp_save = f'/tmp/config.boot.{ext}'
-        save_config(tmp_save)
+        if use_tmp:
+            ext = os.getpid()
+            cmp_saved = f'/tmp/config.boot.{ext}'
+            save_config(cmp_saved)
+        else:
+            cmp_saved = config_file
 
         try:
-            if cmp(tmp_save, archive_config_file, shallow=False):
-                # this will be the case on boot, as well as certain
-                # re-initialiation instances after delete/set
-                os.unlink(tmp_save)
+            if cmp(cmp_saved, archive_config_file, shallow=False):
+                if use_tmp: os.unlink(cmp_saved)
+                os.umask(mask)
                 return False
         except FileNotFoundError:
             pass
 
-        rc, out = rc_cmd(f'sudo mv {tmp_save} {archive_config_file}')
+        rc, out = rc_cmd(f'sudo mv {cmp_saved} {archive_config_file}')
         os.umask(mask)
 
         if rc != 0:

--- a/python/vyos/config_mgmt.py
+++ b/python/vyos/config_mgmt.py
@@ -526,9 +526,8 @@ Proceed ?'''
         return len(l)
 
     def _check_revision_number(self, rev: int) -> bool:
-        # exclude init revision:
         maxrev = self._get_number_of_revisions()
-        if not 0 <= rev < maxrev - 1:
+        if not 0 <= rev < maxrev:
             return False
         return True
 

--- a/python/vyos/config_mgmt.py
+++ b/python/vyos/config_mgmt.py
@@ -200,9 +200,9 @@ Proceed ?'''
             raise ConfigMgmtError(out)
 
         entry = self._read_tmp_log_entry()
-        self._add_log_entry(**entry)
 
         if self._archive_active_config():
+            self._add_log_entry(**entry)
             self._update_archive()
 
         msg = 'Reboot timer stopped'
@@ -334,10 +334,10 @@ Proceed ?'''
             user = self._get_user()
             via = 'init'
             comment = ''
-            self._add_log_entry(user, via, comment)
             # add empty init config before boot-config load for revision
             # and diff consistency
             if self._archive_active_config():
+                self._add_log_entry(user, via, comment)
                 self._update_archive()
 
         os.umask(mask)
@@ -352,9 +352,8 @@ Proceed ?'''
             self._new_log_entry(tmp_file=tmp_log_entry)
             return
 
-        self._add_log_entry()
-
         if self._archive_active_config():
+            self._add_log_entry()
             self._update_archive()
 
     def commit_archive(self):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Following the move to vyos-save-config, and fix of bug T5551, we can correct the archiving and commit log for config-mgmt tools.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5353

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
