### PR TITLE
smoketest: bgp: T4163: use explicit kill to respawn bgpd process

### DIFF
--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -15,7 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+
 from subprocess import run
+from time import sleep
 
 from base_vyostest_shim import VyOSUnitTestSHIM
 
@@ -1160,13 +1162,12 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         mirror_buffer = '32000000'
         bmp_path = base_path + ['bmp']
         target_path = bmp_path + ['target', target_name]
-        bgpd_bmp_pid = process_named_running('bgpd', 'bmp')
         command = ['/opt/vyatta/bin/vyatta-op-cmd-wrapper', 'restart', 'bgp']
 
         self.cli_set(bmp_path)
         # by default the 'bmp' module not loaded for the bgpd
         # expect Error
-        if not bgpd_bmp_pid:
+        if not process_named_running('bgpd', 'bmp'):
             with self.assertRaises(ConfigSessionError):
                 self.cli_commit()
 
@@ -1174,8 +1175,12 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(bmp_path)
         self.cli_set(['system', 'frr', 'bmp'])
         self.cli_commit()
+
         # restart bgpd to apply "-M bmp" and update PID
         run(command, input='Y', text=True)
+        # let the bgpd process recover
+        sleep(10)
+        # update daemon PID - this was a planned daemon restart
         self.daemon_pid = process_named_running(PROCESS_NAME)
 
         # set bmp config but not set address

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -16,7 +16,6 @@
 
 import unittest
 
-from subprocess import run
 from time import sleep
 
 from base_vyostest_shim import VyOSUnitTestSHIM
@@ -25,6 +24,7 @@ from vyos.ifconfig import Section
 from vyos.configsession import ConfigSessionError
 from vyos.template import is_ipv6
 from vyos.utils.process import process_named_running
+from vyos.utils.process import cmd
 
 PROCESS_NAME = 'bgpd'
 ASN = '64512'
@@ -1162,11 +1162,9 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         mirror_buffer = '32000000'
         bmp_path = base_path + ['bmp']
         target_path = bmp_path + ['target', target_name]
-        command = ['/opt/vyatta/bin/vyatta-op-cmd-wrapper', 'restart', 'bgp']
 
+        # by default the 'bmp' module not loaded for the bgpd expect Error
         self.cli_set(bmp_path)
-        # by default the 'bmp' module not loaded for the bgpd
-        # expect Error
         if not process_named_running('bgpd', 'bmp'):
             with self.assertRaises(ConfigSessionError):
                 self.cli_commit()
@@ -1177,7 +1175,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # restart bgpd to apply "-M bmp" and update PID
-        run(command, input='Y', text=True)
+        cmd(f'sudo kill -9 {self.daemon_pid}')
         # let the bgpd process recover
         sleep(10)
         # update daemon PID - this was a planned daemon restart


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

(cherry picked from commit b873112dd7253b64d323e183758dbabaa0f28b6e)


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4163

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

smoketests

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR2.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ... ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ... ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ... ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ... ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ... ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ... ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ... ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ... ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ... ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ... ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok
test_bgp_24_srv6_sid (__main__.TestProtocolsBGP.test_bgp_24_srv6_sid) ... ok
test_bgp_25_bmp (__main__.TestProtocolsBGP.test_bgp_25_bmp) ... ok

----------------------------------------------------------------------
Ran 24 tests in 155.177s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
