### PR TITLE
T4839: firewall: Add dynamic address group in firewall configuration

### DIFF
--- a/data/templates/firewall/nftables-defines.j2
+++ b/data/templates/firewall/nftables-defines.j2
@@ -98,5 +98,26 @@
     }
 {%         endfor %}
 {%     endif %}
+
+{%     if group.dynamic_group is vyos_defined %}
+{%         if group.dynamic_group.address_group is vyos_defined and not is_ipv6 and is_l3 %}
+{%             for group_name, group_conf in group.dynamic_group.address_group.items() %}
+    set DA_{{ group_name }} {
+        type {{ ip_type }}
+        flags dynamic, timeout
+    }
+{%             endfor %}
+{%         endif %}
+
+{%         if group.dynamic_group.ipv6_address_group is vyos_defined and is_ipv6 and is_l3 %}
+{%             for group_name, group_conf in group.dynamic_group.ipv6_address_group.items() %}
+    set DA6_{{ group_name }} {
+        type {{ ip_type }}
+        flags dynamic, timeout
+    }
+{%             endfor %}
+{%         endif %}
+{%     endif %}
+
 {% endif %}
 {% endmacro %}

--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -115,6 +115,35 @@
               #include <include/generic-description.xml.i>
             </children>
           </tagNode>
+          <node name="dynamic-group">
+            <properties>
+              <help>Firewall dynamic group</help>
+            </properties>
+            <children>
+              <tagNode name="address-group">
+                <properties>
+                  <help>Firewall dynamic address group</help>
+                  <constraint>
+                    <regex>[a-zA-Z0-9][\w\-\.]*</regex>
+                  </constraint>
+                </properties>
+                <children>
+                  #include <include/generic-description.xml.i>
+                </children>
+              </tagNode>
+              <tagNode name="ipv6-address-group">
+                <properties>
+                  <help>Firewall dynamic IPv6 address group</help>
+                  <constraint>
+                    <regex>[a-zA-Z0-9][\w\-\.]*</regex>
+                  </constraint>
+                </properties>
+                <children>
+                  #include <include/generic-description.xml.i>
+                </children>
+              </tagNode>
+            </children>
+          </node>
           <tagNode name="interface-group">
             <properties>
               <help>Firewall interface-group</help>

--- a/interface-definitions/include/firewall/add-dynamic-address-groups.xml.i
+++ b/interface-definitions/include/firewall/add-dynamic-address-groups.xml.i
@@ -1,0 +1,34 @@
+<!-- include start from firewall/add-dynamic-address-groups.xml.i -->
+<leafNode name="address-group">
+  <properties>
+    <help>Dynamic address-group</help>
+    <completionHelp>
+      <path>firewall group dynamic-group address-group</path>
+    </completionHelp>
+  </properties>
+</leafNode>
+<leafNode name="timeout">
+  <properties>
+    <help>Set timeout</help>
+    <valueHelp>
+      <format>&lt;number&gt;s</format>
+      <description>Timeout value in seconds</description>
+    </valueHelp>
+    <valueHelp>
+      <format>&lt;number&gt;m</format>
+      <description>Timeout value in minutes</description>
+    </valueHelp>
+    <valueHelp>
+      <format>&lt;number&gt;h</format>
+      <description>Timeout value in hours</description>
+    </valueHelp>
+    <valueHelp>
+      <format>&lt;number&gt;d</format>
+      <description>Timeout value in days</description>
+    </valueHelp>
+    <constraint>
+      <regex>\d+(s|m|h|d)</regex>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/firewall/add-dynamic-ipv6-address-groups.xml.i
+++ b/interface-definitions/include/firewall/add-dynamic-ipv6-address-groups.xml.i
@@ -1,0 +1,34 @@
+<!-- include start from firewall/add-dynamic-ipv6-address-groups.xml.i -->
+<leafNode name="address-group">
+  <properties>
+    <help>Dynamic ipv6-address-group</help>
+    <completionHelp>
+      <path>firewall group dynamic-group ipv6-address-group</path>
+    </completionHelp>
+  </properties>
+</leafNode>
+<leafNode name="timeout">
+  <properties>
+    <help>Set timeout</help>
+    <valueHelp>
+      <format>&lt;number&gt;s</format>
+      <description>Timeout value in seconds</description>
+    </valueHelp>
+    <valueHelp>
+      <format>&lt;number&gt;m</format>
+      <description>Timeout value in minutes</description>
+    </valueHelp>
+    <valueHelp>
+      <format>&lt;number&gt;h</format>
+      <description>Timeout value in hours</description>
+    </valueHelp>
+    <valueHelp>
+      <format>&lt;number&gt;d</format>
+      <description>Timeout value in days</description>
+    </valueHelp>
+    <constraint>
+      <regex>\d+(s|m|h|d)</regex>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/firewall/common-rule-ipv4.xml.i
+++ b/interface-definitions/include/firewall/common-rule-ipv4.xml.i
@@ -1,6 +1,29 @@
 <!-- include start from firewall/common-rule-ipv4.xml.i -->
 #include <include/firewall/common-rule-inet.xml.i>
 #include <include/firewall/ttl.xml.i>
