### PR TITLE
scripts: T4269: node.def generator should automatically add default values (backport)

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -147,7 +147,7 @@
           </leafNode>
           <leafNode name="memory">
             <properties>
-              <help>Memory (RAM) available to this container (default: 512)</help>
+              <help>Memory (RAM) available to this container</help>
               <valueHelp>
                 <format>u32:0</format>
                 <description>Unlimited</description>
@@ -165,7 +165,7 @@
           </leafNode>
           <leafNode name="shared-memory">
             <properties>
-              <help>Shared memory available to this container (default: 64)</help>
+              <help>Shared memory available to this container</help>
               <valueHelp>
                 <format>u32:0</format>
                 <description>Unlimited</description>
@@ -243,7 +243,7 @@
               </leafNode>
               <leafNode name="protocol">
                 <properties>
-                  <help>Transport protocol used for port mapping (default: tcp)</help>
+                  <help>Transport protocol used for port mapping</help>
                   <completionHelp>
                     <list>tcp udp</list>
                   </completionHelp>
@@ -265,7 +265,7 @@
           </tagNode>
           <leafNode name="restart">
             <properties>
-              <help>Restart options for container (default: on-failure)</help>
+              <help>Restart options for container</help>
               <completionHelp>
                 <list>no on-failure always</list>
               </completionHelp>
@@ -312,7 +312,7 @@
               </leafNode>
               <leafNode name="mode">
                 <properties>
-                  <help>Volume access mode ro/rw (default: rw)</help>
+                  <help>Volume access mode ro/rw</help>
                   <completionHelp>
                     <list>ro rw</list>
                   </completionHelp>

--- a/interface-definitions/dhcp-relay.xml.in
+++ b/interface-definitions/dhcp-relay.xml.in
@@ -28,7 +28,7 @@
                   <help>Policy to discard packets that have reached specified hop-count</help>
                   <valueHelp>
                     <format>u32:1-255</format>
-                    <description>Hop count (default: 10)</description>
+                    <description>Hop count</description>
                   </valueHelp>
                   <constraint>
                     <validator name="numeric" argument="--range 1-255"/>
@@ -42,7 +42,7 @@
                   <help>Maximum packet size to send to a DHCPv4/BOOTP server</help>
                   <valueHelp>
                     <format>u32:64-1400</format>
-                    <description>Maximum packet size (default: 576)</description>
+                    <description>Maximum packet size</description>
                   </valueHelp>
                   <constraint>
                     <validator name="numeric" argument="--range 64-1400"/>
@@ -53,7 +53,7 @@
               </leafNode>
               <leafNode name="relay-agents-packets">
                 <properties>
-                  <help>Policy to handle incoming DHCPv4 packets which already contain relay agent options (default: forward)</help>
+                  <help>Policy to handle incoming DHCPv4 packets which already contain relay agent options</help>
                   <completionHelp>
                     <list>append replace forward discard</list>
                   </completionHelp>

--- a/interface-definitions/dhcp-server.xml.in
+++ b/interface-definitions/dhcp-server.xml.in
@@ -198,7 +198,7 @@
                   </leafNode>
                   <leafNode name="lease">
                     <properties>
-                      <help>Lease timeout in seconds (default: 86400)</help>
+                      <help>Lease timeout in seconds</help>
                       <valueHelp>
                         <format>u32</format>
                         <description>DHCP lease time in seconds</description>

--- a/interface-definitions/dhcpv6-relay.xml.in
+++ b/interface-definitions/dhcpv6-relay.xml.in
@@ -36,7 +36,7 @@
               <help>Maximum hop count for which requests will be processed</help>
               <valueHelp>
                 <format>u32:1-255</format>
-                <description>Hop count (default: 10)</description>
+                <description>Hop count</description>
               </valueHelp>
               <constraint>
                 <validator name="numeric" argument="--range 1-255"/>

--- a/interface-definitions/dns-dynamic.xml.in
+++ b/interface-definitions/dns-dynamic.xml.in
@@ -47,7 +47,7 @@
                       </leafNode>
                       <leafNode name="ttl">
                         <properties>
-                          <help>Time To Live (default: 600)</help>
+                          <help>Time To Live</help>
                           <valueHelp>
                             <format>u32:1-86400</format>
                             <description>DNS forwarding cache size</description>

