### PR TITLE
validator: T5816: large community validator should only allos character set and basic format

### DIFF
--- a/src/validators/bgp-large-community-list
+++ b/src/validators/bgp-large-community-list
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 VyOS maintainers and contributors
+# Copyright (C) 2021-2023 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -17,9 +17,8 @@
 import re
 import sys
 
-from vyos.template import is_ipv4
-
 pattern = '(.*):(.*):(.*)'
+allowedChars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', '+', '*', '?', '^', '$', '(', ')', '[', ']', '{', '}', '|', '\\', ':', '-' }
 
 if __name__ == '__main__':
     if len(sys.argv) != 2:
@@ -29,8 +28,7 @@ if __name__ == '__main__':
     if not len(value) == 3:
         sys.exit(1)
 
-    if not (re.match(pattern, sys.argv[1]) and
-           (is_ipv4(value[0]) or value[0].isdigit()) and (value[1].isdigit() or value[1] == '*')):
+    if not (re.match(pattern, sys.argv[1]) and set(sys.argv[1]).issubset(allowedChars)):
         sys.exit(1)
 
     sys.exit(0)


### PR DESCRIPTION
## Change Summary
Fixes the BGP large community validator

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Task(s)
* https://vyos.dev/T5816

## Component(s) name
BGP

## Proposed changes
This fixes regular expressions that were not allowed by the current validator.

## How to test
```
trae@cr01a-vyos# python3 /usr/libexec/vyos/validators/bgp-large-community-list "4242420696:10[0-1]:.*" && echo PASS || echo FAIL
PASS
[edit]
trae@cr01a-vyos# python3 /usr/libexec/vyos/validators/bgp-large-community-list "4242420696:10[0f-1]:.*" && echo PASS || echo FAIL                                                             
FAIL
[edit]
trae@cr01a-vyos# set policy large-community-list ANYCAST_ALL1 rule 10 regex "4242420696:10[0-1]:.*"
[edit]
```

## Smoketest result
N/A - Didn't have any

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
