### PR TITLE
SRv6: T591: initial implementation to support locator definition

### DIFF
--- a/data/configd-include.json
+++ b/data/configd-include.json
@@ -53,6 +53,7 @@
 "protocols_rip.py",
 "protocols_ripng.py",
 "protocols_rpki.py",
+"protocols_segment_routing.py",
 "protocols_static.py",
 "protocols_static_multicast.py",
 "qos.py",

--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -588,6 +588,14 @@ bgp route-reflector allow-outbound-policy
 {% if parameters.tcp_keepalive.idle is vyos_defined and parameters.tcp_keepalive.interval is vyos_defined and parameters.tcp_keepalive.probes is vyos_defined %}
  bgp tcp-keepalive {{ parameters.tcp_keepalive.idle }} {{ parameters.tcp_keepalive.interval }} {{ parameters.tcp_keepalive.probes }}
 {% endif %}
+{% if srv6.locator is vyos_defined %}
+ segment-routing srv6
+  locator {{ srv6.locator }}
+ exit
+{% endif %}
+{% if sid.vpn.per_vrf.export is vyos_defined %}
+ sid vpn per-vrf export {{ sid.vpn.per_vrf.export }}
+{% endif %}
 {% if timers.keepalive is vyos_defined and timers.holdtime is vyos_defined %}
  timers bgp {{ timers.keepalive }} {{ timers.holdtime }}
 {% endif %}

--- a/data/templates/frr/zebra.segment_routing.frr.j2
+++ b/data/templates/frr/zebra.segment_routing.frr.j2
@@ -1,0 +1,23 @@
+!
+{% if srv6.locator is vyos_defined %}
+segment-routing
+ srv6
+  locators
+{%     for locator, locator_config in srv6.locator.items() %}
+   locator {{ locator }}
+{%         if locator_config.prefix is vyos_defined %}
+    prefix {{ locator_config.prefix }} block-len {{ locator_config.block_len }} node-len {{ locator_config.node_len }} func-bits {{ locator_config.func_bits }}
+{%         endif %}
+{%         if locator_config.behavior_usid is vyos_defined %}
+    behavior usid
+{%         endif %}
+    exit
+    !
+{%     endfor %}
+  exit
+  !
+exit
+!
+exit
+!
+{% endif %}

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -1639,6 +1639,66 @@
     #include <include/port-number.xml.i>
   </children>
 </tagNode>
+<node name="srv6">
+  <properties>
+    <help>Segment-Routing SRv6 configuration</help>
+  </properties>
+  <children>
+    <leafNode name="locator">
+      <properties>
+        <help>Specify SRv6 locator</help>
+        <valueHelp>
+          <format>txt</format>
+          <description>SRv6 locator name</description>
+        </valueHelp>
+        <constraint>
+          #include <include/constraint/alpha-numeric-hyphen-underscore.xml.i>
+        </constraint>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<node name="sid">
+  <properties>
+    <help>SID value for VRF</help>
+  </properties>
+  <children>
+    <node name="vpn">
+      <properties>
+        <help>Between current VRF and VPN</help>
+      </properties>
+      <children>
+        <node name="per-vrf">
+          <properties>
+            <help>SID per-VRF (both IPv4 and IPv6 address families)</help>
+          </properties>
+          <children>
+            <leafNode name="export">
+              <properties>
+                <help>For routes leaked from current VRF to VPN</help>
+                <completionHelp>
+                  <list>auto</list>
+                </completionHelp>
+                <valueHelp>
+                  <format>u32:1-1048575</format>
+                  <description>SID allocation index</description>
+                </valueHelp>
+                <valueHelp>
+                  <format>auto</format>
+                  <description>Automatically assign a label</description>
+                </valueHelp>
+                <constraint>
+                  <regex>auto</regex>
+                  <validator name="numeric" argument="--range 1-1048575"/>
+                </constraint>
+              </properties>
+            </leafNode>
+          </children>
+        </node>
+      </children>
+    </node>
+  </children>
+</node>
 <node name="timers">
   <properties>
     <help>BGP protocol timers</help>

--- a/interface-definitions/include/constraint/alpha-numeric-hyphen-underscore.xml.i
+++ b/interface-definitions/include/constraint/alpha-numeric-hyphen-underscore.xml.i
@@ -1,3 +1,3 @@
-<!-- include start from include/constraint/alpha-numeric-hyphen-underscore.xml.i -->
+<!-- include start from constraint/alpha-numeric-hyphen-underscore.xml.i -->
 <regex>[-_a-zA-Z0-9]+</regex>
 <!-- include end -->

