### PR TITLE
T5778: dhcp server: fix op-mode command

### DIFF
--- a/op-mode-definitions/dhcp.xml.in
+++ b/op-mode-definitions/dhcp.xml.in
@@ -42,6 +42,15 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet</command>
                 <children>
+                  <tagNode name="origin">
+                    <properties>
+                      <help>Show DHCP server leases granted by local or remote DHCP server</help>
+                      <completionHelp>
+                        <list>local remote</list>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet --origin $6</command>
+                  </tagNode>
                   <tagNode name="pool">
                     <properties>
                       <help>Show DHCP server leases for a specific pool</help>

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -114,8 +114,9 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[]) -> l
                 data_lease['remaining'] = str(data_lease["remaining"]).split('.')[0]
 
         # Do not add old leases
-        if data_lease['remaining'] != '' and data_lease['pool'] in pool and data_lease['state'] != 'free':
-            if not state or data_lease['state'] in state:
+        if data_lease['remaining'] != '' and data_lease['state'] != 'free':
+            if not state or data_lease['state'] in state or state == 'all':
+                data_lease['pool'] = 'Failover-Server' if data_lease['pool'] == '' else data_lease['pool']
                 data.append(data_lease)
 
         # deduplicate


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix op-mode command `show ip dhcp server leases`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5778

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp server
## Proposed changes
<!--- Describe your changes in detail -->
Before this change:

- `show dhcp server leases state all`: did not work
- `show dhcp server leases pool <pool_name>`: did not apply filter based by pool.
- No leases printed when fail-over is used and IP was granted by remote dhcp-server.
- Add new column that let user know is lease was granted by local or remote Server.
- Add option to filter regarding this new column

