### PR TITLE
ddclient: T5144,T5791: Fix migration to avoid config name conflict

### DIFF
--- a/interface-definitions/dns-dynamic.xml.in
+++ b/interface-definitions/dns-dynamic.xml.in
@@ -19,6 +19,10 @@
                     <format>txt</format>
                     <description>Dynamic DNS service name</description>
                   </valueHelp>
+                  <constraint>
+                    #include <include/constraint/alpha-numeric-hyphen-underscore.xml.i>
+                  </constraint>
+                  <constraintErrorMessage>Dynamic DNS service name must be alphanumeric and can contain hyphens and underscores</constraintErrorMessage>
                 </properties>
                 <children>
                   #include <include/generic-description.xml.i>

--- a/src/migration-scripts/dns-dynamic/0-to-1
+++ b/src/migration-scripts/dns-dynamic/0-to-1
@@ -81,20 +81,33 @@ for address in config.list_nodes(new_base_path):
                 config.rename(new_base_path + [address, 'service', svc_cfg, 'login'], 'username')
             # Apply global 'ipv6-enable' to per <config> 'ip-version: ipv6'
             if config.exists(new_base_path + [address, 'ipv6-enable']):
-                config.set(new_base_path + [address, 'service', svc_cfg, 'ip-version'],
-                           value='ipv6', replace=False)
+                config.set(new_base_path + [address, 'service', svc_cfg, 'ip-version'], 'ipv6')
                 config.delete(new_base_path + [address, 'ipv6-enable'])
             # Apply service protocol mapping upfront, they are not 'auto-detected' anymore
             if svc_cfg in service_protocol_mapping:
                 config.set(new_base_path + [address, 'service', svc_cfg, 'protocol'],
-                           value=service_protocol_mapping.get(svc_cfg), replace=False)
+                           service_protocol_mapping.get(svc_cfg))
 
-    # Migrate "service dns dynamic interface <interface> use-web"
-    #      to "service dns dynamic address <address> web-options"
-    # Also, rename <address> to 'web' literal for backward compatibility
+    # If use-web is set, then:
+    #   Move "service dns dynamic address <address> <service|rfc2136> <service> ..."
+    #     to "service dns dynamic address web <service|rfc2136> <service>-<address> ..."
+    #   Move "service dns dynamic address web use-web ..."
+    #     to "service dns dynamic address web web-options ..."
+    # Note: The config is named <service>-<address> to avoid name conflict with old entries
     if config.exists(new_base_path + [address, 'use-web']):
-        config.rename(new_base_path + [address], 'web')
-        config.rename(new_base_path + ['web', 'use-web'], 'web-options')
+        for svc_type in ['rfc2136', 'service']:
+            if config.exists(new_base_path + [address, svc_type]):
+                config.set(new_base_path + ['web', svc_type])
+                config.set_tag(new_base_path + ['web', svc_type])
+                for svc_cfg in config.list_nodes(new_base_path + [address, svc_type]):
+                    config.copy(new_base_path + [address, svc_type, svc_cfg],
+                                new_base_path + ['web', svc_type, f'{svc_cfg}-{address}'])
+
+        # Multiple web-options were not supported, so copy only the first one
+        if not config.exists(new_base_path + ['web', 'web-options']):
+            config.copy(new_base_path + [address, 'use-web'], new_base_path + ['web', 'web-options'])
+
+        config.delete(new_base_path + [address])
 
 try:
     with open(file_name, 'w') as f:

--- a/src/migration-scripts/dns-dynamic/2-to-3
+++ b/src/migration-scripts/dns-dynamic/2-to-3
@@ -21,9 +21,26 @@
 #        to "service dns dynamic name <service> address <interface> protocol 'nsupdate'"
 # - migrate "service dns dynamic address <interface> service <service> ..."
 #        to "service dns dynamic name <service> address <interface> ..."
+# - normalize the all service names to conform with name constraints
 
 import sys
+import re
+from unicodedata import normalize
 from vyos.configtree import ConfigTree