+<node name="add-address-to-group">
+  <properties>
+    <help>Add ip address to dynamic address-group</help>
+  </properties>
+  <children>
+    <node name="source-address">
+      <properties>
+        <help>Add source ip addresses to dynamic address-group</help>
+      </properties>
+      <children>
+        #include <include/firewall/add-dynamic-address-groups.xml.i>
+      </children>
+    </node>
+    <node name="destination-address">
+      <properties>
+        <help>Add destination ip addresses to dynamic address-group</help>
+      </properties>
+      <children>
+        #include <include/firewall/add-dynamic-address-groups.xml.i>
+      </children>
+    </node>
+  </children>
+</node>
 <node name="destination">
   <properties>
     <help>Destination parameters</help>
@@ -13,6 +36,7 @@
     #include <include/firewall/mac-address.xml.i>
     #include <include/firewall/port.xml.i>
     #include <include/firewall/source-destination-group.xml.i>
+    #include <include/firewall/source-destination-dynamic-group.xml.i>
   </children>
 </node>
 <node name="icmp">
@@ -67,6 +91,7 @@
     #include <include/firewall/mac-address.xml.i>
     #include <include/firewall/port.xml.i>
     #include <include/firewall/source-destination-group.xml.i>
+    #include <include/firewall/source-destination-dynamic-group.xml.i>
   </children>
 </node>
 <!-- include end -->

--- a/interface-definitions/include/firewall/common-rule-ipv6.xml.i
+++ b/interface-definitions/include/firewall/common-rule-ipv6.xml.i
@@ -1,6 +1,29 @@
 <!-- include start from firewall/common-rule-ipv6.xml.i -->
 #include <include/firewall/common-rule-inet.xml.i>
 #include <include/firewall/hop-limit.xml.i>
+<node name="add-address-to-group">
+  <properties>
+    <help>Add ipv6 address to dynamic ipv6-address-group</help>
+  </properties>
+  <children>
+    <node name="source-address">
+      <properties>
+        <help>Add source ipv6 addresses to dynamic ipv6-address-group</help>
+      </properties>
+      <children>
+        #include <include/firewall/add-dynamic-ipv6-address-groups.xml.i>
+      </children>
+    </node>
+    <node name="destination-address">
+      <properties>
+        <help>Add destination ipv6 addresses to dynamic ipv6-address-group</help>
+      </properties>
+      <children>
+        #include <include/firewall/add-dynamic-ipv6-address-groups.xml.i>
+      </children>
+    </node>
+  </children>
+</node>
 <node name="destination">
   <properties>
     <help>Destination parameters</help>
@@ -13,6 +36,7 @@
     #include <include/firewall/mac-address.xml.i>
     #include <include/firewall/port.xml.i>
     #include <include/firewall/source-destination-group-ipv6.xml.i>
+    #include <include/firewall/source-destination-dynamic-group-ipv6.xml.i>
   </children>
 </node>
 <node name="icmpv6">
@@ -67,6 +91,7 @@
     #include <include/firewall/mac-address.xml.i>
     #include <include/firewall/port.xml.i>
     #include <include/firewall/source-destination-group-ipv6.xml.i>
+    #include <include/firewall/source-destination-dynamic-group-ipv6.xml.i>
   </children>
 </node>
 <!-- include end -->

