### PR TITLE
T5530: isis: Adding loop free alternate feature

### DIFF
--- a/data/templates/frr/isisd.frr.j2
+++ b/data/templates/frr/isisd.frr.j2
@@ -159,6 +159,48 @@ router isis VyOS {{ 'vrf ' + vrf if vrf is vyos_defined }}
 {%         endfor %}
 {%     endfor %}
 {% endif %}
+{% if fast_reroute.lfa is vyos_defined %}
+{%     if fast_reroute.lfa.local is vyos_defined %}
+{%         if fast_reroute.lfa.local.load_sharing.disable.level_1 is vyos_defined %}
+ fast-reroute load-sharing disable level-1
+{%         elif fast_reroute.lfa.local.load_sharing.disable.level_2 is vyos_defined %}
+ fast-reroute load-sharing disable level-2
+{%         elif fast_reroute.lfa.local.load_sharing.disable is vyos_defined %}
+ fast-reroute load-sharing disable
+{%         endif %}
+{%         if fast_reroute.lfa.local.priority_limit is vyos_defined %}
+{%             for priority, priority_limit_options in fast_reroute.lfa.local.priority_limit.items() %}
+{%                 for level in priority_limit_options %}
+ fast-reroute priority-limit {{ priority }} {{ level | replace('_', '-') }}
+{%                 endfor %}                   
+{%             endfor %}
+{%         endif %}
+{%         if fast_reroute.lfa.local.tiebreaker is vyos_defined %}
+{%             for tiebreaker, tiebreaker_options in fast_reroute.lfa.local.tiebreaker.items() %}
+{%                 for index, index_options in tiebreaker_options.items() %}
+{%                     for index_value, index_value_options in index_options.items() %}
+{%                         for level in index_value_options %}
+ fast-reroute lfa tiebreaker {{ tiebreaker | replace('_', '-') }} index {{ index_value }} {{ level | replace('_', '-') }}
+{%                         endfor %}
+{%                     endfor %}
+{%                 endfor %}
+{%             endfor %}
+{%         endif %}
+{%     endif %}
+{%     if fast_reroute.lfa.remote.prefix_list is vyos_defined %}
+{%         for prefix_list, prefix_list_options in fast_reroute.lfa.remote.prefix_list.items() %}
+{%             if prefix_list_options.level_1 is vyos_defined %}
+fast-reroute remote-lfa prefix-list {{ prefix_list }} level-1
+{%             endif %}
+{%             if prefix_list_options.level_2 is vyos_defined %}
+fast-reroute remote-lfa prefix-list {{ prefix_list }} level-2
+{%             endif %}
+{%             if prefix_list is vyos_defined and prefix_list_options.level_1 is not vyos_defined and prefix_list_options.level_2 is not vyos_defined %}
+fast-reroute remote-lfa prefix-list {{ prefix_list }}
+{%             endif %}
+{%         endfor %}
+{%     endif %}
+{% endif %}
 {% if redistribute.ipv4 is vyos_defined %}
 {%     for protocol, protocol_options in redistribute.ipv4.items() %}
 {%         for level, level_config in protocol_options.items() %}

--- a/interface-definitions/include/isis/level-1-2-leaf.xml.i
+++ b/interface-definitions/include/isis/level-1-2-leaf.xml.i
@@ -1,0 +1,13 @@
+<!-- include start from isis/level-1-2-leaf.xml.i -->
+<leafNode name="level-1">
+  <properties>
+    <help>Match on IS-IS level-1 routes</help>
+    <valueless/>
+  </properties>
+</leafNode>
+<leafNode name="level-2">
+  <properties>
+    <help>Match on IS-IS level-2 routes</help>
+    <valueless/>
+  </properties>
+</leafNode>

