### PR TITLE
policy: T4704: Allowed to set metric (MED) to (+/-)rtt

### DIFF
--- a/interface-definitions/policy.xml.in
+++ b/interface-definitions/policy.xml.in
@@ -1446,9 +1446,18 @@
                         <format>u32:0-4294967295</format>
                         <description>Metric value</description>
                       </valueHelp>
+                      <valueHelp>
+                        <format>&lt;+/-rtt&gt;</format>
+                        <description>Add or subtract round trip time</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>&lt;rtt&gt;</format>
+                        <description>Round trip time</description>
+                      </valueHelp>
                       <constraint>
                         <validator name="numeric" argument="--relative --"/>
                         <validator name="numeric" argument="--range 0-4294967295"/>
+                        <regex>^[+|-]?rtt$</regex>
                       </constraint>
                     </properties>
                   </leafNode>

--- a/smoketest/scripts/cli/test_policy.py
+++ b/smoketest/scripts/cli/test_policy.py
@@ -1107,6 +1107,33 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                             'metric' : '-20',
                         },
                     },
+                    '30': {
+                        'action': 'permit',
+                        'match': {
+                            'ip-nexthop-addr': ipv4_nexthop_address,
+                        },
+                        'set': {
+                            'metric': 'rtt',
+                        },
+                    },
+                    '40': {
+                        'action': 'permit',
+                        'match': {
+                            'ip-nexthop-addr': ipv4_nexthop_address,
+                        },
+                        'set': {
+                            'metric': '+rtt',
+                        },
+                    },
+                    '50': {
+                        'action': 'permit',
+                        'match': {
+                            'ip-nexthop-addr': ipv4_nexthop_address,
+                        },
+                        'set': {
+                            'metric': '-rtt',
+                        },
+                    },
                 },
             },
         }


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allowed to set metric (MED) to (+/-)rtt in the route-map.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4704

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
policy, route-map, bgp

## Proposed changes
<!--- Describe your changes in detail -->
Allowed to set metric (MED) to (+/-)rtt in the route-map.
https://docs.frrouting.org/en/stable-8.3/routemap.html#clicmd-set-metric-1-4294967295-rtt-rtt-rtt

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos# set policy route-map TEST rule 10 set metric
Possible completions:
   <+/-metric>          Add or subtract metric
   <0-4294967295>       Metric value
   <rtt>                Round trip time
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_policy.py
test_access_list (__main__.TestPolicy.test_access_list) ... ok
test_access_list6 (__main__.TestPolicy.test_access_list6) ... ok
test_as_path_list (__main__.TestPolicy.test_as_path_list) ... ok
test_community_list (__main__.TestPolicy.test_community_list) ... ok
test_delete_ipv4_ipv6_table_id (__main__.TestPolicy.test_delete_ipv4_ipv6_table_id) ... ok
test_destination_ipv6_table_id (__main__.TestPolicy.test_destination_ipv6_table_id) ... ok
test_destination_table_id (__main__.TestPolicy.test_destination_table_id) ... ok
test_extended_community_list (__main__.TestPolicy.test_extended_community_list) ... ok
test_fwmark_ipv6_table_id (__main__.TestPolicy.test_fwmark_ipv6_table_id) ... ok
test_fwmark_sources_destination_ipv6_table_id (__main__.TestPolicy.test_fwmark_sources_destination_ipv6_table_id) ... ok
test_fwmark_sources_destination_table_id (__main__.TestPolicy.test_fwmark_sources_destination_table_id) ... ok
test_fwmark_sources_ipv6_table_id (__main__.TestPolicy.test_fwmark_sources_ipv6_table_id) ... ok
test_fwmark_sources_table_id (__main__.TestPolicy.test_fwmark_sources_table_id) ... ok
test_fwmark_table_id (__main__.TestPolicy.test_fwmark_table_id) ... ok
test_iif_sources_ipv6_table_id (__main__.TestPolicy.test_iif_sources_ipv6_table_id) ... ok
test_iif_sources_table_id (__main__.TestPolicy.test_iif_sources_table_id) ... ok
test_ipv6_table_id (__main__.TestPolicy.test_ipv6_table_id) ... ok
test_large_community_list (__main__.TestPolicy.test_large_community_list) ... ok
test_multiple_commit_ipv4_table_id (__main__.TestPolicy.test_multiple_commit_ipv4_table_id) ... ok
test_prefix_list (__main__.TestPolicy.test_prefix_list) ... ok
test_prefix_list6 (__main__.TestPolicy.test_prefix_list6) ... ok
test_prefix_list_duplicates (__main__.TestPolicy.test_prefix_list_duplicates) ...
Rule "21" contains a duplicate prefix definition!

ok
test_protocol_destination_table_id (__main__.TestPolicy.test_protocol_destination_table_id) ... ok
test_protocol_port_address_fwmark_table_id (__main__.TestPolicy.test_protocol_port_address_fwmark_table_id) ... ok
test_route_map (__main__.TestPolicy.test_route_map) ... ok
test_route_map_community_set (__main__.TestPolicy.test_route_map_community_set) ... ok
test_table_id (__main__.TestPolicy.test_table_id) ... ok

----------------------------------------------------------------------
Ran 27 tests in 132.375s

OK

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
