### PR TITLE
T5842: Rewritten PPTP to get_config_dict

### DIFF
--- a/data/templates/accel-ppp/pptp.config.j2
+++ b/data/templates/accel-ppp/pptp.config.j2
@@ -3,18 +3,22 @@
 log_syslog
 pptp
 shaper
-{% if auth_mode == 'local' %}
-chap-secrets
-{% elif auth_mode == 'radius' %}
-radius
-{% endif %}
+{# Common authentication backend definitions #}
+{% include 'accel-ppp/config_modules_auth_mode.j2' %}
 ippool
-{% for proto in auth_proto %}
-{{ proto }}
-{% endfor %}
+{# Common authentication protocols (pap, chap ...) #}
+{% if authentication.require is vyos_defined %}
+{%     if authentication.require == 'chap' %}
+auth_chap_md5
+{%     elif authentication.require == 'mschap' %}
+auth_mschap_v1
+{%     else %}
+auth_{{ authentication.require.replace('-', '_') }}
+{%     endif %}
+{% endif %}
 
 [core]
-thread-count={{ thread_cnt }}
+thread-count={{ thread_count }}
 
 [common]
 {% if max_concurrent_sessions is vyos_defined %}
@@ -26,16 +30,12 @@ syslog=accel-pptp,daemon
 copy=1
 level=5
 
-{% if dnsv4 %}
-[dns]
-{%     for dns in dnsv4 %}
-dns{{ loop.index }}={{ dns }}
-{%     endfor %}
-{% endif %}
+{# Common DNS name-server definition #}
+{% include 'accel-ppp/config_name_server.j2' %}
 
-{% if wins %}
+{% if wins_server is vyos_defined %}
 [wins]
-{%     for server in wins %}
+{%     for server in wins_server %}
 wins{{ loop.index }}={{ server }}
 {%     endfor %}
 {% endif %}
@@ -43,12 +43,12 @@ wins{{ loop.index }}={{ server }}
 
 [pptp]
 ifname=pptp%d
-{% if outside_addr %}
-bind={{ outside_addr }}
+{% if outside_address is vyos_defined %}
+bind={{ outside_address }}
 {% endif %}
 verbose=1
 ppp-max-mtu={{ mtu }}
-mppe={{ ppp_mppe }}
+mppe={{ authentication.mppe }}
 echo-interval=10
 echo-failure=3
 {% if default_pool is vyos_defined %}
@@ -66,52 +66,11 @@ verbose=5
 check-ip=1
 single-session=replace
 
-{% if auth_mode == 'local' %}
-[chap-secrets]
-chap-secrets={{ chap_secrets_file }}
-{% elif auth_mode == 'radius' %}
-[radius]
-verbose=1
-{%     for r in radius_server %}
-server={{ r.server }},{{ r.key }},auth-port={{ r.port }},acct-port={{ r.acct_port }},req-limit=0,fail-time={{ r.fail_time }}
-{%     endfor %}
-{%     if radius_acct_interim_interval is vyos_defined %}
-acct-interim-interval={{ radius_acct_interim_interval }}
-{%     endif %}
-{%     if radius_acct_inter_jitter %}
-acct-interim-jitter={{ radius_acct_inter_jitter }}
-{%     endif %}
-acct-timeout={{ radius_acct_tmo }}
-timeout={{ radius_timeout }}
-max-try={{ radius_max_try }}
-{%     if radius_nas_id %}
-nas-identifier={{ radius_nas_id }}
-{%     endif %}
-{%     if radius_nas_ip %}
-nas-ip-address={{ radius_nas_ip }}
-{%     endif %}
-{%     if radius_source_address %}
-bind={{ radius_source_address }}
-{%     endif %}
-{% endif %}
-{# Both chap-secrets and radius block required the gw-ip-address #}
-{% if gateway_address is vyos_defined %}
-gw-ip-address={{ gateway_address }}
-{% endif %}
+{# Common chap-secrets and RADIUS server/option definitions #}
+{% include 'accel-ppp/config_chap_secrets_radius.j2' %}
 
-{% if radius_shaper_enable %}
-[shaper]
-verbose=1
-{%     if radius_shaper_attr %}
-attr={{ radius_shaper_attr }}
-{%     endif %}
-{%     if radius_shaper_multiplier %}
-rate-multiplier={{ radius_shaper_multiplier }}
-{%     endif %}
-{%     if radius_shaper_vendor %}
-vendor={{ radius_shaper_vendor }}
-{%     endif %}
-{% endif %}
+{# Common RADIUS shaper configuration #}
+{% include 'accel-ppp/config_shaper_radius.j2' %}
 
 [cli]
 tcp=127.0.0.1:2003

--- a/interface-definitions/vpn-pptp.xml.in
+++ b/interface-definitions/vpn-pptp.xml.in
@@ -15,6 +15,9 @@
             <children>
               #include <include/accel-ppp/max-concurrent-sessions.xml.i>
               #include <include/accel-ppp/mtu-128-16384.xml.i>
+              <leafNode name="mtu">
+                <defaultValue>1436</defaultValue>
+              </leafNode>
               <leafNode name="outside-address">
                 <properties>
                   <help>External IP address to which VPN clients will connect</help>
@@ -35,6 +38,9 @@
                   <leafNode name="require">
                     <properties>
                       <help>Authentication protocol for remote access peer PPTP VPN</help>
+                      <completionHelp>
+                        <list>pap chap mschap mschap-v2</list>
+                      </completionHelp>
                       <valueHelp>
                         <format>pap</format>
                         <description>Require the peer to authenticate itself using PAP [Password Authentication Protocol].</description>
@@ -51,7 +57,11 @@
                         <format>mschap-v2</format>
                         <description>Require the peer to authenticate itself using MS-CHAPv2 [Microsoft Challenge Handshake Authentication Protocol, Version 2].</description>
                       </valueHelp>
+                      <constraint>
+                        <regex>(pap|chap|mschap|mschap-v2)</regex>
+                      </constraint>
                     </properties>
+                    <defaultValue>mschap-v2</defaultValue>
                   </leafNode>
                   <leafNode name="mppe">
                     <properties>
@@ -75,6 +85,7 @@
                         <list>deny prefer require</list>
                       </completionHelp>
                     </properties>
+                    <defaultValue>prefer</defaultValue>
                   </leafNode>
                   #include <include/accel-ppp/auth-mode.xml.i>
                   <node name="local-users">
@@ -97,6 +108,7 @@
                             <properties>
                               <help>Static client IP address</help>
                             </properties>
+                            <defaultValue>*</defaultValue>
                           </leafNode>
                         </children>
                       </tagNode>
@@ -109,6 +121,16 @@
                   </node>
                   #include <include/radius-auth-server-ipv4.xml.i>
                   #include <include/accel-ppp/radius-additions.xml.i>
+                  <node name="radius">
+                    <children>
+                      <leafNode name="timeout">
+                        <defaultValue>30</defaultValue>
+                      </leafNode>
+                      <leafNode name="acct-timeout">
+                        <defaultValue>30</defaultValue>
+                      </leafNode>
+                    </children>
+                  </node>
                 </children>
               </node>
               #include <include/accel-ppp/default-pool.xml.i>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Rewritten PPTP to get_config_dict
Fixed 'dynamic-author' commands. These commands did not create anything in accel-ppp config.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5842

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pptp

## Proposed changes
<!--- Describe your changes in detail -->
Rewritten PPTP to get_config_dict
Fixed 'dynamic-author' commands. These commands did not create anything in accel-ppp config.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
CLI Configuration
```
set vpn pptp remote-access authentication radius dynamic-author key 'test'
set vpn pptp remote-access authentication radius dynamic-author port '6000'
set vpn pptp remote-access authentication radius dynamic-author server '10.0.0.1'
```

Before
empty

After
```
[radius]
....
dae-server=10.0.0.1:6000,test
....
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_pptp.py
test_accel_ipv4_pool (__main__.TestVPNPPTPServer.test_accel_ipv4_pool)
Test accel-ppp IPv4 pool ... ok
test_accel_local_authentication (__main__.TestVPNPPTPServer.test_accel_local_authentication) ... ok
test_accel_name_servers (__main__.TestVPNPPTPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNPPTPServer.test_accel_next_pool)
T5099 required specific order ... ok
test_accel_radius_authentication (__main__.TestVPNPPTPServer.test_accel_radius_authentication) ... ok

----------------------------------------------------------------------
Ran 5 tests in 20.341s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