--- a/interface-definitions/include/isis/lfa-local.xml.i
+++ b/interface-definitions/include/isis/lfa-local.xml.i
@@ -1,0 +1,128 @@
+<!-- include start from isis/lfa-local.xml.i -->
+<node name="local">
+  <properties>
+    <help>Local loop free alternate options</help>
+  </properties>
+  <children>
+    <node name="load-sharing">
+      <properties>
+        <help>Load share prefixes across multiple backups</help>
+      </properties>
+      <children>
+        <node name="disable">
+          <properties>
+            <help>Disable load sharing</help>
+          </properties>
+          <children>
+            #include <include/isis/level-1-2-leaf.xml.i>
+          </children>
+        </node>
+      </children>
+    </node>
+    <node name="priority-limit">
+      <properties>
+        <help>Limit backup computation up to the prefix priority</help>
+      </properties>
+      <children>
+        <node name="medium">
+          <properties>
+            <help>Compute for critical, high, and medium priority prefixes</help>
+          </properties>
+          <children>
+            #include <include/isis/level-1-2-leaf.xml.i>
+          </children>
+        </node>
+        <node name="high">
+          <properties>
+            <help>Compute for critical, and high priority prefixes</help>
+          </properties>
+          <children>
+            #include <include/isis/level-1-2-leaf.xml.i>
+          </children>
+        </node>
+        <node name="critical">
+          <properties>
+            <help>Compute for critical priority prefixes only</help>
+          </properties>
+          <children>
+            #include <include/isis/level-1-2-leaf.xml.i>
+          </children>
+        </node>
+      </children>
+    </node>
+    <node name="tiebreaker">
+      <properties>
+        <help>Configure tiebreaker for multiple backups</help>
+      </properties>
+      <children>
+        <node name="downstream">
+          <properties>
+            <help>Prefer backup path via downstream node</help>
+          </properties>
+          <children>
+            <tagNode name="index">
+              <properties>
+                <help>Set preference order among tiebreakers</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                    <description>The index integer value</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+              <children>
+                #include <include/isis/level-1-2-leaf.xml.i>
+              </children>
+            </tagNode>
+          </children>
+        </node>
+        <node name="lowest-backup-metric">
+          <properties>
+            <help>Prefer backup path with lowest total metric</help>
+          </properties>
+          <children>
+            <tagNode name="index">
+              <properties>
+                <help>Set preference order among tiebreakers</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                    <description>The index integer value</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+              <children>
+                #include <include/isis/level-1-2-leaf.xml.i>
+              </children>
+            </tagNode>
+          </children>
+        </node>
+        <node name="node-protecting">
+          <properties>
+            <help>Prefer node protecting backup path</help>
+          </properties>
+          <children>
+            <tagNode name="index">
+              <properties>
+                <help>Set preference order among tiebreakers</help>
+                <valueHelp>
+                  <format>u32:1-255</format>
+                    <description>The index integer value</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-255"/>
+                </constraint>
+              </properties>
+              <children>
+                #include <include/isis/level-1-2-leaf.xml.i>
+              </children>
+            </tagNode>
+          </children>
+        </node>
+      </children>
+    </node>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/isis/lfa-protocol.xml.i
+++ b/interface-definitions/include/isis/lfa-protocol.xml.i
@@ -1,0 +1,11 @@
+<!-- include start from isis/lfa-protocol.xml.i -->
+<node name="lfa">
+  <properties>
+    <help>Loop free alternate functionality</help>
+  </properties>
+  <children>
+    #include <include/isis/lfa-remote.xml.i>
+    #include <include/isis/lfa-local.xml.i>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/isis/lfa-remote.xml.i
+++ b/interface-definitions/include/isis/lfa-remote.xml.i
@@ -1,0 +1,28 @@
+<!-- include start from isis/lfa-remote.xml.i -->
+<node name="remote">
+  <properties>
+    <help>Remote loop free alternate options</help>
+  </properties>
+  <children>
+    <tagNode name="prefix-list">
+      <properties>
+        <help>Filter PQ node router ID based on prefix list</help>
+        <completionHelp>
+          <path>policy prefix-list</path>
+        </completionHelp>
+        <valueHelp>
+          <format>txt</format>
+          <description>Name of IPv4/IPv6 prefix-list</description>
+        </valueHelp>
+        <constraint>
+          #include <include/constraint/alpha-numeric-hyphen-underscore.xml.i>
+        </constraint>
+        <constraintErrorMessage>Name of prefix-list can only contain alpha-numeric letters, hyphen and underscores</constraintErrorMessage>
+      </properties>
+      <children>
+        #include <include/isis/level-1-2-leaf.xml.i>
+      </children>
+    </tagNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/isis/protocol-common-config.xml.i
+++ b/interface-definitions/include/isis/protocol-common-config.xml.i
@@ -153,6 +153,14 @@
   </properties>
 </leafNode>
 #include <include/isis/ldp-sync-protocol.xml.i>
