### PR TITLE
T5900 dns forwarding: reliability improvements

### DIFF
--- a/data/templates/dns-forwarding/recursor.conf.j2
+++ b/data/templates/dns-forwarding/recursor.conf.j2
@@ -45,6 +45,11 @@ dns64-prefix={{ dns64_prefix }}
 dont-throttle-netmasks={{ dont_throttle_netmasks | join(',') }}
 {% endif %}
 
+{% if serve_stale_extensions is vyos_defined %}
+# serve-stale-extensions
+serve-stale-extensions={{ serve_stale_extensions }}
+{% endif %}
+
 # serve rfc1918 records
 serve-rfc1918={{ 'no' if no_serve_rfc1918 is vyos_defined else 'yes' }}
 

--- a/data/templates/dns-forwarding/recursor.conf.j2
+++ b/data/templates/dns-forwarding/recursor.conf.j2
@@ -40,6 +40,11 @@ dnssec={{ dnssec }}
 dns64-prefix={{ dns64_prefix }}
 {% endif %}
 
+{% if dont_throttle_netmasks is vyos_defined %}
+# dont-throttle-netmasks
+dont-throttle-netmasks={{ dont_throttle_netmasks | join(',') }}
+{% endif %}
+
 # serve rfc1918 records
 serve-rfc1918={{ 'no' if no_serve_rfc1918 is vyos_defined else 'yes' }}
 

--- a/data/templates/dns-forwarding/recursor.conf.j2
+++ b/data/templates/dns-forwarding/recursor.conf.j2
@@ -42,12 +42,12 @@ dns64-prefix={{ dns64_prefix }}
 
 {% if dont_throttle_netmasks is vyos_defined %}
 # dont-throttle-netmasks
-dont-throttle-netmasks={{ dont_throttle_netmasks | join(',') }}
+dont-throttle-netmasks={{ exclude_throttle_address | join(',') }}
 {% endif %}
 
 {% if serve_stale_extensions is vyos_defined %}
 # serve-stale-extensions
-serve-stale-extensions={{ serve_stale_extensions }}
+serve-stale-extensions={{ serve_stale_extension }}
 {% endif %}
 
 # serve rfc1918 records

--- a/interface-definitions/service_dns_forwarding.xml.in
+++ b/interface-definitions/service_dns_forwarding.xml.in
@@ -670,9 +670,9 @@
                 </properties>
                 <defaultValue>3600</defaultValue>
               </leafNode>
-              <leafNode name="serve-stale-extensions">
+              <leafNode name="serve-stale-extension">
                 <properties>
-                  <help>Maximum number of times an expired record’s TTL is extended by 30s when serving stale</help>
+                  <help>Number of times the expired TTL of a record is extended by 30 seconds when serving stale</help>
                   <valueHelp>
                     <format>u32:0-65535</format>
                     <description>Number of times to extend the TTL</description>
@@ -707,7 +707,7 @@
                   <valueless/>
                 </properties>
               </leafNode>
-              <leafNode name="dont-throttle-netmasks">
+              <leafNode name="exclude-throttle-address">
                 <properties>
                   <help>IP address or subnet</help>
                   <valueHelp>

--- a/interface-definitions/service_dns_forwarding.xml.in
+++ b/interface-definitions/service_dns_forwarding.xml.in
@@ -670,6 +670,19 @@
                 </properties>
                 <defaultValue>3600</defaultValue>
               </leafNode>
+              <leafNode name="serve-stale-extensions">
+                <properties>
+                  <help>Maximum number of times an expired record’s TTL is extended by 30s when serving stale</help>
+                  <valueHelp>
+                    <format>u32:0-65535</format>
+                    <description>Number of times to extend the TTL</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-65535"/>
+                  </constraint>
+                </properties>
+                <defaultValue>0</defaultValue>
+              </leafNode>
               <leafNode name="timeout">
                 <properties>
                   <help>Number of milliseconds to wait for a remote authoritative server to respond</help>

--- a/interface-definitions/service_dns_forwarding.xml.in
+++ b/interface-definitions/service_dns_forwarding.xml.in
@@ -694,6 +694,34 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <leafNode name="dont-throttle-netmasks">
+                <properties>
+                  <help>IP address or subnet</help>
+                  <valueHelp>
+                    <format>ipv4</format>
+                    <description>IPv4 address to match</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ipv4net</format>
+                    <description>IPv4 prefix to match</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ipv6</format>
+                    <description>IPv6 address</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ipv6net</format>
+                    <description>IPv6 address</description>
+                  </valueHelp>
+                  <multi/>
+                  <constraint>
+                    <validator name="ipv4-address"/>
+                    <validator name="ipv4-prefix"/>
+                    <validator name="ipv6-address"/>
+                    <validator name="ipv6-prefix"/>
+                  </constraint>
+                </properties>
+              </leafNode>
             </children>
           </node>
         </children>

--- a/smoketest/scripts/cli/test_service_dns_forwarding.py
+++ b/smoketest/scripts/cli/test_service_dns_forwarding.py
@@ -262,6 +262,21 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         tmp = get_config_value('dont-throttle-netmasks')
         self.assertEqual(tmp, ','.join(dont_throttle_netmasks_examples))
 
