### PR TITLE
pppoe: T5630: allow to specify MRU in addition to already configurable MTU (backport #2335)

### DIFF
--- a/data/templates/pppoe/peer.tmpl
+++ b/data/templates/pppoe/peer.tmpl
@@ -50,7 +50,7 @@ ifname {{ ifname }}
 ipparam {{ ifname }}
 debug
 mtu {{ mtu }}
-mru {{ mtu }}
+mru {{ mru }}
 
 {% if authentication is defined %}
 {{ 'user "' + authentication.user + '"' if authentication.user is defined }}

--- a/interface-definitions/interfaces-pppoe.xml.in
+++ b/interface-definitions/interfaces-pppoe.xml.in
@@ -114,6 +114,20 @@
           <leafNode name="mtu">
             <defaultValue>1492</defaultValue>
           </leafNode>
+          <leafNode name="mru">
+            <properties>
+              <help>Maximum Receive Unit (MRU)</help>
+              <valueHelp>
+                <format>u32:128-16384</format>
+                <description>Maximum Receive Unit in byte</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 128-16384"/>
+              </constraint>
+              <constraintErrorMessage>MRU must be between 128 and 16384</constraintErrorMessage>
+            </properties>
+            <defaultValue>1492</defaultValue>
+          </leafNode>
           <leafNode name="no-peer-dns">
             <properties>
               <help>Do not use DNS servers provided by the peer</help>

--- a/smoketest/scripts/cli/test_interfaces_pppoe.py
+++ b/smoketest/scripts/cli/test_interfaces_pppoe.py
@@ -58,11 +58,13 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
             user = 'VyOS-user-' + interface
             passwd = 'VyOS-passwd-' + interface
             mtu = '1400'
+            mru = '1300'
 
             self.cli_set(base_path + [interface, 'authentication', 'user', user])
             self.cli_set(base_path + [interface, 'authentication', 'password', passwd])
             self.cli_set(base_path + [interface, 'default-route', 'auto'])
             self.cli_set(base_path + [interface, 'mtu', mtu])
+            self.cli_set(base_path + [interface, 'mru', mru])
             self.cli_set(base_path + [interface, 'no-peer-dns'])
 
             # check validate() - a source-interface is required
@@ -80,6 +82,8 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
 
             tmp = get_config_value(interface, 'mtu')[1]
             self.assertEqual(tmp, mtu)
+            tmp = get_config_value(interface, 'mru')[1]
+            self.assertEqual(tmp, mru)
             tmp = get_config_value(interface, 'user')[1].replace('"', '')
             self.assertEqual(tmp, user)
             tmp = get_config_value(interface, 'password')[1].replace('"', '')

--- a/smoketest/scripts/cli/test_interfaces_pppoe.py
+++ b/smoketest/scripts/cli/test_interfaces_pppoe.py
@@ -64,7 +64,7 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
             self.cli_set(base_path + [interface, 'authentication', 'password', passwd])
             self.cli_set(base_path + [interface, 'default-route', 'auto'])
             self.cli_set(base_path + [interface, 'mtu', mtu])
-            self.cli_set(base_path + [interface, 'mru', mru])
+            self.cli_set(base_path + [interface, 'mru', '9000'])
             self.cli_set(base_path + [interface, 'no-peer-dns'])
 
             # check validate() - a source-interface is required
@@ -72,8 +72,13 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
                 self.cli_commit()
             self.cli_set(base_path + [interface, 'source-interface', self._source_interface])
 
-            # commit changes
-            self.cli_commit()
+            # check validate() - MRU needs to be less or equal then MTU
+            with self.assertRaises(ConfigSessionError):
+                self.cli_commit()
+            self.cli_set(base_path + [interface, 'mru', mru])
+
+        # commit changes
+        self.cli_commit()
 
         # verify configuration file(s)
         for interface in self._interfaces:

--- a/src/conf_mode/interfaces-pppoe.py
+++ b/src/conf_mode/interfaces-pppoe.py
@@ -59,6 +59,11 @@ def verify(pppoe):
     if {'connect_on_demand', 'vrf'} <= set(pppoe):
         raise ConfigError('On-demand dialing and VRF can not be used at the same time')
 
+    # both MTU and MRU have default values, thus we do not need to check
+    # if the key exists
+    if int(pppoe['mru']) > int(pppoe['mtu']):
+        raise ConfigError('PPPoE MRU needs to be lower then MTU!')
+
     return None
 
 def generate(pppoe):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

pppoe: T5630: allow to specify MRU in addition to already configurable MTU

Set the MRU (Maximum Receive Unit) value to n. PPPd will ask the peer to send packets of no more than n bytes. The value of n must be between 128 and 16384, the default was always 1492 to match PPPoE MTU.

A value of 296 works well on very slow links (40 bytes for TCP/IP header + 256 bytes of data). Note that for the IPv6 protocol, the MRU must be at least 1280.

CLI:
`set interfaces pppoe pppoe0 mru 1280`

(cherry picked from commit e062a8c11856f213983f5b41f50d4f9dbc0dde0f)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5630

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/2346
* https://github.com/vyos/vyos-1x/pull/2335

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests or

```
set interfaces pppoe pppoe0 mtu 1492
set interfaces pppoe pppoe0 mru 1452
set interfaces pppoe pppoe0 authentication user 'userid'
set interfaces pppoe pppoe0 authentication password 'secret'
set interfaces pppoe pppoe0 source-interface 'eth0'
```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR3.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_pppoe.py
test_pppoe_authentication (__main__.PPPoEInterfaceTest) ... ok
test_pppoe_clent_disabled_interface (__main__.PPPoEInterfaceTest) ... ok
test_pppoe_client (__main__.PPPoEInterfaceTest) ... ok
test_pppoe_dhcpv6pd (__main__.PPPoEInterfaceTest) ... ok
test_pppoe_options (__main__.PPPoEInterfaceTest) ... ok

----------------------------------------------------------------------
Ran 5 tests in 160.622s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
