### PR TITLE
T5729: firewall: multiple backports

### DIFF
--- a/interface-definitions/include/firewall/common-rule-inet.xml.i
+++ b/interface-definitions/include/firewall/common-rule-inet.xml.i
@@ -3,6 +3,7 @@
 #include <include/generic-description.xml.i>
 #include <include/firewall/dscp.xml.i>
 #include <include/firewall/packet-options.xml.i>
+#include <include/firewall/firewall-mark.xml.i>
 #include <include/firewall/connection-mark.xml.i>
 #include <include/firewall/conntrack-helper.xml.i>
 #include <include/firewall/nft-queue.xml.i>
@@ -81,44 +82,7 @@
     </leafNode>
   </children>
 </node>
-<leafNode name="log">
-  <properties>
-    <help>Option to log packets matching rule</help>
-    <completionHelp>
-      <list>enable disable</list>
-    </completionHelp>
-    <valueHelp>
-      <format>enable</format>
-      <description>Enable log</description>
-    </valueHelp>
-    <valueHelp>
-      <format>disable</format>
-      <description>Disable log</description>
-    </valueHelp>
-    <constraint>
-      <regex>(enable|disable)</regex>
-    </constraint>
-  </properties>
-</leafNode>
-<leafNode name="log">
-  <properties>
-    <help>Option to log packets matching rule</help>
-    <completionHelp>
-      <list>enable disable</list>
-    </completionHelp>
-    <valueHelp>
-      <format>enable</format>
-      <description>Enable log</description>
-    </valueHelp>
-    <valueHelp>
-      <format>disable</format>
-      <description>Disable log</description>
-    </valueHelp>
-    <constraint>
-      <regex>(enable|disable)</regex>
-    </constraint>
-  </properties>
-</leafNode>
+#include <include/firewall/log.xml.i>
 #include <include/firewall/rule-log-options.xml.i>
 <node name="connection-status">
   <properties>
@@ -220,89 +184,7 @@
     </leafNode>
   </children>
 </node>
-<node name="state">
-  <properties>
-    <help>Session state</help>
-  </properties>
-  <children>
-    <leafNode name="established">
-      <properties>
-        <help>Established state</help>
-        <completionHelp>
-          <list>enable disable</list>
-        </completionHelp>
-        <valueHelp>
-          <format>enable</format>
-          <description>Enable</description>
-        </valueHelp>
-        <valueHelp>
-          <format>disable</format>
-          <description>Disable</description>
-        </valueHelp>
-        <constraint>
-          <regex>(enable|disable)</regex>
-        </constraint>
-      </properties>
-    </leafNode>
-    <leafNode name="invalid">
-      <properties>
-        <help>Invalid state</help>
-        <completionHelp>
-          <list>enable disable</list>
-        </completionHelp>
-        <valueHelp>
-          <format>enable</format>
-          <description>Enable</description>
-        </valueHelp>
-        <valueHelp>
-          <format>disable</format>
-          <description>Disable</description>
-        </valueHelp>
-        <constraint>
-          <regex>(enable|disable)</regex>
-        </constraint>
-      </properties>
-    </leafNode>
-    <leafNode name="new">
-      <properties>
-        <help>New state</help>
-        <completionHelp>
-          <list>enable disable</list>
-        </completionHelp>
-        <valueHelp>
-          <format>enable</format>
-          <description>Enable</description>
-        </valueHelp>
-        <valueHelp>
-          <format>disable</format>
-          <description>Disable</description>
-        </valueHelp>
-        <constraint>
-          <regex>(enable|disable)</regex>
-        </constraint>
-      </properties>
-    </leafNode>
-    <leafNode name="related">
-      <properties>
-        <help>Related state</help>
-        <completionHelp>
-          <list>enable disable</list>
-        </completionHelp>
-        <valueHelp>
-          <format>enable</format>
-          <description>Enable</description>
-        </valueHelp>
-        <valueHelp>
-          <format>disable</format>
-          <description>Disable</description>
-        </valueHelp>
-        <constraint>
-          <regex>(enable|disable)</regex>
-        </constraint>
-      </properties>
-    </leafNode>
-  </children>
-</node>
+#include <include/firewall/state.xml.i>
 #include <include/firewall/tcp-flags.xml.i>
 <node name="time">
   <properties>

