### PR TITLE
T5637: firewall: extend rule for default-action to firewall bridge

### DIFF
--- a/data/templates/firewall/nftables-bridge.j2
+++ b/data/templates/firewall/nftables-bridge.j2
@@ -2,9 +2,8 @@
 {% set ns = namespace(sets=[]) %}
 {% if bridge.forward is vyos_defined %}
 {%     for prior, conf in bridge.forward.items() %}
-{%         set def_action = conf.default_action %}
     chain VYOS_FORWARD_{{ prior }} {
-        type filter hook forward priority {{ prior }}; policy {{ def_action }};
+        type filter hook forward priority {{ prior }}; policy accept;
 {%         if conf.rule is vyos_defined %}
 {%             for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
     {{ rule_conf | nft_rule('FWD', prior, rule_id, 'bri') }}
@@ -13,6 +12,7 @@
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
+    {{ conf | nft_default_rule('FWD-filter', 'bri') }}
     }
 {%     endfor %}
 {% endif %}
@@ -28,7 +28,7 @@
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
-    {{ conf | nft_default_rule(name_text) }}
+    {{ conf | nft_default_rule(name_text, 'bri') }}
     }
 {%     endfor %}
 {% endif %}

--- a/data/templates/firewall/nftables-zone.j2
+++ b/data/templates/firewall/nftables-zone.j2
@@ -1,7 +1,13 @@
 
-{% macro zone_chains(zone, ipv6=False) %}
-{% set fw_name = 'ipv6_name' if ipv6 else 'name' %}
-{% set suffix = '6' if ipv6 else '' %}
+{% macro zone_chains(zone, family) %}
+{% if family == 'ipv6' %}
+{%     set fw_name = 'ipv6_name' %}
+{%     set suffix = '6' %}
+{% else %}
+{%     set fw_name = 'name' %}
+{%     set suffix = '' %}
+{% endif %}
+
     chain VYOS_ZONE_FORWARD {
         type filter hook forward priority 1; policy accept;
 {% for zone_name, zone_conf in zone.items() %}
@@ -36,7 +42,7 @@
         iifname { {{ zone[from_zone].interface | join(",") }} } counter return
 {%             endfor %}
 {%         endif %}
-        {{ zone_conf | nft_default_rule('zone_' + zone_name) }}
+        {{ zone_conf | nft_default_rule('zone_' + zone_name, family) }}
     }
     chain VZONE_{{ zone_name }}_OUT {
         oifname lo counter return
@@ -46,7 +52,7 @@
         oifname { {{ zone[from_zone].interface | join(",") }} } counter return
 {%             endfor %}
 {%         endif %}
-        {{ zone_conf | nft_default_rule('zone_' + zone_name) }}
+        {{ zone_conf | nft_default_rule('zone_' + zone_name, family) }}
     }
 {%     else %}
     chain VZONE_{{ zone_name }} {
@@ -62,7 +68,7 @@
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
-        {{ zone_conf | nft_default_rule('zone_' + zone_name) }}
+        {{ zone_conf | nft_default_rule('zone_' + zone_name, family) }}
     }
 {%     endif %}
 {% endfor %}

--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -54,7 +54,7 @@ table ip vyos_filter {
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}
-        {{ conf | nft_default_rule('FWD-filter') }}
+        {{ conf | nft_default_rule('FWD-filter', 'ipv4') }}
     }
 {%         endfor %}
 {%     endif %}
@@ -71,7 +71,7 @@ table ip vyos_filter {
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}
-        {{ conf | nft_default_rule('INP-filter') }}
+        {{ conf | nft_default_rule('INP-filter', 'ipv4') }}
     }
 {%         endfor %}
 {%     endif %}
@@ -88,7 +88,7 @@ table ip vyos_filter {
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}
-        {{ conf | nft_default_rule('OUT-filter') }}
+        {{ conf | nft_default_rule('OUT-filter', 'ipv4') }}
     }
 {%         endfor %}
 {%     endif %}
