### PR TITLE
http: T5762: api: make API socket backend communication the one and only default

### DIFF
--- a/data/templates/https/nginx.default.j2
+++ b/data/templates/https/nginx.default.j2
@@ -38,11 +38,7 @@ server {
         # proxy settings for HTTP API, if enabled; 503, if not
         location ~ ^/(retrieve|configure|config-file|image|container-image|generate|show|reset|docs|openapi.json|redoc|graphql) {
 {%     if server.api %}
-{%         if server.api.socket %}
                 proxy_pass http://unix:/run/api.sock;
-{%         else %}
-                proxy_pass http://localhost:{{ server.api.port }};
-{%         endif %}
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header X-Forwarded-Proto $scheme;
                 proxy_read_timeout 600;

--- a/interface-definitions/https.xml.in
+++ b/interface-definitions/https.xml.in
@@ -68,7 +68,6 @@
               <priority>1002</priority>
             </properties>
             <children>
-              #include <include/port-number.xml.i>
               <node name="keys">
                 <properties>
                   <help>HTTP API keys</help>
@@ -99,12 +98,6 @@
                   <help>Debug</help>
                   <valueless/>
                   <hidden/>
-                </properties>
-              </leafNode>
-              <leafNode name="socket">
-                <properties>
-                  <help>Run server on Unix domain socket</help>
-                  <valueless/>
                 </properties>
               </leafNode>
               <node name="graphql">

--- a/interface-definitions/include/version/https-version.xml.i
+++ b/interface-definitions/include/version/https-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/https-version.xml.i -->
-<syntaxVersion component='https' version='4'></syntaxVersion>
+<syntaxVersion component='https' version='5'></syntaxVersion>
 <!-- include end -->

--- a/smoketest/config-tests/basic-api-service
+++ b/smoketest/config-tests/basic-api-service
@@ -1,0 +1,12 @@
+set interfaces ethernet eth0 address '192.0.2.1/31'
+set interfaces ethernet eth0 address '2001:db8::1234/64'
+set interfaces loopback lo
+set service ntp server time1.vyos.net
+set service ntp server time2.vyos.net
+set service ntp server time3.vyos.net
+set service https api keys id 1 key 'S3cur3'
+set system config-management commit-revisions '100'
+set system host-name 'vyos'
+set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'
+set system login user vyos authentication plaintext-password ''
+set system console device ttyS0 speed '115200'

--- a/smoketest/configs/basic-api-service
+++ b/smoketest/configs/basic-api-service
@@ -1,0 +1,66 @@
+interfaces {
+    ethernet eth0 {
+        address 192.0.2.1/31
+        address 2001:db8::1234/64
+    }
+    ethernet eth1 {
+    }
+    loopback lo {
+    }
+}
+service {
+    https {
+        api {
+            keys {
+                id 1 {
+                    key S3cur3
+                }
+            }
+            socket
+        }
+    }
+    ssh {
+    }
+}
+system {
+    config-management {
+        commit-revisions 100
+    }
+    console {
+        device ttyS0 {
+            speed 115200
+        }
+    }
+    host-name vyos
+    login {
+        user vyos {
+            authentication {
+                encrypted-password $6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/
+                plaintext-password ""
+            }
+        }
+    }
+    ntp {
+        server time1.vyos.net {
+        }
+        server time2.vyos.net {
+        }
+        server time3.vyos.net {
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level info
+            }
+            facility protocols {
+                level debug
+            }
+        }
+    }
+}
+
+
+// Warning: Do not remove the following line.
+// vyos-config-version: "broadcast-relay@1:cluster@1:config-management@1:conntrack@1:conntrack-sync@1:dhcp-relay@2:dhcp-server@5:dhcpv6-server@1:dns-forwarding@3:firewall@5:https@2:interfaces@13:ipoe-server@1:ipsec@5:l2tp@3:lldp@1:mdns@1:nat@5:ntp@1:pppoe-server@5:pptp@2:qos@1:quagga@6:salt@1:snmp@2:ssh@2:sstp@3:system@19:vrrp@2:vyos-accel-ppp@2:wanloadbalance@3:webgui@1:webproxy@2:zone-policy@1"
+// Release version: 1.3-rolling-202010241631

--- a/src/conf_mode/https.py
+++ b/src/conf_mode/https.py
@@ -215,14 +215,9 @@ def generate(https):
         api_data = vyos.defaults.api_data
     api_settings = https.get('api', {})
     if api_settings:
-        port = api_settings.get('port', '')
-        if port:
-            api_data['port'] = port
         vhosts = https.get('api-restrict', {}).get('virtual-host', [])
         if vhosts:
             api_data['vhost'] = vhosts[:]
-        if 'socket' in list(api_settings):
-            api_data['socket'] = True
 
     if api_data:
         vhost_list = api_data.get('vhost', [])

--- a/src/etc/sysctl.d/30-vyos-router.conf
+++ b/src/etc/sysctl.d/30-vyos-router.conf
@@ -105,3 +105,11 @@ net.core.rps_sock_flow_entries = 32768
 net.core.default_qdisc=fq_codel
 net.ipv4.tcp_congestion_control=bbr
 
+# VRF - Virtual routing and forwarding
+# When net.vrf.strict_mode=0 (default) it is possible to associate multiple
+# VRF devices to the same table. Conversely, when net.vrf.strict_mode=1 a
+# table can be associated to a single VRF device.
+#
+# A VRF table can be used by the VyOS CLI only once (ensured by verify()),
+# this simply adds an additional Kernel safety net
+net.vrf.strict_mode=1

--- a/src/migration-scripts/https/4-to-5
+++ b/src/migration-scripts/https/4-to-5
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T5762: http: api: smoketests fail as they can not establish IPv6 connection
+#        to uvicorn backend server, always make the UNIX domain socket the
+#        default way of communication
+
+import sys
+
+from vyos.configtree import ConfigTree
+
+if len(sys.argv) < 2:
+    print("Must specify file name!")
+    sys.exit(1)
+
+file_name = sys.argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+
+base = ['service', 'https']
+if not config.exists(base):
+    # Nothing to do
+    sys.exit(0)
+
+# Delete "socket" CLI option - we always use UNIX domain sockets for
+# NGINX <-> API server communication
+if config.exists(base + ['api', 'socket']):
+    config.delete(base + ['api', 'socket'])
+
+# There is no need for an API service port, as UNIX domain sockets
+# are used
+if config.exists(base + ['api', 'port']):
+    config.delete(base + ['api', 'port'])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    sys.exit(1)

--- a/src/services/vyos-http-api-server
+++ b/src/services/vyos-http-api-server
@@ -825,15 +825,7 @@ def initialization(session: ConfigSession, app: FastAPI = app):
     if app.state.vyos_graphql:
         graphql_init(app)
 
-    if not server_config['socket']:
-        config = ApiServerConfig(app,
-                                 host=server_config["listen_address"],
-                                 port=int(server_config["port"]),
-                                 proxy_headers=True)
-    else:
-        config = ApiServerConfig(app,
-                                 uds="/run/api.sock",
-                                 proxy_headers=True)
+    config = ApiServerConfig(app, uds="/run/api.sock", proxy_headers=True)
     server = ApiServer(config)
 
 def run_server():


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Why: Smoketests fail as they can not establish IPv6 connection to uvicorn backend server.

https://github.com/vyos/vyos-1x/pull/2481 added a bunch of new smoketests.

While debugging those failing, it was uncovered, that uvicorn only listens on IPv4 connections

```
vyos@vyos# netstat -tulnp | grep 8080
(Not all processes could be identified, non-owned process info
 will not be shown, you would have to be root to see it all.)
tcp        0      0 127.0.0.1:8080          0.0.0.0:*               LISTEN      -
```

As the CLI already has an option to move the API communication from an IP to a UNIX domain socket, the best idea is to make this the default way of communication, as we never directly talk to the API server but rather use the NGINX reverse proxy.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5762

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-1x/pull/2481

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
https api

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_https.py
test_api_auth (__main__.TestHTTPSService.test_api_auth) ... ok
test_api_config_file (__main__.TestHTTPSService.test_api_config_file) ... ok
test_api_configure (__main__.TestHTTPSService.test_api_configure) ... ok
test_api_generate (__main__.TestHTTPSService.test_api_generate) ... ok
test_api_reset (__main__.TestHTTPSService.test_api_reset) ... ok
test_api_show (__main__.TestHTTPSService.test_api_show) ... ok
test_certificate (__main__.TestHTTPSService.test_certificate) ... ok
test_server_block (__main__.TestHTTPSService.test_server_block) ... ok

----------------------------------------------------------------------
Ran 8 tests in 76.139s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
