### PR TITLE
container: T5829: verify container network used supports the given AFI (backport)

### DIFF
--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -142,11 +142,17 @@ def verify(container):
                     for address in container_config['network'][network_name]['address']:
                         network = None
                         if is_ipv4(address):
-                            network = [x for x in container['network'][network_name]['prefix'] if is_ipv4(x)][0]
-                            cnt_ipv4 += 1
+                            try:
+                                network = [x for x in container['network'][network_name]['prefix'] if is_ipv4(x)][0]
+                                cnt_ipv4 += 1
+                            except:
+                                raise ConfigError(f'Network "{network_name}" does not contain an IPv4 prefix!')
                         elif is_ipv6(address):
-                            network = [x for x in container['network'][network_name]['prefix'] if is_ipv6(x)][0]
-                            cnt_ipv6 += 1
+                            try:
+                                network = [x for x in container['network'][network_name]['prefix'] if is_ipv6(x)][0]
+                                cnt_ipv6 += 1
+                            except:
+                                raise ConfigError(f'Network "{network_name}" does not contain an IPv6 prefix!')
 
                         # Specified container IP address must belong to network prefix
                         if ip_address(address) not in ip_network(network):

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -238,9 +238,9 @@ def verify(container):
     # A network attached to a container can not be deleted
     if {'network_remove', 'name'} <= set(container):
         for network in container['network_remove']:
-            for container, container_config in container['name'].items():
-                if 'network' in container_config and network in container_config['network']:
-                    raise ConfigError(f'Can not remove network "{network}", used by container "{container}"!')
+            for c, c_config in container['name'].items():
+                if 'network' in c_config and network in c_config['network']:
+                    raise ConfigError(f'Can not remove network "{network}", used by container "{c}"!')
 
     if 'registry' in container:
         for registry, registry_config in container['registry'].items():


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

* cherry picked from commit e70ca62c474b4e2cc135851a6e5cceee037bf378
* cherry picked from commit 405cc66041d8035500f7b7116301983c48464a9b

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5829

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

container

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set container name unifi-1 environment TZ value 'Europe/Berlin'
set container name unifi-1 image 'jacobalberty/unifi:v7.5'
set container name unifi-1 memory '1024'
set container name unifi-1 network unifi address '172.29.2.10'
set container name unifi-1 network unifi address '2001:db8::2'
set container name unifi-1 volume config destination '/unifi'
set container name unifi-1 volume config source '/config/unifi-1'
set container name unifi-2 environment TZ value 'Europe/Berlin'
set container name unifi-2 image 'jacobalberty/unifi:v7.5'
set container name unifi-2 memory '1024'
set container name unifi-2 network unifi address '172.29.2.20'
set container name unifi-2 volume config destination '/unifi'
set container name unifi-2 volume config source '/config/unifi-2'
set container name unifi-3 environment TZ value 'Europe/Berlin'
set container name unifi-3 image 'jacobalberty/unifi:v7.5'
set container name unifi-3 memory '1024'
set container name unifi-3 network unifi address '172.29.2.30'
set container name unifi-3 volume config destination '/unifi'
set container name unifi-3 volume config source '/config/unifi-3'
set container network unifi prefix '172.29.2.0/24'
set container network unifi prefix '2001:db8::/64'
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
