### PR TITLE
T5688: Fixed ip pool migration scripts for l2tp, sstp, pppoe

### DIFF
--- a/smoketest/configs/pppoe-server
+++ b/smoketest/configs/pppoe-server
@@ -39,8 +39,9 @@ service {
             mode local
         }
         client-ip-pool {
-            start 192.168.0.100
-            stop 192.168.0.200
+            subnet 10.0.0.0/24
+            subnet 10.0.1.0/24
+            subnet 10.0.2.0/24
         }
         gateway-address 192.168.0.2
         interface eth1 {

--- a/src/migration-scripts/l2tp/4-to-5
+++ b/src/migration-scripts/l2tp/4-to-5
@@ -45,12 +45,22 @@ if not config.exists(pool_base):
     exit(0)
 default_pool = ''
 range_pool_name = 'default-range-pool'
-subnet_pool_name = 'default-subnet-pool'
+subnet_base_name = 'default-subnet-pool'
+number = 1
+subnet_pool_name = f'{subnet_base_name}-{number}'
+prev_subnet_pool = subnet_pool_name
 if config.exists(pool_base + ['subnet']):
-    subnet = config.return_value(pool_base + ['subnet'])
-    config.delete(pool_base + ['subnet'])
-    config.set(pool_base + [subnet_pool_name, 'range'], value=subnet)
     default_pool = subnet_pool_name
+    for subnet in config.return_values(pool_base + ['subnet']):
+        config.set(pool_base + [subnet_pool_name, 'range'], value=subnet)
+        if prev_subnet_pool != subnet_pool_name:
+            config.set(pool_base + [prev_subnet_pool, 'next-pool'],
+                       value=subnet_pool_name)
+            prev_subnet_pool = subnet_pool_name
+        number += 1
+        subnet_pool_name = f'{subnet_base_name}-{number}'
+
+    config.delete(pool_base + ['subnet'])
 
 if config.exists(pool_base + ['start']) and config.exists(pool_base + ['stop']):
     start_ip = config.return_value(pool_base + ['start'])
@@ -61,7 +71,7 @@ if config.exists(pool_base + ['start']) and config.exists(pool_base + ['stop']):
     config.set(pool_base + [range_pool_name, 'range'], value=ip_range)
     if default_pool:
         config.set(pool_base + [range_pool_name, 'next-pool'],
-                   value=subnet_pool_name)
+                   value=default_pool)
     default_pool = range_pool_name
 
 if default_pool:

--- a/src/migration-scripts/pppoe-server/6-to-7
+++ b/src/migration-scripts/pppoe-server/6-to-7
@@ -50,13 +50,24 @@ if not config.exists(pool_base):
     exit(0)
 default_pool = ''
 range_pool_name = 'default-range-pool'
-subnet_pool_name = 'default-subnet-pool'
+
+subnet_base_name = 'default-subnet-pool'
+number = 1
+subnet_pool_name = f'{subnet_base_name}-{number}'
+prev_subnet_pool = subnet_pool_name
 #Default nameless pools migrations
 if config.exists(pool_base + ['subnet']):
-    subnet = config.return_value(pool_base + ['subnet'])
-    config.delete(pool_base + ['subnet'])
-    config.set(pool_base + [subnet_pool_name, 'range'], value=subnet)
     default_pool = subnet_pool_name
+    for subnet in config.return_values(pool_base + ['subnet']):
+        config.set(pool_base + [subnet_pool_name, 'range'], value=subnet)
+        if prev_subnet_pool != subnet_pool_name:
+            config.set(pool_base + [prev_subnet_pool, 'next-pool'],
+                       value=subnet_pool_name)
+            prev_subnet_pool = subnet_pool_name
+        number += 1
+        subnet_pool_name = f'{subnet_base_name}-{number}'
+
+    config.delete(pool_base + ['subnet'])
 
 if config.exists(pool_base + ['start']) and config.exists(pool_base + ['stop']):
     start_ip = config.return_value(pool_base + ['start'])
@@ -67,7 +78,7 @@ if config.exists(pool_base + ['start']) and config.exists(pool_base + ['stop']):
     config.set(pool_base + [range_pool_name, 'range'], value=ip_range)
     if default_pool:
         config.set(pool_base + [range_pool_name, 'next-pool'],
-                   value=subnet_pool_name)
+                   value=default_pool)
     default_pool = range_pool_name
 
 gateway = ''

--- a/src/migration-scripts/sstp/4-to-5
+++ b/src/migration-scripts/sstp/4-to-5
@@ -43,12 +43,23 @@ if not config.exists(base):
 if not config.exists(pool_base):
     exit(0)
 
-subnet_pool_name = 'default-subnet-pool'
+subnet_base_name = 'default-subnet-pool'
+number = 1
+subnet_pool_name = f'{subnet_base_name}-{number}'
+prev_subnet_pool = subnet_pool_name
 if config.exists(pool_base + ['subnet']):
-    subnet = config.return_value(pool_base + ['subnet'])
+    default_pool = subnet_pool_name
+    for subnet in config.return_values(pool_base + ['subnet']):
+        config.set(pool_base + [subnet_pool_name, 'range'], value=subnet)
+        if prev_subnet_pool != subnet_pool_name:
+            config.set(pool_base + [prev_subnet_pool, 'next-pool'],
+                       value=subnet_pool_name)
+            prev_subnet_pool = subnet_pool_name
+        number += 1
+        subnet_pool_name = f'{subnet_base_name}-{number}'
+
     config.delete(pool_base + ['subnet'])
-    config.set(pool_base + [subnet_pool_name, 'range'], value=subnet)
-    config.set(base + ['default-pool'], value=subnet_pool_name)
+    config.set(base + ['default-pool'], value=default_pool)
 # format as tag node
 config.set_tag(pool_base)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed migration 'subnet' option in l2tp, sstp, pppoe. 
'subnet' option can contain several values.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5688

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
l2tp, pppoe, sstp

## Proposed changes
<!--- Describe your changes in detail -->
Fixed migration 'subnet' option in l2tp, sstp, pppoe. 
'subnet' option can contain several values.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Before migration:
```
set vpn l2tp remote-access client-ip-pool subnet '10.0.0.0/24'
set vpn l2tp remote-access client-ip-pool subnet '10.0.2.0/24'
set vpn l2tp remote-access client-ip-pool subnet '10.0.3.0/24'
```
After migration, without fixes
```
set vpn l2tp remote-access client-ip-pool default-subnet-pool range '10.0.0.0/24'
set vpn l2tp remote-access default-pool 'default-subnet-pool'
```
After migration, with fixes
```
set vpn l2tp remote-access client-ip-pool default-subnet-pool-1 next-pool 'default-subnet-pool-2'
set vpn l2tp remote-access client-ip-pool default-subnet-pool-1 range '10.0.0.0/24'
set vpn l2tp remote-access client-ip-pool default-subnet-pool-2 next-pool 'default-subnet-pool-3'
set vpn l2tp remote-access client-ip-pool default-subnet-pool-2 range '10.0.2.0/24'
set vpn l2tp remote-access client-ip-pool default-subnet-pool-3 range '10.0.3.0/24'
set vpn l2tp remote-access default-pool 'default-subnet-pool-1'
```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
