### PR TITLE
T5871: ipsec remote access VPN: specify "cacerts" for client auth

### DIFF
--- a/data/templates/ipsec/swanctl/remote_access.j2
+++ b/data/templates/ipsec/swanctl/remote_access.j2
@@ -35,6 +35,11 @@
             auth = {{ rw_conf.authentication.client_mode }}
             eap_id = %any
 {% endif %}
+{% if rw_conf.authentication.client_mode is vyos_defined('eap-tls') or rw_conf.authentication.client_mode is vyos_defined('x509') %}
+{#          pass all configured CAs as filenames, separated by commas #}
+{#          this will produce a string like "MyCA1.pem,MyCA2.pem" #}
+            cacerts = {{ '.pem,'.join(rw_conf.authentication.x509.ca_certificate) ~ '.pem' }}
+{% endif %}
         }
         children {
             ikev2-vpn  {

--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -757,6 +757,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             f'id = "{local_id}"',
             f'auth = pubkey',
             f'certs = peer1.pem',
+            f'cacerts = MyVyOS-CA.pem',
             f'auth = eap-tls',
             f'eap_id = %any',
             f'esp_proposals = aes256-sha512,aes256-sha384,aes256-sha256,aes256-sha1,aes128gcm128-sha256',
@@ -840,6 +841,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
         self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'x509', 'ca-certificate', ca_name])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'x509', 'ca-certificate', int_ca_name])
 
         self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'esp-group', esp_group])
         self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'ike-group', ike_group])
@@ -867,6 +869,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             f'id = "{local_id}"',
             f'auth = pubkey',
             f'certs = peer1.pem',
+            f'cacerts = MyVyOS-CA.pem,MyVyOS-IntCA.pem',
             f'esp_proposals = aes256-sha512,aes256-sha384,aes256-sha256,aes256-sha1,aes128gcm128-sha256',
             f'rekey_time = {eap_lifetime}s',
             f'rand_time = 540s',
@@ -894,6 +897,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         # Check Root CA, Intermediate CA and Peer cert/key pair is present
         self.assertTrue(os.path.exists(os.path.join(CA_PATH, f'{ca_name}.pem')))
+        self.assertTrue(os.path.exists(os.path.join(CA_PATH, f'{int_ca_name}.pem')))
         self.assertTrue(os.path.exists(os.path.join(CERT_PATH, f'{peer_name}.pem')))
 
         self.tearDownPKI()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
For authentication methods that depend on validating a client certificate against a CA (e.g. EAP-TLS), we currently do not explicitly tell strongswan which CA to use. This PR specifies the `cacerts` option explicitly for every connection to ensure the connection only accepts certificates signed by its specific CA.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5871

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
N/A

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec remote-access

## Proposed changes
<!--- Describe your changes in detail -->
The configured CA certificate fro the connection is added to the swanctl.conf connection definition using the `cacerts` option.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Example configuration:
```
[edit vpn ipsec remote-access connection ClientVPN]
lucas@lcn-router# show
 authentication {
     client-mode eap-tls
     local-id <local id>
     server-mode x509
     x509 {
         ca-certificate <ca certificate name>
         certificate <server certificate name>
     }
 }
 local-address <router IP address>
 ...
```

Validate that `/etc/swanctl/swanctl.conf` specifies `cacerts = <ca certificate name>_1.pem` under `remote`.

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
