### PR TITLE
T5749: Add a more scrict search for get_vrf method

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -115,7 +115,7 @@ class Interface(Control):
         },
         'vrf': {
             'shellcmd': 'ip -json -detail link list dev {ifname}',
-            'format': lambda j: jmespath.search('[*].master | [0]', json.loads(j)),
+            'format': lambda j: jmespath.search('[?linkinfo.info_slave_kind == `vrf`].master | [0]', json.loads(j)),
         },
     }
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The current implementation is wrong as it searches `master` in the iproute2 JSON output. 
It needs to be corrected, as it could include bridges or bonding interfaces.
Add the more strict search `info_slave_kind == vrf`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5749

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrf
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
config:
```
set interfaces bonding bond0 member interface 'eth1'
set interfaces bonding bond0 member interface 'eth2'
set interfaces ethernet eth3 vrf 'foo'
set vrf name foo table '1234'
```
Before the fix unexpected vrf `bond`:
```
vyos@r4:~$ show int
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address         MAC                VRF        MTU  S/L    Description
-----------  -----------------  -----------------  -------  -----  -----  -------------
bond0        -                  b6:91:e9:33:b5:58  default   1500  u/u
eth0         192.168.122.14/24  52:54:00:f1:fd:77  default   1500  u/u    WAN
             192.168.122.10/24
eth1         -                  b6:91:e9:33:b5:58  bond0     1500  u/u    LAN
eth2         -                  b6:91:e9:33:b5:58  bond0     1500  u/u    LAN-eth2
eth3         -                  52:54:00:09:a4:b4  foo       1500  A/D
eth4         -                  52:54:00:2c:51:09  default   1500  A/D
eth5         -                  52:54:00:f3:1d:e8  default   1500  A/D
lo           127.0.0.1/8        00:00:00:00:00:00  default  65536  u/u
             ::1/128
tun0         -                  n/a                default   1476  u/u
vyos@r4:~$ 
```

After the fix shows correctly (only eth3 under vrf):
```
vyos@r4:~$ show int
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address         MAC                VRF        MTU  S/L    Description
-----------  -----------------  -----------------  -------  -----  -----  -------------
bond0        -                  b6:91:e9:33:b5:58  default   1500  u/u
eth0         192.168.122.14/24  52:54:00:f1:fd:77  default   1500  u/u    WAN
             192.168.122.10/24
eth1         -                  b6:91:e9:33:b5:58  default   1500  u/u    LAN
eth2         -                  b6:91:e9:33:b5:58  default   1500  u/u    LAN-eth2
eth3         -                  52:54:00:09:a4:b4  foo       1500  A/D
eth4         -                  52:54:00:2c:51:09  default   1500  A/D
eth5         -                  52:54:00:f3:1d:e8  default   1500  A/D
lo           127.0.0.1/8        00:00:00:00:00:00  default  65536  u/u
             ::1/128
tun0         -                  n/a                default   1476  u/u
vyos@r4:~$ 
```
The full JSON
```
vyos@r4:~$ sudo ip --json -detail link list dev eth3 | jq
[
  {
    "ifindex": 5,
    "ifname": "eth3",
    "flags": [
      "BROADCAST",
      "MULTICAST"
    ],
    "mtu": 1500,
    "qdisc": "noop",
    "master": "foo",
    "operstate": "DOWN",
    "linkmode": "DEFAULT",
    "group": "default",
    "txqlen": 1000,
    "link_type": "ether",
    "address": "52:54:00:09:a4:b4",
    "broadcast": "ff:ff:ff:ff:ff:ff",
    "promiscuity": 0,
    "allmulti": 0,
    "min_mtu": 68,
    "max_mtu": 65535,
    "linkinfo": {
      "info_slave_kind": "vrf",
      "info_slave_data": {
        "table": 1234
      }
    },
    "inet6_addr_gen_mode": "none",
    "num_tx_queues": 1,
    "num_rx_queues": 1,
    "gso_max_size": 65536,
    "gso_max_segs": 65535,
    "tso_max_size": 65536,
    "tso_max_segs": 65535,
    "gro_max_size": 65536,
    "parentbus": "virtio",
    "parentdev": "virtio4",
    "altnames": [
      "enp4s0"
    ]
  }
]

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
