### PR TITLE
op mode: T5582: Add 'force ntp synchronization'

### DIFF
--- a/op-mode-definitions/ntp.xml.in
+++ b/op-mode-definitions/ntp.xml.in
@@ -18,4 +18,21 @@
       </node>
     </children>
   </node>
+  <node name="force">
+    <children>
+      <node name="ntp">
+        <properties>
+          <help>NTP (Network Time Protocol) operations</help>
+        </properties>
+        <children>
+          <node name="synchronization">
+            <properties>
+              <help>Force NTP time synchronization</help>
+            </properties>
+            <command>sudo chronyc makestep</command>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
 </interfaceDefinition>

--- a/op-mode-definitions/ntp.xml.in
+++ b/op-mode-definitions/ntp.xml.in
@@ -29,6 +29,17 @@
             <properties>
               <help>Force NTP time synchronization</help>
             </properties>
+            <children>
+              <tagNode name="vrf">
+                <properties>
+                  <help>Force NTP time synchronization in given VRF</help>
+                  <completionHelp>
+                    <path>vrf name</path>
+                  </completionHelp>
+                </properties>
+                <command>sudo ip vrf exec $5 chronyc makestep</command>
+              </tagNode>
+            </children>
             <command>sudo chronyc makestep</command>
           </node>
         </children>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5582

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Op mode.

## Proposed changes
<!--- Describe your changes in detail -->

Add a command to force NTP sync.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
run force ntp synchronization
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
