### PR TITLE
T5700: Fix deprecate telegraf plugin input net

### DIFF
--- a/data/templates/telegraf/telegraf.j2
+++ b/data/templates/telegraf/telegraf.j2
@@ -89,7 +89,7 @@
     ignore_fs = ["devtmpfs", "devfs"]
 [[inputs.diskio]]
 [[inputs.mem]]
-[[inputs.net]]
+[[inputs.nstat]]
 [[inputs.system]]
 [[inputs.netstat]]
 [[inputs.processes]]


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix deprecate telegraf plugin input net
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Fix deprecated plugin `input.net`

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5700

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
telegraf
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service monitoring telegraf prometheus-client
```
Before the fix:
```
Nov 02 12:10:11 r4 telegraf[4017]: 2023-11-02T10:10:11Z I! [agent] Config: Interval:15s, Quiet:false, Hostname:"r4", Flush Interval:15s
Nov 02 12:10:11 r4 telegraf[4017]: 2023-11-02T10:10:11Z W! DeprecationWarning: Value "false" for option "ignore_protocol_stats" of plugin "inputs.net" deprecated since version 1.27.3 and will be removed in 1.36.0: use the 'inputs.nstat' plugin instead


```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_monitoring_telegraf.py
test_01_basic_config (__main__.TestMonitoringTelegraf.test_01_basic_config) ... ok

----------------------------------------------------------------------
Ran 1 test in 4.410s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
