### PR TITLE
T5567: Increase allowed range for maximum-object-size to 1GB for webproxy

### DIFF
--- a/interface-definitions/service-webproxy.xml.in
+++ b/interface-definitions/service-webproxy.xml.in
@@ -353,7 +353,7 @@
                 <description>Object size in KB</description>
               </valueHelp>
               <constraint>
-                <validator name="numeric" argument="--range 1-100000"/>
+                <validator name="numeric" argument="--range 1-1000000"/>
               </constraint>
             </properties>
           </leafNode>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
In Sagitta, the size of cachable objects has been limited to 100MB by config constraint. This results in packages like linux-firmware not being cachable anymore. The fix allows to cache objects up to 1G in size.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5567

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
webproxy

## Proposed changes
<!--- Describe your changes in detail -->
The integrated webproxy (squid) is a handy tool to limit access to websites and - more important - to speed up networks behind lower-capacity-uplinks. Squid can cache objects and deliver them upon request from the cache without the need to download it again. This prooves expecially handy when doing updates on many hosts. In Sagitta, the size of cachable objects has been limited to 100MB by config constraint. This results in packages like linux-firmware not being cachable anymore. The fix allows to cache objects up to 1G in size.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
1. Enter VyOS config mode
2. `set service webproxy maximum-object-size 875000`
3. The fix is successful, when this change can be committed and saved. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
