### PR TITLE
T3642: add missing base64 CLI validators

### DIFF
--- a/interface-definitions/interfaces_wireguard.xml.in
+++ b/interface-definitions/interfaces_wireguard.xml.in
@@ -44,9 +44,9 @@
             <properties>
               <help>Base64 encoded private key</help>
               <constraint>
-                <regex>[0-9a-zA-Z\+/]{43}=</regex>
+                <validator name="base64"/>
               </constraint>
-              <constraintErrorMessage>Key is not valid 44-character (32-bytes) base64</constraintErrorMessage>
+              <constraintErrorMessage>Key is not base64-encoded</constraintErrorMessage>
             </properties>
           </leafNode>
           <tagNode name="peer">
@@ -64,18 +64,18 @@
                 <properties>
                   <help>base64 encoded public key</help>
                   <constraint>
-                    <regex>[0-9a-zA-Z\+/]{43}=</regex>
+                    <validator name="base64"/>
                   </constraint>
-                  <constraintErrorMessage>Key is not valid 44-character (32-bytes) base64</constraintErrorMessage>
+                  <constraintErrorMessage>Key is not base64-encoded</constraintErrorMessage>
                 </properties>
               </leafNode>
               <leafNode name="preshared-key">
                 <properties>
                   <help>base64 encoded preshared key</help>
                   <constraint>
-                    <regex>[0-9a-zA-Z\+/]{43}=</regex>
+                    <validator name="base64"/>
                   </constraint>
-                  <constraintErrorMessage>Key is not valid 44-character (32-bytes) base64</constraintErrorMessage>
+                  <constraintErrorMessage>Key is not base64-encoded</constraintErrorMessage>
                 </properties>
               </leafNode>
               <leafNode name="allowed-ips">

--- a/interface-definitions/pki.xml.in
+++ b/interface-definitions/pki.xml.in
@@ -14,6 +14,10 @@
           <leafNode name="certificate">
             <properties>
               <help>CA certificate in PEM format</help>
+              <constraint>
+                <validator name="base64"/>
+              </constraint>
+              <constraintErrorMessage>CA certificate is not base64-encoded</constraintErrorMessage>
             </properties>
           </leafNode>
           #include <include/generic-description.xml.i>
@@ -25,6 +29,10 @@
               <leafNode name="key">
                 <properties>
                   <help>CA private key in PEM format</help>
+                  <constraint>
+                    <validator name="base64"/>
+                  </constraint>
+                  <constraintErrorMessage>CA private key is not base64-encoded</constraintErrorMessage>
                 </properties>
               </leafNode>
               <leafNode name="password-protected">
@@ -38,6 +46,10 @@
           <leafNode name="crl">
             <properties>
               <help>Certificate revocation list in PEM format</help>
+              <constraint>
+                <validator name="base64"/>
+              </constraint>
+              <constraintErrorMessage>CRL is not base64-encoded</constraintErrorMessage>
               <multi/>
             </properties>
           </leafNode>
@@ -57,6 +69,10 @@
           <leafNode name="certificate">
             <properties>
               <help>Certificate in PEM format</help>
+              <constraint>
+                <validator name="base64"/>
+              </constraint>
+              <constraintErrorMessage>Certificate is not base64-encoded</constraintErrorMessage>
             </properties>
           </leafNode>
           #include <include/generic-description.xml.i>
@@ -68,6 +84,10 @@
               <leafNode name="key">
                 <properties>
                   <help>Certificate private key in PEM format</help>
+                  <constraint>
+                    <validator name="base64"/>
+                  </constraint>
+                  <constraintErrorMessage>Certificate private key is not base64-encoded</constraintErrorMessage>
                 </properties>
               </leafNode>
               <leafNode name="password-protected">
@@ -94,6 +114,10 @@
           <leafNode name="parameters">
             <properties>
               <help>DH parameters in PEM format</help>
+              <constraint>
+                <validator name="base64"/>
+              </constraint>
+              <constraintErrorMessage>DH parameters are not base64-encoded</constraintErrorMessage>
             </properties>
           </leafNode>
         </children>
