### PR TITLE
configdict: T5894: add get_config_dict() flag with_pki

### DIFF
--- a/interface-definitions/include/accel-ppp/client-ip-pool.xml.i
+++ b/interface-definitions/include/accel-ppp/client-ip-pool.xml.i
@@ -7,7 +7,7 @@
       <description>Name of IP pool</description>
     </valueHelp>
     <constraint>
-      <regex>[-_a-zA-Z0-9.]+</regex>
+      #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
     </constraint>
   </properties>
   <children>
@@ -37,7 +37,7 @@
           <description>Name of IP pool</description>
         </valueHelp>
         <constraint>
-          <regex>[-_a-zA-Z0-9.]+</regex>
+          #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
         </constraint>
       </properties>
     </leafNode>

--- a/interface-definitions/include/accel-ppp/default-pool.xml.i
+++ b/interface-definitions/include/accel-ppp/default-pool.xml.i
@@ -7,7 +7,7 @@
       <description>Default IP pool</description>
     </valueHelp>
     <constraint>
-      <regex>[-_a-zA-Z0-9.]+</regex>
+      #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
     </constraint>
   </properties>
 </leafNode>

--- a/interface-definitions/include/bgp/afi-route-map-export-import.xml.i
+++ b/interface-definitions/include/bgp/afi-route-map-export-import.xml.i
@@ -10,7 +10,7 @@
       <description>Route map name</description>
     </valueHelp>
     <constraint>
-      <regex>[-_a-zA-Z0-9.]+</regex>
+      #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
     </constraint>
     <constraintErrorMessage>Name of route-map can only contain alpha-numeric letters, hyphen and underscores</constraintErrorMessage>
   </properties>
@@ -26,7 +26,7 @@
       <description>Route map name</description>
     </valueHelp>
     <constraint>
-      <regex>[-_a-zA-Z0-9.]+</regex>
+      #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
     </constraint>
     <constraintErrorMessage>Name of route-map can only contain alpha-numeric letters, hyphen and underscores</constraintErrorMessage>
   </properties>

--- a/interface-definitions/include/bgp/neighbor-afi-ipv4-ipv6-common.xml.i
+++ b/interface-definitions/include/bgp/neighbor-afi-ipv4-ipv6-common.xml.i
@@ -28,7 +28,7 @@
           <description>Route map name</description>
         </valueHelp>
         <constraint>
-          <regex>[-_a-zA-Z0-9.]+</regex>
+          #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
         </constraint>
         <constraintErrorMessage>Name of route-map can only contain alpha-numeric letters, hyphen and underscores</constraintErrorMessage>
       </properties>
@@ -44,7 +44,7 @@
           <description>Route map name</description>
         </valueHelp>
         <constraint>
-          <regex>[-_a-zA-Z0-9.]+</regex>
+          #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
         </constraint>
         <constraintErrorMessage>Name of route-map can only contain alpha-numeric letters, hyphen and underscores</constraintErrorMessage>
       </properties>
@@ -60,7 +60,7 @@
           <description>Route map name</description>
         </valueHelp>
         <constraint>
-          <regex>[-_a-zA-Z0-9.]+</regex>
+          #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
         </constraint>
         <constraintErrorMessage>Name of route-map can only contain alpha-numeric letters, hyphen and underscores</constraintErrorMessage>
       </properties>
@@ -185,7 +185,7 @@
       <description>Route map name</description>
     </valueHelp>
     <constraint>
-      <regex>[-_a-zA-Z0-9.]+</regex>
+      #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
     </constraint>
     <constraintErrorMessage>Name of route-map can only contain alpha-numeric letters, hyphen and underscores</constraintErrorMessage>
   </properties>

--- a/interface-definitions/include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i
+++ b/interface-definitions/include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i
@@ -1,0 +1,3 @@
+<!-- include start from constraint/alpha-numeric-hyphen-underscore-dot.xml.i -->
+<regex>[-_a-zA-Z0-9.]+</regex>
+<!-- include end -->

--- a/interface-definitions/include/route-map.xml.i
+++ b/interface-definitions/include/route-map.xml.i
@@ -10,7 +10,7 @@
       <description>Route map name</description>
     </valueHelp>
     <constraint>
-      <regex>[-_a-zA-Z0-9.]+</regex>
+      #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
     </constraint>
     <constraintErrorMessage>Name of route-map can only contain alpha-numeric letters, hyphen and underscores</constraintErrorMessage>
   </properties>