--- a/interface-definitions/include/firewall/firewall-mark.xml.i
+++ b/interface-definitions/include/firewall/firewall-mark.xml.i
@@ -1,0 +1,26 @@
+<!-- include start from firewall/firewall-mark.xml.i -->
+<leafNode name="mark">
+  <properties>
+    <help>Firewall mark</help>
+    <valueHelp>
+      <format>u32:0-2147483647</format>
+      <description>Firewall mark to match</description>
+    </valueHelp>
+    <valueHelp>
+      <format>!u32:0-2147483647</format>
+      <description>Inverted Firewall mark to match</description>
+    </valueHelp>
+    <valueHelp>
+      <format>&lt;start-end&gt;</format>
+      <description>Firewall mark range to match</description>
+    </valueHelp>
+    <valueHelp>
+      <format>!&lt;start-end&gt;</format>
+      <description>Firewall mark inverted range to match</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric-exclude" argument="--allow-range --range 0-2147483647"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/firewall/log.xml.i
+++ b/interface-definitions/include/firewall/log.xml.i
@@ -1,15 +1,7 @@
 <!-- include start from firewall/log.xml.i -->
-<node name="log">
+<leafNode name="log">
   <properties>
-    <help>Option to log packets</help>
+    <help>Enable log</help>
+    <valueless/>
   </properties>
-  <children>
-    <leafNode name="enable">
-      <properties>
-        <help>Enable logging</help>
-        <valueless/>
-      </properties>
-    </leafNode>
-  </children>
-</node>
-<!-- include end -->
+</leafNode>

--- a/interface-definitions/include/firewall/state.xml.i
+++ b/interface-definitions/include/firewall/state.xml.i
@@ -1,0 +1,30 @@
+<!-- include start from firewall/state.xml.i -->
+<leafNode name="state">
+  <properties>
+    <help>Session state</help>
+    <completionHelp>
+      <list>established invalid new related</list>
+    </completionHelp>
+    <valueHelp>
+      <format>established</format>
+      <description>Established state</description>
+    </valueHelp>
+    <valueHelp>
+      <format>invalid</format>
+      <description>Invalid state</description>
+    </valueHelp>
+    <valueHelp>
+      <format>new</format>
+      <description>New state</description>
+    </valueHelp>
+    <valueHelp>
+      <format>related</format>
+      <description>Related state</description>
+    </valueHelp>
+    <constraint>
+      <regex>(established|invalid|new|related)</regex>
+    </constraint>
+    <multi/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/nat-rule.xml.i
+++ b/interface-definitions/include/nat-rule.xml.i
@@ -34,12 +34,7 @@
         #include <include/firewall/nat-balance.xml.i>
       </children>
     </node>
-    <leafNode name="log">
-      <properties>
-        <help>NAT rule logging</help>
-        <valueless/>
-      </properties>
-    </leafNode>
+    #include <include/firewall/log.xml.i>
     <leafNode name="packet-type">
       <properties>
         <help>Packet type</help>

--- a/interface-definitions/include/policy/route-common.xml.i
+++ b/interface-definitions/include/policy/route-common.xml.i
@@ -1,6 +1,7 @@
 <!-- include start from policy/route-common.xml.i -->
 #include <include/policy/route-rule-action.xml.i>
 #include <include/generic-description.xml.i>
+#include <include/firewall/firewall-mark.xml.i>
 <leafNode name="disable">
   <properties>
     <help>Option to disable firewall rule</help>
@@ -76,25 +77,7 @@
     </leafNode>
   </children>
 </node>
-<leafNode name="log">
-  <properties>
-    <help>Option to log packets matching rule</help>
-    <completionHelp>
-      <list>enable disable</list>
-    </completionHelp>
-    <valueHelp>
-      <format>enable</format>
-      <description>Enable log</description>
-    </valueHelp>
-    <valueHelp>
-      <format>disable</format>
-      <description>Disable log</description>
-    </valueHelp>
-    <constraint>
-      <regex>(enable|disable)</regex>
-    </constraint>
-  </properties>
-</leafNode>
+#include <include/firewall/log.xml.i>
 <leafNode name="protocol">
   <properties>
     <help>Protocol to match (protocol name, number, or "all")</help>
@@ -230,89 +213,7 @@
     </leafNode>
   </children>
 </node>
