### PR TITLE
bridge: T5670: add missing constraint on "member interface" node

### DIFF
--- a/interface-definitions/interfaces-bridge.xml.in
+++ b/interface-definitions/interfaces-bridge.xml.in
@@ -123,6 +123,9 @@
                   <completionHelp>
                     <script>${vyos_completion_dir}/list_interfaces --bridgeable</script>
                   </completionHelp>
+                  <constraint>
+                    #include <include/constraint/interface-name.xml.i>
+                  </constraint>
                 </properties>
                 <children>
                   <leafNode name="native-vlan">

--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -258,10 +258,10 @@ def has_address_configured(conf, intf):
     old_level = conf.get_level()
     conf.set_level([])
 
-    intfpath = 'interfaces ' + Section.get_config_path(intf)
-    if ( conf.exists(f'{intfpath} address') or
-            conf.exists(f'{intfpath} ipv6 address autoconf') or
-            conf.exists(f'{intfpath} ipv6 address eui64') ):
+    intfpath = ['interfaces', Section.get_config_path(intf)]
+    if (conf.exists([intfpath, 'address']) or
+        conf.exists([intfpath, 'ipv6', 'address', 'autoconf']) or
+        conf.exists([intfpath, 'ipv6', 'address', 'eui64'])):
         ret = True
 
     conf.set_level(old_level)
@@ -279,8 +279,7 @@ def has_vrf_configured(conf, intf):
     old_level = conf.get_level()
     conf.set_level([])
 
-    tmp = ['interfaces', Section.get_config_path(intf), 'vrf']
-    if conf.exists(tmp):
+    if conf.exists(['interfaces', Section.get_config_path(intf), 'vrf']):
         ret = True
 
     conf.set_level(old_level)
@@ -298,8 +297,7 @@ def has_vlan_subinterface_configured(conf, intf):
     ret = False
 
     intfpath = ['interfaces', Section.section(intf), intf]
-    if ( conf.exists(intfpath + ['vif']) or
-            conf.exists(intfpath + ['vif-s'])):
+    if (conf.exists(intfpath + ['vif']) or conf.exists(intfpath + ['vif-s'])):
         ret = True
 
     return ret


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

One could specify a bridge member of VXLAN1 interface, but it is not possible
to create a VXLAN interface with the name of VXLAN1 - prohibited by VXLAN
interface name validator.

Add missing interface-name validator code


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5670

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
### Before
```
cpo@LR1.wue3# set interfaces bridge br0 member interface VXLAN1
[edit]
```

### After

```
cpo@LR1.wue3# set interfaces bridge br0 member interface VXLAN1

  Invalid value
  Value validation failed
  Set failed
```

### Smoketest Results

```
cpo@LR1.wue3:~$ TEST_ETH="eth1 eth2" /usr/libexec/vyos/tests/smoke/cli/test_interfaces_bridge.py
test_add_multiple_ip_addresses (__main__.BridgeInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_remove_bridge_member (__main__.BridgeInterfaceTest.test_add_remove_bridge_member) ... ok
test_add_single_ip_address (__main__.BridgeInterfaceTest.test_add_single_ip_address) ... ok
test_bridge_vif_members (__main__.BridgeInterfaceTest.test_bridge_vif_members) ... ok
test_bridge_vif_s_vif_c_members (__main__.BridgeInterfaceTest.test_bridge_vif_s_vif_c_members) ... ok
test_bridge_vlan_filter (__main__.BridgeInterfaceTest.test_bridge_vlan_filter) ... ok
test_dhcp_client_options (__main__.BridgeInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.BridgeInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.BridgeInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.BridgeInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.BridgeInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.BridgeInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.BridgeInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_igmp_querier_snooping (__main__.BridgeInterfaceTest.test_igmp_querier_snooping) ... ok
test_interface_description (__main__.BridgeInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.BridgeInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.BridgeInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.BridgeInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.BridgeInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.BridgeInterfaceTest.test_ipv6_link_local_address) ... ok
test_isolated_interfaces (__main__.BridgeInterfaceTest.test_isolated_interfaces) ... ok
test_mtu_1200_no_ipv6_interface (__main__.BridgeInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.BridgeInterfaceTest.test_span_mirror) ... ok
test_vif_8021q_interfaces (__main__.BridgeInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.BridgeInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.BridgeInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.BridgeInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.BridgeInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.BridgeInterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'

----------------------------------------------------------------------
Ran 29 tests in 115.320s

OK (skipped=2)

cpo@LR1.wue3:~$ TEST_ETH="eth1 eth2" /usr/libexec/vyos/tests/smoke/cli/test_interfaces_bonding.py
test_add_multiple_ip_addresses (__main__.BondingInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.BondingInterfaceTest.test_add_single_ip_address) ... ok
test_bonding_hash_policy (__main__.BondingInterfaceTest.test_bonding_hash_policy) ... ok
test_bonding_lacp_rate (__main__.BondingInterfaceTest.test_bonding_lacp_rate) ... ok
test_bonding_mii_monitoring_interval (__main__.BondingInterfaceTest.test_bonding_mii_monitoring_interval) ... ok
test_bonding_min_links (__main__.BondingInterfaceTest.test_bonding_min_links) ... ok
test_bonding_multi_use_member (__main__.BondingInterfaceTest.test_bonding_multi_use_member) ... ok
test_bonding_remove_member (__main__.BondingInterfaceTest.test_bonding_remove_member) ... ok
test_bonding_source_bridge_interface (__main__.BondingInterfaceTest.test_bonding_source_bridge_interface) ... ok
test_bonding_source_interface (__main__.BondingInterfaceTest.test_bonding_source_interface) ... ok
test_bonding_uniq_member_description (__main__.BondingInterfaceTest.test_bonding_uniq_member_description) ... ok
test_dhcp_client_options (__main__.BondingInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.BondingInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.BondingInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.BondingInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.BondingInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.BondingInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.BondingInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_interface_description (__main__.BondingInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.BondingInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.BondingInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.BondingInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.BondingInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.BondingInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.BondingInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.BondingInterfaceTest.test_span_mirror) ... ok
test_vif_8021q_interfaces (__main__.BondingInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.BondingInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.BondingInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.BondingInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.BondingInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.BondingInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 32 tests in 146.540s

OK

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
