### PR TITLE
T5591: Cleanup of FRR daemons-file and various FRR fixes

### DIFF
--- a/data/templates/frr/daemons.frr.tmpl
+++ b/data/templates/frr/daemons.frr.tmpl
@@ -10,6 +10,7 @@
 #
 # And these must be disabled aswell since they are currently missing a VyOS CLI:
 #
+# eigrp
 # sharpd
 # fabricd
 # pathd
@@ -28,7 +29,7 @@ pimd=no
 pim6d=yes
 ldpd=yes
 nhrpd=no
-eigrpd=yes
+eigrpd=no
 babeld=yes
 sharpd=no
 pbrd=no

--- a/data/templates/frr/daemons.frr.tmpl
+++ b/data/templates/frr/daemons.frr.tmpl
@@ -1,4 +1,17 @@
-zebra=yes
+#
+# The watchfrr, zebra, mgmtd and staticd daemons are always started.
+#
+# Note: The following FRR-services must be kept disabled because they are replaced by other packages in VyOS:
+#
+# pimd   Replaced by package igmpproxy.
+# nhrpd  Replaced by package opennhrp.
+# pbrd   Replaced by PBR in nftables.
+# vrrpd  Replaced by package keepalived.
+#
+
+#zebra=yes
+#mgmtd=yes
+#staticd=yes
 bgpd=yes
 ospfd=yes
 ospf6d=yes
@@ -11,47 +24,82 @@ ldpd=yes
 nhrpd=no
 eigrpd=yes
 babeld=yes
-sharpd=no
+sharpd=yes
 pbrd=no
 bfdd=yes
-staticd=yes
+fabricd=yes
+vrrpd=no
+pathd=yes
+
+#
+# Define defaults for all services even those who shall be kept disabled.
+#
+
+zebra_options="  --daemon -A 127.0.0.1 -s 90000000{{ ' -M snmp' if snmp.zebra is vyos_defined }}{{ ' -M irdp' if irdp is vyos_defined }}"
+mgmtd_options="  --daemon -A 127.0.0.1"
+staticd_options="--daemon -A 127.0.0.1"
+bgpd_options="   --daemon -A 127.0.0.1 -M rpki{{ ' -M snmp' if snmp.bgpd is vyos_defined }}{{ ' -M bmp' if bmp is vyos_defined }}"
+ospfd_options="  --daemon -A 127.0.0.1{{ ' -M snmp' if snmp.ospfd is vyos_defined }}"
+ospf6d_options=" --daemon -A ::1{{ ' -M snmp' if snmp.ospf6d is vyos_defined }}"
+ripd_options="   --daemon -A 127.0.0.1{{ ' -M snmp' if snmp.ripd is vyos_defined }}"
+ripngd_options=" --daemon -A ::1"
+isisd_options="  --daemon -A 127.0.0.1{{ ' -M snmp' if snmp.isisd is vyos_defined }}"
+pimd_options="   --daemon -A 127.0.0.1"
+pim6d_options="  --daemon -A ::1"
+ldpd_options="   --daemon -A 127.0.0.1{{ ' -M snmp' if snmp.ldpd is vyos_defined }}"
+nhrpd_options="  --daemon -A 127.0.0.1"
+eigrpd_options=" --daemon -A 127.0.0.1"
+babeld_options=" --daemon -A 127.0.0.1"
+sharpd_options=" --daemon -A 127.0.0.1"
+pbrd_options="   --daemon -A 127.0.0.1"
+bfdd_options="   --daemon -A 127.0.0.1"
+fabricd_options="--daemon -A 127.0.0.1"
+vrrpd_options="  --daemon -A 127.0.0.1"
+pathd_options="  --daemon -A 127.0.0.1"
+
+#frr_global_options=""
+
+#zebra_wrap=""
+#mgmtd_wrap=""
+#staticd_wrap=""
+#bgpd_wrap=""
+#ospfd_wrap=""
+#ospf6d_wrap=""
+#ripd_wrap=""
+#ripngd_wrap=""
+#isisd_wrap=""
+#pimd_wrap=""
+#pim6d_wrap=""
+#ldpd_wrap=""
+#nhrpd_wrap=""
+#eigrpd_wrap=""
+#babeld_wrap=""
+#sharpd_wrap=""
+#pbrd_wrap=""
+#bfdd_wrap=""
+#fabricd_wrap=""
+#vrrpd_wrap=""
+#pathd_wrap=""
+
+#all_wrap=""
+
+#
+# Other options.
+#
+# For more information see:
+# https://github.com/FRRouting/frr/blob/stable/9.0/tools/etc/frr/daemons
+# https://docs.frrouting.org/en/stable-9.0/setup.html
+#
 
 vtysh_enable=yes
