### PR TITLE
T5698 EVPN ESI Multihoming

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -373,6 +373,26 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {%         if afi_config.advertise_svi_ip is vyos_defined %}
   advertise-svi-ip
 {%         endif %}
+{%         if afi_config.default_originate.ipv4 is vyos_defined %}
+  default-originate ipv4
+{%         endif %}
+{%         if afi_config.default_originate.ipv6 is vyos_defined %}
+  default-originate ipv6
+{%         endif %}
+{%         if afi_config.disable_ead_evi_rx is vyos_defined %}
+  disable-ead-evi-rx
+{%         endif %}
+{%         if afi_config.disable_ead_evi_tx is vyos_defined %}
+  disable-ead-evi-tx
+{%         endif %}
+{%         if afi_config.ead_es_frag.evi_limit is vyos_defined %}
+  ead-es-frag evi-limit {{ afi_config.ead_es_frag.evi_limit }}
+{%         endif %}
+{%         if afi_config.ead_es_route_target.export is vyos_defined %}
+{%             for route_target in afi_config.ead_es_route_target.export %}
+ ead-es-route-target export {{ route_target }}
+{%             endfor %}
+{%         endif %}
 {%         if afi_config.rt_auto_derive is vyos_defined %}
   autort rfc8365-compatible
 {%         endif %}

--- a/data/templates/frr/evpn.mh.frr.j2
+++ b/data/templates/frr/evpn.mh.frr.j2
@@ -1,0 +1,16 @@
+!
+interface {{ ifname }}
+{% if evpn.es_df_pref is vyos_defined %}
+ evpn mh es-df-pref {{ evpn.es_df_pref }}
+{% endif %}
+{% if evpn.es_id is vyos_defined %}
+ evpn mh es-id {{ evpn.es_id }}
+{% endif %}
+{% if evpn.es_sys_mac is vyos_defined %}
+ evpn mh es-sys-mac {{ evpn.es_sys_mac }}
+{% endif %}
+{% if evpn.uplink is vyos_defined %}
+ evpn mh uplink
+{% endif %}
+exit
+!

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -806,6 +806,76 @@
             <valueless/>
           </properties>
         </leafNode>
+        <node name="default-originate">
+          <properties>
+            <help>Originate a default route</help>
+          </properties>
+          <children>
+            <leafNode name="ipv4">
+              <properties>
+                <help>IPv4 address family</help>
+                <valueless/>
+              </properties>
+            </leafNode>
+            <leafNode name="ipv6">
+              <properties>
+                <help>IPv6 address family</help>
+                <valueless/>
+              </properties>
+            </leafNode>
+          </children>
+        </node>
+        <leafNode name="disable-ead-evi-rx">
+          <properties>
+            <help>Activate PE on EAD-ES even if EAD-EVI is not received</help>
+            <valueless/>
+          </properties>
+        </leafNode>
+        <leafNode name="disable-ead-evi-tx">
+          <properties>
+            <help>Do not advertise EAD-EVI for local ESs</help>
+            <valueless/>
+          </properties>
+        </leafNode>
+        <node name="ead-es-frag">
+          <properties>
+            <help>EAD ES fragment config</help>
+          </properties>
+          <children>
+            <leafNode name="evi-limit">
+              <properties>
+                <help>EVIs per-fragment</help>
+                <valueHelp>
+                  <format>u32:1-1000</format>
+                  <description>limit</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-1000"/>
+                </constraint>
+              </properties>
+            </leafNode>
+          </children>
+        </node>
+        <node name="ead-es-route-target">
+          <properties>
+            <help>EAD ES Route Target</help>
+          </properties>
+          <children>
+            <leafNode name="export">
+              <properties>
+                <help>Route Target export</help>
+                <valueHelp>
+                  <format>txt</format>
+                  <description>Route target (A.B.C.D:MN|EF:OPQR|GHJK:MN)</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="bgp-rd-rt" argument="--route-target-multi"/>
+                </constraint>
+                <multi/>
+              </properties>
+            </leafNode>
+          </children>
+        </node>
         <node name="flooding">
           <properties>
             <help>Specify handling for BUM packets</help>

--- a/interface-definitions/interfaces-bonding.xml.in
+++ b/interface-definitions/interfaces-bonding.xml.in
@@ -104,7 +104,7 @@
               </leafNode>
               <leafNode name="uplink">
                 <properties>
