### PR TITLE
T5561: nat: inbound|outbound interface should not be mandatory

### DIFF
--- a/smoketest/scripts/cli/test_nat.py
+++ b/smoketest/scripts/cli/test_nat.py
@@ -155,11 +155,6 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
         rule = '5'
         self.cli_set(src_path + ['rule', rule, 'source', 'address', '192.0.2.0/24'])
 
-        # check validate() - outbound-interface must be defined
-        with self.assertRaises(ConfigSessionError):
-            self.cli_commit()
-        self.cli_set(src_path + ['rule', rule, 'outbound-interface', 'eth0'])
-
         # check validate() - translation address not specified
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()

--- a/src/conf_mode/nat.py
+++ b/src/conf_mode/nat.py
@@ -195,11 +195,10 @@ def verify(nat):
     if dict_search('source.rule', nat):
         for rule, config in dict_search('source.rule', nat).items():
             err_msg = f'Source NAT configuration error in rule {rule}:'
-            if 'outbound_interface' not in config:
-                raise ConfigError(f'{err_msg} outbound-interface not specified')
 
-            if config['outbound_interface'] not in 'any' and config['outbound_interface'] not in interfaces():
-                Warning(f'rule "{rule}" interface "{config["outbound_interface"]}" does not exist on this system')
+            if 'outbound_interface' in config:
+                if config['outbound_interface'] not in 'any' and config['outbound_interface'] not in interfaces():
+                    Warning(f'rule "{rule}" interface "{config["outbound_interface"]}" does not exist on this system')
 
             if not dict_search('translation.address', config) and not dict_search('translation.port', config):
                 if 'exclude' not in config and 'backend' not in config['load_balance']:
@@ -218,11 +217,9 @@ def verify(nat):
         for rule, config in dict_search('destination.rule', nat).items():
             err_msg = f'Destination NAT configuration error in rule {rule}:'
 
-            if 'inbound_interface' not in config:
-                raise ConfigError(f'{err_msg}\n' \
-                                  'inbound-interface not specified')
-            elif config['inbound_interface'] not in 'any' and config['inbound_interface'] not in interfaces():
-                Warning(f'rule "{rule}" interface "{config["inbound_interface"]}" does not exist on this system')
+            if 'inbound_interface' in config:
+                if config['inbound_interface'] not in 'any' and config['inbound_interface'] not in interfaces():
+                    Warning(f'rule "{rule}" interface "{config["inbound_interface"]}" does not exist on this system')
 
             if not dict_search('translation.address', config) and not dict_search('translation.port', config) and 'redirect' not in config['translation']:
                 if 'exclude' not in config and 'backend' not in config['load_balance']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Defining inbound|outbound interface should not be mandatory while configuring dNAT|sNAT rule

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):
Improvement: remove unnecessary NAT restriction

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5561

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos# run show config commands | grep nat
set nat destination rule 10 destination port '22'
set nat destination rule 10 protocol 'tcp'
set nat destination rule 10 translation address '192.0.2.2'
set nat source rule 10 source address '198.51.100.2'
set nat source rule 10 translation address '203.0.113.99'
[edit]
vyos@vyos# sudo nft -s list table ip vyos_nat
table ip vyos_nat {
        chain PREROUTING {
                type nat hook prerouting priority dstnat; policy accept;
                counter jump VYOS_PRE_DNAT_HOOK
                tcp dport 22 counter dnat to 192.0.2.2 comment "DST-NAT-10"
        }

        chain POSTROUTING {
                type nat hook postrouting priority srcnat; policy accept;
                counter jump VYOS_PRE_SNAT_HOOK
                ip saddr 198.51.100.2 counter snat to 203.0.113.99 comment "SRC-NAT-10"
        }

        chain VYOS_PRE_DNAT_HOOK {
                return
        }

        chain VYOS_PRE_SNAT_HOOK {
                return
        }
}
[edit]
vyos@vyos# 

```



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
