### PR TITLE
srv6: T591: enable SR enabled packet processing on defined interfaces

### DIFF
--- a/interface-definitions/protocols-segment-routing.xml.in
+++ b/interface-definitions/protocols-segment-routing.xml.in
@@ -8,6 +8,54 @@
           <priority>900</priority>
         </properties>
         <children>
+          <tagNode name="interface">
+            <properties>
+              <help>Interface specific Segment Routing options</help>
+              <completionHelp>
+                <script>${vyos_completion_dir}/list_interfaces</script>
+              </completionHelp>
+              <valueHelp>
+                <format>txt</format>
+                <description>Interface name</description>
+              </valueHelp>
+              <constraint>
+                #include <include/constraint/interface-name.xml.i>
+              </constraint>
+            </properties>
+            <children>
+              <node name="srv6">
+                <properties>
+                  <help>Accept SR-enabled IPv6 packets on this interface</help>
+                </properties>
+                <children>
+                  <leafNode name="hmac">
+                    <properties>
+                      <help>Define HMAC policy for ingress SR-enabled packets on this interface</help>
+                      <completionHelp>
+                        <list>accept drop ignore</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>accept</format>
+                        <description>Accept packets without HMAC, validate packets with HMAC</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>drop</format>
+                        <description>Drop packets without HMAC, validate packets with HMAC</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>ignore</format>
+                        <description>Ignore HMAC field.</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>(accept|drop|ignore)</regex>
+                      </constraint>
+                    </properties>
+                    <defaultValue>accept</defaultValue>
+                  </leafNode>
+                </children>
+              </node>
+            </children>
+          </tagNode>
           <node name="srv6">
             <properties>
               <help>Segment-Routing SRv6 configuration</help>

--- a/src/conf_mode/protocols_segment_routing.py
+++ b/src/conf_mode/protocols_segment_routing.py
@@ -19,7 +19,10 @@ import os
 from sys import exit
 
 from vyos.config import Config
+from vyos.configdict import node_changed
 from vyos.template import render_to_string
+from vyos.utils.dict import dict_search
+from vyos.utils.system import sysctl_write
 from vyos import ConfigError
 from vyos import frr
 from vyos import airbag
@@ -32,33 +35,74 @@ def get_config(config=None):
         conf = Config()
 
     base = ['protocols', 'segment-routing']
-    sr = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True, no_tag_node_value_mangle=True)
+    sr = conf.get_config_dict(base, key_mangling=('-', '_'),
+                              get_first_key=True,
+                              no_tag_node_value_mangle=True,
+                              with_recursive_defaults=True)
 
-    # We have gathered the dict representation of the CLI, but there are default
-    # options which we need to update into the dictionary retrived.
-    sr = conf.merge_defaults(sr, recursive=True)
+    # FRR has VRF support for different routing daemons. As interfaces belong
+    # to VRFs - or the global VRF, we need to check for changed interfaces so
+    # that they will be properly rendered for the FRR config. Also this eases
+    # removal of interfaces from the running configuration.
+    interfaces_removed = node_changed(conf, base + ['interface'])
+    if interfaces_removed:
+        sr['interface_removed'] = list(interfaces_removed)
 
+    import pprint
+    pprint.pprint(sr)
     return sr
 
-def verify(static):
+def verify(sr):
+    if 'srv6' in sr:
+        srv6_enable = False
+        if 'interface' in sr:
+            for interface, interface_config in sr['interface'].items():
+                if 'srv6' in interface_config:
+                    srv6_enable = True
+                    break
+        if not srv6_enable:
+            raise ConfigError('SRv6 should be enabled on at least one interface!')
     return None
 
-def generate(static):
-    if not static:
+def generate(sr):
+    if not sr:
         return None
 
-    static['new_frr_config'] = render_to_string('frr/zebra.segment_routing.frr.j2', static)
+    sr['new_frr_config'] = render_to_string('frr/zebra.segment_routing.frr.j2', sr)
     return None
 
-def apply(static):
+def apply(sr):
     zebra_daemon = 'zebra'
+
+    if 'interface_removed' in sr:
+        for interface in sr['interface_removed']:
+            # Disable processing of IPv6-SR packets
+            sysctl_write(f'net.ipv6.conf.{interface}.seg6_enabled', '0')
+
+    if 'interface' in sr:
+        for interface, interface_config in sr['interface'].items():
+            # Accept or drop SR-enabled IPv6 packets on this interface
+            if 'srv6' in interface_config:
+                sysctl_write(f'net.ipv6.conf.{interface}.seg6_enabled', '1')
+                # Define HMAC policy for ingress SR-enabled packets on this interface
+                # It's a redundant check as HMAC has a default value - but better safe
+                # then sorry
+                tmp = dict_search('srv6.hmac', interface_config)
+                if tmp == 'accept':
+                    sysctl_write(f'net.ipv6.conf.{interface}.seg6_require_hmac', '0')
+                elif tmp == 'drop':
+                    sysctl_write(f'net.ipv6.conf.{interface}.seg6_require_hmac', '1')
+                elif tmp == 'ignore':
+                    sysctl_write(f'net.ipv6.conf.{interface}.seg6_require_hmac', '-1')
+            else:
+                sysctl_write(f'net.ipv6.conf.{interface}.seg6_enabled', '0')
 
     # Save original configuration prior to starting any commit actions
     frr_cfg = frr.FRRConfig()
     frr_cfg.load_configuration(zebra_daemon)
     frr_cfg.modify_section(r'^segment-routing')