--- a/interface-definitions/dns-forwarding.xml.in
+++ b/interface-definitions/dns-forwarding.xml.in
@@ -16,7 +16,7 @@
             <children>
               <leafNode name="cache-size">
                 <properties>
-                  <help>DNS forwarding cache size (default: 10000)</help>
+                  <help>DNS forwarding cache size</help>
                   <valueHelp>
                     <format>u32:0-2147483647</format>
                     <description>DNS forwarding cache size</description>
@@ -50,7 +50,7 @@
               </leafNode>
               <leafNode name="dnssec">
                 <properties>
-                  <help>DNSSEC mode (default: process-no-validate)</help>
+                  <help>DNSSEC mode</help>
                   <completionHelp>
                     <list>off process-no-validate process log-fail validate</list>
                   </completionHelp>
@@ -153,7 +153,7 @@
               </leafNode>
               <leafNode name="negative-ttl">
                 <properties>
-                  <help>Maximum amount of time negative entries are cached (default: 3600)</help>
+                  <help>Maximum amount of time negative entries are cached</help>
                   <valueHelp>
                     <format>u32:0-7200</format>
                     <description>Seconds to cache NXDOMAIN entries</description>

--- a/interface-definitions/igmp-proxy.xml.in
+++ b/interface-definitions/igmp-proxy.xml.in
@@ -39,7 +39,7 @@
               </leafNode>
               <leafNode name="role">
                 <properties>
-                  <help>IGMP interface role (default: downstream)</help>
+                  <help>IGMP interface role</help>
                   <completionHelp>
                     <list>upstream downstream disabled</list>
                   </completionHelp>
@@ -49,7 +49,7 @@
                   </valueHelp>
                   <valueHelp>
                     <format>downstream</format>
-                    <description>Downstream interface(s) (default)</description>
+                    <description>Downstream interface(s)</description>
                   </valueHelp>
                   <valueHelp>
                     <format>disabled</format>
@@ -63,10 +63,10 @@
               </leafNode>
               <leafNode name="threshold">
                 <properties>
-                  <help>TTL threshold (default: 1)</help>
+                  <help>TTL threshold</help>
                   <valueHelp>
                     <format>u32:1-255</format>
-                    <description>TTL threshold for the interfaces (default: 1)</description>
+                    <description>TTL threshold for the interfaces</description>
                   </valueHelp>
                   <constraint>
                     <validator name="numeric" argument="--range 1-255"/>

--- a/interface-definitions/include/accel-ppp/client-ipv6-pool.xml.i
+++ b/interface-definitions/include/accel-ppp/client-ipv6-pool.xml.i
@@ -21,7 +21,7 @@
               <help>Prefix length used for individual client</help>
               <valueHelp>
                 <format>u32:48-128</format>
-                <description>Client prefix length (default: 64)</description>
+                <description>Client prefix length</description>
               </valueHelp>
               <constraint>
                 <validator name="numeric" argument="--range 48-128"/>

--- a/interface-definitions/include/accel-ppp/radius-additions.xml.i
+++ b/interface-definitions/include/accel-ppp/radius-additions.xml.i
@@ -21,7 +21,7 @@
             <help>Accounting port</help>
             <valueHelp>
               <format>u32:1-65535</format>
-              <description>Numeric IP port (default: 1813)</description>
+              <description>Numeric IP port</description>
             </valueHelp>
             <constraint>
               <validator name="numeric" argument="--range 1-65535"/>
@@ -130,7 +130,7 @@
         </leafNode>
         <leafNode name="port">
           <properties>
-            <help>Port for Dynamic Authorization Extension server (DM/CoA) (default: 1700)</help>
+            <help>Port for Dynamic Authorization Extension server (DM/CoA)</help>
             <valueHelp>
               <format>u32:1-65535</format>
               <description>TCP port</description>

--- a/interface-definitions/include/interface/ipv6-dup-addr-detect-transmits.xml.i
+++ b/interface-definitions/include/interface/ipv6-dup-addr-detect-transmits.xml.i
@@ -1,7 +1,7 @@
 <!-- include start from interface/ipv6-dup-addr-detect-transmits.xml.i -->
 <leafNode name="dup-addr-detect-transmits">
   <properties>
