### PR TITLE
rpki: T2044: add to daemons Jinja2 template

### DIFF
--- a/data/templates/frr/daemons.frr.tmpl
+++ b/data/templates/frr/daemons.frr.tmpl
@@ -1,4 +1,26 @@
-zebra=yes
+#
+# The watchfrr, zebra, mgmtd and staticd daemons are always started.
+#
+# Note: The following FRR-services must be kept disabled because they are replaced by other packages in VyOS:
+#
+# pimd   Replaced by package igmpproxy.
+# nhrpd  Replaced by package opennhrp.
+# pbrd   Replaced by PBR in nftables.
+# vrrpd  Replaced by package keepalived.
+#
+# And these must be disabled aswell since they are currently missing a VyOS CLI:
+#
+# eigrp
+# sharpd
+# fabricd
+# pathd
+#
+# The zebra, mgmtd and staticd daemons are always started and can not be disabled
+#
+#zebra=yes
+#mgmtd=yes
+#staticd=yes
+
 bgpd=yes
 ospfd=yes
 ospf6d=yes
@@ -6,6 +28,7 @@ ripd=yes
 ripngd=yes
 isisd=yes
 pimd=no
+pim6d=no
 ldpd=yes
 nhrpd=no
 eigrpd=no
@@ -13,42 +36,79 @@ babeld=yes
 sharpd=no
 pbrd=no
 bfdd=yes
-staticd=yes
+fabricd=no
+vrrpd=no
+pathd=no
+
+#
+# Define defaults for all services even those who shall be kept disabled.
+#
+
+zebra_options="  --daemon -A 127.0.0.1 -s 90000000{{ ' -M snmp' if snmp.zebra is vyos_defined }}{{ ' -M irdp' if irdp is vyos_defined }}"
+mgmtd_options="  --daemon -A 127.0.0.1"
+staticd_options="--daemon -A 127.0.0.1"
+bgpd_options="   --daemon -A 127.0.0.1 -M rpki{{ ' -M snmp' if snmp.bgpd is vyos_defined }}{{ ' -M bmp' if bmp is vyos_defined }}"
+ospfd_options="  --daemon -A 127.0.0.1{{ ' -M snmp' if snmp.ospfd is vyos_defined }}"
+ospf6d_options=" --daemon -A ::1{{ ' -M snmp' if snmp.ospf6d is vyos_defined }}"
+ripd_options="   --daemon -A 127.0.0.1{{ ' -M snmp' if snmp.ripd is vyos_defined }}"
+ripngd_options=" --daemon -A ::1"
+isisd_options="  --daemon -A 127.0.0.1{{ ' -M snmp' if snmp.isisd is vyos_defined }}"
+pimd_options="   --daemon -A 127.0.0.1"
+pim6d_options="  --daemon -A ::1"
+ldpd_options="   --daemon -A 127.0.0.1{{ ' -M snmp' if snmp.ldpd is vyos_defined }}"
+nhrpd_options="  --daemon -A 127.0.0.1"
+eigrpd_options=" --daemon -A 127.0.0.1"
+babeld_options=" --daemon -A 127.0.0.1"
+sharpd_options=" --daemon -A 127.0.0.1"
+pbrd_options="   --daemon -A 127.0.0.1"
+bfdd_options="   --daemon -A 127.0.0.1"
+fabricd_options="--daemon -A 127.0.0.1"
+vrrpd_options="  --daemon -A 127.0.0.1"
+pathd_options="  --daemon -A 127.0.0.1"
+
+#frr_global_options=""
+
+#zebra_wrap=""
+#mgmtd_wrap=""
+#staticd_wrap=""
+#bgpd_wrap=""
+#ospfd_wrap=""
+#ospf6d_wrap=""
+#ripd_wrap=""
+#ripngd_wrap=""
+#isisd_wrap=""
+#pimd_wrap=""
+#pim6d_wrap=""
+#ldpd_wrap=""
+#nhrpd_wrap=""
+#eigrpd_wrap=""
+#babeld_wrap=""
+#sharpd_wrap=""
+#pbrd_wrap=""
+#bfdd_wrap=""
+#fabricd_wrap=""
+#vrrpd_wrap=""
+#pathd_wrap=""
+
+#all_wrap=""
+
+#
+# Other options.
+#
+# For more information see:
+# https://github.com/FRRouting/frr/blob/stable/9.0/tools/etc/frr/daemons
+# https://docs.frrouting.org/en/stable-9.0/setup.html
+#
 
 vtysh_enable=yes