-<node name="state">
-  <properties>
-    <help>Session state</help>
-  </properties>
-  <children>
-    <leafNode name="established">
-      <properties>
-        <help>Established state</help>
-        <completionHelp>
-          <list>enable disable</list>
-        </completionHelp>
-        <valueHelp>
-          <format>enable</format>
-          <description>Enable</description>
-        </valueHelp>
-        <valueHelp>
-          <format>disable</format>
-          <description>Disable</description>
-        </valueHelp>
-        <constraint>
-          <regex>(enable|disable)</regex>
-        </constraint>
-      </properties>
-    </leafNode>
-    <leafNode name="invalid">
-      <properties>
-        <help>Invalid state</help>
-        <completionHelp>
-          <list>enable disable</list>
-        </completionHelp>
-        <valueHelp>
-          <format>enable</format>
-          <description>Enable</description>
-        </valueHelp>
-        <valueHelp>
-          <format>disable</format>
-          <description>Disable</description>
-        </valueHelp>
-        <constraint>
-          <regex>(enable|disable)</regex>
-        </constraint>
-      </properties>
-    </leafNode>
-    <leafNode name="new">
-      <properties>
-        <help>New state</help>
-        <completionHelp>
-          <list>enable disable</list>
-        </completionHelp>
-        <valueHelp>
-          <format>enable</format>
-          <description>Enable</description>
-        </valueHelp>
-        <valueHelp>
-          <format>disable</format>
-          <description>Disable</description>
-        </valueHelp>
-        <constraint>
-          <regex>(enable|disable)</regex>
-        </constraint>
-      </properties>
-    </leafNode>
-    <leafNode name="related">
-      <properties>
-        <help>Related state</help>
-        <completionHelp>
-          <list>enable disable</list>
-        </completionHelp>
-        <valueHelp>
-          <format>enable</format>
-          <description>Enable</description>
-        </valueHelp>
-        <valueHelp>
-          <format>disable</format>
-          <description>Disable</description>
-        </valueHelp>
-        <constraint>
-          <regex>(enable|disable)</regex>
-        </constraint>
-      </properties>
-    </leafNode>
-  </children>
-</node>
+#include <include/firewall/state.xml.i>
 #include <include/firewall/tcp-flags.xml.i>
 <node name="time">
   <properties>

--- a/interface-definitions/include/version/firewall-version.xml.i
+++ b/interface-definitions/include/version/firewall-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/firewall-version.xml.i -->
-<syntaxVersion component='firewall' version='12'></syntaxVersion>
+<syntaxVersion component='firewall' version='13'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/include/version/policy-version.xml.i
+++ b/interface-definitions/include/version/policy-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/policy-version.xml.i -->
-<syntaxVersion component='policy' version='6'></syntaxVersion>
+<syntaxVersion component='policy' version='7'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/nat66.xml.in
+++ b/interface-definitions/nat66.xml.in
@@ -32,12 +32,7 @@
                 </properties>
               </leafNode>
               #include <include/nat-exclude.xml.i>
-              <leafNode name="log">
-                <properties>
-                  <help>NAT66 rule logging</help>
-                  <valueless/>
-                </properties>
-              </leafNode>
+              #include <include/firewall/log.xml.i>
               #include <include/firewall/outbound-interface-no-group.xml.i>
               #include <include/nat/protocol.xml.i>
               <node name="destination">

