### PR TITLE
mdns: T5719: Add op-mode commands to mDNS repeater

### DIFF
--- a/op-mode-definitions/mdns-reflector.xml.in
+++ b/op-mode-definitions/mdns-reflector.xml.in
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="monitor">
+    <children>
+      <node name="log">
+        <children>
+          <node name="mdns">
+            <properties>
+              <help>Monitor last lines of multicast Domain Name System related services</help>
+            </properties>
+            <children>
+              <node name="repeater">
+                <properties>
+                  <help>Monitor last lines of mDNS repeater service</help>
+                </properties>
+                <command>journalctl --no-hostname --follow --boot --unit avahi-daemon.service</command>
+              </node>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+  <node name="show">
+    <children>
+      <node name="log">
+        <children>
+          <node name="mdns">
+            <properties>
+              <help>Show log for multicast Domain Name System related services</help>
+            </properties>
+            <children>
+              <node name="repeater">
+                <properties>
+                  <help>Show log for mDNS repeater service</help>
+                </properties>
+                <command>journalctl --no-hostname --boot --unit avahi-daemon.service</command>
+              </node>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+  <node name="restart">
+    <children>
+      <node name="mdns">
+        <properties>
+          <help>Restart specific multicast Domain Name System service</help>
+        </properties>
+        <children>
+          <node name="repeater">
+            <properties>
+              <help>Restart mDNS repeater service</help>
+            </properties>
+            <command>sudo systemctl restart avahi-daemon.service</command>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The following ones are available now:
- restart mdns repeater
- show log mdns repeater
- monitor log mdns repeater

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5719

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
mdns repeater

## Proposed changes
<!--- Describe your changes in detail -->

The following op-mode commands for mdns repeater are available now:
- restart mdns repeater
- show log mdns repeater
- monitor log mdns repeater

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos-15a0:~$ restart mdns repeater

vyos@vyos-15a0:~$ monitor log mdns repeater
Nov 06 20:30:08 avahi-daemon[11289]: Joining mDNS multicast group on interface br0.5.IPv4 with address 10.16.5.1.
Nov 06 20:30:08 avahi-daemon[11289]: New relevant interface br0.16.IPv4 for mDNS.
Nov 06 20:30:08 avahi-daemon[11289]: Joining mDNS multicast group on interface br0.IPv4 with address 10.16.0.1.
Nov 06 20:30:08 avahi-daemon[11289]: New relevant interface br0.IPv4 for mDNS.
Nov 06 20:30:08 avahi-daemon[11289]: Network interface enumeration completed.
Nov 06 20:30:08 avahi-daemon[11289]: Server startup complete. Host name is vyos-15a0.local. Local service cookie is 3921645558.

vyos@vyos-15a0:~$ show log mdns repeater
...
...
...
Nov 06 20:30:08 avahi-daemon[11289]: Joining mDNS multicast group on interface br0.5.IPv4 with address 10.16.5.1.
Nov 06 20:30:08 avahi-daemon[11289]: New relevant interface br0.16.IPv4 for mDNS.
Nov 06 20:30:08 avahi-daemon[11289]: Joining mDNS multicast group on interface br0.IPv4 with address 10.16.0.1.
Nov 06 20:30:08 avahi-daemon[11289]: New relevant interface br0.IPv4 for mDNS.
Nov 06 20:30:08 avahi-daemon[11289]: Network interface enumeration completed.
Nov 06 20:30:08 avahi-daemon[11289]: Server startup complete. Host name is vyos-15a0.local. Local service cookie is 3921645558.
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
