### PR TITLE
T5901: Add DHCP base_path dir during first boot

### DIFF
--- a/src/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook
+++ b/src/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook
@@ -29,6 +29,7 @@ fi
 
 if [ "$RUN" = "yes" ]; then
         BASE_PATH=$(python3 -c "from vyos.defaults import directories; print(directories['isc_dhclient_dir'])")
+        mkdir -p ${BASE_PATH}
         LOG=${BASE_PATH}/dhclient_"$interface"."$proto"lease
         echo `date` > $LOG
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
We should create dhclient base_path dir `/run/dhclient` during the first boot.

It fixes cloud-init boot issues
```
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 33: /run/dhclient/dhclient_eth0.lease: No such file or directory
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5901

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-client hook
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Boot cloud-init image
before the fix we can see hook errors:
```
vyos@ci-router1:~$ cat /var/log/cloud-init-output.log 
Cloud-init v. 22.1-437-g3e026561-1~bddeb running 'init-local' at Fri, 05 Jan 2024 18:01:48 +0000. Up 17.13 seconds.
Cloud-init v. 22.1-437-g3e026561-1~bddeb running 'init' at Fri, 05 Jan 2024 18:01:52 +0000. Up 21.04 seconds.
ci-info: ++++++++++++++++++++++++++++++++Net device info++++++++++++++++++++++++++++++++
ci-info: +--------+------+----------------+---------------+--------+-------------------+
ci-info: | Device |  Up  |    Address     |      Mask     | Scope  |     Hw-Address    |
ci-info: +--------+------+----------------+---------------+--------+-------------------+
ci-info: |  eth0  | True | 192.168.122.43 | 255.255.255.0 | global | 52:54:00:82:e4:16 |
ci-info: |   lo   | True |   127.0.0.1    |   255.0.0.0   |  host  |         .         |
ci-info: |   lo   | True |    ::1/128     |       .       |  host  |         .         |
ci-info: +--------+------+----------------+---------------+--------+-------------------+
ci-info: +++++++++++++++++++++++++++++++Route IPv4 info+++++++++++++++++++++++++++++++
ci-info: +-------+---------------+---------------+---------------+-----------+-------+
ci-info: | Route |  Destination  |    Gateway    |    Genmask    | Interface | Flags |
ci-info: +-------+---------------+---------------+---------------+-----------+-------+
ci-info: |   0   |    0.0.0.0    | 192.168.122.1 |    0.0.0.0    |    eth0   |   UG  |
ci-info: |   1   | 192.168.122.0 |    0.0.0.0    | 255.255.255.0 |    eth0   |   U   |
ci-info: +-------+---------------+---------------+---------------+-----------+-------+
ci-info: +++++++++++++++++++Route IPv6 info+++++++++++++++++++
ci-info: +-------+-------------+---------+-----------+-------+
ci-info: | Route | Destination | Gateway | Interface | Flags |
ci-info: +-------+-------------+---------+-----------+-------+
ci-info: |   1   |  multicast  |    ::   |    eth0   |   U   |
ci-info: +-------+-------------+---------+-----------+-------+
Cloud-init v. 22.1-437-g3e026561-1~bddeb running 'modules:config' at Fri, 05 Jan 2024 18:01:53 +0000. Up 22.12 seconds.
Killed old client process
Internet Systems Consortium DHCP Client 4.4.3-P1
Copyright 2004-2022 Internet Systems Consortium.
All rights reserved.
For info, please visit https://www.isc.org/software/dhcp/

Listening on LPF/eth0/52:54:00:82:e4:16
Sending on   LPF/eth0/52:54:00:82:e4:16
Sending on   Socket/fallback
DHCPRELEASE of 192.168.122.43 on eth0 to 192.168.122.1 port 67
Status of zebra: FAILED
Status of mgmtd: FAILED
Status of staticd: FAILED
RTNETLINK answers: No such process
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 33: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
/etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook: line 43: /run/dhclient/dhclient_eth0.lease: No such file or directory
Traceback (most recent call last):
  File "<stdin>", line 39, in <module>
