### PR TITLE
T5677: show lldp neighbors shows empty platform if descr not in lldpctl output

### DIFF
--- a/src/op_mode/lldp.py
+++ b/src/op_mode/lldp.py
@@ -114,7 +114,10 @@ def _get_formatted_output(raw_data):
 
             # Remote software platform
             platform = jmespath.search('chassis.[*][0][0].descr', values)
-            tmp.append(platform[:37])
+            if platform:
+                tmp.append(platform[:37])
+            else:
+                tmp.append('')
 
             # Remote interface
             interface = jmespath.search('port.descr', values)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
If no `descr` is found in the `lldpctl -f json` output for neighbors then output an empty `platform` in `show lldp neighbors` instead of throwing a TypeError

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5677

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
LLDP

## Proposed changes
Handle when there is no `descr` in the `lldpctl -f json` output from a neighbor

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Little tedious to test, but if you have a neighbor that does not have a `descr` in `lldpctl -f json`, you will receive a TypeError
This can be confirmed by running `lldpctl -f json` and looking to see if there is not a `descr` key. After one is found, the code change proposed can be made, then `show lldp neighbors` run again and it will not throw a TypeError, and output an expected neighbors output

In my case, it is VyOS deployed in EVE-NG, connected to an Arista vEOS VM


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
