### PR TITLE
vxlan: T5759: change default MTU from 1450 -> 1500 bytes

### DIFF
--- a/interface-definitions/interfaces-vxlan.xml.in
+++ b/interface-definitions/interfaces-vxlan.xml.in
@@ -48,9 +48,6 @@
           #include <include/interface/mac.xml.i>
           #include <include/interface/mtu-1200-16000.xml.i>
           #include <include/interface/mirror.xml.i>
-          <leafNode name="mtu">
-            <defaultValue>1450</defaultValue>
-          </leafNode>
           <node name="parameters">
             <properties>
               <help>VXLAN tunnel parameters</help>

--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -412,10 +412,9 @@ class BasicInterfaceTest:
 
             for intf in self._interfaces:
                 base = self._base_path + [intf]
-                self.cli_set(base + ['mtu', self._mtu])
-
                 for option in self._options.get(intf, []):
                     self.cli_set(base + option.split())
+                self.cli_set(base + ['mtu', self._mtu])
 
             # check validate() - can not set low MTU if 'no-default-link-local'
             # is not set on CLI

--- a/src/migration-scripts/interfaces/31-to-32
+++ b/src/migration-scripts/interfaces/31-to-32
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # T5671: change port to IANA assigned default port
+# T5759: change default MTU 1450 -> 1500
 
 from sys import argv
 from sys import exit
@@ -42,6 +43,9 @@ for vxlan in config.list_nodes(base):
 
     if not config.exists(base + [vxlan, 'port']):
         config.set(base + [vxlan, 'port'], value='8472')
+
+    if not config.exists(base + [vxlan, 'mtu']):
+        config.set(base + [vxlan, 'mtu'], value='1450')
 
 try:
     with open(file_name, 'w') as f:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Found an odd behavior on Linux and the VyOS CLI implementation. If adding VXLAN interfaces using iproute2 the MTU differs depending on the creation syntax:

```bash
ip -4 link add vxlan100 type vxlan dstport 4789 external df unset tos inherit \
  ttl 16 nolearning vnifilter local 172.16.33.201
ip -4 link add vxlan200 type vxlan id 200 dstport 4789 local 172.16.33.201 dev eth0 ip -6 link add vxlan300 type vxlan id 300 dstport 4789 local 2001:db8:1::1 dev eth0

132: vxlan300: <BROADCAST,MULTICAST> mtu 1430 qdisc noop state DOWN group default qlen 1000
    link/ether 4e:fb:e3:f5:d9:59 brd ff:ff:ff:ff:ff:ff
133: vxlan200: <BROADCAST,MULTICAST> mtu 1450 qdisc noop state DOWN group default qlen 1000
    link/ether 0e:4e:f4:76:59:3f brd ff:ff:ff:ff:ff:ff
134: vxlan100: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether ba:b6:b7:0c:b1:37 brd ff:ff:ff:ff:ff:ff
```
VyOS always sets a default MTU of 1450 bytes which is correct for IPv4 p2p links or multicast, but invalid for IPv6 p2p. Also this will break EVPN deployments as ethernet bridges with MTU < 1500 bytes are less fun.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5759

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

VXLAN

## Proposed changes
<!--- Describe your changes in detail -->

Increase default MTU to 1500 bytes. Migrate old configurations to use 1450 bytes if not specified otherwise on the CLI.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
test_add_multiple_ip_addresses (__main__.VXLANInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.VXLANInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.VXLANInterfaceTest.test_dhcp_client_options) ... skipped 'not supported'
test_dhcp_disable_interface (__main__.VXLANInterfaceTest.test_dhcp_disable_interface) ... skipped 'not supported'
test_dhcp_vrf (__main__.VXLANInterfaceTest.test_dhcp_vrf) ... skipped 'not supported'
test_dhcpv6_client_options (__main__.VXLANInterfaceTest.test_dhcpv6_client_options) ... skipped 'not supported'
test_dhcpv6_vrf (__main__.VXLANInterfaceTest.test_dhcpv6_vrf) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.VXLANInterfaceTest.test_dhcpv6pd_auto_sla_id) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.VXLANInterfaceTest.test_dhcpv6pd_manual_sla_id) ... skipped 'not supported'
test_interface_description (__main__.VXLANInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.VXLANInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.VXLANInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.VXLANInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.VXLANInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.VXLANInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.VXLANInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.VXLANInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.VXLANInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.VXLANInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.VXLANInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.VXLANInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.VXLANInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.VXLANInterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'
test_vxlan_external (__main__.VXLANInterfaceTest.test_vxlan_external) ... ok
test_vxlan_neighbor_suppress (__main__.VXLANInterfaceTest.test_vxlan_neighbor_suppress) ... ok
test_vxlan_parameters (__main__.VXLANInterfaceTest.test_vxlan_parameters) ... ok
test_vxlan_vlan_vni_mapping (__main__.VXLANInterfaceTest.test_vxlan_vlan_vni_mapping) ... ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
