### PR TITLE
pppoe: T5630: make MRU default to MTU if unspecified (backport #2527)

### DIFF
--- a/interface-definitions/interfaces-pppoe.xml.in
+++ b/interface-definitions/interfaces-pppoe.xml.in
@@ -116,7 +116,7 @@
           </leafNode>
           <leafNode name="mru">
             <properties>
-              <help>Maximum Receive Unit (MRU)</help>
+              <help>Maximum Receive Unit (MRU) (default: MTU value)</help>
               <valueHelp>
                 <format>u32:128-16384</format>
                 <description>Maximum Receive Unit in byte</description>
@@ -126,7 +126,6 @@
               </constraint>
               <constraintErrorMessage>MRU must be between 128 and 16384</constraintErrorMessage>
             </properties>
-            <defaultValue>1492</defaultValue>
           </leafNode>
           <leafNode name="no-peer-dns">
             <properties>

--- a/src/conf_mode/interfaces-pppoe.py
+++ b/src/conf_mode/interfaces-pppoe.py
@@ -44,6 +44,12 @@ def get_config(config=None):
     base = ['interfaces', 'pppoe']
     pppoe = get_interface_dict(conf, base)
 
+    if 'deleted' not in pppoe:
+        # We always set the MRU value to the MTU size. This code path only re-creates
+        # the old behavior if MRU is not set on the CLI.
+        if 'mru' not in pppoe:
+            pppoe['mru'] = pppoe['mtu']
+
     return pppoe
 
 def verify(pppoe):


### PR DESCRIPTION
This is an automatic backport of pull request https://github.com/vyos/vyos-1x/pull/2527 done by [Mergify](https://mergify.com/).

```
~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_pppoe.py
test_pppoe_authentication (__main__.PPPoEInterfaceTest) ... ok
test_pppoe_clent_disabled_interface (__main__.PPPoEInterfaceTest) ... ok
test_pppoe_client (__main__.PPPoEInterfaceTest) ... ok
test_pppoe_dhcpv6pd (__main__.PPPoEInterfaceTest) ... ok
test_pppoe_mtu_mru (__main__.PPPoEInterfaceTest) ... ok
test_pppoe_options (__main__.PPPoEInterfaceTest) ... ok

----------------------------------------------------------------------
Ran 6 tests in 189.964s

OK

```