--- a/interface-definitions/include/constraint/dhcp-client-string-option.xml.i
+++ b/interface-definitions/include/constraint/dhcp-client-string-option.xml.i
@@ -1,4 +1,4 @@
-<!-- include start from include/constraint/dhcp-client-string-option.xml.i -->
+<!-- include start from constraint/dhcp-client-string-option.xml.i -->
 <regex>[-_a-zA-Z0-9\s]+</regex>
 <regex>([a-fA-F0-9][a-fA-F0-9]:){2,}[a-fA-F0-9][a-fA-F0-9]</regex>
 <!-- include end -->

--- a/interface-definitions/protocols-segment-routing.xml.in
+++ b/interface-definitions/protocols-segment-routing.xml.in
@@ -1,0 +1,89 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="protocols">
+    <children>
+       <node name="segment-routing" owner="${vyos_conf_scripts_dir}/protocols_segment_routing.py">
+        <properties>
+          <help>Segment Routing</help>
+          <priority>900</priority>
+        </properties>
+        <children>
+          <node name="srv6">
+            <properties>
+              <help>Segment-Routing SRv6 configuration</help>
+            </properties>
+            <children>
+              <tagNode name="locator">
+                <properties>
+                  <help>Segment Routing SRv6 locator</help>
+                  <constraint>
+                    #include <include/constraint/alpha-numeric-hyphen-underscore.xml.i>
+                  </constraint>
+                </properties>
+                <children>
+                  <leafNode name="behavior-usid">
+                    <properties>
+                      <help>Set SRv6 behavior uSID</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="prefix">
+                    <properties>
+                      <help>SRv6 locator prefix</help>
+                      <valueHelp>
+                        <format>ipv6net</format>
+                        <description>SRv6 locator prefix</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="ipv6-prefix"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="block-len">
+                    <properties>
+                      <help>Configure SRv6 locator block length in bits</help>
+                      <valueHelp>
+                        <format>u32:16-64</format>
+                        <description>Specify SRv6 locator block length in bits</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 16-64"/>
+                      </constraint>
+                    </properties>
+                    <defaultValue>40</defaultValue>
+                  </leafNode>
+                  <leafNode name="func-bits">
+                    <properties>
+                      <help>Configure SRv6 locator function length in bits</help>
+                      <valueHelp>
+                        <format>u32:0-64</format>
+                        <description>Specify SRv6 locator function length in bits</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-64"/>
+                      </constraint>
+                    </properties>
+                    <defaultValue>16</defaultValue>
+                  </leafNode>
+                  <leafNode name="node-len">
+                    <properties>
+                      <help>Configure SRv6 locator node length in bits</help>
+                      <valueHelp>
+                        <format>u32:16-64</format>
+                        <description>Configure SRv6 locator node length in bits</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 16-64"/>
+                      </constraint>
+                    </properties>
+                    <defaultValue>24</defaultValue>
+                  </leafNode>
+                </children>
+              </tagNode>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/op-mode-definitions/show-bgp.xml.in
+++ b/op-mode-definitions/show-bgp.xml.in
@@ -100,6 +100,19 @@
             </children>
           </tagNode>
           #include <include/vtysh-generic-wide.xml.i>
+          <node name="segment-routing">
+            <properties>
+              <help>BGP Segment Routing</help>
+            </properties>
+            <children>
+              <leafNode name="srv6">
+                <properties>
+                  <help>BGP Segment Routing SRv6</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+              </leafNode>
+            </children>
+          </node>
         </children>
       </node>
     </children>

--- a/op-mode-definitions/show-segment-routing.xml.in
+++ b/op-mode-definitions/show-segment-routing.xml.in
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="show">
+    <children>
+      <node name="segment-routing">
+        <properties>
+          <help>Show Segment Routing</help>
+        </properties>
+        <children>
+          <node name="srv6">
+            <properties>
+              <help>Segment Routing SRv6</help>
+            </properties>
+            <children>
+              <node name="locator">
+                <properties>
+                  <help>Locator Information</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+              </node>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -1133,5 +1133,20 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f' mpls bgp forwarding', frrconfig)
             self.cli_delete(['interfaces', 'ethernet', interface, 'vrf'])
 