-    <help>Number of NS messages to send while performing DAD (default: 1)</help>
+    <help>Number of NS messages to send while performing DAD</help>
     <valueHelp>
       <format>u32:0</format>
       <description>Disable Duplicate Address Dectection (DAD)</description>
@@ -14,5 +14,6 @@
       <validator name="numeric" argument="--non-negative"/>
     </constraint>
   </properties>
+  <defaultValue>1</defaultValue>
 </leafNode>
 <!-- include end -->

--- a/interface-definitions/include/interface/vif-s.xml.i
+++ b/interface-definitions/include/interface/vif-s.xml.i
@@ -20,7 +20,7 @@
     #include <include/interface/disable.xml.i>
     <leafNode name="protocol">
       <properties>
-        <help>Protocol used for service VLAN (default: 802.1ad)</help>
+        <help>Protocol used for service VLAN</help>
         <completionHelp>
           <list>802.1ad 802.1q</list>
         </completionHelp>

--- a/interface-definitions/include/radius-server-port.xml.i
+++ b/interface-definitions/include/radius-server-port.xml.i
@@ -4,7 +4,7 @@
     <help>Authentication port</help>
     <valueHelp>
       <format>u32:1-65535</format>
-      <description>Numeric IP port (default: 1812)</description>
+      <description>Numeric IP port</description>
     </valueHelp>
     <constraint>
       <validator name="numeric" argument="--range 1-65535"/>

--- a/interface-definitions/interfaces-bonding.xml.in
+++ b/interface-definitions/interfaces-bonding.xml.in
@@ -64,7 +64,7 @@
               </completionHelp>
               <valueHelp>
                 <format>layer2</format>
-                <description>use MAC addresses to generate the hash (802.3ad, default)</description>
+                <description>use MAC addresses to generate the hash</description>
               </valueHelp>
               <valueHelp>
                 <format>layer2+3</format>
@@ -130,7 +130,7 @@
               </completionHelp>
               <valueHelp>
                 <format>slow</format>
-                <description>Request partner to transmit LACPDUs every 30 seconds (default)</description>
+                <description>Request partner to transmit LACPDUs every 30 seconds</description>
               </valueHelp>
               <valueHelp>
                 <format>fast</format>
@@ -150,7 +150,7 @@
               </completionHelp>
               <valueHelp>
                 <format>802.3ad</format>
-                <description>IEEE 802.3ad Dynamic link aggregation (Default)</description>
+                <description>IEEE 802.3ad Dynamic link aggregation</description>
               </valueHelp>
               <valueHelp>
                 <format>active-backup</format>

--- a/interface-definitions/interfaces-bridge.xml.in
+++ b/interface-definitions/interfaces-bridge.xml.in
@@ -26,7 +26,7 @@
               </valueHelp>
               <valueHelp>
                 <format>u32:10-1000000</format>
-                <description>MAC address aging time in seconds (default: 300)</description>
+                <description>MAC address aging time in seconds</description>
               </valueHelp>
               <constraint>
                 <validator name="numeric" argument="--range 0-0 --range 10-1000000"/>

--- a/interface-definitions/interfaces-ethernet.xml.in
+++ b/interface-definitions/interfaces-ethernet.xml.in
@@ -36,7 +36,7 @@
               </completionHelp>
               <valueHelp>
                 <format>auto</format>
-                <description>Auto negotiation (default)</description>
+                <description>Auto negotiation</description>
               </valueHelp>
               <valueHelp>
                 <format>half</format>
@@ -105,7 +105,7 @@
           </node>
           <leafNode name="speed">
             <properties>
-              <help>Link speed (default: auto)</help>
+              <help>Link speed</help>
               <completionHelp>
                 <list>auto 10 100 1000 2500 5000 10000 25000 40000 50000 100000</list>
               </completionHelp>

--- a/interface-definitions/interfaces-l2tpv3.xml.in
+++ b/interface-definitions/interfaces-l2tpv3.xml.in
@@ -20,7 +20,7 @@
           #include <include/interface/description.xml.i>
           <leafNode name="destination-port">
             <properties>
