### PR TITLE
T5974: Fix QoS shape bandwidth and ceil calculation for default

### DIFF
--- a/python/vyos/qos/trafficshaper.py
+++ b/python/vyos/qos/trafficshaper.py
@@ -99,7 +99,11 @@ class TrafficShaper(QoSBase):
                 self._cmd(tmp)
 
         if 'default' in config:
-                rate = self._rate_convert(config['default']['bandwidth'])
+                if config['default']['bandwidth'].endswith('%'):
+                    percent = config['default']['bandwidth'].rstrip('%')
+                    rate = self._rate_convert(config['bandwidth']) * int(percent) // 100
+                else:
+                    rate = self._rate_convert(config['default']['bandwidth'])
                 burst = config['default']['burst']
                 quantum = config['default']['codel_quantum']
                 tmp = f'tc class replace dev {self._interface} parent {self._parent:x}:1 classid {self._parent:x}:{default_minor_id:x} htb rate {rate} burst {burst} quantum {quantum}'
@@ -107,7 +111,11 @@ class TrafficShaper(QoSBase):
                     priority = config['default']['priority']
                     tmp += f' prio {priority}'
                 if 'ceiling' in config['default']:
-                    f_ceil = self._rate_convert(config['default']['ceiling'])
+                    if config['default']['ceiling'].endswith('%'):
+                        percent = config['default']['ceiling'].rstrip('%')
+                        f_ceil = self._rate_convert(config['bandwidth']) * int(percent) // 100
+                    else:
+                        f_ceil = self._rate_convert(config['default']['ceiling'])
                     tmp += f' ceil {f_ceil}'
                 self._cmd(tmp)
 


### PR DESCRIPTION
The default `bandwidth` and `ceiling` should calculate values based on <tag> bandwidth but currently it gets the value from qos.base `/sys/class/net/{self._interface}/speed`

```
set qos policy shaper SHAPER bandwidth '20mbit'
set qos policy shaper SHAPER default bandwidth '95%'
set qos policy shaper SHAPER default ceiling '100%'
```

It causes wrong calculations for class `default` i.e 
950Mbit for bandwidth (expected 95% of bandwidth = 19Mbit)
1Gbit for ceil (expected 100% of bandwidth = 20Mbit)

Get incorrect values:
```
r4# tc class show dev eth1
class htb 1:1 root rate 20Mbit ceil 20Mbit burst 1600b cburst 1600b
class htb 1:a parent 1:1 leaf 8053: prio 0 rate 200Kbit ceil 200Kbit burst 1Mb cburst 1600b
class htb 1:b parent 1:1 leaf 8054: prio 7 rate 950Mbit ceil 1Gbit burst 15200b cburst 1375b
```

Fix this

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5974

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
qos
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set qos policy shaper SHAPER bandwidth '20mbit'

set qos policy shaper SHAPER class 10 bandwidth '1%'
set qos policy shaper SHAPER class 10 burst '1mb'
set qos policy shaper SHAPER class 10 match dns ip protocol 'udp'
set qos policy shaper SHAPER class 10 match dns ip source port '53'

set qos policy shaper SHAPER default bandwidth '95%'
set qos policy shaper SHAPER default burst '15k'
set qos policy shaper SHAPER default ceiling '100%'

set qos interface eth1 egress SHAPER

commit
```
Before the fix we get incorrect values 950Mbit and 1Gbit:
```
vyos@r4# tc class show dev eth1
class htb 1:1 root rate 20Mbit ceil 20Mbit burst 1600b cburst 1600b
class htb 1:a parent 1:1 leaf 8053: prio 0 rate 200Kbit ceil 200Kbit burst 1Mb cburst 1600b
class htb 1:b parent 1:1 leaf 8054: prio 7 rate 950Mbit ceil 1Gbit burst 15200b cburst 1375b
[edit]
vyos@r4#
```
After the fix:
```
vyos@r4# tc class show dev eth1
class htb 1:1 root rate 20Mbit ceil 20Mbit burst 1600b cburst 1600b
class htb 1:a parent 1:1 leaf 8094: prio 0 rate 200Kbit ceil 200Kbit burst 1Mb cburst 1600b
class htb 1:b parent 1:1 leaf 8095: prio 7 rate 19Mbit ceil 20Mbit burst 15Kb cburst 1600b
[edit]
vyos@r4# 
```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_qos.py
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... skipped 'tc returns invalid JSON here - needs iproute2 fix'
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok

----------------------------------------------------------------------
Ran 11 tests in 79.321s

OK (skipped=1)
vyos@r4:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
