### PR TITLE
T5602: Reverse-proxy add option backup for backend server

### DIFF
--- a/data/templates/load-balancing/haproxy.cfg.j2
+++ b/data/templates/load-balancing/haproxy.cfg.j2
@@ -146,7 +146,7 @@ backend {{ back }}
 {%         if back_config.server is vyos_defined %}
 {%             set ssl_back =  'ssl ca-file /run/haproxy/' ~ back_config.ssl.ca_certificate ~ '.pem' if back_config.ssl.ca_certificate is vyos_defined else '' %}
 {%             for server, server_config in back_config.server.items() %}
-    server {{ server }} {{ server_config.address }}:{{ server_config.port }}{{ ' check' if server_config.check is vyos_defined }}{{ ' send-proxy' if server_config.send_proxy is vyos_defined }}{{ ' send-proxy-v2' if server_config.send_proxy_v2 is vyos_defined }} {{ ssl_back }}
+    server {{ server }} {{ server_config.address }}:{{ server_config.port }}{{ ' check' if server_config.check is vyos_defined }}{{ ' backup' if server_config.backup is vyos_defined }}{{ ' send-proxy' if server_config.send_proxy is vyos_defined }}{{ ' send-proxy-v2' if server_config.send_proxy_v2 is vyos_defined }} {{ ssl_back }}
 {%             endfor %}
 {%         endif %}
 {%         if back_config.timeout.check is vyos_defined %}

--- a/interface-definitions/load-balancing-haproxy.xml.in
+++ b/interface-definitions/load-balancing-haproxy.xml.in
@@ -124,6 +124,12 @@
                       </constraint>
                     </properties>
                   </leafNode>
+                  <leafNode name="backup">
+                    <properties>
+                      <help>Use backup server if other servers are not available</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
                   <leafNode name="check">
                     <properties>
                       <help>Active health check backend server</help>

--- a/smoketest/scripts/cli/test_load_balancing_reverse_proxy.py
+++ b/smoketest/scripts/cli/test_load_balancing_reverse_proxy.py
@@ -74,6 +74,7 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
         self.cli_set(back_base + [bk_second_name, 'mode', mode])
         self.cli_set(back_base + [bk_second_name, 'server', bk_second_name, 'address', bk_server_second])
         self.cli_set(back_base + [bk_second_name, 'server', bk_second_name, 'port', bk_server_port])
+        self.cli_set(back_base + [bk_second_name, 'server', bk_second_name, 'backup'])
 
         self.cli_set(base_path + ['global-parameters', 'max-connections', max_connections])
 
@@ -106,6 +107,7 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'backend {bk_second_name}', config)
         self.assertIn(f'mode {mode}', config)
         self.assertIn(f'server {bk_second_name} {bk_server_second}:{bk_server_port}', config)
+        self.assertIn(f'server {bk_second_name} {bk_server_second}:{bk_server_port} backup', config)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
A `backup` server can be defined to take over in the case of all other backends failing
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5602

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
reverse-proxy, load-balancing, haproxy
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Use `backup` option for a backend server
```
set load-balancing reverse-proxy service my-tcp-api backend 'bk-01'
set load-balancing reverse-proxy service my-tcp-api mode 'tcp'
set load-balancing reverse-proxy service my-tcp-api port '8888'

set load-balancing reverse-proxy backend bk-01 balance 'round-robin'
set load-balancing reverse-proxy backend bk-01 mode 'tcp'

set load-balancing reverse-proxy backend bk-01 server srv01 address '192.0.2.11'
set load-balancing reverse-proxy backend bk-01 server srv01 port '8881'
set load-balancing reverse-proxy backend bk-01 server srv02 address '192.0.2.12'
set load-balancing reverse-proxy backend bk-01 server srv02 port '8882'
set load-balancing reverse-proxy backend bk-01 server srv03 address '192.0.2.13'
set load-balancing reverse-proxy backend bk-01 server srv03 port '8883'
set load-balancing reverse-proxy backend bk-01 server srv03 backup
```
Check haproxy.cfg
```
...
# Backend
backend bk-01
    balance roundrobin
    mode tcp
    server srv01 192.0.2.11:8881 
    server srv02 192.0.2.12:8882 
    server srv03 192.0.2.13:8883 backup 
```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_load_balancing_reverse_proxy.py
test_01_lb_reverse_proxy_domain (__main__.TestLoadBalancingReverseProxy.test_01_lb_reverse_proxy_domain) ... ok

----------------------------------------------------------------------
Ran 1 test in 6.292s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
