### PR TITLE
T5827: made show system image alphabetical

### DIFF
--- a/python/vyos/system/grub.py
+++ b/python/vyos/system/grub.py
@@ -138,7 +138,7 @@ def version_list(root_dir: str = '') -> list[str]:
     versions_list: list[str] = []
     for file in versions_files:
         versions_list.append(file.stem)
-    versions_list.sort()
+    versions_list.sort(reverse=True)
 
     return versions_list
 

--- a/python/vyos/system/grub.py
+++ b/python/vyos/system/grub.py
@@ -138,6 +138,8 @@ def version_list(root_dir: str = '') -> list[str]:
     versions_list: list[str] = []
     for file in versions_files:
         versions_list.append(file.stem)
+    versions_list.sort()
+
     return versions_list
 
 

--- a/src/op_mode/image_manager.py
+++ b/src/op_mode/image_manager.py
@@ -157,7 +157,7 @@ def rename_image(name_old: str, name_new: str) -> None:
 def list_images() -> None:
     """Print list of available images for CLI hints"""
     images_list: list[str] = grub.version_list()
-    image_list.sort()
+    images_list.sort()
 
     for image_name in images_list:
         print(image_name)

--- a/src/op_mode/image_manager.py
+++ b/src/op_mode/image_manager.py
@@ -157,8 +157,6 @@ def rename_image(name_old: str, name_new: str) -> None:
 def list_images() -> None:
     """Print list of available images for CLI hints"""
     images_list: list[str] = grub.version_list()
-    images_list.sort()
-
     for image_name in images_list:
         print(image_name)
 

--- a/src/op_mode/image_manager.py
+++ b/src/op_mode/image_manager.py
@@ -157,6 +157,8 @@ def rename_image(name_old: str, name_new: str) -> None:
 def list_images() -> None:
     """Print list of available images for CLI hints"""
     images_list: list[str] = grub.version_list()
+    image_list.sort()
+
     for image_name in images_list:
         print(image_name)
 


### PR DESCRIPTION
## Change Summary
Fixes the `show system image` command not listing images in alphabetical order.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T5827
* https://vyos.dev/T4516

## Component(s) name
system image

## Proposed changes
added `sort()`

## How to test
```
root@cr01a-vyos:~# /usr/libexec/vyos/op_mode/image_manager.py --action list
1.4-rolling-202309070021
1.5-rolling-202310100022
1.5-rolling-202310190118
1.5-rolling-202311231639
1.5-rolling-202311300023
1.5-rolling-202312040024
1.5-rolling-202312130023
```
## Smoketest result
None AFAIK?

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