Note: If an active lease is found while parsing dhcp lease file, and pool=='', then it means is an active lease granted by remote Server. Adding such information in "Pool" column so it's visible for the user.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
One server, multiple pools:
```
# Config:
vyos@SECONDARY:~$ show config comm | grep dhcp
set service dhcp-server shared-network-name LAN subnet 192.168.11.0/24 default-router '192.168.11.1'
set service dhcp-server shared-network-name LAN subnet 192.168.11.0/24 domain-name 'vyos.net'
set service dhcp-server shared-network-name LAN subnet 192.168.11.0/24 name-server '192.168.11.1'
set service dhcp-server shared-network-name LAN subnet 192.168.11.0/24 range 0 start '192.168.11.20'
set service dhcp-server shared-network-name LAN subnet 192.168.11.0/24 range 0 stop '192.168.11.250'
set service dhcp-server shared-network-name VIF-1001 subnet 10.11.11.0/24 default-router '10.11.11.1'
set service dhcp-server shared-network-name VIF-1001 subnet 10.11.11.0/24 name-server '1.1.1.1'
set service dhcp-server shared-network-name VIF-1001 subnet 10.11.11.0/24 range 0 start '10.11.11.101'
set service dhcp-server shared-network-name VIF-1001 subnet 10.11.11.0/24 range 0 stop '10.11.11.120'
vyos@SECONDARY:~$ 
vyos@SECONDARY:~$ show dhcp server leases 
IP Address     MAC address        State    Lease start          Lease expiration     Remaining    Pool      Hostname    Origin
-------------  -----------------  -------  -------------------  -------------------  -----------  --------  ----------  --------
192.168.11.20  00:50:79:66:68:07  active   2023/11/29 10:00:35  2023/11/30 10:00:35  23:59:00     LAN       VPCS1       local
192.168.11.22  50:00:00:06:00:00  active   2023/11/29 10:01:03  2023/11/30 10:01:03  23:59:28     LAN       VYOS-6      local
192.168.11.21  00:50:79:66:68:09  active   2023/11/29 10:01:03  2023/11/30 10:01:03  23:59:28     LAN       VPCS1       local
192.168.11.23  50:00:00:05:00:00  active   2023/11/29 10:01:04  2023/11/30 10:01:04  23:59:29     LAN       VYOS5       local
10.11.11.101   00:50:79:66:68:08  active   2023/11/29 10:00:36  2023/11/30 10:00:36  23:59:01     VIF-1001  VPCS1       local
10.11.11.102   50:00:00:06:00:00  active   2023/11/29 10:01:03  2023/11/30 10:01:03  23:59:28     VIF-1001  VYOS-6      local
10.11.11.103   50:00:00:05:00:00  active   2023/11/29 10:01:05  2023/11/30 10:01:05  23:59:30     VIF-1001  VYOS5       local
vyos@SECONDARY:~$ show dhcp server leases origin local 
IP Address     MAC address        State    Lease start          Lease expiration     Remaining    Pool      Hostname    Origin
-------------  -----------------  -------  -------------------  -------------------  -----------  --------  ----------  --------
192.168.11.20  00:50:79:66:68:07  active   2023/11/29 10:00:35  2023/11/30 10:00:35  23:58:57     LAN       VPCS1       local
192.168.11.22  50:00:00:06:00:00  active   2023/11/29 10:01:03  2023/11/30 10:01:03  23:59:25     LAN       VYOS-6      local
192.168.11.21  00:50:79:66:68:09  active   2023/11/29 10:01:03  2023/11/30 10:01:03  23:59:25     LAN       VPCS1       local
192.168.11.23  50:00:00:05:00:00  active   2023/11/29 10:01:04  2023/11/30 10:01:04  23:59:26     LAN       VYOS5       local
10.11.11.101   00:50:79:66:68:08  active   2023/11/29 10:00:36  2023/11/30 10:00:36  23:58:58     VIF-1001  VPCS1       local
10.11.11.102   50:00:00:06:00:00  active   2023/11/29 10:01:03  2023/11/30 10:01:03  23:59:25     VIF-1001  VYOS-6      local
10.11.11.103   50:00:00:05:00:00  active   2023/11/29 10:01:05  2023/11/30 10:01:05  23:59:27     VIF-1001  VYOS5       local
vyos@SECONDARY:~$ show dhcp server leases origin remote 
IP Address    MAC address    State    Lease start    Lease expiration    Remaining    Pool    Hostname    Origin
------------  -------------  -------  -------------  ------------------  -----------  ------  ----------  --------
vyos@SECONDARY:~$ show dhcp server leases pool LAN 
IP Address     MAC address        State    Lease start          Lease expiration     Remaining    Pool    Hostname    Origin
-------------  -----------------  -------  -------------------  -------------------  -----------  ------  ----------  --------
192.168.11.20  00:50:79:66:68:07  active   2023/11/29 10:00:35  2023/11/30 10:00:35  23:58:43     LAN     VPCS1       local
192.168.11.22  50:00:00:06:00:00  active   2023/11/29 10:01:03  2023/11/30 10:01:03  23:59:11     LAN     VYOS-6      local
192.168.11.21  00:50:79:66:68:09  active   2023/11/29 10:01:03  2023/11/30 10:01:03  23:59:11     LAN     VPCS1       local
192.168.11.23  50:00:00:05:00:00  active   2023/11/29 10:01:04  2023/11/30 10:01:04  23:59:12     LAN     VYOS5       local
vyos@SECONDARY:~$ show dhcp server leases pool VIF-1001 
IP Address    MAC address        State    Lease start          Lease expiration     Remaining    Pool      Hostname    Origin
------------  -----------------  -------  -------------------  -------------------  -----------  --------  ----------  --------
10.11.11.101  00:50:79:66:68:08  active   2023/11/29 10:00:36  2023/11/30 10:00:36  23:58:41     VIF-1001  VPCS1       local
10.11.11.102  50:00:00:06:00:00  active   2023/11/29 10:01:03  2023/11/30 10:01:03  23:59:08     VIF-1001  VYOS-6      local
10.11.11.103  50:00:00:05:00:00  active   2023/11/29 10:01:05  2023/11/30 10:01:05  23:59:10     VIF-1001  VYOS5       local
vyos@SECONDARY:~$ 

```