--- a/interface-definitions/pki.xml.in
+++ b/interface-definitions/pki.xml.in
@@ -9,6 +9,9 @@
       <tagNode name="ca">
         <properties>
           <help>Certificate Authority</help>
+          <constraint>
+            #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+          </constraint>
         </properties>
         <children>
           <leafNode name="certificate">
@@ -64,6 +67,9 @@
       <tagNode name="certificate">
         <properties>
           <help>Certificate</help>
+          <constraint>
+            #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+          </constraint>
         </properties>
         <children>
           <leafNode name="certificate">
@@ -109,6 +115,9 @@
       <tagNode name="dh">
         <properties>
           <help>Diffie-Hellman parameters</help>
+          <constraint>
+            #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+          </constraint>
         </properties>
         <children>
           <leafNode name="parameters">

--- a/interface-definitions/policy.xml.in
+++ b/interface-definitions/policy.xml.in
@@ -476,7 +476,7 @@
             <description>Route map name</description>
           </valueHelp>
           <constraint>
-            <regex>[-_a-zA-Z0-9.]+</regex>
+            #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
           </constraint>
           <constraintErrorMessage>Name of route-map can only contain alpha-numeric letters, hyphen and underscores</constraintErrorMessage>
         </properties>

--- a/interface-definitions/service_dhcp-server.xml.in
+++ b/interface-definitions/service_dhcp-server.xml.in
@@ -38,7 +38,7 @@
                 <properties>
                   <help>Peer name used to identify connection</help>
                   <constraint>
-                    <regex>[-_a-zA-Z0-9.]+</regex>
+                    #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
                   </constraint>
                   <constraintErrorMessage>Invalid failover peer name. May only contain letters, numbers and .-_</constraintErrorMessage>
                 </properties>
@@ -78,7 +78,7 @@
             <properties>
               <help>Name of DHCP shared network</help>
               <constraint>
-                <regex>[-_a-zA-Z0-9.]+</regex>
+                #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
               </constraint>
               <constraintErrorMessage>Invalid shared network name. May only contain letters, numbers and .-_</constraintErrorMessage>
             </properties>
@@ -251,7 +251,7 @@
                     <properties>
                       <help>DHCP lease range</help>
                       <constraint>
-                        <regex>[-_a-zA-Z0-9.]+</regex>
+                        #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
                       </constraint>
                       <constraintErrorMessage>Invalid range name, may only be alphanumeric, dot and hyphen</constraintErrorMessage>
                     </properties>

--- a/interface-definitions/service_dhcpv6-server.xml.in
+++ b/interface-definitions/service_dhcpv6-server.xml.in
@@ -34,7 +34,7 @@
             <properties>
               <help>DHCPv6 shared network name</help>
               <constraint>
-                <regex>[-_a-zA-Z0-9.]+</regex>
+                #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
               </constraint>
               <constraintErrorMessage>Invalid DHCPv6 shared network name. May only contain letters, numbers and .-_</constraintErrorMessage>
             </properties>
@@ -185,7 +185,7 @@
                     <properties>
                       <help>NIS domain name for client to use</help>
                       <constraint>
-                        <regex>[-_a-zA-Z0-9.]+</regex>
+                        #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
                       </constraint>
                       <constraintErrorMessage>Invalid NIS domain name</constraintErrorMessage>
                     </properties>
@@ -207,7 +207,7 @@
                     <properties>
                       <help>NIS+ domain name for client to use</help>
                       <constraint>
-                        <regex>[-_a-zA-Z0-9.]+</regex>
+                        #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
                       </constraint>
                       <constraintErrorMessage>Invalid NIS+ domain name. May only contain letters, numbers and .-_</constraintErrorMessage>
                     </properties>

--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -29,7 +29,7 @@ There are multiple types of config tree nodes in VyOS, each requires
 its own set of operations.
 
 *Leaf nodes* (such as "address" in interfaces) can have values, but cannot
-have children. 
+have children.
 Leaf nodes can have one value, multiple values, or no values at all.
 
 For example, "system host-name" is a single-value leaf node,
