### PR TITLE
xml: T5854: clear empty paths left by embedded override of defaultValue

### DIFF
--- a/scripts/override-default
+++ b/scripts/override-default
@@ -41,6 +41,14 @@ if debug:
 else:
     logger.setLevel(logging.INFO)
 
+def clear_empty_path(el):
+    # on the odd chance of interleaved comments
+    tmp = [l for l in el if isinstance(l.tag, str)]
+    if not tmp:
+        p = el.getparent()
+        p.remove(el)
+        clear_empty_path(p)
+
 def override_element(l: list):
     """
     Allow multiple override elements; use the final one (in document order).
@@ -59,7 +67,9 @@ def override_element(l: list):
 
     # remove all but overridden element
     for el in parents:
-        el.getparent().remove(el)
+        tmp = el.getparent()
+        tmp.remove(el)
+        clear_empty_path(tmp)
 
 def merge_remaining(l: list, elementtree):
     """
@@ -81,7 +91,9 @@ def merge_remaining(l: list, elementtree):
                 # override_element() has already run
                 for child in el:
                     rp[0].append(deepcopy(child))
-                el.getparent().remove(el)
+                tmp = el.getparent()
+                tmp.remove(el)
+                clear_empty_path(tmp)
 
 def collect_and_override(dir_name):
     """
@@ -104,7 +116,7 @@ def collect_and_override(dir_name):
 
         for k, v in defv.items():
             if len(v) > 1:
-                logger.info(f"overridding default in path '{k}'")
+                logger.info(f"overriding default in path '{k}'")
                 override_element(v)
 
         to_merge = list(defv)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

For overriding defaultValue elements with XML fragments containing parent nodes, one needs to clean up leftover empty paths: example use case:

```
#include <include/accel-ppp/radius-additions.xml.i>
 <node name="radius">
   <children>
     <leafNode name="timeout">
       <defaultValue>30</defaultValue>
     </leafNode>
     <leafNode name="acct-timeout">
       <defaultValue>30</defaultValue>
     </leafNode>
   </children>
 </node>
```


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5854

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
