### PR TITLE
bgp: T591: SRv6 improvements

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -402,6 +402,9 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {%         if afi_config.flooding.head_end_replication is vyos_defined %}
   flooding head-end-replication
 {%         endif %}
+{%         if afi_config.nexthop.vpn.export is vyos_defined %}
+  nexthop vpn export {{ afi_config.nexthop.vpn.export }}
+{%         endif %}
 {%         if afi_config.rd.vpn.export is vyos_defined %}
   rd vpn export {{ afi_config.rd.vpn.export }}
 {%         endif %}

--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -436,6 +436,9 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {%         if afi_config.route_map.vpn.import is vyos_defined %}
   route-map vpn import {{ afi_config.route_map.vpn.import }}
 {%         endif %}
+{%         if afi_config.sid.vpn.export is vyos_defined %}
+ sid vpn export {{ afi_config.sid.vpn.export }}
+{%         endif %}
 {%         if afi_config.vni is vyos_defined %}
 {%             for vni, vni_config in afi_config.vni.items() %}
   vni {{ vni }}

--- a/interface-definitions/include/bgp/afi-nexthop-vpn-export.xml.i
+++ b/interface-definitions/include/bgp/afi-nexthop-vpn-export.xml.i
@@ -1,0 +1,32 @@
+<!-- include start from bgp/afi-nexthop-vpn-export.xml.i -->
+<node name="nexthop">
+  <properties>
+    <help>Specify next hop to use for VRF advertised prefixes</help>
+  </properties>
+  <children>
+    <node name="vpn">
+      <properties>
+        <help>Between current address-family and vpn</help>
+      </properties>
+      <children>
+        <leafNode name="export">
+          <properties>
+            <help>For routes leaked from current address-family to vpn</help>
+            <valueHelp>
+                <format>ipv4</format>
+                <description>BGP neighbor IP address</description>
+              </valueHelp>
+              <valueHelp>
+                <format>ipv6</format>
+                <description>BGP neighbor IPv6 address</description>
+              </valueHelp>
+              <constraint>
+                <validator name="ip-address"/>
+              </constraint>
+          </properties>
+        </leafNode>
+      </children>
+    </node>
+  </children>
+</node>
+  <!-- include end -->

--- a/interface-definitions/include/bgp/afi-sid.xml.i
+++ b/interface-definitions/include/bgp/afi-sid.xml.i
@@ -1,0 +1,36 @@
+<!-- include start from bgp/sid.xml.i -->
+<node name="sid">
+    <properties>
+      <help>SID value for VRF</help>
+    </properties>
+    <children>
+      <node name="vpn">
+        <properties>
+          <help>Between current VRF and VPN</help>
+        </properties>
+        <children>
+          <leafNode name="export">
+            <properties>
+              <help>For routes leaked from current VRF to VPN</help>
+              <completionHelp>
+                <list>auto</list>
+              </completionHelp>
+              <valueHelp>
+                <format>u32:1-1048575</format>
+                <description>SID allocation index</description>
+              </valueHelp>
+              <valueHelp>
+                <format>auto</format>
+                <description>Automatically assign a label</description>
+              </valueHelp>
+              <constraint>
+                <regex>auto</regex>
+                <validator name="numeric" argument="--range 1-1048575"/>
+              </constraint>
+            </properties>
+          </leafNode>
+        </children>
+      </node>
+    </children>
+  </node>
+  <!-- include end -->

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -188,6 +188,7 @@
             </leafNode>
           </children>
         </node>
+        #include <include/bgp/afi-sid.xml.i>
       </children>
     </node>
     <node name="ipv4-multicast">
@@ -555,6 +556,7 @@
             </leafNode>
           </children>
         </node>
+        #include <include/bgp/afi-sid.xml.i>
       </children>
     </node>
     <node name="ipv6-multicast">

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -120,6 +120,7 @@
         #include <include/bgp/afi-rd.xml.i>
         #include <include/bgp/afi-route-map-vpn.xml.i>
         #include <include/bgp/afi-route-target-vpn.xml.i>
+        #include <include/bgp/afi-nexthop-vpn-export.xml.i>
         <node name="redistribute">
           <properties>
             <help>Redistribute routes from other protocols into BGP</help>
@@ -496,6 +497,7 @@
         #include <include/bgp/afi-rd.xml.i>
         #include <include/bgp/afi-route-map-vpn.xml.i>
         #include <include/bgp/afi-route-target-vpn.xml.i>
+        #include <include/bgp/afi-nexthop-vpn-export.xml.i>
         <node name="redistribute">
           <properties>
             <help>Redistribute routes from other protocols into BGP</help>

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -1139,6 +1139,8 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
     def test_bgp_24_srv6_sid(self):
         locator_name = 'VyOS_foo'
         sid = 'auto'
+        nexthop_ipv4 = '192.0.0.1'
+        nexthop_ipv6 = '2001:db8:100:200::2'
 
         self.cli_set(base_path + ['srv6', 'locator', locator_name])
         self.cli_set(base_path + ['sid', 'vpn', 'per-vrf', 'export', sid])
