### PR TITLE
vti: T5769: restore interface settings on down -> up event

### DIFF
--- a/src/etc/ipsec.d/vti-up-down
+++ b/src/etc/ipsec.d/vti-up-down
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 VyOS maintainers and contributors
+# Copyright (C) 2021-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -13,8 +13,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-## Script called up strongswan to bring the vti interface up/down based on the state of the IPSec tunnel.
-## Called as vti_up_down vti_intf_name
+
+# Script called up strongswan to bring the VTI interface up/down based on
+# the state of the IPSec tunnel. Called as vti_up_down vti_intf_name
 
 import os
 import sys
@@ -25,9 +26,10 @@ from syslog import LOG_PID
 from syslog import LOG_INFO
 
 from vyos.configquery import ConfigTreeQuery
+from vyos.configdict import get_interface_dict
+from vyos.ifconfig import VTIIf
 from vyos.utils.process import call
 from vyos.utils.network import get_interface_config
-from vyos.utils.network import get_interface_address
 
 if __name__ == '__main__':
     verb = os.getenv('PLUTO_VERB')
@@ -48,14 +50,13 @@ if __name__ == '__main__':
 
     vti_link_up = (vti_link['operstate'] != 'DOWN' if 'operstate' in vti_link else False)
 
-    config = ConfigTreeQuery()
-    vti_dict = config.get_config_dict(['interfaces', 'vti', interface],
-                                      get_first_key=True)
-
     if verb in ['up-client', 'up-host']:
         if not vti_link_up:
-            if 'disable' not in vti_dict:
-                call(f'sudo ip link set {interface} up')
+            conf = ConfigTreeQuery()
+            _, vti = get_interface_dict(conf.config, ['interfaces', 'vti'], interface)
+            if 'disable' not in vti:
+                tmp = VTIIf(interface)
+                tmp.update(vti)
             else:
                 syslog(f'Interface {interface} is admin down ...')
     elif verb in ['down-client', 'down-host']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

On VTI interface link down the link-local IPv6 address is removed. As soon as the IPSec tunnel is online again, vti-up-down helper is called which only places the interface in up state using iproute2 command

    sudo ip link set vti0 up

This does not restore the IPv6 LL address. Instead use `vyos.ifconfig` to properly re-initialize the VTI interface using the generic `update()` method.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5769

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
VTI interface

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

### R1

```
set interfaces vti vti10 address '10.0.0.2/31'

set vpn ipsec authentication psk peer_172-18-202-10 id '172.18.201.10'
set vpn ipsec authentication psk peer_172-18-202-10 id '172.18.202.10'
set vpn ipsec authentication psk peer_172-18-202-10 secret 'secretkey'
set vpn ipsec esp-group ESP_DEFAULT lifetime '3600'
set vpn ipsec esp-group ESP_DEFAULT mode 'tunnel'
set vpn ipsec esp-group ESP_DEFAULT pfs 'dh-group19'
set vpn ipsec esp-group ESP_DEFAULT proposal 10 encryption 'aes256gcm128'
set vpn ipsec esp-group ESP_DEFAULT proposal 10 hash 'sha256'
set vpn ipsec ike-group IKEv2_DEFAULT close-action 'none'
set vpn ipsec ike-group IKEv2_DEFAULT dead-peer-detection action 'hold'
set vpn ipsec ike-group IKEv2_DEFAULT dead-peer-detection interval '30'
set vpn ipsec ike-group IKEv2_DEFAULT dead-peer-detection timeout '120'
set vpn ipsec ike-group IKEv2_DEFAULT disable-mobike
set vpn ipsec ike-group IKEv2_DEFAULT key-exchange 'ikev2'
set vpn ipsec ike-group IKEv2_DEFAULT lifetime '10800'
set vpn ipsec ike-group IKEv2_DEFAULT proposal 10 dh-group '19'
set vpn ipsec ike-group IKEv2_DEFAULT proposal 10 encryption 'aes256gcm128'
set vpn ipsec ike-group IKEv2_DEFAULT proposal 10 hash 'sha256'
set vpn ipsec interface 'eth0.201'
set vpn ipsec site-to-site peer peer_172-18-202-10 authentication local-id '172.18.201.10'
set vpn ipsec site-to-site peer peer_172-18-202-10 authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer peer_172-18-202-10 authentication remote-id '172.18.202.10'
set vpn ipsec site-to-site peer peer_172-18-202-10 connection-type 'initiate'
set vpn ipsec site-to-site peer peer_172-18-202-10 ike-group 'IKEv2_DEFAULT'
set vpn ipsec site-to-site peer peer_172-18-202-10 ikev2-reauth 'inherit'
set vpn ipsec site-to-site peer peer_172-18-202-10 local-address '172.18.201.10'
set vpn ipsec site-to-site peer peer_172-18-202-10 remote-address '172.18.202.10'
set vpn ipsec site-to-site peer peer_172-18-202-10 vti bind 'vti10'
set vpn ipsec site-to-site peer peer_172-18-202-10 vti esp-group 'ESP_DEFAULT'
```

