### PR TITLE
bonding: T5254: Fixed changing ethernet when it is a bond member

### DIFF
--- a/data/config-mode-dependencies/vyos-1x.json
+++ b/data/config-mode-dependencies/vyos-1x.json
@@ -6,6 +6,9 @@
                 "group_resync": ["conntrack", "nat", "policy-route"]
               },
   "http_api": {"https": ["https"]},
+  "interfaces_bonding": {
+           "ethernet": ["interfaces-ethernet"]
+         },
   "load_balancing_wan": {
                           "conntrack": ["conntrack"],
                           "conntrack_sync": ["conntrack_sync"]

--- a/interface-definitions/include/version/interfaces-version.xml.i
+++ b/interface-definitions/include/version/interfaces-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/interfaces-version.xml.i -->
-<syntaxVersion component='interfaces' version='30'></syntaxVersion>
+<syntaxVersion component='interfaces' version='31'></syntaxVersion>
 <!-- include end -->

--- a/python/vyos/ifconfig/bond.py
+++ b/python/vyos/ifconfig/bond.py
@@ -92,6 +92,19 @@ class BondIf(Interface):
         }
     }}
 
+    @staticmethod
+    def get_inherit_bond_options() -> list:
+        """
+        Returns list of option
+        which are inherited from bond interface to member interfaces
+        :return: List of interface options
+        :rtype: list
+        """
+        options = [
+            'mtu'
+        ]
+        return options
+
     def remove(self):
         """
         Remove interface from operating system. Removing the interface

--- a/python/vyos/ifconfig/ethernet.py
+++ b/python/vyos/ifconfig/ethernet.py
@@ -75,6 +75,40 @@ class EthernetIf(Interface):
         },
     }}
 
+    @staticmethod
+    def get_bond_member_allowed_options() -> list:
+        """
+        Return list of options which are allowed for changing,
+        when interface is a bond member
+        :return: List of interface options
+        :rtype: list
+        """
+        bond_allowed_sections = [
+            'description',
+            'disable',
+            'disable_flow_control',
+            'disable_link_detect',
+            'duplex',
+            'eapol.ca_certificate',
+            'eapol.certificate',
+            'eapol.passphrase',
+            'mirror.egress',
+            'mirror.ingress',
+            'offload.gro',
+            'offload.gso',
+            'offload.lro',
+            'offload.rfs',
+            'offload.rps',
+            'offload.sg',
+            'offload.tso',
+            'redirect',
+            'ring_buffer.rx',
+            'ring_buffer.tx',
+            'speed',
+            'hw_id'
+        ]
+        return bond_allowed_sections
+
     def __init__(self, ifname, **kargs):
         super().__init__(ifname, **kargs)
         self.ethtool = Ethtool(ifname)

--- a/python/vyos/utils/dict.py
+++ b/python/vyos/utils/dict.py
@@ -199,6 +199,31 @@ def dict_search_recursive(dict_object, key, path=[]):
             for x in dict_search_recursive(j, key, new_path):
                 yield x
 
+
+def dict_set(key_path, value, dict_object):
+    """ Set value to Python dictionary (dict_object) using path to key delimited by dot (.).
+        The key will be added if it does not exist.
+    """
+    path_list = key_path.split(".")
+    dynamic_dict = dict_object
+    if len(path_list) > 0:
+        for i in range(0, len(path_list)-1):
+            dynamic_dict = dynamic_dict[path_list[i]]
+        dynamic_dict[path_list[len(path_list)-1]] = value
+
+def dict_delete(key_path, dict_object):
+    """ Delete key in Python dictionary (dict_object) using path to key delimited by dot (.).
+    """
+    path_dict = dict_object
+    path_list = key_path.split('.')
+    inside = path_list[:-1]
+    if not inside:
+        del dict_object[path_list]
+    else:
+        for key in path_list[:-1]:
+            path_dict = path_dict[key]
+        del path_dict[path_list[len(path_list)-1]]
+
 def dict_to_list(d, save_key_to=None):
     """ Convert a dict to a list of dicts.
 
@@ -227,6 +252,39 @@ def dict_to_list(d, save_key_to=None):
             collect.append(item)
 
     return collect
