### PR TITLE
dhcp: T5787: Allow disabled duplicates on static-mapping

### DIFF
--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -387,6 +387,9 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.cli_set(pool + ['static-mapping', 'dupe1', 'ip-address', inc_ip(subnet, 10)])
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
+        # Should allow disabled duplicate
+        self.cli_set(pool + ['static-mapping', 'dupe1', 'disable'])
+        self.cli_commit()
         self.cli_delete(pool + ['static-mapping', 'dupe1'])
 
         # cannot have mappings with duplicate MAC addresses

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -246,19 +246,21 @@ def verify(dhcp):
                             raise ConfigError(f'Either MAC address or Client identifier (DUID) is required for '
                                               f'static mapping "{mapping}" within shared-network "{network}, {subnet}"!')
 
-                        if mapping_config['ip_address'] in used_ips:
-                            raise ConfigError(f'Configured IP address for static mapping "{mapping}" already exists on another static mapping')
-                        used_ips.append(mapping_config['ip_address'])
+                        if 'disable' not in mapping_config:
+                            if mapping_config['ip_address'] in used_ips:
+                                raise ConfigError(f'Configured IP address for static mapping "{mapping}" already exists on another static mapping')
+                            used_ips.append(mapping_config['ip_address'])
 
-                    if 'mac' in mapping_config:
-                        if mapping_config['mac'] in used_mac:
-                            raise ConfigError(f'Configured MAC address for static mapping "{mapping}" already exists on another static mapping')
-                        used_mac.append(mapping_config['mac'])
+                    if 'disable' not in mapping_config:
+                        if 'mac' in mapping_config:
+                            if mapping_config['mac'] in used_mac:
+                                raise ConfigError(f'Configured MAC address for static mapping "{mapping}" already exists on another static mapping')
+                            used_mac.append(mapping_config['mac'])
 
-                    if 'duid' in mapping_config:
-                        if mapping_config['duid'] in used_duid:
-                            raise ConfigError(f'Configured DUID for static mapping "{mapping}" already exists on another static mapping')
-                        used_duid.append(mapping_config['duid'])
+                        if 'duid' in mapping_config:
+                            if mapping_config['duid'] in used_duid:
+                                raise ConfigError(f'Configured DUID for static mapping "{mapping}" already exists on another static mapping')
+                            used_duid.append(mapping_config['duid'])
 
             # There must be one subnet connected to a listen interface.
             # This only counts if the network itself is not disabled!


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow duplicate static mappings if disabled

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5787

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-server

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py
DEBUG - test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range)... ok
DEBUG - test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
DEBUG - test_dhcp_failover (__main__.TestServiceDHCPServer.test_dhcp_failover) ... ok
DEBUG - test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
DEBUG - test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
DEBUG - test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... ok
DEBUG - test_dhcp_single_pool_options_scoped (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options_scoped) ... ok
DEBUG - test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... ok
DEBUG - test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 9 tests in 41.755s
DEBUG -
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
