### PR TITLE
op-mode: T5904: add "show ipv6 route vrf <name> <prefix>" command

### DIFF
--- a/op-mode-definitions/show-ipv6-route.xml.in
+++ b/op-mode-definitions/show-ipv6-route.xml.in
@@ -82,6 +82,23 @@
                     </properties>
                     <command>${vyos_op_scripts_dir}/route.py show_summary --family inet6 --vrf $5</command>
                   </node>
+                  <node name="node.tag">
+                    <properties>
+                      <help>Show IPv6 routes of given address or prefix</help>
+                      <completionHelp>
+                        <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                    <children>
+                      <node name="longer-prefixes">
+                        <properties>
+                          <help>Show longer prefixes of routes for given prefix</help>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                      </node>
+                    </children>
+                  </node>
                   #include <include/show-route-bgp.xml.i>
                   #include <include/show-route-connected.xml.i>
                   #include <include/show-route-isis.xml.i>
@@ -103,6 +120,7 @@
                 <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
               </completionHelp>
             </properties>
+            <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
             <children>
               <node name="longer-prefixes">
                 <properties>
@@ -111,7 +129,6 @@
                 <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
               </node>
             </children>
-            <command>vtysh -c "show ipv6 route $4"</command>
           </tagNode>
         </children>
       </node>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

We've always had a command to display discrete IPv6 routes/prefixes within the global VRF. This commit also adds support for a discrete VRF.

```
vyos@vyos:~$ show ipv6 route vrf all
Possible completions:
  <Enter>               Execute the current command
  <h:h:h:h:h:h:h:h>     Show IPv6 routes of given address or prefix
  <h:h:h:h:h:h:h:h/x>
```


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5904

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
vyos@vyos# run show ipv6 route vrf orange
Codes: K - kernel route, C - connected, S - static, R - RIPng,
       O - OSPFv3, I - IS-IS, B - BGP, N - NHRP, T - Table,
       v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

VRF orange:
C>* 2001:db8::/64 is directly connected, eth0.202, 00:00:05
C>* fe80::/64 is directly connected, eth0.202, 00:00:05

vyos@vyos# run show ipv6 route vrf orange 2001:db8::/64
Routing entry for 2001:db8::/64
  Known via "connected", distance 0, metric 0, vrf orange, best
  Last update 00:00:10 ago
  * directly connected, eth0.202
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
