### PR TITLE
ddclient: T5791: Adjust warning messages, minor refactor and smoketest updates

### DIFF
--- a/smoketest/scripts/cli/test_service_dns_dynamic.py
+++ b/smoketest/scripts/cli/test_service_dns_dynamic.py
@@ -288,7 +288,36 @@ class TestServiceDDNS(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'password=\'{password}\'', ddclient_conf)
         self.assertIn(f'{hostname}', ddclient_conf)
 
-    def test_07_dyndns_vrf(self):
+    def test_07_dyndns_dynamic_interface(self):
+        # Check if DDNS service can be configured and runs
+        svc_path = name_path + ['namecheap']
+        proto = 'namecheap'
+        dyn_interface = 'pppoe587'
+
+        self.cli_set(svc_path + ['address', dyn_interface])
+        self.cli_set(svc_path + ['protocol', proto])
+        self.cli_set(svc_path + ['server', server])
+        self.cli_set(svc_path + ['username', username])
+        self.cli_set(svc_path + ['password', password])
+        self.cli_set(svc_path + ['host-name', hostname])
+
+        # Dynamic interface will raise a warning but still go through
+        # XXX: We should have idiomatic class "ConfigSessionWarning" wrapping
+        #      "Warning" similar to "ConfigSessionError".
+        # with self.assertWarns(Warning):
+        #     self.cli_commit()
+        self.cli_commit()
+
+        # Check the generating config parameters
+        ddclient_conf = cmd(f'sudo cat {DDCLIENT_CONF}')
+        self.assertIn(f'ifv4={dyn_interface}', ddclient_conf)
+        self.assertIn(f'protocol={proto}', ddclient_conf)
+        self.assertIn(f'server={server}', ddclient_conf)
+        self.assertIn(f'login={username}', ddclient_conf)
+        self.assertIn(f'password=\'{password}\'', ddclient_conf)
+        self.assertIn(f'{hostname}', ddclient_conf)
+
+    def test_08_dyndns_vrf(self):
         # Table number randomized, but should be within range 100-65535
         vrf_table = '58710'
         vrf_name = f'vyos-test-{vrf_table}'

--- a/smoketest/scripts/cli/test_service_dns_dynamic.py
+++ b/smoketest/scripts/cli/test_service_dns_dynamic.py
@@ -17,8 +17,6 @@
 import os
 import unittest
 import tempfile
-import random
-import string
 
 from base_vyostest_shim import VyOSUnitTestSHIM
 
@@ -67,14 +65,12 @@ class TestServiceDDNS(VyOSUnitTestSHIM.TestCase):
             self.cli_set(name_path + [svc, 'address', interface])
             self.cli_set(name_path + [svc, 'host-name', hostname])
             self.cli_set(name_path + [svc, 'password', password])
-            self.cli_set(name_path + [svc, 'zone', zone])
-            self.cli_set(name_path + [svc, 'ttl', ttl])
             for opt, value in details.items():
                 self.cli_set(name_path + [svc, opt, value])
 
-            # 'zone' option is supported and required by 'cloudfare', but not 'freedns' and 'zoneedit'
+            # 'zone' option is supported by 'cloudfare' and 'zoneedit1', but not 'freedns'
             self.cli_set(name_path + [svc, 'zone', zone])
-            if details['protocol'] == 'cloudflare':
+            if details['protocol'] in ['cloudflare', 'zoneedit1']:
                 pass
             else:
                 # exception is raised for unsupported ones


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This is a follow-up to #2602 with the following changes:
- ~exclude pseudo-interfaces from strict checking~
- adjust warning messages and minor refactoring
- add a corresponding smoke test
- cleanup smoke tests a bit

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5791

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dns dynamic

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@v15-1210:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_service_dns_dynamic.py 
test_01_dyndns_service_standard (__main__.TestServiceDDNS.test_01_dyndns_service_standard) ... 
"zone" is not supported for Dynamic DNS service "freedns" with protocol
"freedns"


"ttl" is not supported for Dynamic DNS service "freedns" with protocol
"freedns"


"ttl" is not supported for Dynamic DNS service "zoneedit" with protocol
"zoneedit1"

ok
test_02_dyndns_service_ipv6 (__main__.TestServiceDDNS.test_02_dyndns_service_ipv6) ... 
"expiry-time" must be greater than "wait-time" for Dynamic DNS service
"dynv6"

ok
test_03_dyndns_service_dual_stack (__main__.TestServiceDDNS.test_03_dyndns_service_dual_stack) ... 
Both IPv4 and IPv6 at the same time is not supported for Dynamic DNS
service "google" with protocol "googledomains"

ok
test_04_dyndns_rfc2136 (__main__.TestServiceDDNS.test_04_dyndns_rfc2136) ... ok
test_05_dyndns_hostname (__main__.TestServiceDDNS.test_05_dyndns_hostname) ... ok
test_06_dyndns_web_options (__main__.TestServiceDDNS.test_06_dyndns_web_options) ... 
"web-options" is applicable only when using HTTP(S) web request to
obtain the IP address

ok
test_07_dyndns_dynamic_interface (__main__.TestServiceDDNS.test_07_dyndns_dynamic_interface) ... 
WARNING: Interface "pppoe587" does not exist for Dynamic DNS service
"namecheap" yet! The service will not operate correctly till the
interface is configured.

ok
test_08_dyndns_vrf (__main__.TestServiceDDNS.test_08_dyndns_vrf) ... ok

----------------------------------------------------------------------
Ran 8 tests in 292.142s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
