### PR TITLE
T160: Add NAT64

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -112,6 +112,9 @@ Depends:
   wireless-regdb,
   wpasupplicant (>= 0.6.7),
 # End "interfaces wireless"
+# For "nat64"
+  jool,
+# End "nat64"
 # For "interfaces wwan"
   modemmanager,
   usb-modeswitch,

--- a/interface-definitions/include/nat64/protocol.xml.i
+++ b/interface-definitions/include/nat64/protocol.xml.i
@@ -1,0 +1,27 @@
+<!-- include start from nat64/protocol.xml.i -->
+<node name="protocol">
+  <properties>
+    <help>Apply translation address to a specfic protocol</help>
+  </properties>
+  <children>
+    <leafNode name="tcp">
+      <properties>
+        <help>Transmission Control Protocol</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+    <leafNode name="udp">
+      <properties>
+        <help>User Datagram Protocol</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+    <leafNode name="icmp">
+      <properties>
+        <help>Internet Control Message Protocol</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/nat64.xml.in
+++ b/interface-definitions/nat64.xml.in
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="nat64" owner="${vyos_conf_scripts_dir}/nat64.py">
+    <properties>
+      <help>IPv6-to-IPv4 Network Address Translation (NAT64) Settings</help>
+      <priority>501</priority>
+    </properties>
+    <children>
+      <node name="source">
+        <properties>
+          <help>IPv6 source to IPv4 destination address translation</help>
+        </properties>
+        <children>
+          <tagNode name="rule">
+            <properties>
+              <help>Source NAT64 rule number</help>
+              <valueHelp>
+                <format>u32:1-999999</format>
+                <description>Number for this rule</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 1-999999"/>
+              </constraint>
+              <constraintErrorMessage>NAT64 rule number must be between 1 and 999999</constraintErrorMessage>
+            </properties>
+            <children>
+              #include <include/generic-description.xml.i>
+              #include <include/generic-disable-node.xml.i>
+              <node name="source">
+                <properties>
+                  <help>IPv6 source prefix options</help>
+                </properties>
+                <children>
+                  <leafNode name="prefix">
+                    <properties>
+                      <help>IPv6 prefix to be translated</help>
+                      <valueHelp>
+                        <format>ipv6net</format>
+                        <description>IPv6 prefix</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="ipv6-prefix"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+              <node name="translation">
+                <properties>
+                  <help>Translated IPv4 address options</help>
+                </properties>
+                <children>
+                  <tagNode name="pool">
+                    <properties>
+                      <help>Translation IPv4 pool number</help>
+                      <valueHelp>
+                        <format>u32:1-999999</format>
+                        <description>Number for this rule</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-999999"/>
+                      </constraint>
+                      <constraintErrorMessage>NAT64 pool number must be between 1 and 999999</constraintErrorMessage>
+                    </properties>
+                    <children>
+                      #include <include/generic-description.xml.i>
+                      #include <include/generic-disable-node.xml.i>
+                      #include <include/nat-translation-port.xml.i>
+                      #include <include/nat64/protocol.xml.i>
+                      <leafNode name="address">
+                        <properties>
+                          <help>IPv4 address or prefix to translate to</help>
+                          <valueHelp>
+                            <format>ipv4</format>
+                            <description>IPv4 address</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>ipv4net</format>
+                            <description>IPv4 prefix</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="ipv4-address"/>
+                            <validator name="ipv4-prefix"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </tagNode>
+                </children>
+              </node>
+            </children>
+          </tagNode>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/src/conf_mode/nat64.py
+++ b/src/conf_mode/nat64.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=empty-docstring,missing-module-docstring
+
+import csv
+import os
+import re
+
+from ipaddress import IPv6Network
+from json import dumps as json_write
+
+from vyos import ConfigError
+from vyos import airbag
+from vyos.config import Config
+from vyos.configdict import dict_merge
+from vyos.configdict import is_node_changed
+from vyos.utils.dict import dict_search
+from vyos.utils.file import write_file
+from vyos.utils.kernel import check_kmod
+from vyos.utils.process import cmd
+from vyos.utils.process import run
+
+airbag.enable()
+
+INSTANCE_REGEX = re.compile(r"instance-(\d+)")
+JOOL_CONFIG_DIR = "/run/jool"
+
+
+def get_config(config: Config | None = None) -> None:
+    if config is None:
+        config = Config()
+
+    base = ["nat64"]
+    nat64 = config.get_config_dict(base, key_mangling=("-", "_"), get_first_key=True)
+
+    base_src = base + ["source", "rule"]
+
+    # Load in existing instances so we can destroy any unknown
+    lines = cmd("jool instance display --csv").splitlines()
+    for _, instance, _ in csv.reader(lines):
+        match = INSTANCE_REGEX.fullmatch(instance)
+        if not match:
+            # FIXME: Instances that don't match should be ignored but WARN'ed to the user
+            continue
+        num = match.group(1)
+
+        rules = nat64.setdefault("source", {}).setdefault("rule", {})
+        # Mark it for deletion
+        if num not in rules:
+            rules[num] = {"deleted": True}
+            continue
+
+        # If the user changes the mode, recreate the instance else Jool fails with:
+        # Jool error: Sorry; you can't change an instance's framework for now.
+        if is_node_changed(config, base_src + [f"instance-{num}", "mode"]):
+            rules[num]["recreate"] = True
+
+        # If the user changes the pool6, recreate the instance else Jool fails with:
+        # Jool error: Sorry; you can't change a NAT64 instance's pool6 for now.
+        if dict_search("source.prefix", rules[num]) and is_node_changed(
+            config,
+            base_src + [num, "source", "prefix"],
+        ):
+            rules[num]["recreate"] = True
+
+    return nat64
+
+
+def verify(nat64) -> None:
+    if not nat64:
+        # no need to verify the CLI as nat64 is going to be deactivated
+        return
+
+    if dict_search("source.rule", nat64):
+        # Ensure only 1 netfilter instance per namespace
+        nf_rules = filter(
+            lambda i: "deleted" not in i and i.get('mode') == "netfilter",
+            nat64["source"]["rule"].values(),
+        )
+        next(nf_rules, None)  # Discard the first element
+        if next(nf_rules, None) is not None:
+            raise ConfigError(
+                "Jool permits only 1 NAT64 netfilter instance (per network namespace)"
+            )
+
+        for rule, instance in nat64["source"]["rule"].items():
+            if "deleted" in instance:
+                continue
+
+            # Verify that source.prefix is set and is a /96
+            if not dict_search("source.prefix", instance):
+                raise ConfigError(f"Source NAT64 rule {rule} missing source prefix")
+            if IPv6Network(instance["source"]["prefix"]).prefixlen != 96:
+                raise ConfigError(f"Source NAT64 rule {rule} source prefix must be /96")
+
+            pools = dict_search("translation.pool", instance)
+            if pools:
+                for num, pool in pools.items():
+                    if "address" not in pool:
+                        raise ConfigError(
+                            f"Source NAT64 rule {rule} translation pool "
+                            f"{num} missing address/prefix"
+                        )
+                    if "port" not in pool:
+                        raise ConfigError(
+                            f"Source NAT64 rule {rule} translation pool "
+                            f"{num} missing port(-range)"
+                        )
+
+
+def generate(nat64) -> None:
+    os.makedirs(JOOL_CONFIG_DIR, exist_ok=True)
+
+    if dict_search("source.rule", nat64):
+        for rule, instance in nat64["source"]["rule"].items():
+            if "deleted" in instance:
+                # Delete the unused instance file
+                os.unlink(os.path.join(JOOL_CONFIG_DIR, f"instance-{rule}.json"))
+                continue
+
+            name = f"instance-{rule}"
+            config = {
+                "instance": name,
+                "framework": "netfilter",
+                "global": {
+                    "pool6": instance["source"]["prefix"],
+                    "manually-enabled": "disable" not in instance,
+                },
+                # "bib": [],
+            }
+
+            if "description" in instance:
+                config["comment"] = instance["description"]
+
+            if dict_search("translation.pool", instance):
+                pool4 = []
+                for pool in instance["translation"]["pool"].values():
+                    if "disable" in pool:
+                        continue
+
+                    protos = pool.get("protocol", {}).keys() or ("tcp", "udp", "icmp")
+                    for proto in protos:
+                        obj = {
+                            "protocol": proto.upper(),
+                            "prefix": pool["address"],
+                            "port range": pool["port"],
+                        }
+                        if "description" in pool:
+                            obj["comment"] = pool["description"]
+
+                        pool4.append(obj)
+
+                if pool4:
+                    config["pool4"] = pool4
+
+            write_file(f'{JOOL_CONFIG_DIR}/{name}.json', json_write(config, indent=2))
+
+
+def apply(nat64) -> None:
+    if not nat64:
+        return
+
+    if dict_search("source.rule", nat64):
+        # Deletions first to avoid conflicts
+        for rule, instance in nat64["source"]["rule"].items():
+            if not any(k in instance for k in ("deleted", "recreate")):
+                continue
+
+            ret = run(f"jool instance remove instance-{rule}")
+            if ret != 0:
+                raise ConfigError(
+                    f"Failed to remove nat64 source rule {rule} (jool instance instance-{rule})"
+                )
+
+        # Now creations
+        for rule, instance in nat64["source"]["rule"].items():
+            if "deleted" in instance:
+                continue
+
+            name = f"instance-{rule}"
+            ret = run(f"jool -i {name} file handle {JOOL_CONFIG_DIR}/{name}.json")
+            if ret != 0:
+                raise ConfigError(f"Failed to set jool instance {name}")
+
+
+if __name__ == "__main__":
+    try:
+        check_kmod(["jool"])
+        c = get_config()
+        verify(c)
+        generate(c)
+        apply(c)
+    except ConfigError as e:
+        print(e)
+        exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add NAT64

