### PR TITLE
op-mode: T5890: Fix arguments passed to generate_system_login_user.py

### DIFF
--- a/op-mode-definitions/generate-system-login-user.xml.in
+++ b/op-mode-definitions/generate-system-login-user.xml.in
@@ -35,19 +35,19 @@
                             <properties>
                               <help>Duration of single time interval</help>
                             </properties>
-                            <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate-limit "$9"</command>
+                            <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate_limit "$9"</command>
                             <children>
                               <tagNode name="rate-time">
                                 <properties>
                                   <help>The number of digits in the one-time password</help>
                                 </properties>
-                                <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate-limit "$9" --rate-time "${11}" </command>
+                                <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate_limit "$9" --rate_time "${11}" </command>
                                 <children>
                                   <tagNode name="window-size">
                                     <properties>
                                       <help>The number of digits in the one-time password</help>
                                     </properties>
-                                    <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate-limit "$9" --rate-time "${11}" --window-size "${13}"</command>
+                                    <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate_limit "$9" --rate_time "${11}" --window_size "${13}"</command>
                                   </tagNode>
                                 </children>
                               </tagNode>
@@ -57,19 +57,19 @@
                             <properties>
                               <help>The number of digits in the one-time password</help>
                             </properties>
-                            <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --window-size "${9}"</command>
+                            <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --window_size "${9}"</command>
                             <children>
                               <tagNode name="rate-limit">
                                 <properties>
                                   <help>Duration of single time interval</help>
                                 </properties>
-                                <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate-limit "${11}" --window-size "${9}"</command>
+                                <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate_limit "${11}" --window_size "${9}"</command>
                                 <children>
                                   <tagNode name="rate-time">
                                     <properties>
                                       <help>Duration of single time interval</help>
                                     </properties>
-                                    <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate-limit "${11}" --rate-time "${13}" --window-size "${9}"</command>
+                                    <command>sudo ${vyos_op_scripts_dir}/generate_system_login_user.py --username "$5" --rate_limit "${11}" --rate_time "${13}" --window_size "${9}"</command>
                                   </tagNode>
                                 </children>
                               </tagNode>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5890

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
op-mode

## Proposed changes
<!--- Describe your changes in detail -->
This PR updates the op-mode command arguments passed to the `generate_system_login_user.py` script. Previously, multi-word arguments were passed with words delimited by dashes, however [the script expects](https://github.com/vyos/vyos-1x/blob/current/src/op_mode/generate_system_login_user.py#L30-L32) multi-word arguments with words delimited by underscores.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
Before:
```
$ generate system login username vyos otp-key hotp-time rate-limit 3 rate-time 30 window-size 4
usage: generate_system_login_user.py [-h] -u USERNAME [-l RATE_LIMIT] [-t RATE_TIME] [-w WINDOW_SIZE] [-i INTERVAL] [-d DIGITS]
generate_system_login_user.py: error: unrecognized arguments: --rate-limit 3 --rate-time 30 --window-size 4
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