+
+def normalize_name(name):
+    """Normalize service names to conform with name constraints.
+
+    This is necessary as part of migration because there were no constraints in
+    the old name format.
+    """
+    # Normalize unicode characters to ASCII (NFKD)
+    # Replace all separators with hypens, strip leading and trailing hyphens
+    name = normalize('NFKD', name).encode('ascii', 'ignore').decode()
+    name = re.sub(r'(\s|\W)+', '-', name).strip('-')
+
+    return name
+
 
 if len(sys.argv) < 2:
     print("Must specify file name!")
@@ -64,21 +81,35 @@ for address in config.list_nodes(address_path):
 
     for svc_type in ['service', 'rfc2136']:
         if config.exists(address_path_tag + [svc_type]):
-            # Move RFC2136 as service configuration, rename to avoid name conflict and set protocol to 'nsupdate'
+            # Set protocol to 'nsupdate' for RFC2136 configuration
             if svc_type == 'rfc2136':
-                for rfc_cfg_old in config.list_nodes(address_path_tag + ['rfc2136']):
-                    rfc_cfg_new = f'{rfc_cfg_old}-rfc2136'
-                    config.rename(address_path_tag + ['rfc2136', rfc_cfg_old], rfc_cfg_new)
-                    config.set(address_path_tag + ['rfc2136', rfc_cfg_new, 'protocol'], 'nsupdate')
+                for rfc_cfg in config.list_nodes(address_path_tag + ['rfc2136']):
+                    config.set(address_path_tag + ['rfc2136', rfc_cfg, 'protocol'], 'nsupdate')
 
             # Add address as config value in each service before moving the service path
-            # And then copy the services from 'address <interface> service <service>' to 'name <service>'
+            # And then copy the services from 'address <interface> service <service>'
+            #                              to 'name (service|rfc2136)-<service>-<address>'
+            # Note: The new service is named (service|rfc2136)-<service>-<address>
+            #       to avoid name conflict with old entries
             for svc_cfg in config.list_nodes(address_path_tag + [svc_type]):
                 config.set(address_path_tag + [svc_type, svc_cfg, 'address'], address)
-                config.copy(address_path_tag + [svc_type, svc_cfg], name_path + [svc_cfg])
+                config.copy(address_path_tag + [svc_type, svc_cfg],
+                            name_path + ['-'.join([svc_type, svc_cfg, address])])
 
 # Finally cleanup the old address path
 config.delete(address_path)
+
+# Normalize the all service names to conform with name constraints
+index = 1
+for name in config.list_nodes(name_path):
+    new_name = normalize_name(name)
+    if new_name != name:
+        # Append index if there is still a name conflicts after normalization
+        # For example, "foo-?(" and "foo-!)" both normalize to "foo-"
+        if config.exists(name_path + [new_name]):
+            new_name = f'{new_name}-{index}'
+            index += 1
+        config.rename(name_path + [name], new_name)
 
 try:
     with open(file_name, 'w') as f:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This PR has fix for two potential issues:

* As part of T5144, we merged all services that used web-based address lookup under `service dns dynamic address web ...`. When migrating from `service dns dynamic interface <interface> ...` to `service dns dynamic address <address> ...`, the config name can potentially have a conflict when `address == 'web'`. Although the `/run/ddclient/ddclient.conf` that was generated earlier was incorrect, one could still potentially have misconfigured VyOS config without realizing it.
We now append the old <interface> name to the config name to avoid conflict.

* As part of T5791, since `service dns dynamic address <address> service <service> ...` changed to `service dns dynamic name <service> address <address> ...`, the resulting service and address config flip can result in conflicting `service` name.
We now migrate the service name to `<service>-<address>` to avoid the conflict.
So `service dns dynamic address <address> service <service> ...` is migrated to `service dns dynamic name <service>-<address> address <address> ...`

* Additionally, based on the recommendation in the PR review, service names now conform to alphanumeric constraints. The migration script normalizes the old names to conform to the constraints.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5144
* https://vyos.dev/T5791
* https://vyos.dev/T5721

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dns dynamic

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
