### PR TITLE
T5944: Fix reboot in arg

### DIFF
--- a/src/op_mode/powerctrl.py
+++ b/src/op_mode/powerctrl.py
@@ -191,7 +191,7 @@ def main():
                         nargs="*",
                         metavar="HH:MM")
 
-    action.add_argument("--reboot_in", "-i",
+    action.add_argument("--reboot-in", "-i",
                         help="Reboot the system",
                         nargs="*",
                         metavar="Minutes")


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix the arg for the `reboot in x` command
The actual arg is `--reboot_in [Minutes ...]`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5944

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
reboot, power
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Before the fix:
```
vyos@r4:~$ reboot in 1
usage: powerctrl.py [-h] [--yes] (--reboot [HH:MM ...] | --reboot_in [Minutes ...] | --poweroff [Minutes|HH:MM ...] | --cancel | --check)
powerctrl.py: error: one of the arguments --reboot/-r --reboot_in/-i --poweroff/-p --cancel/-c --check is required
vyos@r4:~$ 

```
After the fix:
```vyos@r4:~$ reboot in 1
Warning: there are unsaved configuration changes!
Run 'save' command if you do not want to lose those changes after reboot/shutdown.

Broadcast message from root@debian on pts/3 (Sun 2024-01-14 22:49:19 EET):

The system will reboot at Sun 2024-01-14 22:50:19 EET!

                                                                               
Broadcast message from root@r4 (somewhere) (Sun Jan 14 22:49:19 2024):         
                                                                               
System reboot is scheduled 1
                                                                               
                                                                               
Broadcast message from root@r4 (somewhere) (Sun Jan 14 22:49:19 2024):         
                                                                               
System reboot is scheduled 1
                                                                               
Reboot is scheduled 2024-01-14 22:50:19
vyos@r4:~$ 
vyos@r4:~$ 
vyos@r4:~$ show reboot 
Reboot is scheduled 2024-01-14 22:50:19
vyos@r4:~$ 
Broadcast message from root@debian on pts/3 (Sun 2024-01-14 22:50:19 EET):

The system will reboot now!

Connection to 192.168.122.14 closed by remote host.
Connection to 192.168.122.14 closed.

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
