### PR TITLE
openvpn: T4974: Fixes for OpenVPN DCO functionality

### DIFF
--- a/python/vyos/ifconfig/vtun.py
+++ b/python/vyos/ifconfig/vtun.py
@@ -23,22 +23,18 @@ class VTunIf(Interface):
         **{
             'section': 'openvpn',
             'prefixes': ['vtun', ],
+            'eternal': 'vtun[0-9]+$',
             'bridgeable': True,
         },
     }
 
     def _create(self):
-        """ Depending on OpenVPN operation mode the interface is created
-        immediately (e.g. Server mode) or once the connection to the server is
-        established (client mode). The latter will only be brought up once the
-        server can be reached, thus we might need to create this interface in
-        advance for the service to be operational. """
-        try:
-            cmd = 'openvpn --mktun --dev-type {device_type} --dev {ifname}'.format(**self.config)
-            return self._cmd(cmd)
-        except PermissionError:
-            # interface created by OpenVPN daemon in the meantime ...
-            pass
+        # Interface is managed by OpenVPN daemon
+        pass
+
+    def _delete(self):
+        # Interface is managed by OpenVPN daemon
+        pass
 
     def add_addr(self, addr):
         # IP addresses are managed by OpenVPN daemon


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
- Remove interface creation/deletion logic, OpenVPN service handles it (DCO does not work if interface is already created)
- Fix `enable-dco` typo
- Remove interface check in client smoketests - Interface is not created until connection established
- Update smoketest to verify DCO

Known issue: An instance running in client mode that fails to establish connection (most likely to occur on boot) will not create an interface. As result, any processing inside `VTunIf.update()` (description/VRF/etc.) will not be applied.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4974

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openvpn

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py
DEBUG - test_openvpn_client_interfaces (__main__.TestInterfacesOpenVPN.test_openvpn_client_interfaces) ... ok
DEBUG - test_openvpn_client_verify (__main__.TestInterfacesOpenVPN.test_openvpn_client_verify) ... ok
DEBUG - test_openvpn_options (__main__.TestInterfacesOpenVPN.test_openvpn_options) ... ok
DEBUG - test_openvpn_server_net30_topology (__main__.TestInterfacesOpenVPN.test_openvpn_server_net30_topology) ... ok
DEBUG - test_openvpn_server_subnet_topology (__main__.TestInterfacesOpenVPN.test_openvpn_server_subnet_topology) ... ok
DEBUG - test_openvpn_server_verify (__main__.TestInterfacesOpenVPN.test_openvpn_server_verify) ... ok
DEBUG - test_openvpn_site2site_interfaces_tun (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_interfaces_tun) ... ok
DEBUG - test_openvpn_site2site_verify (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_verify) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 8 tests in 170.206s
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