+    def test_serve_stale_extensions(self):
+        for network in allow_from:
+            self.cli_set(base_path + ['allow-from', network])
+        for address in listen_adress:
+            self.cli_set(base_path + ['listen-address', address])
+
+        self.cli_set(base_path + ['serve-stale-extensions', '20'])
+
+        # commit changes
+        self.cli_commit()
+
+        # verify configuration
+        tmp = get_config_value('serve-stale-extensions')
+        self.assertEqual(tmp, '20')
+
     def test_listening_port(self):
         # We can listen on a different port compared to '53' but only one at a time
         for port in ['1053', '5353']:

--- a/smoketest/scripts/cli/test_service_dns_forwarding.py
+++ b/smoketest/scripts/cli/test_service_dns_forwarding.py
@@ -239,6 +239,29 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         tmp = get_config_value('dns64-prefix')
         self.assertEqual(tmp, dns_prefix)
 
+    def test_dont_throttle_netmasks(self):
+        dont_throttle_netmasks_examples = [
+            '192.168.128.255',
+            '10.0.0.0/25',
+            '2001:db8:85a3:8d3:1319:8a2e:370:7348',
+            '64:ff9b::/96'
+        ]
+
+        for network in allow_from:
+            self.cli_set(base_path + ['allow-from', network])
+        for address in listen_adress:
+            self.cli_set(base_path + ['listen-address', address])
+
+        for dont_throttle_netmasks in dont_throttle_netmasks_examples:
+            self.cli_set(base_path + ['dont-throttle-netmasks', dont_throttle_netmasks])
+
+        # commit changes
+        self.cli_commit()
+
+        # verify dont-throttle-netmasks configuration
+        tmp = get_config_value('dont-throttle-netmasks')
+        self.assertEqual(tmp, ','.join(dont_throttle_netmasks_examples))
+
     def test_listening_port(self):
         # We can listen on a different port compared to '53' but only one at a time
         for port in ['1053', '5353']:

--- a/smoketest/scripts/cli/test_service_dns_forwarding.py
+++ b/smoketest/scripts/cli/test_service_dns_forwarding.py
@@ -239,8 +239,8 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         tmp = get_config_value('dns64-prefix')
         self.assertEqual(tmp, dns_prefix)
 
-    def test_dont_throttle_netmasks(self):
-        dont_throttle_netmasks_examples = [
+    def test_exclude_throttle_adress(self):
+        exclude_throttle_adress_examples = [
             '192.168.128.255',
             '10.0.0.0/25',
             '2001:db8:85a3:8d3:1319:8a2e:370:7348',
@@ -252,29 +252,29 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         for address in listen_adress:
             self.cli_set(base_path + ['listen-address', address])
 
-        for dont_throttle_netmasks in dont_throttle_netmasks_examples:
-            self.cli_set(base_path + ['dont-throttle-netmasks', dont_throttle_netmasks])
+        for exclude_throttle_adress in exclude_throttle_adress_examples:
+            self.cli_set(base_path + ['exclude-throttle-address', exclude_throttle_adress])
 
         # commit changes
         self.cli_commit()
 
         # verify dont-throttle-netmasks configuration
-        tmp = get_config_value('dont-throttle-netmasks')
-        self.assertEqual(tmp, ','.join(dont_throttle_netmasks_examples))
+        tmp = get_config_value('exclude-throttle-address')
+        self.assertEqual(tmp, ','.join(exclude_throttle_adress_examples))
 
-    def test_serve_stale_extensions(self):
+    def test_serve_stale_extension(self):
         for network in allow_from:
             self.cli_set(base_path + ['allow-from', network])
         for address in listen_adress:
             self.cli_set(base_path + ['listen-address', address])
 
-        self.cli_set(base_path + ['serve-stale-extensions', '20'])
+        self.cli_set(base_path + ['serve-stale-extension', '20'])
 
         # commit changes
         self.cli_commit()
 
         # verify configuration
-        tmp = get_config_value('serve-stale-extensions')
+        tmp = get_config_value('serve-stale-extension')
         self.assertEqual(tmp, '20')
 
     def test_listening_port(self):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
dns forwarding: [T5900](https://vyos.dev/T5900)
implement in vyos the powerdns dont-throttle-netmasks and server-stale-extensions options.
see https://docs.powerdns.com/recursor/appendices/internals.html#serve-stale about serving stale records.
this will transform the dns cache into a LRU cache

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5900

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dns forwarder
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@vyos:~# /usr/libexec/vyos/tests/smoke/cli/test_service_dns_forwarding.py
test_basic_forwarding (__main__.TestServicePowerDNS.test_basic_forwarding) ...
DNS forwarding requires a listen-address


DNS forwarding requires a listen-address

ok
test_dns64 (__main__.TestServicePowerDNS.test_dns64) ...
DNS 6to4 prefix must be of length /96

ok
test_dnssec (__main__.TestServicePowerDNS.test_dnssec) ... ok
test_domain_forwarding (__main__.TestServicePowerDNS.test_domain_forwarding) ... ok
test_dont_throttle_netmasks (__main__.TestServicePowerDNS.test_dont_throttle_netmasks) ... ok
test_external_nameserver (__main__.TestServicePowerDNS.test_external_nameserver) ... ok
test_listening_port (__main__.TestServicePowerDNS.test_listening_port) ... ok
test_no_rfc1918_forwarding (__main__.TestServicePowerDNS.test_no_rfc1918_forwarding) ... ok
test_serve_stale_extensions (__main__.TestServicePowerDNS.test_serve_stale_extensions) ... ok

----------------------------------------------------------------------
Ran 9 tests in 32.120s

OK

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