@@ -111,6 +135,10 @@
               <leafNode name="key">
                 <properties>
                   <help>Public key in PEM format</help>
+                  <constraint>
+                    <validator name="base64"/>
+                  </constraint>
+                  <constraintErrorMessage>Public key is not base64-encoded</constraintErrorMessage>
                 </properties>
               </leafNode>
             </children>
@@ -123,6 +151,10 @@
               <leafNode name="key">
                 <properties>
                   <help>Private key in PEM format</help>
+                  <constraint>
+                    <validator name="base64"/>
+                  </constraint>
+                  <constraintErrorMessage>Private key is not base64-encoded</constraintErrorMessage>
                 </properties>
               </leafNode>
               <leafNode name="password-protected">

--- a/smoketest/scripts/cli/test_pki.py
+++ b/smoketest/scripts/cli/test_pki.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 VyOS maintainers and contributors
+# Copyright (C) 2021-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -182,30 +182,6 @@ class TestPKI(VyOSUnitTestSHIM.TestCase):
 
     def test_invalid_ca_valid_certificate(self):
         self.cli_set(base_path + ['ca', 'smoketest', 'certificate', valid_cert.replace('\n','')])
-
-        with self.assertRaises(ConfigSessionError):
-            self.cli_commit()
-
-    def test_invalid_certificate(self):
-        self.cli_set(base_path + ['certificate', 'smoketest', 'certificate', 'invalidcertdata'])
-
-        with self.assertRaises(ConfigSessionError):
-            self.cli_commit()
-
-    def test_invalid_public_key(self):
-        self.cli_set(base_path + ['key-pair', 'smoketest', 'public', 'key', 'invalidkeydata'])
-
-        with self.assertRaises(ConfigSessionError):
-            self.cli_commit()
-
-    def test_invalid_private_key(self):
-        self.cli_set(base_path + ['key-pair', 'smoketest', 'private', 'key', 'invalidkeydata'])
-
-        with self.assertRaises(ConfigSessionError):
-            self.cli_commit()
-
-    def test_invalid_dh_parameters(self):
-        self.cli_set(base_path + ['dh', 'smoketest', 'parameters', 'thisisinvalid'])
 
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Both WireGuard and the PKI subsystem use base64 encoded leafNodes to store keys. WireGuard used a custom regex to validate this, but the PKI subsytem had no input validation at all.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3642

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* PKI
* WireGuard

## Proposed changes
<!--- Describe your changes in detail -->

For every PEM key, call the `base64` validation helper.

Move custom WireGuard base64 validator to common `base64` validator

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_pki.py
test_certificate_eapol_update (__main__.TestPKI.test_certificate_eapol_update) ... ok
test_certificate_https_update (__main__.TestPKI.test_certificate_https_update) ... ok
test_certificate_in_use (__main__.TestPKI.test_certificate_in_use) ... ok
test_invalid_ca_valid_certificate (__main__.TestPKI.test_invalid_ca_valid_certificate) ... ok
test_valid_pki (__main__.TestPKI.test_valid_pki) ... ok

----------------------------------------------------------------------
Ran 5 tests in 24.903s

OK
```

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireguard.py
test_01_wireguard_peer (__main__.WireGuardInterfaceTest.test_01_wireguard_peer) ... ok
test_02_wireguard_add_remove_peer (__main__.WireGuardInterfaceTest.test_02_wireguard_add_remove_peer) ... ok
test_03_wireguard_same_public_key (__main__.WireGuardInterfaceTest.test_03_wireguard_same_public_key) ... ok
test_04_wireguard_threaded (__main__.WireGuardInterfaceTest.test_04_wireguard_threaded) ... ok
test_05_wireguard_peer_pubkey_change (__main__.WireGuardInterfaceTest.test_05_wireguard_peer_pubkey_change) ... ok

----------------------------------------------------------------------
Ran 5 tests in 23.732s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
