### PR TITLE
T5579: show log firewall - Fix and extend command 

### DIFF
--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -133,47 +133,267 @@
             <properties>
               <help>Show log for Firewall</help>
             </properties>
+            <command>journalctl --no-hostname --boot -k | egrep "(ipv[46]|bri)-(FWD|INP|OUT|NAM)"</command>
             <children>
-              <tagNode name="ipv6-name">
+              <node name="bridge">
                 <properties>
-                  <help>Show log for a specified firewall (IPv6)</help>
-                  <completionHelp>
-                    <path>firewall ipv6-name</path>
-                  </completionHelp>
+                  <help>Show firewall bridge log</help>
                 </properties>
-                <command>cat $(printf "%s\n" /var/log/messages* | sort -nr ) | egrep "\[$5-([0-9]+|default)-[ADR]\]"</command>
+                <command>journalctl --no-hostname --boot -k | egrep "bri-(FWD|INP|OUT|NAM)"</command>
                 <children>
-                  <tagNode name="rule">
+                  <node name="forward">
                     <properties>
-                      <help>Show log for a rule in the specified firewall</help>
+                      <help>Show Bridge forward firewall log</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot -k | grep bri-FWD</command>
+                    <children>
+                      <node name="filter">
+                        <properties>
+                          <help>Show Bridge firewall forward filter</help>
+                        </properties>
+                        <command>journalctl --no-hostname --boot -k | grep bri-FWD-filter</command>
+                        <children>
+                          <tagNode name="rule">
+                            <properties>
+                              <help>Show log for a rule in the specified firewall</help>
+                              <completionHelp>
+                                <path>firewall bridge forward filter rule</path>
+                              </completionHelp>
+                            </properties>
+                            <command>journalctl --no-hostname --boot -k | egrep "\[bri-FWD-filter-$8-[ADRJC]\]"</command>
+                          </tagNode>
+                        </children>
+                      </node>
+                    </children>
+                  </node>
+                  <tagNode name="name">
+                    <properties>
+                      <help>Show custom Bridge firewall log</help>
                       <completionHelp>
-                        <path>firewall ipv6-name ${COMP_WORDS[4]} rule</path>
+                        <path>firewall bridge name</path>
                       </completionHelp>
                     </properties>
-                    <command>cat $(printf "%s\n" /var/log/messages* | sort -nr) | grep -e "\[$5-$7-[ADR]\]"</command>
+                    <command>journalctl --no-hostname --boot -k | grep bri-NAM-$6</command>
+                    <children>
+                      <tagNode name="rule">
+                        <properties>
+                          <help>Show log for a rule in the specified firewall</help>
+                          <completionHelp>
+                            <path>firewall bridge name ${COMP_WORDS[5]} rule</path>
+                          </completionHelp>
+                        </properties>
+                        <command>journalctl --no-hostname --boot -k | egrep "\[bri-NAM-$6-$8-[ADRJC]\]"</command>
+                      </tagNode>
+                    </children>
                   </tagNode>
                 </children>
-              </tagNode>
-              <tagNode name="name">
+              </node>
+              <node name="ipv4">
                 <properties>
-                  <help>Show log for a specified firewall (IPv4)</help>
-                  <completionHelp>
-                    <path>firewall name</path>
-                  </completionHelp>
+                  <help>Show firewall IPv4 log</help>
                 </properties>
-                <command>cat $(printf "%s\n" /var/log/messages* | sort -nr ) | egrep "\[$5-([0-9]+|default)-[ADR]\]"</command>
+                <command>journalctl --no-hostname --boot -k | egrep "ipv4-(FWD|INP|OUT|NAM)"</command>
                 <children>
-                  <tagNode name="rule">
+                  <node name="forward">
                     <properties>
