### PR TITLE
T5497: Add ability to resequence rule numbers for firewall

### DIFF
--- a/src/op_mode/generate_firewall_rule-resequence.py
+++ b/src/op_mode/generate_firewall_rule-resequence.py
@@ -120,13 +120,13 @@ if __name__ == "__main__":
 
     # Remove global-options, group and flowtable as they don't need sequencing
     if 'global-options' in config_dict['firewall']:
-      del config_dict['firewall']['global-options']
+        del config_dict['firewall']['global-options']
 
     if 'group' in config_dict['firewall']:
-      del config_dict['firewall']['group']
+        del config_dict['firewall']['group']
 
     if 'flowtable' in config_dict['firewall']:
-      del config_dict['firewall']['flowtable']
+        del config_dict['firewall']['flowtable']
     
     # Convert rule keys to integers, rule "10" -> rule 10
     # This is necessary for sorting the rules

--- a/src/op_mode/generate_firewall_rule-resequence.py
+++ b/src/op_mode/generate_firewall_rule-resequence.py
@@ -116,9 +116,18 @@ if __name__ == "__main__":
         print('Firewall is not configured')
         exit(1)
 
-    #config_dict =  config.get_config_dict('firewall')
     config_dict = config.get_config_dict('firewall')
 
+    # Remove global-options, group and flowtable as they don't need sequencing
+    if 'global-options' in config_dict['firewall']:
+      del config_dict['firewall']['global-options']
+
+    if 'group' in config_dict['firewall']:
+      del config_dict['firewall']['group']
+
+    if 'flowtable' in config_dict['firewall']:
+      del config_dict['firewall']['flowtable']
+    
     # Convert rule keys to integers, rule "10" -> rule 10
     # This is necessary for sorting the rules
     config_dict = convert_rule_keys_to_int(config_dict)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
The first draft of the rule generator would sometimes output lines from nodes that did not need re-sequencing (such as set firewall group). This change removes global-options, group and flowtable before getting sent to the re-sequencing function.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5497

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
generate firewall rule-resequence

## Proposed changes
<!--- Describe your changes in detail -->
This change removes global-options, group and flowtable before getting sent to the re-sequencing function.

## How to test
Example of configuration that triggered the bug:  
https://vyos.dev/T5497#160905

The proposed change fixes that. 
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
