### PR TITLE
T4658: Renamed DPD action value from 'hold' to 'trap'

### DIFF
--- a/data/templates/ipsec/swanctl/peer.j2
+++ b/data/templates/ipsec/swanctl/peer.j2
@@ -83,8 +83,7 @@
                 start_action = none
 {%     endif %}
 {%     if ike.dead_peer_detection is vyos_defined %}
-{%         set dpd_translate = {'clear': 'clear', 'hold': 'trap', 'restart': 'restart'} %}
-                dpd_action = {{ dpd_translate[ike.dead_peer_detection.action] }}
+                dpd_action = {{ ike.dead_peer_detection.action }}
 {%     endif %}
                 close_action = {{ {'none': 'none', 'hold': 'trap', 'restart': 'start'}[ike.close_action] }}
             }
@@ -134,8 +133,7 @@
                 start_action = none
 {%         endif %}
 {%         if ike.dead_peer_detection is vyos_defined %}
-{%             set dpd_translate = {'clear': 'clear', 'hold': 'trap', 'restart': 'restart'} %}
-                dpd_action = {{ dpd_translate[ike.dead_peer_detection.action] }}
+                dpd_action = {{ ike.dead_peer_detection.action }}
 {%         endif %}
                 close_action = {{ {'none': 'none', 'hold': 'trap', 'restart': 'start'}[ike.close_action] }}
 {%         if peer_conf.vti.bind is vyos_defined %}

--- a/interface-definitions/include/version/ipsec-version.xml.i
+++ b/interface-definitions/include/version/ipsec-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/ipsec-version.xml.i -->
-<syntaxVersion component='ipsec' version='12'></syntaxVersion>
+<syntaxVersion component='ipsec' version='13'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -280,10 +280,10 @@
                     <properties>
                       <help>Keep-alive failure action</help>
                       <completionHelp>
-                        <list>hold clear restart</list>
+                        <list>trap clear restart</list>
                       </completionHelp>
                       <valueHelp>
-                        <format>hold</format>
+                        <format>trap</format>
                         <description>Attempt to re-negotiate the connection when matching traffic is seen</description>
                       </valueHelp>
                       <valueHelp>
@@ -295,7 +295,7 @@
                         <description>Attempt to re-negotiate the connection immediately</description>
                       </valueHelp>
                       <constraint>
-                        <regex>(hold|clear|restart)</regex>
+                        <regex>(trap|clear|restart)</regex>
                       </constraint>
                     </properties>
                     <defaultValue>clear</defaultValue>

--- a/src/migration-scripts/ipsec/12-to-13
+++ b/src/migration-scripts/ipsec/12-to-13
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Changed value of dead-peer-detection.action from hold to trap
+
+import re
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['vpn', 'ipsec', 'ike-group']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+else:
+    for ike_group in config.list_nodes(base):
+        base_dpd_action = base + [ike_group, 'dead-peer-detection', 'action']
+        if config.exists(base_dpd_action) and config.return_value(base_dpd_action) == 'hold':
+            config.set(base_dpd_action, 'trap', replace=True)
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print(f'Failed to save the modified config: {e}')
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Renamed DPD action value from 'hold' to 'trap'

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4658

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec

## Proposed changes
<!--- Describe your changes in detail -->
Renamed DPD action value from 'hold' to 'trap'
```
vyos@vyos# set vpn ipsec ike-group TEST1  dead-peer-detection action
Possible completions:
   trap                 Attempt to re-negotiate the connection when matching traffic is seen
   clear                Remove the connection immediately (default)
   restart              Attempt to re-negotiate the connection immediately
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
test_01_dhcp_fail_handling (__main__.TestVPNIPsec.test_01_dhcp_fail_handling) ... You should set correct remote-address "peer main-branch remote-address x.x.x.x"

Failed to get address from dhcp-interface on site-to-site peer main-branch -- skipped
ok
test_02_site_to_site (__main__.TestVPNIPsec.test_02_site_to_site) ... ok
test_03_site_to_site_vti (__main__.TestVPNIPsec.test_03_site_to_site_vti) ...
WARNING: It's recommended to use ipsec vti with the next command
[set vpn ipsec option disable-route-autoinstall]

ok
test_04_dmvpn (__main__.TestVPNIPsec.test_04_dmvpn) ... ok
test_05_x509_site2site (__main__.TestVPNIPsec.test_05_x509_site2site) ...
WARNING: It's recommended to use ipsec vti with the next command
[set vpn ipsec option disable-route-autoinstall]

ok
test_06_flex_vpn_vips (__main__.TestVPNIPsec.test_06_flex_vpn_vips) ... ok
test_07_ikev2_road_warrior (__main__.TestVPNIPsec.test_07_ikev2_road_warrior) ...
Missing esp-group on vyos-rw remote-access config

ok
test_08_ikev2_road_warrior_client_auth_eap_tls (__main__.TestVPNIPsec.test_08_ikev2_road_warrior_client_auth_eap_tls) ...
Missing esp-group on vyos-rw remote-access config

ok
test_09_ikev2_road_warrior_client_auth_x509 (__main__.TestVPNIPsec.test_09_ikev2_road_warrior_client_auth_x509) ...
Missing esp-group on vyos-rw remote-access config

ok

----------------------------------------------------------------------
Ran 9 tests in 38.351s

OK

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
