### PR TITLE
remote: T5726: Disable the progressbar if the shell is noninteractive or the terminal is missing capabilities

### DIFF
--- a/python/vyos/utils/io.py
+++ b/python/vyos/utils/io.py
@@ -62,3 +62,13 @@ def ask_yes_no(question, default=False) -> bool:
                 stdout.write("Please respond with yes/y or no/n\n")
         except EOFError:
             stdout.write("\nPlease respond with yes/y or no/n\n")
+
+def is_interactive():
+    """Try to determine if the routine was called from an interactive shell."""
+    import os, sys
+    return os.getenv('TERM', default=False) and sys.stderr.isatty() and sys.stdout.isatty()
+
+def is_dumb_terminal():
+    """Check if the current TTY is dumb, so that we can disable advanced terminal features."""
+    import os
+    return os.getenv('TERM') in ['vt100', 'dumb']


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This commit removes `friendly_download()` and adapts `download()` and `upload()` to check for shell interactivity, and adds a check for `$TERM` in the progressbar logic to turn all calls into noop on dummy terminals (including Ansible's VyOS module). The interactivity check fixes the image download problem with the HTTPS API.

Please merge the pull requests on `vyatta-op` and `vyatta-cfg-system` before merging this one.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5726
* https://vyos.dev/T5655 (incidental fix)

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
vyos/vyatta-op#82, vyos/vyatta-cfg-system#214

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
remote

## Proposed changes
<!--- Describe your changes in detail -->
In terms of refactoring, I flattened the arglist of calls to the download and upload dispatchers, since the opaque `*args, **kwargs` shorthand seemed to be causing confusion.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
`add system image`, `commit` with commit-archive, `copy file`, especially including remote calls from HTTPS API and the Ansible module

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
