### PR TITLE
T5791: DNS dynamic exclude check for dynamic interfaces PPPoE

### DIFF
--- a/src/conf_mode/dns_dynamic.py
+++ b/src/conf_mode/dns_dynamic.py
@@ -18,6 +18,7 @@ import os
 
 from sys import exit
 
+from vyos.base import Warning
 from vyos.config import Config
 from vyos.configverify import verify_interface_exists
 from vyos.template import render
@@ -88,7 +89,12 @@ def verify(dyndns):
         # If dyndns address is an interface, ensure that it exists
         # and that web-options are not set
         if config['address'] != 'web':
-            verify_interface_exists(config['address'])
+            # exclude check interface for dynamic interfaces
+            interface_filter = ('pppoe', 'sstpc')
+            if config['address'].startswith(interface_filter):
+                Warning(f'interface {config["address"]} does not exist!')
+            else:
+                verify_interface_exists(config['address'])
             if 'web_options' in config:
                 raise ConfigError(f'"web-options" is applicable only when using HTTP(S) web request to obtain the IP address')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Dynamic interfaces such as PPPoE can not exist during verification dns dynamic. As they added and removed dynamically
Add interface_filter to exclude them from checks


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5791

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
Before the fix
```
 DEBUG - test_dialup_router_wireguard_ipv6 (__main__.TestConfigDialupRouterWireguardIpv6.test_dialup_router_wireguard_ipv6) ...
DEBUG - Interface "pppoe0" does not exist!

 DEBUG - ======================================================================
DEBUG - FAIL: test_dialup_router_wireguard_ipv6 (__main__.TestConfigDialupRouterWireguardIpv6.test_dialup_router_wireguard_ipv6)
DEBUG - ----------------------------------------------------------------------
DEBUG - Traceback (most recent call last):
DEBUG -   File "/usr/bin/vyos-configtest", line 51, in test_config_load
DEBUG -     self.session.commit()
DEBUG -   File "/usr/lib/python3/dist-packages/vyos/configsession.py", line 187, in commit
DEBUG -     out = self.__run_command([COMMIT])
DEBUG -           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
DEBUG -   File "/usr/lib/python3/dist-packages/vyos/configsession.py", line 143, in __run_command
DEBUG -     raise ConfigSessionError(output)
DEBUG - vyos.configsession.ConfigSessionError: [[]] failed
```
After the fix:
```
vyos@r4# load dialup-router-wireguard-ipv6
Loading configuration from 'dialup-router-wireguard-ipv6'
Load complete. Use 'commit' to make changes effective.
[edit]
vyos@r4# commit
[ service dns dynamic ]

WARNING: interface pppoe0 does not exist!



```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