NameError: name 'secrets_lines' is not defined
Cloud-init v. 22.1-437-g3e026561-1~bddeb running 'modules:final' at Fri, 05 Jan 2024 18:01:59 +0000. Up 28.41 seconds.
No 'final' modules to run under section 'cloud_final_modules'
vyos@ci-router1:~$
```

After the fix:
```
vyos@ci-router1:~$ cat /var/log/clo
cloud-init.log         cloud-init-output.log  
vyos@ci-router1:~$ cat /var/log/cloud-init-output.log 
Cloud-init v. 22.1-437-g3e026561-1~bddeb running 'init-local' at Mon, 15 Jan 2024 00:51:09 +0000. Up 18.04 seconds.
Cloud-init v. 22.1-437-g3e026561-1~bddeb running 'init' at Mon, 15 Jan 2024 00:51:13 +0000. Up 22.05 seconds.
ci-info: ++++++++++++++++++++++++++++++++Net device info++++++++++++++++++++++++++++++++
ci-info: +--------+------+----------------+---------------+--------+-------------------+
ci-info: | Device |  Up  |    Address     |      Mask     | Scope  |     Hw-Address    |
ci-info: +--------+------+----------------+---------------+--------+-------------------+
ci-info: |  eth0  | True | 192.168.122.41 | 255.255.255.0 | global | 52:54:00:b0:bb:eb |
ci-info: |   lo   | True |   127.0.0.1    |   255.0.0.0   |  host  |         .         |
ci-info: |   lo   | True |    ::1/128     |       .       |  host  |         .         |
ci-info: +--------+------+----------------+---------------+--------+-------------------+
ci-info: +++++++++++++++++++++++++++++++Route IPv4 info+++++++++++++++++++++++++++++++
ci-info: +-------+---------------+---------------+---------------+-----------+-------+
ci-info: | Route |  Destination  |    Gateway    |    Genmask    | Interface | Flags |
ci-info: +-------+---------------+---------------+---------------+-----------+-------+
ci-info: |   0   |    0.0.0.0    | 192.168.122.1 |    0.0.0.0    |    eth0   |   UG  |
ci-info: |   1   | 192.168.122.0 |    0.0.0.0    | 255.255.255.0 |    eth0   |   U   |
ci-info: +-------+---------------+---------------+---------------+-----------+-------+
ci-info: +++++++++++++++++++Route IPv6 info+++++++++++++++++++
ci-info: +-------+-------------+---------+-----------+-------+
ci-info: | Route | Destination | Gateway | Interface | Flags |
ci-info: +-------+-------------+---------+-----------+-------+
ci-info: |   1   |  multicast  |    ::   |    eth0   |   U   |
ci-info: +-------+-------------+---------+-----------+-------+
Cloud-init v. 22.1-437-g3e026561-1~bddeb running 'modules:config' at Mon, 15 Jan 2024 00:51:14 +0000. Up 23.40 seconds.
Killed old client process
Internet Systems Consortium DHCP Client 4.4.3-P1
Copyright 2004-2022 Internet Systems Consortium.
All rights reserved.
For info, please visit https://www.isc.org/software/dhcp/

Listening on LPF/eth0/52:54:00:b0:bb:eb
Sending on   LPF/eth0/52:54:00:b0:bb:eb
Sending on   Socket/fallback
DHCPRELEASE of 192.168.122.41 on eth0 to 192.168.122.1 port 67
Status of zebra: FAILED
Status of mgmtd: FAILED
Status of staticd: FAILED
RTNETLINK answers: No such process
Traceback (most recent call last):
  File "<stdin>", line 39, in <module>
NameError: name 'secrets_lines' is not defined
Cloud-init v. 22.1-437-g3e026561-1~bddeb running 'modules:final' at Mon, 15 Jan 2024 00:51:21 +0000. Up 30.78 seconds.
No 'final' modules to run under section 'cloud_final_modules'
vyos@ci-router1:~$ 

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
