### PR TITLE
T5977: firewall: remove ipsec options in output chain rule definition…

### DIFF
--- a/interface-definitions/include/firewall/common-rule-inet.xml.i
+++ b/interface-definitions/include/firewall/common-rule-inet.xml.i
@@ -32,25 +32,6 @@
     </leafNode>
   </children>
 </node>
-<node name="ipsec">
-  <properties>
-    <help>Inbound IPsec packets</help>
-  </properties>
-  <children>
-    <leafNode name="match-ipsec">
-      <properties>
-        <help>Inbound IPsec packets</help>
-        <valueless/>
-      </properties>
-    </leafNode>
-    <leafNode name="match-none">
-      <properties>
-        <help>Inbound non-IPsec packets</help>
-        <valueless/>
-      </properties>
-    </leafNode>
-  </children>
-</node>
 <node name="limit">
   <properties>
     <help>Rate limit using a token bucket filter</help>

--- a/interface-definitions/include/firewall/ipv4-custom-name.xml.i
+++ b/interface-definitions/include/firewall/ipv4-custom-name.xml.i
@@ -33,6 +33,7 @@
       <children>
         #include <include/firewall/common-rule-ipv4.xml.i>
         #include <include/firewall/inbound-interface.xml.i>
+        #include <include/firewall/match-ipsec.xml.i>
         #include <include/firewall/offload-target.xml.i>
         #include <include/firewall/outbound-interface.xml.i>
       </children>

--- a/interface-definitions/include/firewall/ipv4-hook-forward.xml.i
+++ b/interface-definitions/include/firewall/ipv4-hook-forward.xml.i
@@ -28,6 +28,7 @@
             #include <include/firewall/action-forward.xml.i>
             #include <include/firewall/common-rule-ipv4.xml.i>
             #include <include/firewall/inbound-interface.xml.i>
+            #include <include/firewall/match-ipsec.xml.i>
             #include <include/firewall/offload-target.xml.i>
             #include <include/firewall/outbound-interface.xml.i>
           </children>

--- a/interface-definitions/include/firewall/ipv4-hook-input.xml.i
+++ b/interface-definitions/include/firewall/ipv4-hook-input.xml.i
@@ -27,6 +27,7 @@
           <children>
             #include <include/firewall/common-rule-ipv4.xml.i>
             #include <include/firewall/inbound-interface.xml.i>
+            #include <include/firewall/match-ipsec.xml.i>
           </children>
         </tagNode>
       </children>

--- a/interface-definitions/include/firewall/ipv6-custom-name.xml.i
+++ b/interface-definitions/include/firewall/ipv6-custom-name.xml.i
@@ -33,6 +33,7 @@
       <children>
         #include <include/firewall/common-rule-ipv6.xml.i>
         #include <include/firewall/inbound-interface.xml.i>
+        #include <include/firewall/match-ipsec.xml.i>
         #include <include/firewall/offload-target.xml.i>
         #include <include/firewall/outbound-interface.xml.i>
       </children>

--- a/interface-definitions/include/firewall/ipv6-hook-forward.xml.i
+++ b/interface-definitions/include/firewall/ipv6-hook-forward.xml.i
@@ -28,6 +28,7 @@
             #include <include/firewall/action-forward.xml.i>
             #include <include/firewall/common-rule-ipv6.xml.i>
             #include <include/firewall/inbound-interface.xml.i>
+            #include <include/firewall/match-ipsec.xml.i>
             #include <include/firewall/offload-target.xml.i>
             #include <include/firewall/outbound-interface.xml.i>
           </children>

--- a/interface-definitions/include/firewall/ipv6-hook-input.xml.i
+++ b/interface-definitions/include/firewall/ipv6-hook-input.xml.i
@@ -27,6 +27,7 @@
           <children>
             #include <include/firewall/common-rule-ipv6.xml.i>
             #include <include/firewall/inbound-interface.xml.i>
+            #include <include/firewall/match-ipsec.xml.i>
           </children>
         </tagNode>
       </children>

