### PR TITLE
T5804: nat: allow <any> interface for inbound and outbound

### DIFF
--- a/python/vyos/nat.py
+++ b/python/vyos/nat.py
@@ -34,11 +34,12 @@ def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
     if 'inbound_interface' in rule_conf:
         operator = ''
         if 'name' in rule_conf['inbound_interface']:
-            iiface = rule_conf['inbound_interface']['name']
-            if iiface[0] == '!':
-                operator = '!='
-                iiface = iiface[1:]
-            output.append(f'iifname {operator} {{{iiface}}}')
+            if rule_conf['inbound_interface']['name'] != 'any':
+                iiface = rule_conf['inbound_interface']['name']
+                if iiface[0] == '!':
+                    operator = '!='
+                    iiface = iiface[1:]
+                output.append(f'iifname {operator} {{{iiface}}}')
         else:
             iiface = rule_conf['inbound_interface']['group']
             if iiface[0] == '!':
@@ -49,11 +50,12 @@ def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
     if 'outbound_interface' in rule_conf:
         operator = ''
         if 'name' in rule_conf['outbound_interface']:
-            oiface = rule_conf['outbound_interface']['name']
-            if oiface[0] == '!':
-                operator = '!='
-                oiface = oiface[1:]
-            output.append(f'oifname {operator} {{{oiface}}}')
+            if rule_conf['outbound_interface']['name'] != 'any':
+                oiface = rule_conf['outbound_interface']['name']
+                if oiface[0] == '!':
+                    operator = '!='
+                    oiface = oiface[1:]
+                output.append(f'oifname {operator} {{{oiface}}}')
         else:
             oiface = rule_conf['outbound_interface']['group']
             if oiface[0] == '!':

--- a/smoketest/scripts/cli/test_nat.py
+++ b/smoketest/scripts/cli/test_nat.py
@@ -188,7 +188,7 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
     def test_dnat_without_translation_address(self):
-        self.cli_set(dst_path + ['rule', '1', 'inbound-interface', 'name', 'eth1'])
+        self.cli_set(dst_path + ['rule', '1', 'inbound-interface', 'name', 'any'])
         self.cli_set(dst_path + ['rule', '1', 'destination', 'port', '443'])
         self.cli_set(dst_path + ['rule', '1', 'protocol', 'tcp'])
         self.cli_set(dst_path + ['rule', '1', 'packet-type', 'host'])
@@ -197,7 +197,7 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         nftables_search = [
-            ['iifname "eth1"', 'tcp dport 443', 'pkttype host', 'dnat to :443']
+            ['tcp dport 443', 'pkttype host', 'dnat to :443']
         ]
 
         self.verify_nftables(nftables_search, 'ip vyos_nat')

--- a/src/migration-scripts/nat/6-to-7
+++ b/src/migration-scripts/nat/6-to-7
@@ -21,6 +21,7 @@
 # to
 #   'set nat [source|destination] rule X [inbound-interface|outbound interface] name <iface>'
 #   'set nat [source|destination] rule X [inbound-interface|outbound interface] group <iface_group>'
+# Also remove command if interface == any
 
 from sys import argv,exit
 from vyos.configtree import ConfigTree
@@ -56,8 +57,11 @@ for direction in ['source', 'destination']:
             if config.exists(base + [iface]):
                 if config.exists(base + [iface, 'interface-name']):
                     tmp = config.return_value(base + [iface, 'interface-name'])
-                    config.delete(base + [iface, 'interface-name'])
-                    config.set(base + [iface, 'name'], value=tmp)
+                    if tmp != 'any':
+                        config.delete(base + [iface, 'interface-name'])
+                        config.set(base + [iface, 'name'], value=tmp)
+                    else:
+                        config.delete(base + [iface])
 
 try:
     with open(file_name, 'w') as f:

--- a/src/op_mode/nat.py
+++ b/src/op_mode/nat.py
@@ -28,9 +28,6 @@ from vyos.configquery import ConfigTreeQuery
 from vyos.utils.process import cmd
 from vyos.utils.dict import dict_search
 
