### PR TITLE
T5963: Fix QoS shaper rate calculations and set default 1Gbit

### DIFF
--- a/python/vyos/qos/base.py
+++ b/python/vyos/qos/base.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2022-2024 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -166,14 +166,17 @@ class QoSBase:
         }
 
         if rate == 'auto' or rate.endswith('%'):
-            speed = 10
+            speed = 1000
+            default_speed = speed
             # Not all interfaces have valid entries in the speed file. PPPoE
             # interfaces have the appropriate speed file, but you can not read it:
             # cat: /sys/class/net/pppoe7/speed: Invalid argument
             try:
                 speed = read_file(f'/sys/class/net/{self._interface}/speed')
                 if not speed.isnumeric():
-                    Warning('Interface speed cannot be determined (assuming 10 Mbit/s)')
+                    Warning('Interface speed cannot be determined (assuming 1000 Mbit/s)')
+                if int(speed) < 1:
+                    speed = default_speed
                 if rate.endswith('%'):
                     percent = rate.rstrip('%')
                     speed = int(speed) * int(percent) // 100


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
It is impossible to detect interface speed for some devices for exmaple virtio interfaces:
```
vyos@r4:~$ cat /sys/class/net/eth1/speed
-1
```

It causes wrong negative calcultaions like:
 - bandwidth: -1000000
 - 4% of bandwidth: -40000

tc class replace dev eth1 parent 1: classid 1:1 htb rate -1000000
tc class replace dev eth1 parent 1:1 classid 1:a htb rate -40000

Fix this by checking negative value.
Add default interface speed to 1000 Mbit if we cannot detect the interface speed, the current default value 10 Mbit is too low for nowadays.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5963
* https://vyos.dev/T5962

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
qos, shaper
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
touch /tmp/vyos.qos.debug

set qos policy shaper SHAPER class 10 bandwidth '4%'
set qos policy shaper SHAPER class 10 match lowdelay ip dscp 'lowdelay'
set qos policy shaper SHAPER default bandwidth '2mbit'

set qos interface eth1 egress SHAPER
commit
```
Before the fix we have negative values/rates for bandwidth
```
WARNING: Interface speed cannot be determined (assuming 10 Mbit/s)

DEBUG/QoS: tc qdisc replace dev eth1 root handle 1: htb r2q 1 default b
DEBUG/QoS: tc class replace dev eth1 parent 1: classid 1:1 htb rate -1000000
DEBUG/QoS: tc class replace dev eth1 parent 1:1 classid 1:a htb rate -40000 burst 15k quantum 1514
DEBUG/QoS: tc class replace dev eth1 parent 1:1 classid 1:b htb rate 2000000 burst 15k quantum 1514 prio 20

DEBUG/QoS: tc qdisc replace dev eth1 parent 1:a sfq
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:b sfq
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:a fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5 noecn
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:b fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5 noecn

DEBUG/QoS: tc filter add dev eth1 parent 1: protocol all prio 1 u32 match ip dsfield 16 0xff flowid 1:a
DEBUG/QoS: tc filter add dev eth1 parent 1: protocol all prio 1 u32 match ip dsfield 16 0xff flowid 1:a action police rate -1000000 burst 15k flowid 1:a
```
And incorrect values from TC (before the fix) **18446744Tbit**:
```
vyos@r4# sudo tc class show dev eth1
class htb 1:1 root rate 18446744Tbit ceil 18446744Tbit burst 0b cburst 0b
class htb 1:a parent 1:1 leaf 8003: prio 0 rate 18446744Tbit ceil 18446744Tbit burst 0b cburst 0b
class htb 1:b parent 1:1 leaf 8004: prio 7 rate 2Mbit ceil 2Mbit burst 15Kb cburst 1600b
[edit]
vyos@r4#
```
After the fix, all looks good:
```
DEBUG/QoS: tc class replace dev eth1 parent 1:1 classid 1:a htb rate 40000000 burst 15k quantum 1514
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:a sfq
DEBUG/QoS: tc class replace dev eth1 parent 1:1 classid 1:b htb rate 2000000 burst 15k quantum 1514 prio 20
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:b sfq
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:a fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5 noecn
DEBUG/QoS: tc filter add dev eth1 parent 1: protocol all prio 1 u32 match ip dsfield 16 0xff flowid 1:a
DEBUG/QoS: tc filter add dev eth1 parent 1: protocol all prio 1 u32 match ip dsfield 16 0xff flowid 1:a action police rate 40000000 burst 15k flowid 1:a
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:b fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5 noecn

```
TC after the fix
```
vyos@r4# sudo tc class show dev eth1
class htb 1:1 root rate 1Gbit ceil 1Gbit burst 1375b cburst 1375b
class htb 1:a parent 1:1 leaf 8159: prio 0 rate 40Mbit ceil 40Mbit burst 15Kb cburst 1600b
class htb 1:b parent 1:1 leaf 815a: prio 7 rate 2Mbit ceil 2Mbit burst 15Kb cburst 1600b
[edit]
vyos@r4# 

```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_qos.py
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... skipped 'tc returns invalid JSON here - needs iproute2 fix'
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok

----------------------------------------------------------------------
Ran 11 tests in 75.044s

OK (skipped=1)
vyos@r4:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
