### PR TITLE
T2044: RPKI doesn't boot properly

### DIFF
--- a/data/templates/frr/daemons.frr.tmpl
+++ b/data/templates/frr/daemons.frr.tmpl
@@ -17,40 +17,41 @@ bfdd=yes
 staticd=yes
 
 vtysh_enable=yes
-zebra_options="  -s 90000000 --daemon -A 127.0.0.1
+zebra_options="   --daemon -A 127.0.0.1 -s 90000000
 {%- if irdp is defined %} -M irdp{% endif -%}
 {%- if snmp is defined and snmp.zebra is defined %} -M snmp{% endif -%}
 "
-bgpd_options="   --daemon -A 127.0.0.1
+bgpd_options="    --daemon -A 127.0.0.1 -M rpki
 {%- if bmp is defined %} -M bmp{% endif -%}
 {%- if snmp is defined and snmp.bgpd is defined %} -M snmp{% endif -%}
 "
-ospfd_options="  --daemon -A 127.0.0.1
+ospfd_options="   --daemon -A 127.0.0.1
 {%- if snmp is defined and snmp.ospfd is defined %} -M snmp{% endif -%}
 "
-ospf6d_options=" --daemon -A ::1
+ospf6d_options="  --daemon -A ::1
 {%- if snmp is defined and snmp.ospf6d is defined %} -M snmp{% endif -%}
 "
-ripd_options="   --daemon -A 127.0.0.1
+ripd_options="    --daemon -A 127.0.0.1
 {%- if snmp is defined and snmp.ripd is defined %} -M snmp{% endif -%}
 "
-ripngd_options=" --daemon -A ::1"
-isisd_options="  --daemon -A 127.0.0.1
+ripngd_options="  --daemon -A ::1"
+isisd_options="   --daemon -A 127.0.0.1
 {%- if snmp is defined and snmp.isisd is defined %} -M snmp{% endif -%}
 "
-pimd_options="  --daemon -A 127.0.0.1"
-pim6d_options=" --daemon -A ::1"
-ldpd_options="  --daemon -A 127.0.0.1
+pimd_options="    --daemon -A 127.0.0.1"
+pim6d_options="   --daemon -A ::1"
+ldpd_options="    --daemon -A 127.0.0.1
 {%- if snmp is defined and snmp.ldpd is defined %} -M snmp{% endif -%}
 "
-mgmtd_options=" --daemon -A 127.0.0.1"
-nhrpd_options="  --daemon -A 127.0.0.1"
+mgmtd_options="   --daemon -A 127.0.0.1"
+nhrpd_options="   --daemon -A 127.0.0.1"
 eigrpd_options="  --daemon -A 127.0.0.1"
 babeld_options="  --daemon -A 127.0.0.1"
 sharpd_options="  --daemon -A 127.0.0.1"
-pbrd_options="  --daemon -A 127.0.0.1"
-staticd_options="  --daemon -A 127.0.0.1"
-bfdd_options="  --daemon -A 127.0.0.1"
+pbrd_options="    --daemon -A 127.0.0.1"
+staticd_options=" --daemon -A 127.0.0.1"
+bfdd_options="    --daemon -A 127.0.0.1"
 
 watchfrr_enable=no
 valgrind_enable=no
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixing template for daemons-file used by FRR.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T2044
* https://vyos.dev/T5039
* https://github.com/vyos/vyos-build/pull/401

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
frr, bgp

## Proposed changes
<!--- Describe your changes in detail -->
https://github.com/vyos/vyos-build/pull/401 who is part of T5039 removed a duplicated daemons-file used by FRR.

Turns out that the remaining daemons-file (data/templates/frr/daemons.frr.tmpl) isnt properly synced.

This PR fixes this along with missing syntax to enable module rpki for FRR/bgp, missing this probably caused the failed nightly builds at:

https://github.com/vyos/vyos-rolling-nightly-builds/actions/runs/6179287424/job/16773987622#step:10:28642

and

https://github.com/vyos/vyos-rolling-nightly-builds/actions/runs/6179287424/job/16773987622#step:10:28487

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Verify with `ps auxwww | grep -i frr` that frr/bgpd have "-M rpki" loaded:

```
/usr/lib/frr/bgpd -d -F traditional --daemon -A 127.0.0.1 -M rpki -M snmp
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
