### PR TITLE
https api: T5772: check if keys are configured unless PAM auth is enabled for GraphQL (backport #2522)

### DIFF
--- a/python/vyos/util.py
+++ b/python/vyos/util.py
@@ -237,3 +237,22 @@ def process_named_running(name):
         if name in p.name():
             return p.pid
     return None
+
+def dict_search(path, dict_object):
+    """ Traverse Python dictionary (dict_object) delimited by dot (.).
+    Return value of key if found, None otherwise.
+    This is faster implementation then jmespath.search('foo.bar', dict_object)"""
+    if not isinstance(dict_object, dict) or not path:
+        return None
+
+    parts = path.split('.')
+    inside = parts[:-1]
+    if not inside:
+        if path not in dict_object:
+            return None
+        return dict_object[path]
+    c = dict_object
+    for p in parts[:-1]:
+        c = c.get(p, {})
+    return c.get(parts[-1], None)
+

--- a/src/conf_mode/https.py
+++ b/src/conf_mode/https.py
@@ -23,6 +23,7 @@ import jinja2
 
 import vyos.defaults
 from vyos.config import Config
+from vyos.util import dict_search
 from vyos import ConfigError
 
 config_file = '/etc/nginx/sites-available/default'
@@ -143,7 +144,31 @@ def get_config():
     return https
 
 def verify(https):
+    # Verify API server settings, if present
+    if 'api' in https:
+        keys = dict_search('api.keys.id', https)
+        gql_auth_type = dict_search('api.graphql.authentication.type', https)
+
+        # If "api graphql" is not defined and `gql_auth_type` is None,
+        # there's certainly no JWT auth option, and keys are required
+        jwt_auth = (gql_auth_type == "token")
+
+        # Check for incomplete key configurations in every case
+        valid_keys_exist = False
+        if keys:
+            for k in keys:
+                if 'key' not in keys[k]:
+                    raise ConfigError(f'Missing HTTPS API key string for key id "{k}"')
+                else:
+                    valid_keys_exist = True
+
+        # If only key-based methods are enabled,
+        # fail the commit if no valid key configurations are found
+        if (not valid_keys_exist) and (not jwt_auth):
+            raise ConfigError('At least one HTTPS API key is required unless GraphQL token authentication is enabled')
+
     return None
+
 
 def generate(https):
     if https is None:


### PR DESCRIPTION
This is an automatic backport of pull request #2522 done by [Mergify](https://mergify.com).
Cherry-pick of 8c450ea7f538beb0b2cd21d35c05d18db49a1802 has failed:
