### PR TITLE
T4163: Add BGP Monitoring Protocol BMP feature

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -470,6 +470,38 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {%     endfor %}
 {% endif %}
  !
+{% if bmp is vyos_defined %}
+{%     if bmp.mirror_buffer_limit is vyos_defined %}
+ bmp mirror buffer-limit {{ bmp.mirror_buffer_limit }}
+ !
+{%     endif %}
+{%     if bmp.target is vyos_defined %}
+{%         for bmp, bmp_config in bmp.target.items() %}
+ bmp targets {{ bmp }}
+{%             if bmp_config.mirror is vyos_defined %}
+  bmp mirror
+{%             endif %}
+{%             if bmp_config.monitor is vyos_defined %}
+{%                 if bmp_config.monitor.ipv4_unicast.pre_policy is vyos_defined %}
+  bmp monitor ipv4 unicast pre-policy
+{%                 endif %}
+{%                 if bmp_config.monitor.ipv4_unicast.post_policy is vyos_defined %}
+  bmp monitor ipv4 unicast post-policy
+{%                 endif %}
+{%                 if bmp_config.monitor.ipv6_unicast.pre_policy is vyos_defined %}
+  bmp monitor ipv6 unicast pre-policy
+{%                 endif %}
+{%                 if bmp_config.monitor.ipv6_unicast.post_policy is vyos_defined %}
+  bmp monitor ipv6 unicast post-policy
+{%                 endif %}
+{%             endif %}
+{%             if bmp_config.address is vyos_defined %}
+  bmp connect {{ bmp_config.address }} port {{ bmp_config.port }} min-retry {{ bmp_config.min_retry }} max-retry {{ bmp_config.max_retry }}
+{%             endif %}
+{%         endfor %}
+ exit
+{%     endif %}
+{% endif %}
 {% if peer_group is vyos_defined %}
 {%     for peer, config in peer_group.items() %}
 {{ bgp_neighbor(peer, config, true) }}

--- a/interface-definitions/include/bgp/bmp-monitor-afi-policy.xml.i
+++ b/interface-definitions/include/bgp/bmp-monitor-afi-policy.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from bgp/bmp-monitor-afi-policy.xml.i -->
+<leafNode name="pre-policy">
+  <properties>
+    <help>Send state before policy and filter processing</help>
+    <valueless/>
+  </properties>
+</leafNode>
+<leafNode name="post-policy">
+  <properties>
+    <help>Send state with policy and filters applied</help>
+    <valueless/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -909,6 +909,92 @@
     </node>
   </children>
 </node>
+<node name="bmp">
+  <properties>
+    <help>BGP Monitoring Protocol (BMP)</help>
+  </properties>
+  <children>
+    <leafNode name="mirror-buffer-limit">
+      <properties>
+        <help>Maximum memory used for buffered mirroring messages (in bytes)</help>
+        <valueHelp>
+          <format>u32:0-4294967294</format>
+          <description>Limit in bytes</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 0-4294967294"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <tagNode name="target">
+      <properties>
+        <help>BMP target</help>
+      </properties>
+      <children>
+        #include <include/address-ipv4-ipv6-single.xml.i>
+        #include <include/port-number.xml.i>
+        <leafNode name="port">
+          <defaultValue>5000</defaultValue>
+        </leafNode>
+        <leafNode name="min-retry">
+          <properties>
+            <help>Minimum connection retry interval (in milliseconds)</help>
+            <valueHelp>
+              <format>u32:100-86400000</format>
+              <description>Minimum connection retry interval</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 100-86400000"/>
+            </constraint>
+          </properties>
+          <defaultValue>1000</defaultValue>
+        </leafNode>
+        <leafNode name="max-retry">
+          <properties>
+            <help>Maximum connection retry interval</help>
+            <valueHelp>
+              <format>u32:100-4294967295</format>
+              <description>Maximum connection retry interval</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 100-86400000"/>
+            </constraint>
+          </properties>
+          <defaultValue>2000</defaultValue>
+        </leafNode>
+        <leafNode name="mirror">
+          <properties>
+            <help>Send BMP route mirroring messages</help>
+            <valueless/>
+          </properties>
+        </leafNode>
+        <node name="monitor">
+          <properties>
+            <help>Send BMP route monitoring messages</help>
+          </properties>
+          <children>
+            <node name="ipv4-unicast">
+              <properties>
+                <help>Address family IPv4 unicast</help>
+              </properties>
+              <children>
+                #include <include/bgp/bmp-monitor-afi-policy.xml.i>
+              </children>
+            </node>
+            <node name="ipv6-unicast">
+              <properties>
+                <help>Address family IPv6 unicast</help>
+              </properties>
+              <children>
+                #include <include/bgp/bmp-monitor-afi-policy.xml.i>
+              </children>
+            </node>
+          </children>
+        </node>
+      </children>
+    </tagNode>
+  </children>
+</node>
 <tagNode name="interface">
   <properties>
     <help>Configure interface related parameters, e.g. MPLS</help>