-                      <help>Show log for a rule in the specified firewall</help>
+                      <help>Show firewall IPv4 forward log</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot -k | grep ipv4-FWD</command>
+                    <children>
+                      <node name="filter">
+                        <properties>
+                          <help>Show firewall IPv4 forward filter log</help>
+                        </properties>
+                        <command>journalctl --no-hostname --boot -k | grep ipv4-FWD-filter</command>
+                        <children>
+                          <tagNode name="rule">
+                            <properties>
+                              <help>Show log for a rule in the specified firewall</help>
+                              <completionHelp>
+                                <path>firewall ipv4 forward filter rule</path>
+                              </completionHelp>
+                            </properties>
+                            <command>journalctl --no-hostname --boot -k | egrep "\[ipv4-FWD-filter-$8-[ADRJC]\]"</command>
+                          </tagNode>
+                        </children>
+                      </node>
+                    </children>
+                  </node>
+                  <node name="input">
+                    <properties>
+                      <help>Show firewall IPv4 input log</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot -k | grep ipv4-INP</command>
+                    <children>
+                      <node name="filter">
+                        <properties>
+                          <help>Show firewall IPv4 input filter log</help>
+                        </properties>
+                        <command>journalctl --no-hostname --boot -k | grep ipv4-INP-filter</command>
+                        <children>
+                          <tagNode name="rule">
+                            <properties>
+                              <help>Show log for a rule in the specified firewall</help>
+                              <completionHelp>
+                                <path>firewall ipv4 input filter rule</path>
+                              </completionHelp>
+                            </properties>
+                            <command>journalctl --no-hostname --boot -k | egrep "\[ipv4-INP-filter-$8-[ADRJC]\]"</command>
+                          </tagNode>
+                        </children>
+                      </node>
+                    </children>
+                  </node>
+                  <tagNode name="name">
+                    <properties>
+                      <help>Show custom IPv4 firewall log</help>
                       <completionHelp>
-                        <path>firewall name ${COMP_WORDS[4]} rule</path>
+                        <path>firewall ipv4 name</path>
                       </completionHelp>
                     </properties>
-                    <command>cat $(printf "%s\n" /var/log/messages* | sort -nr) | egrep "\[$5-$7-[ADR]\]"</command>
+                    <command>journalctl --no-hostname --boot -k | grep ipv4-NAM-$6</command>
+                    <children>
+                      <tagNode name="rule">
+                        <properties>
+                          <help>Show log for a rule in the specified firewall</help>
+                          <completionHelp>
+                            <path>firewall ipv4 name ${COMP_WORDS[5]} rule</path>
+                          </completionHelp>
+                        </properties>
+                        <command>journalctl --no-hostname --boot -k | egrep "\[ipv4-NAM-$6-$8-[ADRJC]\]"</command>
+                      </tagNode>
+                    </children>
                   </tagNode>
+                  <node name="output">
+                    <properties>
+                      <help>Show firewall IPv4 output log</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot -k | grep ipv4-OUT</command>
+                    <children>
+                      <node name="filter">
+                        <properties>
+                          <help>Show firewall IPv4 output filter log</help>
+                        </properties>
+                        <command>journalctl --no-hostname --boot -k | grep ipv4-OUT-filter</command>
+                        <children>
+                          <tagNode name="rule">
+                            <properties>
+                              <help>Show log for a rule in the specified firewall</help>
+                              <completionHelp>
+                                <path>firewall ipv4 output filter rule</path>
+                              </completionHelp>
+                            </properties>
+                            <command>journalctl --no-hostname --boot -k | egrep "\[ipv4-OUT-filter-$8-[ADRJC]\]"</command>
+                          </tagNode>
+                        </children>
+                      </node>
+                    </children>
+                  </node>
                 </children>
