### PR TITLE
vxlan: T5669: unable to change port number

### DIFF
--- a/src/conf_mode/interfaces-vxlan.py
+++ b/src/conf_mode/interfaces-vxlan.py
@@ -21,7 +21,7 @@ from netifaces import interfaces
 
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
-from vyos.configdict import leaf_node_changed
+from vyos.configdict import is_node_changed
 from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_mtu_ipv6
@@ -53,7 +53,7 @@ def get_config(config=None):
                        'source-address', 'source-interface', 'vni',
                        'parameters ip dont-fragment', 'parameters ip tos',
                        'parameters ip ttl']:
-        if leaf_node_changed(conf, cli_option.split()):
+        if is_node_changed(conf, cli_option.split()):
             vxlan.update({'rebuild_required': {}})
 
     return vxlan


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

```
set interfaces vxlan vxlan23 address '100.64.10.2/24' set interfaces vxlan vxlan23 remote '192.0.2.1'
set interfaces vxlan vxlan23 source-address '192.0.2.5' set interfaces vxlan vxlan23 vni '23'
commit
```
```
set interfaces vxlan vxlan23 port '4789'
commit
```
```
vyos@r1# ip -d link show dev vxlan23
12: vxlan23: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 22:6e:6d:33:c5:6b brd ff:ff:ff:ff:ff:ff promiscuity 0 minmtu 68 maxmtu 65535
    vxlan id 23 remote 192.0.2.1 local 192.0.2.5 srcport 0 0 dstport 8472
```
Port remains at the default value of 8472

This has been fixed

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5669

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vxlan

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR3.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_vxlan.py
test_01vxlan_parameters (__main__.VXLANInterfaceTest) ... ok
test_add_multiple_ip_addresses (__main__.VXLANInterfaceTest) ... ok
test_add_single_ip_address (__main__.VXLANInterfaceTest) ... ok
test_dhcp_disable_interface (__main__.VXLANInterfaceTest) ... skipped 'not supported'
test_dhcp_vrf (__main__.VXLANInterfaceTest) ... skipped 'not supported'
test_dhcpv6_client_options (__main__.VXLANInterfaceTest) ... skipped 'not supported'
test_dhcpv6_vrf (__main__.VXLANInterfaceTest) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.VXLANInterfaceTest) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.VXLANInterfaceTest) ... skipped 'not supported'
test_interface_description (__main__.VXLANInterfaceTest) ... ok
test_interface_disable (__main__.VXLANInterfaceTest) ... ok
test_interface_ip_options (__main__.VXLANInterfaceTest) ... ok
test_interface_ipv6_options (__main__.VXLANInterfaceTest) ... ok
test_interface_mtu (__main__.VXLANInterfaceTest) ... ok
test_ipv6_link_local_address (__main__.VXLANInterfaceTest) ... ok
test_mtu_1200_no_ipv6_interface (__main__.VXLANInterfaceTest) ... ok
test_span_mirror (__main__.VXLANInterfaceTest) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.VXLANInterfaceTest) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.VXLANInterfaceTest) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.VXLANInterfaceTest) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.VXLANInterfaceTest) ... skipped 'not supported'

----------------------------------------------------------------------
Ran 21 tests in 50.837s

OK (skipped=11)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
