### PR TITLE
dhcp: T3316: add deprecation warning on RAW ISC DHCPD options

### DIFF
--- a/interface-definitions/service_dhcpv6-server.xml.in
+++ b/interface-definitions/service_dhcpv6-server.xml.in
@@ -11,7 +11,7 @@
           #include <include/generic-disable-node.xml.i>
           <node name="global-parameters">
             <properties>
-              <help>Additional global parameters for DHCPv6 server</help>
+              <help>Global options sent to all clients</help>
             </properties>
             <children>
               #include <include/name-server-ipv6.xml.i>

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -22,6 +22,7 @@ from netaddr import IPAddress
 from netaddr import IPRange
 from sys import exit
 
+from vyos.base import DeprecationWarning
 from vyos.config import Config
 from vyos.template import render
 from vyos.utils.dict import dict_search
@@ -149,9 +150,15 @@ def verify(dhcp):
     shared_networks =  len(dhcp['shared_network_name'])
     disabled_shared_networks = 0
 
+    common_deprecation_msg = 'are subject of removal in VyOS 1.5! Please raise a feature request for proper CLI nodes!'
+    if 'global_parameters' in dhcp:
+        DeprecationWarning(f'Additional global parameters {common_deprecation_msg}')
 
     # A shared-network requires a subnet definition
     for network, network_config in dhcp['shared_network_name'].items():
+        if 'shared_network_parameters' in network_config:
+            DeprecationWarning(f'Additional shared network parameters in "{network}" {common_deprecation_msg}')
+
         if 'disable' in network_config:
             disabled_shared_networks += 1
 
@@ -160,6 +167,9 @@ def verify(dhcp):
                               'lease subnet must be configured.')
 
         for subnet, subnet_config in network_config['subnet'].items():
+            if 'subnet_parameters' in subnet_config:
+                DeprecationWarning(f'Additional subnet parameters in "{subnet}" {common_deprecation_msg}')
+
             # All delivered static routes require a next-hop to be set
             if 'static_route' in subnet_config:
                 for route, route_option in subnet_config['static_route'].items():


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The following CLI nodes are deprecated and will be remove in VyOS 1.5 while moving to KEA as DHCP server.

* `set service dhcp-server global-parameters`
* `set service dhcp-server shared-network-name <name> shared-network-parameters`
* `set service dhcp-server shared-network-name <name> subnet <x.x.x.x/y> subnet-parameters`
* `set service dhcpv6-server global-parameters`

Please open feature requests if any DHCP option is missing and should be added as a proper CLI node to make your life easier.

Options are already gone in 1.5 but there was no warning yet!

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): deprecation notice

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3316

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
DHCP server

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set service dhcp-server global-parameters 'foo'
set service dhcp-server shared-network-name NET authoritative
set service dhcp-server shared-network-name NET shared-network-parameters 'bar'
set service dhcp-server shared-network-name NET subnet 172.16.37.0/24 default-router '172.16.37.254'
set service dhcp-server shared-network-name NET subnet 172.16.37.0/24 range 0 start '172.16.37.120'
set service dhcp-server shared-network-name NET subnet 172.16.37.0/24 range 0 stop '172.16.37.149'
set service dhcp-server shared-network-name NET subnet 172.16.37.0/24 subnet-parameters 'baz'
```

```
DEPRECATION WARNING: Additional global parameters are subject of
removal in VyOS 1.5! Please raise a feature request for proper CLI
nodes!


DEPRECATION WARNING: Additional shared network parameters in "NET" are
subject of removal in VyOS 1.5! Please raise a feature request for
proper CLI nodes!


DEPRECATION WARNING: Additional subnet parameters in "172.16.37.0/24"
are subject of removal in VyOS 1.5! Please raise a feature request for
proper CLI nodes!

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR2.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py
test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
test_dhcp_failover (__main__.TestServiceDHCPServer.test_dhcp_failover) ... ok
test_dhcp_invalid_raw_options (__main__.TestServiceDHCPServer.test_dhcp_invalid_raw_options) ... ok
test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... ok
test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... ok
test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... ok

----------------------------------------------------------------------
Ran 9 tests in 40.618s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
