### PR TITLE
T5705: rsyslog: fix error when level=al

### DIFF
--- a/data/templates/rsyslog/rsyslog.conf.j2
+++ b/data/templates/rsyslog/rsyslog.conf.j2
@@ -15,7 +15,7 @@ $outchannel global,/var/log/messages,262144,/usr/sbin/logrotate {{ logrotate }}
 {% if global.facility is vyos_defined %}
 {%     set tmp = [] %}
 {%     for facility, facility_options in global.facility.items() %}
-{%         set _ = tmp.append(facility.replace('all', '*') + '.' + facility_options.level) %}
+{%         set _ = tmp.append(facility.replace('all', '*') + '.' + facility_options.level.replace('all', '*')) %}
 {%     endfor %}
 {{ tmp | join(';') }} :omfile:$global
 {% endif %}
@@ -27,7 +27,7 @@ $outchannel global,/var/log/messages,262144,/usr/sbin/logrotate {{ logrotate }}
 $outchannel {{ file_name }},/var/log/user/{{ file_name }},{{ file_options.archive.size }},/usr/sbin/logrotate {{ logrotate }}
 {%         if file_options.facility is vyos_defined %}
 {%             for facility, facility_options in file_options.facility.items() %}
-{%                 set _ = tmp.append(facility.replace('all', '*') + '.' + facility_options.level) %}
+{%                 set _ = tmp.append(facility.replace('all', '*') + '.' + facility_options.level.replace('all', '*')) %}
 {%             endfor %}
 {%         endif %}
 {{ tmp | join(';') }} :omfile:${{ file }}
