### PR TITLE
T5958: QoS add basic implementation of policy shaper-hfsc

### DIFF
--- a/interface-definitions/include/qos/hfsc-m1.xml.i
+++ b/interface-definitions/include/qos/hfsc-m1.xml.i
@@ -27,6 +27,6 @@
       <description>bps(8),kbps(8*10^3),mbps(8*10^6), gbps, tbps - Byte/sec</description>
     </valueHelp>
   </properties>
-  <defaultValue>100%%</defaultValue>
+  <defaultValue>0bit</defaultValue>
 </leafNode>
 <!-- include end -->

--- a/interface-definitions/include/qos/hfsc-m2.xml.i
+++ b/interface-definitions/include/qos/hfsc-m2.xml.i
@@ -27,6 +27,6 @@
       <description>bps(8),kbps(8*10^3),mbps(8*10^6), gbps, tbps - Byte/sec</description>
     </valueHelp>
   </properties>
-  <defaultValue>100%%</defaultValue>
+  <defaultValue>100%</defaultValue>
 </leafNode>
 <!-- include end -->

--- a/python/vyos/qos/trafficshaper.py
+++ b/python/vyos/qos/trafficshaper.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2022-2024 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -117,8 +117,91 @@ class TrafficShaper(QoSBase):
         # call base class
         super().update(config, direction)
 
-class TrafficShaperHFSC(TrafficShaper):
+class TrafficShaperHFSC(QoSBase):
+    _parent = 1
+    qostype = 'shaper_hfsc'
+
+    # https://man7.org/linux/man-pages/man8/tc-hfsc.8.html
     def update(self, config, direction):
