### PR TITLE
dhclient: T5724: run user hooks using run_hookdir

### DIFF
--- a/src/etc/dhcp/dhclient-enter-hooks.d/99-run-user-hooks
+++ b/src/etc/dhcp/dhclient-enter-hooks.d/99-run-user-hooks
@@ -1,5 +1,5 @@
 #!/bin/bash
 DHCP_PRE_HOOKS="/config/scripts/dhcp-client/pre-hooks.d/"
 if [ -d "${DHCP_PRE_HOOKS}" ] ; then
-    run-parts "${DHCP_PRE_HOOKS}"
+    run_hookdir "${DHCP_PRE_HOOKS}"
 fi

--- a/src/etc/dhcp/dhclient-exit-hooks.d/98-run-user-hooks
+++ b/src/etc/dhcp/dhclient-exit-hooks.d/98-run-user-hooks
@@ -1,5 +1,5 @@
 #!/bin/bash
 DHCP_POST_HOOKS="/config/scripts/dhcp-client/post-hooks.d/"
 if [ -d "${DHCP_POST_HOOKS}" ] ; then
-    run-parts "${DHCP_POST_HOOKS}"
+    run_hookdir "${DHCP_POST_HOOKS}"
 fi


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Execute user hooks using `run_hookdir` instead of `run-parts`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5724

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp

## Proposed changes
<!--- Describe your changes in detail -->
User hooks are executed using `run_hookdir` (defined in the `/sbin/dhclient-script` script) instead of `run-parts`. That allows user hooks to modify variables set by the dhcp client (e.g., the `new_routers` variable to avoid the installation of the default routes).

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Pre-condition: at least one interface (`eth0` for simplicity) receiving IP via `dhcp` and configured to install the default root.

Add a very simple user hook in `/config/scripts/dhcp-client/pre-hooks.d`:

```
RUN="yes"
if [ "$RUN" = "yes" ]; then
    case "$reason" in
        BOUND|RENEW|REBIND|REBOOT)
        new_routers=""
        ;;
    esac
fi
```
Force a `dhcp` renewal and then check the content of the `/var/lib/dhcp/dhclient_eth0.lease` file: the `new_routers` variable should point to an empty string when `reason` is `BOUND` or `RENEW` or `REBIND` or `REBOOT`.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