-              </tagNode>
+              </node>
+              <node name="ipv6">
+                <properties>
+                  <help>Show firewall IPv6 log</help>
+                </properties>
+                <command>journalctl --no-hostname --boot -k | egrep "ipv6-(FWD|INP|OUT|NAM)"</command>
+                <children>
+                  <node name="forward">
+                    <properties>
+                      <help>Show firewall IPv6 forward log</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot -k | grep ipv6-FWD</command>
+                    <children>
+                      <node name="filter">
+                        <properties>
+                          <help>Show firewall IPv6 forward filter log</help>
+                        </properties>
+                        <command>journalctl --no-hostname --boot -k | grep ipv6-FWD-filter</command>
+                        <children>
+                          <tagNode name="rule">
+                            <properties>
+                              <help>Show log for a rule in the specified firewall</help>
+                              <completionHelp>
+                                <path>firewall ipv6 forward filter rule</path>
+                              </completionHelp>
+                            </properties>
+                            <command>journalctl --no-hostname --boot -k | egrep "\[ipv6-FWD-filter-$8-[ADRJC]\]"</command>
+                          </tagNode>
+                        </children>
+                      </node>
+                    </children>
+                  </node>
+                  <node name="input">
+                    <properties>
+                      <help>Show firewall IPv6 input log</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot -k | grep ipv6-INP</command>
+                    <children>
+                      <node name="filter">
+                        <properties>
+                          <help>Show firewall IPv6 input filter log</help>
+                        </properties>
+                        <command>journalctl --no-hostname --boot -k | grep ipv6-INP-filter</command>
+                        <children>
+                          <tagNode name="rule">
+                            <properties>
+                              <help>Show log for a rule in the specified firewall</help>
+                              <completionHelp>
+                                <path>firewall ipv6 input filter rule</path>
+                              </completionHelp>
+                            </properties>
+                            <command>journalctl --no-hostname --boot -k | egrep "\[ipv6-INP-filter-$8-[ADRJC]\]"</command>
+                          </tagNode>
+                        </children>
+                      </node>
+                    </children>
+                  </node>
+                  <tagNode name="name">
+                    <properties>
+                      <help>Show custom IPv6 firewall log</help>
+                      <completionHelp>
+                        <path>firewall ipv6 name</path>
+                      </completionHelp>
+                    </properties>
+                    <command>journalctl --no-hostname --boot -k | grep ipv6-NAM-$6</command>
+                    <children>
+                      <tagNode name="rule">
+                        <properties>
+                          <help>Show log for a rule in the specified firewall</help>
+                          <completionHelp>
+                            <path>firewall ipv6 name ${COMP_WORDS[5]} rule</path>
+                          </completionHelp>
+                        </properties>
+                        <command>journalctl --no-hostname --boot -k | egrep "\[ipv6-NAM-$6-$8-[ADRJC]\]"</command>
+                      </tagNode>
+                    </children>
+                  </tagNode>
+                  <node name="output">
+                    <properties>
+                      <help>Show firewall IPv6 output log</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot -k | grep ipv6-OUT</command>
+                    <children>
+                      <node name="filter">
+                        <properties>
+                          <help>Show firewall IPv6 output filter log</help>
+                        </properties>
+                        <command>journalctl --no-hostname --boot -k | grep ipv6-OUT-filter</command>
+                        <children>
+                          <tagNode name="rule">
+                            <properties>
+                              <help>Show log for a rule in the specified firewall</help>
+                              <completionHelp>
+                                <path>firewall ipv6 output filter rule</path>
+                              </completionHelp>
+                            </properties>
+                            <command>journalctl --no-hostname --boot -k | egrep "\[ipv6-OUT-filter-$8-[ADRJC]\]"</command>
+                          </tagNode>
+                        </children>
+                      </node>
+                    </children>
+                  </node>
+                </children>
+              </node>
             </children>
           </node>
           <leafNode name="flow-accounting">


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix and extend command in order to fit new cli and be able to execute on every layer.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5579

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->
op-mode command: show firewall

