### PR TITLE
T5590: firewall log rule: fix order which rule are processed

### DIFF
--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -249,29 +249,6 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
 
                     output.append(f'{proto} {prefix}port {operator} @P_{group_name}')
 
-    if 'log' in rule_conf and rule_conf['log'] == 'enable':
-        action = rule_conf['action'] if 'action' in rule_conf else 'accept'
-        #output.append(f'log prefix "[{fw_name[:19]}-{rule_id}-{action[:1].upper()}]"')
-        output.append(f'log prefix "[{family}-{hook}-{fw_name}-{rule_id}-{action[:1].upper()}]"')
-                        ##{family}-{hook}-{fw_name}-{rule_id}
-        if 'log_options' in rule_conf:
-
-            if 'level' in rule_conf['log_options']:
-                log_level = rule_conf['log_options']['level']
-                output.append(f'log level {log_level}')
-
-            if 'group' in rule_conf['log_options']:
-                log_group = rule_conf['log_options']['group']
-                output.append(f'log group {log_group}')
-
-                if 'queue_threshold' in rule_conf['log_options']:
-                    queue_threshold = rule_conf['log_options']['queue_threshold']
-                    output.append(f'queue-threshold {queue_threshold}')
-
-                if 'snapshot_length' in rule_conf['log_options']:
-                    log_snaplen = rule_conf['log_options']['snapshot_length']
-                    output.append(f'snaplen {log_snaplen}')
-
     if 'hop_limit' in rule_conf:
         operators = {'eq': '==', 'gt': '>', 'lt': '<'}
         for op, operator in operators.items():
@@ -393,6 +370,28 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
         if 'priority' in rule_conf['vlan']:
             output.append(f'vlan pcp {rule_conf["vlan"]["priority"]}')
 
+    if 'log' in rule_conf and rule_conf['log'] == 'enable':
+        action = rule_conf['action'] if 'action' in rule_conf else 'accept'
+        #output.append(f'log prefix "[{fw_name[:19]}-{rule_id}-{action[:1].upper()}]"')
+        output.append(f'log prefix "[{family}-{hook}-{fw_name}-{rule_id}-{action[:1].upper()}]"')
+                        ##{family}-{hook}-{fw_name}-{rule_id}
+        if 'log_options' in rule_conf:
+
+            if 'level' in rule_conf['log_options']:
+                log_level = rule_conf['log_options']['level']
+                output.append(f'log level {log_level}')
+
+            if 'group' in rule_conf['log_options']:
+                log_group = rule_conf['log_options']['group']
+                output.append(f'log group {log_group}')
+
+                if 'queue_threshold' in rule_conf['log_options']:
+                    queue_threshold = rule_conf['log_options']['queue_threshold']
+                    output.append(f'queue-threshold {queue_threshold}')
+
+                if 'snapshot_length' in rule_conf['log_options']:
+                    log_snaplen = rule_conf['log_options']['snapshot_length']
+                    output.append(f'snaplen {log_snaplen}')
 
     output.append('counter')
 

--- a/smoketest/scripts/cli/test_policy_route.py
+++ b/smoketest/scripts/cli/test_policy_route.py
@@ -250,7 +250,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
             ['meta l4proto udp', 'drop'],
             ['tcp flags syn / syn,ack', 'meta mark set ' + mark_hex],
             ['ct state new', 'tcp dport 22', 'ip saddr 198.51.100.0/24', 'ip ttl > 2', 'meta mark set ' + mark_hex],
-            ['meta l4proto icmp', 'log prefix "[ipv4-route-smoketest-4-A]"', 'icmp type echo-request', 'ip length { 128, 1024-2048 }', 'meta pkttype other', 'meta mark set ' + mark_hex],
+            ['log prefix "[ipv4-route-smoketest-4-A]"', 'icmp type echo-request', 'ip length { 128, 1024-2048 }', 'meta pkttype other', 'meta mark set ' + mark_hex],
             ['ip dscp { 0x29, 0x39-0x3b }', 'meta mark set ' + mark_hex]
         ]
 
@@ -262,7 +262,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
             ['meta l4proto udp', 'drop'],
             ['tcp flags syn / syn,ack', 'meta mark set ' + mark_hex],
             ['ct state new', 'tcp dport 22', 'ip6 saddr 2001:db8::/64', 'ip6 hoplimit > 2', 'meta mark set ' + mark_hex],
