### PR TITLE
T5749: Swap show interfaces and show interfaces summary

### DIFF
--- a/op-mode-definitions/show-interfaces.xml.in
+++ b/op-mode-definitions/show-interfaces.xml.in
@@ -6,7 +6,7 @@
         <properties>
           <help>Show network interface information</help>
         </properties>
-        <command>${vyos_op_scripts_dir}/interfaces.py show_summary</command>
+        <command>${vyos_op_scripts_dir}/interfaces.py show_summary_extended</command>
         <children>
           <leafNode name="counters">
             <properties>
@@ -24,7 +24,7 @@
             <properties>
               <help>Show summary information of all interfaces</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary_extended</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary</command>
           </leafNode>
         </children>
       </node>

--- a/src/op_mode/interfaces.py
+++ b/src/op_mode/interfaces.py
@@ -235,6 +235,11 @@ def _get_summary_data(ifname: typing.Optional[str],
     if iftype is None:
         iftype = ''
     ret = []
+
+    def is_interface_has_mac(interface_name):
+        interface_no_mac = ('tun', 'wg')
+        return not any(interface_name.startswith(prefix) for prefix in interface_no_mac)
+
     for interface in filtered_interfaces(ifname, iftype, vif, vrrp):
         res_intf = {}
 
@@ -244,7 +249,7 @@ def _get_summary_data(ifname: typing.Optional[str],
         res_intf['addr'] = [_ for _ in interface.get_addr() if not _.startswith('fe80::')]
         res_intf['description'] = interface.get_alias()
         res_intf['mtu'] = interface.get_mtu()
-        res_intf['mac'] = interface.get_mac()
+        res_intf['mac'] = interface.get_mac() if is_interface_has_mac(interface.ifname) else 'n/a'
         res_intf['vrf'] = interface.get_vrf()
 
         ret.append(res_intf)


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
By default, show VRF, MAC, and MTU for the op-command `show interfaces` 
The original `show interfaces` moved to `show interfaces summary`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5749

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
interfaces
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
vyos@r4# run show int
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address         MAC                VRF          MTU  S/L    Description
-----------  -----------------  -----------------  ---------  -----  -----  -------------
dum0         203.0.113.1/32     96:44:ad:c5:a1:a5  default     1500  u/u
eth0         192.168.122.14/24  52:54:00:f1:fd:77  default     1500  u/u    WAN
eth1         192.0.2.1/24       52:54:00:04:33:2b  foo         1500  u/u    LAN-eth1
eth1v10v4    10.10.10.10/24     00:00:5e:00:01:0a  foo         1500  u/u
eth2         -                  52:54:00:40:2e:af  default     1504  u/u    LAN-eth2
eth3         -                  52:54:00:09:a4:b4  default     1500  A/D
eth4         -                  52:54:00:2c:51:09  default     1500  A/D
eth5         -                  52:54:00:f3:1d:e8  default     1500  A/D
lo           127.0.0.1/8        00:00:00:00:00:00  default    65536  u/u
             ::1/128
tun0         -                  n/a                default     1476  u/u
vtun10       10.10.0.1/24       n/a                default     1500  u/u
```
Summary
```
vyos@r4# run show interfaces summary 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
dum0             203.0.113.1/32                    u/u  
eth0             192.168.122.14/24                 u/u  WAN
eth1             192.0.2.1/24                      u/u  LAN-eth1
eth1v10v4        10.10.10.10/24                    u/u  
eth2             -                                 u/u  LAN-eth2
eth3             -                                 A/D  
eth4             -                                 A/D  
eth5             -                                 A/D  
lo               127.0.0.1/8                       u/u  
                 ::1/128                                
tun0             -                                 u/u  
vtun10           10.10.0.1/24                      u/u  

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
