### PR TITLE
T5775: firewall: re-add state-policy to firewall. These commands are …

### DIFF
--- a/data/templates/firewall/nftables-zone.j2
+++ b/data/templates/firewall/nftables-zone.j2
@@ -1,5 +1,5 @@
 
-{% macro zone_chains(zone, family) %}
+{% macro zone_chains(zone, family, state_policy=False) %}
 {% if family == 'ipv6' %}
 {%     set fw_name = 'ipv6_name' %}
 {%     set suffix = '6' %}
@@ -10,6 +10,9 @@
 
     chain VYOS_ZONE_FORWARD {
         type filter hook forward priority 1; policy accept;
+{% if state_policy %}
+        jump VYOS_STATE_POLICY{{ suffix }}
+{% endif %}
 {% for zone_name, zone_conf in zone.items() %}
 {%     if 'local_zone' not in zone_conf %}
         oifname { {{ zone_conf.interface | join(',') }} } counter jump VZONE_{{ zone_name }}
@@ -18,6 +21,9 @@
     }
     chain VYOS_ZONE_LOCAL {
         type filter hook input priority 1; policy accept;
+{% if state_policy %}
+        jump VYOS_STATE_POLICY{{ suffix }}
+{% endif %}
 {% for zone_name, zone_conf in zone.items() %}
 {%     if 'local_zone' in zone_conf %}
         counter jump VZONE_{{ zone_name }}_IN
@@ -26,6 +32,9 @@
     }
     chain VYOS_ZONE_OUTPUT {
         type filter hook output priority 1; policy accept;
+{% if state_policy %}
+        jump VYOS_STATE_POLICY{{ suffix }}
+{% endif %}
 {% for zone_name, zone_conf in zone.items() %}
 {%     if 'local_zone' in zone_conf %}
         counter jump VZONE_{{ zone_name }}_OUT

--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -46,6 +46,9 @@ table ip vyos_filter {
 {%         for prior, conf in ipv4.forward.items() %}
     chain VYOS_FORWARD_{{ prior }} {
         type filter hook forward priority {{ prior }}; policy accept;
+{%             if global_options.state_policy is vyos_defined %}
+        jump VYOS_STATE_POLICY
+{%             endif %}
 {%             if conf.rule is vyos_defined %}
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
         {{ rule_conf | nft_rule('FWD', prior, rule_id) }}
@@ -63,6 +66,9 @@ table ip vyos_filter {
 {%         for prior, conf in ipv4.input.items() %}
     chain VYOS_INPUT_{{ prior }} {
         type filter hook input priority {{ prior }}; policy accept;
+{%             if global_options.state_policy is vyos_defined %}
+        jump VYOS_STATE_POLICY
+{%             endif %}
 {%             if conf.rule is vyos_defined %}
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
         {{ rule_conf | nft_rule('INP',prior, rule_id) }}
@@ -80,6 +86,9 @@ table ip vyos_filter {
 {%         for prior, conf in ipv4.output.items() %}
     chain VYOS_OUTPUT_{{ prior }} {
         type filter hook output priority {{ prior }}; policy accept;
+{%             if global_options.state_policy is vyos_defined %}
+        jump VYOS_STATE_POLICY
+{%             endif %}
 {%             if conf.rule is vyos_defined %}
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
         {{ rule_conf | nft_rule('OUT', prior, rule_id) }}
@@ -154,7 +163,21 @@ table ip vyos_filter {
 {{ group_tmpl.groups(group, False, True) }}
 
 {% if zone is vyos_defined %}
-{{ zone_tmpl.zone_chains(zone, 'ipv4') }}
+{{ zone_tmpl.zone_chains(zone, 'ipv4', global_options.state_policy is vyos_defined) }}
+{% endif %}
+{% if global_options.state_policy is vyos_defined %}
+    chain VYOS_STATE_POLICY {
+{%     if global_options.state_policy.established is vyos_defined %}
+        {{ global_options.state_policy.established | nft_state_policy('established') }}
+{%     endif %}
+{%     if global_options.state_policy.invalid is vyos_defined %}
+        {{ global_options.state_policy.invalid | nft_state_policy('invalid') }}
+{%     endif %}
+{%     if global_options.state_policy.related is vyos_defined %}
+        {{ global_options.state_policy.related | nft_state_policy('related') }}
+{%     endif %}
+        return
+    }
 {% endif %}
 }
 
@@ -174,6 +197,9 @@ table ip6 vyos_filter {
 {%         for prior, conf in ipv6.forward.items() %}
     chain VYOS_IPV6_FORWARD_{{ prior }} {
         type filter hook forward priority {{ prior }}; policy accept;
+{%             if global_options.state_policy is vyos_defined %}
+        jump VYOS_STATE_POLICY6
+{%             endif %}
 {%             if conf.rule is vyos_defined %}
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
         {{ rule_conf | nft_rule('FWD', prior, rule_id ,'ip6') }}
@@ -191,6 +217,9 @@ table ip6 vyos_filter {
 {%         for prior, conf in ipv6.input.items() %}
     chain VYOS_IPV6_INPUT_{{ prior }} {
         type filter hook input priority {{ prior }}; policy accept;
+{%             if global_options.state_policy is vyos_defined %}
+        jump VYOS_STATE_POLICY6
+{%             endif %}
 {%             if conf.rule is vyos_defined %}
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
         {{ rule_conf | nft_rule('INP', prior, rule_id ,'ip6') }}
@@ -208,6 +237,9 @@ table ip6 vyos_filter {
 {%         for prior, conf in ipv6.output.items() %}
     chain VYOS_IPV6_OUTPUT_{{ prior }} {
         type filter hook output priority {{ prior }}; policy accept;
+{%             if global_options.state_policy is vyos_defined %}
+        jump VYOS_STATE_POLICY6
+{%             endif %}
 {%             if conf.rule is vyos_defined %}
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
         {{ rule_conf | nft_rule('OUT', prior, rule_id ,'ip6') }}
@@ -266,7 +298,21 @@ table ip6 vyos_filter {
 {% endif %}
 {{ group_tmpl.groups(group, True, True) }}
 {% if zone is vyos_defined %}
-{{ zone_tmpl.zone_chains(zone, 'ipv6') }}
+{{ zone_tmpl.zone_chains(zone, 'ipv6', global_options.state_policy is vyos_defined) }}
+{% endif %}
+{% if global_options.state_policy is vyos_defined %}
+    chain VYOS_STATE_POLICY6 {
+{%     if global_options.state_policy.established is vyos_defined %}
+        {{ global_options.state_policy.established | nft_state_policy('established') }}
+{%     endif %}
+{%     if global_options.state_policy.invalid is vyos_defined %}
+        {{ global_options.state_policy.invalid | nft_state_policy('invalid') }}
+{%     endif %}
+{%     if global_options.state_policy.related is vyos_defined %}
+        {{ global_options.state_policy.related | nft_state_policy('related') }}
+{%     endif %}
+        return
+    }
 {% endif %}
 }
 

--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -393,7 +393,7 @@
             <properties>
               <help>Zone from which to filter traffic</help>
               <completionHelp>
-                <path>zone-policy zone</path>
+                <path>firewall zone</path>
               </completionHelp>
             </properties>
             <children>

--- a/interface-definitions/include/firewall/global-options.xml.i
+++ b/interface-definitions/include/firewall/global-options.xml.i
@@ -167,6 +167,43 @@
       </properties>
       <defaultValue>disable</defaultValue>
     </leafNode>
+    <node name="state-policy">
+      <properties>
+        <help>Global firewall state-policy</help>
+      </properties>
+      <children>
+        <node name="established">
+          <properties>
+            <help>Global firewall policy for packets part of an established connection</help>
+          </properties>
+          <children>
+            #include <include/firewall/action-accept-drop-reject.xml.i>
+            #include <include/firewall/log.xml.i>
+            #include <include/firewall/rule-log-level.xml.i>
+          </children>
+        </node>
+        <node name="invalid">
+          <properties>
+            <help>Global firewall policy for packets part of an invalid connection</help>
+          </properties>
+          <children>
+            #include <include/firewall/action-accept-drop-reject.xml.i>
+            #include <include/firewall/log.xml.i>
+            #include <include/firewall/rule-log-level.xml.i>
+          </children>
+        </node>
+        <node name="related">
+          <properties>
+            <help>Global firewall policy for packets part of a related connection</help>
+          </properties>
+          <children>
+            #include <include/firewall/action-accept-drop-reject.xml.i>
+            #include <include/firewall/log.xml.i>
+            #include <include/firewall/rule-log-level.xml.i>
+          </children>
+        </node>
+      </children>
+    </node>
     <leafNode name="syn-cookies">
       <properties>
         <help>Policy for using TCP SYN cookies with IPv4</help>

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -602,7 +602,7 @@ def nft_default_rule(fw_conf, fw_name, family):
 def nft_state_policy(conf, state):
     out = [f'ct state {state}']
 
-    if 'log' in conf and 'enable' in conf['log']:
+    if 'log' in conf:
         log_state = state[:3].upper()
         log_action = (conf['action'] if 'action' in conf else 'accept')[:1].upper()
         out.append(f'log prefix "[STATE-POLICY-{log_state}-{log_action}]"')

--- a/src/migration-scripts/firewall/10-to-11
+++ b/src/migration-scripts/firewall/10-to-11
@@ -63,19 +63,11 @@ if not config.exists(base):
 
 ### Migration of state policies
 if config.exists(base + ['state-policy']):
-    for family in ['ipv4', 'ipv6']:
-        for hook in ['forward', 'input', 'output']:
-            for priority in ['filter']:
-                # Add default-action== accept for compatibility reasons:
-                config.set(base + [family, hook, priority, 'default-action'], value='accept')
-                position = 1
-                for state in config.list_nodes(base + ['state-policy']):
-                    action = config.return_value(base + ['state-policy', state, 'action'])
-                    config.set(base + [family, hook, priority, 'rule'])
-                    config.set_tag(base + [family, hook, priority, 'rule'])
-                    config.set(base + [family, hook, priority, 'rule', position, 'state', state], value='enable')
-                    config.set(base + [family, hook, priority, 'rule', position, 'action'], value=action)
-                    position = position + 1
+    for state in config.list_nodes(base + ['state-policy']):
+        action = config.return_value(base + ['state-policy', state, 'action'])
+        config.set(base + ['global-options', 'state-policy', state, 'action'], value=action)
+        if config.exists(base + ['state-policy', state, 'log']):
+            config.set(base + ['global-options', 'state-policy', state, 'log'], value='enable')
     config.delete(base + ['state-policy'])
 
 ## migration of global options:

--- a/src/migration-scripts/firewall/12-to-13
+++ b/src/migration-scripts/firewall/12-to-13
@@ -49,6 +49,15 @@ if not config.exists(base):
     # Nothing to do
     exit(0)
 
+# State Policy logs:
+if config.exists(base + ['global-options', 'state-policy']):
+    for state in config.list_nodes(base + ['global-options', 'state-policy']):
+        if config.exists(base + ['global-options', 'state-policy', state, 'log']):
+            log_value = config.return_value(base + ['global-options', 'state-policy', state, 'log'])
+            config.delete(base + ['global-options', 'state-policy', state, 'log'])
+            if log_value == 'enable':
+                config.set(base + ['global-options', 'state-policy', state, 'log'])
+
 for family in ['ipv4', 'ipv6', 'bridge']:
     if config.exists(base + [family]):
         for hook in ['forward', 'input', 'output', 'name']:


### PR DESCRIPTION
…now included in <set firewall global-options state-policy> node.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):
Re add state-policy to firewall

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5775

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Config:
```
vyos@ZONE-STATE:~$ show config comm | grep fire
set firewall global-options state-policy established action 'accept'
set firewall global-options state-policy established log
set firewall global-options state-policy invalid action 'drop'
set firewall global-options state-policy related action 'accept'
set firewall ipv4 forward filter rule 101 action 'drop'
set firewall ipv4 forward filter rule 101 protocol 'gre'
set firewall ipv4 input filter rule 22 action 'reject'
set firewall ipv4 input filter rule 22 source address '1.2.3.4'
set firewall ipv4 name LAN_to_LOCAL rule 10 action 'accept'
set firewall ipv4 name LAN_to_WAN default-action 'accept'
set firewall ipv4 name LOCAL_to_WAN default-action 'accept'
set firewall ipv4 name WAN_to_LAN default-action 'drop'
set firewall ipv4 name WAN_to_LOCAL default-action 'drop'
set firewall ipv4 name WAN_to_LOCAL rule 10 action 'accept'
set firewall ipv4 name WAN_to_LOCAL rule 10 source address '192.168.0.0/16'
set firewall zone LAN from WAN firewall name 'WAN_to_LAN'
set firewall zone LAN interface 'eth1'
set firewall zone LOCAL from LAN firewall name 'LAN_to_LOCAL'
set firewall zone LOCAL from WAN firewall name 'WAN_to_LOCAL'
set firewall zone LOCAL local-zone
set firewall zone WAN from LAN firewall name 'LAN_to_WAN'
set firewall zone WAN from LOCAL firewall name 'LOCAL_to_WAN'
set firewall zone WAN interface 'eth0'
vyos@ZONE-STATE:~$ 
```
Generate ipv4 ruleset:
```
vyos@ZONE-STATE:~$ sudo nft -s list table ip vyos_filter
table ip vyos_filter {
        chain VYOS_FORWARD_filter {
                type filter hook forward priority filter; policy accept;
                jump VYOS_STATE_POLICY
                meta l4proto gre counter drop comment "ipv4-FWD-filter-101"
                counter accept comment "FWD-filter default-action accept"
        }

        chain VYOS_INPUT_filter {
                type filter hook input priority filter; policy accept;
                jump VYOS_STATE_POLICY
                ip saddr 1.2.3.4 counter reject comment "ipv4-INP-filter-22"
                counter accept comment "INP-filter default-action accept"
        }

        chain VYOS_OUTPUT_filter {
                type filter hook output priority filter; policy accept;
                jump VYOS_STATE_POLICY
                counter accept comment "OUT-filter default-action accept"
        }

        chain VYOS_FRAG_MARK {
                type filter hook prerouting priority -450; policy accept;
                ip frag-off & 16383 != 0 meta mark set 0x000ffff1 return
        }

        chain NAME_LAN_to_LOCAL {
                counter accept comment "ipv4-NAM-LAN_to_LOCAL-10"
                counter drop comment "LAN_to_LOCAL default-action drop"
        }

        chain NAME_LAN_to_WAN {
                counter accept comment "LAN_to_WAN default-action accept"
        }

        chain NAME_LOCAL_to_WAN {
                counter accept comment "LOCAL_to_WAN default-action accept"
        }

        chain NAME_WAN_to_LAN {
                counter drop comment "WAN_to_LAN default-action drop"
        }

        chain NAME_WAN_to_LOCAL {
                ip saddr 192.168.0.0/16 counter accept comment "ipv4-NAM-WAN_to_LOCAL-10"
                counter drop comment "WAN_to_LOCAL default-action drop"
        }

        chain VYOS_ZONE_FORWARD {
                type filter hook forward priority filter + 1; policy accept;
                jump VYOS_STATE_POLICY
                oifname "eth1" counter jump VZONE_LAN
                oifname "eth0" counter jump VZONE_WAN
        }

        chain VYOS_ZONE_LOCAL {
                type filter hook input priority filter + 1; policy accept;
                jump VYOS_STATE_POLICY
                counter jump VZONE_LOCAL_IN
        }

        chain VYOS_ZONE_OUTPUT {
                type filter hook output priority filter + 1; policy accept;
                jump VYOS_STATE_POLICY
                counter jump VZONE_LOCAL_OUT
        }

        chain VZONE_LAN {
                iifname "eth1" counter return
                iifname "eth0" counter jump NAME_WAN_to_LAN
                iifname "eth0" counter return
                counter drop comment "zone_LAN default-action drop"
        }

        chain VZONE_LOCAL_IN {
                iifname "lo" counter return
                iifname "eth1" counter jump NAME_LAN_to_LOCAL
                iifname "eth1" counter return
                iifname "eth0" counter jump NAME_WAN_to_LOCAL
                iifname "eth0" counter return
                counter drop comment "zone_LOCAL default-action drop"
        }

        chain VZONE_LOCAL_OUT {
                oifname "lo" counter return
                oifname "eth0" counter jump NAME_LOCAL_to_WAN
                oifname "eth0" counter return
                counter drop comment "zone_LOCAL default-action drop"
        }

        chain VZONE_WAN {
                iifname "eth0" counter return
                iifname "eth1" counter jump NAME_LAN_to_WAN
                iifname "eth1" counter return
                counter drop comment "zone_WAN default-action drop"
        }

        chain VYOS_STATE_POLICY {
                ct state established log prefix "[STATE-POLICY-EST-A]" counter accept
                ct state invalid counter drop
                ct state related counter accept
                return
        }
}
vyos@ZONE-STATE:~$
```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@ZONE-STATE:/usr/libexec/vyos/tests/smoke/cli# ./test_firewall.py 
test_bridge_basic_rules (__main__.TestFirewall.test_bridge_basic_rules) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... 
Interface "eth0" does not support hardware offload

ok
test_geoip (__main__.TestFirewall.test_geoip) ... Updating GeoIP. Please wait...
Updating GeoIP. Please wait...
ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... 
"synproxy" option allowed only for action synproxy

ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... 
Group "smoketest_network1" has a circular reference

ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok

----------------------------------------------------------------------
Ran 16 tests in 37.858s

OK
root@ZONE-STATE:/usr/libexec/vyos/tests/smoke/cli# 

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
