### PR TITLE
T5616: firewall and policy: add option to be able to match firewall marks

### DIFF
--- a/interface-definitions/include/firewall/common-rule-inet.xml.i
+++ b/interface-definitions/include/firewall/common-rule-inet.xml.i
@@ -3,6 +3,7 @@
 #include <include/generic-description.xml.i>
 #include <include/firewall/dscp.xml.i>
 #include <include/firewall/packet-options.xml.i>
+#include <include/firewall/firewall-mark.xml.i>
 #include <include/firewall/connection-mark.xml.i>
 #include <include/firewall/conntrack-helper.xml.i>
 #include <include/firewall/nft-queue.xml.i>

--- a/interface-definitions/include/firewall/firewall-mark.xml.i
+++ b/interface-definitions/include/firewall/firewall-mark.xml.i
@@ -1,0 +1,26 @@
+<!-- include start from firewall/firewall-mark.xml.i -->
+<leafNode name="mark">
+  <properties>
+    <help>Firewall mark</help>
+    <valueHelp>
+      <format>u32:0-2147483647</format>
+      <description>Firewall mark to match</description>
+    </valueHelp>
+    <valueHelp>
+      <format>!u32:0-2147483647</format>
+      <description>Inverted Firewall mark to match</description>
+    </valueHelp>
+    <valueHelp>
+      <format>&lt;start-end&gt;</format>
+      <description>Firewall mark range to match</description>
+    </valueHelp>
+    <valueHelp>
+      <format>!&lt;start-end&gt;</format>
+      <description>Firewall mark inverted range to match</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric-exclude" argument="--allow-range --range 0-2147483647"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/policy/route-common.xml.i
+++ b/interface-definitions/include/policy/route-common.xml.i
@@ -1,6 +1,7 @@
 <!-- include start from policy/route-common.xml.i -->
 #include <include/policy/route-rule-action.xml.i>
 #include <include/generic-description.xml.i>
+#include <include/firewall/firewall-mark.xml.i>
 <leafNode name="disable">
   <properties>
     <help>Option to disable firewall rule</help>

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -381,6 +381,14 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
         conn_mark_str = ','.join(rule_conf['connection_mark'])
         output.append(f'ct mark {{{conn_mark_str}}}')
 
+    if 'mark' in rule_conf:
+        mark = rule_conf['mark']
+        operator = ''
+        if mark[0] == '!':
+            operator = '!='
+            mark = mark[1:]
+        output.append(f'meta mark {operator} {{{mark}}}')
+
     if 'vlan' in rule_conf:
         if 'id' in rule_conf['vlan']:
             output.append(f'vlan id {rule_conf["vlan"]["id"]}')

--- a/src/validators/numeric-exclude
+++ b/src/validators/numeric-exclude
@@ -1,0 +1,8 @@
+#!/bin/sh
+path=$(dirname "$0")
+num="${@: -1}"
+if [ "${num:0:1}" != "!" ]; then
+   ${path}/numeric $@
+else
+    ${path}/numeric ${@:1:$#-1} ${num:1}
+fi


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add options for matching firewall mark in firewall filter and in policy route

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5616

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
policy

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```

vyos@fwall-mark# run show config comm | grep mark
set firewall ipv4 name FOO rule 10 mark '7'
set firewall ipv4 name FOO rule 20 mark '500-900'
set firewall ipv4 name FOO rule 30 mark '!666'
set firewall ipv4 name FOO rule 40 mark '!100-200'
set firewall ipv6 name FOO6 rule 10 mark '7'
set firewall ipv6 name FOO6 rule 20 mark '500-900'
set firewall ipv6 name FOO6 rule 30 mark '!666'
set firewall ipv6 name FOO6 rule 40 mark '!100-200'
set policy route BAR rule 10 mark '55'
set policy route BAR rule 20 mark '99-210'
set policy route BAR rule 30 mark '!846874'
set policy route BAR rule 40 mark '!5001-16000'
set policy route6 BAR6 rule 10 mark '55'
set policy route6 BAR6 rule 20 mark '99-210'
set policy route6 BAR6 rule 30 mark '!846874'
set policy route6 BAR6 rule 40 mark '!5001-16000'
set system host-name 'fwall-mark'
[edit]
vyos@fwall-mark# 
[edit]
vyos@fwall-mark# sudo nft -s list chain ip vyos_filter NAME_FOO | grep mark
                meta mark 0x00000007 counter accept comment "ipv4-NAM-FOO-10"
                meta mark 0x000001f4-0x00000384 counter accept comment "ipv4-NAM-FOO-20"
                meta mark != 0x0000029a counter accept comment "ipv4-NAM-FOO-30"
                meta mark != 0x00000064-0x000000c8 counter accept comment "ipv4-NAM-FOO-40"
[edit]
vyos@fwall-mark# sudo nft -s list chain ip6 vyos_filter NAME6_FOO6 | grep mark
                meta mark 0x00000007 counter accept comment "ipv6-NAM-FOO6-10"
                meta mark 0x000001f4-0x00000384 counter accept comment "ipv6-NAM-FOO6-20"
                meta mark != 0x0000029a counter accept comment "ipv6-NAM-FOO6-30"
                meta mark != 0x00000064-0x000000c8 counter accept comment "ipv6-NAM-FOO6-40"



vyos@fwall-mark# sudo nft -s list chain ip vyos_mangle VYOS_PBR_UD_BAR | grep mark
                meta mark 0x00000037 counter accept comment "ipv4-route-BAR-10"
                meta mark 0x00000063-0x000000d2 counter accept comment "ipv4-route-BAR-20"
                meta mark != 0x000cec1a counter accept comment "ipv4-route-BAR-30"
                meta mark != 0x00001389-0x00003e80 counter accept comment "ipv4-route-BAR-40"
[edit]
vyos@fwall-mark# 
vyos@fwall-mark# sudo nft -s list chain ip6 vyos_mangle VYOS_PBR6_UD_BAR6 | grep mark
                meta mark 0x00000037 counter accept comment "ipv6-route6-BAR6-10"
                meta mark 0x00000063-0x000000d2 counter accept comment "ipv6-route6-BAR6-20"
                meta mark != 0x000cec1a counter accept comment "ipv6-route6-BAR6-30"
                meta mark != 0x00001389-0x00003e80 counter accept comment "ipv6-route6-BAR6-40"
[edit]
vyos@fwall-mark# 
```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@fwall-mark:/usr/libexec/vyos/tests/smoke/cli# ./test_firewall.py 
test_bridge_basic_rules (__main__.TestFirewall.test_bridge_basic_rules) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
test_geoip (__main__.TestFirewall.test_geoip) ... ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok

----------------------------------------------------------------------
Ran 14 tests in 41.148s

OK
root@fwall-mark:/usr/libexec/vyos/tests/smoke/cli# 
root@fwall-mark:/usr/libexec/vyos/tests/smoke/cli# ./test_policy_route.py 
test_pbr_group (__main__.TestPolicyRoute.test_pbr_group) ... ok
test_pbr_mark (__main__.TestPolicyRoute.test_pbr_mark) ... ok
test_pbr_mark_connection (__main__.TestPolicyRoute.test_pbr_mark_connection) ... ok
test_pbr_matching_criteria (__main__.TestPolicyRoute.test_pbr_matching_criteria) ... ok
test_pbr_table (__main__.TestPolicyRoute.test_pbr_table) ... ok

----------------------------------------------------------------------
Ran 5 tests in 15.446s

OK
root@fwall-mark:/usr/libexec/vyos/tests/smoke/cli# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
