### PR TITLE
init: T5239: configure system hostname prior to FRR startup

### DIFF
--- a/python/vyos/utils/config.py
+++ b/python/vyos/utils/config.py
@@ -1,0 +1,34 @@
+# Copyright 2023 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from vyos.defaults import directories
+
+config_file = os.path.join(directories['config'], 'config.boot')
+
+def read_saved_value(path: list):
+    if not isinstance(path, list) or not path:
+        return ''
+    from vyos.configtree import ConfigTree
+    try:
+        with open(config_file) as f:
+            config_string = f.read()
+        ct = ConfigTree(config_string)
+    except Exception:
+        return ''
+    if not ct.exists(path):
+        return ''
+    res = ct.return_values(path)
+    return res[0] if len(res) == 1 else res

--- a/src/helpers/read-saved-value.py
+++ b/src/helpers/read-saved-value.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from argparse import ArgumentParser
+from vyos.utils.config import read_saved_value
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('--path', nargs='*')
+    args = parser.parse_args()
+
+    out = read_saved_value(args.path) if args.path else ''
+    if isinstance(out, list):
+        out = ' '.join(out)
+    print(out)

--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -374,8 +374,11 @@ start ()
       && chgrp ${GROUP} ${vyatta_configdir}
     log_action_end_msg $?
 
-    rm -f /etc/hostname
-    ${vyos_conf_scripts_dir}/host_name.py || log_failure_msg "could not reset host-name"
+    # T5239: early read of system hostname as this value is read-only once during
+    # FRR initialisation
+    tmp=$(${vyos_libexec_dir}/read-saved-value.py --path "system host-name")
+    hostnamectl set-hostname --static "$tmp"
+
     ${vyos_conf_scripts_dir}/system_frr.py || log_failure_msg "could not reset FRR config"
     # If for any reason FRR was not started by system_frr.py - start it anyways.
     # This is a safety net!


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

On first boot after an upgrade /etc/hostname and FRR configuration is not
populated. FRR determines the system hostname once during startup and does not
repect changes of the hostname CLI value.

Thus after an upgrade of VyOS FRR started with a hostname of debian that was
propagated to peers.

The commit retrieves the hostname from the CLI and presets this before FRR is
initially started.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5239

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

Startup sequence extended for system hostname

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
