### PR TITLE
vxlan: T5699: migrate "external" CLI know to "parameters external"

### DIFF
--- a/interface-definitions/interfaces-vxlan.xml.in
+++ b/interface-definitions/interfaces-vxlan.xml.in
@@ -19,12 +19,6 @@
           #include <include/interface/address-ipv4-ipv6.xml.i>
           #include <include/generic-description.xml.i>
           #include <include/interface/disable.xml.i>
-          <leafNode name="external">
-            <properties>
-              <help>Use external control plane</help>
-              <valueless/>
-            </properties>
-          </leafNode>
           <leafNode name="gpe">
             <properties>
               <help>Enable Generic Protocol extension (VXLAN-GPE)</help>
@@ -83,6 +77,12 @@
                   #include <include/interface/parameters-flowlabel.xml.i>
                 </children>
               </node>
+              <leafNode name="external">
+                <properties>
+                  <help>Use external control plane</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
               <leafNode name="nolearning">
                 <properties>
                   <help>Do not add unknown addresses into forwarding database</help>

--- a/python/vyos/ifconfig/vxlan.py
+++ b/python/vyos/ifconfig/vxlan.py
@@ -68,8 +68,8 @@ class VXLANIf(Interface):
         # - https://man7.org/linux/man-pages/man8/ip-link.8.html
         mapping = {
             'group'                      : 'group',
-            'external'                   : 'external',
             'gpe'                        : 'gpe',
+            'parameters.external'        : 'external',
             'parameters.ip.df'           : 'df',
             'parameters.ip.tos'          : 'tos',
             'parameters.ip.ttl'          : 'ttl',

--- a/smoketest/scripts/cli/test_interfaces_vxlan.py
+++ b/smoketest/scripts/cli/test_interfaces_vxlan.py
@@ -107,7 +107,7 @@ class VXLANInterfaceTest(BasicInterfaceTest.TestCase):
     def test_vxlan_external(self):
         interface = 'vxlan0'
         source_address = '192.0.2.1'
-        self.cli_set(self._base_path + [interface, 'external'])
+        self.cli_set(self._base_path + [interface, 'parameters', 'external'])
         self.cli_set(self._base_path + [interface, 'source-address', source_address])
 
         # Both 'VNI' and 'external' can not be specified at the same time.
@@ -150,7 +150,7 @@ class VXLANInterfaceTest(BasicInterfaceTest.TestCase):
             '31': '10031',
         }
 
-        self.cli_set(self._base_path + [interface, 'external'])
+        self.cli_set(self._base_path + [interface, 'parameters', 'external'])
         self.cli_set(self._base_path + [interface, 'source-interface', source_interface])
 
         for vlan, vni in vlan_to_vni.items():

--- a/src/migration-scripts/interfaces/31-to-32
+++ b/src/migration-scripts/interfaces/31-to-32
@@ -27,7 +27,8 @@ if len(argv) < 2:
 file_name = argv[1]
 with open(file_name, 'r') as f:
     config_file = f.read()
-    base = ['interfaces', 'vxlan']
+
+base = ['interfaces', 'vxlan']
 
 config = ConfigTree(config_file)
 if not config.exists(base):
@@ -35,7 +36,11 @@ if not config.exists(base):
     exit(0)
 
 for vxlan in config.list_nodes(base):
-    if not config.exists(base + ['port']):
+    if config.exists(base + [vxlan, 'external']):
+        config.delete(base + [vxlan, 'external'])
+        config.set(base + [vxlan, 'parameters', 'external'])
+
+    if not config.exists(base + [vxlan, 'port']):
         config.set(base + [vxlan, 'port'], value='8472')
 
 try:


### PR DESCRIPTION
As we have a bunch of options under "paramteres" already and "external" is clearly one of them it should be migrated under that node as well.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5699

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* Merge before:
 https://github.com/vyos/vyos-1x/pull/2413

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests



## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```bash
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_vxlan.py
test_add_multiple_ip_addresses (__main__.VXLANInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.VXLANInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.VXLANInterfaceTest.test_dhcp_client_options) ... skipped 'not supported'
test_dhcp_disable_interface (__main__.VXLANInterfaceTest.test_dhcp_disable_interface) ... skipped 'not supported'
test_dhcp_vrf (__main__.VXLANInterfaceTest.test_dhcp_vrf) ... skipped 'not supported'
test_dhcpv6_client_options (__main__.VXLANInterfaceTest.test_dhcpv6_client_options) ... skipped 'not supported'
test_dhcpv6_vrf (__main__.VXLANInterfaceTest.test_dhcpv6_vrf) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.VXLANInterfaceTest.test_dhcpv6pd_auto_sla_id) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.VXLANInterfaceTest.test_dhcpv6pd_manual_sla_id) ... skipped 'not supported'
test_interface_description (__main__.VXLANInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.VXLANInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.VXLANInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.VXLANInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.VXLANInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.VXLANInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.VXLANInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.VXLANInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.VXLANInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.VXLANInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.VXLANInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.VXLANInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.VXLANInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.VXLANInterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'
test_vxlan_external (__main__.VXLANInterfaceTest.test_vxlan_external) ... ok
test_vxlan_parameters (__main__.VXLANInterfaceTest.test_vxlan_parameters) ... ok
test_vxlan_vlan_vni_mapping (__main__.VXLANInterfaceTest.test_vxlan_vlan_vni_mapping) ... ok

----------------------------------------------------------------------
Ran 26 tests in 84.988s

OK (skipped=14)
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
