### PR TITLE
image: T5898: fix kernel-level partition rescan

### DIFF
--- a/python/vyos/system/disk.py
+++ b/python/vyos/system/disk.py
@@ -78,7 +78,7 @@ def parttable_create(drive_path: str, root_size: int) -> None:
     run(command)
     # update partitons in kernel
     sync()
-    run(f'partprobe {drive_path}')
+    run(f'partx -u {drive_path}')
 
     partitions: list[str] = partition_list(drive_path)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
This fix moves from partprobe to partx to rescan the partition table on an affected disk.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5898

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
image

## Proposed changes
One line change -- moving to partx from partprobe, as per the suggested fix in the task.  This is my first attempt at contributing to VyOS (heck, it's my first time even using) but to use it, I had to fix the installer so I could.  Figured it was a good place to start.

## How to test
Take a current copy of of the nightly rolling build ISO (at least 20240105 or the past few days earlier) and try to install it in a VM (my test instance was on a Proxmox 8-managed QEMU VM).  When you try and run the `install image` command, it fails, as per the notes in the task.

After doing the fix, I set up the dev environment and Docker build containers as per the instructions in https://docs.vyos.io/en/latest/contributing/build-vyos.html, built the vyos-1x package and installed manually (and successfully).  A re-roll of the ISO afterwards, adding the custom package, also succeeded.

## Smoketest result
Not certain this is relevant -- I can't seem to find related smoketest code for the image-utils code with a (admittedly cursory) search.  If someone wants to help point me in the right direction, I'll see what I can do.

FWIW, please see the testing methodology above, as it at least lines out what testing I did do to solve my case-specific problem.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
