### PR TITLE
ddclient: T5708: Fix VRF table generation in smoketest

### DIFF
--- a/smoketest/scripts/cli/test_service_dns_dynamic.py
+++ b/smoketest/scripts/cli/test_service_dns_dynamic.py
@@ -297,7 +297,8 @@ class TestServiceDDNS(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'{hostname}', ddclient_conf)
 
     def test_07_dyndns_vrf(self):
-        vrf_table = "".join(random.choices(string.digits, k=5))
+        # Table number randomized, but should be within range 100-65535
+        vrf_table = "".join(random.choices(string.digits, k=4))
         vrf_name = f'vyos-test-{vrf_table}'
         svc_path = ['address', interface, 'service', 'cloudflare']
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Ensure that the random VRF table name is 4 digits long, not 5 and stays within the the range of 100 - 65535.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5708

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
- vyos/vyos-1x#2468

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dns dynamic

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set service dns dynamic interval 600

set service dns dynamic address eth5 service cloudflare host-name 'dyn.example.com'
set service dns dynamic address eth5 service cloudflare ip-version 'both'
set service dns dynamic address eth5 service cloudflare password 'scrambled_string'
set service dns dynamic address eth5 service cloudflare protocol 'cloudflare'
set service dns dynamic address eth5 service cloudflare ttl '300'
set service dns dynamic address eth5 service cloudflare zone 'example.com'

set service dns dynamic address eth5 service namecheap host-name '@.example.com'
set service dns dynamic address eth5 service namecheap username 'example.com'
set service dns dynamic address eth5 service namecheap password 'scrambled_string'
set service dns dynamic address eth5 service namecheap protocol 'namecheap'
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos-15a7:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_dns_dynamic.py
test_01_dyndns_service_standard (__main__.TestServiceDDNS.test_01_dyndns_service_standard) ... 
"zone" is not supported for Dynamic DNS service "freedns" on "eth0" with
protocol "freedns"


"ttl" is not supported for Dynamic DNS service "freedns" on "eth0" with
protocol "freedns"


"ttl" is not supported for Dynamic DNS service "zoneedit" on "eth0" with
protocol "zoneedit1"


"ttl" is not supported for Dynamic DNS service "zoneedit" on "eth0" with
protocol "zoneedit1"

ok
test_02_dyndns_service_ipv6 (__main__.TestServiceDDNS.test_02_dyndns_service_ipv6) ... 
"expiry-time" must be greater than "wait-time"

ok
test_03_dyndns_service_dual_stack (__main__.TestServiceDDNS.test_03_dyndns_service_dual_stack) ... 
Both IPv4 and IPv6 at the same time is not supported for Dynamic DNS
service "google" on "eth0" with protocol "googledomains"

ok
test_04_dyndns_rfc2136 (__main__.TestServiceDDNS.test_04_dyndns_rfc2136) ... ok
test_05_dyndns_hostname (__main__.TestServiceDDNS.test_05_dyndns_hostname) ... ok
test_06_dyndns_web_options (__main__.TestServiceDDNS.test_06_dyndns_web_options) ... 
"web-options" is applicable only when using HTTP(S) web request to
obtain the IP address

ok
test_07_dyndns_vrf (__main__.TestServiceDDNS.test_07_dyndns_vrf) ... ok

----------------------------------------------------------------------
Ran 7 tests in 982.322s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