-              <help>UDP destination port for L2TPv3 tunnel (default: 5000)</help>
+              <help>UDP destination port for L2TPv3 tunnel</help>
               <valueHelp>
                 <format>u32:1-65535</format>
                 <description>Numeric IP port</description>
@@ -34,7 +34,7 @@
           #include <include/interface/disable.xml.i>
           <leafNode name="encapsulation">
             <properties>
-              <help>Encapsulation type (default: UDP)</help>
+              <help>Encapsulation type</help>
               <completionHelp>
                 <list>udp ip</list>
               </completionHelp>
@@ -99,7 +99,7 @@
           </leafNode>
           <leafNode name="source-port">
             <properties>
-              <help>UDP source port for L2TPv3 tunnel (default: 5000)</help>
+              <help>UDP source port for L2TPv3 tunnel</help>
               <valueHelp>
                 <format>u32:1-65535</format>
                 <description>Numeric IP port</description>

--- a/interface-definitions/interfaces-macsec.xml.in
+++ b/interface-definitions/interfaces-macsec.xml.in
@@ -83,7 +83,7 @@
                   </leafNode>
                   <leafNode name="priority">
                     <properties>
-                      <help>Priority of MACsec Key Agreement protocol (MKA) actor (default: 255)</help>
+                      <help>Priority of MACsec Key Agreement protocol (MKA) actor</help>
                       <valueHelp>
                         <format>u32:0-255</format>
                         <description>MACsec Key Agreement protocol (MKA) priority</description>

--- a/interface-definitions/interfaces-openvpn.xml.in
+++ b/interface-definitions/interfaces-openvpn.xml.in
@@ -36,7 +36,7 @@
           #include <include/interface/description.xml.i>
           <leafNode name="device-type">
             <properties>
-              <help>OpenVPN interface device-type (default: tun)</help>
+              <help>OpenVPN interface device-type</help>
               <completionHelp>
                 <list>tun tap</list>
               </completionHelp>
@@ -204,7 +204,7 @@
             <children>
               <leafNode name="failure-count">
                 <properties>
-                  <help>Maximum number of keepalive packet failures (default: 60)</help>
+                  <help>Maximum number of keepalive packet failures</help>
                   <valueHelp>
                     <format>u32:0-1000</format>
                     <description>Maximum number of keepalive packet failures</description>
@@ -217,7 +217,7 @@
               </leafNode>
               <leafNode name="interval">
                 <properties>
-                  <help>Keepalive packet interval in seconds (default: 10)</help>
+                  <help>Keepalive packet interval in seconds</help>
                   <valueHelp>
                     <format>u32:0-600</format>
                     <description>Keepalive packet interval (seconds)</description>
@@ -611,13 +611,13 @@
               </leafNode>
               <leafNode name="topology">
                 <properties>
-                  <help>Topology for clients (default: net30)</help>
+                  <help>Topology for clients</help>
                   <completionHelp>
                     <list>net30 point-to-point subnet</list>
                   </completionHelp>
                   <valueHelp>
                     <format>net30</format>
-                    <description>net30 topology (default)</description>
+                    <description>net30 topology</description>
                   </valueHelp>
                   <valueHelp>
                     <format>point-to-point</format>

--- a/interface-definitions/interfaces-pppoe.xml.in
+++ b/interface-definitions/interfaces-pppoe.xml.in
@@ -21,7 +21,7 @@
           #include <include/interface/dial-on-demand.xml.i>
           <leafNode name="default-route">
             <properties>
-              <help>Default route insertion behaviour (default: auto)</help>
+              <help>Default route insertion behaviour</help>
               <completionHelp>
                 <list>auto none force</list>
               </completionHelp>

--- a/interface-definitions/interfaces-pseudo-ethernet.xml.in
+++ b/interface-definitions/interfaces-pseudo-ethernet.xml.in
@@ -29,7 +29,7 @@
           #include <include/interface/mac.xml.i>
           <leafNode name="mode">
             <properties>
-              <help>Receive mode (default: private)</help>
+              <help>Receive mode</help>
               <completionHelp>
                 <list>private vepa bridge passthru</list>
               </completionHelp>

