### PR TITLE
T3655: Fix NAT problem with VRF

### DIFF
--- a/data/templates/firewall/nftables-vrf-zones.j2
+++ b/data/templates/firewall/nftables-vrf-zones.j2
@@ -7,11 +7,11 @@ table inet vrf_zones {
   # Chain for inbound traffic
   chain vrf_zones_ct_in {
     type filter hook prerouting priority raw; policy accept;
-    counter ct zone set iifname map @ct_iface_map
+    counter ct original zone set iifname map @ct_iface_map
   }
   # Chain for locally-generated traffic
   chain vrf_zones_ct_out {
     type filter hook output priority raw; policy accept;
-    counter ct zone set oifname map @ct_iface_map
+    counter ct original zone set oifname map @ct_iface_map
   }
 }


### PR DESCRIPTION
Linux netfilter patch https://patchwork.ozlabs.org/project/netfilter-devel/patch/d0f84a97f9c86bec4d537536a26d0150873e640d.1439559328.git.daniel@iogearbox.net/ adds direction support for conntrack zones, which makes it possible to do NAT with conflicting IP address/port tuples from multiple, isolated tenants on a host.

According to the description of the kernel patch:
>  ... overlapping tuples can be made unique with the zone identifier in
original direction, where the NAT engine will then allocate a unique tuple in the commonly shared default zone for the reply direction.

I did some basic tests in my lab and it worked fine to forward packets from eth0 to pppoe0.
- eth0 192.168.1.1/24 in VRF red
- pppoe0 dynamic public IP from ISP VRF default
- set vrf name red protocols static route 0.0.0.0/0 interface pppoe0 vrf 'default'
- set protocols static route 192.168.1.0/24 interface eth0 vrf 'red'

`conntrack -L` shows something like:
```
tcp      6 113 ESTABLISHED src=192.168.1.2 dst=1.1.1.1 sport=58946 dport=80 zone-orig=250 packets=6 bytes=391 src=1.1.1.1 dst=<my-public-ip> sport=80 dport=58946 packets=4 bytes=602 [ASSURED] mark=0 helper=tns use=1
```

It would be much appreciated if someone could test this with more complex VRF setup.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3655

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
