### PR TITLE
T5562: Cleanup netns for smoketest load-balancing wan

### DIFF
--- a/smoketest/scripts/cli/test_load_balancing_wan.py
+++ b/smoketest/scripts/cli/test_load_balancing_wan.py
@@ -124,11 +124,12 @@ class TestLoadBalancingWan(VyOSUnitTestSHIM.TestCase):
         self.assertEqual(tmp, original)
 
         # Delete veth interfaces and netns
-        for iface in [iface1, iface2, iface3, container_iface1, container_iface2, container_iface3]:
+        for iface in [iface1, iface2, iface3]:
             call(f'sudo ip link del dev {iface}')
 
         delete_netns(ns1)
         delete_netns(ns2)
+        delete_netns(ns3)
 
     def test_check_chains(self):
 
@@ -246,11 +247,13 @@ class TestLoadBalancingWan(VyOSUnitTestSHIM.TestCase):
         self.assertEqual(tmp, nat_vyos_pre_snat_hook)
 
         # Delete veth interfaces and netns
-        for iface in [iface1, iface2, iface3, container_iface1, container_iface2, container_iface3]:
+        for iface in [iface1, iface2, iface3]:
             call(f'sudo ip link del dev {iface}')
 
         delete_netns(ns1)
         delete_netns(ns2)
+        delete_netns(ns3)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/op_mode/otp.py
+++ b/src/op_mode/otp.py
@@ -23,7 +23,7 @@ from jinja2 import Template
 from vyos.configquery import ConfigTreeQuery
 from vyos.xml import defaults
 from vyos.configdict import dict_merge
-from vyos.util import popen
+from vyos.utils.process import popen
 
 
 users_otp_template = Template("""


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Cleanup nets for the smoketest load-balancing
Remove deleting container interfaces from default netns as those
interfaces leave only in netns.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5562

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
smoketest, netns
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_load_balancing_wan.py
test_check_chains (__main__.TestLoadBalancingWan.test_check_chains) ... ok
test_table_routes (__main__.TestLoadBalancingWan.test_table_routes) ... ok

----------------------------------------------------------------------
Ran 2 tests in 106.729s

OK
vyos@r4:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