@@ -258,7 +258,9 @@ class Config(object):
     def get_config_dict(self, path=[], effective=False, key_mangling=None,
                         get_first_key=False, no_multi_convert=False,
                         no_tag_node_value_mangle=False,
-                        with_defaults=False, with_recursive_defaults=False):
+                        with_defaults=False,
+                        with_recursive_defaults=False,
+                        with_pki=False):
         """
         Args:
             path (str list): Configuration tree path, can be empty
@@ -274,6 +276,7 @@ class Config(object):
         del kwargs['no_multi_convert']
         del kwargs['with_defaults']
         del kwargs['with_recursive_defaults']
+        del kwargs['with_pki']
 
         lpath = self._make_path(path)
         root_dict = self.get_cached_root_dict(effective)
@@ -297,6 +300,13 @@ class Config(object):
             conf_dict = config_dict_merge(defaults, conf_dict)
         else:
             conf_dict = ConfigDict(conf_dict)
+
+        if with_pki and conf_dict:
+            pki_dict = self.get_config_dict(['pki'], key_mangling=('-', '_'),
+                                            no_tag_node_value_mangle=True,
+                                            get_first_key=True)
+            if pki_dict:
+                conf_dict['pki'] = pki_dict
 
         # save optional args for a call to get_config_defaults
         setattr(conf_dict, '_dict_kwargs', kwargs)

--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -163,6 +163,9 @@ def node_changed(conf, path, key_mangling=None, recursive=False, expand_nodes=No
         output.extend(list(tmp['delete'].keys()))
     if expand_nodes & Diff.ADD:
         output.extend(list(tmp['add'].keys()))
+
+    # remove duplicate keys from list, this happens when a node (e.g. description) is altered
+    output = list(dict.fromkeys(output))
     return output
 
 def get_removed_vlans(conf, path, dict):

--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -427,7 +427,7 @@ def get_pppoe_interfaces(conf, vrf=None):
 
     return pppoe_interfaces
 
-def get_interface_dict(config, base, ifname='', recursive_defaults=True):
+def get_interface_dict(config, base, ifname='', recursive_defaults=True, with_pki=False):
     """
     Common utility function to retrieve and mangle the interfaces configuration
     from the CLI input nodes. All interfaces have a common base where value
@@ -459,7 +459,8 @@ def get_interface_dict(config, base, ifname='', recursive_defaults=True):
                                       get_first_key=True,
                                       no_tag_node_value_mangle=True,
                                       with_defaults=True,
-                                      with_recursive_defaults=recursive_defaults)
+                                      with_recursive_defaults=recursive_defaults,
+                                      with_pki=with_pki)
 
         # If interface does not request an IPv4 DHCP address there is no need
         # to keep the dhcp-options key
@@ -623,7 +624,7 @@ def get_vlan_ids(interface):
 
     return vlan_ids
 
-def get_accel_dict(config, base, chap_secrets):
+def get_accel_dict(config, base, chap_secrets, with_pki=False):
     """
     Common utility function to retrieve and mangle the Accel-PPP configuration
     from different CLI input nodes. All Accel-PPP services have a common base
@@ -638,7 +639,8 @@ def get_accel_dict(config, base, chap_secrets):
     dict = config.get_config_dict(base, key_mangling=('-', '_'),
                                   get_first_key=True,
                                   no_tag_node_value_mangle=True,
-                                  with_recursive_defaults=True)
+                                  with_recursive_defaults=True,
+                                  with_pki=with_pki)
 
     # set CPUs cores to process requests
     dict.update({'thread_count' : get_half_cpus()})

--- a/smoketest/scripts/cli/test_service_https.py
+++ b/smoketest/scripts/cli/test_service_https.py
@@ -395,8 +395,7 @@ class TestHTTPSService(VyOSUnitTestSHIM.TestCase):
 
     @ignore_warning(InsecureRequestWarning)
     def test_api_config_file_load_http(self):
-        """Test load config from HTTP URL
-        """
+        # Test load config from HTTP URL
         address = '127.0.0.1'
         key = 'VyOS-key'
         url = f'https://{address}/config-file'

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2021 VyOS maintainers and contributors
+# Copyright (C) 2019-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -150,18 +150,11 @@ def get_config(config=None):
     else:
         conf = Config()
 
-    # This must be called prior to get_interface_dict(), as this function will
-    # alter the config level (config.set_level())
-    pki = conf.get_config_dict(['pki'], key_mangling=('-', '_'),
-                               get_first_key=True, no_tag_node_value_mangle=True)
-
     base = ['interfaces', 'ethernet']
-    ifname, ethernet = get_interface_dict(conf, base)
+    ifname, ethernet = get_interface_dict(conf, base, with_pki=True)
+
     if 'is_bond_member' in ethernet:
         update_bond_options(conf, ethernet)
-
-    if 'deleted' not in ethernet:
-       if pki: ethernet['pki'] = pki
 
     tmp = is_node_changed(conf, base + [ifname, 'speed'])
     if tmp: ethernet.update({'speed_duplex_changed': {}})
@@ -170,8 +163,6 @@ def get_config(config=None):
     if tmp: ethernet.update({'speed_duplex_changed': {}})
 
     return ethernet
-
-
 
 def verify_speed_duplex(ethernet: dict, ethtool: Ethtool):
     """

