### PR TITLE
T1297: vrrp: backport VRRP GARP options to Equuleus

### DIFF
--- a/data/templates/vrrp/keepalived.conf.tmpl
+++ b/data/templates/vrrp/keepalived.conf.tmpl
@@ -12,6 +12,25 @@ global_defs {
 {%     if global_parameters.version is defined %}
     vrrp_version {{ global_parameters.version }}
 {%     endif %}
+
+{%     if global_parameters.garp is defined %}
+{%         if global_parameters.garp.interval is defined %}
+    vrrp_garp_interval {{ global_parameters.garp.interval }}
+{%         endif %}
+{%         if global_parameters.garp.master_delay is defined %}
+    vrrp_garp_master_delay {{ global_parameters.garp.master_delay }}
+{%         endif %}
+{%         if global_parameters.garp.master_refresh is defined %}
+    vrrp_garp_master_refresh {{ global_parameters.garp.master_refresh }}
+{%         endif %}
+{%         if global_parameters.garp.master_refresh_repeat is defined %}
+    vrrp_garp_master_refresh_repeat {{ global_parameters.garp.master_refresh_repeat }}
+{%         endif %}
+{%         if global_parameters.garp.master_repeat is defined %}
+    vrrp_garp_master_repeat {{ global_parameters.garp.master_repeat }}
+{%         endif %}
+{%     endif %}
+
 {% endif %}
     notify_fifo /run/keepalived/keepalived_notify_fifo
     notify_fifo_script /usr/libexec/vyos/system/keepalived-fifo.py
@@ -36,6 +55,25 @@ vrrp_instance {{ name }} {
     virtual_router_id {{ group_config.vrid }}
     priority {{ group_config.priority }}
     advert_int {{ group_config.advertise_interval }}
+
+{%     if group_config.garp is defined %}
+{%         if group_config.garp.interval is defined %}
+    garp_interval {{ group_config.garp.interval }}
+{%         endif %}
+{%         if group_config.garp.master_delay is defined %}
+    garp_master_delay {{ group_config.garp.master_delay }}
+{%         endif %}
+{%         if group_config.garp.master_repeat is defined %}
+    garp_master_repeat {{ group_config.garp.master_repeat }}
+{%         endif %}
+{%         if group_config.garp.master_refresh is defined %}
+    garp_master_refresh {{ group_config.garp.master_refresh }}
+{%         endif %}
+{%         if group_config.garp.master_refresh_repeat is defined %}
+    garp_master_refresh_repeat {{ group_config.garp.master_refresh_repeat }}
+{%         endif %}
+{%     endif %}
+
 {%     if group_config.track is defined and group_config.track.exclude_vrrp_interface is defined %}
     dont_track_primary
 {%     endif %}

--- a/interface-definitions/include/vrrp/garp.xml.i
+++ b/interface-definitions/include/vrrp/garp.xml.i
@@ -1,0 +1,74 @@
+<!-- include start from vrrp/garp.xml.i -->
+<node name="garp">
+  <properties>
+    <help>Gratuitous ARP parameters</help>
+  </properties>
+  <children>
+    <leafNode name="master-delay">
+      <properties>
+        <help>Delay for second set of gratuitous ARPs after transition to MASTER</help>
+        <valueHelp>
+          <format>u32:1-1000</format>
+          <description>Delay for second set of gratuitous ARPs after transition to MASTER</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-1000"/>
+        </constraint>
+      </properties>
+      <defaultValue>5</defaultValue>
+    </leafNode>
+    <leafNode name="master-repeat">
+      <properties>
+        <help>Number of gratuitous ARP messages to send at a time after transition to MASTER</help>
+        <valueHelp>
+          <format>u32:1-255</format>
+          <description>Number of gratuitous ARP messages to send at a time after transition to MASTER</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-255"/>
+        </constraint>
+      </properties>
+      <defaultValue>5</defaultValue>
+    </leafNode>
+    <leafNode name="master-refresh">
+      <properties>
+        <help>Minimum time interval for refreshing gratuitous ARPs while MASTER. 0 means no refresh</help>
+        <valueHelp>
+          <format>u32:1-255</format>
+          <description>Minimum time interval for refreshing gratuitous ARPs while MASTER. 0 means no refresh</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-255"/>
+        </constraint>
+      </properties>
+      <defaultValue>5</defaultValue>
+    </leafNode>
+    <leafNode name="master-refresh-repeat">
+      <properties>
+        <help>Number of gratuitous ARP messages to send at a time while MASTER</help>
+        <valueHelp>
+          <format>u32:1-255</format>
+          <description>Number of gratuitous ARP messages to send at a time while MASTER</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-255"/>
+        </constraint>
+      </properties>
+      <defaultValue>1</defaultValue>
+    </leafNode>
+    <leafNode name="interval">
+      <properties>
+        <help>Delay between gratuitous ARP messages sent on an interface</help>
+        <valueHelp>
+          <format>&lt;0.000-1000&gt;</format>
+          <description>Delay between gratuitous ARP messages sent on an interface</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 0.000-1000 --float"/>
+        </constraint>
+      </properties>
+      <defaultValue>0</defaultValue>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/vrrp.xml.in
+++ b/interface-definitions/vrrp.xml.in
@@ -16,6 +16,7 @@
               <help>VRRP global parameters</help>
             </properties>
             <children>
+              #include <include/vrrp/garp.xml.i>
               <leafNode name="startup-delay">
                 <properties>
                   <help>Time VRRP startup process (in seconds)</help>
@@ -51,6 +52,7 @@
               <help>VRRP group</help>
             </properties>
             <children>
+              #include <include/vrrp/garp.xml.i>
               <leafNode name="interface">
                 <properties>
                   <help>Network interface</help>

--- a/smoketest/scripts/cli/test_ha_vrrp.py
+++ b/smoketest/scripts/cli/test_ha_vrrp.py
@@ -88,6 +88,14 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
         priority = '123'
         preempt_delay = '400'
         startup_delay = '120'
+        garp_master_delay = '2'
+        garp_master_repeat = '3'
+        garp_master_refresh = '4'
+        garp_master_refresh_repeat = '5'
+        garp_interval = '1.5'
+        group_garp_master_delay = '12'
+        group_garp_master_repeat = '13'
+        group_garp_master_refresh = '14'
         vrrp_version = '3'
 
         for group in groups:
@@ -113,9 +121,19 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
             self.cli_set(group_base + ['authentication', 'type', 'plaintext-password'])
             self.cli_set(group_base + ['authentication', 'password', f'{group}'])
 
+            # GARP
+            self.cli_set(group_base + ['garp', 'master-delay', group_garp_master_delay])
+            self.cli_set(group_base + ['garp', 'master-repeat', group_garp_master_repeat])
+            self.cli_set(group_base + ['garp', 'master-refresh', group_garp_master_refresh])
+
             # Global parameters
             self.cli_set(global_param_base + ['startup-delay', f'{startup_delay}'])
             self.cli_set(global_param_base + ['version', vrrp_version])
+            self.cli_set(global_param_base + ['garp', 'interval', f'{garp_interval}'])
+            self.cli_set(global_param_base + ['garp', 'master-delay', f'{garp_master_delay}'])
+            self.cli_set(global_param_base + ['garp', 'master-repeat', f'{garp_master_repeat}'])
+            self.cli_set(global_param_base + ['garp', 'master-refresh', f'{garp_master_refresh}'])
+            self.cli_set(global_param_base + ['garp', 'master-refresh-repeat', f'{garp_master_refresh_repeat}'])
 
         # commit changes
         self.cli_commit()
@@ -124,6 +142,11 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
         config = getConfig(f'global_defs')
         self.assertIn(f'vrrp_startup_delay {startup_delay}', config)
         self.assertIn(f'vrrp_version {vrrp_version}', config)
+        self.assertIn(f'vrrp_garp_interval {garp_interval}', config)
+        self.assertIn(f'vrrp_garp_master_delay {garp_master_delay}', config)
+        self.assertIn(f'vrrp_garp_master_repeat {garp_master_repeat}', config)
+        self.assertIn(f'vrrp_garp_master_refresh {garp_master_refresh}', config)
+        self.assertIn(f'vrrp_garp_master_refresh_repeat {garp_master_refresh_repeat}', config)
 
         for group in groups:
             vlan_id = group.lstrip('VLAN')
@@ -143,6 +166,11 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
             # Authentication
             self.assertIn(f'auth_pass "{group}"', config)
             self.assertIn(f'auth_type PASS', config)
+
+            #GARP
+            self.assertIn(f'garp_master_delay {group_garp_master_delay}', config)
+            self.assertIn(f'garp_master_refresh {group_garp_master_refresh}', config)
+            self.assertIn(f'garp_master_repeat {group_garp_master_repeat}', config)
 
     def test_03_sync_group(self):
         sync_group = 'VyOS'

--- a/src/conf_mode/vrrp.py
+++ b/src/conf_mode/vrrp.py
@@ -57,6 +57,8 @@ def get_config(config=None):
     # options which we need to update into the dictionary retrived.
     if 'group' in vrrp:
         default_values = defaults(base + ['group'])
+        if 'garp' in default_values:
+            del default_values['garp']
         for group in vrrp['group']:
             vrrp['group'][group] = dict_merge(default_values, vrrp['group'][group])
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Backport VRRP GARP options to Equuleus

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):
Backport

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T1297

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-1x/pull/1777

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrrp

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@135-garp:~$ show config comm | grep garp
set high-availability vrrp global-parameters garp interval '1.334'
set high-availability vrrp global-parameters garp master-delay '4'
set high-availability vrrp global-parameters garp master-refresh '5'
set high-availability vrrp global-parameters garp master-repeat '7'
set high-availability vrrp global-parameters garp master-refresh-repeat '6'
set high-availability vrrp group ETH0 garp master-delay '11'
set high-availability vrrp group ETH0 garp master-refresh '12'
set high-availability vrrp group ETH0 garp master-repeat '14'
set high-availability vrrp group ETH0 garp master-refresh-repeat '13'
set system host-name '135-garp'
vyos@135-garp:~$ show vrrp detail | grep ARP
 Gratuitous ARP delay = 4
 Gratuitous ARP repeat = 7
 Gratuitous ARP refresh timer = 5
 Gratuitous ARP refresh repeat = 6
 Gratuitous ARP lower priority delay = 4
 Gratuitous ARP lower priority repeat = 7
 Gratuitous ARP for each secondary VMAC = 0s
 Gratuitous ARP interval = 1.334000
------< Gratuitous ARP delays >------
------< GARP delay group 0 >------
 GARP interval = 1.334
 GARP next time 1704793644.719152 (Tue Jan  9 09:47:24.719152)
   Gratuitous ARP delay = 11
   Gratuitous ARP repeat = 14
   Gratuitous ARP refresh = 12
   Gratuitous ARP refresh repeat = 13
   Gratuitous ARP lower priority delay = 4
   Gratuitous ARP lower priority repeat = 7
   Reset ARP config counter 0
   Reset ARP config counter 0
   Reset ARP config counter 0
   Gratuitous ARP interval 1334ms
   Reset ARP config counter 0
   Reset ARP config counter 0
vyos@135-garp:~$ show vrrp
Name    Interface      VRID  State      Priority  Last Transition
------  -----------  ------  -------  ----------  -----------------
ETH0    eth2            200  MASTER          200  1m18s
vyos@135-garp:~$
```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@135-garp:/usr/libexec/vyos/tests/smoke/cli# ./test_ha_vrrp.py 
test_01_default_values (__main__.TestVRRP) ... ok
test_02_simple_options (__main__.TestVRRP) ... ok
test_03_sync_group (__main__.TestVRRP) ... ok
test_04_exclude_vrrp_interface (__main__.TestVRRP) ... ok

----------------------------------------------------------------------
Ran 4 tests in 14.199s

OK
root@135-garp:/usr/libexec/vyos/tests/smoke/cli# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
