### PR TITLE
frr: T4020: add option to define number of open file descriptors

### DIFF
--- a/data/templates/frr/daemons.frr.tmpl
+++ b/data/templates/frr/daemons.frr.tmpl
@@ -108,7 +108,6 @@ valgrind_enable=no
 
 frr_profile="traditional"
 
-#MAX_FDS=1024
+MAX_FDS={{ descriptors }}
 
 #FRR_NO_ROOT="yes"
-

--- a/interface-definitions/system-frr.xml.in
+++ b/interface-definitions/system-frr.xml.in
@@ -15,6 +15,20 @@
               <valueless/>
             </properties>
           </leafNode>
+          <leafNode name="descriptors">
+            <properties>
+              <help>Number of open file descriptors a process is allowed to use</help>
+              <valueHelp>
+                <format>u32:1024-8192</format>
+                <description>Number of file descriptors</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 1024-8192"/>
+              </constraint>
+              <constraintErrorMessage>Port number must be in range 1024 to 8192</constraintErrorMessage>
+            </properties>
+            <defaultValue>1024</defaultValue>
+          </leafNode>
           <leafNode name="irdp">
             <properties>
               <help>Enable ICMP Router Discovery Protocol support</help>

--- a/src/conf_mode/system_frr.py
+++ b/src/conf_mode/system_frr.py
@@ -40,7 +40,9 @@ def get_config(config=None):
         conf = Config()
 
     base = ['system', 'frr']
-    frr_config = conf.get_config_dict(base, get_first_key=True)
+    frr_config = conf.get_config_dict(base, key_mangling=('-', '_'),
+                                      get_first_key=True,
+                                      with_recursive_defaults=True)
 
     return frr_config
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This allows the operator to control the number of open file descriptors each daemon is allowed to start with. The current assumed value on most operating systems is 1024.

If the operator plans to run bgp with several thousands of peers then this is where we would modify FRR to allow this to happen.

```console
set system frr descriptors <n>
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4020

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-documentation/pull/1184

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
FRR, system startup

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_frr.py
test_frr_bmp (__main__.TestSystemFRR.test_frr_bmp) ... ok
test_frr_bmp_and_snmp (__main__.TestSystemFRR.test_frr_bmp_and_snmp) ... ok
test_frr_file_descriptors (__main__.TestSystemFRR.test_01frr_file_descriptors) ... ok
test_frr_irdp (__main__.TestSystemFRR.test_frr_irdp) ... ok
test_frr_snmp_add_remove (__main__.TestSystemFRR.test_frr_snmp_add_remove) ... ok
test_frr_snmp_empty (__main__.TestSystemFRR.test_frr_snmp_empty) ... ok
test_frr_snmp_multipledaemons (__main__.TestSystemFRR.test_frr_snmp_multipledaemons) ... ok

----------------------------------------------------------------------
Ran 7 tests in 21.114s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