--- a/interface-definitions/include/firewall/source-destination-dynamic-group-ipv6.xml.i
+++ b/interface-definitions/include/firewall/source-destination-dynamic-group-ipv6.xml.i
@@ -1,0 +1,17 @@
+<!-- include start from firewall/source-destination-dynamic-group-ipv6.xml.i -->
+<node name="group">
+  <properties>
+    <help>Group</help>
+  </properties>
+  <children>
+    <leafNode name="dynamic-address-group">
+      <properties>
+        <help>Group of dynamic ipv6 addresses</help>
+        <completionHelp>
+          <path>firewall group dynamic-group ipv6-address-group</path>
+        </completionHelp>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/firewall/source-destination-dynamic-group.xml.i
+++ b/interface-definitions/include/firewall/source-destination-dynamic-group.xml.i
@@ -1,0 +1,17 @@
+<!-- include start from firewall/source-destination-dynamic-group.xml.i -->
+<node name="group">
+  <properties>
+    <help>Group</help>
+  </properties>
+  <children>
+    <leafNode name="dynamic-address-group">
+      <properties>
+        <help>Group of dynamic addresses</help>
+        <completionHelp>
+          <path>firewall group dynamic-group address-group</path>
+        </completionHelp>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/src/conf_mode/nat.py
+++ b/src/conf_mode/nat.py
@@ -69,6 +69,10 @@ def get_config(config=None):
     nat['firewall_group'] = conf.get_config_dict(['firewall', 'group'], key_mangling=('-', '_'), get_first_key=True,
                                     no_tag_node_value_mangle=True)
 
+    # Remove dynamic firewall groups if present:
+    if 'dynamic_group' in nat['firewall_group']:
+        del nat['firewall_group']['dynamic_group']
+
     return nat
 
 def verify_rule(config, err_msg, groups_dict):

--- a/src/conf_mode/policy_route.py
+++ b/src/conf_mode/policy_route.py
@@ -53,6 +53,10 @@ def get_config(config=None):
     policy['firewall_group'] = conf.get_config_dict(['firewall', 'group'], key_mangling=('-', '_'), get_first_key=True,
                                     no_tag_node_value_mangle=True)
 
+    # Remove dynamic firewall groups if present:
+    if 'dynamic_group' in policy['firewall_group']:
+        del policy['firewall_group']['dynamic_group']
+
     return policy
 
 def verify_rule(policy, name, rule_conf, ipv6, rule_id):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add dynamic address group in firewall configuration and appropriate commands to populate such groups using source and destination address of the packet.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4839
 
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configuration example:
```
set firewall group dynamic-group address-group knock-01
set firewall group dynamic-group address-group knock-02
set firewall group dynamic-group address-group knock-allowed
set firewall ipv4 input filter default-action 'drop'
set firewall ipv4 input filter rule 10 action 'drop'
set firewall ipv4 input filter rule 10 add-address-to-group source-address address-group 'knock-01'
set firewall ipv4 input filter rule 10 add-address-to-group source-address timeout '30s'
set firewall ipv4 input filter rule 10 destination port '123'
set firewall ipv4 input filter rule 10 protocol 'tcp'
set firewall ipv4 input filter rule 20 action 'drop'
set firewall ipv4 input filter rule 20 add-address-to-group source-address address-group 'knock-02'
set firewall ipv4 input filter rule 20 add-address-to-group source-address timeout '30s'
set firewall ipv4 input filter rule 20 destination port '234'
set firewall ipv4 input filter rule 20 protocol 'tcp'
set firewall ipv4 input filter rule 20 source group dynamic-address-group 'knock-01'
set firewall ipv4 input filter rule 30 action 'drop'
set firewall ipv4 input filter rule 30 add-address-to-group source-address address-group 'knock-allowed'
set firewall ipv4 input filter rule 30 add-address-to-group source-address timeout '3m'
set firewall ipv4 input filter rule 30 destination port '567'
set firewall ipv4 input filter rule 30 protocol 'tcp'
set firewall ipv4 input filter rule 30 source group dynamic-address-group 'knock-02'
set firewall ipv4 input filter rule 99 action 'accept'
set firewall ipv4 input filter rule 99 source group dynamic-address-group 'knock-allowed'
```
Table ip vyos_filter:
```
vyos@dyn-group# sudo nft list table ip vyos_filter
table ip vyos_filter {
        set DA_knock-01 {
                type ipv4_addr
                size 65535
                flags dynamic,timeout
                elements = { 192.168.89.27 timeout 30s expires 12s794ms }
        }

        set DA_knock-02 {
                type ipv4_addr
                size 65535
                flags dynamic,timeout
                elements = { 192.168.89.27 timeout 30s expires 16s953ms }
        }

        set DA_knock-allowed {
                type ipv4_addr
                size 65535
                flags dynamic,timeout
                elements = { 192.168.89.27 timeout 3m expires 2m51s115ms }
        }

        chain VYOS_FORWARD_filter {
                type filter hook forward priority filter; policy accept;
                counter packets 0 bytes 0 accept comment "FWD-filter default-action accept"
        }

        chain VYOS_INPUT_filter {
                type filter hook input priority filter; policy accept;
                tcp dport 123 counter packets 2 bytes 120 update @DA_knock-01 { ip saddr timeout 30s } drop comment "ipv4-INP-filter-10"
                tcp dport 234 ip saddr @DA_knock-01 counter packets 2 bytes 120 update @DA_knock-02 { ip saddr timeout 30s } drop comment "ipv4-INP-filter-20"
                tcp dport 567 ip saddr @DA_knock-02 counter packets 2 bytes 120 update @DA_knock-allowed { ip saddr timeout 3m } drop comment "ipv4-INP-filter-30"
                ip saddr @DA_knock-allowed counter packets 11 bytes 2325 accept comment "ipv4-INP-filter-99"
                counter packets 3 bytes 563 drop comment "INP-filter default-action drop"
        }
...
```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@dyn-group:/usr/libexec/vyos/tests/smoke/cli# ./test_firewall.py 
test_bridge_basic_rules (__main__.TestFirewall.test_bridge_basic_rules) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... 
Interface "eth0" does not support hardware offload

