### PR TITLE
dhcp: T3316: Kea DHCP and DHCPv6 fixes

### DIFF
--- a/python/vyos/utils/file.py
+++ b/python/vyos/utils/file.py
@@ -149,6 +149,10 @@ def chmod_775(path):
               S_IROTH | S_IXOTH
     chmod(path, bitmask)
 
+def file_permissions(path):
+    """ Return file permissions in string format, e.g '0755' """
+    return oct(os.stat(path).st_mode)[4:]
+
 def makedir(path, user=None, group=None):
     if os.path.exists(path):
         return

--- a/src/conf_mode/dhcp_server.py
+++ b/src/conf_mode/dhcp_server.py
@@ -21,7 +21,6 @@ from ipaddress import ip_network
 from netaddr import IPAddress
 from netaddr import IPRange
 from sys import exit
-from time import sleep
 
 from vyos.config import Config
 from vyos.pki import wrap_certificate
@@ -29,7 +28,6 @@ from vyos.pki import wrap_private_key
 from vyos.template import render
 from vyos.utils.dict import dict_search
 from vyos.utils.dict import dict_search_args
-from vyos.utils.file import chmod_775
 from vyos.utils.file import write_file
 from vyos.utils.process import call
 from vyos.utils.process import run
@@ -361,15 +359,6 @@ def apply(dhcp):
             action = 'stop'
 
         call(f'systemctl {action} {service}.service')
-
-    # op-mode needs ctrl socket permission change
-    i = 0
-    while not os.path.exists(ctrl_socket):
-        if i > 15:
-            break
-        i += 1
-        sleep(1)
-    chmod_775(ctrl_socket)
 
     return None
 

--- a/src/conf_mode/dhcpv6_server.py
+++ b/src/conf_mode/dhcpv6_server.py
@@ -19,13 +19,11 @@ import os
 from ipaddress import ip_address
 from ipaddress import ip_network
 from sys import exit
-from time import sleep
 
 from vyos.config import Config
 from vyos.template import render
 from vyos.template import is_ipv6
 from vyos.utils.process import call
-from vyos.utils.file import chmod_775
 from vyos.utils.file import write_file
 from vyos.utils.dict import dict_search
 from vyos.utils.network import is_subnet_connected
@@ -196,15 +194,6 @@ def apply(dhcpv6):
         return None
 
     call(f'systemctl restart {service_name}')
-
-    # op-mode needs ctrl socket permission change
-    i = 0
-    while not os.path.exists(ctrl_socket):
-        if i > 15:
-            break
-        i += 1
-        sleep(1)
-    chmod_775(ctrl_socket)
 
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
* Move Kea socket permission change on-demand and speed up conf scripts
* Fix issue with DHCP reservations when no `ip-address` value

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3316

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-server, dhcpv6-server

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Static mappings without IP:
```
[edit]
vyos@vyos# set service dhcp-server shared-network-name TEST subnet 10.1.1.0/24 static-mapping TEST mac-address 00:01:02:03:04:05
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# 
```

Op-mode working + socket permissions (775 as required):
```
[edit]
vyos@vyos# run show dhcp server leases
IP Address    MAC address    State    Lease start    Lease expiration    Remaining    Pool    Hostname    Origin
------------  -------------  -------  -------------  ------------------  -----------  ------  ----------  --------
[edit]
vyos@vyos# ls -al /run/kea/
total 12
drwxr-xr-x  2 _kea _kea  140 Dec 17 00:50 .
drwxr-xr-x 37 root root 1060 Dec 17 00:50 ..
srwxrwxr-x  1 _kea _kea    0 Dec 17 00:50 dhcp4-ctrl-socket
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py
DEBUG - test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
DEBUG - test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
DEBUG - test_dhcp_failover (__main__.TestServiceDHCPServer.test_dhcp_failover) ... ok
DEBUG - test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
DEBUG - test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
DEBUG - test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... ok
DEBUG - test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... ok
DEBUG - test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 8 tests in 29.779s
DEBUG -
DEBUG - OK

DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_service_dhcpv6-server.py
DEBUG - test_global_nameserver (__main__.TestServiceDHCPv6Server.test_global_nameserver) ... ok
DEBUG - test_prefix_delegation (__main__.TestServiceDHCPv6Server.test_prefix_delegation) ... ok
DEBUG - test_single_pool (__main__.TestServiceDHCPv6Server.test_single_pool) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 3 tests in 10.005s
DEBUG -
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