-    if 'new_frr_config' in static:
-        frr_cfg.add_before(frr.default_add_before, static['new_frr_config'])
+    if 'new_frr_config' in sr:
+        frr_cfg.add_before(frr.default_add_before, sr['new_frr_config'])
     frr_cfg.commit_configuration(zebra_daemon)
 
     return None

--- a/src/conf_mode/vrf.py
+++ b/src/conf_mode/vrf.py
@@ -214,6 +214,18 @@ def apply(vrf):
             # Delete the VRF Kernel interface
             call(f'ip link delete dev {tmp}')
 
+    # Enable/Disable VRF strict mode
+    # When net.vrf.strict_mode=0 (default) it is possible to associate multiple
+    # VRF devices to the same table. Conversely, when net.vrf.strict_mode=1 a
+    # table can be associated to a single VRF device.
+    #
+    # A VRF table can be used by the VyOS CLI only once (ensured by verify()),
+    # this simply adds an additional Kernel safety net
+    strict_mode = '0'
+    # Set to 1 if any VRF is defined
+    if 'name' in vrf: strict_mode = '1'
+    sysctl_write('net.vrf.strict_mode', strict_mode)
+
     if 'name' in vrf:
         # Separate VRFs in conntrack table
         # check if table already exists

--- a/src/etc/sysctl.d/30-vyos-router.conf
+++ b/src/etc/sysctl.d/30-vyos-router.conf
@@ -105,3 +105,6 @@ net.core.rps_sock_flow_entries = 32768
 net.core.default_qdisc=fq_codel
 net.ipv4.tcp_congestion_control=bbr
 
+# Disable IPv6 Segment Routing packets by default
+net.ipv6.conf.all.seg6_enabled = 0
+net.ipv6.conf.default.seg6_enabled = 0

--- a/src/etc/sysctl.d/30-vyos-router.conf
+++ b/src/etc/sysctl.d/30-vyos-router.conf
@@ -105,11 +105,3 @@ net.core.rps_sock_flow_entries = 32768
 net.core.default_qdisc=fq_codel
 net.ipv4.tcp_congestion_control=bbr
 
-# VRF - Virtual routing and forwarding
-# When net.vrf.strict_mode=0 (default) it is possible to associate multiple
-# VRF devices to the same table. Conversely, when net.vrf.strict_mode=1 a
-# table can be associated to a single VRF device.
-#
-# A VRF table can be used by the VyOS CLI only once (ensured by verify()),
-# this simply adds an additional Kernel safety net
-net.vrf.strict_mode=1


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The Linux Kernel needs to be told if IPv6 SR enabled packets whether should be processed or not. This is done using

```console
    /proc/sys/net/conf/<iface>/seg6_* variables:

    seg6_enabled - BOOL
      Accept or drop SR-enabled IPv6 packets on this interface.
      Relevant packets are those with SRH present and DA = local.
      0 - disabled (default)
      not 0 - enabled
```

Or the VyOS CLI command: `set protocols segment-routing interface eth0 srv6`

In addition :

Enable/Disable VRF strict mode, when net.vrf.strict_mode=0 (default) it is possible to associate multiple VRF devices to the same table. Conversely, when `net.vrf.strict_mode=1` a table can be associated to a single VRF device.

A VRF table can be used by the VyOS CLI only once (ensured by verify()), this simply adds an additional Kernel safety net, but a requirement for IPv6 segment routing headers.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T591

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-1x/pull/2606

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
SRv6

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_segment_routing.py
test_srv6 (__main__.TestProtocolsSegmentRouting.test_srv6) ... ok
test_srv6_sysctl (__main__.TestProtocolsSegmentRouting.test_srv6_sysctl) ... ok

----------------------------------------------------------------------
Ran 2 tests in 14.099s

OK
```

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_vrf.py
test_vrf_assign_interface (__main__.VRFTest.test_vrf_assign_interface) ... ok
test_vrf_bind_all (__main__.VRFTest.test_vrf_bind_all) ... ok
test_vrf_disable_forwarding (__main__.VRFTest.test_vrf_disable_forwarding) ... ok
test_vrf_ip_ipv6_protocol_non_existing_route_map (__main__.VRFTest.test_vrf_ip_ipv6_protocol_non_existing_route_map) ... ok
test_vrf_ip_protocol_route_map (__main__.VRFTest.test_vrf_ip_protocol_route_map) ... ok
test_vrf_ipv6_protocol_route_map (__main__.VRFTest.test_vrf_ipv6_protocol_route_map) ... ok
test_vrf_link_local_ip_addresses (__main__.VRFTest.test_vrf_link_local_ip_addresses) ... ok
test_vrf_loopbacks_ips (__main__.VRFTest.test_vrf_loopbacks_ips) ... ok
test_vrf_static_route (__main__.VRFTest.test_vrf_static_route) ... ok
test_vrf_table_id_is_unalterable (__main__.VRFTest.test_vrf_table_id_is_unalterable) ... ok
test_vrf_vni_add_change_remove (__main__.VRFTest.test_vrf_vni_add_change_remove) ... ok
test_vrf_vni_and_table_id (__main__.VRFTest.test_vrf_vni_and_table_id) ... ok
test_vrf_vni_duplicates (__main__.VRFTest.test_vrf_vni_duplicates) ... ok

----------------------------------------------------------------------
Ran 13 tests in 218.407s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
