### PR TITLE
conntrack: T5376: Fix conntrack-sync vyos.configdep issues

### DIFF
--- a/data/config-mode-dependencies/vyos-1x.json
+++ b/data/config-mode-dependencies/vyos-1x.json
@@ -1,10 +1,23 @@
 {
   "conntrack": {"conntrack_sync": ["conntrack_sync"]},
-  "firewall": {"conntrack": ["conntrack"], "group_resync": ["conntrack", "nat", "policy-route"]},
+  "firewall": {
+                "conntrack": ["conntrack"],
+                "conntrack_sync": ["conntrack_sync"],
+                "group_resync": ["conntrack", "nat", "policy-route"]
+              },
   "http_api": {"https": ["https"]},
-  "load_balancing_wan": {"conntrack": ["conntrack"]},
-  "nat": {"conntrack": ["conntrack"]},
-  "nat66": {"conntrack": ["conntrack"]},
+  "load_balancing_wan": {
+                          "conntrack": ["conntrack"],
+                          "conntrack_sync": ["conntrack_sync"]
+                        },
+  "nat": {
+           "conntrack": ["conntrack"],
+           "conntrack_sync": ["conntrack_sync"]
+         },
+  "nat66": {
+             "conntrack": ["conntrack"],
+             "conntrack_sync": ["conntrack_sync"]
+           },
   "pki": {
            "ethernet": ["interfaces-ethernet"],
            "openvpn": ["interfaces-openvpn"],

--- a/src/conf_mode/conntrack.py
+++ b/src/conf_mode/conntrack.py
@@ -212,7 +212,12 @@ def apply(conntrack):
         module_str = ' '.join(rm_modules)
         cmd(f'rmmod {module_str}')
 
-    call_dependents()
+    try:
+        call_dependents()
+    except ConfigError:
+        # Ignore config errors on dependent due to being called too early. Example:
+        # ConfigError("ConfigError('Interface ethN requires an IP address!')")
+        pass
 
     # We silently ignore all errors
     # See: https://bugzilla.redhat.com/show_bug.cgi?id=1264080


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
- Fixes `KeyError` when conntrack-sync is called via `vyos.configdep` on other conf scripts
- Ignore errors from conntrack-sync being called too early from a dependent

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5376

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall, conntrack

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
DEBUG - vyos@vyos:~$ echo EXITCODE:$?
DEBUG - echo EXITCODE:$?
DEBUG - EXITCODE:0
 INFO - Configtest finished successfully!
 INFO - Powering off system
DEBUG - vyos@vyos:~$ poweroff now
 INFO - Shutting down virtual machine
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