- Fix: adapt commands to new firewall cli structure
- Add options for invoking show command on every layer: show log firewall | show log firewall ipv4 | show log firewall ipv4 forward | ...
- Change how to query for logs: use journalctl

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@raw-test:~$ show log firewall | tail -5
Sep 14 18:40:33 kernel: [ipv4-NAM-FOOAUX-10-A]IN=eth0 OUT= MAC=50:00:00:01:00:00:4c:5e:0c:19:0b:62:08:00 SRC=192.168.70.22 DST=192.168.0.152 LEN=52 TOS=0x10 PREC=0x00 TTL=62 ID=1590 DF PROTO=TCP SPT=35500 DPT=22 WINDOW=15142 RES=0x00 ACK URGP=0 
Sep 14 18:40:33 kernel: [ipv6-INP-filter-8877-J]IN=lo OUT= MAC=00:00:00:00:00:00:00:00:00:00:00:00:86:dd SRC=2001:0000:0000:0000:0000:0000:0000:0001 DST=2001:0000:0000:0000:0000:0000:0000:0001 LEN=152 TC=0 HOPLIMIT=64 FLOWLBL=493647 PROTO=ICMPv6 TYPE=1 CODE=3 [SRC=2001:0000:0000:0000:0000:0000:0000:0001 DST=2001:0000:0000:0000:0000:0000:0000:0005 LEN=104 TC=0 HOPLIMIT=64 FLOWLBL=702489 PROTO=ICMPv6 TYPE=128 CODE=0 ID=47014 SEQ=1 ] 
Sep 14 18:40:33 kernel: [ipv6-NAM-CONTROLV6IN-123-D]IN=lo OUT= MAC=00:00:00:00:00:00:00:00:00:00:00:00:86:dd SRC=2001:0000:0000:0000:0000:0000:0000:0001 DST=2001:0000:0000:0000:0000:0000:0000:0001 LEN=152 TC=0 HOPLIMIT=64 FLOWLBL=493647 PROTO=ICMPv6 TYPE=1 CODE=3 [SRC=2001:0000:0000:0000:0000:0000:0000:0001 DST=2001:0000:0000:0000:0000:0000:0000:0005 LEN=104 TC=0 HOPLIMIT=64 FLOWLBL=702489 PROTO=ICMPv6 TYPE=128 CODE=0 ID=47014 SEQ=1 ] 
Sep 14 18:40:33 kernel: [ipv6-INP-filter-8877-J]IN=lo OUT= MAC=00:00:00:00:00:00:00:00:00:00:00:00:86:dd SRC=2001:0000:0000:0000:0000:0000:0000:0001 DST=2001:0000:0000:0000:0000:0000:0000:0001 LEN=152 TC=0 HOPLIMIT=64 FLOWLBL=493647 PROTO=ICMPv6 TYPE=1 CODE=3 [SRC=2001:0000:0000:0000:0000:0000:0000:0001 DST=2001:0000:0000:0000:0000:0000:0000:0005 LEN=104 TC=0 HOPLIMIT=64 FLOWLBL=702489 PROTO=ICMPv6 TYPE=128 CODE=0 ID=47014 SEQ=2 ] 
Sep 14 18:40:33 kernel: [ipv6-NAM-CONTROLV6IN-123-D]IN=lo OUT= MAC=00:00:00:00:00:00:00:00:00:00:00:00:86:dd SRC=2001:0000:0000:0000:0000:0000:0000:0001 DST=2001:0000:0000:0000:0000:0000:0000:0001 LEN=152 TC=0 HOPLIMIT=64 FLOWLBL=493647 PROTO=ICMPv6 TYPE=1 CODE=3 [SRC=2001:0000:0000:0000:0000:0000:0000:0001 DST=2001:0000:0000:0000:0000:0000:0000:0005 LEN=104 TC=0 HOPLIMIT=64 FLOWLBL=702489 PROTO=ICMPv6 TYPE=128 CODE=0 ID=47014 SEQ=2 ] 

vyos@raw-test:~$ show log firewall bridge | tail -2
Sep 14 18:40:02 kernel: [bri-FWD-filter-1212-J]IN=eth1 OUT=eth2 MAC=00:50:79:66:68:03:50:00:00:02:00:00:08:00 SRC=10.99.99.2 DST=10.99.99.3 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=60356 PROTO=ICMP TYPE=0 CODE=0 ID=33363 SEQ=16 
Sep 14 18:40:02 kernel: [bri-NAM-L2CONTROL-82-A]IN=eth1 OUT=eth2 MAC=00:50:79:66:68:03:50:00:00:02:00:00:08:00 SRC=10.99.99.2 DST=10.99.99.3 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=60356 PROTO=ICMP TYPE=0 CODE=0 ID=33363 SEQ=16 