-zebra_options="  -s 90000000 --daemon -A 127.0.0.1
-{%- if irdp is defined %} -M irdp{% endif -%}
-{%- if snmp is defined and snmp.zebra is defined %} -M snmp{% endif -%}
-"
-bgpd_options="   --daemon -A 127.0.0.1
-{%- if bmp is defined %} -M bmp{% endif -%}
-{%- if snmp is defined and snmp.bgpd is defined %} -M snmp{% endif -%}
-"
-ospfd_options="  --daemon -A 127.0.0.1
-{%- if snmp is defined and snmp.ospfd is defined %} -M snmp{% endif -%}
-"
-ospf6d_options=" --daemon -A ::1
-{%- if snmp is defined and snmp.ospf6d is defined %} -M snmp{% endif -%}
-"
-ripd_options="   --daemon -A 127.0.0.1
-{%- if snmp is defined and snmp.ripd is defined %} -M snmp{% endif -%}
-"
-ripngd_options=" --daemon -A ::1"
-isisd_options="  --daemon -A 127.0.0.1
-{%- if snmp is defined and snmp.isisd is defined %} -M snmp{% endif -%}
-"
-pimd_options="  --daemon -A 127.0.0.1"
-ldpd_options="  --daemon -A 127.0.0.1
-{%- if snmp is defined and snmp.ldpd is defined %} -M snmp{% endif -%}
-"
-mgmtd_options=" --daemon -A 127.0.0.1"
-nhrpd_options="  --daemon -A 127.0.0.1"
-eigrpd_options="  --daemon -A 127.0.0.1"
-babeld_options="  --daemon -A 127.0.0.1"
-sharpd_options="  --daemon -A 127.0.0.1"
-pbrd_options="  --daemon -A 127.0.0.1"
-staticd_options="  --daemon -A 127.0.0.1"
-bfdd_options="  --daemon -A 127.0.0.1"
-
 watchfrr_enable=no
 valgrind_enable=no
+
+#watchfrr_options=""
+
+frr_profile="traditional"
+
+#MAX_FDS=1024
+
+#FRR_NO_ROOT="yes"
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This is a combined backport of commits:

* a4aad1120 - frr: T5591: hint about daemons that always run and can't be disabled
* d9d2b2b96 - frr: T5591: cleanup of daemons file
* 40503a9d7 - T2044: RPKI doesn't boot properly

After moving solely to the rendered FRR daemons configuration BGP was no longer able to process RPKI statements.
This is/was due to initial lack of RPKI support in the rendered daemons configuration. This has been fixed by above commits.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5591
* https://vyos.dev/T2044

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```bash
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_rpki.py ; /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_rpki (__main__.TestProtocolsRPKI.test_rpki) ... ok
test_rpki_ssh (__main__.TestProtocolsRPKI.test_rpki_ssh) ... skipped 'Currently untested, see: https://github.com/FRRouting/frr/issues/7978'
test_rpki_verify_preference (__main__.TestProtocolsRPKI.test_rpki_verify_preference) ... ok

----------------------------------------------------------------------
Ran 3 tests in 5.083s

OK (skipped=1)
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ... ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ... ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ... ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ... ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ... ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ... ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ... ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ... ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ... ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ... ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok

----------------------------------------------------------------------
Ran 22 tests in 121.966s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