@@ -108,7 +108,7 @@ table ip vyos_filter {
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}
-        {{ conf | nft_default_rule('PRE-filter') }}
+        {{ conf | nft_default_rule('PRE-filter', 'ipv4') }}
     }
 {%         endfor %}
 {%     endif %}
@@ -124,7 +124,7 @@ table ip vyos_filter {
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}
-        {{ conf | nft_default_rule(name_text) }}
+        {{ conf | nft_default_rule(name_text, 'ipv4') }}
     }
 {%         endfor %}
 {%     endif %}
@@ -154,7 +154,7 @@ table ip vyos_filter {
 {{ group_tmpl.groups(group, False, True) }}
 
 {% if zone is vyos_defined %}
-{{ zone_tmpl.zone_chains(zone, False) }}
+{{ zone_tmpl.zone_chains(zone, 'ipv4') }}
 {% endif %}
 }
 
@@ -182,7 +182,7 @@ table ip6 vyos_filter {
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}
-        {{ conf | nft_default_rule('FWD-filter', ipv6=True) }}
+        {{ conf | nft_default_rule('FWD-filter', 'ipv6') }}
     }
 {%         endfor %}
 {%     endif %}
@@ -199,7 +199,7 @@ table ip6 vyos_filter {
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}
-        {{ conf | nft_default_rule('INP-filter', ipv6=True) }}
+        {{ conf | nft_default_rule('INP-filter', 'ipv6') }}
     }
 {%         endfor %}
 {%     endif %}
@@ -216,7 +216,7 @@ table ip6 vyos_filter {
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}
-        {{ conf | nft_default_rule('OUT-filter', ipv6=True) }}
+        {{ conf | nft_default_rule('OUT-filter', 'ipv6') }}
     }
 {%         endfor %}
 {%     endif %}
@@ -237,7 +237,7 @@ table ip6 vyos_filter {
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}
-        {{ conf | nft_default_rule(name_text, ipv6=True) }}
+        {{ conf | nft_default_rule(name_text, 'ipv6') }}
     }
 {%         endfor %}
 {%     endif %}
@@ -266,7 +266,7 @@ table ip6 vyos_filter {
 {% endif %}
 {{ group_tmpl.groups(group, True, True) }}
 {% if zone is vyos_defined %}
-{{ zone_tmpl.zone_chains(zone, True) }}
+{{ zone_tmpl.zone_chains(zone, 'ipv6') }}
 {% endif %}
 }
 

--- a/interface-definitions/include/firewall/bridge-hook-forward.xml.i
+++ b/interface-definitions/include/firewall/bridge-hook-forward.xml.i
@@ -10,6 +10,7 @@
       </properties>
       <children>
         #include <include/firewall/default-action-base-chains.xml.i>
+        #include <include/firewall/enable-default-log.xml.i>
         #include <include/generic-description.xml.i>
         <tagNode name="rule">
           <properties>

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -579,10 +579,10 @@ def nft_rule(rule_conf, fw_hook, fw_name, rule_id, ip_name='ip'):
     return parse_rule(rule_conf, fw_hook, fw_name, rule_id, ip_name)
 
 @register_filter('nft_default_rule')
-def nft_default_rule(fw_conf, fw_name, ipv6=False):
+def nft_default_rule(fw_conf, fw_name, family):
     output = ['counter']
     default_action = fw_conf['default_action']
-    family = 'ipv6' if ipv6 else 'ipv4'
+    #family = 'ipv6' if ipv6 else 'ipv4'
 
     if 'enable_default_log' in fw_conf:
         action_suffix = default_action[:1].upper()
@@ -592,7 +592,7 @@ def nft_default_rule(fw_conf, fw_name, ipv6=False):
     output.append(f'{default_action}')
     if 'default_jump_target' in fw_conf:
         target = fw_conf['default_jump_target']
-        def_suffix = '6' if ipv6 else ''
+        def_suffix = '6' if family == 'ipv6' else ''
         output.append(f'NAME{def_suffix}_{target}')
 
     output.append(f'comment "{fw_name} default-action {default_action}"')

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -586,6 +586,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['firewall', 'bridge', 'name', name, 'rule', '1', 'log-options', 'level', 'crit'])
 
         self.cli_set(['firewall', 'bridge', 'forward', 'filter', 'default-action', 'drop'])
