### PR TITLE
T5732: generate firewall rule-resequence drops geoip country-code fro…

### DIFF
--- a/src/op_mode/generate_firewall_rule-resequence.py
+++ b/src/op_mode/generate_firewall_rule-resequence.py
@@ -41,6 +41,10 @@ def convert_to_set_commands(config_dict, parent_key=''):
                 commands.extend(
                     convert_to_set_commands(value, f"{current_key} "))
 
+        elif isinstance(value, list):
+            for item in value:
+                commands.append(f"set {current_key} '{item}'")
+
         elif isinstance(value, str):
             commands.append(f"set {current_key} '{value}'")
 


### PR DESCRIPTION
…m output

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
The current 'generate firewall rule-resequence' drops the country codes from geoip firewall rules. This applies to both 1.4 and 1.5.

Steps to reproduce:

```
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 default-action 'drop'
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 10 action 'drop'
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 10 destination geoip country-code 'us'
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 10 destination geoip country-code 'ca'
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 10 destination geoip inverse-match
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 10 log 'enable'
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 20 action 'accept'
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 20 source address 192.168.0.5

$ show config commands | grep SOMEZONE
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 default-action 'drop'
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 10 action 'drop'
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 10 destination geoip country-code 'us'
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 10 destination geoip country-code 'ca'
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 10 destination geoip inverse-match
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 10 log 'enable'
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 20 action 'accept'
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 20 source address '192.168.0.5'

$ generate firewall rule-resequence | grep SOMEZONE
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 default-action 'drop'
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 100 action 'drop'
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 100 destination geoip inverse-match
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 100 log 'enable'
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 110 action 'accept'
set firewall ipv4 name SOMEZONE-FORWARD-IPV4 rule 110 source address '192.168.0.5'
```

This is because the country-code item in the config_dict is type list and gets skipped by the convert_to_set_commands function.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5732

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
generate firewall rule-resequence

## Proposed changes
<!--- Describe your changes in detail -->
Add support for parsing lists in configs.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

My config:
```
$ show config commands | grep "set firewall ipv4\|set firewall ipv6" | wc -l
349
```
Pre-patch:
```
$ generate firewall rule-resequence | grep "set firewall ipv4\|set firewall ipv6" | wc -l
347
```
Post-patch:
```
$ generate firewall rule-resequence | grep "set firewall ipv4\|set firewall ipv6" | wc -l
349
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
