### PR TITLE
vxlan: T3700: add bridge dependency call when altering member interfaces

### DIFF
--- a/data/config-mode-dependencies/vyos-1x.json
+++ b/data/config-mode-dependencies/vyos-1x.json
@@ -9,6 +9,9 @@
   "interfaces_bonding": {
            "ethernet": ["interfaces-ethernet"]
          },
+  "interfaces_bridge": {
+           "vxlan": ["interfaces-vxlan"]
+         },
   "load_balancing_wan": {
                           "conntrack": ["conntrack"],
                           "conntrack_sync": ["conntrack_sync"]


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Commit 7f6624f5a6f8bd ("vxlan: T3700: support VLAN tunnel mapping of VLAN aware bridges") added support for Single VXLAN Device (SVD) containers supported by the Linux Kernel.

When working with bridge VIFs it turned out that when deleting a VIF all the VXLAN tunnel mappings got deleted, too. In order to avoid this, if the bridge has a VXLAN member interface which vlan-to-vni mapping enabled, we add a dependency that we call VXLAN conf-mode script after messing arround with the bridge VIFs and re-create tunnel mappings.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3700

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```bash
set interfaces bridge br1 enable-vlan
set interfaces bridge br1 member interface eth1 allowed-vlan '810'
set interfaces bridge br1 member interface eth1 allowed-vlan '820'
set interfaces bridge br1 member interface vxlan1

set interfaces vxlan vxlan1 mtu '1500'
set interfaces vxlan vxlan1 parameters external
set interfaces vxlan vxlan1 parameters nolearning
set interfaces vxlan vxlan1 source-address '172.16.254.40'
set interfaces vxlan vxlan1 vlan-to-vni 810 vni '10810'
set interfaces vxlan vxlan1 vlan-to-vni 820 vni '10820'
```

Now `show bridge vlan tunnel` should display the correct results, even after calling `delete interfaces bridge br1 member interface eth1 allowed-vlan '820'`

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```bash
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_vxlan.py
test_add_multiple_ip_addresses (__main__.VXLANInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.VXLANInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.VXLANInterfaceTest.test_dhcp_client_options) ... skipped 'not supported'
test_dhcp_disable_interface (__main__.VXLANInterfaceTest.test_dhcp_disable_interface) ... skipped 'not supported'
test_dhcp_vrf (__main__.VXLANInterfaceTest.test_dhcp_vrf) ... skipped 'not supported'
test_dhcpv6_client_options (__main__.VXLANInterfaceTest.test_dhcpv6_client_options) ... skipped 'not supported'
test_dhcpv6_vrf (__main__.VXLANInterfaceTest.test_dhcpv6_vrf) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.VXLANInterfaceTest.test_dhcpv6pd_auto_sla_id) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.VXLANInterfaceTest.test_dhcpv6pd_manual_sla_id) ... skipped 'not supported'
test_interface_description (__main__.VXLANInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.VXLANInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.VXLANInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.VXLANInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.VXLANInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.VXLANInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.VXLANInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.VXLANInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.VXLANInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.VXLANInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.VXLANInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.VXLANInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.VXLANInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.VXLANInterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'
test_vxlan_external (__main__.VXLANInterfaceTest.test_vxlan_external) ... ok
test_vxlan_neighbor_suppress (__main__.VXLANInterfaceTest.test_vxlan_neighbor_suppress) ... ok
test_vxlan_parameters (__main__.VXLANInterfaceTest.test_vxlan_parameters) ... ok
test_vxlan_vlan_vni_mapping (__main__.VXLANInterfaceTest.test_vxlan_vlan_vni_mapping) ... ok

----------------------------------------------------------------------
Ran 27 tests in 92.253s

OK (skipped=14)
```
```bash
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_bridge.py
test_add_multiple_ip_addresses (__main__.BridgeInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_remove_bridge_member (__main__.BridgeInterfaceTest.test_add_remove_bridge_member) ... ok
test_add_single_ip_address (__main__.BridgeInterfaceTest.test_add_single_ip_address) ... ok
test_bridge_vif_members (__main__.BridgeInterfaceTest.test_bridge_vif_members) ... ok
test_bridge_vif_s_vif_c_members (__main__.BridgeInterfaceTest.test_bridge_vif_s_vif_c_members) ... ok
test_bridge_vlan_filter (__main__.BridgeInterfaceTest.test_bridge_vlan_filter) ... ok
test_dhcp_client_options (__main__.BridgeInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.BridgeInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.BridgeInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.BridgeInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.BridgeInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.BridgeInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.BridgeInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_igmp_querier_snooping (__main__.BridgeInterfaceTest.test_igmp_querier_snooping) ... ok
test_interface_description (__main__.BridgeInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.BridgeInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.BridgeInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.BridgeInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.BridgeInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.BridgeInterfaceTest.test_ipv6_link_local_address) ... ok
test_isolated_interfaces (__main__.BridgeInterfaceTest.test_isolated_interfaces) ... ok
test_mtu_1200_no_ipv6_interface (__main__.BridgeInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.BridgeInterfaceTest.test_span_mirror) ... ok
test_vif_8021q_interfaces (__main__.BridgeInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.BridgeInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.BridgeInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.BridgeInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.BridgeInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.BridgeInterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'

----------------------------------------------------------------------
Ran 29 tests in 111.789s

OK (skipped=2)

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
