### PR TITLE
login: T5521: do not call system-login.py in vyos-router init

### DIFF
--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -234,6 +234,27 @@ cleanup_post_commit_hooks () {
 # system defaults.
 security_reset ()
 {
+
+    # restore NSS cofniguration back to sane system defaults
+    # will be overwritten later when configuration is loaded
+    cat <<EOF >/etc/nsswitch.conf
+passwd:         files
+group:          files
+shadow:         files
+gshadow:        files
+
+# Per T2678, commenting out myhostname
+hosts:          files dns #myhostname
+networks:       files
+
+protocols:      db files
+services:       db files
+ethers:         db files
+rpc:            db files
+
+netgroup:       nis
+EOF
+
     # restore PAM back to virgin state (no radius/tacacs services)
     pam-auth-update --disable radius-mandatory radius-optional
     rm -f /etc/pam_radius_auth.conf
@@ -349,7 +370,6 @@ start ()
     # As VyOS does not execute commands that are not present in the CLI we call
     # the script by hand to have a single source for the login banner and MOTD
     ${vyos_conf_scripts_dir}/system_console.py || log_failure_msg "could not reset serial console"
-    ${vyos_conf_scripts_dir}/system-login.py || log_failure_msg "could not reset system login"
     ${vyos_conf_scripts_dir}/system-login-banner.py || log_failure_msg "could not reset motd and issue files"
     ${vyos_conf_scripts_dir}/system-option.py || log_failure_msg "could not reset system option files"
     ${vyos_conf_scripts_dir}/system-ip.py || log_failure_msg "could not reset system IPv4 options"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Calling system-login.py with no mounted VyOS config has the negative effect that the script will not detect any local useraccounts and thus assumes they all need to be removed from the password backend.

As soon as the VyOS configuration is mounted and the CLI content is processed, system-login.py get's invoked and re-creates the before deleted user accounts. As the account names are sorted in alphabetical order, the name <-> UID mapping can get mixed up during system reboot.

The intention behind calling system-login.py from vyos-router init was to reset system services (PAM, NSS) back to sane defaults with the defaults provided via system-login.py. As PAM is already reset in vyos-router startup script, /etc/nsswitch.conf was the only candidate left.

This is now accomplished by simply creating a standard NSS configuration file tailored for local system accounts.

This is the second revision after the first change via commit 64d32329958 ("login: T5521: home directory owner changed during reboot") got reverted.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5521

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

ISO build `make test` and `make testc` completed without any errors

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```bash
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_login.py
test_add_linux_system_user (__main__.TestSystemLogin.test_add_linux_system_user) ... ok
test_radius_kernel_features (__main__.TestSystemLogin.test_radius_kernel_features) ... ok
test_system_login_max_login_session (__main__.TestSystemLogin.test_system_login_max_login_session) ... ok
test_system_login_otp (__main__.TestSystemLogin.test_system_login_otp) ... ok
test_system_login_radius_ipv4 (__main__.TestSystemLogin.test_system_login_radius_ipv4) ... ok
test_system_login_radius_ipv6 (__main__.TestSystemLogin.test_system_login_radius_ipv6) ... ok
test_system_login_tacacs (__main__.TestSystemLogin.test_system_login_tacacs) ... ok
test_system_login_user (__main__.TestSystemLogin.test_system_login_user) ... ok
test_system_user_ssh_key (__main__.TestSystemLogin.test_system_user_ssh_key) ... ok

----------------------------------------------------------------------
Ran 9 tests in 341.180s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
