### PR TITLE
T5167: Add simple file server

### DIFF
--- a/data/templates/file-server/vyos-fileserver.service.j2
+++ b/data/templates/file-server/vyos-fileserver.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=File server service
+After=vyos-router.service
+
+[Service]
+Type=simple
+Restart=always
+ExecStart=/usr/bin/python3 /usr/libexec/vyos/vyos_service_file-server.py --config /run/vyos-fileserver.conf
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/control
+++ b/debian/control
@@ -59,6 +59,7 @@ Depends:
   python3-pyudev,
   python3-six,
   python3-tabulate,
+  python3-toml,
   python3-voluptuous,
   python3-xmltodict,
   python3-zmq,

--- a/interface-definitions/service_file-server.xml.in
+++ b/interface-definitions/service_file-server.xml.in
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="service">
+    <children>
+      <node name="file-server" owner="${vyos_conf_scripts_dir}/service_file-server.py">
+        <properties>
+          <help>File server</help>
+          <priority>990</priority>
+        </properties>
+        <children>
+          <leafNode name="directory">
+            <properties>
+              <help>Folder containing files served by file server</help>
+            </properties>
+          </leafNode>
+          #include <include/port-number.xml.i>
+          <leafNode name="port">
+            <defaultValue>8000</defaultValue>
+          </leafNode>
+          #include <include/listen-address-ipv4-single.xml.i>
+          <leafNode name="listen-address">
+            <defaultValue>0.0.0.0</defaultValue>
+          </leafNode>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/src/conf_mode/service_file-server.py
+++ b/src/conf_mode/service_file-server.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import toml
+
+from vyos.config import Config
+from vyos.template import render
+from vyos.utils.process import call
+from vyos import ConfigError
+from vyos import airbag
+airbag.enable()
+
+
+service_name = 'vyos-fileserver'
+service_conf = f'/run/{service_name}.conf'
+systemd_service = f'/run/systemd/system/{service_name}.service'
+
+
+def get_config(config=None):
+    if config:
+        conf = config
+    else:
+        conf = Config()
+
+    base = ['service', 'file-server']
+
+    if not conf.exists(base):
+        return None
+
+    config = conf.get_config_dict(base, key_mangling=('-', '_'),
+                                  get_first_key=True,
+                                  no_tag_node_value_mangle=True,
+                                  with_recursive_defaults=True)
+
+    return config
+
+
+def verify(config):
+    # bail out early - looks like removal from running config
+    if config is None:
+        return
+
+    if 'directory' not in config:
+        raise ConfigError('Directory is required!')
+
+
+def generate(config):
+    # bail out early - looks like removal from running config
+    if config is None:
+        # Remove old config and return
+        config_files = [service_conf, systemd_service]
+        for file in config_files:
+            if os.path.isfile(file):
+                os.unlink(file)
+
+        return None
+
+    # Write configuration file
+    with open(service_conf, 'w') as toml_file:
+        toml.dump(config, toml_file)
+    render(systemd_service, f'file-server/{service_name}.service.j2', config)
+
+    return None
+
+
+def apply(config):
+    call('systemctl daemon-reload')
+    if config:
+        call(f'systemctl restart {service_name}.service')
+    else:
+        call(f'systemctl stop {service_name}.service')
+
+
+if __name__ == '__main__':
+    try:
+        c = get_config()
+        verify(c)
+        generate(c)
+        apply(c)
+    except ConfigError as e:
+        print(e)
+        exit(1)

--- a/src/helpers/vyos_service_file-server.py
+++ b/src/helpers/vyos_service_file-server.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+import argparse
+import logging
+import os
+import toml
+
+from functools import partial
+from pathlib import Path
+from http.server import SimpleHTTPRequestHandler
+from http.server import HTTPServer
+
+
+def file_server(server_directory, bind_address='0.0.0.0', bind_port=8000):
+    """Simple file server.
+
+    Args:
+        server_directory (str): The directory containing files to be served.
+        bind_address (str): The IP address to bind the server to. Defaults to '0.0.0.0'.
+        bind_port (int): The port to bind the server to. Defaults to 8000.
+    """
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+    logger.name = os.path.basename(__file__)
+
+    logger.info(f'Serving files from: {server_directory}')
+    logger.info(f'Binding to: {bind_address}:{bind_port}')
+
+    handler_class = partial(SimpleHTTPRequestHandler, directory=server_directory)
+
+    with HTTPServer((bind_address, bind_port), handler_class) as http_server:
+        logger.info(f'Starting file server on http://{bind_address}:{bind_port}')
+        try:
+            http_server.serve_forever()
+        except KeyboardInterrupt:
+            logger.info('File server terminated')
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c',
+                        '--config',
+                        action='store',
+                        help='Path configuration file',
+                        required=True,
+                        type=Path)
+
+    args = parser.parse_args()
+    config_file = args.config
+
+    # Config in TOML format:
+    # $ cat /run/vyos-fileserver.conf
+    #   directory = "/tmp"
+    #   listen_address = "0.0.0.0"
+    #   port = "8000"
+
+    with open(config_file, 'r') as toml_file:
+        config = toml.load(toml_file)
+
+    directory = config.get('directory')
+    listen_address = config.get('listen_address')
+    port = int(config.get('port'))
+
+    # Run file server
+    file_server(directory, listen_address, port)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add a simple fileserver over HTTP.

It is useful, for example, when a TFTP server is to slow. Use something simple and native with HTTP for files.
Useful examples for testing API with image manipulations (natively store images on the local network/local host).
Booting via DHCP/pxe and so on.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5167

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
file-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service file-server listen-address 0.0.0.0
set service file-server port 8000
set service file-server directory '/config/containers'
```
Check:
```
vyos@r4# sudo systemctl status vyos-fileserver.service
● vyos-fileserver.service - File server service
     Loaded: loaded (/run/systemd/system/vyos-fileserver.service; disabled; preset: enabled)
     Active: active (running) since Fri 2023-11-10 03:21:56 EET; 13min ago
   Main PID: 15189 (python3)
      Tasks: 1 (limit: 18720)
     Memory: 10.4M
        CPU: 192ms
     CGroup: /system.slice/vyos-fileserver.service
             └─15189 /usr/bin/python3 /usr/libexec/vyos/vyos_service_file-server.py --config /run/vyos-fileserver.conf



root@r1:/home/vyos# curl 192.168.122.14:8000
<!DOCTYPE HTML>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Directory listing for /</title>
</head>
<body>
<h1>Directory listing for /</h1>
<hr>
<ul>
<li><a href="radius/">radius/</a></li>
</ul>
<hr>
</body>
</html>

```
![radius](https://github.com/vyos/vyos-1x/assets/12792111/6decc31c-c4ac-40e2-8988-64766dfc7c1e)


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
