### PR TITLE
bfd: T5967: add minimum-ttl option

### DIFF
--- a/data/templates/frr/bfdd.frr.j2
+++ b/data/templates/frr/bfdd.frr.j2
@@ -13,6 +13,9 @@ bfd
 {%             if profile_config.echo_mode is vyos_defined %}
   echo-mode
 {%             endif %}
+{%             if profile_config.minimum_ttl is vyos_defined %}
+  minimum-ttl {{ profile_config.minimum_ttl }}
+{%             endif %}
 {%             if profile_config.passive is vyos_defined %}
   passive-mode
 {%             endif %}
@@ -37,6 +40,9 @@ bfd
 {%             endif %}
 {%             if peer_config.echo_mode is vyos_defined %}
   echo-mode
+{%             endif %}
+{%             if peer_config.minimum_ttl is vyos_defined %}
+  minimum-ttl {{ peer_config.minimum_ttl }}
 {%             endif %}
 {%             if peer_config.passive is vyos_defined %}
   passive-mode

--- a/interface-definitions/include/bfd/common.xml.i
+++ b/interface-definitions/include/bfd/common.xml.i
@@ -63,6 +63,18 @@
     </leafNode>
   </children>
 </node>
+<leafNode name="minimum-ttl">
+  <properties>
+    <help>Expect packets with at least this TTL</help>
+    <valueHelp>
+      <format>u32:1-254</format>
+      <description>Minimum TTL expected</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-254"/>
+    </constraint>
+  </properties>
+</leafNode>
 <leafNode name="passive">
   <properties>
     <help>Do not attempt to start sessions</help>

--- a/smoketest/scripts/cli/test_protocols_bfd.py
+++ b/smoketest/scripts/cli/test_protocols_bfd.py
@@ -32,6 +32,7 @@ peers = {
         'multihop'   : '',
         'source_addr': '192.0.2.254',
         'profile'    : 'foo-bar-baz',
+        'minimum_ttl': '20',
     },
     '192.0.2.20' : {
         'echo_mode'  : '',
@@ -63,6 +64,7 @@ profiles = {
         'intv_rx'    : '222',
         'intv_tx'    : '333',
         'shutdown'   : '',
+        'minimum_ttl': '40',
         },
     'foo-bar-baz' : {
         'intv_mult'  : '4',
@@ -109,6 +111,8 @@ class TestProtocolsBFD(VyOSUnitTestSHIM.TestCase):
                 self.cli_set(base_path + ['peer', peer, 'interval', 'receive', peer_config["intv_rx"]])
             if 'intv_tx' in peer_config:
                 self.cli_set(base_path + ['peer', peer, 'interval', 'transmit', peer_config["intv_tx"]])
+            if 'minimum_ttl' in peer_config:
+                self.cli_set(base_path + ['peer', peer, 'minimum-ttl', peer_config["minimum_ttl"]])
             if 'multihop' in peer_config:
                 self.cli_set(base_path + ['peer', peer, 'multihop'])
             if 'passive' in peer_config:
@@ -152,6 +156,8 @@ class TestProtocolsBFD(VyOSUnitTestSHIM.TestCase):
                 self.assertIn(f'receive-interval {peer_config["intv_rx"]}', peerconfig)
             if 'intv_tx' in peer_config:
                 self.assertIn(f'transmit-interval {peer_config["intv_tx"]}', peerconfig)
+            if 'minimum_ttl' in peer_config:
+                self.assertIn(f'minimum-ttl {peer_config["minimum_ttl"]}', peerconfig)
             if 'passive' in peer_config:
                 self.assertIn(f'passive-mode', peerconfig)
             if 'shutdown' in peer_config:
@@ -173,6 +179,8 @@ class TestProtocolsBFD(VyOSUnitTestSHIM.TestCase):
                 self.cli_set(base_path + ['profile', profile, 'interval', 'receive', profile_config["intv_rx"]])
             if 'intv_tx' in profile_config:
                 self.cli_set(base_path + ['profile', profile, 'interval', 'transmit', profile_config["intv_tx"]])
+            if 'minimum_ttl' in profile_config:
+                self.cli_set(base_path + ['profile', profile, 'minimum-ttl', profile_config["minimum_ttl"]])
             if 'passive' in profile_config:
                 self.cli_set(base_path + ['profile', profile, 'passive'])
             if 'shutdown' in profile_config:
@@ -210,6 +218,8 @@ class TestProtocolsBFD(VyOSUnitTestSHIM.TestCase):
                 self.assertIn(f' receive-interval {profile_config["intv_rx"]}', config)
             if 'intv_tx' in profile_config:
                 self.assertIn(f' transmit-interval {profile_config["intv_tx"]}', config)
+            if 'minimum_ttl' in profile_config:
+                self.assertIn(f' minimum-ttl {profile_config["minimum_ttl"]}', config)
             if 'passive' in profile_config:
                 self.assertIn(f' passive-mode', config)
             if 'shutdown' in profile_config:

--- a/src/conf_mode/protocols_bfd.py
+++ b/src/conf_mode/protocols_bfd.py
@@ -72,6 +72,9 @@ def verify(bfd):
                 if 'source' in peer_config and 'interface' in peer_config['source']:
                     raise ConfigError('BFD multihop and source interface cannot be used together')
 
+            if 'minimum_ttl' in peer_config and 'multihop' not in peer_config:
+                raise ConfigError('Minimum TTL is only available for multihop BFD sessions!')
+
             if 'profile' in peer_config:
                 profile_name = peer_config['profile']
                 if 'profile' not in bfd or profile_name not in bfd['profile']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

* `set protocols bfd peer <x.x.x.x> minimum-ttl <1-254>`
* `set protocols bfd profile <name> minimum-ttl <1-254>`

For multi hop sessions only: configure the minimum expected TTL for an incoming BFD control packet.

This feature serves the purpose of thightening the packet validation requirements to avoid receiving BFD control packets from other sessions.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5967

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-documentation/commit/c1716052eba00ad6c612755f55015e840e946828 Update do documentation

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bfd

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set protocols bfd peer 1.1.1.1 minimum-ttl '10'
set protocols bfd peer 1.1.1.1 multihop
set protocols bfd peer 1.1.1.1 source address '172.18.254.201'
```

results in FRR configuration:

```
bfd
 peer 1.1.1.1 multihop local-address 172.18.254.201
  minimum-ttl 10
 exit
 !
exit
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bfd.py
test_bfd_peer (__main__.TestProtocolsBFD.test_bfd_peer) ... ok
test_bfd_profile (__main__.TestProtocolsBFD.test_bfd_profile) ... ok

----------------------------------------------------------------------
Ran 2 tests in 14.097s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
