### PR TITLE
dhcp: T3316: Adjust kea lease files' location and permissions

### DIFF
--- a/debian/vyos-1x.postinst
+++ b/debian/vyos-1x.postinst
@@ -109,10 +109,10 @@ if ! grep -q '^hostsd' /etc/group; then
     addgroup --quiet --system hostsd
 fi
 
-# add dhcpd user for dhcp-server
-if ! grep -q '^dhcpd' /etc/passwd; then
-    adduser --quiet --system --disabled-login --no-create-home --home /run/dhcp-server dhcpd
-    adduser --quiet dhcpd hostsd
+# Add _kea user for kea-dhcp{4,6}-server to vyattacfg
+# The user should exist via kea-common installed as transitive dependency
+if grep -q '^_kea' /etc/passwd; then
+    adduser --quiet _kea vyattacfg
 fi
 
 # ensure the proxy user has a proper shell

--- a/src/op_mode/clear_dhcp_lease.py
+++ b/src/op_mode/clear_dhcp_lease.py
@@ -28,7 +28,7 @@ from vyos.utils.commit import commit_in_progress
 
 config = ConfigTreeQuery()
 base = ['service', 'dhcp-server']
-lease_file = '/config/dhcp4.leases'
+lease_file = '/config/dhcp/dhcp4-leases.csv'
 
 
 def del_lease_ip(address):
@@ -52,7 +52,6 @@ def is_ip_in_leases(address):
     Return True if address found in the lease file
     """
     leases = kea_parse_leases(lease_file)
-    lease_ips = []
     for lease in leases:
         if address == lease['address']:
             return True

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -31,9 +31,6 @@ from vyos.configquery import ConfigTreeQuery
 from vyos.kea import kea_get_active_config
 from vyos.kea import kea_get_pool_from_subnet_id
 from vyos.kea import kea_parse_leases
-from vyos.utils.dict import dict_search
-from vyos.utils.file import read_file
-from vyos.utils.process import cmd
 from vyos.utils.process import is_systemd_service_running
 
 time_string = "%a %b %d %H:%M:%S %Z %Y"
@@ -79,8 +76,8 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[], orig
     Get DHCP server leases
     :return list
     """
-    lease_file = '/config/dhcp6.leases' if family == 'inet6' else '/config/dhcp4.leases'
-    data = []
+    inet_suffix = '6' if family == 'inet6' else '4'
+    lease_file = f'/config/dhcp/dhcp{inet_suffix}-leases.csv'
     leases = kea_parse_leases(lease_file)
 
     if pool is None:
@@ -88,9 +85,9 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[], orig
     else:
         pool = [pool]
 
-    inet_suffix = '6' if family == 'inet6' else '4'
     active_config = kea_get_active_config(inet_suffix)
 
+    data = []
     for lease in leases:
         data_lease = {}
         data_lease['ip'] = lease['address']


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Move the kea lease file to a separate directory `/config/dhcp` that `kea` process can write to so that subprocesses spawned by `kea` process can operate on the lease files.
 
To allow `kea` process to write to `/config/dhcp`, add `_kea` user to `vyattacfg` group. And the lease files are owned completely by `_kea` user to play well with `kea-lfc` process.
 
Specifically, this is necessary for `kea-lfc` which is spawned by `kea` process to clean up expired leases. Since `kea-lfc` creates additional backup lease files, it needs write access to the lease file directory.

Additionally, change the extension of the lease file from `.leases` to `.csv` to reflect the actual file format.

See:
* https://gitlab.isc.org/isc-projects/kea/-/issues/833
* https://lists.isc.org/pipermail/kea-users/2016-April/000328.html

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3316

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp server, dhcpv6 server

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
1. Check that `_kea` user is a member of `vyattacfg`:
```
vyos@v15-c28:~$ getent group vyattacfg | grep '_kea'
vyattacfg:x:102:tacacs15,radius_priv_user,sysadmin,_kea
```

2. Configure `service dhcp-server` as usual

3. Look for the directories, files and their permission in `/config`:
   - `/config/dhcp` should be writable by `vyattacfg` group
   - `/config/dhcp/*` should be owned by `_kea`
```
vyos@v15-c28:~$ ls -ld /config/dhcp
drwxrwxr-x 2 root vyattacfg 4096 Dec 29 00:20 /config/dhcp

vyos@v15-c28:~$ ls -ls /config/dhcp
total 12
4 -rw-r--r-- 1 _kea _kea      103 Dec 29 00:16 dhcp4-leases.csv
4 -rw-r--r-- 1 _kea _kea      462 Dec 29 00:16 dhcp4-leases.csv.2
4 -rw-r--r-- 1 _kea _kea      160 Dec 29 00:20 dhcp6-leases.csv
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@v15-c28:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py 
test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
test_dhcp_failover (__main__.TestServiceDHCPServer.test_dhcp_failover) ... 
No DHCP address range or active static-mapping configured within shared-
network "FAILOVER, 192.0.2.0/25"!

ok
test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... 
No DHCP address range or active static-mapping configured within shared-
network "SMOKE-0815, 192.0.2.0/25"!

ok
test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... 
No DHCP address range or active static-mapping configured within shared-
network "SMOKE-1, 192.0.2.0/25"!

ok
test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... 
No DHCP address range or active static-mapping configured within shared-
network "SMOKE-2, 192.0.2.0/25"!


Either MAC address or Client identifier (DUID) is required for static
mapping "client1" within shared-network "SMOKE-2, 192.0.2.0/25"!

ok

----------------------------------------------------------------------
Ran 8 tests in 203.195s

OK
vyos@v15-c28:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_dhcpv6-server.py 
test_global_nameserver (__main__.TestServiceDHCPv6Server.test_global_nameserver) ... ok
test_prefix_delegation (__main__.TestServiceDHCPv6Server.test_prefix_delegation) ... ok
test_single_pool (__main__.TestServiceDHCPv6Server.test_single_pool) ... 
Either MAC address or Client identifier (DUID) is required for static
mapping "client1" within shared-network "SMOKE-1, 2001:db8:f00::/64"!

ok

----------------------------------------------------------------------
Ran 3 tests in 84.187s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