-base = 'nat'
-unconf_message = 'NAT is not configured'
-
 ArgDirection = typing.Literal['source', 'destination']
 ArgFamily = typing.Literal['inet', 'inet6']
 
@@ -293,8 +290,9 @@ def _verify(func):
     @wraps(func)
     def _wrapper(*args, **kwargs):
         config = ConfigTreeQuery()
+        base = 'nat66' if 'inet6' in sys.argv[1:] else 'nat'
         if not config.exists(base):
-            raise vyos.opmode.UnconfiguredSubsystem(unconf_message)
+            raise vyos.opmode.UnconfiguredSubsystem(f'{base.upper()} is not configured')
         return func(*args, **kwargs)
     return _wrapper
 


### PR DESCRIPTION
…
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow <any> interface for inbound and outbound interface name in vyos cli. When used, append nothing while generating the rule.

<!-- All PR should follow this template to allow a clean and transparent review -->
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5804

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@nat-any:~$ show config comm | grep nat
set nat destination rule 10 destination address '2.2.2.2'
set nat destination rule 10 inbound-interface name 'eth2'
set nat destination rule 10 translation address '3.3.3.3'
set nat destination rule 20 destination address '8.8.8.8'
set nat destination rule 20 inbound-interface name 'any'
set nat destination rule 20 translation address '9.9.9.9'
set nat source rule 10 outbound-interface name 'eth0'
set nat source rule 10 translation address 'masquerade'
set nat source rule 20 outbound-interface name 'any'
set nat source rule 20 translation address '1.1.1.1'
vyos@nat-any:~$ sudo nft list table ip vyos_nat
table ip vyos_nat {
        chain PREROUTING {
                type nat hook prerouting priority dstnat; policy accept;
                counter packets 129 bytes 30933 jump VYOS_PRE_DNAT_HOOK
                iifname "eth2" ip daddr 2.2.2.2 counter packets 0 bytes 0 dnat to 3.3.3.3 comment "DST-NAT-10"
                ip daddr 8.8.8.8 counter packets 0 bytes 0 dnat to 9.9.9.9 comment "DST-NAT-20"
        }

        chain POSTROUTING {
                type nat hook postrouting priority srcnat; policy accept;
                counter packets 2 bytes 152 jump VYOS_PRE_SNAT_HOOK
                oifname "eth0" counter packets 2 bytes 152 masquerade comment "SRC-NAT-10"
                counter packets 0 bytes 0 snat to 1.1.1.1 comment "SRC-NAT-20"
        }

        chain VYOS_PRE_DNAT_HOOK {
                return
        }

        chain VYOS_PRE_SNAT_HOOK {
                return
        }
}
vyos@nat-any:~$ 
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@nat-any:/usr/libexec/vyos/tests/smoke/cli# ./test_nat.py 
test_dnat (__main__.TestNAT.test_dnat) ... ok
test_dnat_negated_addresses (__main__.TestNAT.test_dnat_negated_addresses) ... ok
test_dnat_redirect (__main__.TestNAT.test_dnat_redirect) ... ok
test_dnat_without_translation_address (__main__.TestNAT.test_dnat_without_translation_address) ... ok
test_nat_balance (__main__.TestNAT.test_nat_balance) ... ok
test_nat_no_rules (__main__.TestNAT.test_nat_no_rules) ... ok
test_snat (__main__.TestNAT.test_snat) ... ok
test_snat_groups (__main__.TestNAT.test_snat_groups) ... ok
test_snat_required_translation_address (__main__.TestNAT.test_snat_required_translation_address) ... 
Source NAT configuration error in rule 5: translation requires address
and/or port

ok
test_static_nat (__main__.TestNAT.test_static_nat) ... ok

----------------------------------------------------------------------
Ran 10 tests in 20.896s

OK
root@nat-any:/usr/libexec/vyos/tests/smoke/cli# 

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
