### PR TITLE
T5779: conntrack: Apply fixes to <set system conntrack timeout custom>

### DIFF
--- a/data/templates/conntrack/nftables-ct.j2
+++ b/data/templates/conntrack/nftables-ct.j2
@@ -11,19 +11,32 @@ table ip vyos_conntrack {
 {% if ignore.ipv4.rule is vyos_defined %}
 {%     for rule, rule_config in ignore.ipv4.rule.items() %}
         # rule-{{ rule }} {{ '- ' ~ rule_config.description if rule_config.description is vyos_defined }}
-       {{ rule_config | conntrack_ignore_rule(rule, ipv6=False) }}
+        {{ rule_config | conntrack_rule(rule, 'ignore', ipv6=False) }}
 {%     endfor %}
 {% endif %}
-        return
+         return
     }
     chain VYOS_CT_TIMEOUT {
-{% if timeout.custom.rule is vyos_defined %}
-{%     for rule, rule_config in timeout.custom.rule.items() %}
+{% if timeout.custom.ipv4.rule is vyos_defined %}
+{%     for rule, rule_config in timeout.custom.ipv4.rule.items() %}
         # rule-{{ rule }} {{ '- ' ~ rule_config.description if rule_config.description is vyos_defined }}
+        {{ rule_config | conntrack_rule(rule, 'timeout', ipv6=False) }}
 {%     endfor %}
 {% endif %}
         return
     }
