### PR TITLE
https: T5772: remove the default API key

### DIFF
--- a/python/vyos/defaults.py
+++ b/python/vyos/defaults.py
@@ -50,7 +50,7 @@ api_data = {
     'strict' : False,
     'gql' : False,
     'debug' : False,
-    'api_keys' : [ {"id": "testapp", "key": "qwerty"} ]
+    'api_keys' : [ ]
 }
 
 vyos_cert_data = {

--- a/src/conf_mode/http-api.py
+++ b/src/conf_mode/http-api.py
@@ -39,7 +39,7 @@ vyos_conf_scripts_dir=vyos.defaults.directories['conf_mode']
 def get_config(config=None):
     http_api = deepcopy(vyos.defaults.api_data)
     x = http_api.get('api_keys')
-    if x is None:
+    if not x:
         default_key = None
     else:
         default_key = x[0]


### PR DESCRIPTION
The new verification code prevents it from being used, but it's not a reason to keep it

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Remove the default API key.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5772

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

HTTPS API

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
