### PR TITLE
T5916: Added segment routing check for index size and SRGB size

### DIFF
--- a/src/conf_mode/protocols_ospf.py
+++ b/src/conf_mode/protocols_ospf.py
@@ -213,6 +213,19 @@ def verify(ospf):
                     raise ConfigError(f'Segment routing prefix {prefix} cannot have both explicit-null '\
                                       f'and no-php-flag configured at the same time.')
 
+    # Check for index ranges being larger than the segment routing global block    
+    if dict_search('segment_routing.global_block', ospf):
+        g_high_label_value = dict_search('segment_routing.global_block.high_label_value', ospf)
+        g_low_label_value = dict_search('segment_routing.global_block.low_label_value', ospf)
+        g_label_difference = int(g_high_label_value) - int(g_low_label_value)
+        if dict_search('segment_routing.prefix', ospf):
+            for prefix, prefix_config in ospf['segment_routing']['prefix'].items():
+                if 'index' in prefix_config:
+                    index_size = ospf['segment_routing']['prefix'][prefix]['index']['value']
+                    if int(index_size) > int(g_label_difference):
+                        raise ConfigError(f'Segment routing prefix {prefix} cannot have an '\
+                                          f'index base size larger than the SRGB label base.')
+
     # Check route summarisation
     if 'summary_address' in ospf:
         for prefix, prefix_options in ospf['summary_address'].items():


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

We are adding a check to make sure that the segment routing global base and
the index base do not have a size mismatch. Originally one could configure a
larger index size than segment routing global base size. This is a small check to
prevent that type of configuration in the future.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5916

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
No

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
isis, ospf

## Proposed changes
<!--- Describe your changes in detail -->

What we are basically adding here is a check to first gather the segment routing 
global block and to basically calculate how large it is in size. This is done by checking
the maximum and minimum values and doing just a simple subtraction. Then we do
a check for each prefix that is configured inside of segment routing in IS-IS and OSPF
to make sure that if an index is configured that the size is smaller than the segment
routing global base size. 

## How to test
Baseline configs are:
```
set protocols isis interface lo
set protocols isis net '49.0001.1921.6825.5000.00'
set protocols isis segment-routing global-block high-label-value '600'
set protocols isis segment-routing global-block low-label-value '500'
set protocols isis segment-routing prefix 192.168.255.0/32 index value '50'
set protocols ospf interface lo area '0'
set protocols ospf segment-routing global-block high-label-value '600'
set protocols ospf segment-routing global-block low-label-value '500'
set protocols ospf segment-routing prefix 192.168.255.0/32 index value '50'
```

If one reduces the size of the IS-IS SRGB or OSPF SRGB to below the size of
the index size, we get the following error for both protocols:

```
vyos@vyos:~$ configure
[edit]
vyos@vyos# set protocols isis segment-routing global-block high-label-value '525'
[edit]
vyos@vyos# set protocols ospf segment-routing global-block high-label-value '525'
[edit]
vyos@vyos# commit

Segment routing prefix 192.168.255.0/32 cannot have an index base size
larger than the SRGB label base.

[[protocols isis]] failed

Segment routing prefix 192.168.255.0/32 cannot have an index base size
larger than the SRGB label base.

[[protocols ospf]] failed
Commit failed
```

Individually they work too:

```
vyos@vyos# set protocols isis segment-routing global-block high-label-value '545'
[edit]
vyos@vyos# commit

Segment routing prefix 192.168.255.0/32 cannot have an index base size
larger than the SRGB label base.

[[protocols isis]] failed
Commit failed
[edit]
vyos@vyos# discard

  Changes have been discarded

[edit]
vyos@vyos# set protocols ospf segment-routing global-block high-label-value '510'
[edit]
vyos@vyos# commit

Segment routing prefix 192.168.255.0/32 cannot have an index base size
larger than the SRGB label base.

[[protocols ospf]] failed
Commit failed
[edit]
vyos@vyos# discard

  Changes have been discarded

[edit]
vyos@vyos# exit
```

## Smoketest result

I didn't include a smoketest because the smoketest is not needed in this case.
The smoketest we do already configures the values correctly. 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