-            ['meta l4proto ipv6-icmp', 'log prefix "[ipv6-route6-smoketest6-4-A]"', 'icmpv6 type echo-request', 'ip6 length != { 128, 1024-2048 }', 'meta pkttype multicast', 'meta mark set ' + mark_hex],
+            ['log prefix "[ipv6-route6-smoketest6-4-A]"', 'icmpv6 type echo-request', 'ip6 length != { 128, 1024-2048 }', 'meta pkttype multicast', 'meta mark set ' + mark_hex],
             ['ip6 dscp != { 0x0e-0x13, 0x3d }', 'meta mark set ' + mark_hex]
         ]
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
 firewall log rule: fix order which rule are processed. Log options should be added at the end of the rule, after all matchers and befor action. Also change 2 lines in policy_route smoketest, which suddenly wasn't working as expected

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5590

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Testing config and nft ruleset:
```
vyos@15-clean:~$ show config comm | grep firewall
set firewall ipv4 forward filter rule 116 action 'drop'
set firewall ipv4 forward filter rule 116 destination address '198.51.100.1'
set firewall ipv4 forward filter rule 116 log 'enable'
set firewall ipv4 forward filter rule 116 outbound-interface interface-name 'eth7'
set firewall ipv4 forward filter rule 116 protocol 'tcp'
set firewall ipv4 forward filter rule 116 source port '5544'
vyos@15-clean:~$ sudo nft -s list chain ip vyos_filter VYOS_FORWARD_filter
table ip vyos_filter {
        chain VYOS_FORWARD_filter {
                type filter hook forward priority filter; policy accept;
                ip daddr 198.51.100.1 tcp sport 5544 oifname "eth7" log prefix "[ipv4-FWD-filter-116-D]" counter drop comment "ipv4-FWD-filter-116"
        }
}
vyos@15-clean:~$ 

```



## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@15-clean:/usr/libexec/vyos/tests/smoke/cli# ./test_firewall.py
test_bridge_basic_rules (__main__.TestFirewall.test_bridge_basic_rules) ... ok
test_flow_offload_software (__main__.TestFirewall.test_flow_offload_software) ... ok
test_geoip (__main__.TestFirewall.test_geoip) ... Updating GeoIP. Please wait...
Updating GeoIP. Please wait...
ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok

----------------------------------------------------------------------
Ran 14 tests in 33.286s

OK
root@15-clean:/usr/libexec/vyos/tests/smoke/cli# ./test_nat.py
test_dnat (__main__.TestNAT.test_dnat) ... ok
test_dnat_negated_addresses (__main__.TestNAT.test_dnat_negated_addresses) ... ok
test_dnat_redirect (__main__.TestNAT.test_dnat_redirect) ... ok
test_dnat_without_translation_address (__main__.TestNAT.test_dnat_without_translation_address) ... ok
test_nat_balance (__main__.TestNAT.test_nat_balance) ... ok
test_nat_no_rules (__main__.TestNAT.test_nat_no_rules) ... ok
test_snat (__main__.TestNAT.test_snat) ... ok
test_snat_groups (__main__.TestNAT.test_snat_groups) ... ok
test_snat_required_translation_address (__main__.TestNAT.test_snat_required_translation_address) ...
Source NAT configuration error in rule 5: translation requires address
and/or port

ok
test_static_nat (__main__.TestNAT.test_static_nat) ... ok

----------------------------------------------------------------------
Ran 10 tests in 18.021s
OK
root@15-clean:/usr/libexec/vyos/tests/smoke/cli# ./test_nat66.py 
test_destination_nat66 (__main__.TestNAT66.test_destination_nat66) ... ok
test_destination_nat66_prefix (__main__.TestNAT66.test_destination_nat66_prefix) ... ok
test_destination_nat66_protocol (__main__.TestNAT66.test_destination_nat66_protocol) ... ok
test_destination_nat66_without_translation_address (__main__.TestNAT66.test_destination_nat66_without_translation_address) ... ok
test_nat66_no_rules (__main__.TestNAT66.test_nat66_no_rules) ... ok
test_source_nat66 (__main__.TestNAT66.test_source_nat66) ... ok
test_source_nat66_address (__main__.TestNAT66.test_source_nat66_address) ... ok
test_source_nat66_protocol (__main__.TestNAT66.test_source_nat66_protocol) ... ok
test_source_nat66_required_translation_prefix (__main__.TestNAT66.test_source_nat66_required_translation_prefix) ... 
Source NAT66 configuration error in rule 5: outbound-interface not
specified


Source NAT66 configuration error in rule 5: translation address not
specified

ok

----------------------------------------------------------------------
Ran 9 tests in 13.885s

OK
root@15-clean:/usr/libexec/vyos/tests/smoke/cli# 

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
