### PR TITLE
T5896: firewall: backport interface validator for firewall rules.

### DIFF
--- a/interface-definitions/include/constraint/interface-name-with-wildcard-and-inverted.xml.i
+++ b/interface-definitions/include/constraint/interface-name-with-wildcard-and-inverted.xml.i
@@ -1,4 +1,0 @@
-<!-- include start from constraint/interface-name-with-wildcard-and-inverted.xml.i -->
-<regex>(\!?)(bond|br|dum|en|ersp|eth|gnv|ifb|lan|l2tp|l2tpeth|macsec|peth|ppp|pppoe|pptp|sstp|tun|veth|vti|vtun|vxlan|wg|wlan|wwan)([0-9]?)(\*?)(.+)?|(\!?)lo</regex>
-<validator name="file-path --lookup-path /sys/class/net --directory"/>
-<!-- include end -->

--- a/interface-definitions/include/firewall/match-interface.xml.i
+++ b/interface-definitions/include/firewall/match-interface.xml.i
@@ -4,6 +4,7 @@
     <help>Match interface</help>
     <completionHelp>
       <script>${vyos_completion_dir}/list_interfaces</script>
+      <path>vrf name</path>
     </completionHelp>
     <valueHelp>
       <format>txt</format>
@@ -18,7 +19,8 @@
       <description>Inverted interface name to match</description>
     </valueHelp>
     <constraint>
-      #include <include/constraint/interface-name-with-wildcard-and-inverted.xml.i>
+      <regex>(\!?)(bond|br|dum|en|ersp|eth|gnv|ifb|lan|l2tp|l2tpeth|macsec|peth|ppp|pppoe|pptp|sstp|tun|veth|vti|vtun|vxlan|wg|wlan|wwan)([0-9]?)(\*?)(.+)?|(\!?)lo</regex>
+      <validator name="vrf-name"/>
     </constraint>
   </properties>
 </leafNode>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Backport interface validator for firewall rules.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):
Backport

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5600
* https://vyos.dev/T5896

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-1x/pull/2300

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Steps done in https://vyos.dev/T5896 and config persists on reboot:
```
vyos@1.4.0-rc1:~$ uptime
 11:01:17 up 0 min,  1 user,  load average: 1.38, 0.35, 0.12
vyos@1.4.0-rc1:~$ show container 
CONTAINER ID  IMAGE                            COMMAND      CREATED         STATUS             PORTS       NAMES
fdd71eb8c79e  docker.io/library/alpine:latest  sleep 10000  19 seconds ago  Up 19 seconds ago              test
vyos@1.4.0-rc1:~$ show config
container {
    name test {
        command "sleep 10000"
        image docker.io/alpine:latest
        network test {
        }
    }
    network test {
        prefix 172.16.0.0/24
    }
}
firewall {
    ipv4 {
        name test {
            rule 1 {
                action accept
                inbound-interface {
                    name pod-test
                }
            }
        }
    }
}

vyos@1.4.0-rc1:~$ sudo nft -S list chain ip vyos_filter NAME_test
table ip vyos_filter {
        chain NAME_test {
                iifname "pod-test" counter packets 0 bytes 0 accept comment "ipv4-NAM-test-1"
                counter packets 0 bytes 0 drop comment "test default-action drop"
        }
}
vyos@1.4.0-rc1:~$ 

```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@1:/usr/libexec/vyos/tests/smoke/cli# ./test_firewall.py 
test_bridge_basic_rules (__main__.TestFirewall.test_bridge_basic_rules) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... 
Interface "eth0" does not support hardware offload

ok
test_geoip (__main__.TestFirewall.test_geoip) ... Updating GeoIP. Please wait...
Updating GeoIP. Please wait...
ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... 
Group "smoketest_network1" has a circular reference

ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... 
Interface "eth0" does not support hardware offload

ok

----------------------------------------------------------------------
Ran 16 tests in 37.118s

OK
root@1:/usr/libexec/vyos/tests/smoke/cli#
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
