### PR TITLE
T5747: op-mode add show interfaces summary

### DIFF
--- a/op-mode-definitions/show-interfaces.xml.in
+++ b/op-mode-definitions/show-interfaces.xml.in
@@ -20,6 +20,12 @@
             </properties>
             <command>${vyos_op_scripts_dir}/interfaces.py show</command>
           </leafNode>
+          <leafNode name="summary">
+            <properties>
+              <help>Show summary information of all interfaces</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary_extended</command>
+          </leafNode>
         </children>
       </node>
     </children>

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -571,6 +571,16 @@ class Interface(Control):
         self._cmd(f'ip link set dev {self.ifname} netns {netns}')
         return True
 
+    def get_vrf(self):
+        """
+        Get VRF from interface
+
+        Example:
+        >>> from vyos.ifconfig import Interface
+        >>> Interface('eth0').get_vrf()
+        """
+        return self.get_interface('vrf')
+
     def set_vrf(self, vrf: str) -> bool:
         """
         Add/Remove interface from given VRF instance.


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add op-mode `show interfaces summary`
Add `MAC`, `VRF` and `MTU` options:

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5747

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
interfaces
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
vyos@r4# run show interfaces summary 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address         MAC                VRF        MTU  S/L    Description
-----------  -----------------  -----------------  -------  -----  -----  -------------
dum0         203.0.113.1/32     96:44:ad:c5:a1:a5  default   1500  u/u
eth0         192.168.122.14/24  52:54:00:f1:fd:77  default   1500  u/u    WAN
eth1         192.0.2.1/24       52:54:00:04:33:2b  foo       1500  u/u    LAN-eth1
eth2         -                  52:54:00:40:2e:af  default   1504  u/u    LAN-eth2
eth3         -                  52:54:00:09:a4:b4  default   1500  A/D
eth4         -                  52:54:00:2c:51:09  default   1500  A/D
eth5         -                  52:54:00:f3:1d:e8  default   1500  A/D
lo           127.0.0.1/8        00:00:00:00:00:00  default  65536  u/u
             ::1/128
vtun10       10.10.0.1/24       n/a                default   1500  u/u

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
