### PR TITLE
T5770 Enable MACsec encryption stanza

### DIFF
--- a/python/vyos/ifconfig/macsec.py
+++ b/python/vyos/ifconfig/macsec.py
@@ -45,6 +45,10 @@ class MACsecIf(Interface):
         # create tunnel interface
         cmd  = 'ip link add link {source_interface} {ifname} type {type}'.format(**self.config)
         cmd += f' cipher {self.config["security"]["cipher"]}'
+
+        if 'encrypt' in self.config["security"]:
+            cmd += ' encrypt on'
+
         self._cmd(cmd)
 
         # Check if using static keys

--- a/smoketest/scripts/cli/test_interfaces_macsec.py
+++ b/smoketest/scripts/cli/test_interfaces_macsec.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import re
 import unittest
 
@@ -26,6 +25,7 @@ from vyos.ifconfig import Section
 from vyos.utils.process import cmd
 from vyos.utils.file import read_file
 from vyos.utils.network import get_interface_config
+from vyos.utils.network import interface_exists
 from vyos.utils.process import process_named_running
 
 PROCESS_NAME = 'wpa_supplicant'
@@ -34,10 +34,6 @@ def get_config_value(interface, key):
     tmp = read_file(f'/run/wpa_supplicant/{interface}.conf')
     tmp = re.findall(r'\n?{}=(.*)'.format(key), tmp)
     return tmp[0]
-
-def get_cipher(interface):
-    tmp = get_interface_config(interface)
-    return tmp['linkinfo']['info_data']['cipher_suite'].lower()
 
 class MACsecInterfaceTest(BasicInterfaceTest.TestCase):
     @classmethod
@@ -117,6 +113,10 @@ class MACsecInterfaceTest(BasicInterfaceTest.TestCase):
             tmp = read_file(f'/sys/class/net/{interface}/mtu')
             self.assertEqual(tmp, '1460')
 
+            # Encryption enabled?
+            tmp = get_interface_config(interface)
+            self.assertTrue(tmp['linkinfo']['info_data']['encrypt'])
+
         # Check for running process
         self.assertTrue(process_named_running(PROCESS_NAME))
 
@@ -141,7 +141,8 @@ class MACsecInterfaceTest(BasicInterfaceTest.TestCase):
         self.assertIn(interface, interfaces())
 
         # Verify proper cipher suite (T4537)
-        self.assertEqual(cipher, get_cipher(interface))
+        tmp = get_interface_config(interface)
+        self.assertEqual(cipher, tmp['linkinfo']['info_data']['cipher_suite'].lower())
 
     def test_macsec_gcm_aes_256(self):
         src_interface = 'eth0'
@@ -164,7 +165,8 @@ class MACsecInterfaceTest(BasicInterfaceTest.TestCase):
         self.assertIn(interface, interfaces())
 
         # Verify proper cipher suite (T4537)
-        self.assertEqual(cipher, get_cipher(interface))
+        tmp = get_interface_config(interface)
+        self.assertEqual(cipher, tmp['linkinfo']['info_data']['cipher_suite'].lower())
 
     def test_macsec_source_interface(self):
         # Ensure source-interface can bot be part of any other bond or bridge
@@ -205,7 +207,7 @@ class MACsecInterfaceTest(BasicInterfaceTest.TestCase):
         peer_mac = '00:11:22:33:44:55'
         self.cli_set(self._base_path + [interface])
 
-         # Encrypt link
+        # Encrypt link
         self.cli_set(self._base_path + [interface, 'security', 'encrypt'])
 
         # check validate() - source interface is mandatory
@@ -262,8 +264,12 @@ class MACsecInterfaceTest(BasicInterfaceTest.TestCase):
         # final commit and verify
         self.cli_commit()
         self.assertIn(interface, interfaces())
-        self.assertEqual(cipher2, get_cipher(interface))
-        self.assertTrue(os.path.isdir(f'/sys/class/net/{interface}'))
+        self.assertTrue(interface_exists(interface))
+
+        tmp = get_interface_config(interface)
+        self.assertEqual(cipher, tmp['linkinfo']['info_data']['cipher_suite'].lower())
+        # Encryption enabled?
+        self.assertTrue(tmp['linkinfo']['info_data']['encrypt'])
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Enables encryption mode when using MACsec

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5770

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
MACSEC

## Proposed changes
<!--- Describe your changes in detail -->
Enable encryption when creating MACsec interface using "ip link" command

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
