### PR TITLE
dhcp-client: T5760: add CLI option to pass user-class parameter

### DIFF
--- a/data/templates/dhcp-client/ipv4.j2
+++ b/data/templates/dhcp-client/ipv4.j2
@@ -9,14 +9,21 @@ interface "{{ ifname }}" {
     send host-name "{{ dhcp_options.host_name }}";
 {% if dhcp_options.client_id is vyos_defined %}
 {%     set client_id = dhcp_options.client_id %}
-{#   Use HEX representation of client-id as it is send in MAC-address style using hex characters. If not HEX, use double quotes ASCII format #}
-{%     if not dhcp_options.client_id.split(':') | length >= 5 %}
-{%         set client_id = '"' + dhcp_options.client_id + '"' %}
+{#   Use HEX representation of client-id as it is send in MAC-address style using hex characters. #}
+{#   If not HEX, use double quotes ASCII format #}
+{%     if not client_id.split(':') | length >= 3 %}
+{%         set client_id = '"' ~ dhcp_options.client_id ~ '"' %}
 {%     endif %}
     send dhcp-client-identifier {{ client_id }};
 {% endif %}
 {% if dhcp_options.vendor_class_id is vyos_defined %}
-    send vendor-class-identifier "{{ dhcp_options.vendor_class_id }}";
+{%     set vendor_class_id = dhcp_options.vendor_class_id %}
+{#   Use HEX representation of client-id as it is send in MAC-address style using hex characters. #}
+{#   If not HEX, use double quotes ASCII format #}
+{%     if not vendor_class_id.split(':') | length >= 3 %}
+{%         set vendor_class_id = '"' ~ dhcp_options.vendor_class_id ~ '"' %}
+{%     endif %}
+    send vendor-class-identifier {{ vendor_class_id }};
 {% endif %}
     # The request statement causes the client to request that any server responding to the
     # client send the client its values for the specified options.

--- a/data/templates/dhcp-client/ipv4.j2
+++ b/data/templates/dhcp-client/ipv4.j2
@@ -25,6 +25,15 @@ interface "{{ ifname }}" {
 {%     endif %}
     send vendor-class-identifier {{ vendor_class_id }};
 {% endif %}
+{% if dhcp_options.user_class is vyos_defined %}
+{%     set user_class = dhcp_options.user_class %}
+{#   Use HEX representation of client-id as it is send in MAC-address style using hex characters. #}
+{#   If not HEX, use double quotes ASCII format #}
+{%     if not user_class.split(':') | length >= 3 %}
+{%         set user_class = '"' ~ dhcp_options.user_class ~ '"' %}
+{%     endif %}
+    send user-class {{ user_class }};
+{% endif %}
     # The request statement causes the client to request that any server responding to the
     # client send the client its values for the specified options.
     request subnet-mask, broadcast-address,{{ " routers," if dhcp_options.no_default_route is not vyos_defined }} domain-name-servers,

--- a/interface-definitions/include/constraint/dhcp-client-string-option.xml.i
+++ b/interface-definitions/include/constraint/dhcp-client-string-option.xml.i
@@ -1,0 +1,4 @@
+<!-- include start from include/constraint/dhcp-client-string-option.xml.i -->
+<regex>[-_a-zA-Z0-9\s]+</regex>
+<regex>([a-fA-F0-9][a-fA-F0-9]:){2,}[a-fA-F0-9][a-fA-F0-9]</regex>
+<!-- include end -->

--- a/interface-definitions/include/interface/dhcp-options.xml.i
+++ b/interface-definitions/include/interface/dhcp-options.xml.i
@@ -43,6 +43,18 @@
         </constraint>
       </properties>
     </leafNode>
+    <leafNode name="user-class">
+      <properties>
+        <help>Identify to the DHCP server, user configurable option</help>
+        <valueHelp>
+          <format>txt</format>
+          <description>DHCP option string</description>
+        </valueHelp>
+        <constraint>
+          #include <include/constraint/dhcp-client-string-option.xml.i>
+        </constraint>
+      </properties>
+    </leafNode>
     #include <include/interface/no-default-route.xml.i>
     #include <include/interface/default-route-distance.xml.i>
     <leafNode name="reject">

--- a/interface-definitions/include/interface/dhcp-options.xml.i
+++ b/interface-definitions/include/interface/dhcp-options.xml.i
@@ -7,6 +7,13 @@
     <leafNode name="client-id">
       <properties>
         <help>Identifier used by client to identify itself to the DHCP server</help>
+        <valueHelp>
+          <format>txt</format>
+          <description>DHCP option string</description>
+        </valueHelp>
+        <constraint>
+          #include <include/constraint/dhcp-client-string-option.xml.i>
+        </constraint>
       </properties>
     </leafNode>
     <leafNode name="host-name">
@@ -27,6 +34,13 @@
     <leafNode name="vendor-class-id">
       <properties>
         <help>Identify the vendor client type to the DHCP server</help>
+        <valueHelp>
+          <format>txt</format>
+          <description>DHCP option string</description>
+        </valueHelp>
+        <constraint>
+          #include <include/constraint/dhcp-client-string-option.xml.i>
+        </constraint>
       </properties>
     </leafNode>
     #include <include/interface/no-default-route.xml.i>

--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -158,14 +158,20 @@ class BasicInterfaceTest:
             if not self._test_dhcp or not self._test_vrf:
                 self.skipTest('not supported')
 
+            client_id = 'VyOS-router'
             distance = '100'
+            hostname = 'vyos'
+            vendor_class_id = 'vyos-vendor'
 
             for interface in self._interfaces:
                 for option in self._options.get(interface, []):
                     self.cli_set(self._base_path + [interface] + option.split())
 
                 self.cli_set(self._base_path + [interface, 'address', 'dhcp'])
+                self.cli_set(self._base_path + [interface, 'dhcp-options', 'client-id', client_id])
                 self.cli_set(self._base_path + [interface, 'dhcp-options', 'default-route-distance', distance])
+                self.cli_set(self._base_path + [interface, 'dhcp-options', 'host-name', hostname])
+                self.cli_set(self._base_path + [interface, 'dhcp-options', 'vendor-class-id', vendor_class_id])
 
             self.cli_commit()
 
@@ -175,8 +181,11 @@ class BasicInterfaceTest:
                 self.assertTrue(dhclient_pid)
 
                 dhclient_config = read_file(f'{dhclient_base_dir}/dhclient_{interface}.conf')
-                self.assertIn('request subnet-mask, broadcast-address, routers, domain-name-servers', dhclient_config)
-                self.assertIn('require subnet-mask;', dhclient_config)
+                self.assertIn(f'request subnet-mask, broadcast-address, routers, domain-name-servers', dhclient_config)
+                self.assertIn(f'require subnet-mask;', dhclient_config)
+                self.assertIn(f'send host-name "{hostname}";', dhclient_config)
+                self.assertIn(f'send dhcp-client-identifier "{client_id}";', dhclient_config)
+                self.assertIn(f'send vendor-class-identifier "{vendor_class_id}";', dhclient_config)
 
                 # and the commandline has the appropriate options
                 cmdline = read_file(f'/proc/{dhclient_pid}/cmdline')

--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -162,6 +162,7 @@ class BasicInterfaceTest:
             distance = '100'
             hostname = 'vyos'
             vendor_class_id = 'vyos-vendor'
+            user_class = 'vyos'
 
             for interface in self._interfaces:
                 for option in self._options.get(interface, []):
@@ -172,6 +173,7 @@ class BasicInterfaceTest:
                 self.cli_set(self._base_path + [interface, 'dhcp-options', 'default-route-distance', distance])
                 self.cli_set(self._base_path + [interface, 'dhcp-options', 'host-name', hostname])
                 self.cli_set(self._base_path + [interface, 'dhcp-options', 'vendor-class-id', vendor_class_id])
+                self.cli_set(self._base_path + [interface, 'dhcp-options', 'user-class', user_class])
 
             self.cli_commit()
 
@@ -186,6 +188,7 @@ class BasicInterfaceTest:
                 self.assertIn(f'send host-name "{hostname}";', dhclient_config)
                 self.assertIn(f'send dhcp-client-identifier "{client_id}";', dhclient_config)
                 self.assertIn(f'send vendor-class-identifier "{vendor_class_id}";', dhclient_config)
+                self.assertIn(f'send user-class "{user_class}";', dhclient_config)
 
                 # and the commandline has the appropriate options
                 cmdline = read_file(f'/proc/{dhclient_pid}/cmdline')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The string data type specifies either an NVT ASCII string enclosed in double quotes, or a series of octets specified in hexadecimal, separated by colons.

* `set interfaces ethernet eth0 dhcp-options client-id CLIENT-FOO`
* `set interfaces ethernet eth0 dhcp-options user-class VyOS`

or

* `set interfaces ethernet eth0 dhcp-options client-id 43:4c:49:45:54:2d:46:4f:4f`
* `set interfaces ethernet eth0 dhcp-options user-class 56:79:4f:53`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5760

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-documentation/pull/1157

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```bash
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_ethernet.py
test_add_multiple_ip_addresses (__main__.EthernetInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.EthernetInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.EthernetInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.EthernetInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.EthernetInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.EthernetInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.EthernetInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol_support (__main__.EthernetInterfaceTest.test_eapol_support) ... ok
test_interface_description (__main__.EthernetInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.EthernetInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.EthernetInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.EthernetInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.EthernetInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.EthernetInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.EthernetInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_non_existing_interface (__main__.EthernetInterfaceTest.test_non_existing_interface) ... ok
test_offloading_rfs (__main__.EthernetInterfaceTest.test_offloading_rfs) ... ok
test_offloading_rps (__main__.EthernetInterfaceTest.test_offloading_rps) ... ok
test_span_mirror (__main__.EthernetInterfaceTest.test_span_mirror) ... ok
test_speed_duplex_verify (__main__.EthernetInterfaceTest.test_speed_duplex_verify) ... ok
test_vif_8021q_interfaces (__main__.EthernetInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.EthernetInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.EthernetInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.EthernetInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.EthernetInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.EthernetInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 28 tests in 120.197s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
