### PR TITLE
T5643: nat: add interface-groups to nat. Use same cli structure for i…

### DIFF
--- a/interface-definitions/nat.xml.in
+++ b/interface-definitions/nat.xml.in
@@ -14,7 +14,7 @@
           #include <include/nat-rule.xml.i>
           <tagNode name="rule">
             <children>
-              #include <include/inbound-interface.xml.i>
+              #include <include/firewall/inbound-interface.xml.i>
               <node name="translation">
                 <properties>
                   <help>Inside NAT IP (destination NAT only)</help>
@@ -77,7 +77,7 @@
               <constraintErrorMessage>NAT rule number must be between 1 and 999999</constraintErrorMessage>
             </properties>
             <children>
-              #include <include/nat-interface.xml.i>
+              #include <include/firewall/outbound-interface.xml.i>
               <node name="translation">
                 <properties>
                   <help>Outside NAT IP (source NAT only)</help>

--- a/python/vyos/nat.py
+++ b/python/vyos/nat.py
@@ -32,14 +32,34 @@ def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
     translation_str = ''
 
     if 'inbound_interface' in rule_conf:
-        ifname = rule_conf['inbound_interface']
-        if ifname != 'any':
-            output.append(f'iifname "{ifname}"')
+        operator = ''
+        if 'interface_name' in rule_conf['inbound_interface']:
+            iiface = rule_conf['inbound_interface']['interface_name']
+            if iiface[0] == '!':
+                operator = '!='
+                iiface = iiface[1:]
+            output.append(f'iifname {operator} {{{iiface}}}')
+        else:
+            iiface = rule_conf['inbound_interface']['interface_group']
+            if iiface[0] == '!':
+                operator = '!='
+                iiface = iiface[1:]
+            output.append(f'iifname {operator} @I_{iiface}')
 
     if 'outbound_interface' in rule_conf:
-        ifname = rule_conf['outbound_interface']
-        if ifname != 'any':
-            output.append(f'oifname "{ifname}"')
+        operator = ''
+        if 'interface_name' in rule_conf['outbound_interface']:
+            oiface = rule_conf['outbound_interface']['interface_name']
+            if oiface[0] == '!':
+                operator = '!='
+                oiface = oiface[1:]
+            output.append(f'oifname {operator} {{{oiface}}}')
+        else:
+            oiface = rule_conf['outbound_interface']['interface_group']
+            if oiface[0] == '!':
+                operator = '!='
+                oiface = oiface[1:]
+            output.append(f'oifname {operator} @I_{oiface}')
 
     if 'protocol' in rule_conf and rule_conf['protocol'] != 'all':
         protocol = rule_conf['protocol']

--- a/smoketest/scripts/cli/test_nat.py
+++ b/smoketest/scripts/cli/test_nat.py
@@ -82,12 +82,12 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
             # or configured destination address for NAT
             if int(rule) < 200:
                 self.cli_set(src_path + ['rule', rule, 'source', 'address', network])
-                self.cli_set(src_path + ['rule', rule, 'outbound-interface', outbound_iface_100])
+                self.cli_set(src_path + ['rule', rule, 'outbound-interface', 'interface-name', outbound_iface_100])
                 self.cli_set(src_path + ['rule', rule, 'translation', 'address', 'masquerade'])
                 nftables_search.append([f'saddr {network}', f'oifname "{outbound_iface_100}"', 'masquerade'])
             else:
                 self.cli_set(src_path + ['rule', rule, 'destination', 'address', network])
-                self.cli_set(src_path + ['rule', rule, 'outbound-interface', outbound_iface_200])
+                self.cli_set(src_path + ['rule', rule, 'outbound-interface', 'interface-name', outbound_iface_200])
                 self.cli_set(src_path + ['rule', rule, 'exclude'])
                 nftables_search.append([f'daddr {network}', f'oifname "{outbound_iface_200}"', 'return'])
 
@@ -98,13 +98,15 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
     def test_snat_groups(self):
         address_group = 'smoketest_addr'
         address_group_member = '192.0.2.1'
+        interface_group = 'smoketest_ifaces'
+        interface_group_member = 'bond.99'
         rule = '100'
-        outbound_iface = 'eth0'
 
         self.cli_set(['firewall', 'group', 'address-group', address_group, 'address', address_group_member])
