### PR TITLE
dhcp: T3316: T5787: T5912: Extend scope of DHCP options, bugfixes

### DIFF
--- a/data/templates/dhcp-server/kea-dhcp4.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp4.conf.j2
@@ -1,8 +1,16 @@
 {
     "Dhcp4": {
         "interfaces-config": {
+{% if listen_address is vyos_defined %}
+            "interfaces": {{ listen_address | kea_address_json }},
+            "dhcp-socket-type": "udp",
+{% elif listen_interface is vyos_defined %}
+            "interfaces": {{ listen_interface | tojson }},
+            "dhcp-socket-type": "raw",
+{% else %}
             "interfaces": [ "*" ],
             "dhcp-socket-type": "raw",
+{% endif %}
             "service-sockets-max-retries": 5,
             "service-sockets-retry-wait-time": 5000
         },

--- a/interface-definitions/include/dhcp/option-v4.xml.i
+++ b/interface-definitions/include/dhcp/option-v4.xml.i
@@ -1,0 +1,257 @@
+<!-- include start from dhcp/option-v4.xml.i -->
+<node name="option">
+  <properties>
+    <help>DHCP option</help>
+  </properties>
+  <children>
+    #include <include/dhcp/captive-portal.xml.i>
+    #include <include/dhcp/domain-name.xml.i>
+    #include <include/dhcp/domain-search.xml.i>
+    #include <include/dhcp/ntp-server.xml.i>
+    #include <include/name-server-ipv4.xml.i>
+    <leafNode name="bootfile-name">
+      <properties>
+        <help>Bootstrap file name</help>
+        <constraint>
+          <regex>[[:ascii:]]{1,253}</regex>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="bootfile-server">
+      <properties>
+        <help>Server from which the initial boot file is to be loaded</help>
+        <valueHelp>
+          <format>ipv4</format>
+          <description>Bootfile server IPv4 address</description>
+        </valueHelp>
+        <valueHelp>
+          <format>hostname</format>
+          <description>Bootfile server FQDN</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv4-address"/>
+          <validator name="fqdn"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="bootfile-size">
+      <properties>
+        <help>Bootstrap file size</help>
+        <valueHelp>
+          <format>u32:1-16</format>
+          <description>Bootstrap file size in 512 byte blocks</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-16"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="client-prefix-length">
+      <properties>
+        <help>Specifies the clients subnet mask as per RFC 950. If unset, subnet declaration is used.</help>
+        <valueHelp>
+          <format>u32:0-32</format>
+          <description>DHCP client prefix length must be 0 to 32</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 0-32"/>
+        </constraint>
+        <constraintErrorMessage>DHCP client prefix length must be 0 to 32</constraintErrorMessage>
+      </properties>
+    </leafNode>
+    <leafNode name="default-router">
+      <properties>
+        <help>IP address of default router</help>
+        <valueHelp>
+          <format>ipv4</format>
+          <description>Default router IPv4 address</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv4-address"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="ip-forwarding">
+      <properties>
+        <help>Enable IP forwarding on client</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+    <leafNode name="ipv6-only-preferred">
+      <properties>
+        <help>Disable IPv4 on IPv6 only hosts (RFC 8925)</help>
+        <valueHelp>
+          <format>u32</format>
+          <description>Seconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 0-4294967295"/>
+        </constraint>
+        <constraintErrorMessage>Seconds must be between 0 and 4294967295 (49 days)</constraintErrorMessage>
+      </properties>
+    </leafNode>
+    <leafNode name="pop-server">
+      <properties>
+        <help>IP address of POP3 server</help>
+        <valueHelp>
+          <format>ipv4</format>
+          <description>POP3 server IPv4 address</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv4-address"/>
+        </constraint>
+        <multi/>
+      </properties>
+    </leafNode>
+    <leafNode name="server-identifier">
+      <properties>
+        <help>Address for DHCP server identifier</help>
+        <valueHelp>
+          <format>ipv4</format>
+          <description>DHCP server identifier IPv4 address</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv4-address"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="smtp-server">
+      <properties>
+        <help>IP address of SMTP server</help>
+        <valueHelp>
+          <format>ipv4</format>
+          <description>SMTP server IPv4 address</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv4-address"/>
+        </constraint>
+        <multi/>
+      </properties>
+    </leafNode>
+    <tagNode name="static-route">
+      <properties>
+        <help>Classless static route destination subnet</help>
+        <valueHelp>
+          <format>ipv4net</format>
+          <description>IPv4 address and prefix length</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv4-prefix"/>
+        </constraint>
+      </properties>
+      <children>
+        <leafNode name="next-hop">
+          <properties>
+            <help>IP address of router to be used to reach the destination subnet</help>
+            <valueHelp>
+              <format>ipv4</format>
+              <description>IPv4 address of router</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ip-address"/>
+            </constraint>
+          </properties>
+        </leafNode>
+      </children>
+    </tagNode >
+    <leafNode name="tftp-server-name">
+      <properties>
+        <help>TFTP server name</help>
+        <valueHelp>
+          <format>ipv4</format>
+          <description>TFTP server IPv4 address</description>
+        </valueHelp>
+        <valueHelp>
+          <format>hostname</format>
+          <description>TFTP server FQDN</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv4-address"/>
+          <validator name="fqdn"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="time-offset">
+      <properties>
+        <help>Client subnet offset in seconds from Coordinated Universal Time (UTC)</help>
+        <valueHelp>
+          <format>[-]N</format>
+          <description>Time offset (number, may be negative)</description>
+        </valueHelp>
+        <constraint>
+          <regex>-?[0-9]+</regex>
+        </constraint>
+        <constraintErrorMessage>Invalid time offset value</constraintErrorMessage>
+      </properties>
+    </leafNode>
+    <leafNode name="time-server">
+      <properties>
+        <help>IP address of time server</help>
+        <valueHelp>
+          <format>ipv4</format>
+          <description>Time server IPv4 address</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv4-address"/>
+        </constraint>
+        <multi/>
+      </properties>
+    </leafNode>
+    <leafNode name="time-zone">
+      <properties>
+        <help>Time zone to send to clients. Uses RFC4833 options 100 and 101</help>
+        <completionHelp>
+          <script>timedatectl list-timezones</script>
+        </completionHelp>
+        <constraint>
+          <validator name="timezone" argument="--validate"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <node name="vendor-option">
+      <properties>
+        <help>Vendor Specific Options</help>
+      </properties>
+      <children>
+        <node name="ubiquiti">
+          <properties>
+            <help>Ubiquiti specific parameters</help>
+          </properties>
+          <children>
+            <leafNode name="unifi-controller">
+              <properties>
+                <help>Address of UniFi controller</help>
+                <valueHelp>
+                  <format>ipv4</format>
+                  <description>IP address of UniFi controller</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="ipv4-address"/>
+                </constraint>
+              </properties>
+            </leafNode>
+          </children>
+        </node>
+      </children>
+    </node>
+    <leafNode name="wins-server">
+      <properties>
+        <help>IP address for Windows Internet Name Service (WINS) server</help>
+        <valueHelp>
+          <format>ipv4</format>
+          <description>WINS server IPv4 address</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv4-address"/>
+        </constraint>
+        <multi/>
+      </properties>
+    </leafNode>
+    <leafNode name="wpad-url">
+      <properties>
+        <help>Web Proxy Autodiscovery (WPAD) URL</help>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/listen-interface-multi-broadcast.xml.i
+++ b/interface-definitions/include/listen-interface-multi-broadcast.xml.i
@@ -1,0 +1,18 @@
+<!-- include start from listen-interface-multi-broadcast.xml.i -->
+<leafNode name="listen-interface">
+  <properties>
+    <help>Interface for DHCP Relay Agent to listen for requests</help>
+    <completionHelp>
+      <script>${vyos_completion_dir}/list_interfaces --broadcast</script>
+    </completionHelp>
+    <valueHelp>
+      <format>txt</format>
+      <description>Interface name</description>
+    </valueHelp>
+    <constraint>
+      #include <include/constraint/interface-name.xml.i>
+    </constraint>
+    <multi/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/version/dhcp-server-version.xml.i
+++ b/interface-definitions/include/version/dhcp-server-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/dhcp-server-version.xml.i -->
-<syntaxVersion component='dhcp-server' version='8'></syntaxVersion>
+<syntaxVersion component='dhcp-server' version='9'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/service_dhcp-server.xml.in
+++ b/interface-definitions/service_dhcp-server.xml.in
@@ -89,12 +89,9 @@
                   <valueless/>
                 </properties>
               </leafNode>
-              #include <include/dhcp/domain-name.xml.i>
-              #include <include/dhcp/domain-search.xml.i>
-              #include <include/dhcp/ntp-server.xml.i>
+              #include <include/dhcp/option-v4.xml.i>
               #include <include/generic-description.xml.i>
               #include <include/generic-disable-node.xml.i>
-              #include <include/name-server-ipv4.xml.i>
               <tagNode name="subnet">
                 <properties>
                   <help>DHCP subnet for shared network</help>
@@ -108,73 +105,9 @@
                   <constraintErrorMessage>Invalid IPv4 subnet definition</constraintErrorMessage>
                 </properties>
                 <children>
-                  <leafNode name="bootfile-name">
-                    <properties>
-                      <help>Bootstrap file name</help>
-                      <constraint>
-                        <regex>[[:ascii:]]{1,253}</regex>
-                      </constraint>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="bootfile-server">
-                    <properties>
-                      <help>Server from which the initial boot file is to be loaded</help>
-                      <valueHelp>
-                        <format>ipv4</format>
-                        <description>Bootfile server IPv4 address</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>hostname</format>
-                        <description>Bootfile server FQDN</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="ipv4-address"/>
-                        <validator name="fqdn"/>
-                      </constraint>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="bootfile-size">
-                    <properties>
-                      <help>Bootstrap file size</help>
-                      <valueHelp>
-                        <format>u32:1-16</format>
-                        <description>Bootstrap file size in 512 byte blocks</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 1-16"/>
-                      </constraint>
-                    </properties>
-                  </leafNode>
-                  #include <include/dhcp/captive-portal.xml.i>
-                  <leafNode name="client-prefix-length">
-                    <properties>
-                      <help>Specifies the clients subnet mask as per RFC 950. If unset, subnet declaration is used.</help>
-                      <valueHelp>
-                        <format>u32:0-32</format>
-                        <description>DHCP client prefix length must be 0 to 32</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 0-32"/>
-                      </constraint>
-                      <constraintErrorMessage>DHCP client prefix length must be 0 to 32</constraintErrorMessage>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="default-router">
-                    <properties>
-                      <help>IP address of default router</help>
-                      <valueHelp>
-                        <format>ipv4</format>
-                        <description>Default router IPv4 address</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="ipv4-address"/>
-                      </constraint>
-                    </properties>
-                  </leafNode>
-                  #include <include/dhcp/domain-name.xml.i>
-                  #include <include/dhcp/domain-search.xml.i>
+                  #include <include/dhcp/option-v4.xml.i>
                   #include <include/generic-description.xml.i>
-                  #include <include/name-server-ipv4.xml.i>
+                  #include <include/generic-disable-node.xml.i>
                   <leafNode name="exclude">
                     <properties>
                       <help>IP address to exclude from DHCP lease range</help>
@@ -186,12 +119,6 @@
                         <validator name="ipv4-address"/>
                       </constraint>
                       <multi/>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="ip-forwarding">
-                    <properties>
-                      <help>Enable IP forwarding on client</help>
-                      <valueless/>
                     </properties>
                   </leafNode>
                   <leafNode name="lease">
@@ -208,45 +135,6 @@
                     </properties>
                     <defaultValue>86400</defaultValue>
                   </leafNode>
-                  #include <include/dhcp/ntp-server.xml.i>
-                  <leafNode name="pop-server">
-                    <properties>
-                      <help>IP address of POP3 server</help>
-                      <valueHelp>
-                        <format>ipv4</format>
-                        <description>POP3 server IPv4 address</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="ipv4-address"/>
-                      </constraint>
-                      <multi/>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="server-identifier">
-                    <properties>
-                      <help>Address for DHCP server identifier</help>
-                      <valueHelp>
-                        <format>ipv4</format>
-                        <description>DHCP server identifier IPv4 address</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="ipv4-address"/>
-                      </constraint>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="smtp-server">
-                    <properties>
-                      <help>IP address of SMTP server</help>
-                      <valueHelp>
-                        <format>ipv4</format>
-                        <description>SMTP server IPv4 address</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="ipv4-address"/>
-                      </constraint>
-                      <multi/>
-                    </properties>
-                  </leafNode>
                   <tagNode name="range">
                     <properties>
                       <help>DHCP lease range</help>
@@ -256,6 +144,7 @@
                       <constraintErrorMessage>Invalid range name, may only be alphanumeric, dot and hyphen</constraintErrorMessage>
                     </properties>
                     <children>
+                      #include <include/dhcp/option-v4.xml.i>
                       <leafNode name="start">
                         <properties>
                           <help>First IP address for DHCP lease range</help>
@@ -291,6 +180,8 @@
                       <constraintErrorMessage>Invalid static mapping hostname</constraintErrorMessage>
                     </properties>
                     <children>
+                      #include <include/dhcp/option-v4.xml.i>
+                      #include <include/generic-description.xml.i>
                       #include <include/generic-disable-node.xml.i>
                       <leafNode name="ip-address">
                         <properties>
@@ -308,143 +199,6 @@
                       #include <include/interface/duid.xml.i>
                     </children>
                   </tagNode>
-                  <tagNode name="static-route">
-                    <properties>
-                      <help>Classless static route destination subnet</help>
-                      <valueHelp>
-                        <format>ipv4net</format>
-                        <description>IPv4 address and prefix length</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="ipv4-prefix"/>
-                      </constraint>
-                    </properties>
-                    <children>
-                      <leafNode name="next-hop">
-                        <properties>
-                          <help>IP address of router to be used to reach the destination subnet</help>
-                          <valueHelp>
-                            <format>ipv4</format>
-                            <description>IPv4 address of router</description>
-                          </valueHelp>
-                          <constraint>
-                            <validator name="ip-address"/>
-                          </constraint>
-                        </properties>
-                      </leafNode>
-                    </children>
-                  </tagNode >
-                  <leafNode name="ipv6-only-preferred">
-                    <properties>
-                      <help>Disable IPv4 on IPv6 only hosts (RFC 8925)</help>
-                      <valueHelp>
-                        <format>u32</format>
-                        <description>Seconds</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 0-4294967295"/>
-                      </constraint>
-                      <constraintErrorMessage>Seconds must be between 0 and 4294967295 (49 days)</constraintErrorMessage>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="tftp-server-name">
-                    <properties>
-                      <help>TFTP server name</help>
-                      <valueHelp>
-                        <format>ipv4</format>
-                        <description>TFTP server IPv4 address</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>hostname</format>
-                        <description>TFTP server FQDN</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="ipv4-address"/>
-                        <validator name="fqdn"/>
-                      </constraint>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="time-offset">
-                    <properties>
-                      <help>Client subnet offset in seconds from Coordinated Universal Time (UTC)</help>
-                      <valueHelp>
-                        <format>[-]N</format>
-                        <description>Time offset (number, may be negative)</description>
-                      </valueHelp>
-                      <constraint>
-                        <regex>-?[0-9]+</regex>
-                      </constraint>
-                      <constraintErrorMessage>Invalid time offset value</constraintErrorMessage>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="time-server">
-                    <properties>
-                      <help>IP address of time server</help>
-                      <valueHelp>
-                        <format>ipv4</format>
-                        <description>Time server IPv4 address</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="ipv4-address"/>
-                      </constraint>
-                      <multi/>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="time-zone">
-                    <properties>
-                      <help>Time zone to send to clients. Uses RFC4833 options 100 and 101</help>
-                      <completionHelp>
-                        <script>timedatectl list-timezones</script>
-                      </completionHelp>
-                      <constraint>
-                        <validator name="timezone" argument="--validate"/>
-                      </constraint>
-                    </properties>
-                  </leafNode>
-                  <node name="vendor-option">
-                    <properties>
-                      <help>Vendor Specific Options</help>
-                    </properties>
-                    <children>
-                      <node name="ubiquiti">
-                        <properties>
-                          <help>Ubiquiti specific parameters</help>
-                        </properties>
-                        <children>
-                          <leafNode name="unifi-controller">
-                            <properties>
-                              <help>Address of UniFi controller</help>
-                              <valueHelp>
-                                <format>ipv4</format>
-                                <description>IP address of UniFi controller</description>
-                              </valueHelp>
-                              <constraint>
-                                <validator name="ipv4-address"/>
-                              </constraint>
-                            </properties>
-                          </leafNode>
-                        </children>
-                      </node>
-                    </children>
-                  </node>
-                  <leafNode name="wins-server">
-                    <properties>
-                      <help>IP address for Windows Internet Name Service (WINS) server</help>
-                      <valueHelp>
-                        <format>ipv4</format>
-                        <description>WINS server IPv4 address</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="ipv4-address"/>
-                      </constraint>
-                      <multi/>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="wpad-url">
-                    <properties>
-                      <help>Web Proxy Autodiscovery (WPAD) URL</help>
-                    </properties>
-                  </leafNode>
                 </children>
               </tagNode>
             </children>

--- a/interface-definitions/service_dhcp-server.xml.in
+++ b/interface-definitions/service_dhcp-server.xml.in
@@ -74,6 +74,7 @@
             </properties>
           </leafNode>
           #include <include/listen-address-ipv4.xml.i>
+          #include <include/listen-interface-multi-broadcast.xml.i>
           <tagNode name="shared-network-name">
             <properties>
               <help>Name of DHCP shared network</help>

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -25,7 +25,7 @@ from vyos.template import netmask_from_cidr
 from vyos.utils.dict import dict_search_args
 from vyos.utils.file import file_permissions
 from vyos.utils.file import read_file
-from vyos.utils.process import cmd
+from vyos.utils.process import run
 
 kea4_options = {
     'name_server': 'domain-name-servers',
@@ -315,7 +315,7 @@ def _ctrl_socket_command(path, command, args=None):
         return None
 
     if file_permissions(path) != '0775':
-        cmd(f'sudo chmod 775 {path}')
+        run(f'sudo chmod 775 {path}')
 
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
         sock.connect(path)

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -92,17 +92,28 @@ def kea_parse_options(config):
         options.append({'name': 'pcode', 'data': tz_string})
         options.append({'name': 'tcode', 'data': config['time_zone']})
 
+    unifi_controller = dict_search_args(config, 'vendor_option', 'ubiquiti', 'unifi_controller')
+    if unifi_controller:
+        options.append({
+            'name': 'unifi-controller',
+            'data': unifi_controller,
+            'space': 'ubnt'
+        })
+
     return options
 
 def kea_parse_subnet(subnet, config):
     out = {'subnet': subnet}
-    options = kea_parse_options(config)
+    options = []
 
-    if 'bootfile_name' in config:
-        out['boot-file-name'] = config['bootfile_name']
+    if 'option' in config:
+        out['option-data'] = kea_parse_options(config['option'])
 
-    if 'bootfile_server' in config:
-        out['next-server'] = config['bootfile_server']
+        if 'bootfile_name' in config['option']:
+            out['boot-file-name'] = config['option']['bootfile_name']
+
+        if 'bootfile_server' in config['option']:
+            out['next-server'] = config['option']['bootfile_server']
 
     if 'lease' in config:
         out['valid-lifetime'] = int(config['lease'])
@@ -112,7 +123,20 @@ def kea_parse_subnet(subnet, config):
         pools = []
         for num, range_config in config['range'].items():
             start, stop = range_config['start'], range_config['stop']
-            pools.append({'pool': f'{start} - {stop}'})
+            pool = {
+                'pool': f'{start} - {stop}'
+            }
+
+            if 'option' in range_config:
+                pool['option-data'] = kea_parse_options(range_config['option'])
+
+                if 'bootfile_name' in range_config['option']:
+                    pool['boot-file-name'] = range_config['option']['bootfile_name']
+
+                if 'bootfile_server' in range_config['option']:
+                    pool['next-server'] = range_config['option']['bootfile_server']
+
+            pools.append(pool)
         out['pools'] = pools
 
     if 'static_mapping' in config:
@@ -134,19 +158,17 @@ def kea_parse_subnet(subnet, config):
             if 'ip_address' in host_config:
                 reservation['ip-address'] = host_config['ip_address']
 
+            if 'option' in host_config:
+                reservation['option-data'] = kea_parse_options(host_config['option'])
+
+                if 'bootfile_name' in host_config['option']:
+                    reservation['boot-file-name'] = host_config['option']['bootfile_name']
+
+                if 'bootfile_server' in host_config['option']:
+                    reservation['next-server'] = host_config['option']['bootfile_server']
+
             reservations.append(reservation)
         out['reservations'] = reservations
-
-    unifi_controller = dict_search_args(config, 'vendor_option', 'ubiquiti', 'unifi_controller')
-    if unifi_controller:
-        options.append({
-            'name': 'unifi-controller',
-            'data': unifi_controller,
-            'space': 'ubnt'
-        })
-
-    if options:
-        out['option-data'] = options
 
     return out
 

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -842,14 +842,21 @@ def kea_shared_network_json(shared_networks):
             'authoritative': ('authoritative' in config),
             'subnet4': []
         }
-        options = kea_parse_options(config)
+
+        if 'option' in config:
+            network['option-data'] = kea_parse_options(config['option'])
+
+            if 'bootfile_name' in config['option']:
+                network['boot-file-name'] = config['option']['bootfile_name']
+
+            if 'bootfile_server' in config['option']:
+                network['next-server'] = config['option']['bootfile_server']
 
         if 'subnet' in config:
             for subnet, subnet_config in config['subnet'].items():
+                if 'disable' in subnet_config:
+                    continue
                 network['subnet4'].append(kea_parse_subnet(subnet, subnet_config))
-
-        if options:
-            network['option-data'] = options
 
         out.append(network)
 

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -786,6 +786,23 @@ def range_to_regex(num_range):
     regex = range_to_regex(num_range)
     return f'({regex})'
 
+@register_filter('kea_address_json')
+def kea_address_json(addresses):
+    from json import dumps
+    from vyos.utils.network import is_addr_assigned
+
+    out = []
+
+    for address in addresses:
+        ifname = is_addr_assigned(address, return_ifname=True)
+
+        if not ifname:
+            continue
+
+        out.append(f'{ifname}/{address}')
+
+    return dumps(out)
+
 @register_filter('kea_failover_json')
 def kea_failover_json(config):
     from json import dumps

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -308,7 +308,7 @@ def is_ipv6_link_local(addr):
 
     return False
 
-def is_addr_assigned(ip_address, vrf=None) -> bool:
+def is_addr_assigned(ip_address, vrf=None, return_ifname=False) -> bool | str:
     """ Verify if the given IPv4/IPv6 address is assigned to any interface """
     from netifaces import interfaces
     from vyos.utils.network import get_interface_config
@@ -323,7 +323,7 @@ def is_addr_assigned(ip_address, vrf=None) -> bool:
             continue
 
         if is_intf_addr_assigned(interface, ip_address):
-            return True
+            return interface if return_ifname else True
 
     return False
 

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -375,6 +375,13 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
             self.cli_commit()
         self.cli_delete(pool + ['static-mapping', 'client1', 'duid'])
 
+        # cannot have mappings with duplicate IP addresses
+        with self.assertRaises(ConfigSessionError):
+            self.cli_set(pool + ['static-mapping', 'dupe1', 'mac', '00:50:00:00:00:01'])
+            self.cli_set(pool + ['static-mapping', 'dupe1', 'ip-address', inc_ip(subnet, 10)])
+            self.cli_commit()
+        self.cli_delete(pool + ['static-mapping', 'dupe1'])
+
         # commit changes
         self.cli_commit()
 

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -223,6 +223,7 @@ def verify(dhcp):
 
             if 'static_mapping' in subnet_config:
                 # Static mappings require just a MAC address (will use an IP from the dynamic pool if IP is not set)
+                used_ips = []
                 for mapping, mapping_config in subnet_config['static_mapping'].items():
                     if 'ip_address' in mapping_config:
                         if ip_address(mapping_config['ip_address']) not in ip_network(subnet):
@@ -233,6 +234,11 @@ def verify(dhcp):
                             ('mac' in mapping_config and 'duid' in mapping_config):
                             raise ConfigError(f'Either MAC address or Client identifier (DUID) is required for '
                                               f'static mapping "{mapping}" within shared-network "{network}, {subnet}"!')
+
+                        if mapping_config['ip_address'] in used_ips:
+                            raise ConfigError(f'Configured IP address for static mapping "{mapping}" exists on another static mapping')
+
+                        used_ips.append(mapping_config['ip_address'])
 
             # There must be one subnet connected to a listen interface.
             # This only counts if the network itself is not disabled!

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -31,6 +31,7 @@ from vyos.utils.file import chmod_775
 from vyos.utils.file import makedir
 from vyos.utils.file import write_file
 from vyos.utils.process import call
+from vyos.utils.network import interface_exists
 from vyos.utils.network import is_subnet_connected
 from vyos.utils.network import is_addr_assigned
 from vyos import ConfigError
@@ -294,11 +295,17 @@ def verify(dhcp):
         else:
             raise ConfigError(f'listen-address "{address}" not configured on any interface')
 
-
     if not listen_ok:
         raise ConfigError('None of the configured subnets have an appropriate primary IP address on any\n'
                           'broadcast interface configured, nor was there an explicit listen-address\n'
                           'configured for serving DHCP relay packets!')
+
+    if 'listen_address' in dhcp and 'listen_interface' in dhcp:
+        raise ConfigError(f'Cannot define listen-address and listen-interface at the same time')
+
+    for interface in (dict_search('listen_interface', dhcp) or []):
+        if not interface_exists(interface):
+            raise ConfigError(f'listen-interface "{interface}" does not exist')
 
     return None
 

--- a/src/migration-scripts/dhcp-server/8-to-9
+++ b/src/migration-scripts/dhcp-server/8-to-9
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T3316:
+# - Migrate dhcp options under new option node
+
+import sys
+import re
+from vyos.configtree import ConfigTree
+
+if len(sys.argv) < 2:
+    print("Must specify file name!")
+    sys.exit(1)
+
+file_name = sys.argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['service', 'dhcp-server', 'shared-network-name']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    sys.exit(0)
+
+option_nodes = ['bootfile-name', 'bootfile-server', 'bootfile-size', 'captive-portal',
+                'client-prefix-length', 'default-router', 'domain-name', 'domain-search',
+                'name-server', 'ip-forwarding', 'ipv6-only-preferred', 'ntp-server',
+                'pop-server', 'server-identifier', 'smtp-server', 'static-route',
+                'tftp-server-name', 'time-offset', 'time-server', 'time-zone',
+                'vendor-option', 'wins-server', 'wpad-url']
+
+for network in config.list_nodes(base):
+    for option in option_nodes:
+        if config.exists(base + [network, option]):
+            config.set(base + [network, 'option'])
+            config.copy(base + [network, option], base + [network, 'option', option])
+            config.delete(base + [network, option])
+
+    if config.exists(base + [network, 'subnet']):
+        for subnet in config.list_nodes(base + [network, 'subnet']):
+            base_subnet = base + [network, 'subnet', subnet]
+            
+            for option in option_nodes:
+                if config.exists(base + [network, 'subnet', subnet, option]):
+                    config.set(base + [network, 'subnet', subnet, 'option'])
+                    config.copy(base + [network, 'subnet', subnet, option], base + [network, 'subnet', subnet, 'option', option])
+                    config.delete(base + [network, 'subnet', subnet, option])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
* Move and migrate DHCP options under `option` include node
* Fix various issues introduced with Kea implementation

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3316
* https://vyos.dev/T5787
* https://vyos.dev/T5912

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-documentation/pull/1231

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-server

## Proposed changes
<!--- Describe your changes in detail -->
* Move (and migrate) DHCP options under an `option` node which can be included as needed in various scopes
* Options can now be defined in shared-network, subnet, range and static-mapping scopes
* Fix handling of `listen-address` and add `listen-interface` as supported by Kea
* Fix `hostfile-update` not updating hostfile for newly allocated leases
* Workaround issue with Kea hooks not appending domain-name suffix to hosts file
* Prevent duplicate IP addresses on static mappings

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Smoketests updated to check expected results for CLI changes made in this PR

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py
DEBUG - test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
DEBUG - test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
DEBUG - test_dhcp_failover (__main__.TestServiceDHCPServer.test_dhcp_failover) ... ok
DEBUG - test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
DEBUG - test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
DEBUG - test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... ok
DEBUG - test_dhcp_single_pool_options_scoped (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options_scoped) ... ok
DEBUG - test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... ok
DEBUG - test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 9 tests in 35.709s
DEBUG -
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
