### PR TITLE
T5683: Fix reverse-proxy PKI filenames mismatch

### DIFF
--- a/src/conf_mode/load-balancing-haproxy.py
+++ b/src/conf_mode/load-balancing-haproxy.py
@@ -94,8 +94,8 @@ def generate(lb):
             if os.path.isfile(file):
                 os.unlink(file)
         # Delete old directories
-        #if os.path.isdir(load_balancing_dir):
-        #    rmtree(load_balancing_dir, ignore_errors=True)
+        if os.path.isdir(load_balancing_dir):
+            rmtree(load_balancing_dir, ignore_errors=True)
 
         return None
 
@@ -106,15 +106,12 @@ def generate(lb):
     # SSL Certificates for frontend
     for front, front_config in lb['service'].items():
         if 'ssl' in front_config:
-            cert_file_path = os.path.join(load_balancing_dir, 'cert.pem')
-            cert_key_path = os.path.join(load_balancing_dir, 'cert.pem.key')
-            ca_cert_file_path = os.path.join(load_balancing_dir, 'ca.pem')
 
             if 'certificate' in front_config['ssl']:
-                #cert_file_path = os.path.join(load_balancing_dir, 'cert.pem')
-                #cert_key_path = os.path.join(load_balancing_dir, 'cert.key')
                 cert_name = front_config['ssl']['certificate']
                 pki_cert = lb['pki']['certificate'][cert_name]
+                cert_file_path = os.path.join(load_balancing_dir, f'{cert_name}.pem')
+                cert_key_path = os.path.join(load_balancing_dir, f'{cert_name}.pem.key')
 
                 with open(cert_file_path, 'w') as f:
                     f.write(wrap_certificate(pki_cert['certificate']))
@@ -126,6 +123,7 @@ def generate(lb):
             if 'ca_certificate' in front_config['ssl']:
                 ca_name = front_config['ssl']['ca_certificate']
                 pki_ca_cert = lb['pki']['ca'][ca_name]
+                ca_cert_file_path = os.path.join(load_balancing_dir, f'{ca_name}.pem')
 
                 with open(ca_cert_file_path, 'w') as f:
                     f.write(wrap_certificate(pki_ca_cert['certificate']))
@@ -133,11 +131,11 @@ def generate(lb):
     # SSL Certificates for backend
     for back, back_config in lb['backend'].items():
         if 'ssl' in back_config:
-            ca_cert_file_path = os.path.join(load_balancing_dir, 'ca.pem')
 
             if 'ca_certificate' in back_config['ssl']:
                 ca_name = back_config['ssl']['ca_certificate']
                 pki_ca_cert = lb['pki']['ca'][ca_name]
+                ca_cert_file_path = os.path.join(load_balancing_dir, f'{ca_name}.pem')
 
                 with open(ca_cert_file_path, 'w') as f:
                     f.write(wrap_certificate(pki_ca_cert['certificate']))


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The current names for certificates are hardcoded in the generated config to:
```
 - ca.pem
 - cert.pem.key
 - cert.pem
```
It causes a generated config certificates and certificates themselves are different (`test-ca-1.pem` vs `ca.pem`)

It is a bug in the initial implementation. Fix required correct names from PKI certificates.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5683

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
reverse-proxy
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set pki ca test-ca-1 certificate 'REDACTED'
set pki certificate test-cert-1 certificate 'REDACTED'
set pki certificate test-cert-1 private key 'REDACTED'

set load-balancing reverse-proxy backend test-backend-1 mode 'http'
set load-balancing reverse-proxy backend test-backend-1 server test-server-1 address '10.11.12.1'
set load-balancing reverse-proxy backend test-backend-1 server test-server-1 port '443'
set load-balancing reverse-proxy backend test-backend-1 ssl ca-certificate 'test-ca-1'
set load-balancing reverse-proxy service test-frontend-1 mode 'http'
set load-balancing reverse-proxy service test-frontend-1 port '8080'
set load-balancing reverse-proxy service test-frontend-1 ssl certificate 'test-cert-1'

commit
```
Before the fix we had wrong certificate names:
```
vyos@r4# ls -l /run/haproxy/
total 16
-rw-r--r-- 1 root haproxy 1294 Oct 25 12:54 ca.pem
-rw-r--r-- 1 root haproxy 1322 Oct 25 12:54 cert.pem
-rw-r--r-- 1 root haproxy 1678 Oct 25 12:54 cert.pem.key
-rw-r--r-- 1 root haproxy 1788 Oct 25 12:54 haproxy.cfg
[edit]
vyos@r4# 

vyos@r4# haproxy -c -- /run/haproxy/haproxy.cfg 
[NOTICE]   (6741) : haproxy version is 2.6.12-1
[NOTICE]   (6741) : path to executable is /usr/sbin/haproxy
[ALERT]    (6741) : config : parsing [/run/haproxy/haproxy.cfg:40] : 'bind :::8080' in section 'frontend' : unable to stat SSL certificate from file '/run/haproxy/test-cert-1.pem' : No such file or directory.
[ALERT]    (6741) : config : [/run/haproxy/haproxy.cfg:51] : 'server test-backend-1/test-server-1' : Couldn't open the ca-file '/run/haproxy/test-ca-1.pem' (No such file or directory).
[ALERT]    (6741) : config : 'ca-file' : unable to load /run/haproxy/test-ca-1.pem.
[ALERT]    (6741) : config : Error(s) found in configuration file : /run/haproxy/haproxy.cfg
[ALERT]    (6741) : config : Fatal errors found in configuration.
[edit]
vyos@r4#
```
haproxy config:
```
# Frontend
frontend test-frontend-1
    bind :::8080 v4v6 ssl crt /run/haproxy/test-cert-1.pem
    mode http


# Backend
backend test-backend-1
    balance roundrobin
    option forwardfor
    http-request set-header X-Forwarded-Port %[dst_port]
    http-request add-header X-Forwarded-Proto https if { ssl_fc }
    mode http
    server test-server-1 10.11.12.1:443 ssl ca-file /run/haproxy/test-ca-1.pem

```

After the fix we have correct certificate names:
```
vyos@r4# ls -la /run/haproxy/
total 16
drwxr-xr-x  2 root root  140 Oct 25 13:11 .
drwxr-xr-x 38 root root 1160 Oct 25 13:11 ..
srw-rw----  1 root root    0 Oct 25 13:11 admin.sock
-rw-r--r--  1 root root 1788 Oct 25 13:11 haproxy.cfg
-rw-r--r--  1 root root 1294 Oct 25 13:11 test-ca-1.pem
-rw-r--r--  1 root root 1322 Oct 25 13:11 test-cert-1.pem
-rw-r--r--  1 root root 1678 Oct 25 13:11 test-cert-1.pem.key
[edit]
vyos@r4# 

vyos@r4# haproxy -c -- /run/haproxy/haproxy.cfg 
Configuration file is valid
[edit]
vyos@r4# 
```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_load_balancing_reverse_proxy.py
test_01_lb_reverse_proxy_domain (__main__.TestLoadBalancingReverseProxy.test_01_lb_reverse_proxy_domain) ... ok

----------------------------------------------------------------------
Ran 1 test in 5.974s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