+        self.cli_set(['firewall', 'group', 'interface-group', interface_group, 'interface', interface_group_member])
 
         self.cli_set(src_path + ['rule', rule, 'source', 'group', 'address-group', address_group])
-        self.cli_set(src_path + ['rule', rule, 'outbound-interface', outbound_iface])
+        self.cli_set(src_path + ['rule', rule, 'outbound-interface', 'interface-group', interface_group])
         self.cli_set(src_path + ['rule', rule, 'translation', 'address', 'masquerade'])
 
         self.cli_commit()
@@ -112,7 +114,7 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
         nftables_search = [
             [f'set A_{address_group}'],
             [f'elements = {{ {address_group_member} }}'],
-            [f'ip saddr @A_{address_group}', f'oifname "{outbound_iface}"', 'masquerade']
+            [f'ip saddr @A_{address_group}', f'oifname @I_{interface_group}', 'masquerade']
         ]
 
         self.verify_nftables(nftables_search, 'ip vyos_nat')
@@ -136,12 +138,12 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
             rule_search = [f'dnat to 192.0.2.1:{port}']
             if int(rule) < 200:
                 self.cli_set(dst_path + ['rule', rule, 'protocol', inbound_proto_100])
-                self.cli_set(dst_path + ['rule', rule, 'inbound-interface', inbound_iface_100])
+                self.cli_set(dst_path + ['rule', rule, 'inbound-interface', 'interface-name', inbound_iface_100])
                 rule_search.append(f'{inbound_proto_100} sport {port}')
                 rule_search.append(f'iifname "{inbound_iface_100}"')
             else:
                 self.cli_set(dst_path + ['rule', rule, 'protocol', inbound_proto_200])
-                self.cli_set(dst_path + ['rule', rule, 'inbound-interface', inbound_iface_200])
+                self.cli_set(dst_path + ['rule', rule, 'inbound-interface', 'interface-name', inbound_iface_200])
                 rule_search.append(f'iifname "{inbound_iface_200}"')
 
             nftables_search.append(rule_search)
@@ -167,7 +169,7 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
         rule = '1000'
         self.cli_set(dst_path + ['rule', rule, 'destination', 'address', '!192.0.2.1'])
         self.cli_set(dst_path + ['rule', rule, 'destination', 'port', '53'])
-        self.cli_set(dst_path + ['rule', rule, 'inbound-interface', 'eth0'])
+        self.cli_set(dst_path + ['rule', rule, 'inbound-interface', 'interface-name', 'eth0'])
         self.cli_set(dst_path + ['rule', rule, 'protocol', 'tcp_udp'])
         self.cli_set(dst_path + ['rule', rule, 'source', 'address', '!192.0.2.1'])
         self.cli_set(dst_path + ['rule', rule, 'translation', 'address', '192.0.2.1'])
@@ -186,7 +188,7 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
     def test_dnat_without_translation_address(self):
-        self.cli_set(dst_path + ['rule', '1', 'inbound-interface', 'eth1'])
+        self.cli_set(dst_path + ['rule', '1', 'inbound-interface', 'interface-name', 'eth1'])
         self.cli_set(dst_path + ['rule', '1', 'destination', 'port', '443'])
         self.cli_set(dst_path + ['rule', '1', 'protocol', 'tcp'])
         self.cli_set(dst_path + ['rule', '1', 'packet-type', 'host'])
@@ -236,13 +238,13 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
         self.cli_set(dst_path + ['rule', '10', 'destination', 'address', dst_addr_1])
         self.cli_set(dst_path + ['rule', '10', 'destination', 'port', dest_port])
         self.cli_set(dst_path + ['rule', '10', 'protocol', protocol])
-        self.cli_set(dst_path + ['rule', '10', 'inbound-interface', ifname])
+        self.cli_set(dst_path + ['rule', '10', 'inbound-interface', 'interface-name', ifname])
         self.cli_set(dst_path + ['rule', '10', 'translation', 'redirect', 'port', redirected_port])
 
         self.cli_set(dst_path + ['rule', '20', 'destination', 'address', dst_addr_1])
         self.cli_set(dst_path + ['rule', '20', 'destination', 'port', dest_port])
         self.cli_set(dst_path + ['rule', '20', 'protocol', protocol])