### R2

```
set interfaces vti vti10 address '10.0.0.3/31'
set vpn ipsec authentication psk peer_172-18-201-10 id '172.18.202.10'
set vpn ipsec authentication psk peer_172-18-201-10 id '172.18.201.10'
set vpn ipsec authentication psk peer_172-18-201-10 secret 'secretkey'
set vpn ipsec esp-group ESP_DEFAULT lifetime '3600'
set vpn ipsec esp-group ESP_DEFAULT mode 'tunnel'
set vpn ipsec esp-group ESP_DEFAULT pfs 'dh-group19'
set vpn ipsec esp-group ESP_DEFAULT proposal 10 encryption 'aes256gcm128'
set vpn ipsec esp-group ESP_DEFAULT proposal 10 hash 'sha256'
set vpn ipsec ike-group IKEv2_DEFAULT close-action 'none'
set vpn ipsec ike-group IKEv2_DEFAULT dead-peer-detection action 'hold'
set vpn ipsec ike-group IKEv2_DEFAULT dead-peer-detection interval '30'
set vpn ipsec ike-group IKEv2_DEFAULT dead-peer-detection timeout '120'
set vpn ipsec ike-group IKEv2_DEFAULT disable-mobike
set vpn ipsec ike-group IKEv2_DEFAULT key-exchange 'ikev2'
set vpn ipsec ike-group IKEv2_DEFAULT lifetime '10800'
set vpn ipsec ike-group IKEv2_DEFAULT proposal 10 dh-group '19'
set vpn ipsec ike-group IKEv2_DEFAULT proposal 10 encryption 'aes256gcm128'
set vpn ipsec ike-group IKEv2_DEFAULT proposal 10 hash 'sha256'
set vpn ipsec interface 'eth0.202'
set vpn ipsec site-to-site peer peer_172-18-201-10 authentication local-id '172.18.202.10'
set vpn ipsec site-to-site peer peer_172-18-201-10 authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer peer_172-18-201-10 authentication remote-id '172.18.201.10'
set vpn ipsec site-to-site peer peer_172-18-201-10 connection-type 'initiate'
set vpn ipsec site-to-site peer peer_172-18-201-10 ike-group 'IKEv2_DEFAULT'
set vpn ipsec site-to-site peer peer_172-18-201-10 ikev2-reauth 'inherit'
set vpn ipsec site-to-site peer peer_172-18-201-10 local-address '172.18.202.10'
set vpn ipsec site-to-site peer peer_172-18-201-10 remote-address '172.18.201.10'
set vpn ipsec site-to-site peer peer_172-18-201-10 vti bind 'vti10'
set vpn ipsec site-to-site peer peer_172-18-201-10 vti esp-group 'ESP_DEFAULT'
```

After the tunnel is up, reboot R2 and check R1 link-local IPv6 address

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
