### PR TITLE
T5941: Migration policy delete orphaned interface policy

### DIFF
--- a/src/migration-scripts/policy/4-to-5
+++ b/src/migration-scripts/policy/4-to-5
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022 VyOS maintainers and contributors
+# Copyright (C) 2022-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -37,7 +37,53 @@ base4 = ['policy', 'route']
 base6 = ['policy', 'route6']
 config = ConfigTree(config_file)
 
+
+def delete_orphaned_interface_policy(config, iftype, ifname, vif=None, vifs=None, vifc=None):
+    """Delete unexpected policy on interfaces in cases when
+       policy does not exist but inreface has a policy configuration
+       Example T5941:
+         set interfaces bonding bond0 vif 995 policy
+    """
+    if_path = ['interfaces', iftype, ifname]
+
+    if vif:
+        if_path += ['vif', vif]
+    elif vifs:
+        if_path += ['vif-s', vifs]
+        if vifc:
+            if_path += ['vif-c', vifc]
+
+    if not config.exists(if_path + ['policy']):
+        return
+
+    config.delete(if_path + ['policy'])
+
+
 if not config.exists(base4) and not config.exists(base6):
+    # Delete orphaned nodes on interfaces T5941
+    for iftype in config.list_nodes(['interfaces']):
+        for ifname in config.list_nodes(['interfaces', iftype]):
+            delete_orphaned_interface_policy(config, iftype, ifname)
+
+            if config.exists(['interfaces', iftype, ifname, 'vif']):
+                for vif in config.list_nodes(['interfaces', iftype, ifname, 'vif']):
+                    delete_orphaned_interface_policy(config, iftype, ifname, vif=vif)
+
+            if config.exists(['interfaces', iftype, ifname, 'vif-s']):
+                for vifs in config.list_nodes(['interfaces', iftype, ifname, 'vif-s']):
+                    delete_orphaned_interface_policy(config, iftype, ifname, vifs=vifs)
+
+                    if config.exists(['interfaces', iftype, ifname, 'vif-s', vifs, 'vif-c']):
+                        for vifc in config.list_nodes(['interfaces', iftype, ifname, 'vif-s', vifs, 'vif-c']):
+                            delete_orphaned_interface_policy(config, iftype, ifname, vifs=vifs, vifc=vifc)
+
+    try:
+        with open(file_name, 'w') as f:
+            f.write(config.to_string())
+    except OSError as e:
+        print("Failed to save the modified config: {}".format(e))
+        exit(1)
+
     # Nothing to do
     exit(0)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
We can get an orphaned interface policy when the policy name is removed from the interface, but the node `policy` is still attached to the interface.

For example we have orphaned node policy on an interface:
```
set interfaces bonding bond0 vif 995 policy
```

This causes of incorrect migration and we do not see VLANs on the bonding interface after update.

Delete policy from all interfaces if the policy does not exist.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5941

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
The similar PR https://github.com/vyos/vyos-1x/pull/2892

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
To reproduce:
```
set interfaces bonding bond0 member interface 'eth1'
set interfaces bonding bond0 vif 995 policy
```
After update, we do not have interface `bond0.995` but it is present in the /config/config.boot:
Example:
```
vyos@r1# cat tmp.txt 
interfaces {
    bonding bond0 {
        member {
            interface eth1
        }
        vif 995 {
            policy {
            }
        }
    }

```
Show interface before fix (do not see bond0.995):
```
vyos@r1:~$ show int
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address         MAC                VRF        MTU  S/L    Description
-----------  -----------------  -----------------  -------  -----  -----  -------------
bond0        -                  6e:8c:13:0e:d0:79  default   1500  u/u
dum0         203.0.113.1/32     c6:d3:03:b3:98:c2  default   1500  u/u
eth0         192.168.122.11/24  52:54:00:ed:60:b3  default   1500  u/u    WAN
eth1         -                  6e:8c:13:0e:d0:79  default   1500  u/u    LAN

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
