### PR TITLE
T5600: firewall: change constraints for inbound|outbound interface-name

### DIFF
--- a/interface-definitions/include/constraint/interface-name-with-wildcard-and-inverted.xml.i
+++ b/interface-definitions/include/constraint/interface-name-with-wildcard-and-inverted.xml.i
@@ -1,4 +1,0 @@
-<!-- include start from constraint/interface-name-with-wildcard-and-inverted.xml.i -->
-<regex>(\!?)(bond|br|dum|en|ersp|eth|gnv|ifb|lan|l2tp|l2tpeth|macsec|peth|ppp|pppoe|pptp|sstp|tun|veth|vti|vtun|vxlan|wg|wlan|wwan)([0-9]?)(\*?)(.+)?|(\!?)lo</regex>
-<validator name="file-path --lookup-path /sys/class/net --directory"/>
-<!-- include end -->

--- a/interface-definitions/include/firewall/match-interface.xml.i
+++ b/interface-definitions/include/firewall/match-interface.xml.i
@@ -4,6 +4,7 @@
     <help>Match interface</help>
     <completionHelp>
       <script>${vyos_completion_dir}/list_interfaces</script>
+      <path>vrf name</path>
     </completionHelp>
     <valueHelp>
       <format>txt</format>
@@ -18,7 +19,8 @@
       <description>Inverted interface name to match</description>
     </valueHelp>
     <constraint>
-      #include <include/constraint/interface-name-with-wildcard-and-inverted.xml.i>
+      <regex>(\!?)(bond|br|dum|en|ersp|eth|gnv|ifb|lan|l2tp|l2tpeth|macsec|peth|ppp|pppoe|pptp|sstp|tun|veth|vti|vtun|vxlan|wg|wlan|wwan)([0-9]?)(\*?)(.+)?|(\!?)lo</regex>
+      <validator name="vrf-name"/>
     </constraint>
   </properties>
 </leafNode>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
change constraints for inbound|outbound interface-name. Now user can use VRF, and negated VRF, and configuration wonn't be broken after reboot.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5600

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->
Do not look at `/sys/class/net` for interface validation, because during reboot, firewall is loaded before VRF, and this makes firewall configuration load fail.

This PR uses validator `vrf-name`, which does not validate that given VRF actually exists in the system. It just validates that the input has same format as vrfs... So now user can use existent VRFs in firwall, but also vrf (or just name/strings) which does not exists on the system.


## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
## Configuration and nft chain:
vyos@vyos# run show config comm | grep "fire\|vrf"
set firewall ipv4 forward filter rule 10 action 'accept'
set firewall ipv4 forward filter rule 10 inbound-interface interface-name 'eth1*'
set firewall ipv4 forward filter rule 10 outbound-interface interface-name '!vtun88'
set firewall ipv4 forward filter rule 20 action 'accept'
set firewall ipv4 forward filter rule 20 outbound-interface interface-name '!MGMT-OK'
set firewall ipv4 forward filter rule 30 action 'drop'
set firewall ipv4 forward filter rule 30 inbound-interface interface-name 'bond0.99'
set firewall ipv4 forward filter rule 40 action 'accept'
set firewall ipv4 forward filter rule 40 outbound-interface interface-name 'AUX'
set vrf name AUX table '122'
set vrf name FOO table '111'
set vrf name MGMT-OK table '133'
[edit]
vyos@vyos# sudo nft list chain ip vyos_filter VYOS_FORWARD_filter
table ip vyos_filter {
        chain VYOS_FORWARD_filter {
                type filter hook forward priority filter; policy accept;
                iifname "eth1*" oifname != "vtun88" counter packets 0 bytes 0 accept comment "ipv4-FWD-filter-10"
                oifname != "MGMT-OK" counter packets 0 bytes 0 accept comment "ipv4-FWD-filter-20"
                iifname "bond0.99" counter packets 0 bytes 0 drop comment "ipv4-FWD-filter-30"
                oifname "AUX" counter packets 0 bytes 0 accept comment "ipv4-FWD-filter-40"
        }
}
[edit]
vyos@vyos#
```

Check reboot:
```
##Reboots works as expected:
[   21.807206] vyos-router[689]: Waiting for NICs to settle down: settled in 3sec..
[   24.745346] vyos-router[689]: Mounting VyOS Config...done.
[   33.129109] vyos-router[689]: Starting VyOS router: migrate configure.
[   33.328212] vyos-config[697]: Configuration success

Welcome to VyOS - vyos ttyS0

vyos login: 
```

Help completion now includes interfaces and vrfs:
```
vyos@vyos# set firewall ipv4 name BAR rule 10 inbound-interface interface-name 
Possible completions:
   <text>               Interface name
   txt*                 Interface name with wildcard
   !<text>              Inverted interface name to match
   AUX                  
   FOO                  
   MGMT-OK              
   br0                  
   eth0                 
   eth1                 
   eth2                 
   eth3                 
   lo                   

      
[edit]
vyos@vyos#

```



## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@vyos:/usr/libexec/vyos/tests/smoke/cli# ./test_firewall.py 
test_bridge_basic_rules (__main__.TestFirewall.test_bridge_basic_rules) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
test_geoip (__main__.TestFirewall.test_geoip) ... ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok

----------------------------------------------------------------------
Ran 14 tests in 42.415s

OK
root@vyos:/usr/libexec/vyos/tests/smoke/cli# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