--- a/interface-definitions/include/firewall/match-ipsec.xml.i
+++ b/interface-definitions/include/firewall/match-ipsec.xml.i
@@ -1,0 +1,21 @@
+<!-- include start from firewall/match-ipsec.xml.i -->
+<node name="ipsec">
+  <properties>
+    <help>Inbound IPsec packets</help>
+  </properties>
+  <children>
+    <leafNode name="match-ipsec">
+      <properties>
+        <help>Inbound IPsec packets</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+    <leafNode name="match-none">
+      <properties>
+        <help>Inbound non-IPsec packets</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->


### PR DESCRIPTION
…s, since it's not supported.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5977

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Ipsec options no longer available in output chains:
```
vyos@vyos# set firewall ipv6 output filter rule 10 
Possible completions:
   action               Rule action
+  connection-mark      Connection mark
 > connection-status    Connection status
+  conntrack-helper     Match related traffic from conntrack helpers
   description          Description
 > destination          Destination parameters
   disable              Option to disable firewall rule
+  dscp                 DSCP value
+  dscp-exclude         DSCP value not to match
 > fragment             IP fragment match
 > hop-limit            Hop limit
 > icmpv6               ICMPv6 type and code information
   jump-target          Set jump target. Action jump must be defined to use this setting
 > limit                Rate limit using a token bucket filter
   log                  Log packets hitting this rule
 > log-options          Log options
   mark                 Firewall mark
 > outbound-interface   Match outbound-interface
+  packet-length        Payload size in bytes, including header and data to match
+  packet-length-exclude
                        Payload size in bytes, including header and data not to match
   packet-type          Packet type
   protocol             Protocol to match (protocol name, number, or "all")
   queue                Queue target to use. Action queue must be defined to use this
                        setting
+  queue-options        Options used for queue target. Action queue must be defined to
                        use this setting
 > recent               Parameters for matching recently seen sources
 > source               Source parameters
+  state                Session state
 > synproxy             Synproxy options
 > tcp                  TCP options to match
 > time                 Time to match rule

      
[edit]
vyos@vyos#
vyos@vyos# set firewall ipv4 output filter rule 10 
Possible completions:
   action               Rule action
+  connection-mark      Connection mark
 > connection-status    Connection status
+  conntrack-helper     Match related traffic from conntrack helpers
   description          Description
 > destination          Destination parameters
   disable              Option to disable firewall rule
+  dscp                 DSCP value
+  dscp-exclude         DSCP value not to match
 > fragment             IP fragment match
 > icmp                 ICMP type and code information
   jump-target          Set jump target. Action jump must be defined to use this setting
 > limit                Rate limit using a token bucket filter
   log                  Log packets hitting this rule
 > log-options          Log options
   mark                 Firewall mark
 > outbound-interface   Match outbound-interface
+  packet-length        Payload size in bytes, including header and data to match
+  packet-length-exclude
                        Payload size in bytes, including header and data not to match
   packet-type          Packet type
   protocol             Protocol to match (protocol name, number, or "all")
   queue                Queue target to use. Action queue must be defined to use this
                        setting
+  queue-options        Options used for queue target. Action queue must be defined to
                        use this setting
 > recent               Parameters for matching recently seen sources
 > source               Source parameters
+  state                Session state
 > synproxy             Synproxy options
 > tcp                  TCP options to match
 > time                 Time to match rule
 > ttl                  Time to live limit

      
[edit]
vyos@vyos# set firewall ipv4 output filter rule 10
```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@vyos:/usr/libexec/vyos/tests/smoke/cli# ./test_firewall.py 
test_bridge_basic_rules (__main__.TestFirewall.test_bridge_basic_rules) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... 
Interface "eth0" does not support hardware offload

ok
test_geoip (__main__.TestFirewall.test_geoip) ... Updating GeoIP. Please wait...
Updating GeoIP. Please wait...
ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... 
"synproxy" option allowed only for action synproxy

ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... 
Group "smoketest_network1" has a circular reference

ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... 
Interface "eth0" does not support hardware offload

ok

----------------------------------------------------------------------
Ran 17 tests in 39.253s

OK
root@vyos:/usr/libexec/vyos/tests/smoke/cli#
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
