### PR TITLE
T5489: Change default qdisc from 'fq' to 'fq_codel'

### DIFF
--- a/src/etc/sysctl.d/30-vyos-router.conf
+++ b/src/etc/sysctl.d/30-vyos-router.conf
@@ -21,7 +21,6 @@ net.ipv4.conf.all.arp_filter=0
 
 # https://vyos.dev/T300
 net.ipv4.conf.all.arp_ignore=0
-
 net.ipv4.conf.all.arp_announce=2
 
 # Enable packet forwarding for IPv4
@@ -103,6 +102,6 @@ net.ipv4.igmp_max_memberships = 512
 net.core.rps_sock_flow_entries = 32768
 
 # Congestion control
-net.core.default_qdisc=fq
+net.core.default_qdisc=fq_codel
 net.ipv4.tcp_congestion_control=bbr
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Default qdisc should be "fq_codel" rather than "fq" with "bbr" as congestion control in modern Linux kernels.

This is a followup on https://github.com/vyos/vyos-1x/pull/2224

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5489

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/2224
 
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
sysctl

## Proposed changes
<!--- Describe your changes in detail -->
Change following parameters in `src/etc/sysctl.d/30-vyos-router.conf` from:
```
net.core.default_qdisc=fq
net.ipv4.tcp_congestion_control=bbr
```
to:
```
net.core.default_qdisc=fq_codel
net.ipv4.tcp_congestion_control=bbr
```

Ref:

https://www.bufferbloat.net/projects/codel/wiki/

```
Either qdisc can be enabled by default via a single sysctl option in /etc/sysctl.conf:

net.core.default_qdisc = fq_codel - best general purpose qdisc

net.core.default_qdisc = fq - for fat servers, fq_codel for routers.
```

Also thread in https://forum.vyos.io/t/bbr-and-fq-as-new-defaults/12344/10

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
After install/upgrade verify default settings through:

```
# sudo cat /etc/sysctl.d/30-vyos-router.conf
...
# Congestion control
net.core.default_qdisc=fq_codel
net.ipv4.tcp_congestion_control=bbr
```
or:
```
vyos@vyos:~$ sudo sysctl -a | grep net.core.default_qdisc
net.core.default_qdisc = fq_codel
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