-zebra_options="   --daemon -A 127.0.0.1 -s 90000000
-{%- if irdp is defined %} -M irdp{% endif -%}
-{%- if snmp is defined and snmp.zebra is defined %} -M snmp{% endif -%}
-"
-bgpd_options="    --daemon -A 127.0.0.1 -M rpki
-{%- if bmp is defined %} -M bmp{% endif -%}
-{%- if snmp is defined and snmp.bgpd is defined %} -M snmp{% endif -%}
-"
-ospfd_options="   --daemon -A 127.0.0.1
-{%- if snmp is defined and snmp.ospfd is defined %} -M snmp{% endif -%}
-"
-ospf6d_options="  --daemon -A ::1
-{%- if snmp is defined and snmp.ospf6d is defined %} -M snmp{% endif -%}
-"
-ripd_options="    --daemon -A 127.0.0.1
-{%- if snmp is defined and snmp.ripd is defined %} -M snmp{% endif -%}
-"
-ripngd_options="  --daemon -A ::1"
-isisd_options="   --daemon -A 127.0.0.1
-{%- if snmp is defined and snmp.isisd is defined %} -M snmp{% endif -%}
-"
-pimd_options="    --daemon -A 127.0.0.1"
-pim6d_options="   --daemon -A ::1"
-ldpd_options="    --daemon -A 127.0.0.1
-{%- if snmp is defined and snmp.ldpd is defined %} -M snmp{% endif -%}
-"
-mgmtd_options="   --daemon -A 127.0.0.1"
-nhrpd_options="   --daemon -A 127.0.0.1"
-eigrpd_options="  --daemon -A 127.0.0.1"
-babeld_options="  --daemon -A 127.0.0.1"
-sharpd_options="  --daemon -A 127.0.0.1"
-pbrd_options="    --daemon -A 127.0.0.1"
-staticd_options=" --daemon -A 127.0.0.1"
-bfdd_options="    --daemon -A 127.0.0.1"
-
 watchfrr_enable=no
 valgrind_enable=no
+
+#watchfrr_options=""
+
+frr_profile="traditional"
+
+#MAX_FDS=1024
+
+#FRR_NO_ROOT="yes"
 

--- a/data/templates/frr/daemons.frr.tmpl
+++ b/data/templates/frr/daemons.frr.tmpl
@@ -8,6 +8,12 @@
 # pbrd   Replaced by PBR in nftables.
 # vrrpd  Replaced by package keepalived.
 #
+# And these must be disabled aswell since they are currently missing a VyOS CLI:
+#
+# sharpd
+# fabricd
+# pathd
+#
 
 #zebra=yes
 #mgmtd=yes
@@ -24,12 +30,12 @@ ldpd=yes
 nhrpd=no
 eigrpd=yes
 babeld=yes
-sharpd=yes
+sharpd=no
 pbrd=no
 bfdd=yes
-fabricd=yes
+fabricd=no
 vrrpd=no
-pathd=yes
+pathd=no
 
 #
 # Define defaults for all services even those who shall be kept disabled.

--- a/op-mode-definitions/restart-frr.xml.in
+++ b/op-mode-definitions/restart-frr.xml.in
@@ -8,29 +8,23 @@
         </properties>
         <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart</command>
       </leafNode>
-      <leafNode name="bfd">
+      <leafNode name="zebra">
         <properties>
-          <help>Restart Bidirectional Forwarding Detection (BFD) daemon</help>
+          <help>Restart Routing Information Base (RIB) IP manager daemon</help>
         </properties>
-        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon bfdd</command>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon zebra</command>
+      </leafNode>
+      <leafNode name="static">
+        <properties>
+          <help>Restart static routing daemon</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon staticd</command>
       </leafNode>
       <leafNode name="bgp">
         <properties>
           <help>Restart Border Gateway Protocol (BGP) routing daemon</help>
         </properties>
         <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon bgpd</command>
-      </leafNode>
-      <leafNode name="isis">
-        <properties>
-          <help>Restart Intermediate System to Intermediate System (IS-IS) routing daemon</help>
-        </properties>
-        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon isisd</command>
-      </leafNode>
-      <leafNode name="ldp">
-        <properties>
-          <help>Restart the Label Distribution Protocol (LDP) daemon</help>
-        </properties>
-        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon ldpd</command>
       </leafNode>
       <leafNode name="ospf">
         <properties>
