### PR TITLE
T5807: fix op-mode command <show nat66>

### DIFF
--- a/src/op_mode/nat.py
+++ b/src/op_mode/nat.py
@@ -28,9 +28,6 @@ from vyos.configquery import ConfigTreeQuery
 from vyos.utils.process import cmd
 from vyos.utils.dict import dict_search
 
-base = 'nat'
-unconf_message = 'NAT is not configured'
-
 ArgDirection = typing.Literal['source', 'destination']
 ArgFamily = typing.Literal['inet', 'inet6']
 
@@ -293,8 +290,9 @@ def _verify(func):
     @wraps(func)
     def _wrapper(*args, **kwargs):
         config = ConfigTreeQuery()
+        base = 'nat66' if 'inet6' in sys.argv[1:] else 'nat'
         if not config.exists(base):
-            raise vyos.opmode.UnconfiguredSubsystem(unconf_message)
+            raise vyos.opmode.UnconfiguredSubsystem(f'{base.upper()} is not configured')
         return func(*args, **kwargs)
     return _wrapper
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix op-mode command <show nat66>, which only display rules if nat was configured. In this commit, check is fixed and rules are printed as expected.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5807

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat66

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Only nat66 rules:
```
vyos@vyos:~$ show config comm | grep nat
set nat66 destination rule 100 destination address '2001:db8::1'
set nat66 destination rule 100 inbound-interface name 'eth1'
set nat66 destination rule 100 translation address '2001:db8:2222::1'
set nat66 source rule 100 outbound-interface name 'eth2'
set nat66 source rule 100 source prefix '2001:db8:2222::/64'
set nat66 source rule 100 translation address 'masquerade'
vyos@vyos:~$ show nat66 source rules 
Rule    Source              Destination    Proto    Out-Int    Translation
------  ------------------  -------------  -------  ---------  -------------
100     2001:db8:2222::/64  ::/0           IP6      eth2       masquerade
        sport any           dport any
vyos@vyos:~$ show nat66 destination rules 
Rule    Source     Destination    Proto    In-Int    Translation
------  ---------  -------------  -------  --------  ----------------
100     ::/0       2001:db8::1    any      eth1      2001:db8:2222::1
        sport any  dport any
vyos@vyos:~$ 
vyos@vyos:~$ show nat source rules 
NAT is not configured
vyos@vyos:~$ 
```
Only nat rules:
```
vyos@vyos:~$ show config comm | grep nat
set nat destination rule 20 inbound-interface name 'eth2'
set nat destination rule 20 translation address '198.51.100.1'
set nat source rule 10 outbound-interface name 'eth3'
set nat source rule 10 translation address 'masquerade'
vyos@vyos:~$ 
vyos@vyos:~$ show nat source rules 
Rule    Source     Destination    Proto    Out-Int    Translation
------  ---------  -------------  -------  ---------  -------------
10      0.0.0.0/0  0.0.0.0/0      any      eth3       masquerade
        sport any  dport any
vyos@vyos:~$ show nat destination rules 
Rule    Source     Destination    Proto    In-Int    Translation
------  ---------  -------------  -------  --------  -------------
20      0.0.0.0/0  0.0.0.0/0      any      eth2      198.51.100.1
        sport any  dport any
     
vyos@vyos:~$ show nat66 source rules 
NAT66 is not configured
vyos@vyos:~$ show nat66 destination rules 
NAT66 is not configured
vyos@vyos:~$ 

```



## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