-        self.cli_set(dst_path + ['rule', '20', 'inbound-interface', ifname])
+        self.cli_set(dst_path + ['rule', '20', 'inbound-interface', 'interface-name', ifname])
         self.cli_set(dst_path + ['rule', '20', 'translation', 'redirect'])
 
         self.cli_commit()
@@ -266,7 +268,7 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
         weight_4 = '65'
         dst_port = '443'
 
-        self.cli_set(dst_path + ['rule', '1', 'inbound-interface', ifname])
+        self.cli_set(dst_path + ['rule', '1', 'inbound-interface', 'interface-name', ifname])
         self.cli_set(dst_path + ['rule', '1', 'protocol', 'tcp'])
         self.cli_set(dst_path + ['rule', '1', 'destination', 'port', dst_port])
         self.cli_set(dst_path + ['rule', '1', 'load-balance', 'hash', 'source-address'])
@@ -276,7 +278,7 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
         self.cli_set(dst_path + ['rule', '1', 'load-balance', 'backend', member_1, 'weight', weight_1])
         self.cli_set(dst_path + ['rule', '1', 'load-balance', 'backend', member_2, 'weight', weight_2])
 
-        self.cli_set(src_path + ['rule', '1', 'outbound-interface', ifname])
+        self.cli_set(src_path + ['rule', '1', 'outbound-interface', 'interface-name', ifname])
         self.cli_set(src_path + ['rule', '1', 'load-balance', 'hash', 'random'])
         self.cli_set(src_path + ['rule', '1', 'load-balance', 'backend', member_3, 'weight', weight_3])
         self.cli_set(src_path + ['rule', '1', 'load-balance', 'backend', member_4, 'weight', weight_4])

--- a/src/conf_mode/nat.py
+++ b/src/conf_mode/nat.py
@@ -151,8 +151,11 @@ def verify(nat):
             err_msg = f'Source NAT configuration error in rule {rule}:'
 
             if 'outbound_interface' in config:
-                if config['outbound_interface'] not in 'any' and config['outbound_interface'] not in interfaces():
-                    Warning(f'rule "{rule}" interface "{config["outbound_interface"]}" does not exist on this system')
+                if 'interface_name' in config['outbound_interface'] and 'interface_group' in config['outbound_interface']:
+                    raise ConfigError(f'Cannot specify both interface-group and interface-name for nat source rule "{rule}"')
+                elif 'interface_name' in config['outbound_interface']:
+                    if config['outbound_interface']['interface_name'] not in 'any' and config['outbound_interface']['interface_name'] not in interfaces():
+                        Warning(f'rule "{rule}" interface "{config["outbound_interface"]["interface_name"]}" does not exist on this system')
 
             if not dict_search('translation.address', config) and not dict_search('translation.port', config):
                 if 'exclude' not in config and 'backend' not in config['load_balance']:
@@ -172,8 +175,11 @@ def verify(nat):
             err_msg = f'Destination NAT configuration error in rule {rule}:'
 
             if 'inbound_interface' in config:
-                if config['inbound_interface'] not in 'any' and config['inbound_interface'] not in interfaces():
-                    Warning(f'rule "{rule}" interface "{config["inbound_interface"]}" does not exist on this system')
+                if 'interface_name' in config['inbound_interface'] and 'interface_group' in config['inbound_interface']:
+                    raise ConfigError(f'Cannot specify both interface-group and interface-name for destination nat rule "{rule}"')
+                elif 'interface_name' in config['inbound_interface']:
+                    if config['inbound_interface']['interface_name'] not in 'any' and config['inbound_interface']['interface_name'] not in interfaces():
+                        Warning(f'rule "{rule}" interface "{config["inbound_interface"]["interface_name"]}" does not exist on this system')
 
             if not dict_search('translation.address', config) and not dict_search('translation.port', config) and 'redirect' not in config['translation']:
                 if 'exclude' not in config and 'backend' not in config['load_balance']:

--- a/src/migration-scripts/nat/5-to-6
+++ b/src/migration-scripts/nat/5-to-6
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T5643: move from 'set nat [source|destination] rule X [inbound-interface|outbound interface] <iface>'
+# to
+# 'set nat [source|destination] rule X [inbound-interface|outbound interface] interface-name <iface>'
+
+from sys import argv,exit
+from vyos.configtree import ConfigTree
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+
+if not config.exists(['nat']):
+    # Nothing to do
+    exit(0)
+
+for direction in ['source', 'destination']:
+    # If a node doesn't exist, we obviously have nothing to do.
+    if not config.exists(['nat', direction]):
+        continue
+
+    # However, we also need to handle the case when a 'source' or 'destination' sub-node does exist,
+    # but there are no rules under it.
+    if not config.list_nodes(['nat', direction]):
+        continue
+
+    for rule in config.list_nodes(['nat', direction, 'rule']):
+        base = ['nat', direction, 'rule', rule]
+        for iface in ['inbound-interface','outbound-interface']:
+            if config.exists(base + [iface]):
+                tmp = config.return_value(base + [iface])
+                config.delete(base + [iface])
+                config.set(base + [iface, 'interface-name'], value=tmp)
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add interface-groups to nat. Use same cli structure for interface-name|interface-group as in firewall.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5643

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configuration example:
```
vyos@nat-iface:~$ show configuration commands | grep "nat\|group"
set firewall group address-group AG-01 address '198.51.100.123'
set firewall group interface-group IF-01 interface 'eth3'
set firewall group interface-group IF-01 interface 'vtun88'
set firewall group interface-group IF-01 interface 'pppoe*'
set nat destination rule 10 destination port '1122'
set nat destination rule 10 inbound-interface interface-name 'vtun88'
set nat destination rule 10 protocol 'tcp'
set nat destination rule 10 source group address-group 'AG-01'
set nat destination rule 10 translation address '198.51.100.55'
set nat destination rule 20 destination address '203.0.113.66'
set nat destination rule 20 inbound-interface interface-group '!IF-01'
set nat destination rule 20 translation address '198.51.100.66'
set nat source rule 10 outbound-interface interface-name '!bond0.99'
set nat source rule 10 translation address '1.2.3.4'
set nat source rule 20 outbound-interface interface-group 'IF-01'
set nat source rule 20 translation address '192.0.2.2'
```
Rules generated:
```
vyos@nat-iface:~$ sudo nft -s list table ip vyos_nat
table ip vyos_nat {
        set A_AG-01 {
                type ipv4_addr
                flags interval
                auto-merge
                elements = { 198.51.100.123 }
        }

        set I_IF-01 {
                type ifname
                flags interval
                auto-merge
                elements = { "eth3",
                             "pppoe*",
                             "vtun88" }
        }

        chain PREROUTING {
                type nat hook prerouting priority dstnat; policy accept;
                counter jump VYOS_PRE_DNAT_HOOK
                iifname "vtun88" ip saddr @A_AG-01 tcp dport 1122 counter dnat to 198.51.100.55 comment "DST-NAT-10"
                iifname != @I_IF-01 ip daddr 203.0.113.66 counter dnat to 198.51.100.66 comment "DST-NAT-20"
        }

        chain POSTROUTING {
                type nat hook postrouting priority srcnat; policy accept;
                counter jump VYOS_PRE_SNAT_HOOK
                oifname != "bond0.99" counter snat to 1.2.3.4 comment "SRC-NAT-10"
                oifname @I_IF-01 counter snat to 192.0.2.2 comment "SRC-NAT-20"
        }

        chain VYOS_PRE_DNAT_HOOK {
                return
        }

        chain VYOS_PRE_SNAT_HOOK {
                return
        }
}
vyos@nat-iface:~$
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@nat-iface:/usr/libexec/vyos/tests/smoke/cli# ./test_nat.py 
test_dnat (__main__.TestNAT.test_dnat) ... ok
test_dnat_negated_addresses (__main__.TestNAT.test_dnat_negated_addresses) ... ok
test_dnat_redirect (__main__.TestNAT.test_dnat_redirect) ... ok
test_dnat_without_translation_address (__main__.TestNAT.test_dnat_without_translation_address) ... ok
test_nat_balance (__main__.TestNAT.test_nat_balance) ... ok
test_nat_no_rules (__main__.TestNAT.test_nat_no_rules) ... ok
test_snat (__main__.TestNAT.test_snat) ... ok
test_snat_groups (__main__.TestNAT.test_snat_groups) ... ok
test_snat_required_translation_address (__main__.TestNAT.test_snat_required_translation_address) ... ok
test_static_nat (__main__.TestNAT.test_static_nat) ... ok

----------------------------------------------------------------------
Ran 10 tests in 24.575s

OK
root@nat-iface:/usr/libexec/vyos/tests/smoke/cli#
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