--- a/src/conf_mode/interfaces_openvpn.py
+++ b/src/conf_mode/interfaces_openvpn.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2023 VyOS maintainers and contributors
+# Copyright (C) 2019-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -89,15 +89,11 @@ def get_config(config=None):
         conf = Config()
     base = ['interfaces', 'openvpn']
 
-    ifname, openvpn = get_interface_dict(conf, base)
+    ifname, openvpn = get_interface_dict(conf, base, with_pki=True)
     openvpn['auth_user_pass_file'] = '/run/openvpn/{ifname}.pw'.format(**openvpn)
 
     if 'deleted' in openvpn:
         return openvpn
-
-    openvpn['pki'] = conf.get_config_dict(['pki'], key_mangling=('-', '_'),
-                                        get_first_key=True,
-                                        no_tag_node_value_mangle=True)
 
     if is_node_changed(conf, base + [ifname, 'openvpn-option']):
         openvpn.update({'restart_required': {}})
@@ -167,9 +163,10 @@ def verify_pki(openvpn):
             raise ConfigError(f'Invalid shared-secret on openvpn interface {interface}')
 
         # If PSK settings are correct, warn about its deprecation
-        DeprecationWarning("OpenVPN shared-secret support will be removed in future VyOS versions.\n\
-        Please migrate your site-to-site tunnels to TLS.\n\
-        You can use self-signed certificates with peer fingerprint verification, consult the documentation for details.")
+        DeprecationWarning('OpenVPN shared-secret support will be removed in future '\
+                           'VyOS versions. Please migrate your site-to-site tunnels to '\
+                           'TLS. You can use self-signed certificates with peer fingerprint '\
+                           'verification, consult the documentation for details.')
 
     if tls:
         if (mode in ['server', 'client']) and ('ca_certificate' not in tls):
@@ -729,4 +726,3 @@ if __name__ == '__main__':
     except ConfigError as e:
         print(e)
         exit(1)
-

--- a/src/conf_mode/interfaces_sstpc.py
+++ b/src/conf_mode/interfaces_sstpc.py
@@ -45,7 +45,7 @@ def get_config(config=None):
     else:
         conf = Config()
     base = ['interfaces', 'sstpc']
-    ifname, sstpc = get_interface_dict(conf, base)
+    ifname, sstpc = get_interface_dict(conf, base, with_pki=True)
 
     # We should only terminate the SSTP client session if critical parameters
     # change. All parameters that can be changed on-the-fly (like interface
@@ -57,10 +57,6 @@ def get_config(config=None):
             # bail out early - no need to further process other nodes
             break
 
-    # Load PKI certificates for later processing
-    sstpc['pki'] = conf.get_config_dict(['pki'], key_mangling=('-', '_'),
-                                        get_first_key=True,
-                                        no_tag_node_value_mangle=True)
     return sstpc
 
 def verify(sstpc):

--- a/src/conf_mode/load-balancing_reverse-proxy.py
+++ b/src/conf_mode/load-balancing_reverse-proxy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2023 VyOS maintainers and contributors
+# Copyright (C) 2023-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -43,17 +43,14 @@ def get_config(config=None):
         conf = Config()
 
     base = ['load-balancing', 'reverse-proxy']
+    if not conf.exists(base):
+        return None
     lb = conf.get_config_dict(base,
                               get_first_key=True,
                               key_mangling=('-', '_'),
-                              no_tag_node_value_mangle=True)
-
-    if lb:
-        lb['pki'] = conf.get_config_dict(['pki'], key_mangling=('-', '_'),
-                                    get_first_key=True, no_tag_node_value_mangle=True)
-
-    if lb:
-        lb = conf.merge_defaults(lb, recursive=True)
+                              no_tag_node_value_mangle=True,
+                              with_recursive_defaults=True,
+                              with_pki=True)
 
     return lb
 

