### PR TITLE
T5925: Containers change systemd KillMode

### DIFF
--- a/data/templates/container/systemd-unit.j2
+++ b/data/templates/container/systemd-unit.j2
@@ -13,5 +13,5 @@ ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%n.cid -t 5
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%n.cid
 ExecStopPost=/bin/rm -f %t/%n.cid
 PIDFile=%t/%n.pid
-KillMode=none
+KillMode=control-group
 Type=forking


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
By default, we use the `KillMode=none` mode for containers.
Change to `control-group` as `none` id deprecated

Another solution could be to delete `KillNode` and use `TimeoutStopSec={{.TimeoutStopSec}}`
https://github.com/containers/podman/pull/8889


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Change podman stop process

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5925

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
container
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set container name alp01 allow-host-networks
set container name alp01 image 'alpine'
commit
delete container
commit
```
Before the fix:
```
Jan 12 11:40:18 r4 systemd[1]: /run/systemd/system/vyos-container-alp01.service:16: Unit uses KillMode=none. This is unsafe, as it disables systemd's process lifecycle management for the service. Please update the service to use a safer KillMode=, such as 'mixed' or 'control-group'. Support for KillMode=none is deprecated and will eventually be removed.
```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_container.py
test_basic (__main__.TestContainer.test_basic) ... ok
test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... ok
test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... ok
test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... ok

----------------------------------------------------------------------
Ran 4 tests in 111.168s

OK
vyos@r4:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