--- a/interface-definitions/interfaces-tunnel.xml.in
+++ b/interface-definitions/interfaces-tunnel.xml.in
@@ -157,7 +157,7 @@
                       </completionHelp>
                       <valueHelp>
                         <format>u32:0-255</format>
-                        <description>Encaplimit (default: 4)</description>
+                        <description>Encaplimit</description>
                       </valueHelp>
                       <valueHelp>
                         <format>none</format>

--- a/interface-definitions/interfaces-vxlan.xml.in
+++ b/interface-definitions/interfaces-vxlan.xml.in
@@ -46,7 +46,7 @@
           </leafNode>
           <leafNode name="port">
             <properties>
-              <help>Destination port of VXLAN tunnel (default: 8472)</help>
+              <help>Destination port of VXLAN tunnel</help>
               <valueHelp>
                 <format>u32:1-65535</format>
                 <description>Numeric IP port</description>

--- a/interface-definitions/interfaces-wireless.xml.in
+++ b/interface-definitions/interfaces-wireless.xml.in
@@ -432,7 +432,7 @@
           </node>
           <leafNode name="channel">
             <properties>
-              <help>Wireless radio channel (default: 0)</help>
+              <help>Wireless radio channel</help>
               <valueHelp>
                 <format>0</format>
                 <description>Automatic Channel Selection (ACS)</description>
@@ -516,7 +516,7 @@
               </completionHelp>
               <valueHelp>
                 <format>disabled</format>
-                <description>no MFP (hostapd default)</description>
+                <description>no MFP</description>
               </valueHelp>
               <valueHelp>
                 <format>optional</format>
@@ -548,7 +548,7 @@
               </valueHelp>
               <valueHelp>
                 <format>g</format>
-                <description>802.11g - 54 Mbits/sec (default)</description>
+                <description>802.11g - 54 Mbits/sec</description>
               </valueHelp>
               <valueHelp>
                 <format>n</format>
@@ -566,7 +566,7 @@
           </leafNode>
           <leafNode name="physical-device">
             <properties>
-              <help>Wireless physical device (default: phy0)</help>
+              <help>Wireless physical device</help>
               <completionHelp>
                 <script>${vyos_completion_dir}/list_wireless_phys.sh</script>
               </completionHelp>

--- a/interface-definitions/protocols-rpki.xml.in
+++ b/interface-definitions/protocols-rpki.xml.in
@@ -82,7 +82,7 @@
           </tagNode>
           <leafNode name="polling-period">
             <properties>
-              <help>RPKI cache polling period (default: 300)</help>
+              <help>RPKI cache polling period</help>
               <valueHelp>
                 <format>u32:1-86400</format>
                 <description>Polling period in seconds</description>

--- a/interface-definitions/service_console-server.xml.in
+++ b/interface-definitions/service_console-server.xml.in
@@ -41,7 +41,7 @@
               </leafNode>
               <leafNode name="data-bits">
                 <properties>
-                  <help>Serial port data bits (default: 8)</help>
+                  <help>Serial port data bits</help>
                   <completionHelp>
                     <list>7 8</list>
                   </completionHelp>
@@ -53,7 +53,7 @@
               </leafNode>
               <leafNode name="stop-bits">
                 <properties>
-                  <help>Serial port stop bits (default: 1)</help>
+                  <help>Serial port stop bits</help>
                   <completionHelp>
                     <list>1 2</list>
                   </completionHelp>
@@ -65,7 +65,7 @@
               </leafNode>
               <leafNode name="parity">
                 <properties>
-                  <help>Parity setting (default: none)</help>
+                  <help>Parity setting</help>
                   <completionHelp>
                     <list>even odd none</list>
                   </completionHelp>

--- a/interface-definitions/service_monitoring_telegraf.xml.in
+++ b/interface-definitions/service_monitoring_telegraf.xml.in
@@ -50,13 +50,13 @@
               </leafNode>
               <leafNode name="source">
                 <properties>
-                  <help>Source parameters for monitoring (default: all)</help>
+                  <help>Source parameters for monitoring</help>
                   <completionHelp>
                     <list>all hardware-utilization logs network system telegraf</list>
                   </completionHelp>
                   <valueHelp>
                     <format>all</format>
