### PR TITLE
T5865: Moved ipv6 pools to named ipv6 pools in accel-ppp

### DIFF
--- a/data/templates/accel-ppp/config_ipv6_pool.j2
+++ b/data/templates/accel-ppp/config_ipv6_pool.j2
@@ -3,20 +3,19 @@
 AdvAutonomousFlag=1
 verbose=1
 
-{%     if client_ipv6_pool.prefix is vyos_defined %}
 [ipv6-pool]
-{%         for prefix, options in client_ipv6_pool.prefix.items() %}
-{{ prefix }},{{ options.mask }}
-{%         endfor %}
-{%         if client_ipv6_pool.delegate is vyos_defined %}
-{%             for prefix, options in client_ipv6_pool.delegate.items() %}
-delegate={{ prefix }},{{ options.delegation_prefix }}
+{%     for pool_name, pool_config in client_ipv6_pool.items() %}
+{%         if pool_config.prefix is vyos_defined %}
+{%             for prefix, options in pool_config.prefix.items() %}
+{{ prefix }},{{ options.mask }},name={{ pool_name }}
 {%             endfor %}
 {%         endif %}
-{%     endif %}
-
-{%     if client_ipv6_pool.delegate is vyos_defined %}
+{%         if pool_config.delegate is vyos_defined %}
+{%             for prefix, options in pool_config.delegate.items() %}
+delegate={{ prefix }},{{ options.delegation_prefix }},name={{ pool_name }}
+{%             endfor %}
+{%         endif %}
+{%     endfor %}
 [ipv6-dhcp]
 verbose=1
-{%     endif %}
 {% endif %}

--- a/data/templates/accel-ppp/ipoe.config.j2
+++ b/data/templates/accel-ppp/ipoe.config.j2
@@ -58,6 +58,10 @@ password=csid
 {% if default_pool is vyos_defined %}
 ip-pool={{ default_pool }}
 {% endif %}
+{% if default_ipv6_pool is vyos_defined %}
+ipv6-pool={{ default_ipv6_pool }}
+ipv6-pool-delegate={{ default_ipv6_pool }}
+{% endif %}
 {% if gateway_address is vyos_defined %}
 {%     for gw_addr in gateway_address %}
 gw-ip-address={{ gw_addr }}

--- a/data/templates/accel-ppp/l2tp.config.j2
+++ b/data/templates/accel-ppp/l2tp.config.j2
@@ -51,6 +51,10 @@ host-name={{ lns.host_name }}
 {% if default_pool is vyos_defined %}
 ip-pool={{ default_pool }}
 {% endif %}
+{% if default_ipv6_pool is vyos_defined %}
+ipv6-pool={{ default_ipv6_pool }}
+ipv6-pool-delegate={{ default_ipv6_pool }}
+{% endif %}
 
 [client-ip-range]
 0.0.0.0/0

--- a/data/templates/accel-ppp/pppoe.config.j2
+++ b/data/templates/accel-ppp/pppoe.config.j2
@@ -143,6 +143,10 @@ noauth=1
 {% if default_pool is vyos_defined %}
 ip-pool={{ default_pool }}
 {% endif %}
+{% if default_ipv6_pool is vyos_defined %}
+ipv6-pool={{ default_ipv6_pool }}
+ipv6-pool-delegate={{ default_ipv6_pool }}
+{% endif %}
 
 {% if limits is vyos_defined %}
 [connlimit]

--- a/data/templates/accel-ppp/sstp.config.j2
+++ b/data/templates/accel-ppp/sstp.config.j2
@@ -39,6 +39,10 @@ ssl-keyfile=/run/accel-pppd/sstp-cert.key
 {% if default_pool is vyos_defined %}
 ip-pool={{ default_pool }}
 {% endif %}
