### PR TITLE
vyos.utils: T5749: fix get_vrf_members() call to iproute2

### DIFF
--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -61,14 +61,17 @@ def get_vrf_members(vrf: str) -> list:
     """
     import json
     from vyos.utils.process import cmd
-    if not interface_exists(vrf):
-        raise ValueError(f'VRF "{vrf}" does not exist!')
-    output = cmd(f'ip --json --brief link show master {vrf}')
-    answer = json.loads(output)
     interfaces = []
-    for data in answer:
-        if 'ifname' in data:
-            interfaces.append(data.get('ifname'))
+    try:
+        if not interface_exists(vrf):
+            raise ValueError(f'VRF "{vrf}" does not exist!')
+        output = cmd(f'ip --json --brief link show vrf {vrf}')
+        answer = json.loads(output)
+        for data in answer:
+            if 'ifname' in data:
+                interfaces.append(data.get('ifname'))
+    except:
+        pass
     return interfaces
 
 def get_interface_vrf(interface):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The iproute2 master argument is used for both a VRF and a bridge device. Using this in the VRF context would retrieve and report back the wrong interfaces:

Old implementation:
===================
```
>>> from vyos.utils.network import get_vrf_members
>>> get_vrf_members('br1')
['eth1', 'eth2', 'vxlan1']

>>> get_vrf_members('black')
['br1.3002', 'br1.4000', 'pim6reg10200']
```

The new implementation:
=======================
```
>>> from vyos.utils.network import get_vrf_members
>>> get_vrf_members('br1')
[]
>>> get_vrf_members('black')
['br1.3002', 'br1.4000', 'pim6reg10200']
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5749

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
>>> from vyos.utils.network import get_vrf_members
>>> get_vrf_members('br1')
[]
>>> get_vrf_members('black')
['br1.3002', 'br1.4000', 'pim6reg10200']
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