-                  <help>Uplink to the VxLAN core</help>
+                  <help>Uplink to the VXLAN core</help>
                   <valueless/>
                 </properties>
               </leafNode>

--- a/interface-definitions/interfaces-bonding.xml.in
+++ b/interface-definitions/interfaces-bonding.xml.in
@@ -56,6 +56,60 @@
           #include <include/interface/disable.xml.i>
           #include <include/interface/vrf.xml.i>
           #include <include/interface/mirror.xml.i>
+          <node name="evpn">
+            <properties>
+              <help>EVPN Multihoming</help>
+            </properties>
+            <children>
+              <leafNode name="es-df-pref">
+                <properties>
+                  <help>Preference value used for designated forwarder (DF) election</help>
+                  <valueHelp>
+                    <format>u32:1-65535</format>
+                    <description>DF Preference value</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 1-65535"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="es-id">
+                <properties>
+                  <help>Ethernet segment identifier</help>
+                  <valueHelp>
+                    <format>u32:1-16777215</format>
+                    <description>Local discriminator</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>10-byte ID - 00:11:22:33:44:55:AA:BB:CC:DD</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 1-65535"/>
+                    <regex>([0-9A-Fa-f][0-9A-Fa-f]:){9}[0-9A-Fa-f][0-9A-Fa-f]</regex>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="es-sys-mac">
+                <properties>
+                  <help>Ethernet segment system MAC</help>
+                  <valueHelp>
+                    <format>macaddr</format>
+                    <description>MAC address</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="mac-address"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="uplink">
+                <properties>
+                  <help>Uplink to the VxLAN core</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+            </children>
+          </node>
           <leafNode name="hash-policy">
             <properties>
               <help>Bonding transmit hash policy</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add support for all active-active Ethernet Multihoming as alternative implementation to classical MLAG using our EVPN capabilities


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5698 

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bond
bgp

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set interfaces bonding bond10 evpn es-df-pref '50'
set interfaces bonding bond10 evpn es-id '10'
set interfaces bonding bond10 evpn es-sys-mac '01:23:45:67:89:ab'
set interfaces bonding bond10 member interface 'eth3'
set interfaces bonding bond10 mode '802.3ad'
``` 

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```bash
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ... ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ... ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ... ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ... ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ... ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ... ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ... ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ... ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ... ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ... ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok

----------------------------------------------------------------------
Ran 22 tests in 124.665s

OK
```

```bash
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_bonding.py
test_add_multiple_ip_addresses (__main__.BondingInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.BondingInterfaceTest.test_add_single_ip_address) ... ok
test_bonding_evpn_multihoming (__main__.BondingInterfaceTest.test_bonding_evpn_multihoming) ... ok
test_bonding_hash_policy (__main__.BondingInterfaceTest.test_bonding_hash_policy) ... ok
test_bonding_lacp_rate (__main__.BondingInterfaceTest.test_bonding_lacp_rate) ... ok
test_bonding_mii_monitoring_interval (__main__.BondingInterfaceTest.test_bonding_mii_monitoring_interval) ... ok
test_bonding_min_links (__main__.BondingInterfaceTest.test_bonding_min_links) ... ok
test_bonding_multi_use_member (__main__.BondingInterfaceTest.test_bonding_multi_use_member) ... ok
test_bonding_remove_member (__main__.BondingInterfaceTest.test_bonding_remove_member) ... ok
test_bonding_source_bridge_interface (__main__.BondingInterfaceTest.test_bonding_source_bridge_interface) ... ok
test_bonding_source_interface (__main__.BondingInterfaceTest.test_bonding_source_interface) ... ok
test_bonding_uniq_member_description (__main__.BondingInterfaceTest.test_bonding_uniq_member_description) ... ok
test_dhcp_client_options (__main__.BondingInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.BondingInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.BondingInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.BondingInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.BondingInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.BondingInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.BondingInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_interface_description (__main__.BondingInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.BondingInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.BondingInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.BondingInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.BondingInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.BondingInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.BondingInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.BondingInterfaceTest.test_span_mirror) ... ok
test_vif_8021q_interfaces (__main__.BondingInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.BondingInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.BondingInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.BondingInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.BondingInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.BondingInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 33 tests in 178.997s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
