### PR TITLE
image-tools: T4516: exit grub-update service if running in docker

### DIFF
--- a/python/vyos/system/image.py
+++ b/python/vyos/system/image.py
@@ -261,3 +261,8 @@ def is_live_boot() -> bool:
         if boot_type == 'live':
             return True
     return False
+
+def is_running_as_container() -> bool:
+    if Path('/.dockerenv').exists():
+        return True
+    return False

--- a/src/system/grub_update.py
+++ b/src/system/grub_update.py
@@ -41,6 +41,9 @@ if __name__ == '__main__':
     if image.is_live_boot():
         exit(0)
 
+    if image.is_running_as_container():
+        exit(0)
+
     # Skip everything if update is not required
     if not cfg_check_update():
         exit(0)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

There is no GRUB configuration the service can read if the image runs as container.

This will be useful when running in e.g. containerlab

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4516

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-build/pull/462

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

GRUB

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

None available

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