+
+def dict_to_paths_values(conf: dict) -> dict:
+    """
+    Convert nested dictionary to simple dictionary, where key is a path is delimited by dot (.).
+    """
+    list_of_paths = []
+    dict_of_options ={}
+    for path in dict_to_key_paths(conf):
+        str_path = '.'.join(path)
+        list_of_paths.append(str_path)
+
+    for path in list_of_paths:
+        dict_of_options[path] = dict_search(path,conf)
+
+    return dict_of_options
+def dict_to_key_paths(d: dict) -> list:
+    """ Generator to return list of key paths from dict of list[str]|str
+    """
+    def func(d, path):
+        if isinstance(d, dict):
+            if not d:
+                yield path
+            for k, v in d.items():
+                for r in func(v, path + [k]):
+                    yield r
+        elif isinstance(d, list):
+            yield path
+        elif isinstance(d, str):
+            yield path
+        else:
+            raise ValueError('object is not a dict of strings/list of strings')
+    for r in func(d, []):
+        yield r
 
 def dict_to_paths(d: dict) -> list:
     """ Generator to return list of paths from dict of list[str]|str
@@ -305,3 +363,4 @@ class FixedDict(dict):
         if k not in self._allowed:
             raise ConfigError(f'Option "{k}" has no defined default')
         super().__setitem__(k, v)
+

--- a/src/conf_mode/interfaces-ethernet.py
+++ b/src/conf_mode/interfaces-ethernet.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import pprint
 
 from glob import glob
 from sys import exit
@@ -35,6 +36,7 @@ from vyos.configverify import verify_vrf
 from vyos.configverify import verify_bond_bridge_member
 from vyos.ethtool import Ethtool
 from vyos.ifconfig import EthernetIf
+from vyos.ifconfig import BondIf
 from vyos.pki import find_chain
 from vyos.pki import encode_certificate
 from vyos.pki import load_certificate
@@ -42,6 +44,9 @@ from vyos.pki import wrap_private_key
 from vyos.template import render
 from vyos.utils.process import call
 from vyos.utils.dict import dict_search
+from vyos.utils.dict import dict_to_paths_values
+from vyos.utils.dict import dict_set
+from vyos.utils.dict import dict_delete
 from vyos.utils.file import write_file
 from vyos import ConfigError
 from vyos import airbag
@@ -50,6 +55,90 @@ airbag.enable()
 # XXX: wpa_supplicant works on the source interface
 cfg_dir = '/run/wpa_supplicant'
 wpa_suppl_conf = '/run/wpa_supplicant/{ifname}.conf'
+
+def update_bond_options(conf: Config, eth_conf: dict) -> list:
+    """
+    Return list of blocked options if interface is a bond member
+    :param conf: Config object
+    :type conf: Config
+    :param eth_conf: Ethernet config dictionary
+    :type eth_conf: dict
+    :return: List of blocked options
+    :rtype: list
+    """
+    blocked_list = []
+    bond_name = list(eth_conf['is_bond_member'].keys())[0]
+    config_without_defaults = conf.get_config_dict(
+        ['interfaces', 'ethernet', eth_conf['ifname']],
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+        with_defaults=False,
+        with_recursive_defaults=False)
+    config_with_defaults = conf.get_config_dict(
+        ['interfaces', 'ethernet', eth_conf['ifname']],
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+        with_defaults=True,
+        with_recursive_defaults=True)
+    bond_config_with_defaults = conf.get_config_dict(
+        ['interfaces', 'bonding', bond_name],
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+        with_defaults=True,
+        with_recursive_defaults=True)
+    eth_dict_paths = dict_to_paths_values(config_without_defaults)
+    eth_path_base = ['interfaces', 'ethernet', eth_conf['ifname']]
+
+    #if option is configured under ethernet section
+    for option_path, option_value in eth_dict_paths.items():
+        bond_option_value = dict_search(option_path, bond_config_with_defaults)
+
+        #If option is allowed for changing then continue
+        if option_path in EthernetIf.get_bond_member_allowed_options():
+            continue
+        # if option is inherited from bond then set valued from bond interface
+        if option_path in BondIf.get_inherit_bond_options():
+            # If option equals to bond option then do nothing
+            if option_value == bond_option_value:
+                continue
+            else:
+                # if ethernet has option and bond interface has
+                # then copy it from bond
+                if bond_option_value is not None:
+                    if is_node_changed(conf, eth_path_base + option_path.split('.')):
+                        Warning(
+                            f'Cannot apply "{option_path.replace(".", " ")}" to "{option_value}".' \
+                            f' Interface "{eth_conf["ifname"]}" is a bond member.' \
+                            f' Option is inherited from bond "{bond_name}"')
+                    dict_set(option_path, bond_option_value, eth_conf)
+                    continue
+                # if ethernet has option and bond interface does not have
+                # then delete it form dict and do not apply it
+                else:
+                    if is_node_changed(conf, eth_path_base + option_path.split('.')):
+                        Warning(
+                            f'Cannot apply "{option_path.replace(".", " ")}".' \
+                            f' Interface "{eth_conf["ifname"]}" is a bond member.' \
+                            f' Option is inherited from bond "{bond_name}"')
+                    dict_delete(option_path, eth_conf)
+        blocked_list.append(option_path)
+
+    # if inherited option is not configured under ethernet section but configured under bond section
+    for option_path in BondIf.get_inherit_bond_options():
+        bond_option_value = dict_search(option_path, bond_config_with_defaults)
+        if bond_option_value is not None:
+            if option_path not in eth_dict_paths:
+                if is_node_changed(conf, eth_path_base + option_path.split('.')):
+                    Warning(
+                        f'Cannot apply "{option_path.replace(".", " ")}" to "{dict_search(option_path, config_with_defaults)}".' \
+                        f' Interface "{eth_conf["ifname"]}" is a bond member. ' \
+                        f'Option is inherited from bond "{bond_name}"')
+                dict_set(option_path, bond_option_value, eth_conf)
+    eth_conf['bond_blocked_changes'] = blocked_list
+    return None
 
 def get_config(config=None):
     """
@@ -68,6 +157,8 @@ def get_config(config=None):
 
     base = ['interfaces', 'ethernet']
     ifname, ethernet = get_interface_dict(conf, base)
+    if 'is_bond_member' in ethernet:
+        update_bond_options(conf, ethernet)
 
     if 'deleted' not in ethernet:
        if pki: ethernet['pki'] = pki
@@ -80,10 +171,140 @@ def get_config(config=None):
 
     return ethernet
 
+
+
+def verify_speed_duplex(ethernet: dict, ethtool: Ethtool):
+    """
+     Verify speed and duplex
+    :param ethernet: dictionary which is received from get_interface_dict
+    :type ethernet: dict
+    :param ethtool: Ethernet object
+    :type ethtool: Ethtool
+    """
+    if ((ethernet['speed'] == 'auto' and ethernet['duplex'] != 'auto') or
+            (ethernet['speed'] != 'auto' and ethernet['duplex'] == 'auto')):
+        raise ConfigError(
+            'Speed/Duplex missmatch. Must be both auto or manually configured')
+
+    if ethernet['speed'] != 'auto' and ethernet['duplex'] != 'auto':
+        # We need to verify if the requested speed and duplex setting is
+        # supported by the underlaying NIC.
+        speed = ethernet['speed']
+        duplex = ethernet['duplex']
+        if not ethtool.check_speed_duplex(speed, duplex):
+            raise ConfigError(
+                f'Adapter does not support changing speed ' \
+                f'and duplex settings to: {speed}/{duplex}!')
+
+
+def verify_flow_control(ethernet: dict, ethtool: Ethtool):
+    """
+     Verify flow control
+    :param ethernet: dictionary which is received from get_interface_dict
+    :type ethernet: dict
+    :param ethtool: Ethernet object
+    :type ethtool: Ethtool
+    """
+    if 'disable_flow_control' in ethernet:
+        if not ethtool.check_flow_control():
+            raise ConfigError(
+                'Adapter does not support changing flow-control settings!')
+
+
+def verify_ring_buffer(ethernet: dict, ethtool: Ethtool):
+    """
+     Verify ring buffer
+    :param ethernet: dictionary which is received from get_interface_dict
+    :type ethernet: dict
+    :param ethtool: Ethernet object
+    :type ethtool: Ethtool
+    """
+    if 'ring_buffer' in ethernet:
+        max_rx = ethtool.get_ring_buffer_max('rx')
+        if not max_rx:
+            raise ConfigError(
+                'Driver does not support RX ring-buffer configuration!')
+
+        max_tx = ethtool.get_ring_buffer_max('tx')
+        if not max_tx:
+            raise ConfigError(
+                'Driver does not support TX ring-buffer configuration!')
+
+        rx = dict_search('ring_buffer.rx', ethernet)
+        if rx and int(rx) > int(max_rx):
+            raise ConfigError(f'Driver only supports a maximum RX ring-buffer ' \
+                              f'size of "{max_rx}" bytes!')
+
+        tx = dict_search('ring_buffer.tx', ethernet)
+        if tx and int(tx) > int(max_tx):
+            raise ConfigError(f'Driver only supports a maximum TX ring-buffer ' \
+                              f'size of "{max_tx}" bytes!')
+
+
+def verify_offload(ethernet: dict, ethtool: Ethtool):
+    """
+     Verify offloading capabilities
+    :param ethernet: dictionary which is received from get_interface_dict
+    :type ethernet: dict
+    :param ethtool: Ethernet object
+    :type ethtool: Ethtool
+    """
+    if dict_search('offload.rps', ethernet) != None:
+        if not os.path.exists(f'/sys/class/net/{ethernet["ifname"]}/queues/rx-0/rps_cpus'):
+            raise ConfigError('Interface does not suport RPS!')
+    driver = ethtool.get_driver_name()
+    # T3342 - Xen driver requires special treatment
+    if driver == 'vif':
+        if int(ethernet['mtu']) > 1500 and dict_search('offload.sg', ethernet) == None:
+            raise ConfigError('Xen netback drivers requires scatter-gatter offloading '\
+                              'for MTU size larger then 1500 bytes')
+
+
+def verify_allowedbond_changes(ethernet: dict):
+    """
+     Verify changed options if interface is in bonding
+    :param ethernet: dictionary which is received from get_interface_dict
+    :type ethernet: dict
+    """
+    if 'bond_blocked_changes' in ethernet:
+        for option in ethernet['bond_blocked_changes']:
+            raise ConfigError(f'Cannot configure "{option.replace(".", " ")}"' \
+                              f' on interface "{ethernet["ifname"]}".' \
+                              f' Interface is a bond member')
+
+
 def verify(ethernet):
     if 'deleted' in ethernet:
         return None
