### PR TITLE
T5676: Use addr_prefix instead of addr in NAT66 source rule prefix parsing

### DIFF
--- a/python/vyos/nat.py
+++ b/python/vyos/nat.py
@@ -150,7 +150,7 @@ def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
             operator = ''
             if addr_prefix[:1] == '!':
                 operator = '!='
-                addr_prefix = addr[1:]
+                addr_prefix = addr_prefix[1:]
             output.append(f'ip6 {prefix}addr {operator} {addr_prefix}')
 
         port = dict_search_args(side_conf, 'port')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

Use `addr_prefix` instead of `addr` in NAT66 source rule for source/destination prefix parsing

NAT66 Source rule uses a source/destination **prefix**, all NAT44 and destination NAT66 use **address** (unsure why the inconsistency)

```
yzguy@test-R1# set nat66 source rule 1 source
Possible completions:
   port                 Port number
   prefix               IPv6 prefix to be translated

yzguy@test-R1# set nat66 source rule 1 destination
Possible completions:
   port                 Port number
   prefix               IPv6 prefix to be translated
```

Will need to be backported to 1.4, unsure about < 1.4

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5676

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
NAT66

## Proposed changes
Fix code to use the `addr_prefix` when the rule specifies a negation source/destination prefix

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
-->

Create NAT66  source rule with a source or destination prefix, commit

Example rule
```
set nat66 source rule 10 description 'NAT exclude loopbacks'
set nat66 source rule 10 destination prefix '!fd12:3456:789a:ffff::/64'
set nat66 source rule 10 outbound-interface 'eth0'
set nat66 source rule 10 source prefix 'fd12:3456:c0de:1::/64'
```

TypeError will be thrown, change Ln 153 to `addr_prefix = addr_prefix[1:]`

Commit again, it will succeed

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
