### PR TITLE
firewall: T5614: Add support for matching on conntrack helper

### DIFF
--- a/interface-definitions/include/firewall/common-rule-inet.xml.i
+++ b/interface-definitions/include/firewall/common-rule-inet.xml.i
@@ -4,6 +4,7 @@
 #include <include/firewall/dscp.xml.i>
 #include <include/firewall/packet-options.xml.i>
 #include <include/firewall/connection-mark.xml.i>
+#include <include/firewall/conntrack-helper.xml.i>
 #include <include/firewall/nft-queue.xml.i>
 <leafNode name="disable">
   <properties>

--- a/interface-definitions/include/firewall/conntrack-helper.xml.i
+++ b/interface-definitions/include/firewall/conntrack-helper.xml.i
@@ -1,0 +1,42 @@
+<!-- include start from firewall/conntrack-helper.xml.i -->
+<leafNode name="conntrack-helper">
+  <properties>
+    <help>Match related traffic from conntrack helpers</help>
+    <completionHelp>
+      <list>ftp h323 pptp nfs sip tftp sqlnet</list>
+    </completionHelp>
+    <valueHelp>
+      <format>ftp</format>
+      <description>Related traffic from FTP helper</description>
+    </valueHelp>
+    <valueHelp>
+      <format>h323</format>
+      <description>Related traffic from H.323 helper</description>
+    </valueHelp>
+    <valueHelp>
+      <format>pptp</format>
+      <description>Related traffic from PPTP helper</description>
+    </valueHelp>
+    <valueHelp>
+      <format>nfs</format>
+      <description>Related traffic from NFS helper</description>
+    </valueHelp>
+    <valueHelp>
+      <format>sip</format>
+      <description>Related traffic from SIP helper</description>
+    </valueHelp>
+    <valueHelp>
+      <format>tftp</format>
+      <description>Related traffic from TFTP helper</description>
+    </valueHelp>
+    <valueHelp>
+      <format>sqlnet</format>
+      <description>Related traffic from SQLNet helper</description>
+    </valueHelp>
+    <constraint>
+      <regex>(ftp|h323|pptp|nfs|sip|tftp|sqlnet)</regex>
+    </constraint>
+    <multi/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -102,6 +102,20 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
         if states:
             output.append(f'ct state {{{states}}}')
 
+    if 'conntrack_helper' in rule_conf:
+        helper_map = {'h323': ['RAS', 'Q.931'], 'nfs': ['rpc'], 'sqlnet': ['tns']}
+        helper_out = []
+
+        for helper in rule_conf['conntrack_helper']:
+            if helper in helper_map:
+                helper_out.extend(helper_map[helper])
+            else:
+                helper_out.append(helper)
+
+        if helper_out:
+            helper_str = ','.join(f'"{s}"' for s in helper_out)
+            output.append(f'ct helper {{{helper_str}}}')
+
     if 'connection_status' in rule_conf and rule_conf['connection_status']:
         status = rule_conf['connection_status']
         if status['nat'] == 'destination':

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -503,12 +503,15 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['firewall', 'ipv4', 'name', name, 'rule', '2', 'state', 'invalid', 'enable'])
         self.cli_set(['firewall', 'ipv4', 'name', name, 'rule', '3', 'action', 'accept'])
         self.cli_set(['firewall', 'ipv4', 'name', name, 'rule', '3', 'state', 'new', 'enable'])
-
         self.cli_set(['firewall', 'ipv4', 'name', name, 'rule', '3', 'connection-status', 'nat', 'destination'])
         self.cli_set(['firewall', 'ipv4', 'name', name, 'rule', '4', 'action', 'accept'])
         self.cli_set(['firewall', 'ipv4', 'name', name, 'rule', '4', 'state', 'new', 'enable'])
         self.cli_set(['firewall', 'ipv4', 'name', name, 'rule', '4', 'state', 'established', 'enable'])
         self.cli_set(['firewall', 'ipv4', 'name', name, 'rule', '4', 'connection-status', 'nat', 'source'])
+        self.cli_set(['firewall', 'ipv4', 'name', name, 'rule', '5', 'action', 'accept'])
+        self.cli_set(['firewall', 'ipv4', 'name', name, 'rule', '5', 'state', 'related', 'enable'])
+        self.cli_set(['firewall', 'ipv4', 'name', name, 'rule', '5', 'conntrack-helper', 'ftp'])
+        self.cli_set(['firewall', 'ipv4', 'name', name, 'rule', '5', 'conntrack-helper', 'pptp'])
 
         self.cli_commit()
 
@@ -517,6 +520,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['ct state invalid', 'reject'],
             ['ct state new', 'ct status dnat', 'accept'],
             ['ct state { established, new }', 'ct status snat', 'accept'],
+            ['ct state related', 'ct helper { "ftp", "pptp" }', 'accept'],
             ['drop', f'comment "{name} default-action drop"']
         ]
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add firewall rule syntax `conntrack-helper [ftp|pptp|nfs...]` to add ability to secure conntrack helpers

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5614

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_firewall.py
DEBUG - test_bridge_basic_rules (__main__.TestFirewall.test_bridge_basic_rules) ... ok
DEBUG - test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
DEBUG - test_geoip (__main__.TestFirewall.test_geoip) ... ok
DEBUG - test_groups (__main__.TestFirewall.test_groups) ... ok
DEBUG - test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
DEBUG - test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
DEBUG - test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
DEBUG - test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
DEBUG - test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
DEBUG - test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
DEBUG - test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
DEBUG - test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
DEBUG - test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
DEBUG - test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 14 tests in 58.911s
DEBUG -
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
