### PR TITLE
T5798: load-balancing revese-proxy add multiple SSL certificates

### DIFF
--- a/data/templates/load-balancing/haproxy.cfg.j2
+++ b/data/templates/load-balancing/haproxy.cfg.j2
@@ -50,13 +50,19 @@ defaults
 {% if service is vyos_defined %}
 {%     for front, front_config in service.items() %}
 frontend {{ front }}
-{%         set ssl_front =  'ssl crt /run/haproxy/' ~ front_config.ssl.certificate ~ '.pem' if front_config.ssl.certificate is vyos_defined else '' %}
+{%         set ssl_front = [] %}
+{%         if front_config.ssl.certificate is vyos_defined and front_config.ssl.certificate is iterable %}
+{%             for cert in front_config.ssl.certificate %}
+{%                 set _ = ssl_front.append('crt /run/haproxy/' ~ cert ~ '.pem') %}
+{%             endfor %}
+{%         endif %}
+{%         set ssl_directive = 'ssl' if ssl_front else '' %}
 {%         if front_config.listen_address is vyos_defined %}
 {%             for address in front_config.listen_address %}
-    bind {{ address | bracketize_ipv6 }}:{{ front_config.port }} {{ ssl_front }}
+    bind {{ address | bracketize_ipv6 }}:{{ front_config.port }} {{ ssl_directive }} {{ ssl_front | join(' ') }}
 {%             endfor %}
 {%         else %}
-    bind :::{{ front_config.port }} v4v6 {{ ssl_front }}
+    bind :::{{ front_config.port }} v4v6 {{ ssl_directive }} {{ ssl_front | join(' ') }}
 {%         endif %}
 {%         if front_config.redirect_http_to_https is vyos_defined %}
     http-request redirect scheme https unless { ssl_fc }
@@ -161,4 +167,3 @@ backend {{ back }}
 
 {%     endfor %}
 {% endif %}
-

--- a/interface-definitions/include/pki/certificate-multi.xml.i
+++ b/interface-definitions/include/pki/certificate-multi.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from pki/certificate-multi.xml.i -->
+<leafNode name="certificate">
+  <properties>
+    <help>Certificate in PKI configuration</help>
+    <completionHelp>
+      <path>pki certificate</path>
+    </completionHelp>
+    <valueHelp>
+      <format>txt</format>
+      <description>Name of certificate in PKI configuration</description>
+    </valueHelp>
+    <multi/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/load-balancing-haproxy.xml.in
+++ b/interface-definitions/load-balancing-haproxy.xml.in
@@ -49,7 +49,7 @@
                   <help>SSL Certificate, SSL Key and CA</help>
                 </properties>
                 <children>
-                  #include <include/pki/certificate.xml.i>
+                  #include <include/pki/certificate-multi.xml.i>
                 </children>
               </node>
             </children>

--- a/src/conf_mode/load-balancing-haproxy.py
+++ b/src/conf_mode/load-balancing-haproxy.py
@@ -108,17 +108,19 @@ def generate(lb):
         if 'ssl' in front_config:
 
             if 'certificate' in front_config['ssl']:
-                cert_name = front_config['ssl']['certificate']
-                pki_cert = lb['pki']['certificate'][cert_name]
-                cert_file_path = os.path.join(load_balancing_dir, f'{cert_name}.pem')
-                cert_key_path = os.path.join(load_balancing_dir, f'{cert_name}.pem.key')
+                cert_names = front_config['ssl']['certificate']
 
-                with open(cert_file_path, 'w') as f:
-                    f.write(wrap_certificate(pki_cert['certificate']))
+                for cert_name in cert_names:
+                    pki_cert = lb['pki']['certificate'][cert_name]
+                    cert_file_path = os.path.join(load_balancing_dir, f'{cert_name}.pem')
+                    cert_key_path = os.path.join(load_balancing_dir, f'{cert_name}.pem.key')
 
-                if 'private' in pki_cert and 'key' in pki_cert['private']:
-                    with open(cert_key_path, 'w') as f:
-                        f.write(wrap_private_key(pki_cert['private']['key']))
+                    with open(cert_file_path, 'w') as f:
+                        f.write(wrap_certificate(pki_cert['certificate']))
+
+                    if 'private' in pki_cert and 'key' in pki_cert['private']:
+                        with open(cert_key_path, 'w') as f:
+                            f.write(wrap_private_key(pki_cert['private']['key']))
 
             if 'ca_certificate' in front_config['ssl']:
                 ca_name = front_config['ssl']['ca_certificate']


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add the ability to configure multiple SSL certificates for frontend/service.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5798

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
load-balancing, haproxy, reverse-proxy
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add multiple SSL certificates for one service (frontend)
```
set load-balancing reverse-proxy service web mode http
set load-balancing reverse-proxy service web port 443
set load-balancing reverse-proxy service web ssl certificate cert 
set load-balancing reverse-proxy service web ssl certificate client1 
set load-balancing reverse-proxy backend bk01 server srv01 address 192.0.2.1
set load-balancing reverse-proxy backend bk01 server srv01 port 9898

```
Check that the configuration is valid and there is two certificates
```
vyos@r4# sudo haproxy -c -f /run/haproxy/haproxy.cfg 
Configuration file is valid

vyos@r4# cat /run/haproxy/haproxy.cfg | grep Front -A 3
# Frontend
frontend web
    bind :::443 v4v6 ssl crt /run/haproxy/cert.pem crt /run/haproxy/client1.pem
    mode http

```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_load_balancing_reverse_proxy.py
test_01_lb_reverse_proxy_domain (__main__.TestLoadBalancingReverseProxy.test_01_lb_reverse_proxy_domain) ... ok

----------------------------------------------------------------------
Ran 1 test in 5.710s

OK
vyos@r4:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
