### PR TITLE
dns: T5900: fix smoketests for serve-stale-extension and exclude-throttle-address

### DIFF
--- a/data/templates/dns-forwarding/recursor.conf.j2
+++ b/data/templates/dns-forwarding/recursor.conf.j2
@@ -40,12 +40,12 @@ dnssec={{ dnssec }}
 dns64-prefix={{ dns64_prefix }}
 {% endif %}
 
-{% if dont_throttle_netmasks is vyos_defined %}
+{% if exclude_throttle_address is vyos_defined %}
 # dont-throttle-netmasks
 dont-throttle-netmasks={{ exclude_throttle_address | join(',') }}
 {% endif %}
 
-{% if serve_stale_extensions is vyos_defined %}
+{% if serve_stale_extension is vyos_defined %}
 # serve-stale-extensions
 serve-stale-extensions={{ serve_stale_extension }}
 {% endif %}

--- a/smoketest/scripts/cli/test_service_dns_forwarding.py
+++ b/smoketest/scripts/cli/test_service_dns_forwarding.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2022 VyOS maintainers and contributors
+# Copyright (C) 2019-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -43,7 +43,6 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestServicePowerDNS, cls).setUpClass()
-
         # ensure we can also run this test on a live system - so lets clean
         # out the current configuration :)
         cls.cli_delete(cls, base_path)
@@ -259,23 +258,24 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # verify dont-throttle-netmasks configuration
-        tmp = get_config_value('exclude-throttle-address')
+        tmp = get_config_value('dont-throttle-netmasks')
         self.assertEqual(tmp, ','.join(exclude_throttle_adress_examples))
 
     def test_serve_stale_extension(self):
+        server_stale = '20'
         for network in allow_from:
             self.cli_set(base_path + ['allow-from', network])
         for address in listen_adress:
             self.cli_set(base_path + ['listen-address', address])
 
-        self.cli_set(base_path + ['serve-stale-extension', '20'])
+        self.cli_set(base_path + ['serve-stale-extension', server_stale])
 
         # commit changes
         self.cli_commit()
 
         # verify configuration
-        tmp = get_config_value('serve-stale-extension')
-        self.assertEqual(tmp, '20')
+        tmp = get_config_value('serve-stale-extensions')
+        self.assertEqual(tmp, server_stale)
 
     def test_listening_port(self):
         # We can listen on a different port compared to '53' but only one at a time


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This fixes commit 199ceb1f0a ("dns: T5900: add dont-throttle-netmasks and serve-stale-extensions powerdns features") where after the latest review round the Jinja2 template was inconsitently changed and smoketests were not re-run.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5900

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/2757

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_dns_forwarding.py
test_basic_forwarding (__main__.TestServicePowerDNS.test_basic_forwarding) ... ok
test_dns64 (__main__.TestServicePowerDNS.test_dns64) ... ok
test_dnssec (__main__.TestServicePowerDNS.test_dnssec) ... ok
test_domain_forwarding (__main__.TestServicePowerDNS.test_domain_forwarding) ... ok
test_exclude_throttle_adress (__main__.TestServicePowerDNS.test_exclude_throttle_adress) ... ok
test_external_nameserver (__main__.TestServicePowerDNS.test_external_nameserver) ... ok
test_listening_port (__main__.TestServicePowerDNS.test_listening_port) ... ok
test_no_rfc1918_forwarding (__main__.TestServicePowerDNS.test_no_rfc1918_forwarding) ... ok
test_serve_stale_extension (__main__.TestServicePowerDNS.test_serve_stale_extension) ... ok

----------------------------------------------------------------------
Ran 9 tests in 36.311s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