--- a/src/conf_mode/service_https.py
+++ b/src/conf_mode/service_https.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2023 VyOS maintainers and contributors
+# Copyright (C) 2019-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -78,12 +78,7 @@ def get_config(config=None):
 
     diff = get_config_diff(conf)
 
-    https = conf.get_config_dict(base, get_first_key=True)
-
-    if https:
-        https['pki'] = conf.get_config_dict(['pki'], key_mangling=('-', '_'),
-                                            no_tag_node_value_mangle=True,
-                                            get_first_key=True)
+    https = conf.get_config_dict(base, get_first_key=True, with_pki=True)
 
     https['children_changed'] = diff.node_changed_children(base)
     https['api_add_or_delete'] = diff.node_changed_presence(base + ['api'])
@@ -119,7 +114,7 @@ def verify(https):
 
         if 'certificate' in certificates:
             if not https['pki']:
-                raise ConfigError("PKI is not configured")
+                raise ConfigError('PKI is not configured')
 
             cert_name = certificates['certificate']
 

--- a/src/conf_mode/vpn_ipsec.py
+++ b/src/conf_mode/vpn_ipsec.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2023 VyOS maintainers and contributors
+# Copyright (C) 2021-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -87,15 +87,13 @@ def get_config(config=None):
     ipsec = conf.get_config_dict(base, key_mangling=('-', '_'),
                                  no_tag_node_value_mangle=True,
                                  get_first_key=True,
-                                 with_recursive_defaults=True)
+                                 with_recursive_defaults=True,
+                                 with_pki=True)
 
     ipsec['dhcp_no_address'] = {}
     ipsec['install_routes'] = 'no' if conf.exists(base + ["options", "disable-route-autoinstall"]) else default_install_routes
     ipsec['interface_change'] = leaf_node_changed(conf, base + ['interface'])
     ipsec['nhrp_exists'] = conf.exists(['protocols', 'nhrp', 'tunnel'])
-    ipsec['pki'] = conf.get_config_dict(['pki'], key_mangling=('-', '_'),
-                                        no_tag_node_value_mangle=True,
-                                        get_first_key=True)
 
     tmp = conf.get_config_dict(l2tp_base, key_mangling=('-', '_'),
                                no_tag_node_value_mangle=True,

--- a/src/conf_mode/vpn_openconnect.py
+++ b/src/conf_mode/vpn_openconnect.py
@@ -56,12 +56,8 @@ def get_config(config=None):
 
     ocserv = conf.get_config_dict(base, key_mangling=('-', '_'),
                                   get_first_key=True,
-                                  with_recursive_defaults=True)
-
-    if ocserv:
-        ocserv['pki'] = conf.get_config_dict(['pki'], key_mangling=('-', '_'),
-                                             no_tag_node_value_mangle=True,
-                                             get_first_key=True)
+                                  with_recursive_defaults=True,
+                                  with_pki=True)
 
     return ocserv
 

--- a/src/conf_mode/vpn_sstp.py
+++ b/src/conf_mode/vpn_sstp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2023 VyOS maintainers and contributors
+# Copyright (C) 2018-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -54,14 +54,11 @@ def get_config(config=None):
         return None
 
     # retrieve common dictionary keys
-    sstp = get_accel_dict(conf, base, sstp_chap_secrets)
+    sstp = get_accel_dict(conf, base, sstp_chap_secrets, with_pki=True)
     if dict_search('client_ip_pool', sstp):
         # Multiple named pools require ordered values T5099
         sstp['ordered_named_pools'] = get_pools_in_order(dict_search('client_ip_pool', sstp))
-    if sstp:
-        sstp['pki'] = conf.get_config_dict(['pki'], key_mangling=('-', '_'),
-                                           get_first_key=True,
-                                           no_tag_node_value_mangle=True)
+
     sstp['server_type'] = 'sstp'
     return sstp
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

VyOS has several services relaying on the PKI CLI tree to retrieve certificates.
Consuming services like ethernet, openvpn or ipsec all re-implemented the same code to retrieve the certificates from the CLI.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5894

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

configdict

## Proposed changes
<!--- Describe your changes in detail -->

