### PR TITLE
T4856: Fix IPsec DHCP-client exit hook

### DIFF
--- a/src/etc/dhcp/dhclient-exit-hooks.d/99-ipsec-dhclient-hook
+++ b/src/etc/dhcp/dhclient-exit-hooks.d/99-ipsec-dhclient-hook
@@ -71,10 +71,6 @@ if __name__ == '__main__':
                 conf_lines[i] = line.replace(old_ip, new_ip)
                 found = True
 
-        for i, line in enumerate(secrets_lines):
-            if line.find(to_match) > 0:
-                secrets_lines[i] = line.replace(old_ip, new_ip)
-
         if found:
             write_file(SWANCTL_CONF, conf_lines)
             ipsec_down(old_ip)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix IPsec DHCP-client exit hook.
The script `99-ipsec-dhclient-hook` does not have the variable `secrets_lines`, and secret lines itself does not have the  marker `# dhcp:{interface}` in `to_find`

Needs to rewrite this script in the future if it is required

This commit fixes the DHCP-client exit hook:
```
dhclient[6800]: NameError: name 'secrets_lines' is not defined
root[6801]: /etc/dhcp/dhclient-exit-hooks.d/99-ipsec-dhclient-hook returned non-zero exit status 1
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4856

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-client, hook
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces ethernet eth3 address 'dhcp'

set vpn ipsec authentication psk PSK id '192.0.2.1'
set vpn ipsec authentication psk PSK id '192.0.2.2'
set vpn ipsec authentication psk PSK secret '1234567890'
set vpn ipsec esp-group ESP-group lifetime '3600'
set vpn ipsec esp-group ESP-group mode 'tunnel'
set vpn ipsec esp-group ESP-group pfs 'enable'
set vpn ipsec esp-group ESP-group proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-group proposal 1 hash 'sha1'
set vpn ipsec ike-group IKE-group key-exchange 'ikev2'
set vpn ipsec ike-group IKE-group lifetime '28800'
set vpn ipsec ike-group IKE-group proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE-group proposal 1 hash 'sha1'
set vpn ipsec site-to-site peer OFFICE-B authentication local-id '192.0.2.1'
set vpn ipsec site-to-site peer OFFICE-B authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer OFFICE-B authentication remote-id '192.0.2.2'
set vpn ipsec site-to-site peer OFFICE-B connection-type 'initiate'
set vpn ipsec site-to-site peer OFFICE-B dhcp-interface 'eth3'
set vpn ipsec site-to-site peer OFFICE-B ike-group 'IKE-group'
set vpn ipsec site-to-site peer OFFICE-B local-address '192.0.2.1'
set vpn ipsec site-to-site peer OFFICE-B remote-address '192.0.2.2'
set vpn ipsec site-to-site peer OFFICE-B tunnel 0 esp-group 'ESP-group'
set vpn ipsec site-to-site peer OFFICE-B tunnel 0 local prefix '100.64.1.0/24'
set vpn ipsec site-to-site peer OFFICE-B tunnel 0 remote prefix '100.64.2.0/24'

```
Generated strongswan.conf (we see the marker `# dhcp:`) only one time:
```
vyos@r4# cat /etc/swanctl/swanctl.conf 
### Autogenerated by vpn_ipsec.py ###

connections {
    OFFICE-B {
        proposals = aes256-sha1-modp1024
        version = 2
        local_addrs = 192.0.2.1 # dhcp:eth3
        remote_addrs = 192.0.2.2
        dpd_timeout = 120
        dpd_delay = 30
        rekey_time = 28800s
        mobike = yes
        keyingtries = 0
        local {
            id = "192.0.2.1"
            auth = psk
        }
        remote {
            id = "192.0.2.2"
            auth = psk
        }
        children {
            OFFICE-B-tunnel-0 {
                esp_proposals = aes256-sha1-modp1024
                life_time = 3600s
                local_ts = 100.64.1.0/24
                remote_ts = 100.64.2.0/24
                ipcomp = no
                mode = tunnel
                start_action = start
                dpd_action = clear
                close_action = none
            }
        }
    }

}

pools {
}

secrets {
    ike-PSK {
        # ID's from auth psk <tag> id xxx
        id-3aef6145-4153-4141-b8a3-6d400980a56f = "192.0.2.1"
        id-e760ca60-1d1d-4b47-b40d-7bf687dfee26 = "192.0.2.2"
        secret = "1234567890"
    }

}
```

Delete the interface DHCP address and rea-add again
Before the fix **99-ipsec-dhclient-hook returned non-zero exit status 1**:
```
Jan 15 00:10:57 r4 dhclient-script-vyos[6749]: Passing command to /usr/sbin/ip: "link set dev eth3 up"
Jan 15 00:10:57 r4 dhclient-script-vyos[6749]: No changes to apply via vyos-hostsd-client
Jan 15 00:10:57 r4 dhclient[6800]: Traceback (most recent call last):
Jan 15 00:10:57 r4 dhclient[6800]:   File "<stdin>", line 39, in <module>
Jan 15 00:10:57 r4 dhclient[6800]: NameError: name 'secrets_lines' is not defined
Jan 15 00:10:57 r4 root[6801]: /etc/dhcp/dhclient-exit-hooks.d/99-ipsec-dhclient-hook returned non-zero exit status 1

```
After the fix:
```
Jan 15 00:30:49 r4 dhclient-script-vyos[7555]: Passing command to /usr/sbin/ip: "link set dev eth3 up"
Jan 15 00:30:49 r4 dhclient-script-vyos[7555]: No changes to apply via vyos-hostsd-client
Jan 15 00:30:49 r4 dhclient[7553]: Listening on LPF/eth3/52:54:00:09:a4:b4
Jan 15 00:30:49 r4 dhclient[7553]: Listening on LPF/eth3/52:54:00:09:a4:b4
Jan 15 00:30:49 r4 dhclient[7553]: Sending on   LPF/eth3/52:54:00:09:a4:b4
Jan 15 00:30:49 r4 dhclient[7553]: Sending on   Socket/fallback
Jan 15 00:30:49 r4 dhclient[7553]: DHCPDISCOVER on eth3 to 255.255.255.255 port 67 interval 2
```

## Smoketest result


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
