### PR TITLE
frr: T5239: fix process startup order

### DIFF
--- a/debian/vyos-1x.preinst
+++ b/debian/vyos-1x.preinst
@@ -10,3 +10,4 @@ dpkg-divert --package vyos-1x --add --no-rename /etc/skel/.profile
 dpkg-divert --package vyos-1x --add --no-rename /etc/sysctl.d/80-vpp.conf
 dpkg-divert --package vyos-1x --add --no-rename /etc/netplug/netplugd.conf
 dpkg-divert --package vyos-1x --add --no-rename /etc/netplug/netplug
+dpkg-divert --package vyos-1x --add --no-rename /etc/rsyslog.d/45-frr.conf

--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -340,10 +340,6 @@ start ()
     nfct helper add tns inet6 tcp
     nft -f /usr/share/vyos/vyos-firewall-init.conf || log_failure_msg "could not initiate firewall rules"
 
-    rm -f /etc/hostname
-    ${vyos_conf_scripts_dir}/host_name.py || log_failure_msg "could not reset host-name"
-    systemctl start frr.service
-
     # As VyOS does not execute commands that are not present in the CLI we call
     # the script by hand to have a single source for the login banner and MOTD
     ${vyos_conf_scripts_dir}/system_console.py || log_failure_msg "could not reset serial console"
@@ -375,6 +371,13 @@ start ()
     mount -o $tmpfs_opts -t tmpfs none ${vyatta_configdir} \
       && chgrp ${GROUP} ${vyatta_configdir}
     log_action_end_msg $?
+
+    rm -f /etc/hostname
+    ${vyos_conf_scripts_dir}/host_name.py || log_failure_msg "could not reset host-name"
+    ${vyos_conf_scripts_dir}/system_frr.py || log_failure_msg "could not reset FRR config"
+    # If for any reason FRR was not started by system_frr.py - start it anyways.
+    # This is a safety net!
+    systemctl start frr.service
 
     disabled bootfile || init_bootfile
 


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

- Reuse existing utility functions to check if a boot is ongoing (boot_configuration_complete())
- Run system_frr.py script to configure FRR daemon before initial launch
- Add safety net to always have FRR running on the system

This does yet not solve the error in T5239 but it's a small step towards the solution.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5239

## Related PRs

* https://github.com/vyos/vyos-build/pull/401

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
FRR and vyos-router startup

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
