### PR TITLE
ethernet: T5566: disable energy efficient ethernet (EEE) for interfaces

### DIFF
--- a/python/vyos/ifconfig/ethernet.py
+++ b/python/vyos/ifconfig/ethernet.py
@@ -399,6 +399,34 @@ class EthernetIf(Interface):
             print(f'could not set "{rx_tx}" ring-buffer for {ifname}')
         return output
 
+    def set_eee(self, enable):
+        """
+        Enable/Disable Energy Efficient Ethernet (EEE) settings
+
+        Example:
+        >>> from vyos.ifconfig import EthernetIf
+        >>> i = EthernetIf('eth0')
+        >>> i.set_eee(enable=False)
+        """
+        if not isinstance(enable, bool):
+            raise ValueError('Value out of range')
+
+        if not self.ethtool.check_eee():
+            self._debug_msg(f'NIC driver does not support changing EEE settings!')
+            return False
+
+        current = self.ethtool.get_eee()
+        if current != enable:
+            # Assemble command executed on system. Unfortunately there is no way
+            # to change this setting via sysfs
+            cmd = f'ethtool --set-eee {self.ifname} eee '
+            cmd += 'on' if enable else 'off'
+            output, code = self._popen(cmd)
+            if code:
+                Warning(f'could not change "{self.ifname}" EEE setting!')
+            return output
+        return None
+
     def update(self, config):
         """ General helper function which works on a dictionary retrived by
         get_config_dict(). It's main intention is to consolidate the scattered
@@ -408,6 +436,9 @@ class EthernetIf(Interface):
         # disable ethernet flow control (pause frames)
         value = 'off' if 'disable_flow_control' in config else 'on'
         self.set_flow_control(value)
+
+        # Always disable Energy Efficient Ethernet
+        self.set_eee(False)
 
         # GRO (generic receive offload)
         self.set_gro(dict_search('offload.gro', config) != None)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

VyOS is a routing (packet pushing) platform, thus supporting EEE which potentially causes issues is not a good idea. Some recent Intel drivers enable EEE by default, thus we will disable this for every NIC supporting EEE.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5311
* https://vyos.dev/T5566

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
Ethernet

## Proposed changes
<!--- Describe your changes in detail -->
Always disable EEE via ethtool

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

This has been developed by injecting EEE output provided by @zdc to ethtool.py in lack of hardware.

```console
$ sudo ethtool --show-eee eno1 
EEE settings for eno1:
	EEE status: enabled - active
	Tx LPI: 17 (us)
	Supported EEE link modes:  100baseT/Full
	                           1000baseT/Full
	Advertised EEE link modes:  100baseT/Full
	                            1000baseT/Full
	Link partner advertised EEE link modes:  100baseT/Full
	                                         1000baseT/Full
$ sudo ethtool --set-eee eno1 eee off
$ sudo ethtool --show-eee eno1 
EEE settings for eno1:
	EEE status: disabled
	Tx LPI: 17 (us)
	Supported EEE link modes:  100baseT/Full
	                           1000baseT/Full
	Advertised EEE link modes:  100baseT/Full
	                            1000baseT/Full
	Link partner advertised EEE link modes:  100baseT/Full
	                                         1000baseT/Full
$ sudo ethtool --set-eee eno1 eee on
$ sudo ethtool --show-eee eno1 
EEE settings for eno1:
	EEE status: enabled - inactive
	Tx LPI: 17 (us)
	Supported EEE link modes:  100baseT/Full
	                           1000baseT/Full
	Advertised EEE link modes:  100baseT/Full
	                            1000baseT/Full
	Link partner advertised EEE link modes:  Not reported
(some time later...)
$ sudo ethtool --show-eee eno1 
EEE settings for eno1:
	EEE status: enabled - active
	Tx LPI: 17 (us)
	Supported EEE link modes:  100baseT/Full
	                           1000baseT/Full
	Advertised EEE link modes:  100baseT/Full
	                            1000baseT/Full
	Link partner advertised EEE link modes:  100baseT/Full
	                                         1000baseT/Full
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```console
cpo@LR1.wue3:~$ TEST_ETH="eth1 eth2" /usr/libexec/vyos/tests/smoke/cli/test_interfaces_ethernet.py
test_add_multiple_ip_addresses (__main__.EthernetInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.EthernetInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.EthernetInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.EthernetInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.EthernetInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.EthernetInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.EthernetInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol_support (__main__.EthernetInterfaceTest.test_eapol_support) ... ok
test_interface_description (__main__.EthernetInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.EthernetInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.EthernetInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.EthernetInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.EthernetInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.EthernetInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.EthernetInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_non_existing_interface (__main__.EthernetInterfaceTest.test_non_existing_interface) ... ok
test_offloading_rfs (__main__.EthernetInterfaceTest.test_offloading_rfs) ... ok
test_offloading_rps (__main__.EthernetInterfaceTest.test_offloading_rps) ... ok
test_span_mirror (__main__.EthernetInterfaceTest.test_span_mirror) ... ok
test_speed_duplex_verify (__main__.EthernetInterfaceTest.test_speed_duplex_verify) ... ok
test_vif_8021q_interfaces (__main__.EthernetInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.EthernetInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.EthernetInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.EthernetInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.EthernetInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.EthernetInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 28 tests in 201.270s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
