### PR TITLE
mdns: T5723: Always reload systemd daemon before applying changes

### DIFF
--- a/data/templates/mdns-repeater/override.conf.j2
+++ b/data/templates/mdns-repeater/override.conf.j2
@@ -1,0 +1,7 @@
+[Unit]
+After=vyos-router.service
+ConditionPathExists={{ config_file }}
+
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/avahi-daemon --syslog --file {{ config_file }}

--- a/src/etc/systemd/system/avahi-daemon.service.d/override.conf
+++ b/src/etc/systemd/system/avahi-daemon.service.d/override.conf
@@ -1,8 +1,0 @@
-[Unit]
-After=
-After=vyos-router.service
-ConditionPathExists=/run/avahi-daemon/avahi-daemon.conf
-
-[Service]
-ExecStart=
-ExecStart=/usr/sbin/avahi-daemon --syslog --file /run/avahi-daemon/avahi-daemon.conf


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Always reload systemd daemon (`systemctl daemon-reload`) before applying avahi-daemon changes.
Additionally, templatize system service override and move it to the runtime path.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5723

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
mdns repeater

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos15-1107:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_mdns-repeater.py 
test_service_dual_stack (__main__.TestServiceMDNSrepeater.test_service_dual_stack) ... ok
test_service_ipv4 (__main__.TestServiceMDNSrepeater.test_service_ipv4) ... 
mDNS repeater requires an IPv4 address to be configured on interface
"dum40"

ok
test_service_ipv6 (__main__.TestServiceMDNSrepeater.test_service_ipv6) ... 
mDNS repeater requires an IPv6 address to be configured on interface
"dum10"

ok

----------------------------------------------------------------------
Ran 3 tests in 202.125s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