+        self.cli_set(['firewall', 'bridge', 'forward', 'filter', 'enable-default-log'])
         self.cli_set(['firewall', 'bridge', 'forward', 'filter', 'rule', '1', 'action', 'accept'])
         self.cli_set(['firewall', 'bridge', 'forward', 'filter', 'rule', '1', 'vlan', 'id', vlan_id])
         self.cli_set(['firewall', 'bridge', 'forward', 'filter', 'rule', '2', 'action', 'jump'])
@@ -596,11 +597,13 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         nftables_search = [
             ['chain VYOS_FORWARD_filter'],
-            ['type filter hook forward priority filter; policy drop;'],
+            ['type filter hook forward priority filter; policy accept;'],
             [f'vlan id {vlan_id}', 'accept'],
             [f'vlan pcp {vlan_prior}', f'jump NAME_{name}'],
+            ['log prefix "[bri-FWD-filter-default-D]"', 'drop', 'FWD-filter default-action drop'],
             [f'chain NAME_{name}'],
-            [f'ether saddr {mac_address}', f'iifname "{interface_in}"', f'log prefix "[bri-NAM-{name}-1-A]" log level crit', 'accept']
+            [f'ether saddr {mac_address}', f'iifname "{interface_in}"', f'log prefix "[bri-NAM-{name}-1-A]" log level crit', 'accept'],
+            ['accept', f'{name} default-action accept']
         ]
 
         self.verify_nftables(nftables_search, 'bridge vyos_filter')

