### PR TITLE
T3476: Add option latest to add system image

### DIFF
--- a/op-mode-definitions/system-image.xml.in
+++ b/op-mode-definitions/system-image.xml.in
@@ -14,7 +14,7 @@
             <properties>
               <help>Add a new image to the system</help>
               <completionHelp>
-                <list>/path/to/vyos-image.iso "http://example.com/vyos-image.iso"</list>
+                <list>/path/to/vyos-image.iso "http://example.com/vyos-image.iso" latest</list>
               </completionHelp>
             </properties>
             <command>sudo ${vyos_op_scripts_dir}/image_installer.py --action add --image-path "${4}"</command>


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add option `latest` for the op-mode command `add system image`. If the update check is configured, we can get the remote `latest` version from the configured URL
```
set system update-check url 'https://example.com/version.json'
```
This way, we can use "latest" option for image updates:
```
add system image latest
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Improve update system image

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3476

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
vyos@r4:~$ show conf com | match upda
set system update-check auto-check
set system update-check url 'https://raw.githubusercontent.com/vyos/vyos-rolling-nightly-builds/main/version.json'
vyos@r4:~$ 

vyos@r4:~$ add system image latest 
Redirecting to https://objects.githubusercontent.com/github-production-release-asset-2e65be/674742659/2b007c83-d08c-4aed-90ae-ec1dd6052c4d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20231230%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231230T135637Z&X-Amz-Expires=300&X-Amz-Signature=ff7e3fc6696ef9cbbc55f57df2327b70a8f018a5617503a804b23616d0b9f359&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=674742659&response-content-disposition=attachment%3B%20filename%3Dvyos-1.5-rolling-202312300022-amd64.iso&response-content-type=application%2Foctet-stream
The file is 437.000 MiB.
^C#######_____________________________________________________________________________________________________________________________________________________]   5%

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
