### PR TITLE
firewall: T5217: Synproxy bugfix and ct state conflict checking

### DIFF
--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -263,9 +263,8 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
 
                     output.append(f'{proto} {prefix}port {operator} @P_{group_name}')
 
-    if rule_conf['action'] == 'synproxy':
-        if 'synproxy' in rule_conf:
-            output.append('ct state invalid,untracked')
+    if dict_search_args(rule_conf, 'action') == 'synproxy':
+        output.append('ct state invalid,untracked')
 
     if 'hop_limit' in rule_conf:
         operators = {'eq': '==', 'gt': '>', 'lt': '<'}

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -176,6 +176,8 @@ def verify_rule(firewall, rule_conf, ipv6):
     if rule_conf['action'] != 'synproxy' and 'synproxy' in rule_conf:
         raise ConfigError('"synproxy" option allowed only for action synproxy')
     if rule_conf['action'] == 'synproxy':
+        if 'state' in rule_conf:
+            raise ConfigError('For action "synproxy" state cannot be defined')
         if not rule_conf.get('synproxy', {}).get('tcp'):
             raise ConfigError('synproxy TCP MSS is not defined')
         if rule_conf.get('protocol', {}) != 'tcp':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
- Fix synproxy bug in rule parsing
- Add verify check for a conflicting `state` node when synproxy action is set

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5217

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_firewall.py
DEBUG - test_bridge_basic_rules (__main__.TestFirewall.test_bridge_basic_rules) ... ok
DEBUG - test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
DEBUG - test_geoip (__main__.TestFirewall.test_geoip) ... ok
DEBUG - test_groups (__main__.TestFirewall.test_groups) ... ok
DEBUG - test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
DEBUG - test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
DEBUG - test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
DEBUG - test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
DEBUG - test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... ok
DEBUG - test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
DEBUG - test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
DEBUG - test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
DEBUG - test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
DEBUG - test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
DEBUG - test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 15 tests in 60.032s
DEBUG -
DEBUG - OK
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_policy_route.py
DEBUG - test_pbr_group (__main__.TestPolicyRoute.test_pbr_group) ... ok
DEBUG - test_pbr_mark (__main__.TestPolicyRoute.test_pbr_mark) ... ok
DEBUG - test_pbr_mark_connection (__main__.TestPolicyRoute.test_pbr_mark_connection) ... ok
DEBUG - test_pbr_matching_criteria (__main__.TestPolicyRoute.test_pbr_matching_criteria) ... ok
DEBUG - test_pbr_table (__main__.TestPolicyRoute.test_pbr_table) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 5 tests in 23.185s
DEBUG -
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
