### PR TITLE
container: T5867: disable healthchecks due to upstream issue

### DIFF
--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -355,7 +355,7 @@ def generate_run_arguments(name, container_config):
             else:
                 ip_param += f' --ip {address}'
 
-    return f'{container_base_cmd} --net {networks} {ip_param} {entrypoint} {image} {command} {command_arguments}'.strip()
+    return f'{container_base_cmd} --no-healthcheck --net {networks} {ip_param} {entrypoint} {image} {command} {command_arguments}'.strip()
 
 def generate(container):
     # bail out early - looks like removal from running config


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

conmon 402de34b31388b5a2e1c <error>: Unable to send container stderr message to parent Broken pipe

https://github.com/containers/conmon/issues/438

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5867

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-build/pull/480

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set container name unifi-1 environment TZ value 'Europe/Berlin'
set container name unifi-1 image 'jacobalberty/unifi:v7.5'
set container name unifi-1 memory '1024'
set container name unifi-1 network unifi address '172.29.2.10'
set container name unifi-1 network unifi address '2001:db8::2'
set container name unifi-1 volume config destination '/unifi'
set container name unifi-1 volume config source '/config/unifi-1'
set container name unifi-2 environment TZ value 'Europe/Berlin'
set container name unifi-2 image 'jacobalberty/unifi:v7.5'
set container name unifi-2 memory '1024'
set container name unifi-2 network unifi address '172.29.2.20'
set container name unifi-2 volume config destination '/unifi'
set container name unifi-2 volume config source '/config/unifi-2'
set container name unifi-3 environment TZ value 'Europe/Berlin'
set container name unifi-3 image 'jacobalberty/unifi:v7.5'
set container name unifi-3 memory '1024'
set container name unifi-3 network unifi address '172.29.2.30'
set container name unifi-3 volume config destination '/unifi'
set container name unifi-3 volume config source '/config/unifi-3'
set container network unifi prefix '172.29.2.0/24'
set container network unifi prefix '2001:db8::/64'
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
