### PR TITLE
vxlan: T5753: add support for VNI filtering

### DIFF
--- a/interface-definitions/interfaces-vxlan.xml.in
+++ b/interface-definitions/interfaces-vxlan.xml.in
@@ -95,6 +95,12 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <leafNode name="vni-filter">
+                <properties>
+                  <help>Enable VNI filter support</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
             </children>
           </node>
           #include <include/port-number.xml.i>

--- a/op-mode-definitions/show-bridge.xml.in
+++ b/op-mode-definitions/show-bridge.xml.in
@@ -21,6 +21,12 @@
               </leafNode>
             </children>
           </node>
+          <leafNode name="vni">
+            <properties>
+              <help>Virtual Network Identifier</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/bridge.py show_vni</command>
+          </leafNode>
         </children>
       </node>
       <leafNode name="bridge">

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -483,3 +483,36 @@ def get_vxlan_vlan_tunnels(interface: str) -> list:
             os_configured_vlan_ids.append(str(vlanStart))
 
     return os_configured_vlan_ids
+
+def get_vxlan_vni_filter(interface: str) -> list:
+    """ Return a list of strings with VNIs configured in the Kernel"""
+    from json import loads
+    from vyos.utils.process import cmd
+
+    if not interface.startswith('vxlan'):
+        raise ValueError('Only applicable for VXLAN interfaces!')
+
+    # Determine current OS Kernel configured VNI filters in VXLAN interface
+    #
+    # $ bridge -j vni show dev vxlan1
+    # [{"ifname":"vxlan1","vnis":[{"vni":100},{"vni":200},{"vni":300,"vniEnd":399}]}]
+    #
+    # Example output: ['10010', '10020', '10021', '10022']
+    os_configured_vnis = []
+    tmp = loads(cmd(f'bridge --json vni show dev {interface}'))
+    if tmp:
+        for tunnel in tmp[0].get('vnis', {}):
+            vniStart = tunnel['vni']
+            if 'vniEnd' in tunnel:
+                vniEnd = tunnel['vniEnd']
+                # Build a real list for user VNIs
+                vni_list = list(range(vniStart, vniEnd +1))
+                # Convert list of integers to list or strings
+                os_configured_vnis.extend(map(str, vni_list))
+                # Proceed with next tunnel - this one is complete
+                continue
+
+            # Add single tunel id - not part of a range
+            os_configured_vnis.append(str(vniStart))
+
+    return os_configured_vnis

--- a/src/op_mode/bridge.py
+++ b/src/op_mode/bridge.py
@@ -56,6 +56,13 @@ def _get_raw_data_vlan(tunnel:bool=False):
     data_dict = json.loads(json_data)
     return data_dict
 
