### PR TITLE
http: T5762: rename "virtual-host listen-port" -> "virtual-host port"

### DIFF
--- a/interface-definitions/https.xml.in
+++ b/interface-definitions/https.xml.in
@@ -41,17 +41,9 @@
                   </constraint>
                 </properties>
               </leafNode>
-              <leafNode name='listen-port'>
-                <properties>
-                  <help>Port to listen for HTTPS requests; default 443</help>
-                  <valueHelp>
-                    <format>u32:1-65535</format>
-                    <description>Numeric IP port</description>
-                  </valueHelp>
-                  <constraint>
-                    <validator name="numeric" argument="--range 1-65535"/>
-                  </constraint>
-                </properties>
+              #include <include/port-number.xml.i>
+              <leafNode name='port'>
+                <defaultValue>443</defaultValue>
               </leafNode>
               <leafNode name="server-name">
                 <properties>

--- a/python/vyos/defaults.py
+++ b/python/vyos/defaults.py
@@ -51,9 +51,6 @@ https_data = {
 }
 
 api_data = {
-    'listen_address' : '127.0.0.1',
-    'port' : '8080',
-    'socket' : False,
     'strict' : False,
     'debug' : False,
     'api_keys' : [ {'id' : 'testapp', 'key' : 'qwerty'} ]

--- a/smoketest/config-tests/basic-api-service
+++ b/smoketest/config-tests/basic-api-service
@@ -5,6 +5,14 @@ set service ntp server time1.vyos.net
 set service ntp server time2.vyos.net
 set service ntp server time3.vyos.net
 set service https api keys id 1 key 'S3cur3'
+set service https virtual-host bar allow-client address '172.16.0.0/12'
+set service https virtual-host bar port '5555'
+set service https virtual-host foo allow-client address '10.0.0.0/8'
+set service https virtual-host foo allow-client address '2001:db8::/32'
+set service https virtual-host foo port '7777'
+set service https virtual-host baz allow-client address '192.168.0.0/16'
+set service https virtual-host baz port '6666'
+set service https virtual-host baz server-name 'baz'
 set system config-management commit-revisions '100'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'

--- a/smoketest/configs/basic-api-service
+++ b/smoketest/configs/basic-api-service
@@ -18,8 +18,28 @@ service {
             }
             socket
         }
-    }
-    ssh {
+        virtual-host bar {
+            allow-client {
+                address 172.16.0.0/12
+            }
+            listen-port 5555
+            server-name bar
+        }
+        virtual-host baz {
+            allow-client {
+                address 192.168.0.0/16
+            }
+            listen-port 6666
+            server-name baz
+        }
+        virtual-host foo {
+            allow-client {
+                address 10.0.0.0/8
+                address 2001:db8::/32
+            }
+            listen-port 7777
+            server-name foo
+        }
     }
 }
 system {

--- a/smoketest/scripts/cli/test_service_https.py
+++ b/smoketest/scripts/cli/test_service_https.py
@@ -81,7 +81,7 @@ class TestHTTPSService(VyOSUnitTestSHIM.TestCase):
         test_path = base_path + ['virtual-host', vhost_id]
 
         self.cli_set(test_path + ['listen-address', address])
-        self.cli_set(test_path + ['listen-port', port])
+        self.cli_set(test_path + ['port', port])
         self.cli_set(test_path + ['server-name', name])
 
         self.cli_commit()
@@ -102,7 +102,7 @@ class TestHTTPSService(VyOSUnitTestSHIM.TestCase):
     def test_api_auth(self):
         vhost_id = 'example'
         address = '127.0.0.1'
-        port = '443'
+        port = '443' # default value
         name = 'localhost'
 
         key = 'MySuperSecretVyOS'
@@ -110,7 +110,6 @@ class TestHTTPSService(VyOSUnitTestSHIM.TestCase):
 
         test_path = base_path + ['virtual-host', vhost_id]
         self.cli_set(test_path + ['listen-address', address])
-        self.cli_set(test_path + ['listen-port', port])
         self.cli_set(test_path + ['server-name', name])
 
         self.cli_commit()

--- a/src/conf_mode/https.py
+++ b/src/conf_mode/https.py
@@ -122,7 +122,7 @@ def verify(https):
             server_block = deepcopy(default_server_block)
             data = vhost_dict.get(vhost, {})
             server_block['address'] = data.get('listen-address', '*')
-            server_block['port'] = data.get('listen-port', '443')
+            server_block['port'] = data.get('port', '443')
             server_block_list.append(server_block)
 
     for entry in server_block_list:
@@ -156,7 +156,7 @@ def generate(https):
             server_block['id'] = vhost
             data = vhost_dict.get(vhost, {})
             server_block['address'] = data.get('listen-address', '*')
-            server_block['port'] = data.get('listen-port', '443')
+            server_block['port'] = data.get('port', '443')
             name = data.get('server-name', ['_'])
             server_block['name'] = name
             allow_client = data.get('allow-client', {})

--- a/src/migration-scripts/https/4-to-5
+++ b/src/migration-scripts/https/4-to-5
@@ -48,6 +48,12 @@ if config.exists(base + ['api', 'socket']):
 if config.exists(base + ['api', 'port']):
     config.delete(base + ['api', 'port'])
 
+# rename listen-port -> port ver virtual-host
+if config.exists(base + ['virtual-host']):
+    for vhost in config.list_nodes(base + ['virtual-host']):
+        if config.exists(base + ['virtual-host', vhost, 'listen-port']):
+            config.rename(base + ['virtual-host', vhost, 'listen-port'], 'port')
+
 try:
     with open(file_name, 'w') as f:
         f.write(config.to_string())


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This complements commit f5e43b136 ("http: T5762: api: make API socket backend communication the one and only default") o we have a consistent port CLI node across VyOS components.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5762

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-1x/pull/2508

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

https API

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_https.py
test_api_auth (__main__.TestHTTPSService.test_api_auth) ... ok
test_api_config_file (__main__.TestHTTPSService.test_api_config_file) ... ok
test_api_configure (__main__.TestHTTPSService.test_api_configure) ... ok
test_api_generate (__main__.TestHTTPSService.test_api_generate) ... ok
test_api_reset (__main__.TestHTTPSService.test_api_reset) ... ok
test_api_show (__main__.TestHTTPSService.test_api_show) ... ok
test_certificate (__main__.TestHTTPSService.test_certificate) ... ok
test_server_block (__main__.TestHTTPSService.test_server_block) ... ok

----------------------------------------------------------------------
Ran 8 tests in 90.622s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
