### PR TITLE
vrf: netns: T3829: T31: priority needs to be after netns

### DIFF
--- a/interface-definitions/netns.xml.in
+++ b/interface-definitions/netns.xml.in
@@ -3,7 +3,7 @@
   <node name="netns" owner="${vyos_conf_scripts_dir}/netns.py">
     <properties>
       <help>Network namespace</help>
-      <priority>291</priority>
+      <priority>10</priority>
     </properties>
     <children>
       <tagNode name="name">

--- a/interface-definitions/vrf.xml.in
+++ b/interface-definitions/vrf.xml.in
@@ -4,7 +4,7 @@
     <properties>
       <help>Virtual Routing and Forwarding</help>
       <!-- must be before any interface, check /opt/vyatta/sbin/priority.pl -->
-      <priority>299</priority>
+      <priority>11</priority>
     </properties>
     <children>
       <leafNode name="bind-to-all">


### PR DESCRIPTION
A network namespace can have VRFs assigned, thus we need to get the priorities right. This lowers both priorities in general as a VRF or NETNS needs to be available very early as services can run on top of them.

(cherry picked from commit 9dd5ff064a37b4e884f7bd9fb7630bf7829fa1ad)

## Change Summary
Lower priorities for NETNS and VRF, as they should be available earlier for other services.
Fixes https://forum.vyos.io/t/firewall-configuration-failed-to-apply-on-boot-when-using-vrf-interfaces-names/12487
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T31

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
netns, vrf

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