+def _get_raw_data_vni() -> dict:
+    """
+    :returns dict
+    """
+    json_data = cmd(f'bridge --json vni show')
+    data_dict = json.loads(json_data)
+    return data_dict
 
 def _get_raw_data_fdb(bridge):
     """Get MAC-address for the bridge brX
@@ -165,6 +172,22 @@ def _get_formatted_output_vlan_tunnel(data):
     output = tabulate(data_entries, headers)
     return output
 
+def _get_formatted_output_vni(data):
+    data_entries = []
+    for entry in data:
+        interface = entry.get('ifname')
+        vlans = entry.get('vnis')
+        for vlan_entry in vlans:
+            vlan = vlan_entry.get('vni')
+            if vlan_entry.get('vniEnd'):
+                vlan_end = vlan_entry.get('vniEnd')
+                vlan = f'{vlan}-{vlan_end}'
+            data_entries.append([interface, vlan])
+
+    headers = ["Interface", "VNI"]
+    output = tabulate(data_entries, headers)
+    return output
+
 def _get_formatted_output_fdb(data):
     data_entries = []
     for entry in data:
@@ -228,6 +251,12 @@ def show_vlan(raw: bool, tunnel: typing.Optional[bool]):
         else:
             return _get_formatted_output_vlan(bridge_vlan)
 
+def show_vni(raw: bool):
+    bridge_vni = _get_raw_data_vni()
+    if raw:
+        return bridge_vni
+    else:
+        return _get_formatted_output_vni(bridge_vni)
 
 def show_fdb(raw: bool, interface: str):
     fdb_data = _get_raw_data_fdb(interface)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

In a service provider network a service provider typically supports multiple
bridge domains with overlapping vlans. One bridge domain per customer. Vlans in
each bridge domain are mapped to globally unique VXLAN VNI ranges assigned to
each customer.

Without the ability of VNI filtering, we can not provide VXLAN tunnels
with multiple tenants all requiring e.g. VLAN 10.

To Test:
```
set interfaces vxlan vxlan987 parameters external
set interfaces vxlan vxlan987 source-interface eth0
set interfaces vxlan vxlan987 parameters vni-filter
set interfaces vxlan vxlan987 vlan-to-vni 50 vni 10050
set interfaces vxlan vxlan987 vlan-to-vni 51 vni 10051
set interfaces vxlan vxlan987 vlan-to-vni 52 vni 10052
set interfaces vxlan vxlan987 vlan-to-vni 53 vni 10053
set interfaces vxlan vxlan987 vlan-to-vni 54 vni 10054
set interfaces vxlan vxlan987 vlan-to-vni 60 vni 10060
set interfaces vxlan vxlan987 vlan-to-vni 69 vni 10069
set interfaces bridge br0 member interface vxlan987
```

Add new op-mode command: `show bridge vni`

```
Interface    VNI
-----------  -----------
vxlan987     10050-10054
vxlan987     10060
vxlan987     10069
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5753

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-documentation/pull/1155

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```bash
set interfaces vxlan vxlan1 parameters external
set interfaces vxlan vxlan1 parameters nolearning
set interfaces vxlan vxlan1 parameters vni-filter
set interfaces vxlan vxlan1 source-address '172.16.33.201'
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```bash
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_vxlan.py
test_add_multiple_ip_addresses (__main__.VXLANInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.VXLANInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.VXLANInterfaceTest.test_dhcp_client_options) ... skipped 'not supported'
test_dhcp_disable_interface (__main__.VXLANInterfaceTest.test_dhcp_disable_interface) ... skipped 'not supported'
test_dhcp_vrf (__main__.VXLANInterfaceTest.test_dhcp_vrf) ... skipped 'not supported'
test_dhcpv6_client_options (__main__.VXLANInterfaceTest.test_dhcpv6_client_options) ... skipped 'not supported'
test_dhcpv6_vrf (__main__.VXLANInterfaceTest.test_dhcpv6_vrf) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.VXLANInterfaceTest.test_dhcpv6pd_auto_sla_id) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.VXLANInterfaceTest.test_dhcpv6pd_manual_sla_id) ... skipped 'not supported'
test_interface_description (__main__.VXLANInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.VXLANInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.VXLANInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.VXLANInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.VXLANInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.VXLANInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.VXLANInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.VXLANInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.VXLANInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.VXLANInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.VXLANInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.VXLANInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.VXLANInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.VXLANInterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'
test_vxlan_external (__main__.VXLANInterfaceTest.test_vxlan_external) ... ok
test_vxlan_neighbor_suppress (__main__.VXLANInterfaceTest.test_vxlan_neighbor_suppress) ... ok
test_vxlan_parameters (__main__.VXLANInterfaceTest.test_vxlan_parameters) ... ok
test_vxlan_vlan_vni_mapping (__main__.VXLANInterfaceTest.test_vxlan_vlan_vni_mapping) ... ok
test_vxlan_vni_filter (__main__.VXLANInterfaceTest.test_vxlan_vni_filter) ... ok
test_vxlan_vni_filter_add_remove (__main__.VXLANInterfaceTest.test_vxlan_vni_filter_add_remove) ... ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
