### PR TITLE
bridge: T5670: add missing constraint on "member interface" node

### DIFF
--- a/interface-definitions/interfaces-bridge.xml.in
+++ b/interface-definitions/interfaces-bridge.xml.in
@@ -117,6 +117,9 @@
                   <completionHelp>
                     <script>${vyos_completion_dir}/list_interfaces.py --bridgeable</script>
                   </completionHelp>
+                  <constraint>
+                    #include <include/constraint/interface-name.xml.i>
+                  </constraint>
                 </properties>
                 <children>
                   <leafNode name="native-vlan">


### PR DESCRIPTION
One could specify a bridge member of VXLAN1 interface, but it is not possible to create a VXLAN interface with the name of VXLAN1 - prohibited by VXLAN interface name validator.

Add missing interface-name validator code

(cherry picked from commit 45dc149e4e3c0c294deac6fd541bb027d2280ea1)

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5670

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
Manual backport of https://github.com/vyos/vyos-1x/pull/2378

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bridge

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

### Before
```
cpo@LR1.wue3# set interfaces bridge br0 member interface VXLAN1
[edit]
```

### After
```
cpo@LR1.wue3# set interfaces bridge br0 member interface VXLAN1

  Invalid value
  Value validation failed
  Set failed
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
cpo@LR3.wue3:~$ TEST_ETH="eth1" /usr/libexec/vyos/tests/smoke/cli/test_interfaces_bridge.py
test_add_multiple_ip_addresses (__main__.BridgeInterfaceTest) ... ok
test_add_remove_bridge_member (__main__.BridgeInterfaceTest) ... ok
test_add_single_ip_address (__main__.BridgeInterfaceTest) ... ok
test_bridge_vif_members (__main__.BridgeInterfaceTest) ... ok
test_bridge_vif_s_vif_c_members (__main__.BridgeInterfaceTest) ... ok
test_bridge_vlan_filter (__main__.BridgeInterfaceTest) ... ok
test_dhcp_disable_interface (__main__.BridgeInterfaceTest) ... ok
test_dhcp_vrf (__main__.BridgeInterfaceTest) ... ok
test_dhcpv6_client_options (__main__.BridgeInterfaceTest) ... ok
test_dhcpv6_vrf (__main__.BridgeInterfaceTest) ... ok
test_dhcpv6pd_auto_sla_id (__main__.BridgeInterfaceTest) ... ok
test_dhcpv6pd_manual_sla_id (__main__.BridgeInterfaceTest) ... ok
test_interface_description (__main__.BridgeInterfaceTest) ... ok
test_interface_disable (__main__.BridgeInterfaceTest) ... ok
test_interface_ip_options (__main__.BridgeInterfaceTest) ... ok
test_interface_ipv6_options (__main__.BridgeInterfaceTest) ... ok
test_interface_mtu (__main__.BridgeInterfaceTest) ... skipped 'not supported'
test_ipv6_link_local_address (__main__.BridgeInterfaceTest) ... ok
test_isolated_interfaces (__main__.BridgeInterfaceTest) ... ok
test_mtu_1200_no_ipv6_interface (__main__.BridgeInterfaceTest) ... skipped 'not supported'
test_span_mirror (__main__.BridgeInterfaceTest) ... ok
test_vif_8021q_interfaces (__main__.BridgeInterfaceTest) ... ok
test_vif_8021q_lower_up_down (__main__.BridgeInterfaceTest) ... ok
test_vif_8021q_mtu_limits (__main__.BridgeInterfaceTest) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.BridgeInterfaceTest) ... skipped 'not supported'

----------------------------------------------------------------------
Ran 25 tests in 74.801s

OK (skipped=3)

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
