### PR TITLE
T5688: Changed 'range' to multi in 'client-ip-pool' for accell-ppp

### DIFF
--- a/data/templates/accel-ppp/config_ip_pool.j2
+++ b/data/templates/accel-ppp/config_ip_pool.j2
@@ -12,16 +12,20 @@ gw-ip-address={{ gateway_address }}
 {%     endif %}
 {%     for pool in ordered_named_pools %}
 {%         for pool_name, pool_config in pool.items() %}
-{%             set iprange_str = pool_config.range %}
-{%             set iprange_list = pool_config.range.split('-') %}
-{%             if iprange_list | length == 2 %}
-{%                 set last_ip_oct = iprange_list[1].split('.') %}
-{%                 set iprange_str = iprange_list[0] + '-' + last_ip_oct[last_ip_oct | length - 1] %}
-{%             endif %}
-{%             if pool_config.next_pool is vyos_defined %}
+{%             if pool_config.range is vyos_defined %}
+{%                 for range in pool_config.range %}
+{%                     set iprange_str = range %}
+{%                     set iprange_list = range.split('-') %}
+{%                     if iprange_list | length == 2 %}
+{%                         set last_ip_oct = iprange_list[1].split('.') %}
+{%                         set iprange_str = iprange_list[0] + '-' + last_ip_oct[last_ip_oct | length - 1] %}
+{%                     endif %}
+{%                     if loop.last and pool_config.next_pool is vyos_defined %}
 {{ iprange_str }},name={{ pool_name }},next={{ pool_config.next_pool }}
-{%             else %}
+{%                     else %}
 {{ iprange_str }},name={{ pool_name }}
+{%                     endif %}
+{%                 endfor %}
 {%             endif %}
 {%         endfor %}
 {%     endfor %}

--- a/interface-definitions/include/accel-ppp/client-ip-pool.xml.i
+++ b/interface-definitions/include/accel-ppp/client-ip-pool.xml.i
@@ -27,11 +27,15 @@
           <validator name="ipv4-host"/>
           <validator name="ipv4-range-mask"  argument="-m 24 -r"/>
         </constraint>
+        <multi/>
       </properties>
     </leafNode>
     <leafNode name="next-pool">
       <properties>
         <help>Next pool name</help>