+<node name="fast-reroute">
+  <properties>
+    <help>IS-IS fast reroute configuration</help>
+  </properties>
+  <children>
+    #include <include/isis/lfa-protocol.xml.i>
+  </children>
+</node>
 <leafNode name="net">
   <properties>
     <help>A Network Entity Title for this process (ISO only)</help>

--- a/op-mode-definitions/include/isis-common.xml.i
+++ b/op-mode-definitions/include/isis-common.xml.i
@@ -17,6 +17,33 @@
   </properties>
   <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
 </tagNode>
+<node name="fast-reroute">
+  <properties>
+    <help>Show IS-IS fast reroute/loop free alternate (lfa) information</help>
+  </properties>
+  <children>
+    <node name="summary">
+      <properties>
+        <help>Show summary of fast reroute/loop free alternate (lfa) information</help>
+      </properties>
+      <children>
+        <leafNode name="level-1">
+          <properties>
+            <help>Show level-1 specific fast reroute/loop free alternate (lfa) information</help>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+        </leafNode>
+        <leafNode name="level-2">
+          <properties>
+            <help>Show level-2 specific fast reroute/loop free alternate (lfa) information</help>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+        </leafNode>
+      </children>
+      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+    </node>
+  </children>
+</node>
 <leafNode name="hostname">
   <properties>
     <help>Show IS-IS dynamic hostname mapping</help>

--- a/smoketest/scripts/cli/test_protocols_isis.py
+++ b/smoketest/scripts/cli/test_protocols_isis.py
@@ -320,5 +320,65 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f' ipv6 router isis {domain}', tmp)
             self.assertIn(f' no isis mpls ldp-sync', tmp)
 
+    def test_isis_09_lfa(self):
+        prefix_list = 'lfa-prefix-list-test-1'
+        prefix_list_address = '192.168.255.255/32'
+        interface = 'lo'
+
+        self.cli_set(base_path + ['net', net])
+        self.cli_set(base_path + ['interface', interface])
+        self.cli_set(['policy', 'prefix-list', prefix_list, 'rule', '1', 'action', 'permit'])
+        self.cli_set(['policy', 'prefix-list', prefix_list, 'rule', '1', 'prefix', prefix_list_address])
+        
+        # Commit main ISIS changes
+        self.cli_commit()
+
+        # Add remote portion of LFA with prefix list with validation
+        for level in ['level-1', 'level-2']:
+            self.cli_set(base_path + ['fast-reroute', 'lfa', 'remote', 'prefix-list', prefix_list, level])
+            self.cli_commit()
+            tmp = self.getFRRconfig(f'router isis {domain}', daemon='isisd')
+            self.assertIn(f' net {net}', tmp)
+            self.assertIn(f' fast-reroute remote-lfa prefix-list {prefix_list} {level}', tmp)
+            self.cli_delete(base_path + ['fast-reroute'])
+            self.cli_commit()
+
+        # Add local portion of LFA load-sharing portion with validation
+        for level in ['level-1', 'level-2']:
+            self.cli_set(base_path + ['fast-reroute', 'lfa', 'local', 'load-sharing', 'disable', level])
+            self.cli_commit()
+            tmp = self.getFRRconfig(f'router isis {domain}', daemon='isisd')
+            self.assertIn(f' net {net}', tmp)
+            self.assertIn(f' fast-reroute load-sharing disable {level}', tmp)
+            self.cli_delete(base_path + ['fast-reroute'])
+            self.cli_commit()
+
+        # Add local portion of LFA priority-limit portion with validation
+        for priority in ['critical', 'high', 'medium']:
+            for level in ['level-1', 'level-2']:
+                self.cli_set(base_path + ['fast-reroute', 'lfa', 'local', 'priority-limit', priority, level])
+                self.cli_commit()
+                tmp = self.getFRRconfig(f'router isis {domain}', daemon='isisd')
+                self.assertIn(f' net {net}', tmp)
+                self.assertIn(f' fast-reroute priority-limit {priority} {level}', tmp)
+                self.cli_delete(base_path + ['fast-reroute'])
+                self.cli_commit()
+
+        # Add local portion of LFA tiebreaker portion with validation
+        index = '100'
+        for tiebreaker in ['downstream','lowest-backup-metric','node-protecting']:
+            for level in ['level-1', 'level-2']:
+                self.cli_set(base_path + ['fast-reroute', 'lfa', 'local', 'tiebreaker', tiebreaker, 'index', index, level])
+                self.cli_commit()
+                tmp = self.getFRRconfig(f'router isis {domain}', daemon='isisd')
+                self.assertIn(f' net {net}', tmp)
+                self.assertIn(f' fast-reroute lfa tiebreaker {tiebreaker} index {index} {level}', tmp)
+                self.cli_delete(base_path + ['fast-reroute'])
+                self.cli_commit()
+
+        # Clean up and remove prefix list
+        self.cli_delete(['policy', 'prefix-list', prefix_list])
+        self.cli_commit()
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

