### PR TITLE
T5213: Add accounting-interim-interval option for PPPoE-server

### DIFF
--- a/data/templates/accel-ppp/config_chap_secrets_radius.j2
+++ b/data/templates/accel-ppp/config_chap_secrets_radius.j2
@@ -7,6 +7,9 @@ verbose=1
 {%   for server, options in authentication.radius.server.items() if not options.disable is defined %}
 server={{ server }},{{ options.key }},auth-port={{ options.port }},acct-port={{ options.acct_port }},req-limit=0,fail-time={{ options.fail_time }}
 {%   endfor %}
+{%     if authentication.radius.accounting_interim_interval is defined and authentication.radius.accounting_interim_interval is not none %}
+acct-interim-interval={{ authentication.radius.accounting_interim_interval }}
+{%     endif %}
 {%   if authentication.radius.acct_interim_jitter is defined and authentication.radius.acct_interim_jitter is not none %}
 acct-interim-jitter={{ authentication.radius.acct_interim_jitter }}
 {%   endif %}

--- a/interface-definitions/include/accel-ppp/radius-additions.xml.i
+++ b/interface-definitions/include/accel-ppp/radius-additions.xml.i
@@ -1,6 +1,19 @@
 <!-- include start from accel-ppp/radius-additions.xml.i -->
 <node name="radius">
   <children>
+    <leafNode name="accounting-interim-interval">
+      <properties>
+        <help>Interval in seconds to send accounting information</help>
+        <valueHelp>
+          <format>u32:1-3600</format>
+          <description>Interval in seconds to send accounting information</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-3600"/>
+        </constraint>
+        <constraintErrorMessage>Interval value must be between 1 and 3600 seconds</constraintErrorMessage>
+      </properties>
+    </leafNode>
     <leafNode name="acct-interim-jitter">
       <properties>
         <help>Maximum jitter value in seconds to be applied to accounting information interval</help>


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add accounting-interim-interval option for PPPoE-server
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5213

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service pppoe-server access-concentrator 'ACN'
set service pppoe-server authentication mode 'radius'
set service pppoe-server authentication radius accounting-interim-interval '60'
set service pppoe-server authentication radius server 203.0.113.1 key 'vyos-secret'
set service pppoe-server client-ip-pool start '100.64.222.10'
set service pppoe-server client-ip-pool stop '100.64.222.200'
set service pppoe-server gateway-address '100.64.222.1'
set service pppoe-server interface eth2

```
ppppoe.conf
```
vyos@r1# cat /run/accel-pppd/pppoe.conf | grep "\[radius" -A 3
[radius]
verbose=1
server=203.0.113.1,vyos-secret,auth-port=1812,acct-port=1813,req-limit=0,fail-time=0
acct-interim-interval=60

```

## Smoketest result
```
vyos@r1:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py
test_accel_local_authentication (__main__.TestServicePPPoEServer) ... ok
test_accel_name_servers (__main__.TestServicePPPoEServer) ... ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer) ... ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer) ... ok
test_pppoe_server_client_ip_pool (__main__.TestServicePPPoEServer) ... ok
test_pppoe_server_client_ip_pool_name (__main__.TestServicePPPoEServer) ... ok
test_pppoe_server_client_ipv6_pool (__main__.TestServicePPPoEServer) ... ok
test_pppoe_server_ppp_options (__main__.TestServicePPPoEServer) ... ok

----------------------------------------------------------------------
Ran 8 tests in 40.540s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