ok
test_geoip (__main__.TestFirewall.test_geoip) ... Updating GeoIP. Please wait...
Updating GeoIP. Please wait...
ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_dynamic_groups (__main__.TestFirewall.test_ipv4_dynamic_groups) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... 
"synproxy" option allowed only for action synproxy

ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_dynamic_groups (__main__.TestFirewall.test_ipv6_dynamic_groups) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... 
Group "smoketest_network1" has a circular reference

ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... 
Interface "eth0" does not support hardware offload

ok

----------------------------------------------------------------------
Ran 19 tests in 44.426s

OK
root@dyn-group:/usr/libexec/vyos/tests/smoke/cli# 
root@dyn-group:/usr/libexec/vyos/tests/smoke/cli# ./test_policy_route.py 
test_pbr_group (__main__.TestPolicyRoute.test_pbr_group) ... ok
test_pbr_mark (__main__.TestPolicyRoute.test_pbr_mark) ... ok
test_pbr_mark_connection (__main__.TestPolicyRoute.test_pbr_mark_connection) ... ok
test_pbr_matching_criteria (__main__.TestPolicyRoute.test_pbr_matching_criteria) ... ok
test_pbr_table (__main__.TestPolicyRoute.test_pbr_table) ... ok

----------------------------------------------------------------------
Ran 5 tests in 13.249s

OK
root@dyn-group:/usr/libexec/vyos/tests/smoke/cli# ./test_nat.py 
test_dnat (__main__.TestNAT.test_dnat) ... ok
test_dnat_negated_addresses (__main__.TestNAT.test_dnat_negated_addresses) ... ok
test_dnat_redirect (__main__.TestNAT.test_dnat_redirect) ... ok
test_dnat_without_translation_address (__main__.TestNAT.test_dnat_without_translation_address) ... ok
test_nat_balance (__main__.TestNAT.test_nat_balance) ... ok
test_nat_no_rules (__main__.TestNAT.test_nat_no_rules) ... ok
test_snat (__main__.TestNAT.test_snat) ... ok
test_snat_groups (__main__.TestNAT.test_snat_groups) ... ok
test_snat_required_translation_address (__main__.TestNAT.test_snat_required_translation_address) ... 
Source NAT configuration error in rule 5: translation requires address
and/or port

ok
test_static_nat (__main__.TestNAT.test_static_nat) ... ok

----------------------------------------------------------------------
Ran 10 tests in 22.372s

OK
root@dyn-group:/usr/libexec/vyos/tests/smoke/cli# 

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