--- a/smoketest/scripts/cli/test_policy_route.py
+++ b/smoketest/scripts/cli/test_policy_route.py
@@ -191,25 +191,29 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
     def test_pbr_matching_criteria(self):
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '1', 'protocol', 'udp'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '1', 'action', 'drop'])
+        self.cli_set(['policy', 'route', 'smoketest', 'rule', '1', 'mark', '2020'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '2', 'protocol', 'tcp'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '2', 'tcp', 'flags', 'syn'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '2', 'tcp', 'flags', 'not', 'ack'])
+        self.cli_set(['policy', 'route', 'smoketest', 'rule', '2', 'mark', '2-3000'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '2', 'set', 'table', table_id])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '3', 'source', 'address', '198.51.100.0/24'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '3', 'protocol', 'tcp'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '3', 'destination', 'port', '22'])
-        self.cli_set(['policy', 'route', 'smoketest', 'rule', '3', 'state', 'new', 'enable'])
+        self.cli_set(['policy', 'route', 'smoketest', 'rule', '3', 'state', 'new'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '3', 'ttl', 'gt', '2'])
+        self.cli_set(['policy', 'route', 'smoketest', 'rule', '3', 'mark', '!456'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '3', 'set', 'table', table_id])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'protocol', 'icmp'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'icmp', 'type-name', 'echo-request'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'packet-length', '128'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'packet-length', '1024-2048'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'packet-type', 'other'])
-        self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'log', 'enable'])
+        self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'log'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '4', 'set', 'table', table_id])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '5', 'dscp', '41'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '5', 'dscp', '57-59'])
+        self.cli_set(['policy', 'route', 'smoketest', 'rule', '5', 'mark', '!456-500'])
         self.cli_set(['policy', 'route', 'smoketest', 'rule', '5', 'set', 'table', table_id])
 
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '1', 'protocol', 'udp'])
@@ -221,7 +225,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '3', 'source', 'address', '2001:db8::0/64'])
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '3', 'protocol', 'tcp'])
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '3', 'destination', 'port', '22'])
-        self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '3', 'state', 'new', 'enable'])
+        self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '3', 'state', 'new'])
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '3', 'hop-limit', 'gt', '2'])
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '3', 'set', 'table', table_id])
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '4', 'protocol', 'icmpv6'])
@@ -230,7 +234,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '4', 'packet-length-exclude', '1024-2048'])
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '4', 'packet-type', 'multicast'])
 
-        self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '4', 'log', 'enable'])
+        self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '4', 'log'])
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '4', 'set', 'table', table_id])
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '5', 'dscp-exclude', '61'])
         self.cli_set(['policy', 'route6', 'smoketest6', 'rule', '5', 'dscp-exclude', '14-19'])
@@ -247,11 +251,11 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
         # IPv4
         nftables_search = [
             ['iifname { "' + interface + '", "' + interface_wc + '" }', 'jump VYOS_PBR_UD_smoketest'],
-            ['meta l4proto udp', 'drop'],
-            ['tcp flags syn / syn,ack', 'meta mark set ' + mark_hex],
-            ['ct state new', 'tcp dport 22', 'ip saddr 198.51.100.0/24', 'ip ttl > 2', 'meta mark set ' + mark_hex],
-            ['meta l4proto icmp', 'log prefix "[ipv4-route-smoketest-4-A]"', 'icmp type echo-request', 'ip length { 128, 1024-2048 }', 'meta pkttype other', 'meta mark set ' + mark_hex],
-            ['ip dscp { 0x29, 0x39-0x3b }', 'meta mark set ' + mark_hex]
+            ['meta l4proto udp', 'meta mark 0x000007e4', 'drop'],
+            ['tcp flags syn / syn,ack', 'meta mark 0x00000002-0x00000bb8', 'meta mark set ' + mark_hex],
+            ['ct state new', 'tcp dport 22', 'ip saddr 198.51.100.0/24', 'ip ttl > 2', 'meta mark != 0x000001c8', 'meta mark set ' + mark_hex],
+            ['log prefix "[ipv4-route-smoketest-4-A]"', 'icmp type echo-request', 'ip length { 128, 1024-2048 }', 'meta pkttype other', 'meta mark set ' + mark_hex],
+            ['ip dscp { 0x29, 0x39-0x3b }', 'meta mark != 0x000001c8-0x000001f4', 'meta mark set ' + mark_hex]
         ]
 
         self.verify_nftables(nftables_search, 'ip vyos_mangle')
@@ -262,7 +266,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
             ['meta l4proto udp', 'drop'],
             ['tcp flags syn / syn,ack', 'meta mark set ' + mark_hex],
             ['ct state new', 'tcp dport 22', 'ip6 saddr 2001:db8::/64', 'ip6 hoplimit > 2', 'meta mark set ' + mark_hex],
-            ['meta l4proto ipv6-icmp', 'log prefix "[ipv6-route6-smoketest6-4-A]"', 'icmpv6 type echo-request', 'ip6 length != { 128, 1024-2048 }', 'meta pkttype multicast', 'meta mark set ' + mark_hex],
+            ['log prefix "[ipv6-route6-smoketest6-4-A]"', 'icmpv6 type echo-request', 'ip6 length != { 128, 1024-2048 }', 'meta pkttype multicast', 'meta mark set ' + mark_hex],            
             ['ip6 dscp != { 0x0e-0x13, 0x3d }', 'meta mark set ' + mark_hex]
         ]
 

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -249,7 +249,7 @@ def verify_rule(firewall, rule_conf, ipv6):
                 raise ConfigError(f'{side} port-group and port cannot both be defined')
 
     if 'log_options' in rule_conf:
-        if 'log' not in rule_conf or 'enable' not in rule_conf['log']:
+        if 'log' not in rule_conf:
             raise ConfigError('log-options defined, but log is not enable')
 
         if 'snapshot_length' in rule_conf['log_options'] and 'group' not in rule_conf['log_options']:

--- a/src/migration-scripts/firewall/11-to-12
+++ b/src/migration-scripts/firewall/11-to-12
@@ -46,7 +46,6 @@ if not config.exists(base):
     # Nothing to do
     exit(0)
 
-## FORT
 ## Migration from base chains
 #if config.exists(base + ['interface', iface, direction]):
 for family in ['ipv4', 'ipv6']:

--- a/src/migration-scripts/firewall/12-to-13
+++ b/src/migration-scripts/firewall/12-to-13
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T5729: Switch to valueless whenever is possible.
+# From
+    # set firewall ... rule <rule> log enable
+    # set firewall ... rule <rule> state <state> enable
+    # set firewall ... rule <rule> log disable
+    # set firewall ... rule <rule> state <state> disable
+# To
+    # set firewall ... rule <rule> log
+    # set firewall ... rule <rule> state <state>
+    # Remove command if log=disable or <state>=disable
+
+import re
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+from vyos.ifconfig import Section
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['firewall']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+
+for family in ['ipv4', 'ipv6', 'bridge']:
+    if config.exists(base + [family]):
+        for hook in ['forward', 'input', 'output', 'name']:
+            if config.exists(base + [family, hook]):
+                for priority in config.list_nodes(base + [family, hook]):
+                    if config.exists(base + [family, hook, priority, 'rule']):
+                        for rule in config.list_nodes(base + [family, hook, priority, 'rule']):
+                            # Log
+                            if config.exists(base + [family, hook, priority, 'rule', rule, 'log']):
+                                log_value = config.return_value(base + [family, hook, priority, 'rule', rule, 'log'])
+                                config.delete(base + [family, hook, priority, 'rule', rule, 'log'])
+                                if log_value == 'enable':
+                                    config.set(base + [family, hook, priority, 'rule', rule, 'log'])
+                            # State
+                            if config.exists(base + [family, hook, priority, 'rule', rule, 'state']):
+                                flag_enable = 'False'
+                                for state in ['established', 'invalid', 'new', 'related']:
+                                    if config.exists(base + [family, hook, priority, 'rule', rule, 'state', state]):
+                                        state_value = config.return_value(base + [family, hook, priority, 'rule', rule, 'state', state])
+                                        config.delete(base + [family, hook, priority, 'rule', rule, 'state', state])
+                                        if state_value == 'enable':
+                                            config.set(base + [family, hook, priority, 'rule', rule, 'state'], value=state, replace=False)
+                                            flag_enable = 'True'
+                                if flag_enable == 'False':
+                                    config.delete(base + [family, hook, priority, 'rule', rule, 'state'])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)

--- a/src/migration-scripts/policy/6-to-7
+++ b/src/migration-scripts/policy/6-to-7
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T5729: Switch to valueless whenever is possible.
+# From
+    # set policy [route | route6] ... rule <rule> log enable
+    # set policy [route | route6] ... rule <rule> log disable
+# To
+    # set policy [route | route6] ... rule <rule> log
+    # Remove command if log=disable
+
+import re
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+from vyos.ifconfig import Section
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['policy']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+
+for family in ['route', 'route6']:
+    if config.exists(base + [family]):
+
+        for policy_name in config.list_nodes(base + [family]):
+            if config.exists(base + [family, policy_name, 'rule']):
+                for rule in config.list_nodes(base + [family, policy_name, 'rule']):
+                    # Log
+                    if config.exists(base + [family, policy_name, 'rule', rule, 'log']):
+                        log_value = config.return_value(base + [family, policy_name, 'rule', rule, 'log'])
+                        config.delete(base + [family, policy_name, 'rule', rule, 'log'])
+                        if log_value == 'enable':
+                            config.set(base + [family, policy_name, 'rule', rule, 'log'])
+                    # State
+                    if config.exists(base + [family, policy_name, 'rule', rule, 'state']):
+                        flag_enable = 'False'
+                        for state in ['established', 'invalid', 'new', 'related']:
+                            if config.exists(base + [family, policy_name, 'rule', rule, 'state', state]):
+                                state_value = config.return_value(base + [family, policy_name, 'rule', rule, 'state', state])
+                                config.delete(base + [family, policy_name, 'rule', rule, 'state', state])
+                                if state_value == 'enable':
+                                    config.set(base + [family, policy_name, 'rule', rule, 'state'], value=state, replace=False)
+                                    flag_enable = 'True'
+                        if flag_enable == 'False':
+                            config.delete(base + [family, policy_name, 'rule', rule, 'state'])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)

