### PR TITLE
T5880: verify_source_interface() should not allow dynamic interfaces like ppp, l2tp, ipoe or sstpc client interfaces

### DIFF
--- a/interface-definitions/include/constraint/interface-name.xml.i
+++ b/interface-definitions/include/constraint/interface-name.xml.i
@@ -1,4 +1,4 @@
 <!-- include start from constraint/interface-name.xml.i -->
-<regex>(bond|br|dum|en|ersp|eth|gnv|ifb|lan|l2tp|l2tpeth|macsec|peth|ppp|pppoe|pptp|sstp|tun|veth|vti|vtun|vxlan|wg|wlan|wwan)[0-9]+(.\d+)?|lo</regex>
+<regex>(bond|br|dum|en|ersp|eth|gnv|ifb|ipoe|lan|l2tp|l2tpeth|macsec|peth|ppp|pppoe|pptp|sstp|sstpc|tun|veth|vti|vtun|vxlan|wg|wlan|wwan)[0-9]+(.\d+)?|lo</regex>
 <validator name="file-path --lookup-path /sys/class/net --directory"/>
 <!-- include end -->

--- a/smoketest/scripts/cli/test_interfaces_tunnel.py
+++ b/smoketest/scripts/cli/test_interfaces_tunnel.py
@@ -393,5 +393,21 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
             self.assertEqual(tunnel_config['encapsulation'],    conf['linkinfo']['info_kind'])
             self.assertEqual(tunnel_config['remote'],           conf['linkinfo']['info_data']['remote'])
 
+    def test_tunnel_invalid_source_interface(self):
+        encapsulation = 'gre'
+        remote = '192.0.2.1'
+        interface = 'tun7543'
+
+        self.cli_set(self._base_path + [interface, 'encapsulation', encapsulation])
+        self.cli_set(self._base_path + [interface, 'remote', remote])
+
+        for dynamic_interface in ['l2tp0', 'ppp4220', 'sstpc0', 'ipoe654']:
+            self.cli_set(self._base_path + [interface, 'source-interface', dynamic_interface])
+            # verify() - we can not source from dynamic interfaces
+            with self.assertRaises(ConfigSessionError):
+                self.cli_commit()
+        self.cli_set(self._base_path + [interface, 'source-interface', 'eth0'])
+        self.cli_commit()
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/interfaces_tunnel.py
+++ b/src/conf_mode/interfaces_tunnel.py
@@ -24,7 +24,7 @@ from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
 from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
-from vyos.configverify import verify_interface_exists
+from vyos.configverify import verify_source_interface
 from vyos.configverify import verify_mtu_ipv6
 from vyos.configverify import verify_mirror_redirect
 from vyos.configverify import verify_vrf
@@ -166,7 +166,7 @@ def verify(tunnel):
     verify_mirror_redirect(tunnel)
 
     if 'source_interface' in tunnel:
-        verify_interface_exists(tunnel['source_interface'])
+        verify_source_interface(tunnel)
 
     # TTL != 0 and nopmtudisc are incompatible, parameters and ip use default
     # values, thus the keys are always present.


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Interfaces matching the following regex `(ppp|pppoe|sstpc|l2tp|ipoe)[0-9]+` can not be used as source-interface for e.g. a tunnel. The main reason is that these are dynamic interfaces which come and go from a kernel point of view, thus it's not possible to bind an interface to them.

A tunnel interface can not properly be sourced from a pppoe0 interface when such interface is not (yet) connected to the BRAS. It might work on a running system, but subsequent reboots will fail as the source-interface most likely does not yet exist.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5880
* https://vyos.dev/T5879

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* tunnel interface
* `vyos.configverify.verify_source_interface()`

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Extended tunnel smoketests (test_tunnel_invalid_source_interface)

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_tunnel.py
test_add_multiple_ip_addresses (__main__.TunnelInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.TunnelInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.TunnelInterfaceTest.test_dhcp_client_options) ... skipped 'not supported'
test_dhcp_disable_interface (__main__.TunnelInterfaceTest.test_dhcp_disable_interface) ... skipped 'not supported'
test_dhcp_vrf (__main__.TunnelInterfaceTest.test_dhcp_vrf) ... skipped 'not supported'
test_dhcpv6_client_options (__main__.TunnelInterfaceTest.test_dhcpv6_client_options) ... skipped 'not supported'
test_dhcpv6_vrf (__main__.TunnelInterfaceTest.test_dhcpv6_vrf) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.TunnelInterfaceTest.test_dhcpv6pd_auto_sla_id) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.TunnelInterfaceTest.test_dhcpv6pd_manual_sla_id) ... skipped 'not supported'
test_erspan_v1 (__main__.TunnelInterfaceTest.test_erspan_v1) ... ok
test_gretap_parameters_change (__main__.TunnelInterfaceTest.test_gretap_parameters_change) ... ok
test_interface_description (__main__.TunnelInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.TunnelInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.TunnelInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.TunnelInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.TunnelInterfaceTest.test_interface_mtu) ... ok
test_ip6erspan_v2 (__main__.TunnelInterfaceTest.test_ip6erspan_v2) ... ok
test_ipv4_encapsulations (__main__.TunnelInterfaceTest.test_ipv4_encapsulations) ... ok
test_ipv6_encapsulations (__main__.TunnelInterfaceTest.test_ipv6_encapsulations) ... ok
test_ipv6_link_local_address (__main__.TunnelInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.TunnelInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_multiple_gre_tunnel_different_remote (__main__.TunnelInterfaceTest.test_multiple_gre_tunnel_different_remote) ... ok
test_multiple_gre_tunnel_same_remote (__main__.TunnelInterfaceTest.test_multiple_gre_tunnel_same_remote) ... ok
test_span_mirror (__main__.TunnelInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_tunnel_invalid_source_interfacce (__main__.TunnelInterfaceTest.test_tunnel_invalid_source_interfacce) ... ok
test_tunnel_parameters_gre (__main__.TunnelInterfaceTest.test_tunnel_parameters_gre) ... ok
test_tunnel_src_any_gre_key (__main__.TunnelInterfaceTest.test_tunnel_src_any_gre_key) ... ok
test_vif_8021q_interfaces (__main__.TunnelInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.TunnelInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.TunnelInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.TunnelInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.TunnelInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.TunnelInterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'

----------------------------------------------------------------------
Ran 33 tests in 127.821s

OK (skipped=14)
```

In addition `make test` and `make testc` finished successfully on a custom ISO build

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
