### PR TITLE
configdict: T5837: add support to return added nodes when calling node_changed()

### DIFF
--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -104,6 +104,10 @@ def list_diff(first, second):
     return [item for item in first if item not in second]
 
 def is_node_changed(conf, path):
+   """
+   Check if any key under path has been changed and return True.
+   If nothing changed, return false
+   """
    from vyos.configdiff import get_config_diff
    D = get_config_diff(conf, key_mangling=('-', '_'))
    return D.is_node_changed(path)

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -23,7 +23,7 @@ from sys import exit
 
 from vyos.base import Warning
 from vyos.config import Config
-from vyos.configdict import node_changed
+from vyos.configdict import is_node_changed
 from vyos.configdiff import get_config_diff, Diff
 from vyos.configdep import set_dependents, call_dependents
 from vyos.configverify import verify_interface_exists
@@ -133,7 +133,7 @@ def get_config(config=None):
                                     with_recursive_defaults=True)
 
 
-    firewall['group_resync'] = bool('group' in firewall or node_changed(conf, base + ['group']))
+    firewall['group_resync'] = bool('group' in firewall or is_node_changed(conf, base + ['group']))
     if firewall['group_resync']:
         # Update nat and policy-route as firewall groups were updated
         set_dependents('group_resync', conf)

--- a/src/conf_mode/interfaces-bridge.py
+++ b/src/conf_mode/interfaces-bridge.py
@@ -49,7 +49,7 @@ def get_config(config=None):
     ifname, bridge = get_interface_dict(conf, base)
 
     # determine which members have been removed
-    tmp = node_changed(conf, base + [ifname, 'member', 'interface'], key_mangling=('-', '_'))
+    tmp = node_changed(conf, base + [ifname, 'member', 'interface'])
     if tmp:
         if 'member' in bridge:
             bridge['member'].update({'interface_remove' : tmp })

--- a/src/conf_mode/netns.py
+++ b/src/conf_mode/netns.py
@@ -77,8 +77,8 @@ def verify(netns):
     if 'netns_remove' in netns:
         for name, config in netns['netns_remove'].items():
             if 'interface' in config:
-                raise ConfigError(f'Can not remove NETNS "{name}", it still has '\
-                                  f'member interfaces!')
+                raise ConfigError(f'Can not remove network namespace "{name}", it '\
+                                  f'still has member interfaces!')
 
     if 'name' in netns:
         for name, config in netns['name'].items():
@@ -86,7 +86,6 @@ def verify(netns):
             pass
 
     return None
-
 
 def generate(netns):
     if not netns:

--- a/src/conf_mode/protocols_nhrp.py
+++ b/src/conf_mode/protocols_nhrp.py
@@ -37,7 +37,7 @@ def get_config(config=None):
 
     nhrp = conf.get_config_dict(base, key_mangling=('-', '_'),
                                 get_first_key=True, no_tag_node_value_mangle=True)
-    nhrp['del_tunnels'] = node_changed(conf, base + ['tunnel'], key_mangling=('-', '_'))
+    nhrp['del_tunnels'] = node_changed(conf, base + ['tunnel'])
 
     if not conf.exists(base):
         return nhrp


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

In the past, node_changed() suggested it would also return nodes that got added (function comment) but in reality only deleted keys got accounted for.

This commit changes the signature and adds an argument expand_nodes to specify the users interest of a node was deleted (default), added (expand_nodes=Diff.ADD) or even both (expand_nodes=Diff.ADD|Diff.DELETE).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5837

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