+        <completionHelp>
+          <path>${COMP_WORDS[@]:1:${#COMP_WORDS[@]}-4}</path>
+        </completionHelp>
         <valueHelp>
           <format>txt</format>
           <description>Name of IP pool</description>

--- a/interface-definitions/include/accel-ppp/default-pool.xml.i
+++ b/interface-definitions/include/accel-ppp/default-pool.xml.i
@@ -2,6 +2,9 @@
 <leafNode name="default-pool">
   <properties>
     <help>Default client IP pool name</help>
+    <completionHelp>
+      <path>${COMP_WORDS[@]:1:${#COMP_WORDS[@]}-3} client-ip-pool</path>
+    </completionHelp>
     <valueHelp>
       <format>txt</format>
       <description>Default IP pool</description>

--- a/src/conf_mode/vpn_l2tp.py
+++ b/src/conf_mode/vpn_l2tp.py
@@ -71,7 +71,7 @@ def verify(l2tp):
             raise ConfigError('DA/CoE server key required!')
 
     if dict_search('authentication.mode', l2tp) in ['local', 'noauth']:
-        if not l2tp['client_ip_pool'] and not l2tp['client_ipv6_pool']:
+        if not dict_search('client_ip_pool', l2tp) and not dict_search('client_ipv6_pool', l2tp):
             raise ConfigError(
                 "L2TP local auth mode requires local client-ip-pool or client-ipv6-pool to be configured!")
         if dict_search('client_ip_pool', l2tp) and not dict_search('default_pool', l2tp):

--- a/src/migration-scripts/ipoe-server/1-to-2
+++ b/src/migration-scripts/ipoe-server/1-to-2
@@ -57,7 +57,7 @@ for pool_name in config.list_nodes(namedpools_base):
     pool_path = namedpools_base + [pool_name]
     if config.exists(pool_path + ['subnet']):
         subnet = config.return_value(pool_path + ['subnet'])
-        config.set(pool_base + [pool_name, 'range'], value=subnet)
+        config.set(pool_base + [pool_name, 'range'], value=subnet, replace=False)
         # Get netmask from subnet
         mask = subnet.split("/")[1]
     if config.exists(pool_path + ['next-pool']):

--- a/src/migration-scripts/l2tp/4-to-5
+++ b/src/migration-scripts/l2tp/4-to-5
@@ -24,7 +24,7 @@ import os
 from sys import argv
 from sys import exit
 from vyos.configtree import ConfigTree
-
+from vyos.base import Warning
 
 if len(argv) < 2:
     print("Must specify file name!")
@@ -45,33 +45,33 @@ if not config.exists(pool_base):
     exit(0)
 default_pool = ''
 range_pool_name = 'default-range-pool'
-subnet_base_name = 'default-subnet-pool'
-number = 1
-subnet_pool_name = f'{subnet_base_name}-{number}'
-prev_subnet_pool = subnet_pool_name
-if config.exists(pool_base + ['subnet']):
-    default_pool = subnet_pool_name
-    for subnet in config.return_values(pool_base + ['subnet']):
-        config.set(pool_base + [subnet_pool_name, 'range'], value=subnet)
-        if prev_subnet_pool != subnet_pool_name:
-            config.set(pool_base + [prev_subnet_pool, 'next-pool'],
-                       value=subnet_pool_name)
-            prev_subnet_pool = subnet_pool_name
-        number += 1
-        subnet_pool_name = f'{subnet_base_name}-{number}'
-
-    config.delete(pool_base + ['subnet'])
 
 if config.exists(pool_base + ['start']) and config.exists(pool_base + ['stop']):
+    def is_legalrange(ip1: str, ip2: str, mask: str):
+        from ipaddress import IPv4Interface
+        interface1 = IPv4Interface(f'{ip1}/{mask}')
+
+        interface2 = IPv4Interface(f'{ip2}/{mask}')
+        return interface1.network.network_address == interface2.network.network_address and interface2.ip > interface1.ip
+
     start_ip = config.return_value(pool_base + ['start'])
     stop_ip = config.return_value(pool_base + ['stop'])
-    ip_range = f'{start_ip}-{stop_ip}'
+    if is_legalrange(start_ip, stop_ip,'24'):
+        ip_range = f'{start_ip}-{stop_ip}'
+        config.set(pool_base + [range_pool_name, 'range'], value=ip_range, replace=False)
+        default_pool = range_pool_name
+    else:
+        Warning(
+            f'L2TP client-ip-pool range start-ip:{start_ip} and stop-ip:{stop_ip} can not be migrated.')
+
     config.delete(pool_base + ['start'])
     config.delete(pool_base + ['stop'])
-    config.set(pool_base + [range_pool_name, 'range'], value=ip_range)
-    if default_pool:
-        config.set(pool_base + [range_pool_name, 'next-pool'],
-                   value=default_pool)
+
+if config.exists(pool_base + ['subnet']):
+    for subnet in config.return_values(pool_base + ['subnet']):
+        config.set(pool_base + [range_pool_name, 'range'], value=subnet, replace=False)
+
+    config.delete(pool_base + ['subnet'])
     default_pool = range_pool_name
 
 if default_pool:

--- a/src/migration-scripts/pppoe-server/6-to-7
+++ b/src/migration-scripts/pppoe-server/6-to-7
@@ -29,7 +29,7 @@ import os
 from sys import argv
 from sys import exit
 from vyos.configtree import ConfigTree
-
+from vyos.base import Warning
 
 if len(argv) < 2:
     print("Must specify file name!")
@@ -48,38 +48,35 @@ if not config.exists(base):
 
 if not config.exists(pool_base):
     exit(0)
+
 default_pool = ''
 range_pool_name = 'default-range-pool'
 
-subnet_base_name = 'default-subnet-pool'
-number = 1
-subnet_pool_name = f'{subnet_base_name}-{number}'
-prev_subnet_pool = subnet_pool_name
 #Default nameless pools migrations
-if config.exists(pool_base + ['subnet']):
-    default_pool = subnet_pool_name
-    for subnet in config.return_values(pool_base + ['subnet']):
-        config.set(pool_base + [subnet_pool_name, 'range'], value=subnet)
-        if prev_subnet_pool != subnet_pool_name:
-            config.set(pool_base + [prev_subnet_pool, 'next-pool'],
-                       value=subnet_pool_name)
-            prev_subnet_pool = subnet_pool_name
-        number += 1
-        subnet_pool_name = f'{subnet_base_name}-{number}'
-
-    config.delete(pool_base + ['subnet'])
-
 if config.exists(pool_base + ['start']) and config.exists(pool_base + ['stop']):
+    def is_legalrange(ip1: str, ip2: str, mask: str):
+        from ipaddress import IPv4Interface
+        interface1 = IPv4Interface(f'{ip1}/{mask}')
+        interface2 = IPv4Interface(f'{ip2}/{mask}')
+        return interface1.network.network_address == interface2.network.network_address and interface2.ip > interface1.ip
+
     start_ip = config.return_value(pool_base + ['start'])
     stop_ip = config.return_value(pool_base + ['stop'])
-    ip_range = f'{start_ip}-{stop_ip}'
+    if is_legalrange(start_ip, stop_ip, '24'):
+        ip_range = f'{start_ip}-{stop_ip}'
+        config.set(pool_base + [range_pool_name, 'range'], value=ip_range, replace=False)
+        default_pool = range_pool_name
+    else:
+        Warning(
+            f'PPPoE client-ip-pool range start-ip:{start_ip} and stop-ip:{stop_ip} can not be migrated.')
     config.delete(pool_base + ['start'])
     config.delete(pool_base + ['stop'])
-    config.set(pool_base + [range_pool_name, 'range'], value=ip_range)
-    if default_pool:
-        config.set(pool_base + [range_pool_name, 'next-pool'],
-                   value=default_pool)
+
+if config.exists(pool_base + ['subnet']):
     default_pool = range_pool_name
+    for subnet in config.return_values(pool_base + ['subnet']):
+        config.set(pool_base + [range_pool_name, 'range'], value=subnet, replace=False)
+    config.delete(pool_base + ['subnet'])
 
 gateway = ''
 if config.exists(base + ['gateway-address']):
@@ -97,7 +94,7 @@ if config.exists(namedpools_base):
         pool_path = namedpools_base + [pool_name]
         if config.exists(pool_path + ['subnet']):
             subnet = config.return_value(pool_path + ['subnet'])
-            config.set(pool_base + [pool_name, 'range'], value=subnet)
+            config.set(pool_base + [pool_name, 'range'], value=subnet, replace=False)
         if config.exists(pool_path + ['next-pool']):
             next_pool = config.return_value(pool_path + ['next-pool'])
             config.set(pool_base + [pool_name, 'next-pool'], value=next_pool)

--- a/src/migration-scripts/pptp/2-to-3
+++ b/src/migration-scripts/pptp/2-to-3
@@ -23,7 +23,7 @@ import os
 from sys import argv
 from sys import exit
 from vyos.configtree import ConfigTree
-
+from vyos.base import Warning
 
 if len(argv) < 2:
     print("Must specify file name!")
@@ -46,13 +46,24 @@ if not config.exists(pool_base):
 range_pool_name = 'default-range-pool'
 
 if config.exists(pool_base + ['start']) and config.exists(pool_base + ['stop']):
+    def is_legalrange(ip1: str, ip2: str, mask: str):
+        from ipaddress import IPv4Interface
+        interface1 = IPv4Interface(f'{ip1}/{mask}')
+        interface2 = IPv4Interface(f'{ip2}/{mask}')
+        return interface1.network.network_address == interface2.network.network_address and interface2.ip > interface1.ip
+
     start_ip = config.return_value(pool_base + ['start'])
     stop_ip = config.return_value(pool_base + ['stop'])
-    ip_range = f'{start_ip}-{stop_ip}'
+    if is_legalrange(start_ip, stop_ip, '24'):
+        ip_range = f'{start_ip}-{stop_ip}'
+        config.set(pool_base + [range_pool_name, 'range'], value=ip_range, replace=False)
+        config.set(base + ['default-pool'], value=range_pool_name)
+    else:
+        Warning(
+            f'PPTP client-ip-pool range start-ip:{start_ip} and stop-ip:{stop_ip} can not be migrated.')
+
     config.delete(pool_base + ['start'])
     config.delete(pool_base + ['stop'])
-    config.set(pool_base + [range_pool_name, 'range'], value=ip_range)
-    config.set(base + ['default-pool'], value=range_pool_name)
 # format as tag node
 config.set_tag(pool_base)
 

--- a/src/migration-scripts/sstp/4-to-5
+++ b/src/migration-scripts/sstp/4-to-5
@@ -43,21 +43,12 @@ if not config.exists(base):
 if not config.exists(pool_base):
     exit(0)
 
-subnet_base_name = 'default-subnet-pool'
-number = 1
-subnet_pool_name = f'{subnet_base_name}-{number}'
-prev_subnet_pool = subnet_pool_name
-if config.exists(pool_base + ['subnet']):
-    default_pool = subnet_pool_name
-    for subnet in config.return_values(pool_base + ['subnet']):
-        config.set(pool_base + [subnet_pool_name, 'range'], value=subnet)
-        if prev_subnet_pool != subnet_pool_name:
-            config.set(pool_base + [prev_subnet_pool, 'next-pool'],
-                       value=subnet_pool_name)
-            prev_subnet_pool = subnet_pool_name
-        number += 1
-        subnet_pool_name = f'{subnet_base_name}-{number}'
+range_pool_name = 'default-range-pool'
 
+if config.exists(pool_base + ['subnet']):
+    default_pool = range_pool_name
+    for subnet in config.return_values(pool_base + ['subnet']):
+        config.set(pool_base + [range_pool_name, 'range'], value=subnet, replace=False)
     config.delete(pool_base + ['subnet'])
     config.set(base + ['default-pool'], value=default_pool)
 # format as tag node

--- a/src/validators/ipv4-range-mask
+++ b/src/validators/ipv4-range-mask
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-# snippet from https://stackoverflow.com/questions/10768160/ip-address-converter
-ip2dec () {
-    local a b c d ip=$@
-    IFS=. read -r a b c d <<< "$ip"
-    printf '%d\n' "$((a * 256 ** 3 + b * 256 ** 2 + c * 256 + d))"
-}
-
 error_exit() {
   echo "Error: $1 is not a valid IPv4 address range or these IPs are not under /$2"
   exit 1
@@ -22,37 +15,12 @@ do
         r) range=${OPTARG}
     esac
 done
+
 if [[ "${range}" =~ "-" ]]&&[[ ! -z ${mask} ]]; then
-  # This only works with real bash (<<<) - split IP addresses into array with
-  # hyphen as delimiter
-  readarray -d - -t strarr <<< ${range}
-
-  ipaddrcheck --is-ipv4-single ${strarr[0]}
+  ipaddrcheck --range-prefix-length ${mask} --is-ipv4-range ${range}
   if [ $? -gt 0 ]; then
     error_exit ${range} ${mask}
   fi
-
-  ipaddrcheck --is-ipv4-single ${strarr[1]}
-  if [ $? -gt 0 ]; then
-    error_exit ${range} ${mask}
-  fi
-
-  ${vyos_validators_dir}/numeric --range 0-32 ${mask} > /dev/null
-   if [ $? -ne 0 ]; then
-     error_exit ${range} ${mask}
-   fi
-
-  is_in_24=$( grepcidr ${strarr[0]}"/"${mask} <(echo ${strarr[1]}) )
-  if [ -z $is_in_24 ]; then
-    error_exit ${range} ${mask}
-  fi
-
-  start=$(ip2dec ${strarr[0]})
-  stop=$(ip2dec ${strarr[1]})
-  if [ $start -ge $stop ]; then
-    error_exit ${range} ${mask}
-  fi
-
   exit 0
 fi
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Changed node 'range' to multi in 'client-ip-pool' for accell-ppp services.
Added completionHelp to default-pool and next-pool. 
Fixed verification in vpn l2tp config script.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5688

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipoe, l2tp, sstp, pptp, pppoe

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Several ranges under one pool
```
         client-ip-pool TEST {
             next-pool TEST2
             range 10.0.0.5/25
             range 10.0.1.1-10.0.1.10
         }

```
completionHelper
```
vyos@vyos# set service pppoe-server default-pool
Possible completions:
   <text>               Default IP pool
   TEST
   TEST2
   default-range-pool

```
```
vyos@vyos# set service pppoe-server client-ip-pool TEST next-pool
Possible completions:
   <text>               Name of IP pool
   TEST
   TEST2
   default-range-pool
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_ipoe-server.py
test_accel_ipv4_pool (__main__.TestServiceIPoEServer.test_accel_ipv4_pool) ... ok
test_accel_local_authentication (__main__.TestServiceIPoEServer.test_accel_local_authentication) ...
No IPoE interface configured

ok
test_accel_name_servers (__main__.TestServiceIPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServiceIPoEServer.test_accel_next_pool) ... ok
test_accel_radius_authentication (__main__.TestServiceIPoEServer.test_accel_radius_authentication) ... ok

----------------------------------------------------------------------
Ran 5 tests in 17.318s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py
test_accel_ipv4_pool (__main__.TestServicePPPoEServer.test_accel_ipv4_pool) ... ok
test_accel_local_authentication (__main__.TestServicePPPoEServer.test_accel_local_authentication) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_name_servers (__main__.TestServicePPPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServicePPPoEServer.test_accel_next_pool) ... ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer.test_accel_radius_authentication) ... ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer.test_pppoe_server_authentication_protocols) ... ok
test_pppoe_server_client_ipv6_pool (__main__.TestServicePPPoEServer.test_pppoe_server_client_ipv6_pool) ... ok
test_pppoe_server_ppp_options (__main__.TestServicePPPoEServer.test_pppoe_server_ppp_options) ... ok
test_pppoe_server_shaper (__main__.TestServicePPPoEServer.test_pppoe_server_shaper) ... ok
test_pppoe_server_vlan (__main__.TestServicePPPoEServer.test_pppoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 10 tests in 36.345s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_l2tp.py
test_accel_ipv4_pool (__main__.TestVPNL2TPServer.test_accel_ipv4_pool) ... ok
test_accel_local_authentication (__main__.TestVPNL2TPServer.test_accel_local_authentication) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_name_servers (__main__.TestVPNL2TPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNL2TPServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_radius_authentication (__main__.TestVPNL2TPServer.test_accel_radius_authentication) ... ok
test_l2tp_server_authentication_protocols (__main__.TestVPNL2TPServer.test_l2tp_server_authentication_protocols) ... ok
test_l2tp_server_client_ipv6_pool (__main__.TestVPNL2TPServer.test_l2tp_server_client_ipv6_pool) ... ok
test_l2tp_server_ppp_options (__main__.TestVPNL2TPServer.test_l2tp_server_ppp_options) ... ok

----------------------------------------------------------------------
Ran 8 tests in 30.281s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_pptp.py
test_accel_ipv4_pool (__main__.TestVPNPPTPServer.test_accel_ipv4_pool) ... ok
test_accel_local_authentication (__main__.TestVPNPPTPServer.test_accel_local_authentication) ... ok
test_accel_name_servers (__main__.TestVPNPPTPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNPPTPServer.test_accel_next_pool) ... ok
test_accel_radius_authentication (__main__.TestVPNPPTPServer.test_accel_radius_authentication) ... ok

----------------------------------------------------------------------
Ran 5 tests in 20.133s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_sstp.py
test_accel_ipv4_pool (__main__.TestVPNSSTPServer.test_accel_ipv4_pool) ... ok
test_accel_local_authentication (__main__.TestVPNSSTPServer.test_accel_local_authentication) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_name_servers (__main__.TestVPNSSTPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNSSTPServer.test_accel_next_pool) ... ok
test_accel_radius_authentication (__main__.TestVPNSSTPServer.test_accel_radius_authentication) ... ok

----------------------------------------------------------------------
Ran 5 tests in 22.056s

OK

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