### PR DESCRIPTION
Add BMP feature.
BMP (BGP Monitoring Protocol, RFC 7854) is used to send monitoring data from BGP routers to network management entities

https://docs.frrouting.org/en/latest/bmp.html

Example:

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4163

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp, bmp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Enable BMP plugin and restart the service (if the plugin wasn't enabled/configuring before starting FRR) and configure bmp
```
set system frr bmp
commit
run restart bgp

set protocols bgp system-as '65001'
set protocols bgp neighbor 192.168.122.11 address-family ipv4-unicast
set protocols bgp neighbor 192.168.122.11 remote-as '65001'

set protocols bgp bmp mirror-buffer-limit '256000000'
set protocols bgp bmp target foo address '127.0.0.1'
set protocols bgp bmp target foo port '5000'
set protocols bgp bmp target foo min-retry '1000'
set protocols bgp bmp target foo max-retry '2000'
set protocols bgp bmp target foo mirror
set protocols bgp bmp target foo monitor ipv4-unicast post-policy
set protocols bgp bmp target foo monitor ipv4-unicast pre-policy
set protocols bgp bmp target foo monitor ipv6-unicast post-policy
set protocols bgp bmp target foo monitor ipv6-unicast pre-policy

```
Check config:
```
vyos@r4:~$ vtysh -c "show run bgp"
Building configuration...

Current configuration:
!
frr version 9.0.2
frr defaults traditional
hostname r4
log syslog
log facility local7
service integrated-vtysh-config
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp default ipv4-unicast
 no bgp network import-check
 neighbor 192.168.122.11 remote-as 65001
 !
 address-family ipv4 unicast
  neighbor 192.168.122.11 activate
 exit-address-family
 !
 bmp mirror buffer-limit 256000000
 !
 bmp targets foo
  bmp mirror
  bmp monitor ipv4 unicast pre-policy
  bmp monitor ipv4 unicast post-policy
  bmp monitor ipv6 unicast pre-policy
  bmp monitor ipv6 unicast post-policy
  bmp connect 127.0.0.1 port 5000 min-retry 1000 max-retry 2000
 exit
exit
!
rpki
exit
!

```
Check bmp (op-mode)
```
vyos@r4:~$ vtysh -c "show bmp"
BMP state for BGP VRF default:

  Route Mirroring         0 bytes (0 messages) pending
                         67 bytes maximum buffer used
                  256000000 bytes buffer size limit

  Targets "foo":
    Route Mirroring enabled
    Route Monitoring IPv4 unicast pre-policy and post-policy
    Route Monitoring IPv6 unicast pre-policy and post-policy
    Listeners:

    Outbound connections:
 remote           state                    timer      local      
 ----------------------------------------------------------------
 127.0.0.1:5000   Up      127.0.0.1:5000   00:00:11   (unspec)   

    1 connected clients:
 remote           uptime     MonSent   MirrSent   MirrLost   ByteSent   ByteQ   ByteQKernel   
 ---------------------------------------------------------------------------------------------
 127.0.0.1:5000   00:00:11   7         1          0          1091       0       0             

vyos@r4:~$ 

```

An example of collector https://github.com/sbezverk/gobmp:
```
root@r4:/home/vyos# gobmp  --dump=console --v=9
I1213 19:10:56.228733    3805 gobmp.go:73] console publisher has been successfully initialized.
I1213 19:10:56.228945    3805 gobmpsrv.go:33] Starting gobmp server on [::]:5000, intercept mode: false
I1213 19:10:57.733451    3805 gobmpsrv.go:52] client 127.0.0.1:42448 accepted, calling bmpWorker
I1213 19:10:57.733544    3805 common-header.go:25] BMP CommonHeader Raw: [ 0x03, 0x00, 0x00, 0x00, 0x1F, 0x04 ]
I1213 19:10:57.733570    3805 common-header.go:25] BMP CommonHeader Raw: [ 0x03, 0x00, 0x00, 0x00, 0x1F, 0x04 ]
I1213 19:10:57.733583    3805 initiation.go:19] BMP Initiation Message Raw: [ 0x00, 0x01, 0x00, 0x0F, 0x46, 0x52, 0x52, 0x6F, 0x75, 0x74, 0x69, 0x6E, 0x67, 0x20, 0x39, 0x2E, 0x30, 0x2E, 0x32, 0x00, 0x02, 0x00, 0x02, 0x72, 0x34 ]
I1213 19:10:57.733596    3805 common-header.go:25] BMP CommonHeader Raw: [ 0x03, 0x00, 0x00, 0x01, 0x01, 0x03 ]
I1213 19:10:57.733605    3805 common-header.go:25] BMP CommonHeader Raw: [ 0x03, 0x00, 0x00, 0x00, 0x76, 0x00 ]
I1213 19:10:57.733615    3805 common-header.go:25] BMP CommonHeader Raw: [ 0x03, 0x00, 0x00, 0x00, 0x76, 0x00 ]
I1213 19:10:57.733624    3805 per-peer-header.go:177] BMP Per Peer Header Raw: [ 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0xA8, 0x7A, 0x0B, 0x00, 0x00, 0xFD, 0xE9, 0xC0, 0xA8, 0x7A, 0x0B, 0x65, 0x79, 0xE2, 0x77, 0x00, 0x0D, 0x02, 0x1C ]
I1213 19:10:57.733641    3805 route-monitor.go:19] BMP Route Monitor Message Raw: [ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x46, 0x02, 0x00, 0x00, 0x00, 0x2B, 0x40, 0x01, 0x01, 0x00, 0x50, 0x02, 0x00, 0x00, 0x40, 0x03, 0x04, 0xC0, 0xA8, 0x7A, 0x0B, 0x80, 0x04, 0x04, 0x00, 0x00, 0x00, 0x00, 0x40, 0x05, 0x04, 0x00, 0x00, 0x00, 0x64, 0x80, 0x09, 0x04, 0xC0, 0xA8, 0x7A, 0x0B, 0x80, 0x0A, 0x04, 0xC0, 0xA8, 0x7A, 0x0E, 0x18, 0x64, 0x40, 0x00 ] length: 70
I1213 19:10:57.733659    3805 bgp-update.go:113] BGPUpdate Raw: [ 0x00, 0x00, 0x00, 0x2B, 0x40, 0x01, 0x01, 0x00, 0x50, 0x02, 0x00, 0x00, 0x40, 0x03, 0x04, 0xC0, 0xA8, 0x7A, 0x0B, 0x80, 0x04, 0x04, 0x00, 0x00, 0x00, 0x00, 0x40, 0x05, 0x04, 0x00, 0x00, 0x00, 0x64, 0x80, 0x09, 0x04, 0xC0, 0xA8, 0x7A, 0x0B, 0x80, 0x0A, 0x04, 0xC0, 0xA8, 0x7A, 0x0E, 0x18, 0x64, 0x40, 0x00 ]
I1213 19:10:57.733670    3805 bgp-path-attribute.go:21] BGPPathAttributes Raw: [ 0x40, 0x01, 0x01, 0x00, 0x50, 0x02, 0x00, 0x00, 0x40, 0x03, 0x04, 0xC0, 0xA8, 0x7A, 0x0B, 0x80, 0x04, 0x04, 0x00, 0x00, 0x00, 0x00, 0x40, 0x05, 0x04, 0x00, 0x00, 0x00, 0x64, 0x80, 0x09, 0x04, 0xC0, 0xA8, 0x7A, 0x0B, 0x80, 0x0A, 0x04, 0xC0, 0xA8, 0x7A, 0x0E ]
I1213 19:10:57.733679    3805 bgp-base-attributes.go:126] UnmarshalBGPBaseAttributes RAW: [ 0x40, 0x01, 0x01, 0x00, 0x50, 0x02, 0x00, 0x00, 0x40, 0x03, 0x04, 0xC0, 0xA8, 0x7A, 0x0B, 0x80, 0x04, 0x04, 0x00, 0x00, 0x00, 0x00, 0x40, 0x05, 0x04, 0x00, 0x00, 0x00, 0x64, 0x80, 0x09, 0x04, 0xC0, 0xA8, 0x7A, 0x0B, 0x80, 0x0A, 0x04, 0xC0, 0xA8, 0x7A, 0x0E ]
I1213 19:10:57.733789    3805 route.go:30] Routes Raw: [ 0x18, 0x64, 0x40, 0x00 ] Path ID flag: false
gobmp: 19:10:57.733928 {MsgType:74 MsgHash: Msg:{"action":"add","base_attrs":{"base_attr_hash":"507bf6aa503499b4fb61996591f4899f","origin":"igp","nexthop":"192.168.122.11","local_pref":100,"is_atomic_agg":false,"originator_id":"192.168.122.11","cluster_list":"192.168.122.14"},"peer_hash":"d7f2ae47a74a04e0b3b5df159d30617c","peer_ip":"192.168.122.11","peer_type":0,"peer_asn":65001,"timestamp":"2023-12-13T16:57:27.000852508Z","prefix":"100.64.0.0","prefix_len":24,"is_ipv4":true,"nexthop":"192.168.122.11","is_nexthop_ipv4":true,"is_adj_rib_in_post_policy":true,"is_adj_rib_out_post_policy":false,"is_loc_rib_filtered":false}}
I1213 19:10:57.733947    3805 common-header.go:25] BMP CommonHeader Raw: [ 0x03, 0x00, 0x00, 0x01, 0x01, 0x03 ]
I1213 19:10:57.733966    3805 per-peer-header.go:177] BMP Per Peer Header Raw: [ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0xA8, 0x7A, 0x0B, 0x00, 0x00, 0xFD, 0xE9, 0xC0, 0xA8, 0x7A, 0x0B, 0x65, 0x79, 0xE2, 0x76, 0x00, 0x0D, 0x02, 0x1C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0xA8, 0x7A, 0x0E, 0xB4, 0xB8, 0x00, 0xB3, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x72, 0x01, 0x04, 0xFD, 0xE9, 0x00, 0xB4, 0xC0, 0xA8, 0x7A, 0x0E, 0x55, 0x02, 0x06, 0x01, 0x04, 0x00, 0x01, 0x00, 0x01, 0x02, 0x02, 0x80, 0x00, 0x02, 0x02, 0x02, 0x00, 0x02, 0x02, 0x46, 0x00, 0x02, 0x06, 0x41, 0x04, 0x00, 0x00, 0xFD, 0xE9, 0x02, 0x02, 0x06, 0x00, 0x02, 0x06, 0x45, 0x04, 0x00, 0x01, 0x01, 0x01, 0x02, 0x06, 0x49, 0x04, 0x02, 0x72, 0x34, 0x00, 0x02, 0x04, 0x40, 0x02, 0xC0, 0x78, 0x02, 0x09, 0x47, 0x07, 0x00, 0x01, 0x01, 0x80, 0x00, 0x00, 0x00, 0x02, 0x12, 0x4B, 0x10, 0x0F, 0x46, 0x52, 0x52, 0x6F, 0x75, 0x74, 0x69, 0x6E, 0x67, 0x2F, 0x39, 0x2E, 0x30, 0x2E, 0x32, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x4B, 0x01, 0x04, 0xFD, 0xE9, 0x00, 0xB4, 0xC0, 0xA8, 0x7A, 0x0B, 0x2E, 0x02, 0x06, 0x01, 0x04, 0x00, 0x01, 0x00, 0x01, 0x02, 0x02, 0x80, 0x00, 0x02, 0x02, 0x02, 0x00, 0x02, 0x06, 0x41, 0x04, 0x00, 0x00, 0xFD, 0xE9, 0x02, 0x06, 0x45, 0x04, 0x00, 0x01, 0x01, 0x01, 0x02, 0x06, 0x49, 0x04, 0x02, 0x72, 0x31, 0x00, 0x02, 0x04, 0x40, 0x02, 0x00, 0x78 ]
I1213 19:10:57.733997    3805 peer-up.go:33] BMP Peer Up Message Raw: [ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0xA8, 0x7A, 0x0E, 0xB4, 0xB8, 0x00, 0xB3, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x72, 0x01, 0x04, 0xFD, 0xE9, 0x00, 0xB4, 0xC0, 0xA8, 0x7A, 0x0E, 0x55, 0x02, 0x06, 0x01, 0x04, 0x00, 0x01, 0x00, 0x01, 0x02, 0x02, 0x80, 0x00, 0x02, 0x02, 0x02, 0x00, 0x02, 0x02, 0x46, 0x00, 0x02, 0x06, 0x41, 0x04, 0x00, 0x00, 0xFD, 0xE9, 0x02, 0x02, 0x06, 0x00, 0x02, 0x06, 0x45, 0x04, 0x00, 0x01, 0x01, 0x01, 0x02, 0x06, 0x49, 0x04, 0x02, 0x72, 0x34, 0x00, 0x02, 0x04, 0x40, 0x02, 0xC0, 0x78, 0x02, 0x09, 0x47, 0x07, 0x00, 0x01, 0x01, 0x80, 0x00, 0x00, 0x00, 0x02, 0x12, 0x4B, 0x10, 0x0F, 0x46, 0x52, 0x52, 0x6F, 0x75, 0x74, 0x69, 0x6E, 0x67, 0x2F, 0x39, 0x2E, 0x30, 0x2E, 0x32, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x4B, 0x01, 0x04, 0xFD, 0xE9, 0x00, 0xB4, 0xC0, 0xA8, 0x7A, 0x0B, 0x2E, 0x02, 0x06, 0x01, 0x04, 0x00, 0x01, 0x00, 0x01, 0x02, 0x02, 0x80, 0x00, 0x02, 0x02, 0x02, 0x00, 0x02, 0x06, 0x41, 0x04, 0x00, 0x00, 0xFD, 0xE9, 0x02, 0x06, 0x45, 0x04, 0x00, 0x01, 0x01, 0x01, 0x02, 0x06, 0x49, 0x04, 0x02, 0x72, 0x31, 0x00, 0x02, 0x04, 0x40, 0x02, 0x00, 0x78 ]
I1213 19:10:57.734013    3805 bgp-open.go:95] BGPOpenMessage Raw: [ 0x00, 0x72, 0x01, 0x04, 0xFD, 0xE9, 0x00, 0xB4, 0xC0, 0xA8, 0x7A, 0x0E, 0x55, 0x02, 0x06, 0x01, 0x04, 0x00, 0x01, 0x00, 0x01, 0x02, 0x02, 0x80, 0x00, 0x02, 0x02, 0x02, 0x00, 0x02, 0x02, 0x46, 0x00, 0x02, 0x06, 0x41, 0x04, 0x00, 0x00, 0xFD, 0xE9, 0x02, 0x02, 0x06, 0x00, 0x02, 0x06, 0x45, 0x04, 0x00, 0x01, 0x01, 0x01, 0x02, 0x06, 0x49, 0x04, 0x02, 0x72, 0x34, 0x00, 0x02, 0x04, 0x40, 0x02, 0xC0, 0x78, 0x02, 0x09, 0x47, 0x07, 0x00, 0x01, 0x01, 0x80, 0x00, 0x00, 0x00, 0x02, 0x12, 0x4B, 0x10, 0x0F, 0x46, 0x52, 0x52, 0x6F, 0x75, 0x74, 0x69, 0x6E, 0x67, 0x2F, 0x39, 0x2E, 0x30, 0x2E, 0x32 ]
I1213 19:10:57.734026    3805 bgp-information-tlv.go:18] BGPTLV Raw: [ 0x02, 0x06, 0x01, 0x04, 0x00, 0x01, 0x00, 0x01, 0x02, 0x02, 0x80, 0x00, 0x02, 0x02, 0x02, 0x00, 0x02, 0x02, 0x46, 0x00, 0x02, 0x06, 0x41, 0x04, 0x00, 0x00, 0xFD, 0xE9, 0x02, 0x02, 0x06, 0x00, 0x02, 0x06, 0x45, 0x04, 0x00, 0x01, 0x01, 0x01, 0x02, 0x06, 0x49, 0x04, 0x02, 0x72, 0x34, 0x00, 0x02, 0x04, 0x40, 0x02, 0xC0, 0x78, 0x02, 0x09, 0x47, 0x07, 0x00, 0x01, 0x01, 0x80, 0x00, 0x00, 0x00, 0x02, 0x12, 0x4B, 0x10, 0x0F, 0x46, 0x52, 0x52, 0x6F, 0x75, 0x74, 0x69, 0x6E, 0x67, 0x2F, 0x39, 0x2E, 0x30, 0x2E, 0x32 ]
I1213 19:10:57.734034    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x01, 0x04, 0x00, 0x01, 0x00, 0x01 ]
I1213 19:10:57.734042    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x80, 0x00 ]
I1213 19:10:57.734047    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x02, 0x00 ]
I1213 19:10:57.734051    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x46, 0x00 ]
I1213 19:10:57.734056    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x41, 0x04, 0x00, 0x00, 0xFD, 0xE9 ]
I1213 19:10:57.734060    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x06, 0x00 ]
I1213 19:10:57.734067    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x45, 0x04, 0x00, 0x01, 0x01, 0x01 ]
I1213 19:10:57.734079    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x49, 0x04, 0x02, 0x72, 0x34, 0x00 ]
I1213 19:10:57.734085    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x40, 0x02, 0xC0, 0x78 ]
I1213 19:10:57.734091    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x47, 0x07, 0x00, 0x01, 0x01, 0x80, 0x00, 0x00, 0x00 ]
I1213 19:10:57.734096    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x4B, 0x10, 0x0F, 0x46, 0x52, 0x52, 0x6F, 0x75, 0x74, 0x69, 0x6E, 0x67, 0x2F, 0x39, 0x2E, 0x30, 0x2E, 0x32 ]
I1213 19:10:57.734104    3805 bgp-open.go:95] BGPOpenMessage Raw: [ 0x00, 0x4B, 0x01, 0x04, 0xFD, 0xE9, 0x00, 0xB4, 0xC0, 0xA8, 0x7A, 0x0B, 0x2E, 0x02, 0x06, 0x01, 0x04, 0x00, 0x01, 0x00, 0x01, 0x02, 0x02, 0x80, 0x00, 0x02, 0x02, 0x02, 0x00, 0x02, 0x06, 0x41, 0x04, 0x00, 0x00, 0xFD, 0xE9, 0x02, 0x06, 0x45, 0x04, 0x00, 0x01, 0x01, 0x01, 0x02, 0x06, 0x49, 0x04, 0x02, 0x72, 0x31, 0x00, 0x02, 0x04, 0x40, 0x02, 0x00, 0x78 ]
I1213 19:10:57.734111    3805 bgp-information-tlv.go:18] BGPTLV Raw: [ 0x02, 0x06, 0x01, 0x04, 0x00, 0x01, 0x00, 0x01, 0x02, 0x02, 0x80, 0x00, 0x02, 0x02, 0x02, 0x00, 0x02, 0x06, 0x41, 0x04, 0x00, 0x00, 0xFD, 0xE9, 0x02, 0x06, 0x45, 0x04, 0x00, 0x01, 0x01, 0x01, 0x02, 0x06, 0x49, 0x04, 0x02, 0x72, 0x31, 0x00, 0x02, 0x04, 0x40, 0x02, 0x00, 0x78 ]
I1213 19:10:57.734116    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x01, 0x04, 0x00, 0x01, 0x00, 0x01 ]
I1213 19:10:57.734121    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x80, 0x00 ]
I1213 19:10:57.734125    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x02, 0x00 ]
I1213 19:10:57.734132    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x41, 0x04, 0x00, 0x00, 0xFD, 0xE9 ]
I1213 19:10:57.734136    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x45, 0x04, 0x00, 0x01, 0x01, 0x01 ]
I1213 19:10:57.734141    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x49, 0x04, 0x02, 0x72, 0x31, 0x00 ]
I1213 19:10:57.734146    3805 bgp-capability.go:84] UnmarshalBGPCapability Raw: [ 0x40, 0x02, 0x00, 0x78 ]
I1213 19:10:57.734164    3805 bgp-open.go:58] AddPath Capability Raw: [ 0x00, 0x01, 0x01, 0x01 ]
I1213 19:10:57.734176    3805 bgp-open.go:75] AddPath Capability for AFI/SAFI: 1/1 is false
I1213 19:10:57.734201    3805 bgp-open.go:58] AddPath Capability Raw: [ 0x00, 0x01, 0x01, 0x01 ]
I1213 19:10:57.734206    3805 bgp-open.go:75] AddPath Capability for AFI/SAFI: 1/1 is false
I1213 19:10:57.734213    3805 peer.go:83] producer for speaker ip: 192.168.122.14 add path: map[1:false]
gobmp: 19:10:57.734349 {MsgType:10 MsgHash:fd7ab981e725bcc5640d3e3f9299b9b2 Msg:{"action":"add","router_hash":"fd7ab981e725bcc5640d3e3f9299b9b2","remote_bgp_id":"192.168.122.11","router_ip":"192.168.122.14","timestamp":"2023-12-13T16:57:26.000852508Z","remote_asn":65001,"remote_ip":"192.168.122.11","peer_type":0,"peer_rd":"0:0","remote_port":179,"local_asn":65001,"local_ip":"192.168.122.14","local_port":46264,"local_bgp_id":"192.168.122.14","adv_cap":{"1":[{"capability_value":"AAEAAQ==","capability_descr":"Multiprotocol Extensions for BGP-4 : afi=1 safi=1 Unicast IPv4"}],"128":[{"capability_descr":"Prestandard Route Refresh (deprecated)"}],"2":[{"capability_descr":"Route Refresh Capability for BGP-4"}],"6":[{"capability_descr":"BGP Extended Message"}],"64":[{"capability_value":"wHg=","capability_descr":"Graceful Restart Capability"}],"65":[{"capability_value":"AAD96Q==","capability_descr":"Support for 4-octet AS number capability"}],"69":[{"capability_value":"AAEBAQ==","capability_descr":"ADD-PATH Capability"}],"70":[{"capability_descr":"Enhanced Route Refresh Capability"}],"71":[{"capability_value":"AAEBgAAAAA==","capability_descr":"Long-Lived Graceful Restart (LLGR) Capability"}],"73":[{"capability_value":"AnI0AA==","capability_descr":"FQDN Capability"}],"75":[{"capability_value":"D0ZSUm91dGluZy85LjAuMg==","capability_descr":"Unknown capability 75"}]},"recv_cap":{"1":[{"capability_value":"AAEAAQ==","capability_descr":"Multiprotocol Extensions for BGP-4 : afi=1 safi=1 Unicast IPv4"}],"128":[{"capability_descr":"Prestandard Route Refresh (deprecated)"}],"2":[{"capability_descr":"Route Refresh Capability for BGP-4"}],"64":[{"capability_value":"AHg=","capability_descr":"Graceful Restart Capability"}],"65":[{"capability_value":"AAD96Q==","capability_descr":"Support for 4-octet AS number capability"}],"69":[{"capability_value":"AAEBAQ==","capability_descr":"ADD-PATH Capability"}],"73":[{"capability_value":"AnIxAA==","capability_descr":"FQDN Capability"}]},"remote_holddown":180,"adv_holddown":180,"is_l":false,"is_prepolicy":false,"is_ipv4":true,"is_adj_rib_in_post_policy":false,"is_adj_rib_out_post_policy":false,"is_loc_rib_filtered":false}}

```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ... ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ... ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ... ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ... ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ... ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ... ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ... ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ... ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ... ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ... ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok
test_bgp_24_srv6_sid (__main__.TestProtocolsBGP.test_bgp_24_srv6_sid) ... ok
test_bgp_25_bmp (__main__.TestProtocolsBGP.test_bgp_25_bmp) ... WARNING: This is a potentially unsafe function!
You may lose the connection to the router or active configuration after
running this command. Use it at your own risk!

Continue? [y/N] This command is only supported under EVPN VRF
This command is only supported under EVPN VRF
This command is only supported under EVPN VRF
ok

----------------------------------------------------------------------
Ran 24 tests in 150.436s

OK
vyos@r4:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
