### PR TITLE
remote: T5650: Resize-aware progressbar implementation

### DIFF
--- a/python/vyos/progressbar.py
+++ b/python/vyos/progressbar.py
@@ -1,0 +1,70 @@
+# Copyright 2023 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+import math
+import os
+import signal
+import subprocess
+import sys
+
+from vyos.utils.io import print_error
+
+class Progressbar:
+    def __init__(self, step=None):
+        self.total = 0.0
+        self.step = step
+    def __enter__(self):
+        # Recalculate terminal width with every window resize.
+        signal.signal(signal.SIGWINCH, lambda signum, frame: self._update_cols())
+        # Disable line wrapping to prevent the staircase effect.
+        subprocess.run(['tput', 'rmam'], check=False)
+        self._update_cols()
+        # Print an empty progressbar with entry.
+        self.progress(0, 1)
+        return self
+    def __exit__(self, exc_type, kexc_val, exc_tb):
+        # Revert to the default SIGWINCH handler (ie nothing).
+        signal.signal(signal.SIGWINCH, signal.SIG_DFL)
+        # Reenable line wrapping.
+        subprocess.run(['tput', 'smam'], check=False)
+    def _update_cols(self):
+        # `os.get_terminal_size()' is fast enough for our purposes.
+        self.col = max(os.get_terminal_size().columns - 15, 20)
+    def increment(self):
+        """
+        Stateful progressbar taking the step fraction at init and no input at
+        callback (for FTP)
+        """
+        if self.step:
+            if self.total < 1.0:
+                self.total += self.step
+            if self.total >= 1.0:
+                self.total = 1.0
+                # Ignore superfluous calls caused by fuzzy FTP size calculations.
+                self.step = None
+            self.progress(self.total, 1.0)
+    def progress(self, done, total):
+        """
+        Stateless progressbar taking no input at init and current progress with
+        final size at callback (for SSH)
+        """
+        if done <= total:
+            length = math.ceil(self.col * done / total)
+            percentage = str(math.ceil(100 * done / total)).rjust(3)
+            # Carriage return at the end will make sure the line will get overwritten.
+            print_error(f'[{length * "#"}{(self.col - length) * "_"}] {percentage}%', end='\r')
+        # Print a newline to make sure the full progressbar doesn't get overwritten by the next line.
+        if done == total:
+            print_error()

--- a/python/vyos/utils/io.py
+++ b/python/vyos/utils/io.py
@@ -24,45 +24,6 @@ def print_error(str='', end='\n'):
     sys.stderr.write(end)
     sys.stderr.flush()
 
-def make_progressbar():
-    """
-    Make a procedure that takes two arguments `done` and `total` and prints a
-     progressbar based on the ratio thereof, whose length is determined by the
-     width of the terminal.
-    """
-    import shutil, math
-    col, _ = shutil.get_terminal_size()
-    col = max(col - 15, 20)
-    def print_progressbar(done, total):
-        if done <= total:
-            increment = total / col
-            length = math.ceil(done / increment)
-            percentage = str(math.ceil(100 * done / total)).rjust(3)
-            print_error(f'[{length * "#"}{(col - length) * "_"}] {percentage}%', '\r')
-            # Print a newline so that the subsequent prints don't overwrite the full bar.
-        if done == total:
-            print_error()
-    return print_progressbar
-
-def make_incremental_progressbar(increment: float):
-    """
-    Make a generator that displays a progressbar that grows monotonically with
-     every iteration.
-    First call displays it at 0% and every subsequent iteration displays it
-     at `increment` increments where 0.0 < `increment` < 1.0.
-    Intended for FTP and HTTP transfers with stateless callbacks.
-    """
-    print_progressbar = make_progressbar()
-    total = 0.0
-    while total < 1.0:
-        print_progressbar(total, 1.0)
-        yield
-        total += increment
-    print_progressbar(1, 1)
-    # Ignore further calls.
-    while True:
-        yield
-
 def ask_input(question, default='', numeric_only=False, valid_responses=[]):
     question_out = question
     if default:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Replace the existing carriage return based progressbar routines with a proper module implementing a terminal resize aware progressbar that still accommodates for both stateful (generator-like) increments and stateless `progress/total` updates.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5650

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
op-mode, remote

## Proposed changes
<!--- Describe your changes in detail -->
The existing routines are prone to the staircasing effect, where shrinking the terminal will cause the progressbar to wrap over to the next line, making the carriage return return the cursor to the beginning of the next line, filling up the terminal window. This implementation provides a transparent context manager that disables terminal line wrapping and sets a SIGWINCH handler for recalculating the window size on entry (and undoes the changes on exit/exception) to make sure the lines don't flow over. This isn't a 100% foolproof solution because of a terminal I/O race condition between the signal handler and the stderr printer but it 90% alleviates it.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Perform any upload/download operation with a supported protocol.

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