+    if 'is_bond_member' in ethernet:
+        verify_bond_member(ethernet)
+    else:
+        verify_ethernet(ethernet)
 
+
+def verify_bond_member(ethernet):
+    """
+     Verification function for ethernet interface which is in bonding
+    :param ethernet: dictionary which is received from get_interface_dict
+    :type ethernet: dict
+    """
+    ifname = ethernet['ifname']
+    verify_interface_exists(ifname)
+    verify_eapol(ethernet)
+    verify_mirror_redirect(ethernet)
+    ethtool = Ethtool(ifname)
+    verify_speed_duplex(ethernet, ethtool)
+    verify_flow_control(ethernet, ethtool)
+    verify_ring_buffer(ethernet, ethtool)
+    verify_offload(ethernet, ethtool)
+    verify_allowedbond_changes(ethernet)
+
+def verify_ethernet(ethernet):
+    """
+     Verification function for simple ethernet interface
+    :param ethernet: dictionary which is received from get_interface_dict
+    :type ethernet: dict
+    """
     ifname = ethernet['ifname']
     verify_interface_exists(ifname)
     verify_mtu(ethernet)
@@ -94,64 +315,16 @@ def verify(ethernet):
     verify_bond_bridge_member(ethernet)
     verify_eapol(ethernet)
     verify_mirror_redirect(ethernet)
-
     ethtool = Ethtool(ifname)
     # No need to check speed and duplex keys as both have default values.