-                    <description>All parameters (default)</description>
+                    <description>All parameters</description>
                   </valueHelp>
                   <valueHelp>
                     <format>hardware-utilization</format>
@@ -150,7 +150,7 @@
                        <help>Metric version control mapping from Telegraf to Prometheus format</help>
                        <valueHelp>
                          <format>u32:1-2</format>
-                         <description>Metric version (default: 2)</description>
+                         <description>Metric version</description>
                        </valueHelp>
                        <constraint>
                          <validator name="numeric" argument="--range 1-2"/>

--- a/interface-definitions/service_router-advert.xml.in
+++ b/interface-definitions/service_router-advert.xml.in
@@ -18,7 +18,7 @@
             <children>
               <leafNode name="hop-limit">
                 <properties>
-                  <help>Set Hop Count field of the IP header for outgoing packets (default: 64)</help>
+                  <help>Set Hop Count field of the IP header for outgoing packets</help>
                   <valueHelp>
                     <format>u32:0</format>
                     <description>Unspecified (by this router)</description>
@@ -63,7 +63,7 @@
                   </valueHelp>
                   <valueHelp>
                     <format>medium</format>
-                    <description>Default router has medium preference (default)</description>
+                    <description>Default router has medium preference</description>
                   </valueHelp>
                   <valueHelp>
                     <format>high</format>
@@ -108,7 +108,7 @@
                 <children>
                   <leafNode name="max">
                     <properties>
-                      <help>Maximum interval between unsolicited multicast RAs (default: 600)</help>
+                      <help>Maximum interval between unsolicited multicast RAs</help>
                       <valueHelp>
                         <format>u32:4-1800</format>
                         <description>Maximum interval in seconds</description>
@@ -156,7 +156,7 @@
                 <children>
                   <leafNode name="valid-lifetime">
                     <properties>
-                      <help>Time in seconds that the route will remain valid (default: 1800 seconds)</help>
+                      <help>Time in seconds that the route will remain valid</help>
                       <completionHelp>
                         <list>infinity</list>
                       </completionHelp>
@@ -187,7 +187,7 @@
                       </valueHelp>
                       <valueHelp>
                         <format>medium</format>
-                        <description>Route has medium preference (default)</description>
+                        <description>Route has medium preference</description>
                       </valueHelp>
                       <valueHelp>
                         <format>high</format>
@@ -255,7 +255,7 @@
                   </leafNode>
                   <leafNode name="valid-lifetime">
                     <properties>
-                      <help>Time in seconds that the prefix will remain valid (default: 30 days)</help>
+                      <help>Time in seconds that the prefix will remain valid</help>
                       <completionHelp>
                         <list>infinity</list>
                       </completionHelp>

--- a/interface-definitions/service_webproxy.xml.in
+++ b/interface-definitions/service_webproxy.xml.in
@@ -28,7 +28,7 @@
             <children>
               <leafNode name="children">
                 <properties>
-                  <help>Number of authentication helper processes (default: 5)</help>
+                  <help>Number of authentication helper processes</help>
                   <valueHelp>
                     <format>n</format>
                     <description>Number of authentication helper processes</description>
@@ -41,7 +41,7 @@
               </leafNode>
               <leafNode name="credentials-ttl">
                 <properties>
-                  <help>Authenticated session time to live in minutes (default: 60)</help>
+                  <help>Authenticated session time to live in minutes</help>
                   <valueHelp>
                     <format>n</format>
                     <description>Authenticated session timeout</description>
@@ -85,7 +85,7 @@
                   </leafNode>
                   <leafNode name="port">
                     <properties>
-                      <help>LDAP server port to use (default: 389)</help>
+                      <help>LDAP server port to use</help>
                       <valueHelp>
                         <format>u32:1-65535</format>
                         <description>Port number to use</description>
@@ -114,7 +114,7 @@
                   </leafNode>
                   <leafNode name="version">
                     <properties>
-                      <help>LDAP protocol version (default: 3)</help>
+                      <help>LDAP protocol version</help>
                       <completionHelp>
                           <list>2 3</list>
                       </completionHelp>
@@ -186,7 +186,7 @@
               </leafNode>
               <leafNode name="http-port">
                 <properties>
