### PR TITLE
T5165: Implement policy local-route source and destination port

### DIFF
--- a/interface-definitions/policy-local-route.xml.in
+++ b/interface-definitions/policy-local-route.xml.in
@@ -60,6 +60,7 @@
                 </properties>
                 <children>
                   #include <include/policy/local-route_rule_ipv4_address.xml.i>
+                  #include <include/port-number.xml.i>
                 </children>
               </node>
               <node name="destination">
@@ -68,6 +69,7 @@
                 </properties>
                 <children>
                   #include <include/policy/local-route_rule_ipv4_address.xml.i>
+                  #include <include/port-number.xml.i>
                 </children>
               </node>
               #include <include/interface/inbound-interface.xml.i>
@@ -125,12 +127,14 @@
                   </constraint>
                 </properties>
               </leafNode>
+              #include <include/policy/local-route_rule_protocol.xml.i>
               <node name="source">
                 <properties>
                   <help>Source parameters</help>
                 </properties>
                 <children>
                   #include <include/policy/local-route_rule_ipv6_address.xml.i>
+                  #include <include/port-number.xml.i>
                 </children>
               </node>
               <node name="destination">
@@ -139,6 +143,7 @@
                 </properties>
                 <children>
                   #include <include/policy/local-route_rule_ipv6_address.xml.i>
+                  #include <include/port-number.xml.i>
                 </children>
               </node>
               #include <include/interface/inbound-interface.xml.i>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add `policy local-route` source and destination port
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5165

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->
policy, local-route
## How to test
VyOS configuration:
```
set policy local-route rule 23 destination port '222'
set policy local-route rule 23 protocol 'tcp'
set policy local-route rule 23 set table '123'
set policy local-route rule 23 source port '8888'
```
Check:
```
vyos@r4# ip rule show prio 23
23:	from all ipproto tcp sport 8888 dport 222 lookup 123
[edit]
vyos@r4# 
```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_policy.py
test_access_list (__main__.TestPolicy.test_access_list) ... ok
test_access_list6 (__main__.TestPolicy.test_access_list6) ... ok
test_as_path_list (__main__.TestPolicy.test_as_path_list) ... ok
test_community_list (__main__.TestPolicy.test_community_list) ... ok
test_delete_ipv4_ipv6_table_id (__main__.TestPolicy.test_delete_ipv4_ipv6_table_id) ... ok
test_destination_ipv6_table_id (__main__.TestPolicy.test_destination_ipv6_table_id) ... ok
test_destination_table_id (__main__.TestPolicy.test_destination_table_id) ... ok
test_extended_community_list (__main__.TestPolicy.test_extended_community_list) ... ok
test_fwmark_ipv6_table_id (__main__.TestPolicy.test_fwmark_ipv6_table_id) ... ok
test_fwmark_sources_destination_ipv6_table_id (__main__.TestPolicy.test_fwmark_sources_destination_ipv6_table_id) ... ok
test_fwmark_sources_destination_table_id (__main__.TestPolicy.test_fwmark_sources_destination_table_id) ... ok
test_fwmark_sources_ipv6_table_id (__main__.TestPolicy.test_fwmark_sources_ipv6_table_id) ... ok
test_fwmark_sources_table_id (__main__.TestPolicy.test_fwmark_sources_table_id) ... ok
test_fwmark_table_id (__main__.TestPolicy.test_fwmark_table_id) ... ok
test_iif_sources_ipv6_table_id (__main__.TestPolicy.test_iif_sources_ipv6_table_id) ... ok
test_iif_sources_table_id (__main__.TestPolicy.test_iif_sources_table_id) ... ok
test_ipv6_table_id (__main__.TestPolicy.test_ipv6_table_id) ... ok
test_large_community_list (__main__.TestPolicy.test_large_community_list) ... ok
test_multiple_commit_ipv4_table_id (__main__.TestPolicy.test_multiple_commit_ipv4_table_id) ... ok
test_prefix_list (__main__.TestPolicy.test_prefix_list) ... ok
test_prefix_list6 (__main__.TestPolicy.test_prefix_list6) ... ok
test_prefix_list_duplicates (__main__.TestPolicy.test_prefix_list_duplicates) ... ok
test_protocol_destination_table_id (__main__.TestPolicy.test_protocol_destination_table_id) ... ok
test_protocol_port_address_fwmark_table_id (__main__.TestPolicy.test_protocol_port_address_fwmark_table_id) ... ok
test_route_map (__main__.TestPolicy.test_route_map) ... ok
test_route_map_community_set (__main__.TestPolicy.test_route_map_community_set) ... ok
test_table_id (__main__.TestPolicy.test_table_id) ... ok

----------------------------------------------------------------------
Ran 27 tests in 157.675s

OK
vyos@r4:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