We are adding the loop free alternate (LFA) functionality in IS-IS here. This
will allow for said functionality to be enabled as well as a bunch of the 
different options that are available within FRR are exposed to the user.  

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5530

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
isis

## Proposed changes
<!--- Describe your changes in detail -->

We are adding an lfa folder, local and remote, and then options underneath all of them. For the
smoketest we are adding a bunch of tests as well as a lot of these options tend to not be able 
to be configured together as they are mutually exclusive. However everything does seem to 
be able to be configured. Now as for whether or not it actually works properly, I do not know
how to properly test this in a lab. But at least we have the functionality available to us now.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Added the config here:
```
vyos@vyos# compare
[policy]
+ prefix-list test-lfa-prefix-list {
+     rule 1 {
+         action "permit"
+         prefix "10.0.0.0/8"
+     }
+ }
[protocols]
+ isis {
+     interface lo {
+     }
+     lfa {
+         remote {
+             prefix-list test-lfa-prefix-list {
+                 level-1
+                 level-2
+             }
+         }
+     }
+     net "49.0001.1921.6800.1002.00"
+ }
```

Showing that the configuration properly worked:
```
vyos@vyos:~$ vtysh -c "show run"
Building configuration...

Current configuration:
!
frr version 9.0
frr defaults traditional
hostname vyos
log syslog
log facility local7
service integrated-vtysh-config
!
ip route 0.0.0.0/0 10.0.0.65
!
interface lo
 ip router isis VyOS
 ipv6 router isis VyOS
exit
!
interface eth0
exit
!
interface eth1
exit
!
router isis VyOS
 net 49.0001.1921.6800.1002.00
 fast-reroute remote-lfa prefix-list test-lfa-prefix-list level-1
exit
!
ip prefix-list test-lfa-prefix-list seq 1 permit 10.0.0.0/8
!
rpki
exit
!
end
```

Showing that IS-IS actually turned on loop free alternate (lfa) and the statistics
that surround it:
```
vyos@vyos:~$ show isis fast-reroute summary
Area VyOS:
 IS-IS L1 IPv4 Fast ReRoute summary:

 Protection \ Priority     Critical  High      Medium    Low       Total
 -------------------------------------------------------------------------
 Classic LFA               0         0         0         0         0
 Remote LFA                0         0         0         0         0
 Topology Independent LFA  0         0         0         0         0
 ECMP                      0         0         0         0         0
 Unprotected               0         0         0         0         0
 Protection coverage       0.00%     0.00%     0.00%     0.00%     0.00%

 IS-IS L1 IPv6 Fast ReRoute summary:

 Protection \ Priority     Critical  High      Medium    Low       Total
 -------------------------------------------------------------------------
 Classic LFA               0         0         0         0         0
 Remote LFA                0         0         0         0         0
 Topology Independent LFA  0         0         0         0         0
 ECMP                      0         0         0         0         0
 Unprotected               0         0         0         0         0
 Protection coverage       0.00%     0.00%     0.00%     0.00%     0.00%

 IS-IS L2 IPv4 Fast ReRoute summary:

 Protection \ Priority     Critical  High      Medium    Low       Total
 -------------------------------------------------------------------------
 Classic LFA               0         0         0         0         0
 Remote LFA                0         0         0         0         0
 Topology Independent LFA  0         0         0         0         0
 ECMP                      0         0         0         0         0
 Unprotected               0         0         0         0         0
 Protection coverage       0.00%     0.00%     0.00%     0.00%     0.00%

 IS-IS L2 IPv6 Fast ReRoute summary:

 Protection \ Priority     Critical  High      Medium    Low       Total
 -------------------------------------------------------------------------
 Classic LFA               0         0         0         0         0
 Remote LFA                0         0         0         0         0
 Topology Independent LFA  0         0         0         0         0
 ECMP                      0         0         0         0         0
 Unprotected               0         0         0         0         0
 Protection coverage       0.00%     0.00%     0.00%     0.00%     0.00%
```

