### PR TITLE
nat66: T2898: build fix after ndp-proxy backport

### DIFF
--- a/src/conf_mode/nat66.py
+++ b/src/conf_mode/nat66.py
@@ -147,17 +147,6 @@ def apply(nat):
         return None
 
     cmd(f'nft -f {nftables_nat66_config}')
-<<<<<<< HEAD
-
-    if 'deleted' in nat or not dict_search('source.rule', nat):
-        cmd('systemctl stop ndppd')
-        if os.path.isfile(ndppd_config):
-            os.unlink(ndppd_config)
-    else:
-        cmd('systemctl restart ndppd')
-=======
-    call_dependents()
->>>>>>> 4d721a580 (T2898: add ndp-proxy service)
 
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Fix errornous backport 

```diff
-<<<<<<< HEAD
-
-    if 'deleted' in nat or not dict_search('source.rule', nat):
-        cmd('systemctl stop ndppd')
-        if os.path.isfile(ndppd_config):
-            os.unlink(ndppd_config)
-    else:
-        cmd('systemctl restart ndppd')
-=======
-    call_dependents()
->>>>>>> 4d721a580 (T2898: add ndp-proxy service)

```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T2898

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
