### PR TITLE
dhcp: T3316: Support hostname, DUID and MAC address in reservation

### DIFF
--- a/interface-definitions/dhcp-server.xml.in
+++ b/interface-definitions/dhcp-server.xml.in
@@ -284,11 +284,11 @@
                   </tagNode>
                   <tagNode name="static-mapping">
                     <properties>
-                      <help>Name of static mapping</help>
+                      <help>Hostname for static mapping reservation</help>
                       <constraint>
-                        <regex>[-_a-zA-Z0-9.]+</regex>
+                        <validator name="fqdn"/>
                       </constraint>
-                      <constraintErrorMessage>Invalid static mapping name, may only be alphanumeric, dot and hyphen</constraintErrorMessage>
+                      <constraintErrorMessage>Invalid static mapping hostname</constraintErrorMessage>
                     </properties>
                     <children>
                       #include <include/generic-disable-node.xml.i>
@@ -304,18 +304,8 @@
                           </constraint>
                         </properties>
                       </leafNode>
-                      <leafNode name="mac-address">
-                        <properties>
-                          <help>Media Access Control (MAC) address</help>
-                          <valueHelp>
-                            <format>macaddr</format>
-                            <description>Hardware (MAC) address</description>
-                          </valueHelp>
-                          <constraint>
-                            <validator name="mac-address"/>
-                          </constraint>
-                        </properties>
-                      </leafNode>
+                      #include <include/interface/mac.xml.i>
+                      #include <include/interface/duid.xml.i>
                     </children>
                   </tagNode>
                   <tagNode name="static-route">

--- a/interface-definitions/dhcpv6-server.xml.in
+++ b/interface-definitions/dhcpv6-server.xml.in
@@ -301,27 +301,16 @@
                   </leafNode>
                   <tagNode name="static-mapping">
                     <properties>
-                      <help>Name of static mapping</help>
+                      <help>Hostname for static mapping reservation</help>
                       <constraint>
-                        <regex>[-_a-zA-Z0-9.]+</regex>
+                        <validator name="fqdn"/>
                       </constraint>
-                      <constraintErrorMessage>Invalid static mapping name. May only contain letters, numbers and .-_</constraintErrorMessage>
+                      <constraintErrorMessage>Invalid static mapping hostname</constraintErrorMessage>
                     </properties>
                     <children>
                       #include <include/generic-disable-node.xml.i>
-                      <leafNode name="identifier">
-                        <properties>
-                          <help>Client identifier (DUID) for this static mapping</help>
-                          <valueHelp>
-                            <format>h[[:h]...]</format>
-                            <description>DUID: colon-separated hex list (as used by isc-dhcp option dhcpv6.client-id)</description>
-                          </valueHelp>
-                          <constraint>
-                            <regex>([0-9A-Fa-f]{1,2}[:])*([0-9A-Fa-f]{1,2})</regex>
-                          </constraint>
-                          <constraintErrorMessage>Invalid DUID, must be in the format h[[:h]...]</constraintErrorMessage>
-                        </properties>
-                      </leafNode>
+                      #include <include/interface/mac.xml.i>
+                      #include <include/interface/duid.xml.i>
                       <leafNode name="ipv6-address">
                         <properties>
                           <help>Client IPv6 address for this static mapping</help>

--- a/interface-definitions/include/version/dhcp-server-version.xml.i
+++ b/interface-definitions/include/version/dhcp-server-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/dhcp-server-version.xml.i -->
-<syntaxVersion component='dhcp-server' version='7'></syntaxVersion>
+<syntaxVersion component='dhcp-server' version='8'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/include/version/dhcpv6-server-version.xml.i
+++ b/interface-definitions/include/version/dhcpv6-server-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/dhcpv6-server-version.xml.i -->
-<syntaxVersion component='dhcpv6-server' version='2'></syntaxVersion>
+<syntaxVersion component='dhcpv6-server' version='3'></syntaxVersion>
 <!-- include end -->

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -121,14 +121,20 @@ def kea_parse_subnet(subnet, config):
             if 'disable' in host_config:
                 continue
 
