### PR TITLE
T5299: Add missed option ceiling for QoS shaper

### DIFF
--- a/python/vyos/qos/trafficshaper.py
+++ b/python/vyos/qos/trafficshaper.py
@@ -1,4 +1,4 @@
-# Copyright 2022 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2022-2023 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -89,6 +89,10 @@ class TrafficShaper(QoSBase):
                 if 'priority' in cls_config:
                     priority = cls_config['priority']
                     tmp += f' prio {priority}'
+
+                if 'ceiling' in cls_config:
+                    f_ceil = self._rate_convert(cls_config['ceiling'])
+                    tmp += f' ceil {f_ceil}'
                 self._cmd(tmp)
 
                 tmp = f'tc qdisc replace dev {self._interface} parent {self._parent:x}:{cls:x} sfq'
@@ -102,6 +106,9 @@ class TrafficShaper(QoSBase):
                 if 'priority' in config['default']:
                     priority = config['default']['priority']
                     tmp += f' prio {priority}'
+                if 'ceiling' in config['default']:
+                    f_ceil = self._rate_convert(config['default']['ceiling'])
+                    tmp += f' ceil {f_ceil}'
                 self._cmd(tmp)
 
                 tmp = f'tc qdisc replace dev {self._interface} parent {self._parent:x}:{default_minor_id:x} sfq'


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add missed option `ceil` for QoS class `trafficshaper`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5299

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
qos
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set qos interface eth1 egress 'test'
set qos policy shaper test bandwidth '250mbit'
set qos policy shaper test class 23 bandwidth '50mbit'
set qos policy shaper test class 23 ceiling '80mbit'
set qos policy shaper test class 23 match 10 ip destination address '100.64.2.0/24'
set qos policy shaper test default bandwidth '20mbit'
set qos policy shaper test default ceiling '30mbit'
set qos policy shaper test default queue-type 'fair-queue'
```

Before the fix,
expected ceil for default class is **30Mbit** but get **20**
expected ceil for the class 23 is  **80Mbit** but get **50**
```
vyos@r4# tc class show dev eth1
class htb 1:18 parent 1:1 leaf 801d: prio 7 rate 20Mbit ceil 20Mbit burst 15Kb cburst 1600b 
class htb 1:1 root rate 250Mbit ceil 250Mbit burst 1562b cburst 1562b 
class htb 1:17 parent 1:1 leaf 801e: prio 0 rate 50Mbit ceil 50Mbit burst 15Kb cburst 1600b 
```
After the fix:
expected ceil for default class is **30Mbit**
expected ceil for the class 23 is  **80Mbit**
```
vyos@r4# tc class show dev eth1
class htb 1:18 parent 1:1 leaf 8029: prio 7 rate 20Mbit ceil 30Mbit burst 15Kb cburst 1593b 
class htb 1:1 root rate 250Mbit ceil 250Mbit burst 1562b cburst 1562b 
class htb 1:17 parent 1:1 leaf 802a: prio 0 rate 50Mbit ceil 80Mbit burst 15Kb cburst 1600b 
```


## Smoketest result
<!-- Provide the output of the smoketest
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_qos.py
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... skipped 'tc returns invalid JSON here - needs iproute2 fix'
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok

----------------------------------------------------------------------
Ran 11 tests in 48.274s

OK (skipped=1)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