--- a/src/op_mode/firewall.py
+++ b/src/op_mode/firewall.py
@@ -113,19 +113,14 @@ def output_firewall_name(family, hook, priority, firewall_conf, single_rule_id=N
 
     if hook in ['input', 'forward', 'output']:
         def_action = firewall_conf['default_action'] if 'default_action' in firewall_conf else 'accept'
-        row = ['default', def_action, 'all']
-        rule_details = details['default-action']
-        row.append(rule_details.get('packets', 0))
-        row.append(rule_details.get('bytes', 0))
-        rows.append(row)
+    else:
+        def_action = firewall_conf['default_action'] if 'default_action' in firewall_conf else 'drop'
+    row = ['default', def_action, 'all']
+    rule_details = details['default-action']
+    row.append(rule_details.get('packets', 0))
+    row.append(rule_details.get('bytes', 0))
 
-    elif 'default_action' in firewall_conf and not single_rule_id:
-        row = ['default', firewall_conf['default_action'], 'all']
-        if 'default-action' in details:
-            rule_details = details['default-action']
-            row.append(rule_details.get('packets', 0))
-            row.append(rule_details.get('bytes', 0))
-        rows.append(row)
+    rows.append(row)
 
     if rows:
         header = ['Rule', 'Action', 'Protocol', 'Packets', 'Bytes', 'Conditions']
@@ -314,7 +309,7 @@ def show_firewall_group(name=None):
             family = ['ipv6']
             group_type = 'network_group'
         else:
-            family = ['ipv4', 'ipv6']
+            family = ['ipv4', 'ipv6', 'bridge']
 
         for item in family:
             # Look references in firewall


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Extend rule for default-action to firewall bridge in order to be able to catch logs using separate rule for default-action.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5637

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Firewall and bridge configuration:
```
vyos@BRI:~$ show config comm | grep bridge
set firewall bridge forward filter default-action 'drop'
set firewall bridge forward filter enable-default-log
set firewall bridge forward filter rule 10 action 'continue'
set firewall bridge forward filter rule 10 inbound-interface name 'eth2'
set firewall bridge forward filter rule 10 vlan id '22'
set firewall bridge forward filter rule 20 action 'drop'
set firewall bridge forward filter rule 20 inbound-interface group 'TRUNK-RIGHT'
set firewall bridge forward filter rule 20 vlan id '60'
set firewall bridge forward filter rule 30 action 'jump'
set firewall bridge forward filter rule 30 jump-target 'TEST'
set firewall bridge forward filter rule 30 outbound-interface name 'eth1'
set firewall bridge name TEST default-action 'accept'
set firewall bridge name TEST enable-default-log
set firewall bridge name TEST rule 10 action 'continue'
set firewall bridge name TEST rule 10 log
set firewall bridge name TEST rule 10 vlan priority '0'
set interfaces bridge br0 enable-vlan
set interfaces bridge br0 member interface eth1 allowed-vlan '11'
set interfaces bridge br0 member interface eth1 allowed-vlan '12'
set interfaces bridge br0 member interface eth1 allowed-vlan '21'
set interfaces bridge br0 member interface eth1 allowed-vlan '22'
set interfaces bridge br0 member interface eth2 allowed-vlan '11'
set interfaces bridge br0 member interface eth2 allowed-vlan '12'
set interfaces bridge br0 member interface eth2 allowed-vlan '21'
set interfaces bridge br0 member interface eth2 allowed-vlan '22'
vyos@BRI:~$
```
NFT and op-mode command:
```
vyos@BRI:~$ sudo nft list table bridge vyos_filter
table bridge vyos_filter {
	set I_TRUNK-RIGHT {
		type ifname
		flags interval
		auto-merge
		elements = { "eth4" }
	}

	chain VYOS_FORWARD_filter {
		type filter hook forward priority filter; policy accept;
		iifname "eth2" vlan id 22 counter packets 0 bytes 0 continue comment "bri-FWD-filter-10"
		iifname @I_TRUNK-RIGHT vlan id 60 counter packets 0 bytes 0 drop comment "bri-FWD-filter-20"
		oifname "eth1" counter packets 107 bytes 2996 jump NAME_TEST comment "bri-FWD-filter-30"
		counter packets 266 bytes 13664 log prefix "[bri-FWD-filter-default-D]" drop comment "FWD-filter default-action drop"
	}

	chain NAME_TEST {
		vlan pcp 0 log prefix "[bri-NAM-TEST-10-C]" counter packets 107 bytes 2996 continue comment "bri-NAM-TEST-10"
		counter packets 107 bytes 2996 log prefix "[bri-TEST-default-A]" accept comment "TEST default-action accept"
	}
}
vyos@BRI:~$ show firewall bridge 
Rulesets bridge Information

---------------------------------
bridge Firewall "forward filter"

Rule     Action    Protocol      Packets    Bytes  Conditions
-------  --------  ----------  ---------  -------  -----------------------------------
10       continue  all                 0        0  iifname "eth2" vlan id 22  continue
20       drop      all                 0        0  iifname @I_TRUNK-RIGHT vlan id 60
30       jump      all               110     3080  oifname "eth1"  jump NAME_TEST
default  drop      all               273    14028

---------------------------------
bridge Firewall "name TEST"

Rule     Action    Protocol      Packets    Bytes  Conditions
-------  --------  ----------  ---------  -------  --------------------------------------------------
10       continue  all               110     3080  vlan pcp 0  prefix "[bri-NAM-TEST-10-C]"  continue
default  accept    all               110     3080

vyos@BRI:~$ show firewall group 
Firewall Groups

Name         Type             References                Members
-----------  ---------------  ------------------------  ---------
TRUNK-RIGHT  interface_group  bridge-forward-filter-20  eth4
vyos@BRI:~$ 
```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@BRI:/usr/libexec/vyos/tests/smoke/cli# ./test_firewall.py 
test_bridge_basic_rules (__main__.TestFirewall.test_bridge_basic_rules) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... 
Interface "eth0" does not support hardware offload

ok
test_geoip (__main__.TestFirewall.test_geoip) ... Updating GeoIP. Please wait...
Updating GeoIP. Please wait...
ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... 
"synproxy" option allowed only for action synproxy

ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... 
Group "smoketest_network1" has a circular reference

ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok

----------------------------------------------------------------------
Ran 16 tests in 37.964s

OK
root@BRI:/usr/libexec/vyos/tests/smoke/cli# 
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
