### PR TITLE
login: T5875: restore home directory permissions when re-adding user account

### DIFF
--- a/src/conf_mode/system-login.py
+++ b/src/conf_mode/system-login.py
@@ -29,6 +29,7 @@ from vyos.defaults import directories
 from vyos.template import render
 from vyos.template import is_ipv4
 from vyos.utils.dict import dict_search
+from vyos.utils.file import chown
 from vyos.utils.process import cmd
 from vyos.utils.process import call
 from vyos.utils.process import rc_cmd
@@ -334,13 +335,16 @@ def apply(login):
             command += f' --groups frr,frrvty,vyattacfg,sudo,adm,dip,disk,_kea {user}'
             try:
                 cmd(command)
-
                 # we should not rely on the value stored in
                 # user_config['home_directory'], as a crazy user will choose
                 # username root or any other system user which will fail.
                 #
                 # XXX: Should we deny using root at all?
                 home_dir = getpwnam(user).pw_dir
+                # T5875: ensure UID is properly set on home directory if user is re-added
+                if os.path.exists(home_dir):
+                    chown(home_dir, user=user, recursive=True)
+
                 render(f'{home_dir}/.ssh/authorized_keys', 'login/authorized_keys.j2',
                        user_config, permission=0o600,
                        formater=lambda _: _.replace("&quot;", '"'),


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

After deleting a user account and working with a newly added account, we see that after rebooting in the previously saved configuration, the user is re-added but it's home directory might have an old UID set on the filesystem.

This is due to the fact that vyos config does not store UIDs. When adding a user account to the system we now check if the home directory already exists and adjust the ownership to the new UID.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5875

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
User home directory

## Proposed changes
<!--- Describe your changes in detail -->
Call `chown` if the home directory already exists

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_login.py
test_add_linux_system_user (__main__.TestSystemLogin.test_add_linux_system_user) ... ok
test_radius_kernel_features (__main__.TestSystemLogin.test_radius_kernel_features) ... ok
test_system_login_max_login_session (__main__.TestSystemLogin.test_system_login_max_login_session) ... ok
test_system_login_otp (__main__.TestSystemLogin.test_system_login_otp) ... ok
test_system_login_radius_ipv4 (__main__.TestSystemLogin.test_system_login_radius_ipv4) ... ok
test_system_login_radius_ipv6 (__main__.TestSystemLogin.test_system_login_radius_ipv6) ... ok
test_system_login_tacacs (__main__.TestSystemLogin.test_system_login_tacacs) ... ok
test_system_login_user (__main__.TestSystemLogin.test_system_login_user) ... ok
test_system_user_ssh_key (__main__.TestSystemLogin.test_system_user_ssh_key) ... ok

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
