### PR TITLE
ospf: T5936: when migrating passive interfaces set_tag() must be set

### DIFF
--- a/smoketest/configs/ospf-small
+++ b/smoketest/configs/ospf-small
@@ -1,13 +1,63 @@
 interfaces {
     dummy dum0 {
-        address 172.18.254.201/32
+        address 172.18.254.200/32
     }
     ethernet eth0 {
         duplex auto
         smp-affinity auto
         speed auto
         vif 201 {
-            address 172.18.201.10/24
+            address 172.18.201.9/24
+            ip {
+                ospf {
+                    authentication {
+                        md5 {
+                            key-id 10 {
+                                md5-key OSPFVyOSNET
+                            }
+                        }
+                    }
+                    dead-interval 40
+                    hello-interval 10
+                    priority 1
+                    retransmit-interval 5
+                    transmit-delay 1
+                }
+            }
+            ipv6 {
+                ospfv3 {
+                    bfd
+                    cost 40
+                }
+            }
+        }
+        vif 202 {
+            address 172.18.202.9/24
+            ip {
+                ospf {
+                    authentication {
+                        md5 {
+                            key-id 10 {
+                                md5-key OSPFVyOSNET
+                            }
+                        }
+                    }
+                    dead-interval 40
+                    hello-interval 10
+                    priority 1
+                    retransmit-interval 5
+                    transmit-delay 1
+                }
+            }
+            ipv6 {
+                ospfv3 {
+                    bfd
+                    cost 40
+                }
+            }
+        }
+        vif 203 {
+            address 172.18.203.9/24
             ip {
                 ospf {
                     authentication {
@@ -51,48 +101,31 @@ protocols {
     ospf {
         area 0 {
             network 172.18.201.0/24
-            network 172.18.254.201/32
+            network 172.18.202.0/24
+            network 172.18.203.0/24
+            network 172.18.254.200/32
         }
         log-adjacency-changes {
         }
         parameters {
             abr-type cisco
-            router-id 172.18.254.201
+            router-id 172.18.254.200
         }
         passive-interface default
         passive-interface-exclude eth0.201
+        passive-interface-exclude eth0.202
+        passive-interface-exclude eth0.203
     }
     ospfv3 {
         area 0.0.0.0 {
-            interface eth0
+            interface eth0.201
+            interface eth0.202
+            interface eth0.203
             interface eth1
-            interface eth2
-        }
-    }
-    static {
-        route 0.0.0.0/0 {
-            next-hop 172.18.201.254 {
-                distance 10
-            }
         }
     }
 }
 service {
-    lldp {
-        interface all {
-        }
-        snmp {
-            enable
-        }
-    }
-    snmp {
-        community public {
-            authorization ro
-            network 172.16.100.0/24
-        }
-        contact "VyOS maintainers and contributors <maintainers@vyos.io>"
-        location "Jenkins"
-    }
     ssh {
         disable-host-validation
         port 22
@@ -120,11 +153,9 @@ system {
     }
     name-server 172.16.254.30
     ntp {
-        server 0.pool.ntp.org {
+        server time1.vyos.net {
         }
-        server 1.pool.ntp.org {
-        }
-        server 2.pool.ntp.org {
+        server time2.vyos.net {
         }
     }
     sysctl {

--- a/src/migration-scripts/ospf/0-to-1
+++ b/src/migration-scripts/ospf/0-to-1
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 VyOS maintainers and contributors
+# Copyright (C) 2021-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -28,6 +28,7 @@ def ospf_passive_migration(config, ospf_base):
                     default = True
                     continue
                 config.set(ospf_base + ['interface', interface, 'passive'])
+                config.set_tag(ospf_base + ['interface'])
 
             config.delete(ospf_base + ['passive-interface'])
             config.set(ospf_base + ['passive-interface'], value='default')
@@ -35,6 +36,7 @@ def ospf_passive_migration(config, ospf_base):
         if config.exists(ospf_base + ['passive-interface-exclude']):
             for interface in config.return_values(ospf_base + ['passive-interface-exclude']):
                 config.set(ospf_base + ['interface', interface, 'passive', 'disable'])
+                config.set_tag(ospf_base + ['interface'])
             config.delete(ospf_base + ['passive-interface-exclude'])
 
 if len(argv) < 2:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5936

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

* `make testc`
```
DEBUG - vyos@vyos:~$ echo EXITCODE:$?
DEBUG - echo EXITCODE:$?
 INFO - Configtest finished successfully!
 INFO - Powering off system
poweroff nowCODE:0
```

* `make test`

```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_protocols_ospf.py
DEBUG - test_ospf_01_defaults (__main__.TestProtocolsOSPF.test_ospf_01_defaults) ... ok
DEBUG - test_ospf_02_simple (__main__.TestProtocolsOSPF.test_ospf_02_simple) ... ok
DEBUG - test_ospf_03_access_list (__main__.TestProtocolsOSPF.test_ospf_03_access_list) ... ok
DEBUG - test_ospf_04_default_originate (__main__.TestProtocolsOSPF.test_ospf_04_default_originate) ... ok
DEBUG - test_ospf_05_options (__main__.TestProtocolsOSPF.test_ospf_05_options) ... ok
DEBUG - test_ospf_06_neighbor (__main__.TestProtocolsOSPF.test_ospf_06_neighbor) ... ok
DEBUG - test_ospf_07_redistribute (__main__.TestProtocolsOSPF.test_ospf_07_redistribute) ... ok
DEBUG - test_ospf_08_virtual_link (__main__.TestProtocolsOSPF.test_ospf_08_virtual_link) ... ok
DEBUG - test_ospf_09_interface_configuration (__main__.TestProtocolsOSPF.test_ospf_09_interface_configuration) ... ok
DEBUG - test_ospf_11_interface_area (__main__.TestProtocolsOSPF.test_ospf_11_interface_area) ... ok
DEBUG - test_ospf_12_vrfs (__main__.TestProtocolsOSPF.test_ospf_12_vrfs) ... ok
DEBUG - test_ospf_13_export_list (__main__.TestProtocolsOSPF.test_ospf_13_export_list) ... ok
DEBUG - test_ospf_14_segment_routing_configuration (__main__.TestProtocolsOSPF.test_ospf_14_segment_routing_configuration) ... ok
DEBUG - test_ospf_15_ldp_sync (__main__.TestProtocolsOSPF.test_ospf_15_ldp_sync) ... ok
DEBUG - test_ospf_16_graceful_restart (__main__.TestProtocolsOSPF.test_ospf_16_graceful_restart) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 15 tests in 83.373s
DEBUG -
DEBUG - OK
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_protocols_ospfv3.py
DEBUG - test_ospfv3_01_basic (__main__.TestProtocolsOSPFv3.test_ospfv3_01_basic) ... ok
DEBUG - test_ospfv3_02_distance (__main__.TestProtocolsOSPFv3.test_ospfv3_02_distance) ... ok
DEBUG - test_ospfv3_03_redistribute (__main__.TestProtocolsOSPFv3.test_ospfv3_03_redistribute) ... ok
DEBUG - test_ospfv3_04_interfaces (__main__.TestProtocolsOSPFv3.test_ospfv3_04_interfaces) ... ok
DEBUG - test_ospfv3_05_area_stub (__main__.TestProtocolsOSPFv3.test_ospfv3_05_area_stub) ... ok
DEBUG - test_ospfv3_06_area_nssa (__main__.TestProtocolsOSPFv3.test_ospfv3_06_area_nssa) ... ok
DEBUG - test_ospfv3_07_default_originate (__main__.TestProtocolsOSPFv3.test_ospfv3_07_default_originate) ... ok
DEBUG - test_ospfv3_08_vrfs (__main__.TestProtocolsOSPFv3.test_ospfv3_08_vrfs) ... ok
DEBUG - test_ospfv3_09_graceful_restart (__main__.TestProtocolsOSPFv3.test_ospfv3_09_graceful_restart) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 9 tests in 50.958s
DEBUG -
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
