### PR TITLE
ddclient: T5612: Miscellaneous improvements and fixes for dynamic DNS

### DIFF
--- a/data/templates/dns-dynamic/ddclient.conf.j2
+++ b/data/templates/dns-dynamic/ddclient.conf.j2
@@ -66,7 +66,7 @@ use=no
 # Web service dynamic DNS configuration for {{ name }}: [{{ config.protocol }}, {{ host }}]
 {{ render_config(host, address, service_cfg.web_options, ip_suffixes,
                  protocol=config.protocol, server=config.server, zone=config.zone,
-                 login=config.username, password=config.password) }}
+                 login=config.username, password=config.password, ttl=config.ttl) }}
 
 {%                 endfor %}
 {%             endfor %}

--- a/data/templates/dns-dynamic/ddclient.conf.j2
+++ b/data/templates/dns-dynamic/ddclient.conf.j2
@@ -28,19 +28,21 @@ syslog=yes
 ssl=yes
 pid={{ config_file | replace('.conf', '.pid') }}
 cache={{ config_file | replace('.conf', '.cache') }}
-{# Explicitly override global options for reliability #}
-web=googledomains {# ddclient default ('dyndns') doesn't support ssl and results in process lockup #}
-use=no            {# ddclient default ('ip') results in confusing warning message in log #}
+{# ddclient default (web=dyndns) doesn't support ssl and results in process lockup #}
+web=googledomains
+{# ddclient default (use=ip) results in confusing warning message in log #}
+use=no
 
 {% if address is vyos_defined %}
 {%     for address, service_cfg in address.items() %}
 {%         if service_cfg.rfc2136 is vyos_defined %}
 {%             for name, config in service_cfg.rfc2136.items() %}
 {%                 if config.description is vyos_defined %}
-# {{ config.description }}
 
+# {{ config.description }}
 {%                 endif %}
 {%                 for host in config.host_name if config.host_name is vyos_defined %}
+
 # RFC2136 dynamic DNS configuration for {{ name }}: [{{ config.zone }}, {{ host }}]
 {# Don't append 'new-style' compliant suffix ('usev4', 'usev6', 'ifv4', 'ifv6' etc.)
    to the properties since 'nsupdate' doesn't support that yet. #}
@@ -54,12 +56,13 @@ use=no            {# ddclient default ('ip') results in confusing warning messag
 {%         if service_cfg.service is vyos_defined %}
 {%             for name, config in service_cfg.service.items() %}
 {%                 if config.description is vyos_defined %}
-# {{ config.description }}
 
+# {{ config.description }}
 {%                 endif %}
 {%                 for host in config.host_name if config.host_name is vyos_defined %}
 {%                     set ip_suffixes = ['v4', 'v6'] if config.ip_version == 'both'
-                                                      else [config.ip_version[2:]] %} {# 'ipvX' -> 'vX' #}
+                                                      else [config.ip_version[2:]] %}
+
 # Web service dynamic DNS configuration for {{ name }}: [{{ config.protocol }}, {{ host }}]
 {{ render_config(host, address, service_cfg.web_options, ip_suffixes,
                  protocol=config.protocol, server=config.server, zone=config.zone,

--- a/data/templates/dns-dynamic/override.conf.j2
+++ b/data/templates/dns-dynamic/override.conf.j2
@@ -7,4 +7,4 @@ After=vyos-router.service
 PIDFile={{ config_file | replace('.conf', '.pid') }}
 EnvironmentFile=
 ExecStart=
-ExecStart=/usr/bin/ddclient -file {{ config_file }}
+ExecStart={{ vrf_command }}/usr/bin/ddclient -file {{ config_file }}

--- a/interface-definitions/dns-dynamic.xml.in
+++ b/interface-definitions/dns-dynamic.xml.in
@@ -164,6 +164,7 @@
                 </properties>
                 <defaultValue>300</defaultValue>
               </leafNode>
+              #include <include/interface/vrf.xml.i>
             </children>
           </node>
         </children>

--- a/interface-definitions/dns-dynamic.xml.in
+++ b/interface-definitions/dns-dynamic.xml.in
@@ -74,18 +74,7 @@
                         </properties>
                       </leafNode>
                       #include <include/dns/time-to-live.xml.i>
-                      <leafNode name="zone">
-                        <properties>
-                          <help>Forwarding zone to be updated</help>
-                          <valueHelp>
-                            <format>txt</format>
-                            <description>RFC2136 Zone to be updated</description>
-                          </valueHelp>
-                          <constraint>
-                            <validator name="fqdn"/>
-                          </constraint>
-                        </properties>
-                      </leafNode>
+                      #include <include/dns/dynamic-service-zone.xml.i>
                     </children>
                   </tagNode>
                   <tagNode name="service">
@@ -112,15 +101,7 @@
                           </constraint>
                         </properties>
                       </leafNode>
-                      <leafNode name="zone">
-                        <properties>
-                          <help>DNS zone to update (not used by all protocols)</help>
-                          <valueHelp>
-                            <format>txt</format>
-                            <description>Name of DNS zone</description>
-                          </valueHelp>
-                        </properties>
-                      </leafNode>
+                      #include <include/dns/dynamic-service-zone.xml.i>
                       <leafNode name="ip-version">
                         <properties>
                           <help>IP address version to use</help>

--- a/interface-definitions/dns-dynamic.xml.in
+++ b/interface-definitions/dns-dynamic.xml.in
@@ -90,6 +90,7 @@
                       #include <include/dns/dynamic-service-host-name-server.xml.i>
                       #include <include/generic-username.xml.i>
                       #include <include/generic-password.xml.i>
+                      #include <include/dns/time-to-live.xml.i>
                       <leafNode name="protocol">
                         <properties>
                           <help>ddclient protocol used for Dynamic DNS service</help>

--- a/interface-definitions/dns-forwarding.xml.in
+++ b/interface-definitions/dns-forwarding.xml.in
@@ -158,6 +158,9 @@
                             </properties>
                           </leafNode>
                           #include <include/dns/time-to-live.xml.i>
+                          <leafNode name="ttl">
+                              <defaultValue>300</defaultValue>
+                          </leafNode>
                           #include <include/generic-disable-node.xml.i>
                         </children>
                       </tagNode>
@@ -195,6 +198,9 @@
                             </properties>
                           </leafNode>
                           #include <include/dns/time-to-live.xml.i>
+                          <leafNode name="ttl">
+                              <defaultValue>300</defaultValue>
+                          </leafNode>
                           #include <include/generic-disable-node.xml.i>
                         </children>
                       </tagNode>
@@ -227,6 +233,9 @@
                             </properties>
                           </leafNode>
                           #include <include/dns/time-to-live.xml.i>
+                          <leafNode name="ttl">
+                              <defaultValue>300</defaultValue>
+                          </leafNode>
                           #include <include/generic-disable-node.xml.i>
                         </children>
                       </tagNode>
@@ -274,6 +283,9 @@
                             </children>
                           </tagNode>
                           #include <include/dns/time-to-live.xml.i>
+                          <leafNode name="ttl">
+                              <defaultValue>300</defaultValue>
+                          </leafNode>
                           #include <include/generic-disable-node.xml.i>
                         </children>
                       </tagNode>
@@ -302,6 +314,9 @@
                             </properties>
                           </leafNode>
                           #include <include/dns/time-to-live.xml.i>
+                          <leafNode name="ttl">
+                              <defaultValue>300</defaultValue>
+                          </leafNode>
                           #include <include/generic-disable-node.xml.i>
                         </children>
                       </tagNode>
@@ -334,6 +349,9 @@
                             </properties>
                           </leafNode>
                           #include <include/dns/time-to-live.xml.i>
+                          <leafNode name="ttl">
+                              <defaultValue>300</defaultValue>
+                          </leafNode>
                           #include <include/generic-disable-node.xml.i>
                         </children>
                       </tagNode>
@@ -364,6 +382,9 @@
                             </properties>
                           </leafNode>
                           #include <include/dns/time-to-live.xml.i>
+                          <leafNode name="ttl">
+                              <defaultValue>300</defaultValue>
+                          </leafNode>
                           #include <include/generic-disable-node.xml.i>
                         </children>
                       </tagNode>
@@ -393,6 +414,9 @@
                             </properties>
                           </leafNode>
                           #include <include/dns/time-to-live.xml.i>
+                          <leafNode name="ttl">
+                              <defaultValue>300</defaultValue>
+                          </leafNode>
                           #include <include/generic-disable-node.xml.i>
                         </children>
                       </tagNode>
@@ -477,6 +501,9 @@
                             </children>
                           </tagNode>
                           #include <include/dns/time-to-live.xml.i>
+                          <leafNode name="ttl">
+                              <defaultValue>300</defaultValue>
+                          </leafNode>
                           #include <include/generic-disable-node.xml.i>
                         </children>
                       </tagNode>
@@ -585,6 +612,9 @@
                             </children>
                           </tagNode>
                           #include <include/dns/time-to-live.xml.i>
+                          <leafNode name="ttl">
+                              <defaultValue>300</defaultValue>
+                          </leafNode>
                           #include <include/generic-disable-node.xml.i>
                         </children>
                       </tagNode>

--- a/interface-definitions/include/dns/dynamic-service-host-name-server.xml.i
+++ b/interface-definitions/include/dns/dynamic-service-host-name-server.xml.i
@@ -4,8 +4,9 @@
     <help>Hostname to register with Dynamic DNS service</help>
     <constraint>
         #include <include/constraint/host-name.xml.i>
+        <regex>(\@|\*)[-.A-Za-z0-9]*</regex>
     </constraint>
-    <constraintErrorMessage>Host-name must be alphanumeric and can contain hyphens</constraintErrorMessage>
+    <constraintErrorMessage>Host-name must be alphanumeric, can contain hyphens and can be prefixed with '@' or '*'</constraintErrorMessage>
     <multi/>
   </properties>
 </leafNode>

--- a/interface-definitions/include/dns/dynamic-service-zone.xml.i
+++ b/interface-definitions/include/dns/dynamic-service-zone.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from dns/dynamic-service-zone.xml.i -->
+<leafNode name="zone">
+  <properties>
+    <help>DNS zone to be updated</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>Name of DNS zone</description>
+    </valueHelp>
+    <constraint>
+      <validator name="fqdn"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/dns/time-to-live.xml.i
+++ b/interface-definitions/include/dns/time-to-live.xml.i
@@ -10,6 +10,5 @@
       <validator name="numeric" argument="--range 0-2147483647"/>
     </constraint>
   </properties>
-  <defaultValue>300</defaultValue>
 </leafNode>
 <!-- include end -->

--- a/smoketest/scripts/cli/test_service_dns_dynamic.py
+++ b/smoketest/scripts/cli/test_service_dns_dynamic.py
@@ -203,7 +203,31 @@ class TestServiceDDNS(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f'password={key_file.name}', ddclient_conf)
             self.assertIn(f'ttl={ttl}', ddclient_conf)
 
-    def test_05_dyndns_vrf(self):
+    def test_05_dyndns_hostname(self):
+        # Check if DDNS service can be configured and runs
+        svc_path = ['address', interface, 'service', 'namecheap']
+        proto = 'namecheap'
+        hostnames = ['@', 'www', hostname, f'@.{hostname}']
+
+        for name in hostnames:
+            self.cli_set(base_path + svc_path + ['protocol', proto])
+            self.cli_set(base_path + svc_path + ['server', server])
+            self.cli_set(base_path + svc_path + ['username', username])
+            self.cli_set(base_path + svc_path + ['password', password])
+            self.cli_set(base_path + svc_path + ['host-name', name])
+
+            # commit changes
+            self.cli_commit()
+
+            # Check the generating config parameters
+            ddclient_conf = cmd(f'sudo cat {DDCLIENT_CONF}')
+            self.assertIn(f'protocol={proto}', ddclient_conf)
+            self.assertIn(f'server={server}', ddclient_conf)
+            self.assertIn(f'login={username}', ddclient_conf)
+            self.assertIn(f'password={password}', ddclient_conf)
+            self.assertIn(f'{name}', ddclient_conf)
+
+    def test_06_dyndns_vrf(self):
         vrf_name = f'vyos-test-{"".join(random.choices(string.ascii_letters + string.digits, k=5))}'
         svc_path = ['address', interface, 'service', 'cloudflare']
 

--- a/smoketest/scripts/cli/test_service_dns_dynamic.py
+++ b/smoketest/scripts/cli/test_service_dns_dynamic.py
@@ -63,18 +63,29 @@ class TestServiceDDNS(VyOSUnitTestSHIM.TestCase):
             self.cli_set(base_path + ddns + [svc, 'host-name', hostname])
             self.cli_set(base_path + ddns + [svc, 'password', password])
             self.cli_set(base_path + ddns + [svc, 'zone', zone])
+            self.cli_set(base_path + ddns + [svc, 'ttl', ttl])
             for opt, value in details.items():
                 self.cli_set(base_path + ddns + [svc, opt, value])
 
-            # commit changes
+            # 'zone' option is supported and required by 'cloudfare', but not 'freedns' and 'zoneedit'
+            self.cli_set(base_path + ddns + [svc, 'zone', zone])
             if details['protocol'] == 'cloudflare':
                 pass
             else:
-                # zone option does not work on all protocols, an exception is
-                # raised for all others
+                # exception is raised for unsupported ones
                 with self.assertRaises(ConfigSessionError):
                     self.cli_commit()
-                self.cli_delete(base_path + ddns + [svc, 'zone', zone])
+                self.cli_delete(base_path + ddns + [svc, 'zone'])
+
+            # 'ttl' option is supported by 'cloudfare', but not 'freedns' and 'zoneedit'
+            self.cli_set(base_path + ddns + [svc, 'ttl', ttl])
+            if details['protocol'] == 'cloudflare':
+                pass
+            else:
+                # exception is raised for unsupported ones
+                with self.assertRaises(ConfigSessionError):
+                    self.cli_commit()
+                self.cli_delete(base_path + ddns + [svc, 'ttl'])
 
             # commit changes
             self.cli_commit()

--- a/src/completion/list_ddclient_protocols.sh
+++ b/src/completion/list_ddclient_protocols.sh
@@ -14,4 +14,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-echo -n $(ddclient -list-protocols)
+echo -n $(ddclient -list-protocols | grep  -vE 'nsupdate|cloudns')

--- a/src/conf_mode/dns_dynamic.py
+++ b/src/conf_mode/dns_dynamic.py
@@ -35,6 +35,9 @@ zone_required = ['cloudflare', 'godaddy', 'hetzner', 'gandi', 'nfsn']
 # Protocols that do not require username
 username_unnecessary = ['1984', 'cloudflare', 'cloudns', 'duckdns', 'freemyip', 'hetzner', 'keysystems', 'njalla']
 
+# Protocols that support TTL
+ttl_supported = ['cloudflare', 'gandi', 'hetzner', 'dnsexit', 'godaddy', 'nfsn']
+
 # Protocols that support both IPv4 and IPv6
 dualstack_supported = ['cloudflare', 'dyndns2', 'freedns', 'njalla']
 
@@ -96,6 +99,9 @@ def verify(dyndns):
                 if config['protocol'] not in username_unnecessary:
                     if 'username' not in config:
                         raise ConfigError(f'"username" {error_msg}')
+
+                if config['protocol'] not in ttl_supported and 'ttl' in config:
+                    raise ConfigError(f'"{config["protocol"]}" does not support "ttl"')
 
                 if config['ip_version'] == 'both':
                     if config['protocol'] not in dualstack_supported:

--- a/src/conf_mode/dns_dynamic.py
+++ b/src/conf_mode/dns_dynamic.py
@@ -30,13 +30,17 @@ config_file = r'/run/ddclient/ddclient.conf'
 systemd_override = r'/run/systemd/system/ddclient.service.d/override.conf'
 
 # Protocols that require zone
-zone_allowed = ['cloudflare', 'godaddy', 'hetzner', 'gandi', 'nfsn']
+zone_required = ['cloudflare', 'godaddy', 'hetzner', 'gandi', 'nfsn']
 
 # Protocols that do not require username
 username_unnecessary = ['1984', 'cloudflare', 'cloudns', 'duckdns', 'freemyip', 'hetzner', 'keysystems', 'njalla']
 
 # Protocols that support both IPv4 and IPv6
 dualstack_supported = ['cloudflare', 'dyndns2', 'freedns', 'njalla']
+
+# dyndns2 protocol in ddclient honors dual stack for selective servers
+# because of the way it is implemented in ddclient
+dyndns_dualstack_servers = ['members.dyndns.org', 'dynv6.com']
 
 def get_config(config=None):
     if config:
@@ -83,10 +87,10 @@ def verify(dyndns):
                     if field not in config:
                         raise ConfigError(f'"{field.replace("_", "-")}" {error_msg}')
 
-                if config['protocol'] in zone_allowed and 'zone' not in config:
+                if config['protocol'] in zone_required and 'zone' not in config:
                         raise ConfigError(f'"zone" {error_msg}')
 
-                if config['protocol'] not in zone_allowed and 'zone' in config:
+                if config['protocol'] not in zone_required and 'zone' in config:
                         raise ConfigError(f'"{config["protocol"]}" does not support "zone"')
 
                 if config['protocol'] not in username_unnecessary:
@@ -98,7 +102,7 @@ def verify(dyndns):
                         raise ConfigError(f'"{config["protocol"]}" does not support '
                                           f'both IPv4 and IPv6 at the same time')
                     # dyndns2 protocol in ddclient honors dual stack only for dyn.com (dyndns.org)
-                    if config['protocol'] == 'dyndns2' and 'server' in config and config['server'] != 'members.dyndns.org':
+                    if config['protocol'] == 'dyndns2' and 'server' in config and config['server'] not in dyndns_dualstack_servers:
                         raise ConfigError(f'"{config["protocol"]}" does not support '
                                           f'both IPv4 and IPv6 at the same time for "{config["server"]}"')
 

--- a/src/conf_mode/dns_dynamic.py
+++ b/src/conf_mode/dns_dynamic.py
@@ -30,7 +30,7 @@ config_file = r'/run/ddclient/ddclient.conf'
 systemd_override = r'/run/systemd/system/ddclient.service.d/override.conf'
 
 # Protocols that require zone
-zone_required = ['cloudflare', 'godaddy', 'hetzner', 'gandi', 'nfsn']
+zone_necessary = ['cloudflare', 'godaddy', 'hetzner', 'gandi', 'nfsn']
 
 # Protocols that do not require username
 username_unnecessary = ['1984', 'cloudflare', 'cloudns', 'duckdns', 'freemyip', 'hetzner', 'keysystems', 'njalla']
@@ -51,11 +51,11 @@ def get_config(config=None):
     else:
         conf = Config()
 
-    base_level = ['service', 'dns', 'dynamic']
-    if not conf.exists(base_level):
+    base = ['service', 'dns', 'dynamic']
+    if not conf.exists(base):
         return None
 
-    dyndns = conf.get_config_dict(base_level, key_mangling=('-', '_'),
+    dyndns = conf.get_config_dict(base, key_mangling=('-', '_'),
                                   no_tag_node_value_mangle=True,
                                   get_first_key=True,
                                   with_recursive_defaults=True)
@@ -90,15 +90,14 @@ def verify(dyndns):
                     if field not in config:
                         raise ConfigError(f'"{field.replace("_", "-")}" {error_msg}')
 
-                if config['protocol'] in zone_required and 'zone' not in config:
-                        raise ConfigError(f'"zone" {error_msg}')
+                if config['protocol'] in zone_necessary and 'zone' not in config:
+                    raise ConfigError(f'"zone" {error_msg}')
 
-                if config['protocol'] not in zone_required and 'zone' in config:
-                        raise ConfigError(f'"{config["protocol"]}" does not support "zone"')
+                if config['protocol'] not in zone_necessary and 'zone' in config:
+                    raise ConfigError(f'"{config["protocol"]}" does not support "zone"')
 
-                if config['protocol'] not in username_unnecessary:
-                    if 'username' not in config:
-                        raise ConfigError(f'"username" {error_msg}')
+                if config['protocol'] not in username_unnecessary and 'username' not in config:
+                    raise ConfigError(f'"username" {error_msg}')
 
                 if config['protocol'] not in ttl_supported and 'ttl' in config:
                     raise ConfigError(f'"{config["protocol"]}" does not support "ttl"')

--- a/src/conf_mode/dns_dynamic.py
+++ b/src/conf_mode/dns_dynamic.py
@@ -19,6 +19,7 @@ import os
 from sys import exit
 
 from vyos.config import Config
+from vyos.configverify import verify_interface_exists
 from vyos.template import render
 from vyos.utils.process import call
 from vyos import ConfigError
@@ -61,6 +62,10 @@ def verify(dyndns):
         return None
 
     for address in dyndns['address']:
+        # If dyndns address is an interface, ensure it exists
+        if address != 'web':
+            verify_interface_exists(address)
+
         # RFC2136 - configuration validation
         if 'rfc2136' in dyndns['address'][address]:
             for config in dyndns['address'][address]['rfc2136'].values():

--- a/src/validators/ddclient-protocol
+++ b/src/validators/ddclient-protocol
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-ddclient -list-protocols | grep -qw $1
+ddclient -list-protocols | grep -vE 'nsupdate|cloudns' | grep -qw $1
 
 if [ $? -gt 0 ]; then
     echo "Error: $1 is not a valid protocol, please choose from the supported list of protocols"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
- Fix VRF support for ddclient service
- Improve dual stack support for dyndns2 protocol
- Generate more reliable ddclient config
- Refactor zone configuration
- Enable TTL support for web-service based protocols
- Adjust validator and completion for ddclient
- Additional cleanup and refactoring for ddclient scripts
- Relax hostname validation for apex and wildcard entry

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5612

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dns dynamic

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set service dns dynamic address eth5 service cloudflare host-name 'dyn.example.com'
set service dns dynamic address eth5 service cloudflare ip-version 'both'
set service dns dynamic address eth5 service cloudflare password 'scrambled_string'
set service dns dynamic address eth5 service cloudflare protocol 'cloudflare'
set service dns dynamic address eth5 service cloudflare ttl '300'
set service dns dynamic address eth5 service cloudflare zone 'example.com'

set service dns dynamic address eth5 service namecheap host-name '@.example.com'
set service dns dynamic address eth5 service namecheap username 'example.com'
set service dns dynamic address eth5 service namecheap password 'scrambled_string'
set service dns dynamic address eth5 service namecheap protocol 'namecheap'

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos15:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_dns_dynamic.py 
test_01_dyndns_service_standard (__main__.TestServiceDDNS.test_01_dyndns_service_standard) ... 

"freedns" does not support "zone"


"freedns" does not support "ttl"


"zoneedit1" does not support "zone"


"zoneedit1" does not support "ttl"

ok
test_02_dyndns_service_ipv6 (__main__.TestServiceDDNS.test_02_dyndns_service_ipv6) ... ok
test_03_dyndns_service_dual_stack (__main__.TestServiceDDNS.test_03_dyndns_service_dual_stack) ... 
"googledomains" does not support both IPv4 and IPv6 at the same time

ok
test_04_dyndns_rfc2136 (__main__.TestServiceDDNS.test_04_dyndns_rfc2136) ... ok
test_05_dyndns_hostname (__main__.TestServiceDDNS.test_05_dyndns_hostname) ... ok
test_06_dyndns_vrf (__main__.TestServiceDDNS.test_06_dyndns_vrf) ... ok

----------------------------------------------------------------------
Ran 6 tests in 220.985s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