@@ -1158,7 +1160,9 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         # Now test AFI SID
         self.cli_delete(base_path + ['sid'])
         self.cli_set(base_path + ['address-family', 'ipv4-unicast', 'sid', 'vpn', 'export', sid])
+        self.cli_set(base_path + ['address-family', 'ipv4-unicast', 'nexthop', 'vpn', 'export', nexthop_ipv4])
         self.cli_set(base_path + ['address-family', 'ipv6-unicast', 'sid', 'vpn', 'export', sid])
+        self.cli_set(base_path + ['address-family', 'ipv6-unicast', 'nexthop', 'vpn', 'export', nexthop_ipv6])
 
         self.cli_commit()
 
@@ -1169,8 +1173,10 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
 
         afiv4_config = self.getFRRconfig(' address-family ipv4 unicast')
         self.assertIn(f' sid vpn export {sid}', afiv4_config)
+        self.assertIn(f' nexthop vpn export {nexthop_ipv4}', afiv4_config)
         afiv6_config = self.getFRRconfig(' address-family ipv6 unicast')
         self.assertIn(f' sid vpn export {sid}', afiv6_config)
+        self.assertIn(f' nexthop vpn export {nexthop_ipv6}', afiv4_config)
 
     def test_bgp_25_ipv4_ipv6_labeled_unicast_peer_group(self):
         pg_ipv4 = 'foo4'

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -1142,7 +1142,11 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
 
         self.cli_set(base_path + ['srv6', 'locator', locator_name])
         self.cli_set(base_path + ['sid', 'vpn', 'per-vrf', 'export', sid])
-
+        self.cli_set(base_path + ['address-family', 'ipv4-unicast', 'sid', 'vpn', 'export', sid])
+        # verify() - SID per VRF and SID per address-family are mutually exclusive!
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(base_path + ['address-family', 'ipv4-unicast', 'sid'])
         self.cli_commit()
 
         frrconfig = self.getFRRconfig(f'router bgp {ASN}')
@@ -1150,6 +1154,23 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f' segment-routing srv6', frrconfig)
         self.assertIn(f'  locator {locator_name}', frrconfig)
         self.assertIn(f' sid vpn per-vrf export {sid}', frrconfig)
+
+        # Now test AFI SID
+        self.cli_delete(base_path + ['sid'])
+        self.cli_set(base_path + ['address-family', 'ipv4-unicast', 'sid', 'vpn', 'export', sid])
+        self.cli_set(base_path + ['address-family', 'ipv6-unicast', 'sid', 'vpn', 'export', sid])
+
+        self.cli_commit()
+
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
+        self.assertIn(f'router bgp {ASN}', frrconfig)
+        self.assertIn(f' segment-routing srv6', frrconfig)
+        self.assertIn(f'  locator {locator_name}', frrconfig)
+
+        afiv4_config = self.getFRRconfig(' address-family ipv4 unicast')
+        self.assertIn(f' sid vpn export {sid}', afiv4_config)
+        afiv6_config = self.getFRRconfig(' address-family ipv6 unicast')
+        self.assertIn(f' sid vpn export {sid}', afiv6_config)
 
     def test_bgp_25_ipv4_ipv6_labeled_unicast_peer_group(self):
         pg_ipv4 = 'foo4'

--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -542,6 +542,10 @@ def verify(bgp):
                     tmp = dict_search(f'route_map.vpn.{export_import}', afi_config)
                     if tmp: verify_route_map(tmp, bgp)
 
+                # per-vrf sid and per-af sid are mutually exclusive
+                if 'sid' in afi_config and 'sid' in bgp:
+                    raise ConfigError('SID per VRF and SID per address-family are mutually exclusive!')
+
             # Checks only required for L2VPN EVPN
             if afi in ['l2vpn_evpn']:
                 if 'vni' in afi_config:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add VPN nexthop support per address-family. Add SRv6 per address-family SID support

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T591

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/2606
* https://github.com/vyos/vyos-1x/pull/2663

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp


## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set protocols bgp address-family ipv4-unicast nexthop vpn export 192.0.2.1
set protocols bgp address-family ipv6-unicast nexthop vpn export 2001:db8::1
set protocols bgp address-family ipv4-unicast sid vpn export auto
set protocols bgp address-family ipv6-unicast sid vpn export auto
set protocols bgp system-as 100
```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ... ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ... ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ... ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ... ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ... ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ... ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ... ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ... ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ... ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ... ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok
test_bgp_24_srv6_sid (__main__.TestProtocolsBGP.test_bgp_24_srv6_sid) ... ok
test_bgp_25_ipv4_ipv6_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_25_ipv4_ipv6_labeled_unicast_peer_group) ... ok
test_bgp_99_bmp (__main__.TestProtocolsBGP.test_bgp_99_bmp) ... ok

----------------------------------------------------------------------
Ran 25 tests in 165.401s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
