### PR TITLE
smoketest: T5783: check for any abnormal daemon termination

### DIFF
--- a/smoketest/scripts/cli/test_protocols_bfd.py
+++ b/smoketest/scripts/cli/test_protocols_bfd.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 VyOS maintainers and contributors
+# Copyright (C) 2021-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -77,11 +77,23 @@ profiles = {
 }
 
 class TestProtocolsBFD(VyOSUnitTestSHIM.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestProtocolsBFD, cls).setUpClass()
+
+        # Retrieve FRR daemon PID - it is not allowed to crash, thus PID must remain the same
+        cls.daemon_pid = process_named_running(PROCESS_NAME)
+
+        # ensure we can also run this test on a live system - so lets clean
+        # out the current configuration :)
+        cls.cli_delete(cls, base_path)
+
     def tearDown(self):
         self.cli_delete(base_path)
         self.cli_commit()
-        # Check for running process
-        self.assertTrue(process_named_running(PROCESS_NAME))
+
+        # check process health and continuity
+        self.assertEqual(self.daemon_pid, process_named_running(PROCESS_NAME))
 
     def test_bfd_peer(self):
         self.cli_set(['vrf', 'name', vrf_name, 'table', '1000'])

--- a/smoketest/scripts/cli/test_protocols_mpls.py
+++ b/smoketest/scripts/cli/test_protocols_mpls.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 VyOS maintainers and contributors
+# Copyright (C) 2021-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -70,6 +70,9 @@ class TestProtocolsMPLS(VyOSUnitTestSHIM.TestCase):
     def setUpClass(cls):
         super(TestProtocolsMPLS, cls).setUpClass()
 
+        # Retrieve FRR daemon PID - it is not allowed to crash, thus PID must remain the same
+        cls.daemon_pid = process_named_running(PROCESS_NAME)
+
         # ensure we can also run this test on a live system - so lets clean
         # out the current configuration :)
         cls.cli_delete(cls, base_path)
@@ -77,8 +80,9 @@ class TestProtocolsMPLS(VyOSUnitTestSHIM.TestCase):
     def tearDown(self):
         self.cli_delete(base_path)
         self.cli_commit()
-        # Check for running process
-        self.assertTrue(process_named_running(PROCESS_NAME))
+
+        # check process health and continuity
+        self.assertEqual(self.daemon_pid, process_named_running(PROCESS_NAME))
 
     def test_mpls_basic(self):
         router_id = '1.2.3.4'

--- a/smoketest/scripts/cli/test_protocols_pim6.py
+++ b/smoketest/scripts/cli/test_protocols_pim6.py
@@ -25,15 +25,22 @@ PROCESS_NAME = 'pim6d'
 base_path = ['protocols', 'pim6']
 
 class TestProtocolsPIMv6(VyOSUnitTestSHIM.TestCase):
-    def tearDown(self):
-        # Check for running process
-        self.assertTrue(process_named_running(PROCESS_NAME))
+    @classmethod
+    def setUpClass(cls):
+        # call base-classes classmethod
+        super(TestProtocolsPIMv6, cls).setUpClass()
+        # Retrieve FRR daemon PID - it is not allowed to crash, thus PID must remain the same
+        cls.daemon_pid = process_named_running(PROCESS_NAME)
+        # ensure we can also run this test on a live system - so lets clean
+        # out the current configuration :)
+        cls.cli_delete(cls, base_path)
 
+    def tearDown(self):
         self.cli_delete(base_path)
         self.cli_commit()
 
-        # Check for running process
-        self.assertTrue(process_named_running(PROCESS_NAME))
+        # check process health and continuity
+        self.assertEqual(self.daemon_pid, process_named_running(PROCESS_NAME))
 
     def test_pim6_01_mld_simple(self):
         # commit changes

--- a/smoketest/scripts/cli/test_protocols_rip.py
+++ b/smoketest/scripts/cli/test_protocols_rip.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 VyOS maintainers and contributors
+# Copyright (C) 2021-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -34,7 +34,8 @@ class TestProtocolsRIP(VyOSUnitTestSHIM.TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestProtocolsRIP, cls).setUpClass()
-
+        # Retrieve FRR daemon PID - it is not allowed to crash, thus PID must remain the same
+        cls.daemon_pid = process_named_running(PROCESS_NAME)
         # ensure we can also run this test on a live system - so lets clean
         # out the current configuration :)
         cls.cli_delete(cls, base_path)
