### PR TITLE
firewall: T5814: Retain legacy 'accept' behaviour and re-order migration

### DIFF
--- a/src/migration-scripts/firewall/10-to-11
+++ b/src/migration-scripts/firewall/10-to-11
@@ -80,12 +80,27 @@ for option in ['all-ping', 'broadcast-ping', 'config-trap', 'ip-src-route', 'ipv
         config.delete(base + [option])
 
 ### Migration of firewall name and ipv6-name
+### Also migrate legacy 'accept' behaviour
 if config.exists(base + ['name']):
     config.set(['firewall', 'ipv4', 'name'])
     config.set_tag(['firewall', 'ipv4', 'name'])
 
     for ipv4name in config.list_nodes(base + ['name']):
         config.copy(base + ['name', ipv4name], base + ['ipv4', 'name', ipv4name])
+
+        if config.exists(base + ['ipv4', 'name', ipv4name, 'default-action']):
+            action = config.return_value(base + ['ipv4', 'name', ipv4name, 'default-action'])
+
+            if action == 'accept':
+                config.set(base + ['ipv4', 'name', ipv4name, 'default-action'], value='return')
+
+        if config.exists(base + ['ipv4', 'name', ipv4name, 'rule']):
+            for rule_id in config.list_nodes(base + ['ipv4', 'name', ipv4name, 'rule']):
+                action = config.return_value(base + ['ipv4', 'name', ipv4name, 'rule', rule_id, 'action'])
+
+                if action == 'accept':
+                    config.set(base + ['ipv4', 'name', ipv4name, 'rule', rule_id, 'action'], value='return')
+
     config.delete(base + ['name'])
 
 if config.exists(base + ['ipv6-name']):
@@ -94,6 +109,20 @@ if config.exists(base + ['ipv6-name']):
 
     for ipv6name in config.list_nodes(base + ['ipv6-name']):
         config.copy(base + ['ipv6-name', ipv6name], base + ['ipv6', 'name', ipv6name])
+
+        if config.exists(base + ['ipv6', 'name', ipv6name, 'default-action']):
+            action = config.return_value(base + ['ipv6', 'name', ipv6name, 'default-action'])
+
+            if action == 'accept':
+                config.set(base + ['ipv6', 'name', ipv6name, 'default-action'], value='return')
+
+        if config.exists(base + ['ipv6', 'name', ipv6name, 'rule']):
+            for rule_id in config.list_nodes(base + ['ipv6', 'name', ipv6name, 'rule']):
+                action = config.return_value(base + ['ipv6', 'name', ipv6name, 'rule', rule_id, 'action'])
+
+                if action == 'accept':
+                    config.set(base + ['ipv6', 'name', ipv6name, 'rule', rule_id, 'action'], value='return')
+
     config.delete(base + ['ipv6-name'])
 
 ### Migration of firewall interface
@@ -102,8 +131,8 @@ if config.exists(base + ['interface']):
     inp_ipv4_rule = 5
     fwd_ipv6_rule = 5
     inp_ipv6_rule = 5
-    for iface in config.list_nodes(base + ['interface']):
-        for direction in ['in', 'out', 'local']:
+    for direction in ['in', 'out', 'local']:
+        for iface in config.list_nodes(base + ['interface']):
             if config.exists(base + ['interface', iface, direction]):
                 if config.exists(base + ['interface', iface, direction, 'name']):
                     target = config.return_value(base + ['interface', iface, direction, 'name'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Pre-1.4 firewall 'accept' action acted as a 'return'. This change migrates rules from 'accept' to 'return' and ensures these rules meet the expected prior behaviour.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5814

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->
* Migrate rules with 'accept' to use 'return' and ensure these rules meet the expected prior behaviour
* Re-order migrated in/out/local jumps by direction instead of interface

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Tested with config smoketest `dialup-router-wireguard-ipv6` - firewall successfully migrated `accept` rules to `return`

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
