### PR TITLE
ddclient: T5708: Additional smoketests for web-options

### DIFF
--- a/src/conf_mode/dns_dynamic.py
+++ b/src/conf_mode/dns_dynamic.py
@@ -93,7 +93,7 @@ def verify(dyndns):
         # Dynamic DNS service provider - configuration validation
         if 'service' in dyndns['address'][address]:
             for service, config in dyndns['address'][address]['service'].items():
-                error_msg_req = f'is required for Dynamic DNS service "{service}" on "{address}" with protocol "{config["protocol"]}"'
+                error_msg_req = f'is required for Dynamic DNS service "{service}" on "{address}"'
                 error_msg_uns = f'is not supported for Dynamic DNS service "{service}" on "{address}" with protocol "{config["protocol"]}"'
 
                 for field in ['host_name', 'password', 'protocol']:
@@ -101,13 +101,13 @@ def verify(dyndns):
                         raise ConfigError(f'"{field.replace("_", "-")}" {error_msg_req}')
 
                 if config['protocol'] in zone_necessary and 'zone' not in config:
-                    raise ConfigError(f'"zone" {error_msg_req}')
+                    raise ConfigError(f'"zone" {error_msg_req} with protocol "{config["protocol"]}"')
 
                 if config['protocol'] not in zone_supported and 'zone' in config:
                     raise ConfigError(f'"zone" {error_msg_uns}')
 
                 if config['protocol'] not in username_unnecessary and 'username' not in config:
-                    raise ConfigError(f'"username" {error_msg_req}')
+                    raise ConfigError(f'"username" {error_msg_req} with protocol "{config["protocol"]}"')
 
                 if config['protocol'] not in ttl_supported and 'ttl' in config:
                     raise ConfigError(f'"ttl" {error_msg_uns}')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Additional smoketests for web-options validating failure scenarios.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5708

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
vyos/vyos-1x#2467

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dns dynamic

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos15a3:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_service_dns_dynamic.py TestServiceDDNS.test_06_dyndns_web_options
test_06_dyndns_web_options (__main__.TestServiceDDNS.test_06_dyndns_web_options) ... 
"web-options" is applicable only when using HTTP(S) web request to
obtain the IP address

ok

----------------------------------------------------------------------
Ran 1 test in 306.209s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