+    def test_bgp_24_srv6_sid(self):
+        locator_name = 'VyOS_foo'
+        sid = 'auto'
+
+        self.cli_set(base_path + ['srv6', 'locator', locator_name])
+        self.cli_set(base_path + ['sid', 'vpn', 'per-vrf', 'export', sid])
+
+        self.cli_commit()
+
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
+        self.assertIn(f'router bgp {ASN}', frrconfig)
+        self.assertIn(f' segment-routing srv6', frrconfig)
+        self.assertIn(f'  locator {locator_name}', frrconfig)
+        self.assertIn(f' sid vpn per-vrf export {sid}', frrconfig)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/smoketest/scripts/cli/test_protocols_segment_routing.py
+++ b/smoketest/scripts/cli/test_protocols_segment_routing.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+
+from base_vyostest_shim import VyOSUnitTestSHIM
+
+from vyos.configsession import ConfigSessionError
+from vyos.utils.process import cmd
+from vyos.utils.process import process_named_running
+
+base_path = ['protocols', 'segment-routing']
+PROCESS_NAME = 'zebra'
+
+class TestProtocolsSegmentRouting(VyOSUnitTestSHIM.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # call base-classes classmethod
+        super(TestProtocolsSegmentRouting, cls).setUpClass()
+        # Retrieve FRR daemon PID - it is not allowed to crash, thus PID must remain the same
+        cls.daemon_pid = process_named_running(PROCESS_NAME)
+        # ensure we can also run this test on a live system - so lets clean
+        # out the current configuration :)
+        cls.cli_delete(cls, base_path)
+
+    def tearDown(self):
+        self.cli_delete(base_path)
+        self.cli_commit()
+
+        # check process health and continuity
+        self.assertEqual(self.daemon_pid, process_named_running(PROCESS_NAME))
+
+    def test_srv6(self):
+        locators = {
+            'foo' : { 'prefix' : '2001:a::/64' },
+            'foo' : { 'prefix' : '2001:b::/64', 'usid' : {} },
+        }
+
+        for locator, locator_config in locators.items():
+            self.cli_set(base_path + ['srv6', 'locator', locator, 'prefix', locator_config['prefix']])
+            if 'usid' in locator_config:
+                self.cli_set(base_path + ['srv6', 'locator', locator, 'behavior-usid'])
+
+        self.cli_commit()
+
+        frrconfig = self.getFRRconfig(f'segment-routing', daemon='zebra')
+        self.assertIn(f'segment-routing', frrconfig)
+        self.assertIn(f' srv6', frrconfig)
+        self.assertIn(f'  locators', frrconfig)
+        for locator, locator_config in locators.items():
+            self.assertIn(f'   locator {locator}', frrconfig)
+            self.assertIn(f'    prefix {locator_config["prefix"]} block-len 40 node-len 24 func-bits 16', frrconfig)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -93,6 +93,7 @@ def get_config(config=None):
     tmp = conf.get_config_dict(['policy'])
     # Merge policy dict into "regular" config dict
     bgp = dict_merge(tmp, bgp)
+
     return bgp
 
 

--- a/src/conf_mode/protocols_segment_routing.py
+++ b/src/conf_mode/protocols_segment_routing.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from sys import exit
+
+from vyos.config import Config
+from vyos.template import render_to_string
+from vyos import ConfigError
+from vyos import frr
+from vyos import airbag
+airbag.enable()
+
+def get_config(config=None):
+    if config:
+        conf = config
+    else:
+        conf = Config()
+
+    base = ['protocols', 'segment-routing']
+    sr = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True, no_tag_node_value_mangle=True)
+
+    # We have gathered the dict representation of the CLI, but there are default
+    # options which we need to update into the dictionary retrived.
+    sr = conf.merge_defaults(sr, recursive=True)
+
+    return sr
+
+def verify(static):
+    return None
+
+def generate(static):
+    if not static:
+        return None
+
+    static['new_frr_config'] = render_to_string('frr/zebra.segment_routing.frr.j2', static)
+    return None
+
+def apply(static):
+    zebra_daemon = 'zebra'
+
+    # Save original configuration prior to starting any commit actions
+    frr_cfg = frr.FRRConfig()
+    frr_cfg.load_configuration(zebra_daemon)
+    frr_cfg.modify_section(r'^segment-routing')
+    if 'new_frr_config' in static:
+        frr_cfg.add_before(frr.default_add_before, static['new_frr_config'])
+    frr_cfg.commit_configuration(zebra_daemon)
+
+    return None
+
+if __name__ == '__main__':
+    try:
+        c = get_config()
+        verify(c)
+        generate(c)
+        apply(c)
+    except ConfigError as e:
+        print(e)
+        exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Initial implementation for SRv6 locator definition and BGP

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T591

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
FRR

## Proposed changes
<!--- Describe your changes in detail -->

VyOS feature extension (SRv6)

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```console
set protocols segment-routing srv6 locator bar prefix '2001:b::/64'
set protocols segment-routing srv6 locator foo behavior-usid
set protocols segment-routing srv6 locator foo prefix '2001:a::/64'

set protocols bgp sid vpn per-vrf export '99'
set protocols bgp srv6 locator 'foo'
set protocols bgp system-as '100'
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ... ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ... ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ... ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ... ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ... ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ... ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ... ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ... ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ... ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ... ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok
test_bgp_24_srv6_sid (__main__.TestProtocolsBGP.test_bgp_24_srv6_sid) ... ok

cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_segment_routing.py
test_srv6 (__main__.TestProtocolsSegmentRouting.test_srv6) ... ok

----------------------------------------------------------------------
Ran 1 test in 5.669s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
