### PR TITLE
image-tools: T5910: explicitly set transmission speed of serial console

### DIFF
--- a/data/templates/grub/grub_common.j2
+++ b/data/templates/grub/grub_common.j2
@@ -8,9 +8,9 @@ fi
 function setup_serial {
     # initialize the first serial port by default
     if [ "${console_type}" == "ttyS" ]; then
-        serial --unit=${console_num}
+        serial --unit=${console_num} --speed=${console_speed}
     else
-        serial --unit=0
+        serial --unit=0 --speed=${console_speed}
     fi
     terminal_output --append serial console
     terminal_input --append serial console

--- a/data/templates/grub/grub_vyos_version.j2
+++ b/data/templates/grub/grub_vyos_version.j2
@@ -6,16 +6,21 @@
 {% endif %}
 menuentry "{{ version_name }}" --id {{ version_uuid }} {
     set boot_opts="{{ boot_opts_rendered }}"
+    if [ "${console_type}" == "ttyS" ]; then
+        set console_opts="console=${console_type}${console_num},${console_speed}"
+    else
+        set console_opts="console=${console_type}${console_num}"
+    fi
     # load rootfs to RAM
     if [ "${boot_toram}" == "yes" ]; then
         set boot_opts="${boot_opts} toram"
     fi
     if [ "${bootmode}" == "pw_reset" ]; then
-        set boot_opts="${boot_opts} console=${console_type}${console_num} init=/usr/libexec/vyos/system/standalone_root_pw_reset"
+        set boot_opts="${boot_opts} ${console_opts} init=/usr/libexec/vyos/system/standalone_root_pw_reset"
     elif [ "${bootmode}" == "recovery" ]; then
-        set boot_opts="${boot_opts} console=${console_type}${console_num} init=/usr/bin/busybox init"
+        set boot_opts="${boot_opts} ${console_opts} init=/usr/bin/busybox init"
     else
-        set boot_opts="${boot_opts} console=${console_type}${console_num}"
+        set boot_opts="${boot_opts} ${console_opts}"
     fi
     linux "/boot/{{ version_name }}/vmlinuz" ${boot_opts}
     initrd "/boot/{{ version_name }}/initrd.img"

--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -93,6 +93,7 @@ DEFAULT_BOOT_VARS: dict[str, str] = {
     'timeout': '5',
     'console_type': 'tty',
     'console_num': '0',
+    'console_speed': '115200',
     'bootmode': 'normal'
 }
 

--- a/src/system/grub_update.py
+++ b/src/system/grub_update.py
@@ -68,7 +68,8 @@ if __name__ == '__main__':
         'default': grub.gen_version_uuid(default_entry['version']),
         'bootmode': default_entry['bootmode'],
         'console_type': default_entry['console_type'],
-        'console_num': default_entry['console_num']
+        'console_num': default_entry['console_num'],
+        'console_speed': '115200'
     }
     vars.update(default_settings)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The image-tools install scripts do not explicitly set the serial console speed, resulting in a GRUB default of 9600. In the case of a serial-only installation, this is a confounding, as the live image sets transmission speed to 115200, whereas the resulting installed image does not. Explicitly set for both fresh installs and for compatibility mode when legacy images are subsequently removed.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5910

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