@@ -52,27 +46,63 @@
       </leafNode>
       <leafNode name="ripng">
         <properties>
-          <help>Restart Routing Information Protocol NG (RIPng) routing daemon</help>
+          <help>Restart IPv6 Routing Information Protocol (RIPng) routing daemon</help>
         </properties>
         <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon ripngd</command>
       </leafNode>
-      <leafNode name="static">
+      <leafNode name="isis">
         <properties>
-          <help>Restart static routing daemon</help>
+          <help>Restart Intermediate System to Intermediate System (IS-IS) routing daemon</help>
         </properties>
-        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon staticd</command>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon isisd</command>
       </leafNode>
-      <leafNode name="zebra">
+      <leafNode name="pim6">
         <properties>
-          <help>Restart Routing Information Base (RIB) manager daemon</help>
+          <help>Restart IPv6 Protocol Independent Multicast (PIM) daemon</help>
         </properties>
-        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon zebra</command>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon pim6d</command>
+      </leafNode>
+      <leafNode name="ldp">
+        <properties>
+          <help>Restart Label Distribution Protocol (LDP) daemon used by MPLS</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon ldpd</command>
+      </leafNode>
+      <leafNode name="eigrp">
+        <properties>
+          <help>Restart Enhanced Interior Gateway Routing Protocol (EIGRP) daemon</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon eigrpd</command>
       </leafNode>
       <leafNode name="babel">
         <properties>
           <help>Restart Babel routing daemon</help>
         </properties>
         <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon babeld</command>
+      </leafNode>
+      <leafNode name="sharp">
+        <properties>
+          <help>Restart Testing (SHARP) daemon</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon sharpd</command>
+      </leafNode>
+      <leafNode name="bfd">
+        <properties>
+          <help>Restart Bidirectional Forwarding Detection (BFD) daemon</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon bfdd</command>
+      </leafNode>
+      <leafNode name="fabric">
+        <properties>
+          <help>Restart OpenFabric daemon</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon fabricd</command>
+      </leafNode>
+      <leafNode name="path">
+        <properties>
+          <help>Restart Path Computation Element (PCE) Communication Protocol (PCEP) daemon used by SR</help>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon pathd</command>
       </leafNode>
     </children>
   </node>

--- a/op-mode-definitions/restart-frr.xml.in
+++ b/op-mode-definitions/restart-frr.xml.in
@@ -80,29 +80,11 @@
         </properties>
         <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon babeld</command>
       </leafNode>
-      <leafNode name="sharp">
-        <properties>
-          <help>Restart Testing (SHARP) daemon</help>
-        </properties>
-        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon sharpd</command>
-      </leafNode>
       <leafNode name="bfd">
         <properties>
           <help>Restart Bidirectional Forwarding Detection (BFD) daemon</help>
         </properties>
         <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon bfdd</command>
-      </leafNode>
-      <leafNode name="fabric">
-        <properties>
-          <help>Restart OpenFabric daemon</help>
-        </properties>
-        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon fabricd</command>
-      </leafNode>
-      <leafNode name="path">
-        <properties>
-          <help>Restart Path Computation Element (PCE) Communication Protocol (PCEP) daemon used by SR</help>
-        </properties>
-        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon pathd</command>
       </leafNode>
     </children>
   </node>

--- a/op-mode-definitions/restart-frr.xml.in
+++ b/op-mode-definitions/restart-frr.xml.in
@@ -68,12 +68,6 @@
         </properties>
         <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon ldpd</command>
       </leafNode>
-      <leafNode name="eigrp">
-        <properties>
-          <help>Restart Enhanced Interior Gateway Routing Protocol (EIGRP) daemon</help>
-        </properties>
-        <command>sudo ${vyos_op_scripts_dir}/restart_frr.py --action restart --daemon eigrpd</command>
-      </leafNode>
       <leafNode name="babel">
         <properties>
           <help>Restart Babel routing daemon</help>

--- a/python/vyos/frr.py
+++ b/python/vyos/frr.py
@@ -87,8 +87,7 @@ LOG.addHandler(ch)
 LOG.addHandler(ch2)
 
 _frr_daemons = ['zebra', 'staticd', 'bgpd', 'ospfd', 'ospf6d', 'ripd', 'ripngd',
-                'isisd', 'pim6d', 'ldpd', 'eigrpd', 'babeld', 'sharpd', 'bfdd',
-                'fabricd', 'pathd']
+                'isisd', 'pim6d', 'ldpd', 'eigrpd', 'babeld', 'bfdd']
 
 path_vtysh = '/usr/bin/vtysh'
 path_frr_reload = '/usr/lib/frr/frr-reload.py'

