### PR TITLE
configdep: T5839: remove trivially redundant config dependency calls

### DIFF
--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020-2023 VyOS maintainers and contributors
+# Copyright (C) 2020-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -19,6 +19,7 @@ import sys
 import grp
 import re
 import json
+import typing
 import logging
 import signal
 import importlib.util
@@ -29,6 +30,7 @@ from vyos.defaults import directories
 from vyos.utils.boot import boot_configuration_complete
 from vyos.configsource import ConfigSourceString
 from vyos.configsource import ConfigSourceError
+from vyos.configdep import call_dependents
 from vyos.config import Config
 from vyos import ConfigError
 
@@ -198,10 +200,12 @@ def initialization(socket):
         return None
 
     config = Config(config_source=configsource)
+    dependent_func: dict[str, list[typing.Callable]] = {}
+    setattr(config, 'dependent_func', dependent_func)
 
     return config
 
-def process_node_data(config, data) -> int:
+def process_node_data(config, data, last: bool = False) -> int:
     if not config:
         logger.critical(f"Empty config")
         return R_ERROR_DAEMON
@@ -223,10 +227,17 @@ def process_node_data(config, data) -> int:
     args.insert(0, f'{script_name}.py')
 
     if script_name not in include_set:
+        # call dependents now if last element of prio queue is run
+        # independent of configd
+        if last:
+            call_dependents(dependent_func=config.dependent_func)
         return R_PASS
 
     with stdout_redirected(session_out, session_mode):
         result = run_script(conf_mode_scripts[script_name], config, args)
+
+    if last:
+        call_dependents(dependent_func=config.dependent_func)
 
     return result
 
@@ -281,7 +292,9 @@ if __name__ == '__main__':
             socket.send(resp.encode())
             config = initialization(socket)
         elif message["type"] == "node":
-            res = process_node_data(config, message["data"])
+            if message["last"]:
+                logger.debug(f'final element of priority queue')
+            res = process_node_data(config, message["data"], message["last"])
             response = res.to_bytes(1, byteorder=sys.byteorder)
             logger.debug(f"Sending response {res}")
             socket.send(response)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

NOTE: this requires https://github.com/vyos/vyatta-cfg/pull/74

NOTE: this should not be backported until it has had a bit of time in 1.5

Remove redundant calls to config dependencies in two steps:
(1) remove trivial redundancies produced by multiple calls to `set_dependents` within a given config-mode script
(2) add a global list of dependencies under vyos-configd and execute in that context, when script is called with vyos-configd support

The case (1) is necessary as `set_dependents` can be called conditionally; a simple example, used below for demonstration, is that of firewall.py wherein dependents `["system_conntrack", "nat", "policy_route"]` are added if 'group' is present (group-resync), and `["system_conntrack"]` is added unconditionally.

An important consideration is that adjusting the script logic to avoid redundancies is fragile and prone to error and NOT recommended, in favor of a proper solution, provided here.

The case (2) is necessary as otherwise, scripts process local dependency lists without knowledge of other script calls, for examples, firewall 'group-resync' will call `["system_conntrack", "nat", "policy_route"]`, which will incur nat.py calling `["system_conntrack"]` subsequently. Again, one should not need to handle the logic of execution from with the logic of dependency.

Example below:

```
set firewall group address-group AG address '198.122.100.137'
set nat source rule 10 outbound-interface name 'eth1'
set nat source rule 10 source group address-group 'AG'
set nat source rule 10 translation address 'masquerade'
```

Without any redundancy pruning:

--- including set_dependents calls:
```
vyos@vyos# commit
set_dependents: caller nat, dependents ['system_conntrack']
calling: system_conntrack
set_dependents: caller firewall, dependents ['system_conntrack', 'nat', 'policy_route']
set_dependents: caller firewall, dependents ['system_conntrack', 'nat', 'policy_route', 'system_conntrack']
calling: system_conntrack
calling: nat
set_dependents: caller nat, dependents ['system_conntrack']
calling: system_conntrack
calling: policy_route
calling: system_conntrack
```

--- limiting to the resulting script calls:
```
calling: system_conntrack
calling: system_conntrack
calling: nat
calling: system_conntrack
calling: policy_route
calling: system_conntrack
```

With intra-script dependency pruning:

--- including set_dependents calls
```
vyos@vyos# commit
set_dependents: caller nat, dependents ['system_conntrack']
calling: system_conntrack
set_dependents: caller firewall, dependents ['system_conntrack', 'nat', 'policy_route']
set_dependents: caller firewall, dependents ['nat', 'policy_route', 'system_conntrack']
calling: nat
set_dependents: caller nat, dependents ['system_conntrack']
calling: system_conntrack
calling: policy_route
calling: system_conntrack
```

--- with result:
```
calling: system_conntrack
calling: nat
calling: system_conntrack
calling: policy_route
calling: system_conntrack
```

With global dependency list:

--- scripts set dependencies as before:
```
vyos@vyos# commit
set_dependents: caller nat, dependents ['system_conntrack']
set_dependents: caller firewall, dependents ['system_conntrack', 'nat', 'policy_route']
set_dependents: caller firewall, dependents ['nat', 'policy_route', 'system_conntrack']

```
--- dependents are called under vyos-configd:
```
journalctl -u vyos-configd|grep calling
...: calling: nat
...: calling: policy_route
...: calling: system_conntrack

```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5839
* https://vyos.dev/T5660


## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyatta-cfg/pull/74
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