This PR extends the signature of `get_config_dict()` with a new option `with_pki` that defaults to false. If this option is set, the PKI CLI tree will be blended into the resulting dictionary.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_ethernet.py
test_add_multiple_ip_addresses (__main__.EthernetInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.EthernetInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.EthernetInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.EthernetInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.EthernetInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.EthernetInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.EthernetInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol_support (__main__.EthernetInterfaceTest.test_eapol_support) ... ok
test_interface_description (__main__.EthernetInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.EthernetInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.EthernetInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.EthernetInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.EthernetInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.EthernetInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.EthernetInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_non_existing_interface (__main__.EthernetInterfaceTest.test_non_existing_interface) ... ok
test_offloading_rfs (__main__.EthernetInterfaceTest.test_offloading_rfs) ... ok
test_offloading_rps (__main__.EthernetInterfaceTest.test_offloading_rps) ... ok
test_span_mirror (__main__.EthernetInterfaceTest.test_span_mirror) ... ok
test_speed_duplex_verify (__main__.EthernetInterfaceTest.test_speed_duplex_verify) ... ok
test_vif_8021q_interfaces (__main__.EthernetInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.EthernetInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.EthernetInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.EthernetInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.EthernetInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.EthernetInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 28 tests in 123.706s

OK
```

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py
test_openvpn_client_interfaces (__main__.TestInterfacesOpenVPN.test_openvpn_client_interfaces) ... ok
test_openvpn_client_verify (__main__.TestInterfacesOpenVPN.test_openvpn_client_verify) ... ok
test_openvpn_options (__main__.TestInterfacesOpenVPN.test_openvpn_options) ... ok
test_openvpn_server_subnet_topology (__main__.TestInterfacesOpenVPN.test_openvpn_server_subnet_topology) ... ok
test_openvpn_server_verify (__main__.TestInterfacesOpenVPN.test_openvpn_server_verify) ... ok
test_openvpn_site2site_interfaces_tun (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_interfaces_tun) ... ok
test_openvpn_site2site_verify (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_verify) ... ok

----------------------------------------------------------------------
Ran 7 tests in 87.075s

OK
```

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_load-balancing_reverse-proxy.py
test_01_lb_reverse_proxy_domain (__main__.TestLoadBalancingReverseProxy.test_01_lb_reverse_proxy_domain) ... ok

----------------------------------------------------------------------
Ran 1 test in 4.969s

OK

```

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
test_01_dhcp_fail_handling (__main__.TestVPNIPsec.test_01_dhcp_fail_handling) ... ok
test_02_site_to_site (__main__.TestVPNIPsec.test_02_site_to_site) ... ok
test_03_site_to_site_vti (__main__.TestVPNIPsec.test_03_site_to_site_vti) ... ok
test_04_dmvpn (__main__.TestVPNIPsec.test_04_dmvpn) ... ok
test_05_x509_site2site (__main__.TestVPNIPsec.test_05_x509_site2site) ... ok
test_06_flex_vpn_vips (__main__.TestVPNIPsec.test_06_flex_vpn_vips) ... ok
test_07_ikev2_road_warrior (__main__.TestVPNIPsec.test_07_ikev2_road_warrior) ... ok
test_08_ikev2_road_warrior_client_auth_eap_tls (__main__.TestVPNIPsec.test_08_ikev2_road_warrior_client_auth_eap_tls) ... ok
test_09_ikev2_road_warrior_client_auth_x509 (__main__.TestVPNIPsec.test_09_ikev2_road_warrior_client_auth_x509) ... ok

----------------------------------------------------------------------
Ran 9 tests in 53.061s

OK
```

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_openconnect.py
test_ocserv (__main__.TestVPNOpenConnect.test_ocserv) ... ok

----------------------------------------------------------------------
Ran 1 test in 9.761s

OK
```

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_sstp.py
test_accel_ipv4_pool (__main__.TestVPNSSTPServer.test_accel_ipv4_pool) ... ok
test_accel_local_authentication (__main__.TestVPNSSTPServer.test_accel_local_authentication) ... ok
test_accel_name_servers (__main__.TestVPNSSTPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNSSTPServer.test_accel_next_pool) ... ok
test_accel_radius_authentication (__main__.TestVPNSSTPServer.test_accel_radius_authentication) ... ok

----------------------------------------------------------------------
Ran 5 tests in 27.427s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