vyos@raw-test:~$ show log firewall ipv4 input filter rule 10 | tail -2
Sep 14 18:40:57 kernel: [ipv4-INP-filter-10-A]IN=eth0 OUT= MAC=50:00:00:01:00:00:4c:5e:0c:19:0b:62:08:00 SRC=18.193.41.138 DST=192.168.0.152 LEN=76 TOS=0x18 PREC=0xA0 TTL=242 ID=63823 DF PROTO=UDP SPT=123 DPT=50456 LEN=56 
Sep 14 18:41:15 kernel: [ipv4-INP-filter-10-A]IN=eth0 OUT= MAC=ff:ff:ff:ff:ff:ff:4c:5e:0c:19:0b:64:08:00 SRC=172.16.20.1 DST=255.255.255.255 LEN=163 TOS=0x00 PREC=0x00 TTL=64 ID=0 PROTO=UDP SPT=5678 DPT=5678 LEN=143 

vyos@raw-test:~$ show log firewall ipv4 input filter rule 4 | tail -2
Sep 14 18:41:57 kernel: [ipv4-INP-filter-4-J]IN=eth0 OUT= MAC=50:00:00:01:00:00:4c:5e:0c:19:0b:62:08:00 SRC=192.168.70.22 DST=192.168.0.152 LEN=88 TOS=0x10 PREC=0x00 TTL=62 ID=1889 DF PROTO=TCP SPT=35500 DPT=22 WINDOW=15142 RES=0x00 ACK PSH URGP=0 
Sep 14 18:41:57 kernel: [ipv4-INP-filter-4-J]IN=eth0 OUT= MAC=50:00:00:01:00:00:4c:5e:0c:19:0b:62:08:00 SRC=192.168.70.22 DST=192.168.0.152 LEN=52 TOS=0x10 PREC=0x00 TTL=62 ID=1890 DF PROTO=TCP SPT=35500 DPT=22 WINDOW=15142 RES=0x00 ACK URGP=0 

vyos@raw-test:~$ show log firewall ipv6 name CONTROLV6IN rule 123 | tail -2
Sep 14 18:40:33 kernel: [ipv6-NAM-CONTROLV6IN-123-D]IN=lo OUT= MAC=00:00:00:00:00:00:00:00:00:00:00:00:86:dd SRC=2001:0000:0000:0000:0000:0000:0000:0001 DST=2001:0000:0000:0000:0000:0000:0000:0001 LEN=152 TC=0 HOPLIMIT=64 FLOWLBL=493647 PROTO=ICMPv6 TYPE=1 CODE=3 [SRC=2001:0000:0000:0000:0000:0000:0000:0001 DST=2001:0000:0000:0000:0000:0000:0000:0005 LEN=104 TC=0 HOPLIMIT=64 FLOWLBL=702489 PROTO=ICMPv6 TYPE=128 CODE=0 ID=47014 SEQ=1 ] 
Sep 14 18:40:33 kernel: [ipv6-NAM-CONTROLV6IN-123-D]IN=lo OUT= MAC=00:00:00:00:00:00:00:00:00:00:00:00:86:dd SRC=2001:0000:0000:0000:0000:0000:0000:0001 DST=2001:0000:0000:0000:0000:0000:0000:0001 LEN=152 TC=0 HOPLIMIT=64 FLOWLBL=493647 PROTO=ICMPv6 TYPE=1 CODE=3 [SRC=2001:0000:0000:0000:0000:0000:0000:0001 DST=2001:0000:0000:0000:0000:0000:0000:0005 LEN=104 TC=0 HOPLIMIT=64 FLOWLBL=702489 PROTO=ICMPv6 TYPE=128 CODE=0 ID=47014 SEQ=2 ] 
vyos@raw-test:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
