### PR TITLE
T5217: Add firewall synproxy

### DIFF
--- a/interface-definitions/include/firewall/action-forward.xml.i
+++ b/interface-definitions/include/firewall/action-forward.xml.i
@@ -3,7 +3,7 @@
   <properties>
     <help>Rule action</help>
     <completionHelp>
-      <list>accept continue jump reject return drop queue offload</list>
+      <list>accept continue jump reject return drop queue offload synproxy</list>
     </completionHelp>
     <valueHelp>
       <format>accept</format>
@@ -37,8 +37,12 @@
       <format>offload</format>
       <description>Offload packet via flowtable</description>
     </valueHelp>
+    <valueHelp>
+      <format>synproxy</format>
+      <description>Synproxy connections</description>
+    </valueHelp>
     <constraint>
-      <regex>(accept|continue|jump|reject|return|drop|queue|offload)</regex>
+      <regex>(accept|continue|jump|reject|return|drop|queue|offload|synproxy)</regex>
     </constraint>
   </properties>
 </leafNode>

--- a/interface-definitions/include/firewall/action.xml.i
+++ b/interface-definitions/include/firewall/action.xml.i
@@ -3,7 +3,7 @@
   <properties>
     <help>Rule action</help>
     <completionHelp>
-      <list>accept continue jump reject return drop queue</list>
+      <list>accept continue jump reject return drop queue synproxy</list>
     </completionHelp>
     <valueHelp>
       <format>accept</format>
@@ -33,8 +33,12 @@
       <format>queue</format>
       <description>Enqueue packet to userspace</description>
     </valueHelp>
+    <valueHelp>
+      <format>synproxy</format>
+      <description>Synproxy connections</description>
+    </valueHelp>
     <constraint>
-      <regex>(accept|continue|jump|reject|return|drop|queue)</regex>
+      <regex>(accept|continue|jump|reject|return|drop|queue|synproxy)</regex>
     </constraint>
   </properties>
 </leafNode>

--- a/interface-definitions/include/firewall/common-rule-inet.xml.i
+++ b/interface-definitions/include/firewall/common-rule-inet.xml.i
@@ -219,6 +219,7 @@
     </leafNode>
   </children>
 </node>
+#include <include/firewall/synproxy.xml.i>
 <node name="state">
   <properties>
     <help>Session state</help>

--- a/interface-definitions/include/firewall/synproxy.xml.i
+++ b/interface-definitions/include/firewall/synproxy.xml.i
@@ -1,0 +1,40 @@
+<!-- include start from firewall/synproxy.xml.i -->
+<node name="synproxy">
+  <properties>
+    <help>Synproxy options</help>
+  </properties>
+  <children>
+    <node name="tcp">
+      <properties>
+        <help>TCP synproxy options</help>
+      </properties>
+      <children>
+        <leafNode name="mss">
+          <properties>
+            <help>TCP Maximum segment size</help>
+            <valueHelp>
+              <format>u32:501-65535</format>
+              <description>Maximum segment size for synproxy connections</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 501-65535"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="window-scale">
+          <properties>
+            <help>TCP window scale for synproxy connections</help>
+            <valueHelp>
+              <format>u32:1-14</format>
+              <description>TCP window scale</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 1-14"/>
+            </constraint>
+          </properties>
+        </leafNode>
+      </children>
+    </node>
+  </children>
+</node>
+<!-- include end -->

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -249,6 +249,10 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
 
                     output.append(f'{proto} {prefix}port {operator} @P_{group_name}')
 
+    if rule_conf['action'] == 'synproxy':
+        if 'synproxy' in rule_conf:
+            output.append('ct state invalid,untracked')
+
     if 'hop_limit' in rule_conf:
         operators = {'eq': '==', 'gt': '>', 'lt': '<'}
         for op, operator in operators.items():
@@ -419,6 +423,16 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
                 if 'queue_options' in rule_conf:
                     queue_opts = ','.join(rule_conf['queue_options'])
                     output.append(f'{queue_opts}')
