### PR TITLE
image-tools: T5758: restore saving previous data on install

### DIFF
--- a/python/vyos/system/disk.py
+++ b/python/vyos/system/disk.py
@@ -150,7 +150,7 @@ def filesystem_create(partition: str, fstype: str) -> None:
 def partition_mount(partition: str,
                     path: str,
                     fsype: str = '',
-                    overlay_params: dict[str, str] = {}) -> None:
+                    overlay_params: dict[str, str] = {}) -> bool:
     """Mount a partition into a path
 
     Args:
@@ -159,6 +159,9 @@ def partition_mount(partition: str,
         fsype (str): optionally, set fstype ('squashfs', 'overlay', 'iso9660')
         overlay_params (dict): optionally, set overlay parameters.
         Defaults to None.
+
+    Returns:
+        bool: True on success
     """
     if fsype in ['squashfs', 'iso9660']:
         command: str = f'mount -o loop,ro -t {fsype} {partition} {path}'
@@ -171,7 +174,11 @@ def partition_mount(partition: str,
     else:
         command = f'mount {partition} {path}'
 
-    run(command)
+    rc = run(command)
+    if rc == 0:
+        return True
+
+    return False
 
 
 def partition_umount(partition: str = '', path: str = '') -> None:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Restore scanning previous installations for config data and ssh host keys on install.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe):
        -- missing functionality of revision

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5758

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