-    if ((ethernet['speed'] == 'auto' and ethernet['duplex'] != 'auto') or
-        (ethernet['speed'] != 'auto' and ethernet['duplex'] == 'auto')):
-            raise ConfigError('Speed/Duplex missmatch. Must be both auto or manually configured')
-
-    if ethernet['speed'] != 'auto' and ethernet['duplex'] != 'auto':
-        # We need to verify if the requested speed and duplex setting is
-        # supported by the underlaying NIC.
-        speed = ethernet['speed']
-        duplex = ethernet['duplex']
-        if not ethtool.check_speed_duplex(speed, duplex):
-            raise ConfigError(f'Adapter does not support changing speed and duplex '\
-                              f'settings to: {speed}/{duplex}!')
-
-    if 'disable_flow_control' in ethernet:
-        if not ethtool.check_flow_control():
-            raise ConfigError('Adapter does not support changing flow-control settings!')
-
-    if 'ring_buffer' in ethernet:
-        max_rx = ethtool.get_ring_buffer_max('rx')
-        if not max_rx:
-            raise ConfigError('Driver does not support RX ring-buffer configuration!')
-
-        max_tx = ethtool.get_ring_buffer_max('tx')
-        if not max_tx:
-            raise ConfigError('Driver does not support TX ring-buffer configuration!')
-
-        rx = dict_search('ring_buffer.rx', ethernet)
-        if rx and int(rx) > int(max_rx):
-            raise ConfigError(f'Driver only supports a maximum RX ring-buffer '\
-                              f'size of "{max_rx}" bytes!')
-
-        tx = dict_search('ring_buffer.tx', ethernet)
-        if tx and int(tx) > int(max_tx):
-            raise ConfigError(f'Driver only supports a maximum TX ring-buffer '\
-                              f'size of "{max_tx}" bytes!')
-
-    # verify offloading capabilities
-    if dict_search('offload.rps', ethernet) != None:
-        if not os.path.exists(f'/sys/class/net/{ifname}/queues/rx-0/rps_cpus'):
-            raise ConfigError('Interface does not suport RPS!')
-
-    driver = ethtool.get_driver_name()
-    # T3342 - Xen driver requires special treatment
-    if driver == 'vif':
-        if int(ethernet['mtu']) > 1500 and dict_search('offload.sg', ethernet) == None:
-            raise ConfigError('Xen netback drivers requires scatter-gatter offloading '\
-                              'for MTU size larger then 1500 bytes')
-
-    if {'is_bond_member', 'mac'} <= set(ethernet):
-        Warning(f'changing mac address "{mac}" will be ignored as "{ifname}" ' \
-                f'is a member of bond "{is_bond_member}"'.format(**ethernet))
-
+    verify_speed_duplex(ethernet, ethtool)
+    verify_flow_control(ethernet, ethtool)
+    verify_ring_buffer(ethernet, ethtool)
+    verify_offload(ethernet, ethtool)
     # use common function to verify VLAN configuration
     verify_vlan_config(ethernet)
     return None
+
 
 def generate(ethernet):
     # render real configuration file once
@@ -192,7 +365,8 @@ def generate(ethernet):
                 pki_ca_cert = ethernet['pki']['ca'][ca_cert_name]
                 loaded_ca_cert = load_certificate(pki_ca_cert['certificate'])
                 ca_full_chain = find_chain(loaded_ca_cert, loaded_ca_certs)
-                ca_chains.append('\n'.join(encode_certificate(c) for c in ca_full_chain))
+                ca_chains.append(
+                    '\n'.join(encode_certificate(c) for c in ca_full_chain))
 
             write_file(ca_cert_file_path, '\n'.join(ca_chains))
 
@@ -219,6 +393,7 @@ if __name__ == '__main__':
         c = get_config()
         verify(c)
         generate(c)
+
         apply(c)
     except ConfigError as e:
         print(e)

--- a/src/migration-scripts/interfaces/30-to-31
+++ b/src/migration-scripts/interfaces/30-to-31
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021-2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Deletes Wireguard peers if they have the same public key as the router has.
+
+import json
+from sys import argv
+from sys import exit
+from vyos.configtree import ConfigTree
+from vyos.ifconfig import EthernetIf
+from vyos.ifconfig import BondIf
+from vyos.utils.dict import dict_to_paths_values
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+with open(file_name, 'r') as f:
+    config_file = f.read()
+    base = ['interfaces', 'bonding']
+
+config = ConfigTree(config_file)
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+for bond in config.list_nodes(base):
+    member_base = base + [bond, 'member', 'interface']
+    if config.exists(member_base):
+        for interface in config.return_values(member_base):
+            if_base = ['interfaces', 'ethernet', interface]
+            if config.exists(if_base):
+                config_ethernet = json.loads(config.get_subtree(if_base).to_json())
+                eth_dict_paths = dict_to_paths_values(config_ethernet)
+                for option_path, option_value in eth_dict_paths.items():
+                    # If option is allowed for changing then continue
+                    converted_path = option_path.replace('-','_')
+                    if converted_path in EthernetIf.get_bond_member_allowed_options():
+                        continue
+                    # if option is inherited from bond then continue
+                    if converted_path in BondIf.get_inherit_bond_options():
+                        continue
+                    option_path_list = option_path.split('.')
+                    config.delete(if_base + option_path_list)
+                    del option_path_list[-1]
+                    # delete empty node from config
+                    while len(option_path_list) > 0:
+                        if config.list_nodes(if_base + option_path_list):
+                            break
+                        config.delete(if_base + option_path_list)
+                        del option_path_list[-1]
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print(f'Failed to save the modified config: {e}')
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
If ethernet interface is a bond memeber:
  1. Allow for changing only specific parameters which are specified in EthernetIf.get_bond_member_allowed_options function.
  2. Added inheritable parameters from bond interface to ethernet interface which are scpecified in 
      BondIf.get_inherit_bond_options. 
      Users can change inheritable options under ethernet interface but in commit it will be copied from bond interface.
  4. All other parameters are denied for changing.