+
+        # Synproxy
+        if 'synproxy' in rule_conf:
+            synproxy_mss = dict_search_args(rule_conf, 'synproxy', 'tcp', 'mss')
+            if synproxy_mss:
+                output.append(f'mss {synproxy_mss}')
+            synproxy_ws = dict_search_args(rule_conf, 'synproxy', 'tcp', 'window_scale')
+            if synproxy_ws:
+                output.append(f'wscale {synproxy_ws} timestamp sack-perm')
+
     else:
         output.append('return')
 

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2022 VyOS maintainers and contributors
+# Copyright (C) 2021-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -172,6 +172,14 @@ def verify_rule(firewall, rule_conf, ipv6):
 
         if not dict_search_args(firewall, 'flowtable', offload_target):
             raise ConfigError(f'Invalid offload-target. Flowtable "{offload_target}" does not exist on the system')
+
+    if rule_conf['action'] != 'synproxy' and 'synproxy' in rule_conf:
+        raise ConfigError('"synproxy" option allowed only for action synproxy')
+    if rule_conf['action'] == 'synproxy':
+        if not rule_conf.get('synproxy', {}).get('tcp'):
+            raise ConfigError('synproxy TCP MSS is not defined')
+        if rule_conf.get('protocol', {}) != 'tcp':
+            raise ConfigError('For action "synproxy" the protocol must be set to TCP')
 
     if 'queue_options' in rule_conf:
         if 'queue' not in rule_conf['action']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add ability to SYNPROXY connections
It is useful to protect against TCP SYN flood attacks and port-scanners
https://wiki.nftables.org/wiki-nftables/index.php/Synproxy
https://git.netfilter.org/nftables/commit/?id=1188a69604c3df2a63daca9e735fdb535e8f6b63
https://github.com/torvalds/linux/blob/master/net/netfilter/nft_synproxy.c
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5217

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Disable TCP loose option and enable  syncookies/timestamp and configure synproxy
```
set system sysctl parameter net.ipv4.tcp_syncookies value '1'
set system sysctl parameter net.ipv4.tcp_timestamps value '1'

set system conntrack tcp loose 'disable'
set system conntrack ignore ipv4 rule 10 destination port '22'
set system conntrack ignore ipv4 rule 10 protocol 'tcp'
set system conntrack ignore ipv4 rule 10 tcp flags syn

set firewall global-options syn-cookies 'enable'
set firewall ipv4 input filter rule 10 action 'synproxy'
set firewall ipv4 input filter rule 10 destination port '22'
set firewall ipv4 input filter rule 10 inbound-interface interface-name 'eth1'
set firewall ipv4 input filter rule 10 protocol 'tcp'
set firewall ipv4 input filter rule 10 synproxy tcp mss '1460'
set firewall ipv4 input filter rule 10 synproxy tcp window-scale '7'
set firewall ipv4 input filter rule 100 action 'drop'
set firewall ipv4 input filter rule 100 state invalid 'enable'

```
Check table vyos_filter
```
vyos@r4:~$ sudo nft list chain ip vyos_filter VYOS_INPUT_filter
table ip vyos_filter {
	chain VYOS_INPUT_filter {
		type filter hook input priority filter; policy accept;
		tcp dport 22 ct state invalid,untracked iifname "eth1" counter packets 204258 bytes 8170352 synproxy mss 1460 wscale 7 timestamp sack-perm comment "ipv4-INP-filter-10"
		ct state invalid counter packets 2 bytes 284 drop comment "ipv4-INP-filter-100"
	}
}


```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_firewall.py
test_bridge_basic_rules (__main__.TestFirewall.test_bridge_basic_rules) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
test_geoip (__main__.TestFirewall.test_geoip) ... ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok

----------------------------------------------------------------------
Ran 15 tests in 66.892s

OK
vyos@r4:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