Smoketest shows that it passes properly, but the teardown fails. That doesn't seem to
be part of my function though. So I am unsure if that's something that I broke:
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_isis.py
test_isis_01_redistribute (__main__.TestProtocolsISIS.test_isis_01_redistribute) ...
Network entity is mandatory!

ok
test_isis_02_vrfs (__main__.TestProtocolsISIS.test_isis_02_vrfs) ... ok
test_isis_04_default_information (__main__.TestProtocolsISIS.test_isis_04_default_information) ... ok
test_isis_05_password (__main__.TestProtocolsISIS.test_isis_05_password) ...
Can use either md5 or plaintext-password for area-password!


Can use either md5 or plaintext-password for domain-password!

ok
test_isis_06_spf_delay_bfd (__main__.TestProtocolsISIS.test_isis_06_spf_delay_bfd) ...
All types of spf-delay must be configured. Missing: init-delay, long-
delay, time-to-learn, short-delay


All types of spf-delay must be configured. Missing: long-delay, time-to-
learn, short-delay


All types of spf-delay must be configured. Missing: short-delay, time-
to-learn


All types of spf-delay must be configured. Missing: time-to-learn

ok
test_isis_07_segment_routing_configuration (__main__.TestProtocolsISIS.test_isis_07_segment_routing_configuration) ... ok
test_isis_08_ldp_sync (__main__.TestProtocolsISIS.test_isis_08_ldp_sync) ... ok
test_isis_09_lfa (__main__.TestProtocolsISIS.test_isis_09_lfa) ... ok
tearDownClass (__main__.TestProtocolsISIS) ... ERROR

======================================================================
ERROR: tearDownClass (__main__.TestProtocolsISIS)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/libexec/vyos/tests/smoke/cli/base_vyostest_shim.py", line 57, in tearDownClass
    cls._session.migrate_and_load_config(save_config)
  File "/usr/lib/python3/dist-packages/vyos/configsession.py", line 200, in migrate_and_load_config
    out = self.__run_command(MIGRATE_LOAD_CONFIG + [file_path])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/configsession.py", line 139, in __run_command
    raise ConfigSessionError(output)
vyos.configsession.ConfigSessionError: Loading configuration from '/tmp/vyos-smoketest-save'
Traceback (most recent call last):
  File "/usr/libexec/vyos/vyos-load-config.py", line 92, in <module>
    migration.run()
  File "/usr/lib/python3/dist-packages/vyos/migrator.py", line 191, in run
    rev_versions = self.run_migration_scripts(cfg_versions, sys_versions)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/migrator.py", line 93, in run_migration_scripts
    self.init_logger()
  File "/usr/lib/python3/dist-packages/vyos/migrator.py", line 45, in init_logger
    fh = logging.FileHandler(log_file)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/__init__.py", line 1181, in __init__
    StreamHandler.__init__(self, self._open())
                                 ^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/__init__.py", line 1213, in _open
    return open_func(self.baseFilename, self.mode,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/opt/vyatta/etc/config/vyos-migrate.log'


----------------------------------------------------------------------
Ran 8 tests in 55.511s

FAILED (errors=1)

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly

* = Once PR approved, will add documentation