### PR TITLE
ddclient: T5574: Support per-service cache management for providers

### DIFF
--- a/data/templates/dns-dynamic/ddclient.conf.j2
+++ b/data/templates/dns-dynamic/ddclient.conf.j2
@@ -14,10 +14,8 @@ if{{ ipv }}={{ address }}, \
 {%     endif %}
 {% endfor %}
 {# Other service options #}
-{% for k,v in kwargs.items() %}
-{%     if v is vyos_defined %}
-{{ k }}={{ v }}{{ ',' if not loop.last }} \
-{%     endif %}
+{% for k,v in kwargs.items() if v is vyos_defined %}
+{{ k | replace('_', '-') }}={{ v }}{{ ',' if not loop.last }} \
 {% endfor %}
 {# Actual hostname for the service #}
 {{ host }}
@@ -49,7 +47,6 @@ use=no
 {{ render_config(host, address, service_cfg.web_options,
                  protocol='nsupdate', server=config.server, zone=config.zone,
                  password=config.key, ttl=config.ttl) }}
-
 {%                 endfor %}
 {%             endfor %}
 {%         endif %}
@@ -66,8 +63,8 @@ use=no
 # Web service dynamic DNS configuration for {{ name }}: [{{ config.protocol }}, {{ host }}]
 {{ render_config(host, address, service_cfg.web_options, ip_suffixes,
                  protocol=config.protocol, server=config.server, zone=config.zone,
-                 login=config.username, password=config.password, ttl=config.ttl) }}
-
+                 login=config.username, password=config.password, ttl=config.ttl,
+                 min_interval=config.wait_time, max_interval=config.expiry_time) }}
 {%                 endfor %}
 {%             endfor %}
 {%         endif %}

--- a/interface-definitions/dns-dynamic.xml.in
+++ b/interface-definitions/dns-dynamic.xml.in
@@ -61,6 +61,7 @@
                     <children>
                       #include <include/generic-description.xml.i>
                       #include <include/dns/dynamic-service-host-name-server.xml.i>
+                      #include <include/dns/dynamic-service-wait-expiry-time.xml.i>
                       <leafNode name="key">
                         <properties>
                           <help>File containing the TSIG secret key shared with remote DNS server</help>
@@ -88,6 +89,7 @@
                     <children>
                       #include <include/generic-description.xml.i>
                       #include <include/dns/dynamic-service-host-name-server.xml.i>
+                      #include <include/dns/dynamic-service-wait-expiry-time.xml.i>
                       #include <include/generic-username.xml.i>
                       #include <include/generic-password.xml.i>
                       #include <include/dns/time-to-live.xml.i>

--- a/interface-definitions/include/dns/dynamic-service-wait-expiry-time.xml.i
+++ b/interface-definitions/include/dns/dynamic-service-wait-expiry-time.xml.i
@@ -1,0 +1,28 @@
+<!-- include start from dns/dynamic-service-wait-expiry-time.xml.i -->
+<leafNode name="wait-time">
+  <properties>
+    <help>Time in seconds to wait between update attempts</help>
+    <valueHelp>
+      <format>u32:60-86400</format>
+      <description>Time in seconds</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 60-86400"/>
+    </constraint>
+    <constraintErrorMessage>Wait time must be between 60 and 86400 seconds</constraintErrorMessage>
+  </properties>
+</leafNode>
+<leafNode name="expiry-time">
+  <properties>
+    <help>Time in seconds for the hostname to be marked expired in cache</help>
+    <valueHelp>
+      <format>u32:300-2160000</format>
+      <description>Time in seconds</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 300-2160000"/>
+    </constraint>
+    <constraintErrorMessage>Expiry time must be between 300 and 2160000 seconds</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/src/conf_mode/dns_dynamic.py
+++ b/src/conf_mode/dns_dynamic.py
@@ -111,6 +111,9 @@ def verify(dyndns):
                         raise ConfigError(f'"{config["protocol"]}" does not support '
                                           f'both IPv4 and IPv6 at the same time for "{config["server"]}"')
 
+                if {'wait_time', 'expiry_time'} <= config.keys() and int(config['expiry_time']) < int(config['wait_time']):
+                        raise ConfigError(f'"expiry-time" must be greater than "wait-time"')
+
     return None
 
 def generate(dyndns):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add support for per-service cache management for ddclient providers via `wait-time` and `expiry-time` options. This allows for finer-grained control over how often a service is updated and how long the hostname will be cached before being marked expired in ddclient's cache.

More specifically, `wait-time` controls how often ddclient will attempt to check for a change in the hostname's IP address, and `expiry-time` controls how often ddclient to a forced update of the hostname's IP address.

These options intentionally don't have any default values because they are provider-specific. They get treated similar to the other provider-specific options in that they are only used if defined.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5574

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dns dynamic

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set service dns dynamic address <address> service <service> wait-time 300
set service dns dynamic address <address> service <service> expiry-time 3600
```

## Smoketest result
```
test_01_dyndns_service_standard (__main__.TestServiceDDNS.test_01_dyndns_service_standard) ... 
"freedns" does not support "zone"


"zoneedit1" does not support "zone"

ok
test_02_dyndns_service_ipv6 (__main__.TestServiceDDNS.test_02_dyndns_service_ipv6) ... 
"expiry-time" must be greater than "wait-time"

ok
test_03_dyndns_service_dual_stack (__main__.TestServiceDDNS.test_03_dyndns_service_dual_stack) ... ok
test_04_dyndns_rfc2136 (__main__.TestServiceDDNS.test_04_dyndns_rfc2136) ... ok

----------------------------------------------------------------------
Ran 4 tests in 127.691s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
