### PR TITLE
T5953: Changed values of 'close-action' to Strongswan values

### DIFF
--- a/data/templates/ipsec/swanctl/peer.j2
+++ b/data/templates/ipsec/swanctl/peer.j2
@@ -85,7 +85,7 @@
 {%     if ike.dead_peer_detection is vyos_defined %}
                 dpd_action = {{ ike.dead_peer_detection.action }}
 {%     endif %}
-                close_action = {{ {'none': 'none', 'hold': 'trap', 'restart': 'start'}[ike.close_action] }}
+                close_action = {{ ike.close_action }}
             }
 {% elif peer_conf.tunnel is vyos_defined %}
 {%     for tunnel_id, tunnel_conf in peer_conf.tunnel.items() if tunnel_conf.disable is not defined %}
@@ -135,7 +135,7 @@
 {%         if ike.dead_peer_detection is vyos_defined %}
                 dpd_action = {{ ike.dead_peer_detection.action }}
 {%         endif %}
-                close_action = {{ {'none': 'none', 'hold': 'trap', 'restart': 'start'}[ike.close_action] }}
+                close_action = {{ ike.close_action }}
 {%         if peer_conf.vti.bind is vyos_defined %}
 {#             The key defaults to 0 and will match any policies which similarly do not have a lookup key configuration. #}
 {#             Thus we simply shift the key by one to also support a vti0 interface #}

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -251,22 +251,22 @@
                 <properties>
                   <help>Action to take if a child SA is unexpectedly closed</help>
                   <completionHelp>
-                    <list>none hold restart</list>
+                    <list>none trap start</list>
                   </completionHelp>
                   <valueHelp>
                     <format>none</format>
                     <description>Do nothing</description>
                   </valueHelp>
                   <valueHelp>
-                    <format>hold</format>
+                    <format>trap</format>
                     <description>Attempt to re-negotiate when matching traffic is seen</description>
                   </valueHelp>
                   <valueHelp>
-                    <format>restart</format>
+                    <format>start</format>
                     <description>Attempt to re-negotiate the connection immediately</description>
                   </valueHelp>
                   <constraint>
-                    <regex>(none|hold|restart)</regex>
+                    <regex>(none|trap|start)</regex>
                   </constraint>
                 </properties>
                 <defaultValue>none</defaultValue>

--- a/src/migration-scripts/ipsec/12-to-13
+++ b/src/migration-scripts/ipsec/12-to-13
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Changed value of dead-peer-detection.action from hold to trap
+# Changed value of close-action from hold to trap and from restart to start
 
 import re
 
@@ -41,8 +42,14 @@ if not config.exists(base):
 else:
     for ike_group in config.list_nodes(base):
         base_dpd_action = base + [ike_group, 'dead-peer-detection', 'action']
+        base_close_action = base + [ike_group, 'close-action']
         if config.exists(base_dpd_action) and config.return_value(base_dpd_action) == 'hold':
             config.set(base_dpd_action, 'trap', replace=True)
+        if config.exists(base_close_action):
+            if config.return_value(base_close_action) == 'hold':
+                config.set(base_close_action, 'trap', replace=True)
+            if config.return_value(base_close_action) == 'restart':
+                config.set(base_close_action, 'start', replace=True)
 
 try:
     with open(file_name, 'w') as f:


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Changed the value from 'hold' to 'trap' in the 'close-action' option in the IKE group.
Changed the value from 'restart' to 'start' in the 'close-action' option in the IKE group.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5953

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec

## Proposed changes
<!--- Describe your changes in detail -->
Changed the value from 'hold' to 'trap' in the 'close-action' option in the IKE group.
Changed the value from 'restart' to 'start' in the 'close-action' option in the IKE group.
```
vyos@vyos# set vpn ipsec ike-group MyIKEGroup close-action
Possible completions:
   none                 Do nothing (default)
   trap                 Attempt to re-negotiate when matching traffic is seen
   start                Attempt to re-negotiate the connection immediately
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
test_01_dhcp_fail_handling (__main__.TestVPNIPsec.test_01_dhcp_fail_handling) ... You should set correct remote-address "peer main-branch remote-address x.x.x.x"

Failed to get address from dhcp-interface on site-to-site peer main-branch -- skipped
ok
test_02_site_to_site (__main__.TestVPNIPsec.test_02_site_to_site) ... ok
test_03_site_to_site_vti (__main__.TestVPNIPsec.test_03_site_to_site_vti) ...
WARNING: It's recommended to use ipsec vti with the next command
[set vpn ipsec option disable-route-autoinstall]

ok
test_04_dmvpn (__main__.TestVPNIPsec.test_04_dmvpn) ... ok
test_05_x509_site2site (__main__.TestVPNIPsec.test_05_x509_site2site) ...
WARNING: It's recommended to use ipsec vti with the next command
[set vpn ipsec option disable-route-autoinstall]

ok
test_06_flex_vpn_vips (__main__.TestVPNIPsec.test_06_flex_vpn_vips) ... ok
test_07_ikev2_road_warrior (__main__.TestVPNIPsec.test_07_ikev2_road_warrior) ...
Missing esp-group on vyos-rw remote-access config

ok
test_08_ikev2_road_warrior_client_auth_eap_tls (__main__.TestVPNIPsec.test_08_ikev2_road_warrior_client_auth_eap_tls) ...
Missing esp-group on vyos-rw remote-access config

ok
test_09_ikev2_road_warrior_client_auth_x509 (__main__.TestVPNIPsec.test_09_ikev2_road_warrior_client_auth_x509) ...
Missing esp-group on vyos-rw remote-access config

ok

----------------------------------------------------------------------
Ran 9 tests in 38.964s

OK

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