+
+{% if timeout.custom.ipv4.rule is vyos_defined %}
+{%     for rule, rule_config in timeout.custom.ipv4.rule.items() %}
+    ct timeout ct-timeout-{{ rule }} {
+        l3proto ip;
+{%         for protocol, protocol_config in rule_config.protocol.items() %}
+        protocol {{ protocol }};
+        policy = { {{ protocol_config | conntrack_ct_policy() }} }
+{%         endfor %}
+    }
+{%     endfor %}
+{% endif %}
 
     chain PREROUTING {
         type filter hook prerouting priority -300; policy accept;
@@ -80,19 +93,32 @@ table ip6 vyos_conntrack {
 {% if ignore.ipv6.rule is vyos_defined %}
 {%     for rule, rule_config in ignore.ipv6.rule.items() %}
         # rule-{{ rule }} {{ '- ' ~ rule_config.description if rule_config.description is vyos_defined }}
-       {{ rule_config | conntrack_ignore_rule(rule, ipv6=True) }}
+       {{ rule_config | conntrack_rule(rule, 'ignore', ipv6=True) }}
 {%     endfor %}
 {% endif %}
         return
     }
     chain VYOS_CT_TIMEOUT {
-{% if timeout.custom.rule is vyos_defined %}
-{%     for rule, rule_config in timeout.custom.rule.items() %}
+{% if timeout.custom.ipv6.rule is vyos_defined %}
+{%     for rule, rule_config in timeout.custom.ipv6.rule.items() %}
         # rule-{{ rule }} {{ '- ' ~ rule_config.description if rule_config.description is vyos_defined }}
+        {{ rule_config | conntrack_rule(rule, 'timeout', ipv6=True) }}
 {%     endfor %}
 {% endif %}
         return
     }
+
+{% if timeout.custom.ipv6.rule is vyos_defined %}
+{%     for rule, rule_config in timeout.custom.ipv6.rule.items() %}
+    ct timeout ct-timeout-{{ rule }} {
+        l3proto ip;
+{%         for protocol, protocol_config in rule_config.protocol.items() %}
+        protocol {{ protocol }};
+        policy = { {{ protocol_config | conntrack_ct_policy() }} }
+{%         endfor %}
+    }
+{%     endfor %}
+{% endif %}
 
     chain PREROUTING {
         type filter hook prerouting priority -300; policy accept;

--- a/interface-definitions/include/conntrack/timeout-custom-protocols.xml.i
+++ b/interface-definitions/include/conntrack/timeout-custom-protocols.xml.i
@@ -1,0 +1,136 @@
+<!-- include start from conntrack/timeout-custom-protocols.xml.i -->
+<node name="tcp">
+  <properties>
+    <help>TCP connection timeout options</help>
+  </properties>
+  <children>
+    <leafNode name="close-wait">
+      <properties>
+        <help>TCP CLOSE-WAIT timeout in seconds</help>
+        <valueHelp>
+          <format>u32:1-21474836</format>
+          <description>TCP CLOSE-WAIT timeout in seconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-21474836"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="close">
+      <properties>
+        <help>TCP CLOSE timeout in seconds</help>
+        <valueHelp>
+          <format>u32:1-21474836</format>
+          <description>TCP CLOSE timeout in seconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-21474836"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="established">
+      <properties>
+        <help>TCP ESTABLISHED timeout in seconds</help>
+        <valueHelp>
+          <format>u32:1-21474836</format>
+          <description>TCP ESTABLISHED timeout in seconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-21474836"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="fin-wait">
+      <properties>
+        <help>TCP FIN-WAIT timeout in seconds</help>
+        <valueHelp>
+          <format>u32:1-21474836</format>
+          <description>TCP FIN-WAIT timeout in seconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-21474836"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="last-ack">
+      <properties>
+        <help>TCP LAST-ACK timeout in seconds</help>
+        <valueHelp>
+          <format>u32:1-21474836</format>
+          <description>TCP LAST-ACK timeout in seconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-21474836"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="syn-recv">
+      <properties>
+        <help>TCP SYN-RECEIVED timeout in seconds</help>
+        <valueHelp>
+          <format>u32:1-21474836</format>
+          <description>TCP SYN-RECEIVED timeout in seconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-21474836"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="syn-sent">
+      <properties>
+        <help>TCP SYN-SENT timeout in seconds</help>
+        <valueHelp>
+          <format>u32:1-21474836</format>
+          <description>TCP SYN-SENT timeout in seconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-21474836"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="time-wait">
+      <properties>
+        <help>TCP TIME-WAIT timeout in seconds</help>
+        <valueHelp>
+          <format>u32:1-21474836</format>
+          <description>TCP TIME-WAIT timeout in seconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-21474836"/>
+        </constraint>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<node name="udp">
+  <properties>
+    <help>UDP timeout options</help>
+  </properties>
+  <children>
+    <leafNode name="replied">
+      <properties>
+        <help>Timeout for UDP connection seen in both directions</help>
+        <valueHelp>
+          <format>u32:1-21474836</format>
+          <description>Timeout for UDP connection seen in both directions</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-21474836"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="unreplied">
+      <properties>
+        <help>Timeout for unreplied UDP</help>
+        <valueHelp>
+          <format>u32:1-21474836</format>
+          <description>Timeout for unreplied UDP</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-21474836"/>
+        </constraint>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/system-conntrack.xml.in
+++ b/interface-definitions/system-conntrack.xml.in
@@ -385,58 +385,122 @@
                   <help>Define custom timeouts per connection</help>
                 </properties>
                 <children>
-                  <tagNode name="rule">
+                  <node name="ipv4">
                     <properties>
-                      <help>Rule number</help>
-                      <valueHelp>
-                        <format>u32:1-999999</format>
-                        <description>Number of conntrack rule</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 1-999999"/>
-                      </constraint>
-                      <constraintErrorMessage>Ignore rule number must be between 1 and 999999</constraintErrorMessage>
+                      <help>IPv4 rules</help>
                     </properties>
                     <children>
-                      #include <include/generic-description.xml.i>
-                      <node name="destination">
+                      <tagNode name="rule">
                         <properties>
-                          <help>Destination parameters</help>
+                          <help>Rule number</help>
+                          <valueHelp>
+                            <format>u32:1-999999</format>
+                            <description>Number of conntrack rule</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-999999"/>
+                          </constraint>
+                          <constraintErrorMessage>Ignore rule number must be between 1 and 999999</constraintErrorMessage>
                         </properties>
                         <children>
-                          #include <include/nat-address.xml.i>
-                          #include <include/nat-port.xml.i>
+                          #include <include/generic-description.xml.i>
+                          <node name="destination">
+                            <properties>
+                              <help>Destination parameters</help>
+                            </properties>
+                            <children>
+                              #include <include/nat-address.xml.i>
+                              #include <include/nat-port.xml.i>
+                            </children>
+                          </node>
+                          <leafNode name="inbound-interface">
+                            <properties>
+                              <help>Interface to ignore connections tracking on</help>
+                              <completionHelp>
+                                <list>any</list>
+                                <script>${vyos_completion_dir}/list_interfaces</script>
+                              </completionHelp>
+                            </properties>
+                          </leafNode>
+                          <node name="protocol">
+                            <properties>
+                              <help>Customize protocol specific timers, one protocol configuration per rule</help>
+                            </properties>
+                            <children>
+                              #include <include/conntrack/timeout-custom-protocols.xml.i>
+                            </children>
+                          </node>
+                          <node name="source">
+                            <properties>
+                              <help>Source parameters</help>
+                            </properties>
+                            <children>
+                              #include <include/nat-address.xml.i>
+                              #include <include/nat-port.xml.i>
+                            </children>
+                          </node>
                         </children>
-                      </node>
-                      <leafNode name="inbound-interface">
-                        <properties>
-                          <help>Interface to ignore connections tracking on</help>
-                          <completionHelp>
-                            <list>any</list>
-                            <script>${vyos_completion_dir}/list_interfaces</script>
-                          </completionHelp>
-                        </properties>
-                      </leafNode>
-                      #include <include/ip-protocol.xml.i>
-                      <node name="protocol">
-                        <properties>
-                          <help>Customize protocol specific timers, one protocol configuration per rule</help>
-                        </properties>
-                        <children>
-                          #include <include/conntrack/timeout-common-protocols.xml.i>
-                        </children>
-                      </node>
-                      <node name="source">
-                        <properties>
-                          <help>Source parameters</help>
-                        </properties>
-                        <children>
-                          #include <include/nat-address.xml.i>
-                          #include <include/nat-port.xml.i>
-                        </children>
-                      </node>
+                      </tagNode>
                     </children>
-                  </tagNode>
+                  </node>
+                  <node name="ipv6">
+                    <properties>
+                      <help>IPv6 rules</help>
+                    </properties>
+                    <children>
+                      <tagNode name="rule">
+                        <properties>
+                          <help>Rule number</help>
+                          <valueHelp>
+                            <format>u32:1-999999</format>
+                            <description>Number of conntrack rule</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-999999"/>
+                          </constraint>
+                          <constraintErrorMessage>Ignore rule number must be between 1 and 999999</constraintErrorMessage>
+                        </properties>
+                        <children>
+                          #include <include/generic-description.xml.i>
+                          <node name="destination">
+                            <properties>
+                              <help>Destination parameters</help>
+                            </properties>
+                            <children>
+                              #include <include/firewall/address-ipv6.xml.i>
+                              #include <include/nat-port.xml.i>
+                            </children>
+                          </node>
+                          <leafNode name="inbound-interface">
+                            <properties>
+                              <help>Interface to ignore connections tracking on</help>
+                              <completionHelp>
+                                <list>any</list>
+                                <script>${vyos_completion_dir}/list_interfaces</script>
+                              </completionHelp>
+                            </properties>
+                          </leafNode>
+                          <node name="protocol">
+                            <properties>
+                              <help>Customize protocol specific timers, one protocol configuration per rule</help>
+                            </properties>
+                            <children>
+                              #include <include/conntrack/timeout-custom-protocols.xml.i>
+                            </children>
+                          </node>
+                          <node name="source">
+                            <properties>
+                              <help>Source parameters</help>
+                            </properties>
+                            <children>
+                              #include <include/firewall/address-ipv6.xml.i>
+                              #include <include/nat-port.xml.i>
+                            </children>
+                          </node>
+                        </children>
+                      </tagNode>
+                    </children>
+                  </node>
                 </children>
               </node>
               #include <include/conntrack/timeout-common-protocols.xml.i>

--- a/src/conf_mode/conntrack.py
+++ b/src/conf_mode/conntrack.py
@@ -159,6 +159,13 @@ def verify(conntrack):
                                     if not group_obj:
                                         Warning(f'{error_group} "{group_name}" has no members!')
 
+        if dict_search_args(conntrack, 'timeout', 'custom', inet, 'rule') != None:
+            for rule, rule_config in conntrack['timeout']['custom'][inet]['rule'].items():
+                if 'protocol' not in rule_config:
+                    raise ConfigError(f'Conntrack custom timeout rule {rule} requires protocol tcp or udp')
+                else:
+                    if 'tcp' in rule_config['protocol'] and 'udp' in rule_config['protocol']:
+                        raise ConfigError(f'conntrack custom timeout rule {rule} - Cant use both tcp and udp protocol')
     return None
 
 def generate(conntrack):

--- a/src/migration-scripts/conntrack/4-to-5
+++ b/src/migration-scripts/conntrack/4-to-5
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T5779: system conntrack timeout custom
+# Before:
+#   Protocols tcp, udp and icmp allowed. When using udp it did not work
+#   Only ipv4 custom timeout rules
+# Now:
+#   Valid protocols are only tcp or udp.
+#   Extend functionality to ipv6 and move ipv4 custom rules to new node:
+#       set system conntrack timeout custom [ipv4 | ipv6] rule <rule> ...
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['system', 'conntrack']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+
+if config.exists(base + ['timeout', 'custom', 'rule']):
+    for rule in config.list_nodes(base + ['timeout', 'custom', 'rule']):
+        if config.exists(base + ['timeout', 'custom', 'rule', rule, 'protocol', 'tcp']):
+            config.set(base + ['timeout', 'custom', 'ipv4', 'rule'])
+            config.copy(base + ['timeout', 'custom', 'rule', rule], base + ['timeout', 'custom', 'ipv4', 'rule', rule])
+    config.delete(base + ['timeout', 'custom', 'rule'])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Remove what was not working on 1.3, migrate what was working to new syntax and extend feature for ipv6.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5779

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
system conntrack

## Proposed changes
<!--- Describe your changes in detail -->
Section completely not working on 1.5 and 1.4
Partially broken on 1.3
- Remove what was not working on 1.3: using protocol udp.
- Protocols allowed: tcp or udp (icmp not supported).
- Extend feature for ipv6 and migrate valid config to new syntax

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
```
-->
Configuration
```
vyos@LATEST:~$ show config comm | grep timeout
set system conntrack timeout custom ipv4 rule 10 destination address '10.10.10.10-10.10.10.20'
set system conntrack timeout custom ipv4 rule 10 protocol tcp last-ack '1012'
set system conntrack timeout custom ipv4 rule 10 protocol tcp syn-sent '1010'
set system conntrack timeout custom ipv4 rule 20 protocol udp replied '2010'
set system conntrack timeout custom ipv4 rule 20 protocol udp unreplied '2020'
set system conntrack timeout custom ipv4 rule 20 source address '20.20.20.20'
set system conntrack timeout custom ipv4 rule 101 protocol tcp close '55'
set system conntrack timeout custom ipv4 rule 101 source address '1.2.3.4'
set system conntrack timeout custom ipv6 rule 101 destination address '2001:db8::1234'
set system conntrack timeout custom ipv6 rule 101 inbound-interface 'eth4'
set system conntrack timeout custom ipv6 rule 101 protocol udp unreplied '101'
vyos@LATEST:~$ 
```
Content of table `ip vyos_conntrack`
```
table ip vyos_conntrack {
        ct timeout ct-timeout-10 {
                protocol tcp
                l3proto ip
                policy = { syn_sent : 1010, last_ack : 1012 }
        }

        ct timeout ct-timeout-20 {
                protocol udp
                l3proto ip
                policy = { unreplied : 2020, replied : 2010 }
        }

        ct timeout ct-timeout-101 {
                protocol tcp
                l3proto ip
                policy = { close : 55 }
        }

        chain VYOS_CT_TIMEOUT {
                meta l4proto tcp ip daddr 10.10.10.10-10.10.10.20 counter ct timeout set "ct-timeout-10" comment "timeout-10"
                meta l4proto udp ip saddr 20.20.20.20 counter ct timeout set "ct-timeout-20" comment "timeout-20"
                meta l4proto tcp ip saddr 1.2.3.4 counter ct timeout set "ct-timeout-101" comment "timeout-101"
                return
        }

        chain PREROUTING {
                type filter hook prerouting priority raw; policy accept;
                counter jump VYOS_CT_HELPER
                counter jump VYOS_CT_IGNORE
                counter jump VYOS_CT_TIMEOUT
                counter jump FW_CONNTRACK
                counter jump NAT_CONNTRACK
                counter jump WLB_CONNTRACK
                notrack
        }

        chain OUTPUT {
                type filter hook output priority raw; policy accept;
                counter jump VYOS_CT_HELPER
                counter jump VYOS_CT_IGNORE
                counter jump VYOS_CT_TIMEOUT
                counter jump FW_CONNTRACK
                counter jump NAT_CONNTRACK
                notrack
        }

```
Content of table `ip6 vyos_conntrack`
```
vyos@LATEST:~$ sudo nft -s list table ip6 vyos_conntrack
table ip6 vyos_conntrack {
        ct timeout ct-timeout-101 {
                protocol udp
                l3proto ip
                policy = { unreplied : 101 }
        }

        chain VYOS_CT_IGNORE {
                return
        }

        chain VYOS_CT_TIMEOUT {
                iifname "eth4" meta l4proto udp ip6 daddr 2001:db8::1234 counter ct timeout set "ct-timeout-101" comment "timeout-101"
                return
        }

        chain PREROUTING {
                type filter hook prerouting priority raw; policy accept;
                counter jump VYOS_CT_IGNORE
                counter jump VYOS_CT_TIMEOUT
                counter jump FW_CONNTRACK
                counter jump NAT_CONNTRACK
                notrack
        }

        chain OUTPUT {
                type filter hook output priority raw; policy accept;
                counter jump VYOS_CT_IGNORE
                counter jump VYOS_CT_TIMEOUT
                counter jump FW_CONNTRACK
                counter jump NAT_CONNTRACK
                notrack
        }

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@LATEST:/usr/libexec/vyos/tests/smoke/cli# ./test_system_conntrack.py 
test_conntrack_hash_size (__main__.TestSystemConntrack.test_conntrack_hash_size) ... ok
test_conntrack_ignore (__main__.TestSystemConntrack.test_conntrack_ignore) ... ok
test_conntrack_module_enable (__main__.TestSystemConntrack.test_conntrack_module_enable) ... ok
test_conntrack_options (__main__.TestSystemConntrack.test_conntrack_options) ... ok
test_conntrack_timeout_custom (__main__.TestSystemConntrack.test_conntrack_timeout_custom) ... ok

----------------------------------------------------------------------
Ran 5 tests in 27.867s

OK
root@LATEST:/usr/libexec/vyos/tests/smoke/cli#
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
