### PR TITLE
T3983: show pki certificate Doesnt show x509 certificates

### DIFF
--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -896,11 +896,15 @@ def show_certificate(name=None, pem=False):
             cert_subject_cn = cert.subject.rfc4514_string().split(",")[0]
             cert_issuer_cn = cert.issuer.rfc4514_string().split(",")[0]
             cert_type = 'Unknown'
-            ext = cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
-            if ext and ExtendedKeyUsageOID.SERVER_AUTH in ext.value:
-                cert_type = 'Server'
-            elif ext and ExtendedKeyUsageOID.CLIENT_AUTH in ext.value:
-                cert_type = 'Client'
+
+            try:
+                ext = cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
+                if ext and ExtendedKeyUsageOID.SERVER_AUTH in ext.value:
+                    cert_type = 'Server'
+                elif ext and ExtendedKeyUsageOID.CLIENT_AUTH in ext.value:
+                    cert_type = 'Client'
+            except:
+                pass
 
             revoked = 'Yes' if 'revoke' in cert_dict else 'No'
             have_private = 'Yes' if 'private' in cert_dict and 'key' in cert_dict['private'] else 'No'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Imported certificates may not contain ExtendedKeyUsage extensions unlike ones that are generated locally. Trying to view this non existent extension caused an exception. Applicable to 1.5 and 1.4.

Before:
```
$ show pki certificate
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/pki.py", line 1066, in <module>
    show_certificate(None if args.certificate == 'all' else args.certificate, args.pem)
  File "/usr/libexec/vyos/op_mode/pki.py", line 901, in show_certificate
    ext = cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/cryptography/x509/extensions.py", line 141, in get_extension_for_class
    raise ExtensionNotFound(
cryptography.x509.extensions.ExtensionNotFound: No <class 'cryptography.x509.extensions.ExtendedKeyUsage'> extension was found
```

After:
```
$ show pki certificate
Certificates:
Name                Type     Subject CN             Issuer CN                             Issued               Expiry               Revoked    Private Key    CA Present
------------------  -------  ---------------------  ------------------------------------  -------------------  -------------------  ---------  -------------  -------------
TestClient          Client   CN=vyos.io             CN=vyos.io                            2023-11-15 15:57:46  2024-11-14 15:57:46  No         Yes            No
TestServer          Server   CN=vyos.io             CN=vyos.io                            2023-11-15 15:57:05  2024-11-14 15:57:05  No         Yes            No
xyz                 Unknown  CN=xyz                 1.2.840.113549.1.9.1=xyz@xyz.xyz      2023-08-29 18:12:06  2033-08-26 18:12:06  No         Yes            Yes (XYZ-CA)
```


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3983

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
show pki certificate

## Proposed changes
<!--- Describe your changes in detail -->
Add a try: to contain the error if a certificate doesn't contain extended info. 

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Import a certificate without extended key extension.
show pki certificate

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
