### PR TITLE
op-mode: bgp: T5698: add "es-vrf" and "next-hops" CLI commands (backport)

### DIFF
--- a/op-mode-definitions/include/bgp/show-bgp-common.xml.i
+++ b/op-mode-definitions/include/bgp/show-bgp-common.xml.i
@@ -138,9 +138,9 @@
         </tagNode>
         <tagNode name="rd">
           <properties>
-            <help>Show detailed BGP neighbor information</help>
+            <help>Display information for a route distinguisher</help>
             <completionHelp>
-              <list>ASN:NN IPADDRESS:NN</list>
+              <list>ASN:NN IPADDRESS:NN all</list>
             </completionHelp>
           </properties>
           <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>

--- a/op-mode-definitions/include/bgp/show-bgp-common.xml.i
+++ b/op-mode-definitions/include/bgp/show-bgp-common.xml.i
@@ -107,6 +107,12 @@
             #include <include/vni-tagnode.xml.i>
           </children>
         </node>
+        <leafNode name="es-vrf">
+          <properties>
+            <help>Ethernet Segment per VRF</help>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+        </leafNode>
         <leafNode name="import-rt">
           <properties>
             <help>Show import route target</help>
@@ -136,6 +142,12 @@
             </leafNode>
           </children>
         </tagNode>
+        <leafNode name="next-hops">
+          <properties>
+            <help>EVPN Nexthops</help>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+        </leafNode>
         <tagNode name="rd">
           <properties>
             <help>Display information for a route distinguisher</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add new EVPN related op-mode commands

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5698

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
    show bgp l2vpn evpn es-vrf
    show bgp l2vpn evpn next-hops
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