-                  <help>Default Proxy Port (default: 3128)</help>
+                  <help>Default Proxy Port</help>
                   <valueHelp>
                     <format>u32:1025-65535</format>
                     <description>Default port number</description>
@@ -199,7 +199,7 @@
               </leafNode>
                <leafNode name="icp-port">
                 <properties>
-                  <help>Cache peer ICP port (default: disabled)</help>
+                  <help>Cache peer ICP port</help>
                   <valueHelp>
                     <format>u32:1-65535</format>
                     <description>Cache peer ICP port</description>
@@ -212,7 +212,7 @@
               </leafNode>
               <leafNode name="options">
                 <properties>
-                  <help>Cache peer options (default: "no-query default")</help>
+                  <help>Cache peer options</help>
                   <valueHelp>
                     <format>txt</format>
                     <description>Cache peer options</description>
@@ -248,7 +248,7 @@
           </tagNode>
           <leafNode name="cache-size">
             <properties>
-              <help>Disk cache size in MB (default: 100)</help>
+              <help>Disk cache size in MB</help>
                <valueHelp>
                 <format>u32</format>
                 <description>Disk cache size in MB</description>
@@ -262,7 +262,7 @@
           </leafNode>
           <leafNode name="default-port">
             <properties>
-              <help>Default Proxy Port (default: 3128)</help>
+              <help>Default Proxy Port</help>
               <valueHelp>
                 <format>u32:1025-65535</format>
                 <description>Default port number</description>
@@ -423,7 +423,7 @@
                   </node>
                   <leafNode name="redirect-url">
                     <properties>
-                      <help>Redirect URL for filtered websites (default: block.vyos.net)</help>
+                      <help>Redirect URL for filtered websites</help>
                       <valueHelp>
                         <format>url</format>
                         <description>URL for redirect</description>

--- a/interface-definitions/system-login.xml.in
+++ b/interface-definitions/system-login.xml.in
@@ -124,7 +124,7 @@
                       <help>Session timeout</help>
                       <valueHelp>
                         <format>u32:1-30</format>
-                        <description>Session timeout in seconds (default: 2)</description>
+                        <description>Session timeout in seconds</description>
                       </valueHelp>
                       <constraint>
                         <validator name="numeric" argument="--range 1-30"/>
@@ -138,7 +138,7 @@
                       <help>Server priority</help>
                       <valueHelp>
                         <format>u32:1-255</format>
-                        <description>Server priority (default: 255)</description>
+                        <description>Server priority</description>
                       </valueHelp>
                       <constraint>
                         <validator name="numeric" argument="--range 1-255"/>

--- a/interface-definitions/vpn_openconnect.xml.in
+++ b/interface-definitions/vpn_openconnect.xml.in
@@ -60,7 +60,7 @@
                       <help>Session timeout</help>
                       <valueHelp>
                         <format>u32:1-30</format>
-                        <description>Session timeout in seconds (default: 2)</description>
+                        <description>Session timeout in seconds</description>
                       </valueHelp>
                       <constraint>
                         <validator name="numeric" argument="--range 1-30"/>
@@ -80,10 +80,10 @@
             <children>
               <leafNode name="tcp">
                 <properties>
-                  <help>tcp port number to accept connections (default: 443)</help>
+                  <help>tcp port number to accept connections</help>
                   <valueHelp>
                     <format>u32:1-65535</format>
-                    <description>Numeric IP port (default: 443)</description>
+                    <description>Numeric IP port</description>
                   </valueHelp>
                   <constraint>
                     <validator name="numeric" argument="--range 1-65535"/>
@@ -93,10 +93,10 @@
               </leafNode>
               <leafNode name="udp">
                 <properties>
-                  <help>udp port number to accept connections (default: 443)</help>
+                  <help>udp port number to accept connections</help>
                   <valueHelp>
                     <format>u32:1-65535</format>
-                    <description>Numeric IP port (default: 443)</description>
+                    <description>Numeric IP port</description>
                   </valueHelp>
                   <constraint>
                     <validator name="numeric" argument="--range 1-65535"/>
@@ -180,7 +180,7 @@
                       <help>Prefix length used for individual client</help>
                       <valueHelp>
                         <format>u32:48-128</format>
