### PR TITLE
T4309: Conntrack ignore fix to handle interface any

### DIFF
--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -671,7 +671,8 @@ def conntrack_ignore_rule(rule_conf, rule_id, ipv6=False):
 
     if 'inbound_interface' in rule_conf:
         ifname = rule_conf['inbound_interface']
-        output.append(f'iifname {ifname}')
+        if ifname != 'any':
+            output.append(f'iifname {ifname}')
 
     if 'protocol' in rule_conf:
         proto = rule_conf['protocol']


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Interface 'any' not expected in nft rules, it means that option `iifname` shouldn't exist at all

Fix it
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4309
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set system conntrack ignore ipv4 rule 10 inbound-interface 'any'
```
Before the fix unexpected interface `any`:
```
table ip raw {
	chain VYOS_CT_IGNORE {
		iifname "any" counter packets 0 bytes 0 notrack comment "ignore-10"
		return
	}
}
```
After the fix:
```
vyos@r4# sudo nft list chain ip raw VYOS_CT_IGNORE
table ip raw {
	chain VYOS_CT_IGNORE {
		counter packets 137 bytes 12460 notrack comment "ignore-10"
		return
	}
}

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