--- a/src/validators/numeric-exclude
+++ b/src/validators/numeric-exclude
@@ -1,0 +1,8 @@
+#!/bin/sh
+path=$(dirname "$0")
+num="${@: -1}"
+if [ "${num:0:1}" != "!" ]; then
+   ${path}/numeric $@
+else
+    ${path}/numeric ${@:1:$#-1} ${num:1}
+fi


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Multiple backports that were missing in sagitta

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):
Backports

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5729
* https://vyos.dev/T5616
* https://vyos.dev/T5590

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
Original PR for 1.5:
* https://github.com/vyos/vyos-1x/pull/2471
* https://github.com/vyos/vyos-1x/pull/2283
* https://github.com/vyos/vyos-1x/pull/2314
* 
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
policy-route
nat
nat66

## Proposed changes
<!--- Describe your changes in detail -->
Multiple backports that were missing in saggita:

* https://vyos.dev/T5729 --> Move to valules 'log' and 'state'
* https://vyos.dev/T5616 --> Add firewall marks matcher in fwall and policy-route
* https://vyos.dev/T5590 --> Fix log parsing in ruleset


## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@Sagitta-Valueless# set firewall ipv4 name FOO rule 10 action drop 
[edit]
vyos@Sagitta-Valueless# set firewall ipv4 name FOO rule 10 log-options group 4
[edit]
vyos@Sagitta-Valueless# commit

log-options defined, but log is not enable

[[firewall]] failed
Commit failed
[edit]
vyos@Sagitta-Valueless# set firewall ipv4 name FOO rule 10 log
[edit]
vyos@Sagitta-Valueless# commit
....
....
vyos@Sagitta-Valueless# run show config comm | grep "policy\|firewall"
set firewall ipv4 name FOO rule 10 action 'drop'
set firewall ipv4 name FOO rule 10 log
set firewall ipv4 name FOO rule 10 log-options group '4'
set firewall ipv4 name FOO rule 10 protocol 'icmp'
set firewall ipv4 name FOO rule 10 source address '198.51.100.55'
set firewall ipv4 name FOO rule 20 action 'drop'
set firewall ipv4 name FOO rule 20 mark '22334'
set firewall ipv6 name BAR rule 10 action 'reject'
set firewall ipv6 name BAR rule 10 state 'invalid'
set firewall ipv6 name BAR rule 20 action 'accept'
set firewall ipv6 name BAR rule 20 log
set firewall ipv6 name BAR rule 20 state 'related'
set firewall ipv6 name BAR rule 20 state 'new'
set firewall ipv6 name BAR rule 20 state 'established'
set policy route PBR_4 rule 10 action 'accept'
set policy route PBR_4 rule 10 log
set policy route PBR_4 rule 10 mark '9988'
set policy route PBR_4 rule 20 set mark '7777'
set policy route PBR_4 rule 20 state 'new'
set policy route PBR_4 rule 20 state 'related'
[edit]
vyos@Sagitta-Valueless# 

```
And generated chains:
```

vyos@Sagitta-Valueless# sudo nft -s list chain ip vyos_filter NAME_FOO
table ip vyos_filter {
        chain NAME_FOO {
                meta l4proto icmp ip saddr 198.51.100.55 log prefix "[ipv4-NAM-FOO-10-D]" log group 4 counter drop comment "NAM-FOO-10"
                meta mark 0x0000573e counter drop comment "NAM-FOO-20"
                counter drop comment "FOO default-action drop"
        }
}
[edit]
vyos@Sagitta-Valueless# sudo nft -s list chain ip6 vyos_filter NAME6_BAR
table ip6 vyos_filter {
        chain NAME6_BAR {
                ct state invalid counter reject comment "NAM-BAR-10"
                ct state { established, related, new } log prefix "[ipv6-NAM-BAR-20-A]" counter accept comment "NAM-BAR-20"
                counter drop comment "BAR default-action drop"
        }
}
[edit]
vyos@Sagitta-Valueless# 

