### PR TITLE
T5796:backport-add/fixed OCSERV HTTP security headers

### DIFF
--- a/data/templates/ocserv/ocserv_config.tmpl
+++ b/data/templates/ocserv/ocserv_config.tmpl
@@ -85,7 +85,7 @@ route = {{ route }}
 {%   endfor %}
 {% endif %}
 
-
+{% if http_security_headers is defined %}
 # HTTP security headers
 included-http-headers = Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 included-http-headers = X-Frame-Options: deny
@@ -100,3 +100,4 @@ included-http-headers = Cross-Origin-Resource-Policy: same-origin
 included-http-headers = X-XSS-Protection: 0
 included-http-headers = Pragma: no-cache
 included-http-headers = Cache-control: no-store, no-cache
+{% endif %}

--- a/data/templates/ocserv/ocserv_config.tmpl
+++ b/data/templates/ocserv/ocserv_config.tmpl
@@ -84,3 +84,19 @@ route = {{ network_settings.push_route }}
 route = {{ route }}
 {%   endfor %}
 {% endif %}
+
+
+# HTTP security headers
+included-http-headers = Strict-Transport-Security: max-age=31536000 ; includeSubDomains
+included-http-headers = X-Frame-Options: deny
+included-http-headers = X-Content-Type-Options: nosniff
+included-http-headers = Content-Security-Policy: default-src ´none´
+included-http-headers = X-Permitted-Cross-Domain-Policies: none
+included-http-headers = Referrer-Policy: no-referrer
+included-http-headers = Clear-Site-Data: "cache","cookies","storage"
+included-http-headers = Cross-Origin-Embedder-Policy: require-corp
+included-http-headers = Cross-Origin-Opener-Policy: same-origin
+included-http-headers = Cross-Origin-Resource-Policy: same-origin
+included-http-headers = X-XSS-Protection: 0
+included-http-headers = Pragma: no-cache
+included-http-headers = Cache-control: no-store, no-cache

--- a/interface-definitions/vpn_openconnect.xml.in
+++ b/interface-definitions/vpn_openconnect.xml.in
@@ -106,6 +106,12 @@
               </leafNode>
             </children>
           </node>
+          <leafNode name="http-security-headers">
+            <properties>
+              <help>Enable HTTP security headers</help>
+              <valueless/>
+            </properties>
+          </leafNode>
           <node name="ssl">
             <properties>
               <help>SSL Certificate, SSL Key and CA (/config/auth)</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
http security headers (cherry picked from commit db51546)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5796

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openconnect
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@dco1:~$    show openconnect-server sessions
Interface    Username    IP             Remote IP     RX       TX         State      Uptime
-----------  ----------  -------------  ------------  -------  ---------  ---------  --------
sslvpn0      tst         172.20.20.198  192.168.0.40  37.7 KB  152 bytes  connected  1m:43s
```
 00:12:14 dco1 ocserv-worker[7112]: main: CN=oc-srv,O=VyOS,L=Mycity,ST=Delaware,C=US certificate key usage prevents key encipherment; unable to support the RSA ciphersuites; if that is not intent>
Dec 02 00:12:14 dco1 ocserv[7112]: note: setting 'file' as supplemental config option
Dec 02 00:12:18 dco1 ocserv[5989]: sec-mod: sec-mod instance 0 issue cookie
Dec 02 00:12:18 dco1 ocserv[5989]: sec-mod: using 'plain' authentication to authenticate user (session: sBJX91)
Dec 02 00:12:21 dco1 ocserv[5989]: sec-mod: initiating session for user 'tst' (session: sBJX91)
Dec 02 11:49:37 dco1 ocserv[7581]: Parsing plain auth method subconfig using legacy format
Dec 02 11:49:37 dco1 ocserv[7581]: note: vhost:default: setting 'plain' as primary authentication method
Dec 02 11:49:37 dco1 ocserv[7581]: note: setting 'file' as supplemental config option
Dec 02 11:49:37 dco1 ocserv-worker[7581]: main: CN=oc-srv,O=VyOS,L=Mycity,ST=Delaware,C=US certificate key usage prevents key encipherment; unable to support the RSA ciphersuites; if that is not intent>
Dec 02 11:49:40 dco1 ocserv[5989]: sec-mod: sec-mod instance 0 issue cookie
Dec 02 11:49:40 dco1 ocserv[5989]: sec-mod: using 'plain' authentication to authenticate user (session: v61ylj)
Dec 02 11:50:11 dco1 ocserv[5989]: sec-mod: initiating session for user 'tst' (session: v61ylj)


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