The original PR https://github.com/vyos/vyos-1x/pull/1993 
There are no responses from the PR author, and PR had conflicts.

Write fixed for JSON write files and update the base.
Deleted unused default values.
Simple changes.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T160

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat64
## Proposed changes
<!--- Describe your changes in detail -->

## How to test

Add a separate address 192.168.122.10 only for nat64 translations

```
set interfaces ethernet eth0 address '192.168.122.14/24'
set interfaces ethernet eth0 address '192.168.122.10/24'
set interfaces ethernet eth2 address '2001:db8::1/64'

set nat64 source rule 100 source prefix '64:ff9b::/96'
set nat64 source rule 100 translation pool 10 address '192.168.122.10'
set nat64 source rule 100 translation pool 10 port '1-65535'
```
From the IPv6 host only `2001:db8::2` try to ping IPv4 hosts
```
vyos@r12:~$ ping 64:ff9b::192.0.2.5 count 2
PING 64:ff9b::192.0.2.5(64:ff9b::c000:205) 56 data bytes
64 bytes from 64:ff9b::c000:205: icmp_seq=1 ttl=63 time=0.586 ms
64 bytes from 64:ff9b::c000:205: icmp_seq=2 ttl=63 time=0.695 ms

--- 64:ff9b::192.0.2.5 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1010ms
rtt min/avg/max/mdev = 0.586/0.640/0.695/0.060 ms
vyos@r12:~$ 
vyos@r12:~$ 
vyos@r12:~$ 
vyos@r12:~$ 
vyos@r12:~$ ping 64:ff9b::1.1.1.1 count 2
PING 64:ff9b::1.1.1.1(64:ff9b::101:101) 56 data bytes
64 bytes from 64:ff9b::101:101: icmp_seq=1 ttl=58 time=29.0 ms
64 bytes from 64:ff9b::101:101: icmp_seq=2 ttl=58 time=20.0 ms

--- 64:ff9b::1.1.1.1 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1001ms
rtt min/avg/max/mdev = 20.077/24.580/29.083/4.503 ms
vyos@r12:~$ 

```

DUMP from the NAT64 host
```
vyos@r4# sudo tcpdump -ni eth0 host 1.1.1.1
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), snapshot length 262144 bytes
11:44:58.808642 IP 192.168.122.10 > 1.1.1.1: ICMP echo request, id 6884, seq 1, length 64
11:44:58.828382 IP 1.1.1.1 > 192.168.122.10: ICMP echo reply, id 6884, seq 1, length 64
11:44:59.810503 IP 192.168.122.10 > 1.1.1.1: ICMP echo request, id 6884, seq 2, length 64
11:44:59.830197 IP 1.1.1.1 > 192.168.122.10: ICMP echo reply, id 6884, seq 2, length 64

```
Jool
```
vyos@r4# sudo jool instance display
+--------------------+-----------------+-----------+
|          Namespace |            Name | Framework |
+--------------------+-----------------+-----------+
|           b19ee1c0 |    instance-100 | netfilter |
+--------------------+-----------------+-----------+
[edit]
vyos@r4# 

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