vyos@Sagitta-Valueless# sudo nft -s list chain ip vyos_mangle VYOS_PBR_UD_PBR_4
table ip vyos_mangle {
        chain VYOS_PBR_UD_PBR_4 {
                meta mark 0x00002704 log prefix "[ipv4-route-PBR_4-10-A]" counter accept comment "route-PBR_4-10"
                ct state { related, new } counter meta mark set 0x00001e61 return comment "route-PBR_4-20"
        }
}
[edit]

```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
### SMOkETESTS:
root@Sagitta-Valueless:/usr/libexec/vyos/tests/smoke/cli# ./test_firewall.py 
test_geoip (__main__.TestFirewall.test_geoip) ... Updating GeoIP. Please wait...
Updating GeoIP. Please wait...
ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... 
Group "smoketest_network1" has a circular reference

ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok

----------------------------------------------------------------------
Ran 13 tests in 29.726s

OK
root@Sagitta-Valueless:/usr/libexec/vyos/tests/smoke/cli# ./test_policy_route.py 
test_pbr_group (__main__.TestPolicyRoute.test_pbr_group) ... ok
test_pbr_mark (__main__.TestPolicyRoute.test_pbr_mark) ... ok
test_pbr_mark_connection (__main__.TestPolicyRoute.test_pbr_mark_connection) ... ok
test_pbr_matching_criteria (__main__.TestPolicyRoute.test_pbr_matching_criteria) ... ok
test_pbr_table (__main__.TestPolicyRoute.test_pbr_table) ... ok

----------------------------------------------------------------------
Ran 5 tests in 15.148s

OK
root@Sagitta-Valueless:/usr/libexec/vyos/tests/smoke/cli# 
root@Sagitta-Valueless:/usr/libexec/vyos/tests/smoke/cli# ./test_nat.py 
test_dnat (__main__.TestNAT.test_dnat) ... ok
test_dnat_negated_addresses (__main__.TestNAT.test_dnat_negated_addresses) ... ok
test_dnat_redirect (__main__.TestNAT.test_dnat_redirect) ... ok
test_dnat_without_translation_address (__main__.TestNAT.test_dnat_without_translation_address) ... ok
test_nat_balance (__main__.TestNAT.test_nat_balance) ... ok
test_nat_no_rules (__main__.TestNAT.test_nat_no_rules) ... ok
test_snat (__main__.TestNAT.test_snat) ... ok
test_snat_groups (__main__.TestNAT.test_snat_groups) ... ok
test_snat_required_translation_address (__main__.TestNAT.test_snat_required_translation_address) ... 
Source NAT configuration error in rule 5: translation requires address
and/or port

ok
test_static_nat (__main__.TestNAT.test_static_nat) ... ok

----------------------------------------------------------------------
Ran 10 tests in 17.796s

OK
root@Sagitta-Valueless:/usr/libexec/vyos/tests/smoke/cli# 
root@Sagitta-Valueless:/usr/libexec/vyos/tests/smoke/cli# 
root@Sagitta-Valueless:/usr/libexec/vyos/tests/smoke/cli# ./test_nat66.py 
test_destination_nat66 (__main__.TestNAT66.test_destination_nat66) ... ok
test_destination_nat66_prefix (__main__.TestNAT66.test_destination_nat66_prefix) ... ok
test_destination_nat66_protocol (__main__.TestNAT66.test_destination_nat66_protocol) ... ok
test_destination_nat66_without_translation_address (__main__.TestNAT66.test_destination_nat66_without_translation_address) ... ok
test_nat66_no_rules (__main__.TestNAT66.test_nat66_no_rules) ... ok
test_source_nat66 (__main__.TestNAT66.test_source_nat66) ... ok
test_source_nat66_address (__main__.TestNAT66.test_source_nat66_address) ... ok
test_source_nat66_protocol (__main__.TestNAT66.test_source_nat66_protocol) ... ok
test_source_nat66_required_translation_prefix (__main__.TestNAT66.test_source_nat66_required_translation_prefix) ... 
Source NAT66 configuration error in rule 5: translation address not
specified


Source NAT66 configuration error in rule 5: translation address not
specified

ok

----------------------------------------------------------------------
Ran 9 tests in 14.977s

OK
root@Sagitta-Valueless:/usr/libexec/vyos/tests/smoke/cli# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
