### PR TITLE
T5728: OpenVPN server replace first_host_address to vpn_gateway

### DIFF
--- a/data/templates/openvpn/server.conf.j2
+++ b/data/templates/openvpn/server.conf.j2
@@ -79,7 +79,7 @@ server {{ subnet | address_from_cidr }} {{ subnet | netmask_from_cidr }} {{ 'nop
 {%                     if server.push_route is vyos_defined %}
 {%                         for route, route_config in server.push_route.items() %}
 {%                             if route | is_ipv4 %}
-push "route {{ route | address_from_cidr }} {{ route | netmask_from_cidr }} {{ subnet | first_host_address ~ ' ' ~ route_config.metric if route_config.metric is vyos_defined }}"
+push "route {{ route | address_from_cidr }} {{ route | netmask_from_cidr }} {{ 'vpn_gateway' ~ ' ' ~ route_config.metric if route_config.metric is vyos_defined }}"
 {%                             elif route | is_ipv6 %}
 push "route-ipv6 {{ route }}"
 {%                             endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Some OpenVPN clients (OpenVPN3) do not understand the address of the gateway for the pushed networks. It leads that pushed routes are not installed at all.
Replace `subnet | first_host_address` to the `vpn_gateway` to fix it

https://github.com/OpenVPN/openvpn3/blob/01a37cea9715f889b6fa0246a720a53ad49eb045/openvpn/tun/client/tunprop.hpp#L425-L432

https://forum.vyos.io/t/openvpn-split-tunnel-routing/

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5728

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
OpenVPN
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS server site configuration:
```
set interfaces openvpn vtun10 encryption cipher 'aes256gcm'
set interfaces openvpn vtun10 hash 'sha256'
set interfaces openvpn vtun10 local-host '203.0.113.1'
set interfaces openvpn vtun10 local-port '1194'
set interfaces openvpn vtun10 mode 'server'
set interfaces openvpn vtun10 openvpn-option 'mssfix 1420'
set interfaces openvpn vtun10 persistent-tunnel
set interfaces openvpn vtun10 protocol 'udp'
set interfaces openvpn vtun10 server client client1 ip '10.10.0.10'
set interfaces openvpn vtun10 server domain-name 'vyos.net'
set interfaces openvpn vtun10 server max-connections '250'
set interfaces openvpn vtun10 server name-server '10.0.0.1'
set interfaces openvpn vtun10 server push-route 192.0.2.0/24
set interfaces openvpn vtun10 server subnet '10.10.0.0/24'
set interfaces openvpn vtun10 server topology 'subnet'
set interfaces openvpn vtun10 tls ca-certificate 'ca'
set interfaces openvpn vtun10 tls certificate 'cert'
set interfaces openvpn vtun10 tls dh-params 'dh'

```
Connect with the client and check the ip route
Expected routes to `10.10.0.0/24` and `192.0.2.0/24`
Before the fix
```
$ openvpn3 session-start --config /home/sever/openvpn.ovpn
Using configuration profile from file: /home/sever/openvpn.ovpn
Session path: /net/openvpn/v3/sessions/66a4732fs3752s43b1s9fafs8b95cd2c351a
Connected

$ ip route
default via 192.168.122.1 dev enp1s0 proto dhcp metric 100 
10.10.0.0/24 dev tun0 proto kernel scope link src 10.10.0.2 
192.168.122.0/24 dev enp1s0 proto kernel scope link src 192.168.122.205 metric 100 
203.0.113.1 via 192.168.122.14 dev enp1s0 

```
After the fix:
```
$ ip route
default via 192.168.122.1 dev enp1s0 proto dhcp metric 100 
10.10.0.0/24 dev tun0 proto kernel scope link src 10.10.0.2 
192.0.2.0/24 via 10.10.0.1 dev tun0 
192.168.122.0/24 dev enp1s0 proto kernel scope link src 192.168.122.205 metric 100 
203.0.113.1 via 192.168.122.14 dev enp1s0 
```


## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py
test_openvpn_client_interfaces (__main__.TestInterfacesOpenVPN.test_openvpn_client_interfaces) ... ok
test_openvpn_client_verify (__main__.TestInterfacesOpenVPN.test_openvpn_client_verify) ... ok
test_openvpn_options (__main__.TestInterfacesOpenVPN.test_openvpn_options) ... ok
test_openvpn_server_subnet_topology (__main__.TestInterfacesOpenVPN.test_openvpn_server_subnet_topology) ... ok
test_openvpn_server_verify (__main__.TestInterfacesOpenVPN.test_openvpn_server_verify) ... ok
test_openvpn_site2site_interfaces_tun (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_interfaces_tun) ... ok
test_openvpn_site2site_verify (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_verify) ... ok

----------------------------------------------------------------------
Ran 7 tests in 92.175s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