-                        <description>Client prefix length (default: 64)</description>
+                        <description>Client prefix length</description>
                       </valueHelp>
                       <constraint>
                         <validator name="numeric" argument="--range 48-128"/>

--- a/interface-definitions/vrrp.xml.in
+++ b/interface-definitions/vrrp.xml.in
@@ -64,7 +64,7 @@
                   <help>Advertise interval</help>
                   <valueHelp>
                     <format>u32:1-255</format>
-                    <description>Advertise interval in seconds (default: 1)</description>
+                    <description>Advertise interval in seconds</description>
                   </valueHelp>
                   <constraint>
                     <validator name="numeric" argument="--range 1-255"/>
@@ -125,7 +125,7 @@
                 <children>
                   <leafNode name="failure-count">
                     <properties>
-                      <help>Health check failure count required for transition to fault (default: 3)</help>
+                      <help>Health check failure count required for transition to fault</help>
                       <constraint>
                         <validator name="numeric" argument="--positive" />
                       </constraint>
@@ -134,7 +134,7 @@
                   </leafNode>
                   <leafNode name="interval">
                     <properties>
-                      <help>Health check execution interval in seconds (default: 60)</help>
+                      <help>Health check execution interval in seconds</help>
                       <constraint>
                         <validator name="numeric" argument="--positive"/>
                       </constraint>
@@ -206,7 +206,7 @@
               </leafNode>
               <leafNode name="priority">
                 <properties>
-                  <help>Router priority (default: 100)</help>
+                  <help>Router priority</help>
                   <valueHelp>
                     <format>u32:1-255</format>
                     <description>Router priority</description>

--- a/scripts/build-command-templates
+++ b/scripts/build-command-templates
@@ -117,7 +117,7 @@ def collect_validators(ve):
 
     return regex_args + " " + validator_args
 
-def get_properties(p):
+def get_properties(p, default=None):
     props = {}
 
     if p is None:
@@ -125,7 +125,12 @@ def get_properties(p):
 
     # Get the help string
     try:
-        props["help"] = p.find("help").text
+        help = p.find("help").text
+        if default != None:
+            # DNS forwarding for instance has multiple defaults - specified as whitespace separated list
+            tmp = ', '.join(default.text.split())
+            help += f' (default: {tmp})'
+        props["help"] = help
     except:
         pass
 
@@ -134,7 +139,11 @@ def get_properties(p):
         vhe = p.findall("valueHelp")
         vh = []
         for v in vhe:
-            vh.append( (v.find("format").text, v.find("description").text) )
+            format = v.find("format").text
+            description = v.find("description").text
+            if default != None and default.text == format:
+                description += f' (default)'
+            vh.append( (format, description) )
         props["val_help"] = vh
     except:
         props["val_help"] = []
@@ -271,7 +280,7 @@ def process_node(n, tmpl_dir):
         print("Name of the node: {0}. Created directory: {1}\n".format(name, "/".join(my_tmpl_dir)), end="")
     os.makedirs(make_path(my_tmpl_dir), exist_ok=True)
 
-    props = get_properties(props_elem)
+    props = get_properties(props_elem, n.find("defaultValue"))
     if owner:
         props["owner"] = owner
     # Type should not be set for non-tag, non-leaf nodes


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

Please note that this only works if the `<defaultValue>` XML node is used to pass defaults to CLI help and also to Python code. All other places not making use of  `<defaultValue>` stay untouched!

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Since introducing the XML <defaultValue> node it was common, but redundant, practice to also add a help string indicating which value would be used as default if the node is unset.

This makes no sense b/c it's duplicated code/value/characters and prone to error. The node.def scripts should be extended to automatically render the appropriate default value into the CLI help string.

For e.g. SSH the current PoC renders:

```bash
$ cat templates-cfg/service/ssh/port/node.def

multi:
type: txt
help: Port for SSH service (default: 22)
val_help: u32:1-65535; Numeric IP port
...
```
Not all subsystems are already migrated to get_config_dict() and make use of the defaults() call - those subsystems need to be migrated, first before the new default is added to the CLI help.

(cherry picked from commit a68c9238111c6caee78bb28f8054b8f0cfa0e374)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4269

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
XML node.def generator

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
