### PR TITLE
image-tools: T5883: preserve file owner in /config on add system update

### DIFF
--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -257,6 +257,15 @@ def search_previous_installation(disks: list[str]) -> None:
 
     disk.partition_umount(image_drive)
 
+def copy_preserve_owner(src: str, dst: str, *, follow_symlinks=True):
+    if not Path(src).is_file():
+        return
+    if Path(dst).is_dir():
+        dst = Path(dst).joinpath(Path(src).name)
+    st = Path(src).stat()
+    copy(src, dst, follow_symlinks=follow_symlinks)
+    chown(dst, user=st.st_uid)
+
 
 def copy_previous_installation_data(target_dir: str) -> None:
     if Path('/mnt/config').exists():
@@ -812,7 +821,7 @@ def add_image(image_path: str, vrf: str = None, username: str = '',
             chown(target_config_dir, group='vyattacfg')
             chmod_2775(target_config_dir)
             copytree('/opt/vyatta/etc/config/', target_config_dir,
-                     dirs_exist_ok=True)
+                     copy_function=copy_preserve_owner, dirs_exist_ok=True)
         else:
             Path(target_config_dir).mkdir(parents=True)
             chown(target_config_dir, group='vyattacfg')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The /config dir has the set-group-id bit set for group ownership when copying the directory on 'add system image'; user ownership is ignored as in general root is correct. However, for Kea dhcp leases stored in /config/dhcp, this will cause a problem --- preserver user on copy when updating.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5883

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
