### PR TITLE
T5812: Fix for rollback check max revision number

### DIFF
--- a/python/vyos/config_mgmt.py
+++ b/python/vyos/config_mgmt.py
@@ -233,7 +233,7 @@ Proceed ?'''
         msg = ''
 
         if not self._check_revision_number(rev):
-            msg = f'Invalid revision number {rev}: must be 0 < rev < {maxrev}'
+            msg = f'Invalid revision number {rev}: must be 0 < rev < {self.max_revisions}'
             return msg, 1
 
         prompt_str = 'Proceed with reboot ?'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix for rollback check max revision number
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5812

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
rollback
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Before the fix:
```
vyos@r4# rollback 150
Traceback (most recent call last):
  File "/usr/bin/config-mgmt", line 33, in <module>
    sys.exit(load_entry_point('vyos==1.3.0', 'console_scripts', 'config-mgmt')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/config_mgmt.py", line 757, in run
    res, rc = func(**args)
              ^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/config_mgmt.py", line 236, in rollback
    msg = f'Invalid revision number {rev}: must be 0 < rev < {maxrev}'
                                                              ^^^^^^
NameError: name 'maxrev' is not defined
[edit]
vyos@r4#
```
After the fix:
```
vyos@r4# rollback 150
Invalid revision number 150: must be 0 < rev < 100
[edit]
vyos@r4# 
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
