### PR TITLE
T5791: T5918: use genetic pattern to detect dynamic interfaces for ipsec and dynamic dns

### DIFF
--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2020-2024 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -24,6 +24,9 @@
 from vyos import ConfigError
 from vyos.utils.dict import dict_search
 from vyos.utils.dict import dict_search_recursive
+
+# pattern re-used in ipsec migration script
+dynamic_interface_pattern = r'(ppp|pppoe|sstpc|l2tp|ipoe)[0-9]+'
 
 def verify_mtu(config):
     """
@@ -290,7 +293,7 @@ def verify_source_interface(config):
 
     src_ifname = config['source_interface']
     # We do not allow sourcing other interfaces (e.g. tunnel) from dynamic interfaces
-    tmp = re.compile(r'(ppp|pppoe|sstpc|l2tp|ipoe)[0-9]+')
+    tmp = re.compile(dynamic_interface_pattern)
     if tmp.match(src_ifname):
         raise ConfigError(f'Can not source "{ifname}" from dynamic interface "{src_ifname}"!')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Fix after commit 8452d8f4921 ("T5918: Fix typo in verify vpn ipsec interface") so that dynamic interfaces can be used by ipsec but a warning is issued that this will only work after they are available on the system.

PPPoE interfaces are the best example for this, as they are down during system bootup and will be available anytime after the boot once we've dialed into the BRAS.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5791
* https://vyos.dev/T5918

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/2791
* https://github.com/vyos/vyos-1x/pull/2602

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec, dns dynamic

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
test_01_dhcp_fail_handling (__main__.TestVPNIPsec.test_01_dhcp_fail_handling) ... ok
test_02_site_to_site (__main__.TestVPNIPsec.test_02_site_to_site) ... ok
test_03_site_to_site_vti (__main__.TestVPNIPsec.test_03_site_to_site_vti) ... ok
test_04_dmvpn (__main__.TestVPNIPsec.test_04_dmvpn) ... ok
test_05_x509_site2site (__main__.TestVPNIPsec.test_05_x509_site2site) ... ok
test_06_flex_vpn_vips (__main__.TestVPNIPsec.test_06_flex_vpn_vips) ... ok
test_07_ikev2_road_warrior (__main__.TestVPNIPsec.test_07_ikev2_road_warrior) ... ok
test_08_ikev2_road_warrior_client_auth_eap_tls (__main__.TestVPNIPsec.test_08_ikev2_road_warrior_client_auth_eap_tls) ... ok
test_09_ikev2_road_warrior_client_auth_x509 (__main__.TestVPNIPsec.test_09_ikev2_road_warrior_client_auth_x509) ... ok

----------------------------------------------------------------------
Ran 9 tests in 56.215s

OK
```

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_dns_dynamic.py
test_01_dyndns_service_standard (__main__.TestServiceDDNS.test_01_dyndns_service_standard) ... ok
test_02_dyndns_service_ipv6 (__main__.TestServiceDDNS.test_02_dyndns_service_ipv6) ... ok
test_03_dyndns_service_dual_stack (__main__.TestServiceDDNS.test_03_dyndns_service_dual_stack) ... ok
test_04_dyndns_rfc2136 (__main__.TestServiceDDNS.test_04_dyndns_rfc2136) ... ok
test_05_dyndns_hostname (__main__.TestServiceDDNS.test_05_dyndns_hostname) ... ok
test_06_dyndns_web_options (__main__.TestServiceDDNS.test_06_dyndns_web_options) ... ok
test_07_dyndns_dynamic_interface (__main__.TestServiceDDNS.test_07_dyndns_dynamic_interface) ... ok
test_08_dyndns_vrf (__main__.TestServiceDDNS.test_08_dyndns_vrf) ... ok

----------------------------------------------------------------------
Ran 8 tests in 52.089s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