Added migration script. It deletes all denied parameters under ethernet interface if it is a bond member.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5254

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bonding

## Proposed changes
<!--- Describe your changes in detail -->
If ethernet interface is a bond memeber:
  1. Allow for changing only specific parameters which are specified in EthernetIf.get_bond_member_allowed_options function.
  2. Added inheritable parameters from bond interface to ethernet interface which are scpecified in 
      BondIf.get_inherit_bond_options. 
      Users can change inheritable options under ethernet interface but in commit it will be copied from bond interface.
  4. All other parameters are denied for changing.

Added migration script. It deletes all denied parameters under ethernet interface if it is a bond member.
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
1. Adding interface with denied parameters to the bond interface
  Configuration:
  set interfaces ethernet eth1 vif 10
  Commands
vyos@vyos# set interfaces bonding bond1 member interface eth1
[edit]
vyos@vyos# commit

Can not add interface "eth1" to bond, it has a "vif 10" assigned!

[[interfaces bonding bond1]] failed
Commit failed
2. Adding interface with inheritable parameters to the bond interface
Configuration:
```
set interfaces bonding bond1 mtu '5000'
set interfaces ethernet eth1 mtu '2000'
```
Commands
```
vyos@vyos# set interfaces bonding bond1 member interface eth1
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# sudo ip link
3: eth1: <NO-CARRIER,BROADCAST,MULTICAST,SLAVE,UP> mtu 5000 qdisc fq master bond1 state DOWN mode DEFAULT group default qlen 1000
    link/ether 0c:ba:0b:5b:00:01 brd ff:ff:ff:ff:ff:ff
8: bond1: <NO-CARRIER,BROADCAST,MULTICAST,MASTER,UP> mtu 5000 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether 0c:ba:0b:5b:00:01 brd ff:ff:ff:ff:ff:ff
[edit]
```
3. Changing denied parameters under ethernet interface
Configuration
`set interfaces bonding bond1 member interface 'eth1'`
Commands
```
vyos@vyos# set interfaces ethernet eth1 vif 10
[edit]
vyos@vyos# commit

Cannot configure "vif 10" on interface "eth1". Interface is a bond
member

[[interfaces ethernet eth1]] failed
Commit failed
[edit]
```
4.Changing inheritable parameters under ethernet interface
Configuration:
```
set interfaces bonding bond1 member interface 'eth1'
set interfaces bonding bond1 mtu '5000'
set interfaces ethernet eth1 mtu '2000'
```
Commands:
```
vyos@vyos# set interfaces ethernet eth1 mtu 9000
[edit]
vyos@vyos# commit

WARNING: Cannot apply "mtu" to "9000". Interface "eth1" is a bond
member. Option is inherited from bond "bond1"

[edit]
vyos@vyos# ip link
3: eth1: <NO-CARRIER,BROADCAST,MULTICAST,SLAVE,UP> mtu 5000 qdisc fq master bond1 state DOWN mode DEFAULT group default qlen 1000
    link/ether 0c:ba:0b:5b:00:01 brd ff:ff:ff:ff:ff:ff
8: bond1: <NO-CARRIER,BROADCAST,MULTICAST,MASTER,UP> mtu 5000 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether 0c:ba:0b:5b:00:01 brd ff:ff:ff:ff:ff:ff
```

5. Removing the interface ethernet from the bond interface
Configuration:
```
set interfaces bonding bond1 member interface 'eth1'
set interfaces bonding bond1 mtu '5000'
set interfaces ethernet eth1 mtu '9000'
```
Commands
```
vyos@vyos# delete interfaces bonding bond1 member interface eth1
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# ip link
3: eth1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 9000 qdisc fq state DOWN mode DEFAULT group default qlen 1000
    link/ether 0c:ba:0b:5b:00:01 brd ff:ff:ff:ff:ff:ff
8: bond1: <NO-CARRIER,BROADCAST,MULTICAST,MASTER,UP> mtu 5000 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether da:02:ee:d4:35:1d brd ff:ff:ff:ff:ff:ff
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
