### PR TITLE
T160: NAT64 add match firewall mark feature

### DIFF
--- a/interface-definitions/nat64.xml.in
+++ b/interface-definitions/nat64.xml.in
@@ -26,6 +26,25 @@
             <children>
               #include <include/generic-description.xml.i>
               #include <include/generic-disable-node.xml.i>
+              <node name="match">
+                <properties>
+                  <help>Match</help>
+                </properties>
+                <children>
+                  <leafNode name="mark">
+                    <properties>
+                      <help>Match fwmark value</help>
+                      <valueHelp>
+                        <format>u32:1-2147483647</format>
+                        <description>Fwmark value to match against</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-2147483647"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
               <node name="source">
                 <properties>
                   <help>IPv6 source prefix options</help>

--- a/src/conf_mode/nat64.py
+++ b/src/conf_mode/nat64.py
@@ -148,6 +148,11 @@ def generate(nat64) -> None:
 
             if dict_search("translation.pool", instance):
                 pool4 = []
+                # mark
+                mark = ''
+                if dict_search("match.mark", instance):
+                    mark = instance["match"]["mark"]
+
                 for pool in instance["translation"]["pool"].values():
                     if "disable" in pool:
                         continue
@@ -159,6 +164,8 @@ def generate(nat64) -> None:
                             "prefix": pool["address"],
                             "port range": pool["port"],
                         }
+                        if mark:
+                            obj["mark"] = int(mark)
                         if "description" in pool:
                             obj["comment"] = pool["description"]
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Match mark allows to use firewall marks of packets to use a specific pool

Example of instance config /run/jool/instance-100.json
```
  ...
  "pool4": [
    {
      "protocol": "TCP",
      "prefix": "192.0.2.10",
      "port range": "1-65535",
      "mark": 23
    },
   ...
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T160

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
NAT64
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces ethernet eth0 address '192.168.122.14/24'
set interfaces ethernet eth0 address '192.168.122.10/24'
set interfaces ethernet eth2 address '2001:db8::1/64'

set nat64 source rule 100 match mark '23'
set nat64 source rule 100 source prefix '64:ff9b::/96'
set nat64 source rule 100 translation pool 10 address '192.168.122.10'
set nat64 source rule 100 translation pool 10 port '1-65535'
```
Generated config:
```
vyos@r4# cat /run/jool/instance-100.json 
{
  "instance": "instance-100",
  "framework": "netfilter",
  "global": {
    "pool6": "64:ff9b::/96",
    "manually-enabled": true
  },
  "comment": "foo",
  "pool4": [
    {
      "protocol": "TCP",
      "prefix": "192.168.122.10",
      "port range": "1-65535",
      "mark": 23
    },
    {
      "protocol": "UDP",
      "prefix": "192.168.122.10",
      "port range": "1-65535",
      "mark": 23
    },
    {
      "protocol": "ICMP",
      "prefix": "192.168.122.10",
      "port range": "1-65535",
      "mark": 23
    }
  ]
}
```
Apply, there are no errors
```
vyos@r4# sudo jool -i instance-100 file handle /run/jool/instance-100.json
[edit]
vyos@r4# 

```
Check:
```
vyos@r4# sudo jool -i instance-100 pool4 display --tcp
+------------+-------+--------------------+-----------------+-------------+
|       Mark | Proto |     Max iterations |         Address |       Ports |
+------------+-------+--------------------+-----------------+-------------+
|         23 |   TCP |       1024 ( auto) |  192.168.122.10 |     1-65535 |
+------------+-------+--------------------+-----------------+-------------+
[edit]
vyos@r4# 

```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
