### PR TITLE
T5720: Fix for PPPoE-server adding new interfaces

### DIFF
--- a/src/conf_mode/service_pppoe-server.py
+++ b/src/conf_mode/service_pppoe-server.py
@@ -48,9 +48,12 @@ def get_config(config=None):
     # reload-or-restart does not implemented in accel-ppp
     # use this workaround until it will be implemented
     # https://phabricator.accel-ppp.org/T3
-    if is_node_changed(conf, base + ['client-ip-pool']) or is_node_changed(
-            conf, base + ['client-ipv6-pool']):
+    conditions = [is_node_changed(conf, base + ['client-ip-pool']),
+                  is_node_changed(conf, base + ['client-ipv6-pool']),
+                  is_node_changed(conf, base + ['interface'])]
+    if any(conditions):
         pppoe.update({'restart_required': {}})
+
     return pppoe
 
 def verify(pppoe):


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
If we add a new interface for PPPoe-server we MUST restart the `accel-ppp@pppoe.service` as `reload` is not implemented for accel-ppp daemon
Otherwise, we have a listen interface in the `/run/accel-pppd/pppoe.conf`, which does not work.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5720

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Initial configuration:
```
set service pppoe-server access-concentrator 'ACN'
set service pppoe-server authentication local-users username foo disable
set service pppoe-server authentication local-users username foo password 'bar'
set service pppoe-server authentication mode 'local'
set service pppoe-server authentication radius rate-limit attribute 'Cisco-AVPair'
set service pppoe-server authentication radius rate-limit enable
set service pppoe-server authentication radius rate-limit vendor 'Cisco'
set service pppoe-server authentication radius server 203.0.113.1 key 'vyos-secret'
set service pppoe-server client-ip-pool name ONE gateway-address '100.64.0.1'
set service pppoe-server client-ip-pool name ONE subnet '100.64.0.0/18'
set service pppoe-server interface eth1
set service pppoe-server interface eth1.23
set service pppoe-server name-server '100.64.0.1'
```
Before the fix, add a new interface `eth2` and check pppoe-server interfaces (expected **eth2** is not present in the output):
```
vyos@r4# set service pppoe-server interface eth2
[edit]
vyos@r4# commit
[edit]
vyos@r4#
vyos@r4# run show pppoe-server interfaces 
 interface:   connections:    state:
-----------------------------------
     eth1              0    active
  eth1.23              0    active
[edit]
vyos@r4#
```
After the fix the new interface **eth2** in the output:
```
vyos@r4# set service pppoe-server interface eth2
[edit]
vyos@r4# commit
run show [edit]
vyos@r4# run show pppoe-server interfaces 
 interface:   connections:    state:
-----------------------------------
     eth1              0    active
  eth1.23              0    active
     eth2              0    active
[edit]
vyos@r4# 

```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py
test_accel_local_authentication (__main__.TestServicePPPoEServer.test_accel_local_authentication) ... ok
test_accel_name_servers (__main__.TestServicePPPoEServer.test_accel_name_servers) ... ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer.test_accel_radius_authentication) ... ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer.test_pppoe_server_authentication_protocols) ... ok
test_pppoe_server_client_ip_pool (__main__.TestServicePPPoEServer.test_pppoe_server_client_ip_pool) ... ok
test_pppoe_server_client_ip_pool_name (__main__.TestServicePPPoEServer.test_pppoe_server_client_ip_pool_name) ... ok
test_pppoe_server_client_ipv6_pool (__main__.TestServicePPPoEServer.test_pppoe_server_client_ipv6_pool) ... ok
test_pppoe_server_ppp_options (__main__.TestServicePPPoEServer.test_pppoe_server_ppp_options) ... ok
test_pppoe_server_vlan (__main__.TestServicePPPoEServer.test_pppoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 9 tests in 45.685s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
