### PR TITLE
wireguard: T5707: remove previously deconfigured peer

### DIFF
--- a/python/vyos/ifconfig/wireguard.py
+++ b/python/vyos/ifconfig/wireguard.py
@@ -167,11 +167,6 @@ class WireGuardIf(Interface):
         interface setup code and provide a single point of entry when workin
         on any interface. """
 
-        # remove no longer associated peers first
-        if 'peer_remove' in config:
-            for peer, public_key in config['peer_remove'].items():
-                self._cmd(f'wg set {self.ifname} peer {public_key} remove')
-
         tmp_file = NamedTemporaryFile('w')
         tmp_file.write(config['private_key'])
         tmp_file.flush()


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Changing the public key of a peer (updating the key material) left the old WireGuard peer in place, as the key removal command used the new key.

WireGuard only supports peer removal based on the configured public-key, by deleting the entire interface this is the shortcut instead of parsing out all peers and removing them one by one.

Peer reconfiguration will always come with a short downtime while the WireGuard interface is recreated.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5707

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
WireGuard

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Added a new smoketest `test_05_wireguard_peer_pubkey_change`

Or use:

```
set interfaces wireguard wg1337 address 172.16.0.1/24
set interfaces wireguard wg1337 port 1337
set interfaces wireguard wg1337 private-key iJi4lb2HhkLx2KSAGOjji2alKkYsJjSPkHkrcpxgEVU=
set interfaces wireguard wg1337 peer VyOS public-key srQ8VF6z/LDjKCzpxBzFpmaNUOeuHYzIfc2dcmoc/h4=
set interfaces wireguard wg1337 peer VyOS allowed-ips 10.205.212.10/32
commit
```

Now use `sudo wg show wg1337` to compare the public keys

```bash
interface: wg1337
  public key: UMtmJkFRLBddcaP/QjwMx+GAey7eLgHm55iIqs9oXE0=
  private key: (hidden)
  listening port: 1337

peer: srQ8VF6z/LDjKCzpxBzFpmaNUOeuHYzIfc2dcmoc/h4=
  allowed ips: 10.205.212.10/32
```

Now change the public key and compare again

```
set interfaces wireguard wg1337 peer VyOS public-key 8pbMHiQ7NECVP7F65Mb2W8+4ldGG2oaGvDSpSEsOBn8=
commit
```

```bash
interface: wg1337
  public key: UMtmJkFRLBddcaP/QjwMx+GAey7eLgHm55iIqs9oXE0=
  private key: (hidden)
  listening port: 1337

peer: 8pbMHiQ7NECVP7F65Mb2W8+4ldGG2oaGvDSpSEsOBn8=
  allowed ips: 10.205.212.10/32
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireguard.py
test_01_wireguard_peer (__main__.WireGuardInterfaceTest.test_01_wireguard_peer) ... ok
test_02_wireguard_add_remove_peer (__main__.WireGuardInterfaceTest.test_02_wireguard_add_remove_peer) ... ok
test_03_wireguard_same_public_key (__main__.WireGuardInterfaceTest.test_03_wireguard_same_public_key) ... ok
test_04_wireguard_threaded (__main__.WireGuardInterfaceTest.test_04_wireguard_threaded) ... ok
test_05_wireguard_peer_pubkey_change (__main__.WireGuardInterfaceTest.test_05_wireguard_peer_pubkey_change) ... ok

----------------------------------------------------------------------
Ran 5 tests in 20.706s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
