### PR TITLE
T5704: PPPoE L2TP SSTP IPoE add option max-concurrent-sessions

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.j2
+++ b/data/templates/accel-ppp/ipoe.config.j2
@@ -14,6 +14,11 @@ ippool
 [core]
 thread-count={{ thread_count }}
 
+[common]
+{% if max_concurrent_sessions is vyos_defined %}
+max-starting={{ max_concurrent_sessions }}
+{% endif %}
+
 [log]
 syslog=accel-ipoe,daemon
 copy=1

--- a/data/templates/accel-ppp/l2tp.config.j2
+++ b/data/templates/accel-ppp/l2tp.config.j2
@@ -20,6 +20,11 @@ ipv6_dhcp
 [core]
 thread-count={{ thread_cnt }}
 
+[common]
+{% if max_concurrent_sessions is vyos_defined %}
+max-starting={{ max_concurrent_sessions }}
+{% endif %}
+
 [log]
 syslog=accel-l2tp,daemon
 copy=1

--- a/data/templates/accel-ppp/pppoe.config.j2
+++ b/data/templates/accel-ppp/pppoe.config.j2
@@ -62,9 +62,12 @@ wins{{ loop.index }}={{ server }}
 {# Common chap-secrets and RADIUS server/option definitions #}
 {% include 'accel-ppp/config_chap_secrets_radius.j2' %}
 
-{% if session_control is vyos_defined and session_control is not vyos_defined('disable') %}
 [common]
+{% if session_control is vyos_defined and session_control is not vyos_defined('disable') %}
 single-session={{ session_control }}
+{% endif %}
+{% if max_concurrent_sessions is vyos_defined %}
+max-starting={{ max_concurrent_sessions }}
 {% endif %}
 
 [ppp]

--- a/data/templates/accel-ppp/pptp.config.j2
+++ b/data/templates/accel-ppp/pptp.config.j2
@@ -16,6 +16,11 @@ ippool
 [core]
 thread-count={{ thread_cnt }}
 
+[common]
+{% if max_concurrent_sessions is vyos_defined %}
+max-starting={{ max_concurrent_sessions }}
+{% endif %}
+
 [log]
 syslog=accel-pptp,daemon
 copy=1

--- a/data/templates/accel-ppp/sstp.config.j2
+++ b/data/templates/accel-ppp/sstp.config.j2
@@ -16,6 +16,9 @@ thread-count={{ thread_count }}
 
 [common]
 single-session=replace
+{% if max_concurrent_sessions is vyos_defined %}
+max-starting={{ max_concurrent_sessions }}
+{% endif %}
 
 [log]
 syslog=accel-sstp,daemon

--- a/interface-definitions/include/accel-ppp/max-concurrent-sessions.xml.i
+++ b/interface-definitions/include/accel-ppp/max-concurrent-sessions.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from accel-ppp/max-concurrent-sessions.xml.i -->
+<leafNode name="max-concurrent-sessions">
+  <properties>
+    <help>Maximum number of concurrent session start attempts</help>
+    <valueHelp>
+      <format>u32:0-65535</format>
+      <description>Maximum number of concurrent session start attempts</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--allow-range --range 0-65535"/>
+    </constraint>
+    <constraintErrorMessage>Maximum concurent sessions must be in range 0-65535</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/service-ipoe-server.xml.in
+++ b/interface-definitions/service-ipoe-server.xml.in
@@ -102,6 +102,7 @@
               #include <include/accel-ppp/vlan.xml.i>
             </children>
           </tagNode>
+          #include <include/accel-ppp/max-concurrent-sessions.xml.i>
           #include <include/name-server-ipv4-ipv6.xml.i>
           <node name="client-ip-pool">
             <properties>

--- a/interface-definitions/service-pppoe-server.xml.in
+++ b/interface-definitions/service-pppoe-server.xml.in
@@ -73,6 +73,7 @@
             </children>
           </tagNode>
           #include <include/accel-ppp/gateway-address.xml.i>
+          #include <include/accel-ppp/max-concurrent-sessions.xml.i>
           #include <include/accel-ppp/mtu-128-16384.xml.i>
           <node name="limits">
             <properties>

--- a/interface-definitions/vpn-l2tp.xml.in
+++ b/interface-definitions/vpn-l2tp.xml.in
@@ -13,6 +13,7 @@
               <help>Remote access L2TP VPN</help>
             </properties>
             <children>
+              #include <include/accel-ppp/max-concurrent-sessions.xml.i>
               #include <include/accel-ppp/mtu-128-16384.xml.i>
               <leafNode name="outside-address">
                 <properties>

--- a/interface-definitions/vpn-pptp.xml.in
+++ b/interface-definitions/vpn-pptp.xml.in
@@ -13,6 +13,7 @@
               <help>Remote access PPTP VPN</help>
             </properties>
             <children>
+              #include <include/accel-ppp/max-concurrent-sessions.xml.i>
               #include <include/accel-ppp/mtu-128-16384.xml.i>
               <leafNode name="outside-address">
                 <properties>

--- a/interface-definitions/vpn-sstp.xml.in
+++ b/interface-definitions/vpn-sstp.xml.in
@@ -25,6 +25,7 @@
               </node>
             </children>
           </node>
+          #include <include/accel-ppp/max-concurrent-sessions.xml.i>
           #include <include/interface/mtu-68-1500.xml.i>
           #include <include/accel-ppp/gateway-address.xml.i>
           #include <include/name-server-ipv4-ipv6.xml.i>


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add `max-starting` option:
```
  [common]
  max-starting=N
```
Specifies maximum concurrent session attempts which server may processed
```
  set service pppoe-server max-concurrent-sessions '30'
```
Useful to prevent high CPU utilization and compat execution scripts per time.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5704

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
accel-ppp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service pppoe-server access-concentrator 'ACN'
set service pppoe-server authentication local-users username foo password 'bar'
set service pppoe-server authentication mode 'local'
set service pppoe-server client-ip-pool start '100.64.0.10'
set service pppoe-server client-ip-pool stop '100.64.0.200'
set service pppoe-server gateway-address '100.64.0.1'
set service pppoe-server interface eth0
set service pppoe-server max-concurrent-sessions '30'
set service pppoe-server name-server '100.64.0.1'
```
Expected config:
```
[common]
single-session=replace
max-starting=30

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
