### PR TITLE
pppoe: T5630: make MRU default to MTU if unspecified

### DIFF
--- a/interface-definitions/interfaces-pppoe.xml.in
+++ b/interface-definitions/interfaces-pppoe.xml.in
@@ -111,7 +111,7 @@
           </leafNode>
           <leafNode name="mru">
             <properties>
-              <help>Maximum Receive Unit (MRU)</help>
+              <help>Maximum Receive Unit (MRU) (default: MTU value)</help>
               <valueHelp>
                 <format>u32:128-16384</format>
                 <description>Maximum Receive Unit in byte</description>
@@ -121,7 +121,6 @@
               </constraint>
               <constraintErrorMessage>MRU must be between 128 and 16384</constraintErrorMessage>
             </properties>
-            <defaultValue>1492</defaultValue>
           </leafNode>
           #include <include/interface/no-peer-dns.xml.i>
           <leafNode name="remote-address">

--- a/src/conf_mode/interfaces-pppoe.py
+++ b/src/conf_mode/interfaces-pppoe.py
@@ -61,6 +61,12 @@ def get_config(config=None):
             # bail out early - no need to further process other nodes
             break
 
+    if 'deleted' not in pppoe:
+        # We always set the MRU value to the MTU size. This code path only re-creates
+        # the old behavior if MRU is not set on the CLI.
+        if 'mru' not in pppoe:
+            pppoe['mru'] = pppoe['mtu']
+
     return pppoe
 
 def verify(pppoe):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This fixes the implementation in e062a8c11 ("pppoe: T5630: allow to specify MRU in addition to already configurable MTU") and restores the bahavior that MRU defaults to MTU if MRU is not explicitly set.

This was the behavior in VyOS 1.3.3 and below before we added ability to define the MRU value.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5630

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-1x/pull/2335 
* https://github.com/vyos/vyos-1x/pull/2346
* https://github.com/vyos/vyos-1x/pull/2347

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```bash
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_pppoe.py
test_pppoe_authentication (__main__.PPPoEInterfaceTest.test_pppoe_authentication) ... ok
test_pppoe_client (__main__.PPPoEInterfaceTest.test_pppoe_client) ... ok
test_pppoe_client_disabled_interface (__main__.PPPoEInterfaceTest.test_pppoe_client_disabled_interface) ... ok
test_pppoe_dhcpv6pd (__main__.PPPoEInterfaceTest.test_pppoe_dhcpv6pd) ... ok
test_pppoe_mtu_mru (__main__.PPPoEInterfaceTest.test_pppoe_mtu_mru) ... ok
test_pppoe_options (__main__.PPPoEInterfaceTest.test_pppoe_options) ... ok

----------------------------------------------------------------------
Ran 6 tests in 39.845s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