+{% if default_ipv6_pool is vyos_defined %}
+ipv6-pool={{ default_ipv6_pool }}
+ipv6-pool-delegate={{ default_ipv6_pool }}
+{% endif %}
 
 {# Common IP pool definitions #}
 {% include 'accel-ppp/config_ip_pool.j2' %}

--- a/interface-definitions/include/accel-ppp/client-ipv6-pool.xml.i
+++ b/interface-definitions/include/accel-ppp/client-ipv6-pool.xml.i
@@ -1,7 +1,14 @@
 <!-- include start from accel-ppp/client-ipv6-pool.xml.i -->
-<node name="client-ipv6-pool">
+<tagNode name="client-ipv6-pool">
   <properties>
     <help>Pool of client IPv6 addresses</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>Name of IPv6 pool</description>
+    </valueHelp>
+    <constraint>
+      #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+    </constraint>
   </properties>
   <children>
     <tagNode name="prefix">
@@ -58,5 +65,5 @@
       </children>
     </tagNode>
   </children>
-</node>
+</tagNode>
 <!-- include end -->

--- a/interface-definitions/include/accel-ppp/default-ipv6-pool.xml.i
+++ b/interface-definitions/include/accel-ppp/default-ipv6-pool.xml.i
@@ -1,0 +1,17 @@
+<!-- include start from accel-ppp/default-pool.xml.i -->
+<leafNode name="default-ipv6-pool">
+  <properties>
+    <help>Default client IPv6 pool name</help>
+    <completionHelp>
+      <path>${COMP_WORDS[@]:1:${#COMP_WORDS[@]}-3} client-ipv6-pool</path>
+    </completionHelp>
+    <valueHelp>
+      <format>txt</format>
+      <description>Default IPv6 pool</description>
+    </valueHelp>
+    <constraint>
+      #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/version/ipoe-server-version.xml.i
+++ b/interface-definitions/include/version/ipoe-server-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/ipoe-server-version.xml.i -->
-<syntaxVersion component='ipoe-server' version='2'></syntaxVersion>
+<syntaxVersion component='ipoe-server' version='3'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/include/version/l2tp-version.xml.i
+++ b/interface-definitions/include/version/l2tp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/l2tp-version.xml.i -->
-<syntaxVersion component='l2tp' version='6'></syntaxVersion>
+<syntaxVersion component='l2tp' version='7'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/include/version/pppoe-server-version.xml.i
+++ b/interface-definitions/include/version/pppoe-server-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/pppoe-server-version.xml.i -->
-<syntaxVersion component='pppoe-server' version='7'></syntaxVersion>
+<syntaxVersion component='pppoe-server' version='8'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/include/version/sstp-version.xml.i
+++ b/interface-definitions/include/version/sstp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/sstp-version.xml.i -->
-<syntaxVersion component='sstp' version='5'></syntaxVersion>
+<syntaxVersion component='sstp' version='6'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/service_ipoe-server.xml.in
+++ b/interface-definitions/service_ipoe-server.xml.in
@@ -183,6 +183,7 @@
             </children>
           </node>
           #include <include/accel-ppp/default-pool.xml.i>
+          #include <include/accel-ppp/default-ipv6-pool.xml.i>
         </children>
       </node>
     </children>

--- a/interface-definitions/service_pppoe-server.xml.in
+++ b/interface-definitions/service_pppoe-server.xml.in
@@ -274,6 +274,7 @@
             </children>
           </node>
           #include <include/accel-ppp/default-pool.xml.i>
+          #include <include/accel-ppp/default-ipv6-pool.xml.i>
         </children>
       </node>
     </children>

--- a/interface-definitions/vpn_l2tp.xml.in
+++ b/interface-definitions/vpn_l2tp.xml.in
@@ -154,6 +154,7 @@
                 </children>
               </node>
               #include <include/accel-ppp/default-pool.xml.i>
+              #include <include/accel-ppp/default-ipv6-pool.xml.i>
             </children>
           </node>
         </children>

--- a/interface-definitions/vpn_pptp.xml.in
+++ b/interface-definitions/vpn_pptp.xml.in
@@ -134,6 +134,7 @@
                 </children>
               </node>
               #include <include/accel-ppp/default-pool.xml.i>
+              #include <include/accel-ppp/default-ipv6-pool.xml.i>
             </children>
           </node>
         </children>

--- a/interface-definitions/vpn_sstp.xml.in
+++ b/interface-definitions/vpn_sstp.xml.in
@@ -36,6 +36,7 @@
             <defaultValue>443</defaultValue>
           </leafNode>
           #include <include/accel-ppp/default-pool.xml.i>
+          #include <include/accel-ppp/default-ipv6-pool.xml.i>
           <node name="ppp-options">
             <properties>
               <help>PPP (Point-to-Point Protocol) settings</help>

--- a/smoketest/scripts/cli/test_service_ipoe-server.py
+++ b/smoketest/scripts/cli/test_service_ipoe-server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022-2023 VyOS maintainers and contributors
+# Copyright (C) 2022-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -188,6 +188,45 @@ gw-ip-address={third_gateway.split('/')[0]}
 {first_subnet},name={first_pool},next={second_pool}"""
         self.assertIn(pool_config, config)
 
+    def test_accel_ipv6_pool(self):
+        # Test configuration of IPv6 client pools
+        self.basic_config(is_gateway=False, is_client_pool=False)
+
+        pool_name = 'ipv6_test_pool'
+        prefix_1 = '2001:db8:fffe::/56'
+        prefix_mask = '64'
+        prefix_2 = '2001:db8:ffff::/56'
+        client_prefix_1 = f'{prefix_1},{prefix_mask}'
+        client_prefix_2 = f'{prefix_2},{prefix_mask}'
+        self.set(['client-ipv6-pool', pool_name, 'prefix', prefix_1, 'mask',
+                  prefix_mask])
+        self.set(['client-ipv6-pool', pool_name, 'prefix', prefix_2, 'mask',
+                  prefix_mask])
+
+        delegate_1_prefix = '2001:db8:fff1::/56'
+        delegate_2_prefix = '2001:db8:fff2::/56'
+        delegate_mask = '64'
+        self.set(['client-ipv6-pool', pool_name, 'delegate', delegate_1_prefix,
+                  'delegation-prefix', delegate_mask])
+        self.set(['client-ipv6-pool', pool_name, 'delegate', delegate_2_prefix,
+                  'delegation-prefix', delegate_mask])
+
+        # commit changes
+        self.cli_commit()
+
+        # Validate configuration values
+        conf = ConfigParser(allow_no_value=True, delimiters='=', strict=False)
+        conf.read(self._config_file)
+
+        for tmp in ['ipv6pool', 'ipv6_nd', 'ipv6_dhcp']:
+            self.assertEqual(conf['modules'][tmp], None)
+
+        config = self.getConfig("ipv6-pool")
+        pool_config = f"""{client_prefix_1},name={pool_name}
+{client_prefix_2},name={pool_name}
+delegate={delegate_1_prefix},{delegate_mask},name={pool_name}
+delegate={delegate_2_prefix},{delegate_mask},name={pool_name}"""
+        self.assertIn(pool_config, config)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/smoketest/scripts/cli/test_vpn_pptp.py
+++ b/smoketest/scripts/cli/test_vpn_pptp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2023 VyOS maintainers and contributors
+# Copyright (C) 2023-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -217,6 +217,10 @@ class TestVPNPPTPServer(BasicAccelPPPTest.TestCase):
         self.assertEqual(f"acct-port=0", server[3])
         self.assertEqual(f"req-limit=0", server[4])
         self.assertEqual(f"fail-time=0", server[5])
+
+    @unittest.skip("IPv6 is not implemented in PPTP")
+    def test_accel_ipv6_pool(self):
+        pass
 
 
 if __name__ == '__main__':

--- a/src/conf_mode/service_ipoe-server.py
+++ b/src/conf_mode/service_ipoe-server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2023 VyOS maintainers and contributors
+# Copyright (C) 2018-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -79,9 +79,6 @@ def verify(ipoe):
             if 'key' not in radius_config:
                 raise ConfigError(f'Missing RADIUS secret key for server "{server}"')
 
-    if 'client_ipv6_pool' in ipoe:
-        if 'delegate' in ipoe['client_ipv6_pool'] and 'prefix' not in ipoe['client_ipv6_pool']:
-            raise ConfigError('IPoE IPv6 deletate-prefix requires IPv6 prefix to be configured!')
 
     return None
 

--- a/src/conf_mode/service_pppoe-server.py
+++ b/src/conf_mode/service_pppoe-server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2023 VyOS maintainers and contributors
+# Copyright (C) 2018-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -84,6 +84,7 @@ def verify(pppoe):
     if dict_search('authentication.radius.dynamic_author.server', pppoe):
         if not dict_search('authentication.radius.dynamic_author.key', pppoe):
             raise ConfigError('DA/CoE server key required!')
+
 
     return None
 

--- a/src/conf_mode/vpn_l2tp.py
+++ b/src/conf_mode/vpn_l2tp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2023 VyOS maintainers and contributors
+# Copyright (C) 2019-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -70,14 +70,8 @@ def verify(l2tp):
         if not dict_search('authentication.radius.dynamic_author.key', l2tp):
             raise ConfigError('DA/CoE server key required!')
 
-    if dict_search('authentication.mode', l2tp) in ['local', 'noauth']:
-        if not dict_search('client_ip_pool', l2tp) and not dict_search('client_ipv6_pool', l2tp):
-            raise ConfigError(
-                "L2TP local auth mode requires local client-ip-pool or client-ipv6-pool to be configured!")
-        if dict_search('client_ip_pool', l2tp) and not dict_search('default_pool', l2tp):
-            Warning("'default-pool' is not defined")
-
     verify_accel_ppp_ip_pool(l2tp)
+
 
     if 'wins_server' in l2tp and len(l2tp['wins_server']) > 2:
         raise ConfigError(

--- a/src/conf_mode/vpn_pptp.py
+++ b/src/conf_mode/vpn_pptp.py
@@ -80,12 +80,6 @@ def verify(pptp):
                 raise ConfigError(
                     f'Missing RADIUS secret key for server "{server}"')
 
-    if auth_mode == 'local' or auth_mode == 'noauth':
-        if not dict_search('client_ip_pool', pptp):
-            raise ConfigError(
-                'PPTP local auth mode requires local client-ip-pool '
-                'to be configured!')
-
     verify_accel_ppp_ip_pool(pptp)
 
     if 'name_server' in pptp:

--- a/src/conf_mode/vpn_sstp.py
+++ b/src/conf_mode/vpn_sstp.py
@@ -74,11 +74,8 @@ def verify(sstp):
         raise ConfigError(f'"{proto}" port "{port}" is used by another service')
 
     verify_accel_ppp_base_service(sstp)
-
-    if 'client_ip_pool' not in sstp and 'client_ipv6_pool' not in sstp:
-        raise ConfigError('Client IP subnet required')
-
     verify_accel_ppp_ip_pool(sstp)
+
     #
     # SSL certificate checks
     #

--- a/src/migration-scripts/ipoe-server/2-to-3
+++ b/src/migration-scripts/ipoe-server/2-to-3
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Migrating to named ipv6 pools
+
+import os
+
+from sys import argv
+from sys import exit
+from vyos.configtree import ConfigTree
+
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+base = ['service', 'ipoe-server']
+pool_base = base + ['client-ipv6-pool']
+if not config.exists(base):
+    exit(0)
+
+if not config.exists(pool_base):
+    exit(0)
+
+ipv6_pool_name = 'ipv6-pool'
+config.copy(pool_base, pool_base + [ipv6_pool_name])
+
+if config.exists(pool_base + ['prefix']):
+    config.delete(pool_base + ['prefix'])
+    config.set(base + ['default-ipv6-pool'], value=ipv6_pool_name)
+if config.exists(pool_base + ['delegate']):
+    config.delete(pool_base + ['delegate'])
+
+# format as tag node
+config.set_tag(pool_base)
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)

--- a/src/migration-scripts/l2tp/6-to-7
+++ b/src/migration-scripts/l2tp/6-to-7
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Migrating to named ipv6 pools
+
+import os
+
+from sys import argv
+from sys import exit
+from vyos.configtree import ConfigTree
+
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+base = ['vpn', 'l2tp', 'remote-access']
+pool_base = base + ['client-ipv6-pool']
+if not config.exists(base):
+    exit(0)
+
+if not config.exists(pool_base):
+    exit(0)
+
+ipv6_pool_name = 'ipv6-pool'
+config.copy(pool_base, pool_base + [ipv6_pool_name])
+
+if config.exists(pool_base + ['prefix']):
+    config.delete(pool_base + ['prefix'])
+    config.set(base + ['default-ipv6-pool'], value=ipv6_pool_name)
+if config.exists(pool_base + ['delegate']):
+    config.delete(pool_base + ['delegate'])
+# format as tag node
+config.set_tag(pool_base)
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)

--- a/src/migration-scripts/pppoe-server/7-to-8
+++ b/src/migration-scripts/pppoe-server/7-to-8
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Migrating to named ipv6 pools
+
+import os
+
+from sys import argv
+from sys import exit
+from vyos.configtree import ConfigTree
+
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+base = ['service', 'pppoe-server']
+pool_base = base + ['client-ipv6-pool']
+if not config.exists(base):
+    exit(0)
+
+if not config.exists(pool_base):
+    exit(0)
+
+ipv6_pool_name = 'ipv6-pool'
+config.copy(pool_base, pool_base + [ipv6_pool_name])
+
+if config.exists(pool_base + ['prefix']):
+    config.delete(pool_base + ['prefix'])
+    config.set(base + ['default-ipv6-pool'], value=ipv6_pool_name)
+if config.exists(pool_base + ['delegate']):
+    config.delete(pool_base + ['delegate'])
+
+# format as tag node
+config.set_tag(pool_base)
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)

--- a/src/migration-scripts/sstp/5-to-6
+++ b/src/migration-scripts/sstp/5-to-6
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Migrating to named ipv6 pools
+
+import os
+import pprint
+
+from sys import argv
+from sys import exit
+from vyos.configtree import ConfigTree
+
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+base = ['vpn', 'sstp']
+pool_base = base + ['client-ipv6-pool']
+if not config.exists(base):
+    exit(0)
+
+if not config.exists(pool_base):
+    exit(0)
+
+ipv6_pool_name = 'ipv6-pool'
+config.copy(pool_base, pool_base + [ipv6_pool_name])
+
+if config.exists(pool_base + ['prefix']):
+    config.delete(pool_base + ['prefix'])
+    config.set(base + ['default-ipv6-pool'], value=ipv6_pool_name)
+if config.exists(pool_base + ['delegate']):
+    config.delete(pool_base + ['delegate'])
+
+# format as tag node
+config.set_tag(pool_base)
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Moved ipv6 pools to named ipv6 pools in accel-ppp services

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5865

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe, ipoe, l2tp, sstp

## Proposed changes
<!--- Describe your changes in detail -->
Moved ipv6 pools to named ipv6 pools in accel-ppp services
Old format of IPv6 pools
```
set vpn sstp client-ipv6-pool delegate 2A02:838F:F881::/48 delegation-prefix '64'
set vpn sstp client-ipv6-pool prefix 2001:db8:8002::/48 mask '64'
set vpn sstp client-ipv6-pool prefix 2001:db8:8003::/48 mask '64'

```
New format
```
set vpn sstp client-ipv6-pool ipv6-pool delegate 2A02:838F:F881::/48 delegation-prefix '64'
set vpn sstp client-ipv6-pool ipv6-pool prefix 2001:db8:8002::/48 mask '64'
set vpn sstp client-ipv6-pool ipv6-pool prefix 2001:db8:8003::/48 mask '64'
set vpn sstp default-ipv6-pool 'ipv6-pool'
```
It allows to create multiple IPv6 pools and to use Radius attributes **_Delegated-IPv6-Prefix-Pool_** and **_Stateful-IPv6-Address-Pool_**
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_ipoe-server.py
test_accel_ipv4_pool (__main__.TestServiceIPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServiceIPoEServer.test_accel_ipv6_pool) ...
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_local_authentication (__main__.TestServiceIPoEServer.test_accel_local_authentication) ...
No IPoE interface configured

ok
test_accel_name_servers (__main__.TestServiceIPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServiceIPoEServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_radius_authentication (__main__.TestServiceIPoEServer.test_accel_radius_authentication) ... ok

----------------------------------------------------------------------
Ran 6 tests in 20.365s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py
test_accel_ipv4_pool (__main__.TestServicePPPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServicePPPoEServer.test_accel_ipv6_pool) ...
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_local_authentication (__main__.TestServicePPPoEServer.test_accel_local_authentication) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_name_servers (__main__.TestServicePPPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServicePPPoEServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer.test_accel_radius_authentication) ... ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer.test_pppoe_server_authentication_protocols) ... ok
test_pppoe_server_ppp_options (__main__.TestServicePPPoEServer.test_pppoe_server_ppp_options) ... ok
test_pppoe_server_shaper (__main__.TestServicePPPoEServer.test_pppoe_server_shaper) ... ok
test_pppoe_server_vlan (__main__.TestServicePPPoEServer.test_pppoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 10 tests in 35.606s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_l2tp.py
test_accel_ipv4_pool (__main__.TestVPNL2TPServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestVPNL2TPServer.test_accel_ipv6_pool) ...
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_local_authentication (__main__.TestVPNL2TPServer.test_accel_local_authentication) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_name_servers (__main__.TestVPNL2TPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNL2TPServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_radius_authentication (__main__.TestVPNL2TPServer.test_accel_radius_authentication) ... ok
test_l2tp_server_authentication_protocols (__main__.TestVPNL2TPServer.test_l2tp_server_authentication_protocols) ... ok
test_l2tp_server_ppp_options (__main__.TestVPNL2TPServer.test_l2tp_server_ppp_options) ... ok

----------------------------------------------------------------------
Ran 8 tests in 30.226s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_pptp.py
test_accel_ipv4_pool (__main__.TestVPNPPTPServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestVPNPPTPServer.test_accel_ipv6_pool) ... skipped 'IPv6 is not implemented in PPTP'
test_accel_local_authentication (__main__.TestVPNPPTPServer.test_accel_local_authentication) ... ok
test_accel_name_servers (__main__.TestVPNPPTPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNPPTPServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_radius_authentication (__main__.TestVPNPPTPServer.test_accel_radius_authentication) ... ok

----------------------------------------------------------------------
Ran 6 tests in 19.989s

OK (skipped=1)
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_sstp.py
test_accel_ipv4_pool (__main__.TestVPNSSTPServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestVPNSSTPServer.test_accel_ipv6_pool) ...
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_local_authentication (__main__.TestVPNSSTPServer.test_accel_local_authentication) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_name_servers (__main__.TestVPNSSTPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNSSTPServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_radius_authentication (__main__.TestVPNSSTPServer.test_accel_radius_authentication) ... ok

----------------------------------------------------------------------
Ran 6 tests in 25.082s

OK
vyos@vyos:~$
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