--- a/python/vyos/frr.py
+++ b/python/vyos/frr.py
@@ -86,8 +86,12 @@ ch2 = logging.StreamHandler(stream=sys.stdout)
 LOG.addHandler(ch)
 LOG.addHandler(ch2)
 
+# Full list of FRR 9.0/stable daemons for reference
+#_frr_daemons = ['zebra', 'staticd', 'bgpd', 'ospfd', 'ospf6d', 'ripd', 'ripngd',
+#                'isisd', 'pim6d', 'ldpd', 'eigrpd', 'babeld', 'sharpd', 'bfdd',
+#                'fabricd', 'pathd']
 _frr_daemons = ['zebra', 'staticd', 'bgpd', 'ospfd', 'ospf6d', 'ripd', 'ripngd',
-                'isisd', 'pim6d', 'ldpd', 'eigrpd', 'babeld', 'bfdd']
+                'isisd', 'pim6d', 'ldpd', 'babeld', 'bfdd']
 
 path_vtysh = '/usr/bin/vtysh'
 path_frr_reload = '/usr/lib/frr/frr-reload.py'

--- a/python/vyos/frr.py
+++ b/python/vyos/frr.py
@@ -86,9 +86,9 @@ ch2 = logging.StreamHandler(stream=sys.stdout)
 LOG.addHandler(ch)
 LOG.addHandler(ch2)
 
-_frr_daemons = ['zebra', 'bgpd', 'fabricd', 'isisd', 'ospf6d', 'ospfd', 'pbrd',
-                'pimd', 'ripd', 'ripngd', 'sharpd', 'staticd', 'vrrpd', 'ldpd',
-                'bfdd', 'eigrpd', 'babeld' ,'pim6d']
+_frr_daemons = ['zebra', 'staticd', 'bgpd', 'ospfd', 'ospf6d', 'ripd', 'ripngd',
+                'isisd', 'pim6d', 'ldpd', 'eigrpd', 'babeld', 'sharpd', 'bfdd',
+                'fabricd', 'pathd']
 
 path_vtysh = '/usr/bin/vtysh'
 path_frr_reload = '/usr/lib/frr/frr-reload.py'

--- a/src/conf_mode/snmp.py
+++ b/src/conf_mode/snmp.py
@@ -253,9 +253,7 @@ def apply(snmp):
     # Enable AgentX in FRR
     # This should be done for each daemon individually because common command
     # works only if all the daemons started with SNMP support
