### PR TITLE
T5840: Add override for systemd kea-ctrl-agent.service

### DIFF
--- a/data/templates/dhcp-server/10-override.conf.j2
+++ b/data/templates/dhcp-server/10-override.conf.j2
@@ -1,0 +1,2 @@
+[Unit]
+ConditionFileNotEmpty=

--- a/src/conf_mode/dhcp_server.py
+++ b/src/conf_mode/dhcp_server.py
@@ -41,6 +41,7 @@ ctrl_config_file = '/run/kea/kea-ctrl-agent.conf'
 ctrl_socket = '/run/kea/dhcp4-ctrl-socket'
 config_file = '/run/kea/kea-dhcp4.conf'
 lease_file = '/config/dhcp4.leases'
+systemd_override = r'/run/systemd/system/kea-ctrl-agent.service.d/10-override.conf'
 
 ca_cert_file = '/run/kea/kea-failover-ca.pem'
 cert_file = '/run/kea/kea-failover.pem'
@@ -331,6 +332,8 @@ def generate(dhcp):
             write_file(ca_cert_file, wrap_certificate(ca_cert_data), user='_kea', mode=0o600)
 
             dhcp['failover']['ca_cert_file'] = ca_cert_file
+
+        render(systemd_override, 'dhcp-server/10-override.conf.j2', dhcp)
 
     render(ctrl_config_file, 'dhcp-server/kea-ctrl-agent.conf.j2', dhcp)
     render(config_file, 'dhcp-server/kea-dhcp4.conf.j2', dhcp)


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

After update `KEA to 2.4.x` in the[ bf04cd8fea44d375fb7d93d75a1f31c220730c88](https://github.com/vyos/vyos-build/commit/bf04cd8fea44d375fb7d93d75a1f31c220730c88) there is a file that expects `ConditionFileNotEmpty=/etc/kea/kea-api-password`
 It cause the unit `kea-ctrl-agent.service` cannot start
```
systemd[1]: kea-ctrl-agent.service - Kea Control Agent was skipped because of an unmet condition check (ConditionFileNotEmpty=/etc/kea/kea-api-password)
```
Override systemd `kea-ctrl-agent.service` do not check this file

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5840

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces dummy dum8765 address '192.0.2.1/24'

set service dhcp-server shared-network-name SMOKE-1 subnet 192.0.2.0/24 default-router '192.0.2.1'
set service dhcp-server shared-network-name SMOKE-1 subnet 192.0.2.0/24 domain-name 'vyos.net'
set service dhcp-server shared-network-name SMOKE-1 subnet 192.0.2.0/24 name-server '192.0.2.2'
set service dhcp-server shared-network-name SMOKE-1 subnet 192.0.2.0/24 name-server '192.0.2.3'
set service dhcp-server shared-network-name SMOKE-1 subnet 192.0.2.0/24 range 0 start '192.0.2.10'
set service dhcp-server shared-network-name SMOKE-1 subnet 192.0.2.0/24 range 0 stop '192.0.2.20'

set service dhcp-server failover name 'FLSRV'
set service dhcp-server failover remote '192.0.2.5'
set service dhcp-server failover source-address '192.0.2.1'
set service dhcp-server failover status 'primary'

```
Before the fix:
```
DEBUG - ======================================================================
DEBUG - FAIL: test_dhcp_failover (__main__.TestServiceDHCPServer.test_dhcp_failover)
DEBUG - ----------------------------------------------------------------------
DEBUG - Traceback (most recent call last):
DEBUG -   File "/usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py", line 623, in test_dhcp_failover
DEBUG -     self.assertTrue(process_named_running(CTRL_PROCESS_NAME))
DEBUG - AssertionError: None is not true


vyos@r4# ps ax | grep -i kea | egrep -v grep
  24368 ?        Ssl    0:00 /usr/sbin/kea-dhcp4 -c /run/kea/kea-dhcp4.conf
[edit]

Dec 22 16:50:32 r4 systemd[1]: kea-ctrl-agent.service - Kea Control Agent was skipped because of an unmet condition check (ConditionFileNotEmpty=/etc/kea/kea-api-password).
```
After the fix:
Check the service `kea-ctrl-agent.conf` in processes:
```
vyos@r4# ps ax | grep kea
  21122 ?        Ssl    0:00 /usr/sbin/kea-ctrl-agent -c /run/kea/kea-ctrl-agent.conf
  21130 ?        Ssl    0:00 /usr/sbin/kea-dhcp4 -c /run/kea/kea-dhcp4.conf
  21202 pts/0    S+     0:00 grep kea
[edit]
vyos@r4# 

```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py
test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
test_dhcp_failover (__main__.TestServiceDHCPServer.test_dhcp_failover) ... ok
test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... ok
test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... ok
test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... ok

----------------------------------------------------------------------
Ran 8 tests in 36.385s

OK
vyos@r4:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