-            obj = {
-                'hw-address': host_config['mac_address']
+            reservation = {
+                'hostname': host,
             }
 
-            if 'ip_address' in host_config:
-                obj['ip-address'] = host_config['ip_address']
+            if 'mac' in host_config:
+                reservation['hw-address'] = host_config['mac']
 
-            reservations.append(obj)
+            if 'duid' in host_config:
+                reservation['duid'] = host_config['duid']
+
+            if 'ip_address' in host_config:
+                reservation['ip-address'] = host_config['ip_address']
+
+            reservations.append(reservation)
         out['reservations'] = reservations
 
     unifi_controller = dict_search_args(config, 'vendor_option', 'ubiquiti', 'unifi_controller')
@@ -178,7 +184,7 @@ def kea6_parse_options(config):
 
         if addrs:
             options.append({'name': 'sip-server-addr', 'data': ", ".join(addrs)})
-        
+
         if hosts:
             options.append({'name': 'sip-server-dns', 'data': ", ".join(hosts)})
 
@@ -234,10 +240,15 @@ def kea6_parse_subnet(subnet, config):
             if 'disable' in host_config:
                 continue
 
-            reservation = {}
+            reservation = {
+                'hostname': host
+            }
 
-            if 'identifier' in host_config:
-                reservation['duid'] = host_config['identifier']
+            if 'mac' in host_config:
+                reservation['hw-address'] = host_config['mac']
+
+            if 'duid' in host_config:
+                reservation['duid'] = host_config['duid']
 
             if 'ipv6_address' in host_config:
                 reservation['ip-addresses'] = [ host_config['ipv6_address'] ]
@@ -305,7 +316,7 @@ def kea_get_active_config(inet):
     ctrl_socket = f'/run/kea/dhcp{inet}-ctrl-socket'
 
     config = _ctrl_socket_command(ctrl_socket, 'config-get')
-    
+
     if not config or 'result' not in config or config['result'] != 0:
         return None
 

--- a/src/conf_mode/dhcp_server.py
+++ b/src/conf_mode/dhcp_server.py
@@ -18,7 +18,6 @@ import os
 
 from ipaddress import ip_address
 from ipaddress import ip_network
-from netaddr import IPAddress
 from netaddr import IPRange
 from sys import exit
 
@@ -141,7 +140,7 @@ def get_config(config=None):
                                 {'range' : new_range_dict})
 
     if dict_search('failover.certificate', dhcp):
-        dhcp['pki'] = conf.get_config_dict(['pki'], key_mangling=('-', '_'), get_first_key=True, no_tag_node_value_mangle=True) 
+        dhcp['pki'] = conf.get_config_dict(['pki'], key_mangling=('-', '_'), get_first_key=True, no_tag_node_value_mangle=True)
 
     return dhcp
 
@@ -226,9 +225,10 @@ def verify(dhcp):
                             raise ConfigError(f'Configured static lease address for mapping "{mapping}" is\n' \
                                               f'not within shared-network "{network}, {subnet}"!')
 
-                        if 'mac_address' not in mapping_config:
-                            raise ConfigError(f'MAC address required for static mapping "{mapping}"\n' \
-                                              f'within shared-network "{network}, {subnet}"!')
+                        if ('mac' not in mapping_config and 'duid' not in mapping_config) or \
+                            ('mac' in mapping_config and 'duid' in mapping_config):
+                            raise ConfigError(f'Either MAC address or Client identifier (DUID) is required for '
+                                              f'static mapping "{mapping}" within shared-network "{network}, {subnet}"!')
 
             # There must be one subnet connected to a listen interface.
             # This only counts if the network itself is not disabled!

--- a/src/conf_mode/dhcpv6_server.py
+++ b/src/conf_mode/dhcpv6_server.py
@@ -135,6 +135,11 @@ def verify(dhcpv6):
                         if ip_address(mapping_config['ipv6_address']) not in ip_network(subnet):
                             raise ConfigError(f'static-mapping address for mapping "{mapping}" is not in subnet "{subnet}"!')
 
+                        if ('mac' not in mapping_config and 'duid' not in mapping_config) or \
+                            ('mac' in mapping_config and 'duid' in mapping_config):
+                            raise ConfigError(f'Either MAC address or Client identifier (DUID) is required for '
+                                              f'static mapping "{mapping}" within shared-network "{network}, {subnet}"!')
+
             if 'vendor_option' in subnet_config:
                 if len(dict_search('vendor_option.cisco.tftp_server', subnet_config)) > 2:
                     raise ConfigError(f'No more then two Cisco tftp-servers should be defined for subnet "{subnet}"!')

--- a/src/migration-scripts/dhcp-server/7-to-8
+++ b/src/migration-scripts/dhcp-server/7-to-8
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T3316:
+# - Adjust hostname to have valid FQDN characters only (underscores aren't allowed anymore)
+# - Rename "service dhcp-server shared-network-name ... static-mapping <hostname> mac-address ..."
+#       to "service dhcp-server shared-network-name ... static-mapping <hostname> mac ..."
+
+import sys
+import re
+from vyos.configtree import ConfigTree
+
+if len(sys.argv) < 2:
+    print("Must specify file name!")
+    sys.exit(1)
+
+file_name = sys.argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['service', 'dhcp-server', 'shared-network-name']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    sys.exit(0)
+
+for network in config.list_nodes(base):
+    # Run this for every specified 'subnet'
+    if config.exists(base + [network, 'subnet']):
+        for subnet in config.list_nodes(base + [network, 'subnet']):
+            base_subnet = base + [network, 'subnet', subnet]
+            if config.exists(base_subnet + ['static-mapping']):
+                for hostname in config.list_nodes(base_subnet + ['static-mapping']):
+                    base_mapping = base_subnet + ['static-mapping', hostname]
+
+                    # Rename the 'mac-address' node to 'mac'
+                    if config.exists(base_mapping + ['mac-address']):
+                        config.rename(base_mapping + ['mac-address'], 'mac')
+
+                    # Adjust hostname to have valid FQDN characters only
+                    new_hostname = re.sub(r'[^a-zA-Z0-9-.]', '-', hostname)
+                    if new_hostname != hostname:
+                        config.rename(base_mapping, new_hostname)
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)