+        class_id_max = 0
+        if 'class' in config:
+            tmp = list(config['class'])
+            tmp.sort()
+            class_id_max = tmp[-1]
+
+        r2q = 10
+        # bandwidth is a mandatory CLI node
+        speed = self._rate_convert(config['bandwidth'])
+        speed_bps = int(speed) // 8
+
+        # need a bigger r2q if going fast than 16 mbits/sec
+        if (speed_bps // r2q) >= MAXQUANTUM: # integer division
+            r2q = ceil(speed_bps // MAXQUANTUM)
+        else:
+            # if there is a slow class then may need smaller value
+            if 'class' in config:
+                min_speed = speed_bps
+                for cls, cls_options in config['class'].items():
+                    # find class with the lowest bandwidth used
+                    if 'bandwidth' in cls_options:
+                        bw_bps = int(self._rate_convert(cls_options['bandwidth'])) // 8 # bandwidth in bytes per second
+                        if bw_bps < min_speed:
+                            min_speed = bw_bps
+
+                while (r2q > 1) and (min_speed // r2q) < MINQUANTUM:
+                    tmp = r2q -1
+                    if (speed_bps // tmp) >= MAXQUANTUM:
+                        break
+                    r2q = tmp
+
+        default_minor_id = int(class_id_max) +1
+        tmp = f'tc qdisc replace dev {self._interface} root handle {self._parent:x}: hfsc default {default_minor_id:x}' # default is in hex
+        self._cmd(tmp)
+
+        tmp = f'tc class replace dev {self._interface} parent {self._parent:x}: classid {self._parent:x}:1 hfsc sc rate {speed} ul rate {speed}'
+        self._cmd(tmp)
+
+        if 'class' in config:
+            for cls, cls_config in config['class'].items():
+                # class id is used later on and passed as hex, thus this needs to be an int
+                cls = int(cls)
+                # ls m1
+                if cls_config.get('linkshare', {}).get('m1').endswith('%'):
+                    percent = cls_config['linkshare']['m1'].rstrip('%')
+                    m_one_rate = self._rate_convert(config['bandwidth']) * int(percent) // 100
+                else:
+                    m_one_rate = cls_config['linkshare']['m1']
+                # ls m2
+                if cls_config.get('linkshare', {}).get('m2').endswith('%'):
+                    percent = cls_config['linkshare']['m2'].rstrip('%')
+                    m_two_rate = self._rate_convert(config['bandwidth']) * int(percent) // 100
+                else:
+                    m_two_rate = self._rate_convert(cls_config['linkshare']['m2'])
+
+                tmp = f'tc class replace dev {self._interface} parent {self._parent:x}:1 classid {self._parent:x}:{cls:x} hfsc ls m1 {m_one_rate} m2 {m_two_rate} '
+                self._cmd(tmp)
+
+                tmp = f'tc qdisc replace dev {self._interface} parent {self._parent:x}:{cls:x} sfq perturb 10'
+                self._cmd(tmp)
+
+        if 'default' in config:
+            # ls m1
+            if config.get('default', {}).get('linkshare', {}).get('m1').endswith('%'):
+                percent = config['default']['linkshare']['m1'].rstrip('%')
+                m_one_rate = self._rate_convert(config['default']['linkshare']['m1']) * int(percent) // 100
+            else:
+                m_one_rate = config['default']['linkshare']['m1']
+            # ls m2
+            if config.get('default', {}).get('linkshare', {}).get('m2').endswith('%'):
+                percent = config['default']['linkshare']['m2'].rstrip('%')
+                m_two_rate = self._rate_convert(config['default']['linkshare']['m2']) * int(percent) // 100
+            else:
+                m_two_rate = self._rate_convert(config['default']['linkshare']['m2'])
+            tmp = f'tc class replace dev {self._interface} parent {self._parent:x}:1 classid {self._parent:x}:{default_minor_id:x} hfsc ls m1 {m_one_rate} m2 {m_two_rate} '
+            self._cmd(tmp)
+
+            tmp = f'tc qdisc replace dev {self._interface} parent {self._parent:x}:{default_minor_id:x} sfq perturb 10'
+            self._cmd(tmp)
+
         # call base class
         super().update(config, direction)
-

--- a/src/conf_mode/qos.py
+++ b/src/conf_mode/qos.py
@@ -149,7 +149,7 @@ def verify(qos):
                 if 'class' in policy_config:
                     for cls, cls_config in policy_config['class'].items():
                         # bandwidth is not mandatory for priority-queue - that is why this is on the exception list
-                        if 'bandwidth' not in cls_config and policy_type not in ['priority_queue', 'round_robin']:
+                        if 'bandwidth' not in cls_config and policy_type not in ['priority_queue', 'round_robin', 'shaper_hfsc']:
                             raise ConfigError(f'Bandwidth must be defined for policy "{policy}" class "{cls}"!')
                     if 'match' in cls_config:
                         for match, match_config in cls_config['match'].items():
@@ -173,7 +173,7 @@ def verify(qos):
                     if 'default' not in policy_config:
                         raise ConfigError(f'Policy {policy} misses "default" class!')
                 if 'default' in policy_config:
-                    if 'bandwidth' not in policy_config['default'] and policy_type not in ['priority_queue', 'round_robin']:
+                    if 'bandwidth' not in policy_config['default'] and policy_type not in ['priority_queue', 'round_robin', 'shaper_hfsc']:
                         raise ConfigError('Bandwidth not defined for default traffic!')
 
     # we should check interface ingress/egress configuration after verifying that


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
QoS policy shaper-hfsc was not implemented after rewriting the traffic-policy to qos policy. We had CLI, but it does not use the correct class. Add a basic implementation of policy shaper-hfsc. Write the class `TrafficShaperHFS`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5958

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
qos
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set qos policy shaper-hfsc SHAPE bandwidth '400mbit'
set qos policy shaper-hfsc SHAPE class 10 linkshare m2 '200mbit'
set qos policy shaper-hfsc SHAPE class 10 match DST ip destination address '192.0.2.1/32'
set qos policy shaper-hfsc SHAPE default linkshare m2 '111mbit'

set qos interface eth1 egress SHAPE

```
commit:
```
DEBUG/QoS: tc qdisc replace dev eth1 root handle 1: hfsc default b
DEBUG/QoS: tc class replace dev eth1 parent 1: classid 1:1 hfsc sc rate 400000000 ul rate 400000000
DEBUG/QoS: tc class replace dev eth1 parent 1:1 classid 1:a hfsc ls m1 0bit m2 200000000 
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:a sfq perturb 10
DEBUG/QoS: tc class replace dev eth1 parent 1:1 classid 1:b hfsc ls m1 0bit m2 111000000 
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:b sfq perturb 10
{'bandwidth': '400mbit',
 'class': {'10': {'linkshare': {'m1': '0bit', 'm2': '200mbit'},
                  'match': {'DST': {'ip': {'destination': {'address': '192.0.2.1/32'}}}},
                  'realtime': {'m1': '0bit', 'm2': '100%'},
                  'upperlimit': {'m1': '0bit', 'm2': '100%'}}},
 'default': {'linkshare': {'m1': '0bit', 'm2': '111mbit'},
             'realtime': {'m1': '0bit', 'm2': '100%'},
             'upperlimit': {'m1': '0bit', 'm2': '100%'}}}
DEBUG/QoS: tc filter add dev eth1 parent 1: protocol all u32 match ip dst 192.0.2.1/32 flowid 1:a

[edit]
vyos@r4# 

```
Check TC:
```
vyos@r4# tc qdisc show dev eth1
qdisc hfsc 1: root refcnt 2 default b 
qdisc sfq 807b: parent 1:b limit 127p quantum 1514b depth 127 divisor 1024 perturb 10sec 
qdisc sfq 807a: parent 1:a limit 127p quantum 1514b depth 127 divisor 1024 perturb 10sec 
[edit]
vyos@r4# 
[edit]
vyos@r4# tc class show dev eth1
class hfsc 1: root 
class hfsc 1:1 parent 1: sc m1 0bit d 0us m2 400Mbit ul m1 0bit d 0us m2 400Mbit 
class hfsc 1:a parent 1:1 leaf 807a: ls m1 0bit d 0us m2 200Mbit 
class hfsc 1:b parent 1:1 leaf 807b: ls m1 0bit d 0us m2 111Mbit 
[edit]
vyos@r4# 
[edit]
vyos@r4# tc filter show dev eth1
filter parent 1: protocol all pref 49152 u32 chain 0 
filter parent 1: protocol all pref 49152 u32 chain 0 fh 800: ht divisor 1 
filter parent 1: protocol all pref 49152 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 flowid 1:a not_in_hw 
  match c0000201/ffffffff at 16
[edit]
vyos@r4# 
```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_qos.py
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... skipped 'tc returns invalid JSON here - needs iproute2 fix'
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok

----------------------------------------------------------------------
Ran 11 tests in 71.759s

OK (skipped=1)
vyos@r4:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
