### PR TITLE
T5859: Fixed format of pool range in the accel-ppp config

### DIFF
--- a/data/templates/accel-ppp/config_ip_pool.j2
+++ b/data/templates/accel-ppp/config_ip_pool.j2
@@ -12,10 +12,16 @@ gw-ip-address={{ gateway_address }}
 {%     endif %}
 {%     for pool in ordered_named_pools %}
 {%         for pool_name, pool_config in pool.items() %}
+{%             set iprange_str = pool_config.range %}
+{%             set iprange_list = pool_config.range.split('-') %}
+{%             if iprange_list | length == 2 %}
+{%                 set last_ip_oct = iprange_list[1].split('.') %}
+{%                 set iprange_str = iprange_list[0] + '-' + last_ip_oct[last_ip_oct | length - 1] %}
+{%             endif %}
 {%             if pool_config.next_pool is vyos_defined %}
-{{ pool_config.range }},name={{ pool_name }},next={{ pool_config.next_pool }}
+{{ iprange_str }},name={{ pool_name }},next={{ pool_config.next_pool }}
 {%             else %}
-{{ pool_config.range }},name={{ pool_name }}
+{{ iprange_str }},name={{ pool_name }}
 {%             endif %}
 {%         endfor %}
 {%     endfor %}

--- a/smoketest/scripts/cli/base_accel_ppp_test.py
+++ b/smoketest/scripts/cli/base_accel_ppp_test.py
@@ -365,6 +365,7 @@ class BasicAccelPPPTest:
             first_pool = "POOL1"
             second_pool = "POOL2"
             range = "192.0.2.10-192.0.2.20"
+            range_config = "192.0.2.10-20"
 
             self.set(["gateway-address", gateway])
             self.set(["client-ip-pool", first_pool, "range", subnet])
@@ -382,7 +383,7 @@ class BasicAccelPPPTest:
             self.assertEqual(
                 f"{first_pool},next={second_pool}", conf["ip-pool"][f"{subnet},name"]
             )
-            self.assertEqual(second_pool, conf["ip-pool"][f"{range},name"])
+            self.assertEqual(second_pool, conf["ip-pool"][f"{range_config},name"])
             self.assertEqual(gateway, conf["ip-pool"]["gw-ip-address"])
             self.assertEqual(first_pool, conf[self._protocol_section]["ip-pool"])
 

--- a/smoketest/scripts/cli/test_service_ipoe-server.py
+++ b/smoketest/scripts/cli/test_service_ipoe-server.py
@@ -117,6 +117,7 @@ class TestServiceIPoEServer(BasicAccelPPPTest.TestCase):
         first_pool = "POOL1"
         second_pool = "POOL2"
         range = "192.0.2.10-192.0.2.20"
+        range_config = "192.0.2.10-20"
 
         for gw in gateway:
             self.set(["gateway-address", gw])
@@ -141,7 +142,7 @@ class TestServiceIPoEServer(BasicAccelPPPTest.TestCase):
         self.assertIn(
             f"{first_pool},next={second_pool}", conf["ip-pool"][f"{subnet},name"]
         )
-        self.assertIn(second_pool, conf["ip-pool"][f"{range},name"])
+        self.assertIn(second_pool, conf["ip-pool"][f"{range_config},name"])
 
         gw_pool_config_list = conf.get("ip-pool", "gw-ip-address")
         gw_ipoe_config_list = conf.get(self._protocol_section, "gw-ip-address")


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed format of ipv4 pool range from 'x.x.x.x-x.x.x.y' to 'x.x.x.x-y'

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5859

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
l2tp, sstp, pptp, ipoe, pppoe

## Proposed changes
<!--- Describe your changes in detail -->
Fixed format of ipv4 pool range from 'x.x.x.x-x.x.x.y' to 'x.x.x.x-y'

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
CLI Configuration:

`set vpn pptp remote-access client-ip-pool TEST range '10.0.0.100-10.0.0.102'`
/run/accel-pppd/pptp.conf

Before:
```
[ip-pool]
10.0.0.100-10.0.0.102,name=TEST
```
After

```
[ip-pool]
10.0.0.100-102,name=TEST
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_ipoe-server.py
test_accel_ipv4_pool (__main__.TestServiceIPoEServer.test_accel_ipv4_pool) ... ok
test_accel_local_authentication (__main__.TestServiceIPoEServer.test_accel_local_authentication) ...
No IPoE interface configured

ok
test_accel_name_servers (__main__.TestServiceIPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServiceIPoEServer.test_accel_next_pool) ... ok
test_accel_radius_authentication (__main__.TestServiceIPoEServer.test_accel_radius_authentication) ... ok

----------------------------------------------------------------------
Ran 5 tests in 18.508s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py
test_accel_ipv4_pool (__main__.TestServicePPPoEServer.test_accel_ipv4_pool)
Test accel-ppp IPv4 pool ... ok
test_accel_local_authentication (__main__.TestServicePPPoEServer.test_accel_local_authentication) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_name_servers (__main__.TestServicePPPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServicePPPoEServer.test_accel_next_pool)
T5099 required specific order ... ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer.test_accel_radius_authentication) ... ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer.test_pppoe_server_authentication_protocols) ... ok
test_pppoe_server_client_ipv6_pool (__main__.TestServicePPPoEServer.test_pppoe_server_client_ipv6_pool) ... ok
test_pppoe_server_ppp_options (__main__.TestServicePPPoEServer.test_pppoe_server_ppp_options) ... ok
test_pppoe_server_shaper (__main__.TestServicePPPoEServer.test_pppoe_server_shaper) ... ok
test_pppoe_server_vlan (__main__.TestServicePPPoEServer.test_pppoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 10 tests in 36.115s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_l2tp.py
test_accel_ipv4_pool (__main__.TestVPNL2TPServer.test_accel_ipv4_pool)
Test accel-ppp IPv4 pool ... ok
test_accel_local_authentication (__main__.TestVPNL2TPServer.test_accel_local_authentication) ... ok
test_accel_name_servers (__main__.TestVPNL2TPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNL2TPServer.test_accel_next_pool)
T5099 required specific order ... ok
test_accel_radius_authentication (__main__.TestVPNL2TPServer.test_accel_radius_authentication) ... ok

----------------------------------------------------------------------
Ran 5 tests in 20.337s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_sstp.py
test_accel_ipv4_pool (__main__.TestVPNSSTPServer.test_accel_ipv4_pool)
Test accel-ppp IPv4 pool ... ok
test_accel_local_authentication (__main__.TestVPNSSTPServer.test_accel_local_authentication) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_name_servers (__main__.TestVPNSSTPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNSSTPServer.test_accel_next_pool)
T5099 required specific order ... ok
test_accel_radius_authentication (__main__.TestVPNSSTPServer.test_accel_radius_authentication) ... ok

----------------------------------------------------------------------
Ran 5 tests in 21.853s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_pptp.py
test_accel_ipv4_pool (__main__.TestVPNPPTPServer.test_accel_ipv4_pool)
Test accel-ppp IPv4 pool ... ok
test_accel_local_authentication (__main__.TestVPNPPTPServer.test_accel_local_authentication) ... ok
test_accel_name_servers (__main__.TestVPNPPTPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNPPTPServer.test_accel_next_pool)
T5099 required specific order ... ok
test_accel_radius_authentication (__main__.TestVPNPPTPServer.test_accel_radius_authentication) ... ok

----------------------------------------------------------------------
Ran 5 tests in 20.351s

OK

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
