### PR TITLE
login: T5628: fix spwd deprecation warning

### DIFF
--- a/src/op_mode/show_users.py
+++ b/src/op_mode/show_users.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019 VyOS maintainers and contributors
+# Copyright (C) 2019-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import argparse
 import pwd
-import spwd
 import struct
 import sys
 from time import ctime
@@ -48,6 +47,10 @@ def is_locked(user_name: str) -> bool:
     """Check if a given user has password in shadow db"""
 
     try:
+        import warnings
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",category=DeprecationWarning)
+            import spwd
         encrypted_password = spwd.getspnam(user_name)[1]
         return encrypted_password == '*' or encrypted_password.startswith('!')
     except (KeyError, PermissionError):


### PR DESCRIPTION
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add code to ignore deprecation warning. We will stick with Debian 12 and Python 3.11 for a while.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5628

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
op-mode login

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

### Before
```
vyos@vyos:~$ show system login users
/usr/libexec/vyos/op_mode/show_users.py:18: DeprecationWarning: 'spwd' is deprecated and slated for removal in Python 3.13
  import spwd
Username    Type    Locked    Tty    From           Last login
----------  ------  --------  -----  -------------  ------------------------
vyos        vyos    False     pts/0  172.16.33.139  Mon Oct  2 20:42:24 2023
```

### After
```
vyos@vyos:~$ show system login users
Username    Type    Locked    Tty    From           Last login
----------  ------  --------  -----  -------------  ------------------------
vyos        vyos    False     pts/0  172.16.33.139  Mon Oct  2 20:42:24 2023
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
