### PR TITLE
dhcp: T5952: Fix validate duplicate MAC Address on same subnet

### DIFF
--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020-2021 VyOS maintainers and contributors
+# Copyright (C) 2020-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -383,11 +383,29 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(pool + ['static-mapping', 'client1', 'duid'])
 
         # cannot have mappings with duplicate IP addresses
+        self.cli_set(pool + ['static-mapping', 'dupe1', 'mac', '00:50:00:00:fe:ff'])
+        self.cli_set(pool + ['static-mapping', 'dupe1', 'ip-address', inc_ip(subnet, 10)])
         with self.assertRaises(ConfigSessionError):
-            self.cli_set(pool + ['static-mapping', 'dupe1', 'mac', '00:50:00:00:00:01'])
-            self.cli_set(pool + ['static-mapping', 'dupe1', 'ip-address', inc_ip(subnet, 10)])
             self.cli_commit()
         self.cli_delete(pool + ['static-mapping', 'dupe1'])
+
+        # cannot have mappings with duplicate MAC addresses
+        self.cli_set(pool + ['static-mapping', 'dupe2', 'mac', '00:50:00:00:00:10'])
+        self.cli_set(pool + ['static-mapping', 'dupe2', 'ip-address', inc_ip(subnet, 120)])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(pool + ['static-mapping', 'dupe2'])
+
+
+        # cannot have mappings with duplicate MAC addresses
+        self.cli_set(pool + ['static-mapping', 'dupe3', 'duid', '00:01:02:03:04:05:06:07:aa:aa:aa:aa:aa:01'])
+        self.cli_set(pool + ['static-mapping', 'dupe3', 'ip-address', inc_ip(subnet, 121)])
+        self.cli_set(pool + ['static-mapping', 'dupe4', 'duid', '00:01:02:03:04:05:06:07:aa:aa:aa:aa:aa:01'])
+        self.cli_set(pool + ['static-mapping', 'dupe4', 'ip-address', inc_ip(subnet, 121)])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(pool + ['static-mapping', 'dupe3'])
+        self.cli_delete(pool + ['static-mapping', 'dupe4'])
 
         # commit changes
         self.cli_commit()

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -233,6 +233,7 @@ def verify(dhcp):
             if 'static_mapping' in subnet_config:
                 # Static mappings require just a MAC address (will use an IP from the dynamic pool if IP is not set)
                 used_ips = []
+                used_mac = []
                 for mapping, mapping_config in subnet_config['static_mapping'].items():
                     if 'ip_address' in mapping_config:
                         if ip_address(mapping_config['ip_address']) not in ip_network(subnet):
@@ -247,7 +248,11 @@ def verify(dhcp):
                         if mapping_config['ip_address'] in used_ips:
                             raise ConfigError(f'Configured IP address for static mapping "{mapping}" exists on another static mapping')
 
+                        if mapping_config['mac'] in used_mac:
+                            raise ConfigError(f'Configured MAC address for static mapping "{mapping}" exists on another static mapping')
+
                         used_ips.append(mapping_config['ip_address'])
+                        used_mac.append(mapping_config['mac'])
 
             # There must be one subnet connected to a listen interface.
             # This only counts if the network itself is not disabled!

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -247,12 +247,13 @@ def verify(dhcp):
 
                         if mapping_config['ip_address'] in used_ips:
                             raise ConfigError(f'Configured IP address for static mapping "{mapping}" exists on another static mapping')
+                        used_ips.append(mapping_config['ip_address'])
 
+                    if 'mac' in mapping_config:
                         if mapping_config['mac'] in used_mac:
                             raise ConfigError(f'Configured MAC address for static mapping "{mapping}" exists on another static mapping')
-
-                        used_ips.append(mapping_config['ip_address'])
                         used_mac.append(mapping_config['mac'])
+
 
             # There must be one subnet connected to a listen interface.
             # This only counts if the network itself is not disabled!

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2023 VyOS maintainers and contributors
+# Copyright (C) 2018-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -234,6 +234,7 @@ def verify(dhcp):
                 # Static mappings require just a MAC address (will use an IP from the dynamic pool if IP is not set)
                 used_ips = []
                 used_mac = []
+                used_duid = []
                 for mapping, mapping_config in subnet_config['static_mapping'].items():
                     if 'ip_address' in mapping_config:
                         if ip_address(mapping_config['ip_address']) not in ip_network(subnet):
@@ -246,14 +247,18 @@ def verify(dhcp):
                                               f'static mapping "{mapping}" within shared-network "{network}, {subnet}"!')
 
                         if mapping_config['ip_address'] in used_ips:
-                            raise ConfigError(f'Configured IP address for static mapping "{mapping}" exists on another static mapping')
+                            raise ConfigError(f'Configured IP address for static mapping "{mapping}" already exists on another static mapping')
                         used_ips.append(mapping_config['ip_address'])
 
                     if 'mac' in mapping_config:
                         if mapping_config['mac'] in used_mac:
-                            raise ConfigError(f'Configured MAC address for static mapping "{mapping}" exists on another static mapping')
+                            raise ConfigError(f'Configured MAC address for static mapping "{mapping}" already exists on another static mapping')
                         used_mac.append(mapping_config['mac'])
 
+                    if 'duid' in mapping_config:
+                        if mapping_config['duid'] in used_duid:
+                            raise ConfigError(f'Configured DUID for static mapping "{mapping}" already exists on another static mapping')
+                        used_duid.append(mapping_config['duid'])
 
             # There must be one subnet connected to a listen interface.
             # This only counts if the network itself is not disabled!


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Fix for not allow create static-mappings with the same MAC Address on same subnet -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5952

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- dhcp  -->

## Proposed changes
<!--- Perform a validation if the same MAC Address exist on the same subnet don't allow save the configuration-->

## How to test
<!---
set service dhcp-server shared-network-name lan subnet 10.5.5.0/24 static-mapping server ip-address '10.5.5.4'
set service dhcp-server shared-network-name lan subnet 10.5.5.0/24 static-mapping server mac '00:00:00:00:00:00'
set service dhcp-server shared-network-name lan subnet 10.5.5.0/24 static-mapping server1 ip-address '10.5.5.5'
set service dhcp-server shared-network-name lan subnet 10.5.5.0/24 static-mapping server1 mac '00:00:00:00:00:00'
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