@@ -38,7 +38,7 @@ $outchannel {{ file_name }},/var/log/user/{{ file_name }},{{ file_options.archiv
 # Console logging
 {%     set tmp = [] %}
 {%     for facility, facility_options in console.facility.items() %}
-{%         set _ = tmp.append(facility.replace('all', '*') + '.' + facility_options.level) %}
+{%         set _ = tmp.append(facility.replace('all', '*') + '.' + facility_options.level.replace('all', '*')) %}
 {%     endfor %}
 {{ tmp | join(';') }} /dev/console
 {% endif %}
@@ -49,7 +49,7 @@ $outchannel {{ file_name }},/var/log/user/{{ file_name }},{{ file_options.archiv
 {%         set tmp = [] %}
 {%         if host_options.facility is vyos_defined %}
 {%             for facility, facility_options in host_options.facility.items() %}
-{%                 set _ = tmp.append(facility.replace('all', '*') + '.' + facility_options.level) %}
+{%                 set _ = tmp.append(facility.replace('all', '*') + '.' + facility_options.level.replace('all', '*')) %}
 {%             endfor %}
 {%         endif %}
 {%         if host_options.protocol is vyos_defined('tcp') %}
@@ -70,7 +70,7 @@ $outchannel {{ file_name }},/var/log/user/{{ file_name }},{{ file_options.archiv
 {%         set tmp = [] %}
 {%         if user_options.facility is vyos_defined %}
 {%             for facility, facility_options in user_options.facility.items() %}
-{%                 set _ = tmp.append(facility.replace('all', '*') + '.' + facility_options.level) %}
+{%                 set _ = tmp.append(facility.replace('all', '*') + '.' + facility_options.level.replace('all', '*')) %}
 {%             endfor %}
 {%         endif %}
 {{ tmp | join(';') }} :omusrmsg:{{ username }}

--- a/smoketest/scripts/cli/test_system_syslog.py
+++ b/smoketest/scripts/cli/test_system_syslog.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2019-2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import unittest
+
+from base_vyostest_shim import VyOSUnitTestSHIM
+
+from vyos.configsession import ConfigSessionError
+from vyos.template import is_ipv4
+from vyos.template import address_from_cidr
+from vyos.utils.process import call
+from vyos.utils.process import DEVNULL
+from vyos.utils.file import read_file
+from vyos.utils.process import process_named_running
+from vyos.version import get_version_data
+
+PROCESS_NAME = 'rsyslogd'
+RSYSLOG_CONF = '/etc/rsyslog.d/00-vyos.conf'
+
+base_path = ['system', 'syslog']
+
+def get_config_value(key):
+    tmp = read_file(RSYSLOG_CONF)
+    tmp = re.findall(r'\n?{}\s+(.*)'.format(key), tmp)
+    return tmp[0]
+
+class TestRSYSLOGService(VyOSUnitTestSHIM.TestCase): 
+    @classmethod
+    def setUpClass(cls):
+        super(TestRSYSLOGService, cls).setUpClass()  
+
+        # ensure we can also run this test on a live system - so lets clean
+        # out the current configuration :)
+        cls.cli_delete(cls, base_path)
+
+    def tearDown(self):
+        # Check for running process
+        self.assertTrue(process_named_running(PROCESS_NAME))
+
+        # delete testing SYSLOG config
+        self.cli_delete(base_path)
+        self.cli_commit()
+
+        # Check for running process
+        self.assertFalse(process_named_running(PROCESS_NAME))
+
+    def test_syslog_basic(self):
+        host1 = '198.51.100.1'
+        host2 = '192.0.2.1'
+
+        self.cli_set(base_path + ['host', host1, 'port', '999'])
+        self.cli_set(base_path + ['host', host1, 'facility', 'all', 'level', 'all'])
+        self.cli_set(base_path + ['host', host2, 'facility', 'kern', 'level', 'err'])
+        self.cli_set(base_path + ['console', 'facility', 'all', 'level', 'warning'])
+
+
+        self.cli_commit()
+        # verify log level and facilities in config file
+        # *.warning /dev/console
+        # *.* @198.51.100.1:999
+        # kern.err @192.0.2.1:514
+        config = [get_config_value('\*.\*'), get_config_value('kern.err'), get_config_value('\*.warning')]
+        expected = ['@198.51.100.1:999', '@192.0.2.1:514', '/dev/console']
+
+        for i in range(0,3):
+            self.assertIn(expected[i], config[i])
+        # Check for running process
+        self.assertTrue(process_named_running(PROCESS_NAME))
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix error while defining syslog and log-level=all.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5705

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
syslog

## Proposed changes
<!--- Describe your changes in detail -->
In template, when facility=all change it to wildcard -> facility=*

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@rsyslog-test:~$ show config comm | grep syslog
set system host-name 'rsyslog-test'
set system syslog console facility auth level 'err'
set system syslog global facility all level 'info'
set system syslog global facility local7 level 'debug'
set system syslog host 192.0.2.99 facility kern level 'all'
set system syslog host 192.0.2.99 port '998'
set system syslog host 203.0.113.99 facility all level 'warning'
vyos@rsyslog-test:~$ 
vyos@rsyslog-test:~$ sudo systemctl status rsyslog
● rsyslog.service - System Logging Service
     Loaded: loaded (/lib/systemd/system/rsyslog.service; enabled; preset: enab>
    Drop-In: /run/systemd/system/rsyslog.service.d
             └─override.conf
     Active: active (running) since Thu 2023-11-02 09:24:03 UTC; 41s ago
...
...

vyos@rsyslog-test:~$ cat /etc/rsyslog.d/00-vyos.conf 
### Autogenerated by system-syslog.py ###

$ModLoad immark
$MarkMessagePeriod 1200

# We always log to /var/log/messages
$outchannel global,/var/log/messages,262144,/usr/sbin/logrotate /etc/logrotate.d/vyos-rsyslog
*.info;local7.debug :omfile:$global


# Console logging
auth.err /dev/console

# Remote logging
kern.* @192.0.2.99:998
*.warning @203.0.113.99:514
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@rsyslog-test:/usr/libexec/vyos/tests/smoke/cli# ./test_system_syslog.py
test_syslog_basic (__main__.TestRSYSLOGService.test_syslog_basic) ... ok

----------------------------------------------------------------------
Ran 1 test in 2.522s

OK
root@rsyslog-test:/usr/libexec/vyos/tests/smoke/cli# 
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
