### PR TITLE
dhcpv6: T3316: Extend scope of DHCP options, bugfixes

### DIFF
--- a/data/templates/dhcp-server/kea-dhcp6.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp6.conf.j2
@@ -1,7 +1,11 @@
 {
     "Dhcp6": {
         "interfaces-config": {
+{% if listen_interface is vyos_defined %}
+            "interfaces": {{ listen_interface | tojson }},
+{% else %}
             "interfaces": [ "*" ],
+{% endif %}
             "service-sockets-max-retries": 5,
             "service-sockets-retry-wait-time": 5000
         },

--- a/interface-definitions/include/dhcp/option-v6.xml.i
+++ b/interface-definitions/include/dhcp/option-v6.xml.i
@@ -1,0 +1,110 @@
+<!-- include start from dhcp/option-v6.xml.i -->
+<node name="option">
+  <properties>
+    <help>DHCPv6 option</help>
+  </properties>
+  <children>
+    #include <include/dhcp/captive-portal.xml.i>
+    #include <include/dhcp/domain-search.xml.i>
+    #include <include/name-server-ipv6.xml.i>
+    <leafNode name="nis-domain">
+      <properties>
+        <help>NIS domain name for client to use</help>
+        <constraint>
+          #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+        </constraint>
+        <constraintErrorMessage>Invalid NIS domain name</constraintErrorMessage>
+      </properties>
+    </leafNode>
+    <leafNode name="nis-server">
+      <properties>
+        <help>IPv6 address of a NIS Server</help>
+        <valueHelp>
+          <format>ipv6</format>
+          <description>IPv6 address of NIS server</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv6-address"/>
+        </constraint>
+        <multi/>
+      </properties>
+    </leafNode>
+    <leafNode name="nisplus-domain">
+      <properties>
+        <help>NIS+ domain name for client to use</help>
+        <constraint>
+          #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+        </constraint>
+        <constraintErrorMessage>Invalid NIS+ domain name. May only contain letters, numbers and .-_</constraintErrorMessage>
+      </properties>
+    </leafNode>
+    <leafNode name="nisplus-server">
+      <properties>
+        <help>IPv6 address of a NIS+ Server</help>
+        <valueHelp>
+          <format>ipv6</format>
+          <description>IPv6 address of NIS+ server</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv6-address"/>
+        </constraint>
+        <multi/>
+      </properties>
+    </leafNode>
+    <leafNode name="sip-server">
+      <properties>
+        <help>IPv6 address of SIP server</help>
+        <valueHelp>
+          <format>ipv6</format>
+          <description>IPv6 address of SIP server</description>
+        </valueHelp>
+        <valueHelp>
+          <format>hostname</format>
+          <description>FQDN of SIP server</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv6-address"/>
+          <validator name="fqdn"/>
+        </constraint>
+        <multi/>
+      </properties>
+    </leafNode>
+    <leafNode name="sntp-server">
+      <properties>
+        <help>IPv6 address of an SNTP server for client to use</help>
+        <constraint>
+          <validator name="ipv6-address"/>
+        </constraint>
+        <multi/>
+      </properties>
+    </leafNode>
+    <node name="vendor-option">
+      <properties>
+        <help>Vendor Specific Options</help>
+      </properties>
+      <children>
+        <node name="cisco">
+          <properties>
+            <help>Cisco specific parameters</help>
+          </properties>
+          <children>
+            <leafNode name="tftp-server">
+              <properties>
+                <help>TFTP server name</help>
+                <valueHelp>
+                  <format>ipv6</format>
+                  <description>TFTP server IPv6 address</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="ipv6-address"/>
+                </constraint>
+                <multi/>
+              </properties>
+            </leafNode>
+          </children>
+        </node>
+      </children>
+    </node>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/service_dhcpv6-server.xml.in
+++ b/interface-definitions/service_dhcpv6-server.xml.in
@@ -9,6 +9,7 @@
         </properties>
         <children>
           #include <include/generic-disable-node.xml.i>
+          #include <include/listen-interface-multi-broadcast.xml.i>
           <node name="global-parameters">
             <properties>
               <help>Additional global parameters for DHCPv6 server</help>

--- a/interface-definitions/service_dhcpv6-server.xml.in
+++ b/interface-definitions/service_dhcpv6-server.xml.in
@@ -89,11 +89,17 @@
                   </constraint>
                 </properties>
                 <children>
-                  <node name="address-range">
+                  #include <include/dhcp/option-v6.xml.i>
+                  <tagNode name="range">
                     <properties>
                       <help>Parameters setting ranges for assigning IPv6 addresses</help>
+                      <constraint>
+                        #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+                      </constraint>
+                      <constraintErrorMessage>Invalid range name, may only be alphanumeric, dot and hyphen</constraintErrorMessage>
                     </properties>
                     <children>
+                      #include <include/dhcp/option-v6.xml.i>
                       <leafNode name="prefix">
                         <properties>
                           <help>IPv6 prefix defining range of addresses to assign</help>
@@ -104,10 +110,9 @@
                           <constraint>
                             <validator name="ipv6-prefix"/>
                           </constraint>
-                          <multi/>
                         </properties>
                       </leafNode>
-                      <tagNode name="start">
+                      <leafNode name="start">
                         <properties>
                           <help>First in range of consecutive IPv6 addresses to assign</help>
                           <valueHelp>
@@ -118,25 +123,21 @@
                             <validator name="ipv6-address"/>
                           </constraint>
                         </properties>
-                        <children>
-                          <leafNode name="stop">
-                            <properties>
-                              <help>Last in range of consecutive IPv6 addresses</help>
-                              <valueHelp>
-                                <format>ipv6</format>
-                                <description>IPv6 address</description>
-                              </valueHelp>
-                              <constraint>
-                                <validator name="ipv6-address"/>
-                              </constraint>
-                            </properties>
-                          </leafNode>
-                        </children>
-                      </tagNode>
+                      </leafNode>
+                      <leafNode name="stop">
+                        <properties>
+                          <help>Last in range of consecutive IPv6 addresses</help>
+                          <valueHelp>
+                            <format>ipv6</format>
+                            <description>IPv6 address</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="ipv6-address"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
                     </children>
-                  </node>
-                  #include <include/dhcp/captive-portal.xml.i>
-                  #include <include/dhcp/domain-search.xml.i>
+                  </tagNode>
                   <node name="lease-time">
                     <properties>
                       <help>Parameters relating to the lease time</help>
@@ -180,51 +181,6 @@
                       </leafNode>
                     </children>
                   </node>
-                  #include <include/name-server-ipv6.xml.i>
-                  <leafNode name="nis-domain">
-                    <properties>
-                      <help>NIS domain name for client to use</help>
-                      <constraint>
-                        #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
-                      </constraint>
-                      <constraintErrorMessage>Invalid NIS domain name</constraintErrorMessage>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="nis-server">
-                    <properties>
-                      <help>IPv6 address of a NIS Server</help>
-                      <valueHelp>
-                        <format>ipv6</format>
-                        <description>IPv6 address of NIS server</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="ipv6-address"/>
-                      </constraint>
-                      <multi/>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="nisplus-domain">
-                    <properties>
-                      <help>NIS+ domain name for client to use</help>
-                      <constraint>
-                        #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
-                      </constraint>
-                      <constraintErrorMessage>Invalid NIS+ domain name. May only contain letters, numbers and .-_</constraintErrorMessage>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="nisplus-server">
-                    <properties>
-                      <help>IPv6 address of a NIS+ Server</help>
-                      <valueHelp>
-                        <format>ipv6</format>
-                        <description>IPv6 address of NIS+ server</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="ipv6-address"/>
-                      </constraint>
-                      <multi/>
-                    </properties>
-                  </leafNode>
                   <node name="prefix-delegation">
                     <properties>
                       <help>Parameters relating to IPv6 prefix delegation</help>
@@ -272,33 +228,6 @@
                       </tagNode>
                     </children>
                   </node>
-                  <leafNode name="sip-server">
-                    <properties>
-                      <help>IPv6 address of SIP server</help>
-                      <valueHelp>
-                        <format>ipv6</format>
-                        <description>IPv6 address of SIP server</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>hostname</format>
-                        <description>FQDN of SIP server</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="ipv6-address"/>
-                        <validator name="fqdn"/>
-                      </constraint>
-                      <multi/>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="sntp-server">
-                    <properties>
-                      <help>IPv6 address of an SNTP server for client to use</help>
-                      <constraint>
-                        <validator name="ipv6-address"/>
-                      </constraint>
-                      <multi/>
-                    </properties>
-                  </leafNode>
                   <tagNode name="static-mapping">
                     <properties>
                       <help>Hostname for static mapping reservation</help>
@@ -308,6 +237,7 @@
                       <constraintErrorMessage>Invalid static mapping hostname</constraintErrorMessage>
                     </properties>
                     <children>
+                      #include <include/dhcp/option-v6.xml.i>
                       #include <include/generic-disable-node.xml.i>
                       #include <include/interface/mac.xml.i>
                       #include <include/interface/duid.xml.i>
@@ -349,33 +279,6 @@
                       </constraint>
                     </properties>
                   </leafNode>
-                  <node name="vendor-option">
-                    <properties>
-                      <help>Vendor Specific Options</help>
-                    </properties>
-                    <children>
-                      <node name="cisco">
-                        <properties>
-                          <help>Cisco specific parameters</help>
-                        </properties>
-                        <children>
-                          <leafNode name="tftp-server">
-                            <properties>
-                              <help>TFTP server name</help>
-                              <valueHelp>
-                                <format>ipv6</format>
-                                <description>TFTP server IPv6 address</description>
-                              </valueHelp>
-                              <constraint>
-                                <validator name="ipv6-address"/>
-                              </constraint>
-                              <multi/>
-                            </properties>
-                          </leafNode>
-                        </children>
-                      </node>
-                    </children>
-                  </node>
                 </children>
               </tagNode>
             </children>

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -894,7 +894,9 @@ def kea6_shared_network_json(shared_networks):
             'name': name,
             'subnet6': []
         }
-        options = kea6_parse_options(config)
+
+        if 'common_options' in config:
+            network['option-data'] = kea6_parse_options(config['common_options'])
 
         if 'interface' in config:
             network['interface'] = config['interface']
@@ -902,9 +904,6 @@ def kea6_shared_network_json(shared_networks):
         if 'subnet' in config:
             for subnet, subnet_config in config['subnet'].items():
                 network['subnet6'].append(kea6_parse_subnet(subnet, subnet_config))
-
-        if options:
-            network['option-data'] = options
 
         out.append(network)
 

--- a/smoketest/configs/basic-vyos
+++ b/smoketest/configs/basic-vyos
@@ -95,10 +95,15 @@ service {
         shared-network-name LAN6 {
             subnet fe88::/56 {
                 address-range {
-                    prefix fe88::/56 {
+                    prefix fe88::/60 {
                         temporary
                     }
+                    start fe88:0000:0000:fe:: {
+                        stop fe88:0000:0000:ff::
+                    }
                 }
+                domain-search vyos.net
+                name-server fe88::1
                 prefix-delegation {
                     start fe88:0000:0000:0001:: {
                         prefix-length 64

--- a/smoketest/scripts/cli/test_service_dhcpv6-server.py
+++ b/smoketest/scripts/cli/test_service_dhcpv6-server.py
@@ -104,24 +104,25 @@ class TestServiceDHCPv6Server(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['preference', preference])
         self.cli_set(pool + ['subnet-id', '1'])
         # we use the first subnet IP address as default gateway
-        self.cli_set(pool + ['name-server', dns_1])
-        self.cli_set(pool + ['name-server', dns_2])
-        self.cli_set(pool + ['name-server', dns_2])
         self.cli_set(pool + ['lease-time', 'default', lease_time])
         self.cli_set(pool + ['lease-time', 'maximum', max_lease_time])
         self.cli_set(pool + ['lease-time', 'minimum', min_lease_time])
-        self.cli_set(pool + ['nis-domain', domain])
-        self.cli_set(pool + ['nisplus-domain', domain])
-        self.cli_set(pool + ['sip-server', sip_server])
-        self.cli_set(pool + ['sntp-server', sntp_server])
-        self.cli_set(pool + ['address-range', 'start', range_start, 'stop', range_stop])
+        self.cli_set(pool + ['option', 'name-server', dns_1])
+        self.cli_set(pool + ['option', 'name-server', dns_2])
+        self.cli_set(pool + ['option', 'name-server', dns_2])
+        self.cli_set(pool + ['option', 'nis-domain', domain])
+        self.cli_set(pool + ['option', 'nisplus-domain', domain])
+        self.cli_set(pool + ['option', 'sip-server', sip_server])
+        self.cli_set(pool + ['option', 'sntp-server', sntp_server])
+        self.cli_set(pool + ['range', '1', 'start', range_start])
+        self.cli_set(pool + ['range', '1', 'stop', range_stop])
 
         for server in nis_servers:
-            self.cli_set(pool + ['nis-server', server])
-            self.cli_set(pool + ['nisplus-server', server])
+            self.cli_set(pool + ['option', 'nis-server', server])
+            self.cli_set(pool + ['option', 'nisplus-server', server])
 
         for search in search_domains:
-            self.cli_set(pool + ['domain-search', search])
+            self.cli_set(pool + ['option', 'domain-search', search])
 
         client_base = 1
         for client in ['client1', 'client2', 'client3']:
@@ -217,7 +218,8 @@ class TestServiceDHCPv6Server(VyOSUnitTestSHIM.TestCase):
 
         pool = base_path + ['shared-network-name', shared_net_name, 'subnet', subnet]
         self.cli_set(pool + ['subnet-id', '1'])
-        self.cli_set(pool + ['address-range', 'start', range_start, 'stop', range_stop])
+        self.cli_set(pool + ['range', '1', 'start', range_start])
+        self.cli_set(pool + ['range', '1', 'stop', range_stop])
         self.cli_set(pool + ['prefix-delegation', 'prefix', delegate_start, 'delegated-length', delegate_len])
         self.cli_set(pool + ['prefix-delegation', 'prefix', delegate_start, 'prefix-length', prefix_len])
 

--- a/src/migration-scripts/dhcpv6-server/3-to-4
+++ b/src/migration-scripts/dhcpv6-server/3-to-4
@@ -16,6 +16,8 @@
 
 # T3316:
 # - Add subnet IDs to existing subnets
+# - Move options to option node
+# - Migrate address-range to range tagNode
 
 import sys
 import re
@@ -37,12 +39,45 @@ if not config.exists(base):
     # Nothing to do
     sys.exit(0)
 
+option_nodes = ['captive-portal', 'domain-search', 'name-server',
+                'nis-domain', 'nis-server', 'nisplus-domain', 'nisplus-server',
+                'sip-server', 'sntp-server', 'vendor-option']
+
 subnet_id = 1
 
 for network in config.list_nodes(base):
     if config.exists(base + [network, 'subnet']):
         for subnet in config.list_nodes(base + [network, 'subnet']):
             base_subnet = base + [network, 'subnet', subnet]
+
+            if config.exists(base_subnet + ['address-range']):
+                config.set(base_subnet + ['range'])
+                config.set_tag(base_subnet + ['range'])
+
+                range_id = 1
+
+                if config.exists(base_subnet + ['address-range', 'prefix']):
+                    for prefix in config.return_values(base_subnet + ['address-range', 'prefix']):
+                        config.set(base_subnet + ['range', range_id, 'prefix'], value=prefix)
+
+                        range_id += 1
+
+                if config.exists(base_subnet + ['address-range', 'start']):
+                    for start in config.list_nodes(base_subnet + ['address-range', 'start']):
+                        stop = config.return_value(base_subnet + ['address-range', 'start', start, 'stop'])
+
+                        config.set(base_subnet + ['range', range_id, 'start'], value=start)
+                        config.set(base_subnet + ['range', range_id, 'stop'], value=stop)
+
+                        range_id += 1
+
+                config.delete(base_subnet + ['address-range'])
+
+            for option in option_nodes:
+                if config.exists(base_subnet + [option]):
+                    config.set(base_subnet + ['option'])
+                    config.copy(base_subnet + [option], base_subnet + ['option', option])
+                    config.delete(base_subnet + [option])
 
             config.set(base_subnet + ['subnet-id'], value=subnet_id)
             subnet_id += 1

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -194,14 +194,11 @@ def _get_pool_size(pool, family='inet'):
     size = 0
     subnets = config.list_nodes(f'{base} subnet')
     for subnet in subnets:
-        if family == 'inet6':
-            ranges = config.list_nodes(f'{base} subnet {subnet} address-range start')
-        else:
-            ranges = config.list_nodes(f'{base} subnet {subnet} range')
+        ranges = config.list_nodes(f'{base} subnet {subnet} range')
         for range in ranges:
             if family == 'inet6':
-                start = config.list_nodes(f'{base} subnet {subnet} address-range start')[0]
-                stop = config.value(f'{base} subnet {subnet} address-range start {start} stop')
+                start = config.value(f'{base} subnet {subnet} range {range} start')
+                stop = config.value(f'{base} subnet {subnet} range {range} stop')
             else:
                 start = config.value(f'{base} subnet {subnet} range {range} start')
                 stop = config.value(f'{base} subnet {subnet} range {range} stop')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
* Move and migrate DHCPv6 options under option include node
* Fix various issues introduced with Kea implementation

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3316

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-documentation/pull/1240

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcpv6-server

## Proposed changes
<!--- Describe your changes in detail -->
* Move (and migrate) DHCPv6 options under an option node which can be included as needed in various scopes
* Options can now be defined in subnet, range and static-mapping scopes
* Migrate `address-range` to `range` tag node to keep consistent with DHCPv4 server CLI syntax
* Add `listen-interface` as supported by Kea
* Fix verify check that defined prefix is a subnet of parent subnet (needs backporting to 1.4)

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Smoketests and config test updated to check expected results/migrations for changes made in this PR

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_service_dhcpv6-server.py
DEBUG - test_global_nameserver (__main__.TestServiceDHCPv6Server.test_global_nameserver) ... ok
DEBUG - test_prefix_delegation (__main__.TestServiceDHCPv6Server.test_prefix_delegation) ... ok
DEBUG - test_single_pool (__main__.TestServiceDHCPv6Server.test_single_pool) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 3 tests in 11.955s
DEBUG -
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