@@ -65,8 +66,8 @@ class TestProtocolsRIP(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(base_path)
         self.cli_commit()
 
-        # Check for running process
-        self.assertTrue(process_named_running(PROCESS_NAME))
+        # check process health and continuity
+        self.assertEqual(self.daemon_pid, process_named_running(PROCESS_NAME))
 
     def test_rip_01_parameters(self):
         distance = '40'

--- a/smoketest/scripts/cli/test_protocols_ripng.py
+++ b/smoketest/scripts/cli/test_protocols_ripng.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 VyOS maintainers and contributors
+# Copyright (C) 2021-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -31,28 +31,43 @@ route_map = 'FooBar123'
 base_path = ['protocols', 'ripng']
 
 class TestProtocolsRIPng(VyOSUnitTestSHIM.TestCase):
-    def setUp(self):
-        self.cli_set(['policy', 'access-list6', acl_in, 'rule', '10', 'action', 'permit'])
-        self.cli_set(['policy', 'access-list6', acl_in, 'rule', '10', 'source', 'any'])
-        self.cli_set(['policy', 'access-list6', acl_out, 'rule', '20', 'action', 'deny'])
-        self.cli_set(['policy', 'access-list6', acl_out, 'rule', '20', 'source', 'any'])
-        self.cli_set(['policy', 'prefix-list6', prefix_list_in, 'rule', '100', 'action', 'permit'])
-        self.cli_set(['policy', 'prefix-list6', prefix_list_in, 'rule', '100', 'prefix', '2001:db8::/32'])
-        self.cli_set(['policy', 'prefix-list6', prefix_list_out, 'rule', '200', 'action', 'deny'])
-        self.cli_set(['policy', 'prefix-list6', prefix_list_out, 'rule', '200', 'prefix', '2001:db8::/32'])
-        self.cli_set(['policy', 'route-map', route_map, 'rule', '10', 'action', 'permit'])
+    @classmethod
+    def setUpClass(cls):
+        # call base-classes classmethod
+        super(TestProtocolsRIPng, cls).setUpClass()
+        # Retrieve FRR daemon PID - it is not allowed to crash, thus PID must remain the same
+        cls.daemon_pid = process_named_running(PROCESS_NAME)
+        # ensure we can also run this test on a live system - so lets clean
+        # out the current configuration :)
+        cls.cli_delete(cls, base_path)
+
+        cls.cli_set(cls, ['policy', 'access-list6', acl_in, 'rule', '10', 'action', 'permit'])
+        cls.cli_set(cls, ['policy', 'access-list6', acl_in, 'rule', '10', 'source', 'any'])
+        cls.cli_set(cls, ['policy', 'access-list6', acl_out, 'rule', '20', 'action', 'deny'])
+        cls.cli_set(cls, ['policy', 'access-list6', acl_out, 'rule', '20', 'source', 'any'])
+        cls.cli_set(cls, ['policy', 'prefix-list6', prefix_list_in, 'rule', '100', 'action', 'permit'])
+        cls.cli_set(cls, ['policy', 'prefix-list6', prefix_list_in, 'rule', '100', 'prefix', '2001:db8::/32'])
+        cls.cli_set(cls, ['policy', 'prefix-list6', prefix_list_out, 'rule', '200', 'action', 'deny'])
+        cls.cli_set(cls, ['policy', 'prefix-list6', prefix_list_out, 'rule', '200', 'prefix', '2001:db8::/32'])
+        cls.cli_set(cls, ['policy', 'route-map', route_map, 'rule', '10', 'action', 'permit'])
+
+    @classmethod
+    def tearDownClass(cls):
+        # call base-classes classmethod
+        super(TestProtocolsRIPng, cls).tearDownClass()
+
+        cls.cli_delete(cls, ['policy', 'access-list6', acl_in])
+        cls.cli_delete(cls, ['policy', 'access-list6', acl_out])
+        cls.cli_delete(cls, ['policy', 'prefix-list6', prefix_list_in])
+        cls.cli_delete(cls, ['policy', 'prefix-list6', prefix_list_out])
+        cls.cli_delete(cls, ['policy', 'route-map', route_map])
 
     def tearDown(self):
         self.cli_delete(base_path)
-        self.cli_delete(['policy', 'access-list6', acl_in])
-        self.cli_delete(['policy', 'access-list6', acl_out])
-        self.cli_delete(['policy', 'prefix-list6', prefix_list_in])
-        self.cli_delete(['policy', 'prefix-list6', prefix_list_out])
-        self.cli_delete(['policy', 'route-map', route_map])
         self.cli_commit()
 
-        # Check for running process
-        self.assertTrue(process_named_running(PROCESS_NAME))
+        # check process health and continuity
+        self.assertEqual(self.daemon_pid, process_named_running(PROCESS_NAME))
 
     def test_ripng_01_parameters(self):
         metric = '8'

--- a/smoketest/scripts/cli/test_protocols_rpki.py
+++ b/smoketest/scripts/cli/test_protocols_rpki.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 VyOS maintainers and contributors
+# Copyright (C) 2021-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -31,6 +31,16 @@ rpki_ssh_key = '/config/auth/id_rsa_rpki'
 rpki_ssh_pub = f'{rpki_ssh_key}.pub'
 
 class TestProtocolsRPKI(VyOSUnitTestSHIM.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # call base-classes classmethod
+        super(TestProtocolsRPKI, cls).setUpClass()
+        # Retrieve FRR daemon PID - it is not allowed to crash, thus PID must remain the same
+        cls.daemon_pid = process_named_running(PROCESS_NAME)
+        # ensure we can also run this test on a live system - so lets clean
+        # out the current configuration :)
+        cls.cli_delete(cls, base_path)
+
     def tearDown(self):
         self.cli_delete(base_path)
         self.cli_commit()
@@ -39,8 +49,8 @@ class TestProtocolsRPKI(VyOSUnitTestSHIM.TestCase):
         # frrconfig = self.getFRRconfig('rpki')
         # self.assertNotIn('rpki', frrconfig)
 
-        # Check for running process
-        self.assertTrue(process_named_running(PROCESS_NAME))
+        # check process health and continuity
+        self.assertEqual(self.daemon_pid, process_named_running(PROCESS_NAME))
 
     def test_rpki(self):
         polling = '7200'


### PR DESCRIPTION
We need to ensure when stressing FRR with the smoketests that no unexpected crash happens. 

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5783

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
FRR

## Proposed changes
<!--- Describe your changes in detail -->

We simply verify the PID of the individual FRR daemons.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```bash
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bfd.py
test_bfd_peer (__main__.TestProtocolsBFD.test_bfd_peer) ... ok
test_bfd_profile (__main__.TestProtocolsBFD.test_bfd_profile) ... ok

----------------------------------------------------------------------
Ran 2 tests in 12.497s

OK
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ... ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ... ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ... ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ... ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ... ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ... ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ... ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ... ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ... ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ... ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok

----------------------------------------------------------------------
Ran 22 tests in 138.770s

OK
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_igmp-proxy.py
test_igmpproxy (__main__.TestProtocolsIGMPProxy.test_igmpproxy) ... ok

----------------------------------------------------------------------
Ran 1 test in 7.922s

OK
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_isis.py
test_isis_01_redistribute (__main__.TestProtocolsISIS.test_isis_01_redistribute) ... ok
test_isis_02_vrfs (__main__.TestProtocolsISIS.test_isis_02_vrfs) ... ok
test_isis_04_default_information (__main__.TestProtocolsISIS.test_isis_04_default_information) ... ok
test_isis_05_password (__main__.TestProtocolsISIS.test_isis_05_password) ... ok
test_isis_06_spf_delay_bfd (__main__.TestProtocolsISIS.test_isis_06_spf_delay_bfd) ... ok
test_isis_07_segment_routing_configuration (__main__.TestProtocolsISIS.test_isis_07_segment_routing_configuration) ... ok
test_isis_08_ldp_sync (__main__.TestProtocolsISIS.test_isis_08_ldp_sync) ... ok
test_isis_09_lfa (__main__.TestProtocolsISIS.test_isis_09_lfa) ... ok

----------------------------------------------------------------------
Ran 8 tests in 119.552s

OK
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_mpls.py
test_mpls_basic (__main__.TestProtocolsMPLS.test_mpls_basic) ... ok

----------------------------------------------------------------------
Ran 1 test in 8.032s

OK
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_ospf.py
test_ospf_01_defaults (__main__.TestProtocolsOSPF.test_ospf_01_defaults) ... ok
test_ospf_02_simple (__main__.TestProtocolsOSPF.test_ospf_02_simple) ... ok
test_ospf_03_access_list (__main__.TestProtocolsOSPF.test_ospf_03_access_list) ... ok
test_ospf_04_default_originate (__main__.TestProtocolsOSPF.test_ospf_04_default_originate) ... ok
test_ospf_05_options (__main__.TestProtocolsOSPF.test_ospf_05_options) ... ok
test_ospf_06_neighbor (__main__.TestProtocolsOSPF.test_ospf_06_neighbor) ... ok
test_ospf_07_redistribute (__main__.TestProtocolsOSPF.test_ospf_07_redistribute) ... ok
test_ospf_08_virtual_link (__main__.TestProtocolsOSPF.test_ospf_08_virtual_link) ... ok
test_ospf_09_interface_configuration (__main__.TestProtocolsOSPF.test_ospf_09_interface_configuration) ... ok
test_ospf_11_interface_area (__main__.TestProtocolsOSPF.test_ospf_11_interface_area) ... ok
test_ospf_12_vrfs (__main__.TestProtocolsOSPF.test_ospf_12_vrfs) ... ok
test_ospf_13_export_list (__main__.TestProtocolsOSPF.test_ospf_13_export_list) ... ok
test_ospf_14_segment_routing_configuration (__main__.TestProtocolsOSPF.test_ospf_14_segment_routing_configuration) ... ok
test_ospf_15_ldp_sync (__main__.TestProtocolsOSPF.test_ospf_15_ldp_sync) ... ok
test_ospf_16_graceful_restart (__main__.TestProtocolsOSPF.test_ospf_16_graceful_restart) ... ok

----------------------------------------------------------------------
Ran 15 tests in 84.593s

OK
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_ospfv3.py
test_ospfv3_01_basic (__main__.TestProtocolsOSPFv3.test_ospfv3_01_basic) ... ok
test_ospfv3_02_distance (__main__.TestProtocolsOSPFv3.test_ospfv3_02_distance) ... ok
test_ospfv3_03_redistribute (__main__.TestProtocolsOSPFv3.test_ospfv3_03_redistribute) ... ok
test_ospfv3_04_interfaces (__main__.TestProtocolsOSPFv3.test_ospfv3_04_interfaces) ... ok
test_ospfv3_05_area_stub (__main__.TestProtocolsOSPFv3.test_ospfv3_05_area_stub) ... ok
test_ospfv3_06_area_nssa (__main__.TestProtocolsOSPFv3.test_ospfv3_06_area_nssa) ... ok
test_ospfv3_07_default_originate (__main__.TestProtocolsOSPFv3.test_ospfv3_07_default_originate) ... ok
test_ospfv3_08_vrfs (__main__.TestProtocolsOSPFv3.test_ospfv3_08_vrfs) ... ok
test_ospfv3_09_graceful_restart (__main__.TestProtocolsOSPFv3.test_ospfv3_09_graceful_restart) ... ok

----------------------------------------------------------------------
Ran 9 tests in 52.541s

OK
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_pim.py
test_01_pim_basic (__main__.TestProtocolsPIM.test_01_pim_basic) ... ok
test_02_pim_advanced (__main__.TestProtocolsPIM.test_02_pim_advanced) ... ok
test_03_pim_igmp_proxy (__main__.TestProtocolsPIM.test_03_pim_igmp_proxy) ... ok
test_04_igmp (__main__.TestProtocolsPIM.test_04_igmp) ... ok

----------------------------------------------------------------------
Ran 4 tests in 19.022s

OK
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_pim6.py
test_pim6_01_mld_simple (__main__.TestProtocolsPIMv6.test_pim6_01_mld_simple) ... ok
test_pim6_02_mld_join (__main__.TestProtocolsPIMv6.test_pim6_02_mld_join) ... ok
test_pim6_03_basic (__main__.TestProtocolsPIMv6.test_pim6_03_basic) ... ok

----------------------------------------------------------------------
Ran 3 tests in 21.710s

OK
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_rip.py
test_rip_01_parameters (__main__.TestProtocolsRIP.test_rip_01_parameters) ... ok
test_rip_02_zebra_route_map (__main__.TestProtocolsRIP.test_rip_02_zebra_route_map) ... ok
test_rip_03_version (__main__.TestProtocolsRIP.test_rip_03_version) ... ok

----------------------------------------------------------------------
Ran 3 tests in 19.387s

OK
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_ripng.py
test_ripng_01_parameters (__main__.TestProtocolsRIPng.test_ripng_01_parameters) ... ok
test_ripng_02_zebra_route_map (__main__.TestProtocolsRIPng.test_ripng_02_zebra_route_map) ... ok

----------------------------------------------------------------------
Ran 2 tests in 14.823s

OK
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_rpki.py
test_rpki (__main__.TestProtocolsRPKI.test_rpki) ... ok
test_rpki_ssh (__main__.TestProtocolsRPKI.test_rpki_ssh) ... skipped 'Currently untested, see: https://github.com/FRRouting/frr/issues/7978'
test_rpki_verify_preference (__main__.TestProtocolsRPKI.test_rpki_verify_preference) ... ok

----------------------------------------------------------------------
Ran 3 tests in 6.415s

OK (skipped=1)
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