-    frr_daemons_list = [
-        'bgpd', 'ospf6d', 'ospfd', 'ripd', 'ripngd', 'isisd', 'ldpd', 'zebra'
-    ]
+    frr_daemons_list = ['zebra', 'bgpd', 'ospf6d', 'ospfd', 'ripd', 'isisd', 'ldpd']
     for frr_daemon in frr_daemons_list:
         call(
             f'vtysh -c "configure terminal" -d {frr_daemon} -c "agentx" >/dev/null'

--- a/src/conf_mode/snmp.py
+++ b/src/conf_mode/snmp.py
@@ -253,6 +253,7 @@ def apply(snmp):
     # Enable AgentX in FRR
     # This should be done for each daemon individually because common command
     # works only if all the daemons started with SNMP support
+    # Following daemons from FRR 9.0/stable have SNMP module compiled in VyOS
     frr_daemons_list = ['zebra', 'bgpd', 'ospf6d', 'ospfd', 'ripd', 'isisd', 'ldpd']
     for frr_daemon in frr_daemons_list:
         call(

--- a/src/op_mode/restart_frr.py
+++ b/src/op_mode/restart_frr.py
@@ -139,7 +139,9 @@ def _reload_config(daemon):
 # define program arguments
 cmd_args_parser = argparse.ArgumentParser(description='restart frr daemons')
 cmd_args_parser.add_argument('--action', choices=['restart'], required=True, help='action to frr daemons')
-cmd_args_parser.add_argument('--daemon', choices=['zebra', 'staticd', 'bgpd', 'ospfd', 'ospf6d', 'ripd', 'ripngd', 'isisd', 'pim6d', 'ldpd', 'eigrpd', 'babeld', 'bfdd'], required=False,  nargs='*', help='select single or multiple daemons')
+# Full list of FRR 9.0/stable daemons for reference
+#cmd_args_parser.add_argument('--daemon', choices=['zebra', 'staticd', 'bgpd', 'ospfd', 'ospf6d', 'ripd', 'ripngd', 'isisd', 'pim6d', 'ldpd', 'eigrpd', 'babeld', 'sharpd', 'bfdd', 'fabricd', 'pathd'], required=False,  nargs='*', help='select single or multiple daemons')
+cmd_args_parser.add_argument('--daemon', choices=['zebra', 'staticd', 'bgpd', 'ospfd', 'ospf6d', 'ripd', 'ripngd', 'isisd', 'pim6d', 'ldpd', 'babeld', 'bfdd'], required=False,  nargs='*', help='select single or multiple daemons')
 # parse arguments
 cmd_args = cmd_args_parser.parse_args()
 

--- a/src/op_mode/restart_frr.py
+++ b/src/op_mode/restart_frr.py
@@ -139,7 +139,7 @@ def _reload_config(daemon):
 # define program arguments
 cmd_args_parser = argparse.ArgumentParser(description='restart frr daemons')
 cmd_args_parser.add_argument('--action', choices=['restart'], required=True, help='action to frr daemons')
-cmd_args_parser.add_argument('--daemon', choices=['zebra', 'staticd', 'bgpd', 'ospfd', 'ospf6d', 'ripd', 'ripngd', 'isisd', 'pim6d', 'ldpd', 'eigrpd', 'babeld', 'sharpd', 'bfdd', 'fabricd', 'pathd'], required=False,  nargs='*', help='select single or multiple daemons')
+cmd_args_parser.add_argument('--daemon', choices=['zebra', 'staticd', 'bgpd', 'ospfd', 'ospf6d', 'ripd', 'ripngd', 'isisd', 'pim6d', 'ldpd', 'eigrpd', 'babeld', 'bfdd'], required=False,  nargs='*', help='select single or multiple daemons')
 # parse arguments
 cmd_args = cmd_args_parser.parse_args()
 

--- a/src/op_mode/restart_frr.py
+++ b/src/op_mode/restart_frr.py
@@ -139,7 +139,7 @@ def _reload_config(daemon):
 # define program arguments
 cmd_args_parser = argparse.ArgumentParser(description='restart frr daemons')
 cmd_args_parser.add_argument('--action', choices=['restart'], required=True, help='action to frr daemons')
-cmd_args_parser.add_argument('--daemon', choices=['bfdd', 'bgpd', 'ldpd', 'ospfd', 'ospf6d', 'isisd', 'ripd', 'ripngd', 'staticd', 'zebra', 'babeld'], required=False,  nargs='*', help='select single or multiple daemons')
+cmd_args_parser.add_argument('--daemon', choices=['zebra', 'staticd', 'bgpd', 'ospfd', 'ospf6d', 'ripd', 'ripngd', 'isisd', 'pim6d', 'ldpd', 'eigrpd', 'babeld', 'sharpd', 'bfdd', 'fabricd', 'pathd'], required=False,  nargs='*', help='select single or multiple daemons')
 # parse arguments
 cmd_args = cmd_args_parser.parse_args()
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Cleanup of daemons-file used by FRR along with some various FRR fixes to match current FRR-version 9.0.1 included in 1.5-rolling.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5591

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build, daemons runned by frr (zebra, mgmtd, staticd, bgpd, ospfd, ospf6d, ripd, ripngd, isisd, pim6d, ldpd, eigrpd, babeld, sharpd, bfdd, fabricd, pathd)

## Proposed changes
<!--- Describe your changes in detail -->
A longer list available at https://vyos.dev/T5591 but in short:

Updated following files to match the config provided by FRR 9.0.1 used in 1.5-rolling.

* data/templates/frr/daemons.frr.tmpl
* src/conf_mode/snmp.py
* python/vyos/frr.py
* src/op_mode/restart_frr.py
* op-mode-definitions/restart-frr.xml.in

The updates will also make debugging easier since the daemons-file better matches the original one at:

https://github.com/FRRouting/frr/blob/stable/9.0/tools/etc/frr/daemons

The affected daemons runned by FRR are:

zebra, mgmtd, staticd, bgpd, ospfd, ospf6d, ripd, ripngd, isisd, pim6d, ldpd, eigrpd, babeld, sharpd, bfdd, fabricd and pathd.

Note that the follow daemons currently shall not be maintained by FRR:

* pimd: Replaced by package igmpproxy.
* nhrpd: Replaced by package opennhrp.
* pbrd: Replaced by PBR in nftables.
* vrrpd: Replaced by package keepalived.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Verify that daemons maintained by FRR are functional after this change:

zebra, mgmtd, staticd, bgpd, ospfd, ospf6d, ripd, ripngd, isisd, pim6d, ldpd, eigrpd, babeld, sharpd, bfdd, fabricd and pathd

Basic tests are to verify if they are running:

```
root@vyos:/home/vyos# ps auxwww | grep -i frr
root        1782  0.1  0.0   8552  3268 ?        S<s  14:31   0:00 /usr/lib/frr/watchfrr -d -F traditional zebra mgmtd bgpd ripd ripngd ospfd ospf6d isisd babeld pim6d ldpd eigrpd staticd bfdd fabricd pathd
frr         1824  0.1  0.3 1192244 27368 ?       S<sl 14:31   0:00 /usr/lib/frr/zebra -d -F traditional --daemon -A 127.0.0.1 -s 90000000 -M snmp
frr         1829  0.0  0.0  10088  6580 ?        S<s  14:31   0:00 /usr/lib/frr/mgmtd -d -F traditional --daemon -A 127.0.0.1
frr         1831  0.0  0.2 258384 17964 ?        S<sl 14:31   0:00 /usr/lib/frr/bgpd -d -F traditional --daemon -A 127.0.0.1 -M rpki -M snmp
frr         1838  0.0  0.1  26884 11692 ?        S<s  14:31   0:00 /usr/lib/frr/ripd -d -F traditional --daemon -A 127.0.0.1 -M snmp
frr         1841  0.0  0.0   9976  5744 ?        S<s  14:31   0:00 /usr/lib/frr/ripngd -d -F traditional --daemon -A ::1
frr         1844  0.0  0.1  29096 13116 ?        S<s  14:31   0:00 /usr/lib/frr/ospfd -d -F traditional --daemon -A 127.0.0.1 -M snmp
frr         1847  0.0  0.1  28060 12500 ?        S<s  14:31   0:00 /usr/lib/frr/ospf6d -d -F traditional --daemon -A ::1 -M snmp
frr         1850  0.0  0.1  28880 13000 ?        S<s  14:31   0:00 /usr/lib/frr/isisd -d -F traditional --daemon -A 127.0.0.1 -M snmp
frr         1853  0.0  0.0   9580  5372 ?        S<s  14:31   0:00 /usr/lib/frr/babeld -d -F traditional --daemon -A 127.0.0.1
frr         1856  0.0  0.0  11180  6148 ?        S<s  14:31   0:00 /usr/lib/frr/pim6d -d -F traditional --daemon -A ::1
frr         1860  0.0  0.0  10044  7304 ?        S<   14:31   0:00 /usr/lib/frr/ldpd -L -u frr -g frr
frr         1861  0.0  0.0  10040  7256 ?        S<   14:31   0:00 /usr/lib/frr/ldpd -E -u frr -g frr
frr         1862  0.0  0.0  23128  6696 ?        S<s  14:31   0:00 /usr/lib/frr/ldpd -d -F traditional --daemon -A 127.0.0.1 -M snmp
frr         1866  0.0  0.0  10184  5900 ?        S<s  14:31   0:00 /usr/lib/frr/eigrpd -d -F traditional --daemon -A 127.0.0.1
frr         1869  0.0  0.0   9816  6168 ?        S<s  14:31   0:00 /usr/lib/frr/staticd -d -F traditional --daemon -A 127.0.0.1
frr         1872  0.0  0.0   9800  5544 ?        S<s  14:31   0:00 /usr/lib/frr/bfdd -d -F traditional --daemon -A 127.0.0.1
frr         1875  0.0  0.0  10828  5988 ?        S<s  14:31   0:00 /usr/lib/frr/fabricd -d -F traditional --daemon -A 127.0.0.1
frr         1879  0.0  0.0   9988  5464 ?        S<s  14:31   0:00 /usr/lib/frr/pathd -d -F traditional --daemon -A 127.0.0.1```
```

Listening on localhost:

```
root@vyos:/home/vyos# netstat -atunp
Active Internet connections (servers and established)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 127.0.0.1:199           0.0.0.0:*               LISTEN      3334/snmpd          
tcp        0      0 192.168.56.2:22         0.0.0.0:*               LISTEN      3475/sshd: /usr/sbi 
tcp        0      0 127.0.0.1:2604          0.0.0.0:*               LISTEN      1844/ospfd          
tcp        0      0 127.0.0.1:2605          0.0.0.0:*               LISTEN      1831/bgpd           
tcp        0      0 127.0.0.1:2602          0.0.0.0:*               LISTEN      1838/ripd           
tcp        0      0 127.0.0.1:2601          0.0.0.0:*               LISTEN      1824/zebra          
tcp        0      0 127.0.0.1:2612          0.0.0.0:*               LISTEN      1862/ldpd           
tcp        0      0 127.0.0.1:2613          0.0.0.0:*               LISTEN      1866/eigrpd         
tcp        0      0 127.0.0.1:2608          0.0.0.0:*               LISTEN      1850/isisd          
tcp        0      0 127.0.0.1:2609          0.0.0.0:*               LISTEN      1853/babeld         
tcp        0      0 127.0.0.1:2622          0.0.0.0:*               LISTEN      1829/mgmtd          
tcp        0      0 127.0.0.1:2621          0.0.0.0:*               LISTEN      1879/pathd          
tcp        0      0 127.0.0.1:2618          0.0.0.0:*               LISTEN      1875/fabricd        
tcp        0      0 127.0.0.1:2616          0.0.0.0:*               LISTEN      1869/staticd        
tcp        0      0 127.0.0.1:2617          0.0.0.0:*               LISTEN      1872/bfdd           
tcp        0      0 192.168.56.2:22         192.168.56.1:57526      ESTABLISHED 3679/sshd: vyos [pr 
tcp6       0      0 ::1:2606                :::*                    LISTEN      1847/ospf6d         
tcp6       0      0 ::1:2603                :::*                    LISTEN      1841/ripngd         
tcp6       0      0 ::1:2622                :::*                    LISTEN      1856/pim6d          
udp        0      0 192.168.56.2:59575      0.0.0.0:*                           3334/snmpd          
udp        0      0 0.0.0.0:3784            0.0.0.0:*                           1872/bfdd           
udp        0      0 0.0.0.0:3784            0.0.0.0:*                           1872/bfdd           
udp        0      0 0.0.0.0:3784            0.0.0.0:*                           1872/bfdd           
udp        0      0 127.0.0.1:123           0.0.0.0:*                           3243/chronyd        
udp        0      0 127.0.0.1:161           0.0.0.0:*                           3334/snmpd          
udp        0      0 192.168.56.2:161        0.0.0.0:*                           3334/snmpd          
udp        0      0 127.0.0.1:323           0.0.0.0:*                           3243/chronyd        
udp        0      0 0.0.0.0:4784            0.0.0.0:*                           1872/bfdd           
udp        0      0 0.0.0.0:4784            0.0.0.0:*                           1872/bfdd           
udp        0      0 0.0.0.0:4784            0.0.0.0:*                           1872/bfdd           
udp6       0      0 :::3784                 :::*                                1872/bfdd           
udp6       0      0 :::3784                 :::*                                1872/bfdd           
udp6       0      0 :::3784                 :::*                                1872/bfdd           
udp6       0      0 :::3785                 :::*                                1872/bfdd           
udp6       0      0 :::3785                 :::*                                1872/bfdd           
udp6       0      0 :::3785                 :::*                                1872/bfdd           
udp6       0      0 ::1:161                 :::*                                3334/snmpd          
udp6       0      0 ::1:323                 :::*                                3243/chronyd        
udp6       0      0 :::4784                 :::*                                1872/bfdd           
udp6       0      0 :::4784                 :::*                                1872/bfdd           
udp6       0      0 :::4784                 :::*                                1872/bfdd
```

And that vtysh (shell of FRR) agrees that everything is working as expected:

```
root@vyos:/home/vyos# vtysh

Hello, this is FRRouting (version 9.0.1).
Copyright 1996-2005 Kunihiro Ishiguro, et al.
vyos# 
vyos# show version
FRRouting 9.0.1 (vyos) on Linux(6.1.53-amd64-vyos).
Copyright 1996-2005 Kunihiro Ishiguro, et al.
configured with:
    '--build=x86_64-linux-gnu' '--prefix=/usr' '--includedir=${prefix}/include' '--mandir=${prefix}/share/man' '--infodir=${prefix}/share/info' '--sysconfdir=/etc' '--localstatedir=/var' '--disable-option-checking' '--disable-silent-rules' '--libdir=${prefix}/lib/x86_64-linux-gnu' '--libexecdir=${prefix}/lib/x86_64-linux-gnu' '--disable-maintainer-mode' '--localstatedir=/var/run/frr' '--sbindir=/usr/lib/frr' '--sysconfdir=/etc/frr' '--with-vtysh-pager=/usr/bin/pager' '--libdir=/usr/lib/x86_64-linux-gnu/frr' '--with-moduledir=/usr/lib/x86_64-linux-gnu/frr/modules' '--disable-dependency-tracking' '--enable-rpki' '--disable-scripting' '--enable-pim6d' '--with-libpam' '--enable-doc' '--enable-doc-html' '--enable-snmp' '--enable-fpm' '--disable-protobuf' '--disable-zeromq' '--enable-ospfapi' '--enable-bgp-vnc' '--enable-multipath=256' '--enable-user=frr' '--enable-group=frr' '--enable-vty-group=frrvty' '--enable-configfile-mask=0640' '--enable-logfile-mask=0640' 'build_alias=x86_64-linux-gnu' 'PYTHON=python3'
vyos# 
vyos# show daemons
 mgmtd zebra ripd ripngd ospfd ospf6d ldpd bgpd isisd eigrpd babeld fabricd watchfrr staticd bfdd pathd pim6d
vyos# 
vyos# show watchfrr
watchfrr global phase: Idle
 Restart Command: "/usr/lib/frr/watchfrr.sh restart %s"
 Start Command: "/usr/lib/frr/watchfrr.sh start %s"
 Stop Command: "/usr/lib/frr/watchfrr.sh stop %s"
 Min Restart Interval: 60
 Max Restart Interval: 600
 Restart Timeout: 20
 Reading Configuration: no
  zebra                Up
  mgmtd                Up
  bgpd                 Up
  ripd                 Up
  ripngd               Up
  ospfd                Up
  ospf6d               Up
  isisd                Up
  babeld               Up
  pim6d                Up
  ldpd                 Up
  eigrpd               Up
  staticd              Up
  bfdd                 Up
  fabricd              Up
  pathd                Up
vyos# 
vyos# show modules
Module information for mgmtd:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
mgmtd        9.0.1                     mgmtd daemon
pid: 1829

Module information for zebra:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
zebra        9.0.1                     zebra daemon
zebra_snmp   9.0.1                     zebra AgentX SNMP module
	from: /usr/lib/x86_64-linux-gnu/frr/modules/zebra_snmp.so
pid: 1824

Module information for ripd:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
ripd         9.0.1                     ripd daemon
ripd_snmp    9.0.1                     ripd AgentX SNMP module
	from: /usr/lib/x86_64-linux-gnu/frr/modules/ripd_snmp.so
pid: 1838

Module information for ripngd:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
ripngd       9.0.1                     ripngd daemon
pid: 1841

Module information for ospfd:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
ospfd        9.0.1                     ospfd daemon
ospfd_snmp   9.0.1                     ospfd AgentX SNMP module
	from: /usr/lib/x86_64-linux-gnu/frr/modules/ospfd_snmp.so
pid: 1844

Module information for ospf6d:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
ospf6d       9.0.1                     ospf6d daemon
ospf6d_snmp  9.0.1                     ospf6d AgentX SNMP module
	from: /usr/lib/x86_64-linux-gnu/frr/modules/ospf6d_snmp.so
pid: 1847

Module information for ldpd:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
ldpd         9.0.1                     ldpd daemon
ldp_snmp     9.0.1                     ldp AgentX SNMP module
	from: /usr/lib/x86_64-linux-gnu/frr/modules/ldpd_snmp.so
pid: 1862

Module information for bgpd:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
bgpd         9.0.1                     bgpd daemon
bgpd_rpki    0.3.6                     Enable RPKI support for FRR.
	from: /usr/lib/x86_64-linux-gnu/frr/modules/bgpd_rpki.so
bgpd_snmp    9.0.1                     bgpd AgentX SNMP module
	from: /usr/lib/x86_64-linux-gnu/frr/modules/bgpd_snmp.so
pid: 1831

Module information for isisd:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
isisd        9.0.1                     isisd daemon
isis_snmp    9.0.1                     isis AgentX SNMP module
	from: /usr/lib/x86_64-linux-gnu/frr/modules/isisd_snmp.so
pid: 1850

Module information for eigrpd:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
eigrpd       9.0.1                     eigrpd daemon
pid: 1866

Module information for babeld:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
babeld       9.0.1                     babeld daemon
pid: 1853

Module information for fabricd:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
fabricd      9.0.1                     fabricd daemon
pid: 1875

Module information for watchfrr:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
watchfrr     9.0.1                     watchfrr daemon
pid: 1782

Module information for staticd:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
staticd      9.0.1                     staticd daemon
pid: 1869

Module information for bfdd:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
bfdd         9.0.1                     bfdd daemon
pid: 1872

Module information for pathd:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
pathd        9.0.1                     pathd daemon
pid: 1879

Module information for pim6d:
Module Name  Version                   Description

libfrr       9.0.1                     libfrr core module
pim6d        9.0.1                     pim6d daemon
pid: 1856
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
