### PR TITLE
T5922: firewall: fix intra-zone filtering parsing rules; update firew…

### DIFF
--- a/data/templates/firewall/nftables-zone.j2
+++ b/data/templates/firewall/nftables-zone.j2
@@ -1,13 +1,6 @@
-
-{% macro zone_chains(zone, family, state_policy=False) %}
-{% if family == 'ipv6' %}
-{%     set fw_name = 'ipv6_name' %}
-{%     set suffix = '6' %}
-{% else %}
-{%     set fw_name = 'name' %}
-{%     set suffix = '' %}
-{% endif %}
-
+{% macro zone_chains(zone, ipv6=False, state_policy=False) %}
+{% set fw_name = 'ipv6_name' if ipv6 else 'name' %}
+{% set suffix = '6' if ipv6 else '' %}
     chain VYOS_ZONE_FORWARD {
         type filter hook forward priority 1; policy accept;
 {% if state_policy %}

--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -163,7 +163,7 @@ table ip vyos_filter {
 {{ group_tmpl.groups(group, False, True) }}
 
 {% if zone is vyos_defined %}
-{{ zone_tmpl.zone_chains(zone, 'ipv4', global_options.state_policy is vyos_defined) }}
+{{ zone_tmpl.zone_chains(zone, False, global_options.state_policy is vyos_defined) }}
 {% endif %}
 {% if global_options.state_policy is vyos_defined %}
     chain VYOS_STATE_POLICY {
@@ -298,7 +298,7 @@ table ip6 vyos_filter {
 {% endif %}
 {{ group_tmpl.groups(group, True, True) }}
 {% if zone is vyos_defined %}
-{{ zone_tmpl.zone_chains(zone, 'ipv6', global_options.state_policy is vyos_defined) }}
+{{ zone_tmpl.zone_chains(zone, True, global_options.state_policy is vyos_defined) }}
 {% endif %}
 {% if global_options.state_policy is vyos_defined %}
     chain VYOS_STATE_POLICY6 {

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -671,8 +671,10 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 ### Zone
     def test_zone_basic(self):
         self.cli_set(['firewall', 'ipv4', 'name', 'smoketest', 'default-action', 'drop'])
+        self.cli_set(['firewall', 'ipv6', 'name', 'smoketestv6', 'default-action', 'drop'])
         self.cli_set(['firewall', 'zone', 'smoketest-eth0', 'interface', 'eth0'])
         self.cli_set(['firewall', 'zone', 'smoketest-eth0', 'from', 'smoketest-local', 'firewall', 'name', 'smoketest'])
+        self.cli_set(['firewall', 'zone', 'smoketest-eth0', 'intra-zone-filtering', 'firewall', 'ipv6-name', 'smoketestv6'])
         self.cli_set(['firewall', 'zone', 'smoketest-local', 'local-zone'])
         self.cli_set(['firewall', 'zone', 'smoketest-local', 'from', 'smoketest-eth0', 'firewall', 'name', 'smoketest'])
         self.cli_set(['firewall', 'global-options', 'state-policy', 'established', 'action', 'accept'])
@@ -704,16 +706,30 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['ct state related', 'accept']
         ]
 
+        nftables_search_v6 = [
+            ['chain VYOS_ZONE_FORWARD'],
+            ['type filter hook forward priority filter + 1'],
+            ['chain VYOS_ZONE_OUTPUT'],
+            ['type filter hook output priority filter + 1'],
+            ['chain VYOS_ZONE_LOCAL'],
+            ['type filter hook input priority filter + 1'],
+            ['chain VZONE_smoketest-eth0'],
+            ['chain VZONE_smoketest-local_IN'],
+            ['chain VZONE_smoketest-local_OUT'],
+            ['oifname "eth0"', 'jump VZONE_smoketest-eth0'],
+            ['jump VZONE_smoketest-local_IN'],
+            ['jump VZONE_smoketest-local_OUT'],
+            ['iifname "eth0"', 'jump NAME6_smoketestv6'],
+            ['jump VYOS_STATE_POLICY6'],
+            ['chain VYOS_STATE_POLICY6'],
+            ['ct state established', 'log prefix "[STATE-POLICY-EST-A]"', 'accept'],
+            ['ct state invalid', 'drop'],
+            ['ct state related', 'accept']
+        ]
+
         nftables_output = cmd('sudo nft list table ip vyos_filter')
-
-        for search in nftables_search:
-            matched = False
-            for line in nftables_output.split("\n"):
-                if all(item in line for item in search):
-                    matched = True
-                    break
-            self.assertTrue(matched)
-
+        self.verify_nftables(nftables_search, 'ip vyos_filter')
+        self.verify_nftables(nftables_search_v6, 'ip6 vyos_filter')
 
     def test_flow_offload(self):
         self.cli_set(['firewall', 'flowtable', 'smoketest', 'interface', 'eth0'])


### PR DESCRIPTION
…all smoketest

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5922

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Config
```
vyos@intra# run show config comm | grep fire
set firewall ipv4 name FOO rule 101 action 'accept'
set firewall ipv4 name FOO rule 202 action 'drop'
set firewall ipv4 name FOO rule 303 action 'reject'
set firewall ipv4 name LAN_to_LOCAL rule 10 action 'accept'
set firewall ipv4 name LAN_to_WAN rule 10 action 'accept'
set firewall ipv4 name LOCAL_to_WAN rule 10 action 'accept'
set firewall ipv4 name LOCAL_to_WAN rule 101 action 'accept'
set firewall ipv4 name LOCAL_to_WAN rule 101 protocol 'tcp'
set firewall ipv4 name LOCAL_to_WAN rule 589 action 'drop'
set firewall ipv4 name LOCAL_to_WAN rule 589 destination address '5.4.3.2'
set firewall ipv4 name WAN_to_LAN rule 10 action 'accept'
set firewall ipv4 name WAN_to_LOCAL rule 19 action 'accept'
set firewall ipv6 name WAN_to_LOCAL_v6 rule 10 action 'accept'
set firewall zone LAN from WAN firewall name 'WAN_to_LAN'
set firewall zone LAN interface 'eth1'
set firewall zone LAN interface 'eth2'
set firewall zone LAN intra-zone-filtering firewall name 'FOO'
set firewall zone LOCAL from LAN firewall name 'LAN_to_LOCAL'
set firewall zone LOCAL from WAN firewall ipv6-name 'WAN_to_LOCAL_v6'
set firewall zone LOCAL from WAN firewall name 'WAN_to_LOCAL'
set firewall zone LOCAL local-zone
set firewall zone WAN from LAN firewall name 'LAN_to_WAN'
set firewall zone WAN from LOCAL firewall name 'LOCAL_to_WAN'
set firewall zone WAN interface 'eth3'
set firewall zone WAN interface 'eth0'
[edit]
vyos@intra# 
```
Chains:
```
vyos@intra# sudo nft list chain ip vyos_filter VZONE_LAN
table ip vyos_filter {
        chain VZONE_LAN {
                iifname { "eth1", "eth2" } counter packets 0 bytes 0 jump NAME_FOO
                iifname { "eth1", "eth2" } counter packets 0 bytes 0 return
                iifname { "eth0", "eth3" } counter packets 0 bytes 0 jump NAME_WAN_to_LAN
                iifname { "eth0", "eth3" } counter packets 0 bytes 0 return
                counter packets 0 bytes 0 drop comment "zone_LAN default-action drop"
        }
}
vyos@intra# sudo nft list chain ip6 vyos_filter VZONE_LAN
table ip6 vyos_filter {
        chain VZONE_LAN {
                iifname { "eth1", "eth2" } counter packets 0 bytes 0 return
                iifname { "eth1", "eth2" } counter packets 0 bytes 0 return
                counter packets 0 bytes 0 drop comment "zone_LAN default-action drop"
        }
}
[edit]
vyos@intra# 
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@intra:/usr/libexec/vyos/tests/smoke/cli# ./test_firewall.py
test_bridge_basic_rules (__main__.TestFirewall.test_bridge_basic_rules) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ...
Interface "eth0" does not support hardware offload

ok
test_geoip (__main__.TestFirewall.test_geoip) ... Updating GeoIP. Please wait...
Updating GeoIP. Please wait...
ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ...
"synproxy" option allowed only for action synproxy

ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ...
Group "smoketest_network1" has a circular reference

ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ...
Interface "eth0" does not support hardware offload

ok

----------------------------------------------------------------------
Ran 17 tests in 41.234s

OK
root@intra:/usr/libexec/vyos/tests/smoke/cli#
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