--- a/src/migration-scripts/dhcpv6-server/2-to-3
+++ b/src/migration-scripts/dhcpv6-server/2-to-3
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T3316:
+# - Adjust hostname to have valid FQDN characters only (underscores aren't allowed anymore)
+# - Adjust duid (old identifier) to comply with duid format
+# - Rename "service dhcpv6-server shared-network-name ... static-mapping <hostname> identifier ..."
+#       to "service dhcpv6-server shared-network-name ... static-mapping <hostname> duid ..."
+# - Rename "service dhcpv6-server shared-network-name ... static-mapping <hostname> mac-address ..."
+#       to "service dhcpv6-server shared-network-name ... static-mapping <hostname> mac ..."
+
+import sys
+import re
+from vyos.configtree import ConfigTree
+
+if len(sys.argv) < 2:
+    print("Must specify file name!")
+    sys.exit(1)
+
+file_name = sys.argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['service', 'dhcpv6-server', 'shared-network-name']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    sys.exit(0)
+
+for network in config.list_nodes(base):
+    # Run this for every specified 'subnet'
+    if config.exists(base + [network, 'subnet']):
+        for subnet in config.list_nodes(base + [network, 'subnet']):
+            base_subnet = base + [network, 'subnet', subnet]
+            if config.exists(base_subnet + ['static-mapping']):
+                for hostname in config.list_nodes(base_subnet + ['static-mapping']):
+                    base_mapping = base_subnet + ['static-mapping', hostname]
+                    if config.exists(base_mapping + ['identifier']):
+
+                        # Adjust duid to comply with duid format (a:3:b:04:... => 0a:03:0b:04:...)
+                        duid = config.return_value(base_mapping + ['identifier'])
+                        new_duid = ':'.join(x.rjust(2,'0') for x in duid.split(':'))
+                        if new_duid != duid:
+                            config.set(base_mapping + ['identifier'], new_duid)
+
+                        # Rename the 'identifier' node to 'duid'
+                        config.rename(base_mapping + ['identifier'], 'duid')
+
+                    # Rename the 'mac-address' node to 'mac'
+                    if config.exists(base_mapping + ['mac-address']):
+                        config.rename(base_mapping + ['mac-address'], 'mac')
+
+                    # Adjust hostname to have valid FQDN characters only
+                    new_hostname = re.sub(r'[^a-zA-Z0-9-.]', '-', hostname)
+                    if new_hostname != hostname:
+                        config.rename(base_mapping, new_hostname)
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Reinstate support for hostname in DHCP reservation. Having `hostname` in allows for server-side assignment of hostname. This is useful for static lookup of hostname.
 
Additionally, support using either of DUID or MAC address for reservation. While MAC address is typically used for IPv4, and DUID is typically used for IPv6, both can be used for both cases in Kea.

For details, see:
- https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp4-srv.html#host-reservations-in-dhcpv4
- https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp6-srv.html#host-reservations-in-dhcpv6
- https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp6-srv.html#mac-hardware-addresses-in-dhcpv6

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3316

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* #2664

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-server, dhcpv6-server

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@v15-1221:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py 
test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
test_dhcp_failover (__main__.TestServiceDHCPServer.test_dhcp_failover) ... 
No DHCP address range or active static-mapping configured within shared-
network "FAILOVER, 192.0.2.0/25"!

ok
test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... 
No DHCP address range or active static-mapping configured within shared-
network "SMOKE-0815, 192.0.2.0/25"!

ok
test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... 
No DHCP address range or active static-mapping configured within shared-
network "SMOKE-1, 192.0.2.0/25"!

ok
test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... 
No DHCP address range or active static-mapping configured within shared-
network "SMOKE-2, 192.0.2.0/25"!


Either MAC address or Client identifier (DUID) is required for static
mapping "client1" within shared-network "SMOKE-2, 192.0.2.0/25"!

ok

----------------------------------------------------------------------
Ran 8 tests in 198.886s

OK
vyos@v15-1221:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_dhcpv6-server.py 
test_global_nameserver (__main__.TestServiceDHCPv6Server.test_global_nameserver) ... ok
test_prefix_delegation (__main__.TestServiceDHCPv6Server.test_prefix_delegation) ... ok
test_single_pool (__main__.TestServiceDHCPv6Server.test_single_pool) ... 
Either MAC address or Client identifier (DUID) is required for static
mapping "client1" within shared-network "SMOKE-1, 2001:db8:f00::/64"!

ok

----------------------------------------------------------------------
Ran 3 tests in 85.947s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