Two servers, with fail-over configuration:
```
vyos@SECONDARY:~$ show config comm | grep dhcp
set service dhcp-server failover name 'FOOBAR'
set service dhcp-server failover remote '192.168.11.11'
set service dhcp-server failover source-address '192.168.11.12'
set service dhcp-server failover status 'secondary'
set service dhcp-server shared-network-name LAN subnet 192.168.11.0/24 default-router '192.168.11.1'
set service dhcp-server shared-network-name LAN subnet 192.168.11.0/24 domain-name 'vyos.net'
set service dhcp-server shared-network-name LAN subnet 192.168.11.0/24 enable-failover
set service dhcp-server shared-network-name LAN subnet 192.168.11.0/24 name-server '192.168.11.1'
set service dhcp-server shared-network-name LAN subnet 192.168.11.0/24 range 0 start '192.168.11.20'
set service dhcp-server shared-network-name LAN subnet 192.168.11.0/24 range 0 stop '192.168.11.250'
set service dhcp-server shared-network-name VIF-1001 subnet 10.11.11.0/24 default-router '10.11.11.1'
set service dhcp-server shared-network-name VIF-1001 subnet 10.11.11.0/24 enable-failover
set service dhcp-server shared-network-name VIF-1001 subnet 10.11.11.0/24 name-server '1.1.1.1'
set service dhcp-server shared-network-name VIF-1001 subnet 10.11.11.0/24 range 0 start '10.11.11.101'
set service dhcp-server shared-network-name VIF-1001 subnet 10.11.11.0/24 range 0 stop '10.11.11.120'
vyos@SECONDARY:~$ 
vyos@SECONDARY:~$ show dhcp server leases 
IP Address      MAC address        State    Lease start          Lease expiration     Remaining    Pool      Hostname    Origin
--------------  -----------------  -------  -------------------  -------------------  -----------  --------  ----------  --------
192.168.11.134  00:50:79:66:68:09  active   2023/11/29 09:51:05  2023/11/29 10:21:05  0:24:10      LAN       VPCS1       local
192.168.11.133  50:00:00:06:00:00  active   2023/11/29 09:51:38  2023/11/29 10:21:38  0:24:43      LAN       VYOS-6      local
192.168.11.132  50:00:00:05:00:00  active   2023/11/29 09:51:43  2023/11/29 10:21:43  0:24:48      LAN       VYOS5       local
10.11.11.110    00:50:79:66:68:08  active   2023/11/29 09:51:07  2023/11/29 10:21:07  0:24:12      VIF-1001  VPCS1       local
10.11.11.109    50:00:00:06:00:00  active   2023/11/29 09:51:38  2023/11/29 10:21:38  0:24:43      VIF-1001  VYOS-6      local
10.11.11.108    50:00:00:05:00:00  active   2023/11/29 09:51:43  2023/11/29 10:21:43  0:24:48      VIF-1001  VYOS5       local
192.168.11.135  00:50:79:66:68:07  active   2023/11/29 09:55:16  2023/11/29 09:59:16  0:02:21                            remote
vyos@SECONDARY:~$ show dhcp server leases origin remote 
IP Address      MAC address        State    Lease start          Lease expiration     Remaining    Pool    Hostname    Origin
--------------  -----------------  -------  -------------------  -------------------  -----------  ------  ----------  --------
192.168.11.135  00:50:79:66:68:07  active   2023/11/29 09:55:16  2023/11/29 09:59:16  0:02:16                          remote
vyos@SECONDARY:~$ show dhcp server leases origin local 
IP Address      MAC address        State    Lease start          Lease expiration     Remaining    Pool      Hostname    Origin
--------------  -----------------  -------  -------------------  -------------------  -----------  --------  ----------  --------
192.168.11.134  00:50:79:66:68:09  active   2023/11/29 09:51:05  2023/11/29 10:21:05  0:24:01      LAN       VPCS1       local
192.168.11.133  50:00:00:06:00:00  active   2023/11/29 09:51:38  2023/11/29 10:21:38  0:24:34      LAN       VYOS-6      local
192.168.11.132  50:00:00:05:00:00  active   2023/11/29 09:51:43  2023/11/29 10:21:43  0:24:39      LAN       VYOS5       local
10.11.11.110    00:50:79:66:68:08  active   2023/11/29 09:51:07  2023/11/29 10:21:07  0:24:03      VIF-1001  VPCS1       local
10.11.11.109    50:00:00:06:00:00  active   2023/11/29 09:51:38  2023/11/29 10:21:38  0:24:34      VIF-1001  VYOS-6      local
10.11.11.108    50:00:00:05:00:00  active   2023/11/29 09:51:43  2023/11/29 10:21:43  0:24:39      VIF-1001  VYOS5       local
vyos@SECONDARY:~$ show dhcp server leases pool LAN 
IP Address      MAC address        State    Lease start          Lease expiration     Remaining    Pool    Hostname    Origin
--------------  -----------------  -------  -------------------  -------------------  -----------  ------  ----------  --------
192.168.11.134  00:50:79:66:68:09  active   2023/11/29 09:51:05  2023/11/29 10:21:05  0:23:55      LAN     VPCS1       local
192.168.11.133  50:00:00:06:00:00  active   2023/11/29 09:51:38  2023/11/29 10:21:38  0:24:28      LAN     VYOS-6      local
192.168.11.132  50:00:00:05:00:00  active   2023/11/29 09:51:43  2023/11/29 10:21:43  0:24:33      LAN     VYOS5       local
vyos@SECONDARY:~$ show dhcp server leases pool VIF-1001 
IP Address    MAC address        State    Lease start          Lease expiration     Remaining    Pool      Hostname    Origin
------------  -----------------  -------  -------------------  -------------------  -----------  --------  ----------  --------
10.11.11.110  00:50:79:66:68:08  active   2023/11/29 09:51:07  2023/11/29 10:21:07  0:23:27      VIF-1001  VPCS1       local
10.11.11.109  50:00:00:06:00:00  active   2023/11/29 09:51:38  2023/11/29 10:21:38  0:23:58      VIF-1001  VYOS-6      local
10.11.11.108  50:00:00:05:00:00  active   2023/11/29 09:51:43  2023/11/29 10:21:43  0:24:03      VIF-1001  VYOS5       local
vyos@SECONDARY:~$ 

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
