### PR TITLE
ntp: T5692: add support to configure leap second behavior

### DIFF
--- a/data/templates/chrony/chrony.conf.j2
+++ b/data/templates/chrony/chrony.conf.j2
@@ -21,7 +21,17 @@ ntsdumpdir /run/chrony
 pidfile {{ config_file | replace('.conf', '.pid') }}
 
 # Determine when will the next leap second occur and what is the current offset
+{% if leap_second is vyos_defined('timezone') %}
 leapsectz right/UTC
+{% elif leap_second is vyos_defined('ignore') %}
+leapsecmode ignore
+{% elif leap_second is vyos_defined('smear') %}
+leapsecmode slew
+maxslewrate 1000
+smoothtime 400 0.001024 leaponly
+{% elif leap_second is vyos_defined('system') %}
+leapsecmode system
+{% endif %}
 
 user {{ user }}
 

--- a/interface-definitions/service_ntp.xml.in
+++ b/interface-definitions/service_ntp.xml.in
@@ -9,6 +9,38 @@
           <priority>900</priority>
         </properties>
         <children>
+          #include <include/allow-client.xml.i>
+          #include <include/generic-interface.xml.i>
+          #include <include/listen-address.xml.i>
+          #include <include/interface/vrf.xml.i>
+          <leafNode name="leap-second">
+            <properties>
+              <help>Leap second behavior</help>
+              <completionHelp>
+                <list>ignore smear system timezone</list>
+              </completionHelp>
+              <valueHelp>
+                <format>ignore</format>
+                <description>No correction is applied to the clock for the leap second</description>
+              </valueHelp>
+              <valueHelp>
+                <format>smear</format>
+                <description>Correct served time slowly be slewing instead of stepping</description>
+              </valueHelp>
+              <valueHelp>
+                <format>system</format>
+                <description>Kernel steps the system clock forward or backward</description>
+              </valueHelp>
+              <valueHelp>
+                <format>timezone</format>
+                <description>Use UTC timezone database to determine when will the next leap second occur</description>
+              </valueHelp>
+              <constraint>
+                <regex>(ignore|smear|system|timezone)</regex>
+              </constraint>
+            </properties>
+            <defaultValue>timezone</defaultValue>
+          </leafNode>
           <tagNode name="server">
             <properties>
               <help>Network Time Protocol (NTP) server</help>
@@ -56,10 +88,6 @@
               </leafNode>
             </children>
           </tagNode>
-          #include <include/allow-client.xml.i>
-          #include <include/generic-interface.xml.i>
-          #include <include/listen-address.xml.i>
-          #include <include/interface/vrf.xml.i>
         </children>
       </node>
     </children>

--- a/src/conf_mode/service_ntp.py
+++ b/src/conf_mode/service_ntp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2023 VyOS maintainers and contributors
+# Copyright (C) 2018-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -42,7 +42,7 @@ def get_config(config=None):
     if not conf.exists(base):
         return None
 
-    ntp = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
+    ntp = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True, with_defaults=True)
     ntp['config_file'] = config_file
     ntp['user'] = user_group
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

* `set service ntp leap-second [ignore|smear|system|timezone]`

Where timezone is the new and old default resulting in adding "leapsectz right/UTC" to chrony.conf. The most prominent new option is "smear" which will add

```
leapsecmode slew
maxslewrate 1000
smoothtime 400 0.001 leaponly
```

to chrony.

See https://chrony-project.org/doc/4.3/chrony.conf.html `leapsecmode` for additional information

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5692

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ntp

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_ntp.py
test_base_options (__main__.TestSystemNTP.test_base_options) ... ok
test_clients (__main__.TestSystemNTP.test_clients) ... ok
test_interface (__main__.TestSystemNTP.test_interface) ... ok
test_leap_seconds (__main__.TestSystemNTP.test_leap_seconds) ... ok
test_vrf (__main__.TestSystemNTP.test_vrf) ... ok

----------------------------------------------------------------------
Ran 5 tests in 25.269s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
