### PR TITLE
T5828: fix grub installation on arm64-efi machines

### DIFF
--- a/python/vyos/system/grub.py
+++ b/python/vyos/system/grub.py
@@ -13,6 +13,8 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
+import platform
+
 from pathlib import Path
 from re import MULTILINE, compile as re_compile
 from typing import Union
@@ -57,16 +59,22 @@ def install(drive_path: str, boot_dir: str, efi_dir: str, id: str = 'VyOS') -> N
         boot_dir (str): a path to '/boot' directory
         efi_dir (str): a path to '/boot/efi' directory
     """
-    commands: list[str] = [
-        f'grub-install --no-floppy --target=i386-pc --boot-directory={boot_dir} \
-            {drive_path} --force',
-        f'grub-install --no-floppy --recheck --target=x86_64-efi \
+
+    efi_installation_arch = "x86_64"
+    if platform.machine() == "aarch64":
+        efi_installation_arch = "arm64"
+    elif platform.machine() == "x86_64":
+        cmd(
+            f'grub-install --no-floppy --target=i386-pc \
+            --boot-directory={boot_dir}  {drive_path} --force'
+        )
+
+    cmd(
+        f'grub-install --no-floppy --recheck --target={efi_installation_arch}-efi \
             --force-extra-removable --boot-directory={boot_dir} \
             --efi-directory={efi_dir} --bootloader-id="{id}" \
             --no-uefi-secure-boot'
-    ]
-    for command in commands:
-        cmd(command)
+    )
 
 
 def gen_version_uuid(version_name: str) -> str:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

Since GRUB installation was migrated to vyos-1x from vyatta-cfg-system ([T4516](https://vyos.dev/T4516)), the GRUB setup has hardcoded references to x86-64, undoing the arm64 support that was previously in vyatta-cfg-system ([T4822](https://vyos.dev/T4822)).

This task adds arm64 support back into it.
Arm64 does not need the legacy MBR/BIOS install step (`grub-install --target=i386-pc`). Apart from that, the EFI install command line is the same as x86-64, except for the target arch (arm64-efi vs x86-64-efi).

TODO: Some Arm embedded platforms do not have runtime EFI variable support (usually those with U-Boot). grub-install will exit with an error, but the install does complete successfully otherwise. These boards will work as they search the removable media path.
I would like to figure out a way to determine when NVRAM support is present and "ignore" such errors.

**Note:** The code formatting is clearly not as elegant as it was before (and I'm not a seasoned python developer). I am open to suggestions on how to format that more elegantly.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5828

## Proposed changes
Detect arm64 architecture and run the correct GRUB install command sequence.

## How to test
Tested on both x86-64 (HyperV VM) and arm64 (Qemu `virt` machine and Traverse Technologies Ten64) running "image install" from ISO

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
