### PR TITLE
T5594: vrrp: extend function is_ipv6_tentative

### DIFF
--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -139,7 +139,7 @@ def is_ipv6_tentative(iface: str, ipv6_address: str) -> bool:
     import json
     from vyos.utils.process import rc_cmd
 
-    rc, out = rc_cmd(f'ip -6 --json address show dev {iface} scope global')
+    rc, out = rc_cmd(f'ip -6 --json address show dev {iface}')
     if rc:
         return False
 


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix VRRP when using ipv6 link local address on hello-source-address

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5594

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrrp
## Proposed changes
<!--- Describe your changes in detail -->
Extend function is_ipv6_tentative to analysis all type of ipv6 address, and not only global ipv6 address. This allows to configure ipv6 link local address on vrrp hello-source-address parameter.
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Smoketest:
```
root@vyos-15:/usr/libexec/vyos/tests/smoke/cli# ./test_ha_vrrp.py 
test_01_default_values (__main__.TestVRRP.test_01_default_values) ... ok
test_02_simple_options (__main__.TestVRRP.test_02_simple_options) ... ok
test_03_sync_group (__main__.TestVRRP.test_03_sync_group) ... ok
test_04_exclude_vrrp_interface (__main__.TestVRRP.test_04_exclude_vrrp_interface) ... ok
```
VRRP config using link local address:
```
set interfaces ethernet eth2 address 'fe80::1/64'
set high-availability vrrp group 20 address 2001:db8::1/64 
set high-availability vrrp group 20 description 'IPv6 VRRP IPs'
set high-availability vrrp group 20 hello-source-address 'fe80::1'
set high-availability vrrp group 20 interface 'eth2'
set high-availability vrrp group 20 rfc3768-compatibility
set high-availability vrrp group 20 vrid '20'

vyos@vyos-15:~$ show vrrp
  Name  Interface      VRID  State      Priority  Last Transition
------  -----------  ------  -------  ----------  -----------------
    20  eth2v20v6        20  MASTER          100  3m36s
vyos@vyos-15:~$ 

```



----------------------------------------------------------------------
Ran 4 tests in 101.603s

OK
root@vyos-15:/usr/libexec/vyos/tests/smoke/cli# 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
