### PR TITLE
T5971: Rewritten ppp options in accel-ppp services

### DIFF
--- a/data/templates/accel-ppp/l2tp.config.j2
+++ b/data/templates/accel-ppp/l2tp.config.j2
@@ -65,30 +65,8 @@ ipv6-pool-delegate={{ default_ipv6_pool }}
 {# Common chap-secrets and RADIUS server/option definitions #}
 {% include 'accel-ppp/config_chap_secrets_radius.j2' %}
 
-[ppp]
-verbose=1
-check-ip=1
-single-session=replace
-lcp-echo-interval={{ ppp_options.lcp_echo_interval }}
-lcp-echo-timeout={{ ppp_options.lcp_echo_timeout }}
-lcp-echo-failure={{ ppp_options.lcp_echo_failure }}
-{# MTU #}
-mtu={{ mtu }}
-ipv6={{ 'allow' if ppp_options.ipv6 is vyos_defined("deny") and client_ipv6_pool is vyos_defined else ppp_options.ipv6 }}
-ipv4={{ ppp_options.ipv4 }}
-mppe={{ ppp_options.mppe }}
-{% if ccp_disable is vyos_defined %}
-ccp=0
-{% endif %}
-unit-preallocate={{ "1" if authentication.radius.preallocate_vif is vyos_defined else "0" }}
-
-{% if ppp_options.ipv6_intf_id is vyos_defined %}
-ipv6-intf-id={{ ppp_options.ipv6_intf_id }}
-{% endif %}
-{% if ppp_options.ipv6_peer_intf_id is vyos_defined %}
-ipv6-peer-intf-id={{ ppp_options.ipv6_peer_intf_id }}
-{% endif %}
-ipv6-accept-peer-intf-id={{ "1" if ppp_options.ipv6_accept_peer_intf_id is vyos_defined else "0" }}
+{# Common ppp-options definitions #}
+{% include 'accel-ppp/ppp-options.j2' %}
 
 {# Common IPv6 pool definitions #}
 {% include 'accel-ppp/config_ipv6_pool.j2' %}
@@ -98,5 +76,4 @@ ipv6-accept-peer-intf-id={{ "1" if ppp_options.ipv6_accept_peer_intf_id is vyos_
 
 [cli]
 tcp=127.0.0.1:2004
-sessions-columns=ifname,username,calling-sid,ip,{{ ip6_column | join(',') }}{{ ',' if ip6_column }}rate-limit,type,comp,state,rx-bytes,tx-bytes,uptime
 

--- a/data/templates/accel-ppp/ppp-options.j2
+++ b/data/templates/accel-ppp/ppp-options.j2
@@ -1,0 +1,39 @@
+#ppp options
+[ppp]
+verbose=1
+check-ip=1
+ccp={{ "0" if ppp_options.disable_ccp is vyos_defined else "1" }}
+unit-preallocate={{ "1" if authentication.radius.preallocate_vif is vyos_defined else "0" }}
+{% if ppp_options.min_mtu is vyos_defined %}
+min-mtu={{ ppp_options.min_mtu }}
+{% endif %}
+{% if ppp_options.mru is vyos_defined %}
+mru={{ ppp_options.mru }}
+{% endif %}
+mppe={{ ppp_options.mppe }}
+lcp-echo-interval={{ ppp_options.lcp_echo_interval }}
+lcp-echo-timeout={{ ppp_options.lcp_echo_timeout }}
+lcp-echo-failure={{ ppp_options.lcp_echo_failure }}
+{% if ppp_options.ipv4 is vyos_defined %}
+ipv4={{ ppp_options.ipv4 }}
+{% endif %}
+{# IPv6 #}
+{% if ppp_options.ipv6 is vyos_defined %}
+ipv6={{ ppp_options.ipv6 }}
+{%     if ppp_options.ipv6_interface_id is vyos_defined %}
+ipv6-intf-id={{ ppp_options.ipv6_interface_id }}
+{%     endif %}
+{%     if ppp_options.ipv6_peer_interface_id is vyos_defined %}
+{%         if ppp_options.ipv6_peer_interface_id == 'ipv4-addr' %}
+ipv6-peer-intf-id=ipv4
+{%         else %}
+ipv6-peer-intf-id={{ ppp_options.ipv6_peer_interface_id }}
+{%         endif %}
+{%     endif %}
+ipv6-accept-peer-intf-id={{ "1" if ppp_options.ipv6_accept_peer_interface_id is vyos_defined else "0" }}
+{% endif %}
+{# MTU #}
+mtu={{ mtu }}
+{% if ppp_options.interface_cache is vyos_defined %}
+unit-cache={{ ppp_options.interface_cache }}
+{% endif %}

--- a/data/templates/accel-ppp/pppoe.config.j2
+++ b/data/templates/accel-ppp/pppoe.config.j2
@@ -70,40 +70,8 @@ single-session={{ session_control }}
 max-starting={{ max_concurrent_sessions }}
 {% endif %}
 
-[ppp]
-verbose=1
-check-ip=1
-ccp={{ "1" if ppp_options.ccp is vyos_defined else "0" }}
-unit-preallocate={{ "1" if authentication.radius.preallocate_vif is vyos_defined else "0" }}
-{% if ppp_options.min_mtu is vyos_defined %}
-min-mtu={{ ppp_options.min_mtu }}
-{% endif %}
-{% if ppp_options.mru is vyos_defined %}
-mru={{ ppp_options.mru }}
-{% endif %}
-mppe={{ ppp_options.mppe }}
-lcp-echo-interval={{ ppp_options.lcp_echo_interval }}
-lcp-echo-timeout={{ ppp_options.lcp_echo_timeout }}
-lcp-echo-failure={{ ppp_options.lcp_echo_failure }}
-{% if ppp_options.ipv4 is vyos_defined %}
-ipv4={{ ppp_options.ipv4 }}
-{% endif %}
-{# IPv6 #}
-{% if ppp_options.ipv6 is vyos_defined %}
-ipv6={{ ppp_options.ipv6 }}
-{%     if ppp_options.ipv6_intf_id is vyos_defined %}
-ipv6-intf-id={{ ppp_options.ipv6_intf_id }}
-{%     endif %}
-{%     if ppp_options.ipv6_peer_intf_id is vyos_defined %}
-ipv6-peer-intf-id={{ ppp_options.ipv6_peer_intf_id }}
-{%     endif %}
-ipv6-accept-peer-intf-id={{ "1" if ppp_options.ipv6_accept_peer_intf_id is vyos_defined else "0" }}
-{% endif %}
-{# MTU #}
-mtu={{ mtu }}
-{% if ppp_options.interface_cache is vyos_defined %}
-unit-cache={{ ppp_options.interface_cache }}
-{% endif %}
+{# Common ppp-options definitions #}
+{% include 'accel-ppp/ppp-options.j2' %}
 
 [pppoe]
 verbose=1

--- a/data/templates/accel-ppp/pptp.config.j2
+++ b/data/templates/accel-ppp/pptp.config.j2
@@ -6,6 +6,8 @@ shaper
 {# Common authentication backend definitions #}
 {% include 'accel-ppp/config_modules_auth_mode.j2' %}
 ippool
+{# Common IPv6 definitions #}
+{% include 'accel-ppp/config_modules_ipv6.j2' %}
 {# Common authentication protocols (pap, chap ...) #}
 {% if authentication.require is vyos_defined %}
 {%     if authentication.require == 'chap' %}
@@ -40,7 +42,6 @@ wins{{ loop.index }}={{ server }}
 {%     endfor %}
 {% endif %}
 
-
 [pptp]
 ifname=pptp%d
 {% if outside_address is vyos_defined %}
@@ -54,6 +55,10 @@ echo-failure=3
 {% if default_pool is vyos_defined %}
 ip-pool={{ default_pool }}
 {% endif %}
+{% if default_ipv6_pool is vyos_defined %}
+ipv6-pool={{ default_ipv6_pool }}
+ipv6-pool-delegate={{ default_ipv6_pool }}
+{% endif %}
 
 [client-ip-range]
 0.0.0.0/0
@@ -61,10 +66,11 @@ ip-pool={{ default_pool }}
 {# Common IP pool definitions #}
 {% include 'accel-ppp/config_ip_pool.j2' %}
 
-[ppp]
-verbose=5
-check-ip=1
-single-session=replace
+{# Common IPv6 pool definitions #}
+{% include 'accel-ppp/config_ipv6_pool.j2' %}
+
+{# Common ppp-options definitions #}
+{% include 'accel-ppp/ppp-options.j2' %}
 
 {# Common chap-secrets and RADIUS server/option definitions #}
 {% include 'accel-ppp/config_chap_secrets_radius.j2' %}

--- a/data/templates/accel-ppp/sstp.config.j2
+++ b/data/templates/accel-ppp/sstp.config.j2
@@ -56,18 +56,8 @@ ipv6-pool-delegate={{ default_ipv6_pool }}
 {# Common chap-secrets and RADIUS server/option definitions #}
 {% include 'accel-ppp/config_chap_secrets_radius.j2' %}
 
-[ppp]
-verbose=1
-check-ip=1
-{# MTU #}
-mtu={{ mtu }}
-unit-preallocate={{ "1" if authentication.radius.preallocate_vif is vyos_defined else "0" }}
-ipv6={{ 'allow' if ppp_options.ipv6 is vyos_defined("deny") and client_ipv6_pool is vyos_defined else ppp_options.ipv6 }}
-ipv4={{ ppp_options.ipv4 }}
-mppe={{ ppp_options.mppe }}
-lcp-echo-interval={{ ppp_options.lcp_echo_interval }}
-lcp-echo-timeout={{ ppp_options.lcp_echo_timeout }}
-lcp-echo-failure={{ ppp_options.lcp_echo_failure }}
+{# Common ppp-options definitions #}
+{% include 'accel-ppp/ppp-options.j2' %}
 
 {# Common RADIUS shaper configuration #}
 {% include 'accel-ppp/config_shaper_radius.j2' %}

--- a/interface-definitions/include/accel-ppp/ppp-options-ipv6-interface-id.xml.i
+++ b/interface-definitions/include/accel-ppp/ppp-options-ipv6-interface-id.xml.i
@@ -1,5 +1,5 @@
 <!-- include start from accel-ppp/ppp-options-ipv6-interface-id.xml.i -->
-<leafNode name="ipv6-intf-id">
+<leafNode name="ipv6-interface-id">
   <properties>
     <help>Fixed or random interface identifier for IPv6</help>
     <completionHelp>
@@ -18,11 +18,11 @@
     </constraint>
   </properties>
 </leafNode>
-<leafNode name="ipv6-peer-intf-id">
+<leafNode name="ipv6-peer-interface-id">
   <properties>
     <help>Peer interface identifier for IPv6</help>
     <completionHelp>
-      <list>random calling-sid ipv4</list>
+      <list>random calling-sid ipv4-addr</list>
     </completionHelp>
     <valueHelp>
       <format>x:x:x:x</format>
@@ -33,7 +33,7 @@
       <description>Use a random interface identifier for IPv6</description>
     </valueHelp>
     <valueHelp>
-      <format>ipv4</format>
+      <format>ipv4-addr</format>
       <description>Calculate interface identifier from IPv4 address, for example 192:168:0:1</description>
     </valueHelp>
     <valueHelp>
@@ -41,11 +41,11 @@
       <description>Calculate interface identifier from calling-station-id</description>
     </valueHelp>
     <constraint>
-      <regex>(random|calling-sid|ipv4|((\d+){1,4}:){3}(\d+){1,4})</regex>
+      <regex>(random|calling-sid|ipv4-addr|((\d+){1,4}:){3}(\d+){1,4})</regex>
     </constraint>
   </properties>
 </leafNode>
-<leafNode name="ipv6-accept-peer-intf-id">
+<leafNode name="ipv6-accept-peer-interface-id">
   <properties>
     <help>Accept peer interface identifier</help>
     <valueless/>

--- a/interface-definitions/include/accel-ppp/ppp-options.xml.i
+++ b/interface-definitions/include/accel-ppp/ppp-options.xml.i
@@ -1,0 +1,65 @@
+<!-- include start from accel-ppp/ppp-options.xml.i -->
+<node name="ppp-options">
+  <properties>
+    <help>Advanced protocol options</help>
+  </properties>
+  <children>
+    <leafNode name="min-mtu">
+      <properties>
+        <help>Minimum acceptable MTU (68-65535)</help>
+        <constraint>
+          <validator name="numeric" argument="--range 68-65535"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="mru">
+      <properties>
+        <help>Preferred MRU (68-65535)</help>
+        <constraint>
+          <validator name="numeric" argument="--range 68-65535"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="disable-ccp">
+      <properties>
+        <help>Disable Compression Control Protocol (CCP)</help>
+        <valueless />
+      </properties>
+    </leafNode>
+    #include <include/accel-ppp/ppp-mppe.xml.i>
+    #include <include/accel-ppp/lcp-echo-interval-failure.xml.i>
+    #include <include/accel-ppp/lcp-echo-timeout.xml.i>
+    #include <include/accel-ppp/ppp-interface-cache.xml.i>
+    <leafNode name="ipv4">
+      <properties>
+        <help>IPv4 (IPCP) negotiation algorithm</help>
+        <constraint>
+          <regex>(deny|allow|prefer|require)</regex>
+        </constraint>
+        <constraintErrorMessage>invalid value</constraintErrorMessage>
+        <valueHelp>
+          <format>deny</format>
+          <description>Do not negotiate IPv4</description>
+        </valueHelp>
+        <valueHelp>
+          <format>allow</format>
+          <description>Negotiate IPv4 only if client requests</description>
+        </valueHelp>
+        <valueHelp>
+          <format>prefer</format>
+          <description>Ask client for IPv4 negotiation, do not fail if it rejects</description>
+        </valueHelp>
+        <valueHelp>
+          <format>require</format>
+          <description>Require IPv4 negotiation</description>
+        </valueHelp>
+        <completionHelp>
+          <list>deny allow prefer require</list>
+        </completionHelp>
+      </properties>
+    </leafNode>
+    #include <include/accel-ppp/ppp-options-ipv6.xml.i>
+    #include <include/accel-ppp/ppp-options-ipv6-interface-id.xml.i>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/version/l2tp-version.xml.i
+++ b/interface-definitions/include/version/l2tp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/l2tp-version.xml.i -->
-<syntaxVersion component='l2tp' version='7'></syntaxVersion>
+<syntaxVersion component='l2tp' version='8'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/include/version/pppoe-server-version.xml.i
+++ b/interface-definitions/include/version/pppoe-server-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/pppoe-server-version.xml.i -->
-<syntaxVersion component='pppoe-server' version='8'></syntaxVersion>
+<syntaxVersion component='pppoe-server' version='9'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/include/version/pptp-version.xml.i
+++ b/interface-definitions/include/version/pptp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/pptp-version.xml.i -->
-<syntaxVersion component='pptp' version='3'></syntaxVersion>
+<syntaxVersion component='pptp' version='4'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/service_pppoe-server.xml.in
+++ b/interface-definitions/service_pppoe-server.xml.in
@@ -103,68 +103,12 @@
             </properties>
           </leafNode>
           #include <include/accel-ppp/wins-server.xml.i>
+          #include <include/accel-ppp/ppp-options.xml.i>
           <node name="ppp-options">
-            <properties>
-              <help>Advanced protocol options</help>
-            </properties>
             <children>
               <leafNode name="min-mtu">
-                <properties>
-                  <help>Minimum acceptable MTU (68-65535)</help>
-                  <constraint>
-                    <validator name="numeric" argument="--range 68-65535"/>
-                  </constraint>
-                </properties>
                 <defaultValue>1280</defaultValue>
               </leafNode>
-              <leafNode name="mru">
-                <properties>
-                  <help>Preferred MRU (68-65535)</help>
-                  <constraint>
-                    <validator name="numeric" argument="--range 68-65535"/>
-                  </constraint>
-                </properties>
-              </leafNode>
-              <leafNode name="ccp">
-                <properties>
-                  <help>CCP negotiation (default disabled)</help>
-                  <valueless />
-                </properties>
-              </leafNode>
-              #include <include/accel-ppp/ppp-mppe.xml.i>
-              #include <include/accel-ppp/lcp-echo-interval-failure.xml.i>
-              #include <include/accel-ppp/lcp-echo-timeout.xml.i>
-              #include <include/accel-ppp/ppp-interface-cache.xml.i>
-              <leafNode name="ipv4">
-                <properties>
-                  <help>IPv4 (IPCP) negotiation algorithm</help>
-                  <constraint>
-                    <regex>(deny|allow|prefer|require)</regex>
-                  </constraint>
-                  <constraintErrorMessage>invalid value</constraintErrorMessage>
-                  <valueHelp>
-                    <format>deny</format>
-                    <description>Do not negotiate IPv4</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>allow</format>
-                    <description>Negotiate IPv4 only if client requests</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>prefer</format>
-                    <description>Ask client for IPv4 negotiation, do not fail if it rejects</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>require</format>
-                    <description>Require IPv4 negotiation</description>
-                  </valueHelp>
-                  <completionHelp>
-                    <list>deny allow prefer require</list>
-                  </completionHelp>
-                </properties>
-              </leafNode>
-              #include <include/accel-ppp/ppp-options-ipv6.xml.i>
-              #include <include/accel-ppp/ppp-options-ipv6-interface-id.xml.i>
             </children>
           </node>
           <tagNode name="pado-delay">

--- a/interface-definitions/vpn_l2tp.xml.in
+++ b/interface-definitions/vpn_l2tp.xml.in
@@ -49,12 +49,6 @@
                   </leafNode>
                 </children>
               </node>
-              <leafNode name="ccp-disable">
-                <properties>
-                  <help>Disable Compression Control Protocol (CCP)</help>
-                  <valueless />
-                </properties>
-              </leafNode>
               <node name="ipsec-settings">
                 <properties>
                   <help>Internet Protocol Security (IPsec) for remote access L2TP VPN</help>
@@ -140,19 +134,7 @@
                   </node>
                 </children>
               </node>
-              <node name="ppp-options">
-                <properties>
-                  <help>Advanced protocol options</help>
-                </properties>
-                <children>
-                  #include <include/accel-ppp/ppp-mppe.xml.i>
-                  #include <include/accel-ppp/ppp-options-ipv4.xml.i>
-                  #include <include/accel-ppp/ppp-options-ipv6.xml.i>
-                  #include <include/accel-ppp/ppp-options-ipv6-interface-id.xml.i>
-                  #include <include/accel-ppp/lcp-echo-interval-failure.xml.i>
-                  #include <include/accel-ppp/lcp-echo-timeout.xml.i>
-                </children>
-              </node>
+              #include <include/accel-ppp/ppp-options.xml.i>
               #include <include/accel-ppp/default-pool.xml.i>
               #include <include/accel-ppp/default-ipv6-pool.xml.i>
             </children>

--- a/interface-definitions/vpn_pptp.xml.in
+++ b/interface-definitions/vpn_pptp.xml.in
@@ -27,7 +27,7 @@
                 </properties>
               </leafNode>
               #include <include/accel-ppp/gateway-address.xml.i>
-              #include <include/name-server-ipv4.xml.i>
+              #include <include/name-server-ipv4-ipv6.xml.i>
               #include <include/accel-ppp/wins-server.xml.i>
               #include <include/accel-ppp/client-ip-pool.xml.i>
               <node name="authentication">
@@ -62,30 +62,6 @@
                       </constraint>
                     </properties>
                     <defaultValue>mschap-v2</defaultValue>
-                  </leafNode>
-                  <leafNode name="mppe">
-                    <properties>
-                      <help>Specifies mppe negotioation preference. (default require mppe 128-bit stateless</help>
-                      <valueHelp>
-                        <format>deny</format>
-                        <description>deny mppe</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>prefer</format>
-                        <description>ask client for mppe, if it rejects do not fail</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>require</format>
-                        <description>ask client for mppe, if it rejects drop connection</description>
-                      </valueHelp>
-                      <constraint>
-                        <regex>(deny|prefer|require)</regex>
-                      </constraint>
-                      <completionHelp>
-                        <list>deny prefer require</list>
-                      </completionHelp>
-                    </properties>
-                    <defaultValue>prefer</defaultValue>
                   </leafNode>
                   #include <include/accel-ppp/auth-mode.xml.i>
                   <node name="local-users">
@@ -134,7 +110,9 @@
                 </children>
               </node>
               #include <include/accel-ppp/default-pool.xml.i>
+              #include <include/accel-ppp/client-ipv6-pool.xml.i>
               #include <include/accel-ppp/default-ipv6-pool.xml.i>
+              #include <include/accel-ppp/ppp-options.xml.i>
             </children>
           </node>
         </children>

--- a/interface-definitions/vpn_sstp.xml.in
+++ b/interface-definitions/vpn_sstp.xml.in
@@ -37,18 +37,7 @@
           </leafNode>
           #include <include/accel-ppp/default-pool.xml.i>
           #include <include/accel-ppp/default-ipv6-pool.xml.i>
-          <node name="ppp-options">
-            <properties>
-              <help>PPP (Point-to-Point Protocol) settings</help>
-            </properties>
-            <children>
-              #include <include/accel-ppp/ppp-mppe.xml.i>
-              #include <include/accel-ppp/ppp-options-ipv4.xml.i>
-              #include <include/accel-ppp/ppp-options-ipv6.xml.i>
-              #include <include/accel-ppp/lcp-echo-interval-failure.xml.i>
-              #include <include/accel-ppp/lcp-echo-timeout.xml.i>
-            </children>
-          </node>
+          #include <include/accel-ppp/ppp-options.xml.i>
           <node name="ssl">
             <properties>
               <help>SSL Certificate, SSL Key and CA</help>

--- a/python/vyos/accel_ppp_util.py
+++ b/python/vyos/accel_ppp_util.py
@@ -187,13 +187,13 @@ def verify_accel_ppp_ip_pool(vpn_config):
         for ipv6_pool, ipv6_pool_config in vpn_config['client_ipv6_pool'].items():
             if 'delegate' in ipv6_pool_config and 'prefix' not in ipv6_pool_config:
                 raise ConfigError(
-                    f'IPoE IPv6 deletate-prefix requires IPv6 prefix to be configured in "{ipv6_pool}"!')
+                    f'IPv6 delegate-prefix requires IPv6 prefix to be configured in "{ipv6_pool}"!')
 
     if dict_search('authentication.mode', vpn_config) in ['local', 'noauth']:
         if not dict_search('client_ip_pool', vpn_config) and not dict_search(
                 'client_ipv6_pool', vpn_config):
             raise ConfigError(
-                "L2TP local auth mode requires local client-ip-pool or client-ipv6-pool to be configured!")
+                "Local auth mode requires local client-ip-pool or client-ipv6-pool to be configured!")
         if dict_search('client_ip_pool', vpn_config) and not dict_search(
                 'default_pool', vpn_config):
             Warning("'default-pool' is not defined")

--- a/smoketest/scripts/cli/test_service_ipoe-server.py
+++ b/smoketest/scripts/cli/test_service_ipoe-server.py
@@ -228,5 +228,9 @@ delegate={delegate_1_prefix},{delegate_mask},name={pool_name}
 delegate={delegate_2_prefix},{delegate_mask},name={pool_name}"""
         self.assertIn(pool_config, config)
 
+    @unittest.skip("PPP is not a part of IPoE")
+    def test_accel_ppp_options(self):
+        pass
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/smoketest/scripts/cli/test_service_pppoe-server.py
+++ b/smoketest/scripts/cli/test_service_pppoe-server.py
@@ -59,9 +59,6 @@ class TestServicePPPoEServer(BasicAccelPPPTest.TestCase):
         self.assertTrue(conf['ppp'].getboolean('verbose'))
         self.assertTrue(conf['ppp'].getboolean('check-ip'))
         self.assertEqual(conf['ppp']['mtu'], mtu)
-        self.assertEqual(conf['ppp']['lcp-echo-interval'], '30')
-        self.assertEqual(conf['ppp']['lcp-echo-timeout'], '0')
-        self.assertEqual(conf['ppp']['lcp-echo-failure'], '3')
 
         super().verify(conf)
 
@@ -70,69 +67,13 @@ class TestServicePPPoEServer(BasicAccelPPPTest.TestCase):
         self.set(['access-concentrator', ac_name])
         self.set(['interface', interface])
 
-
-    def test_pppoe_server_ppp_options(self):
-        # Test configuration of local authentication for PPPoE server
+    def test_pppoe_limits(self):
         self.basic_config()
-
-        # other settings
-        mppe = 'require'
-        self.set(['ppp-options', 'ccp'])
-        self.set(['ppp-options', 'mppe', mppe])
         self.set(['limits', 'connection-limit', '20/min'])
-
-        # min-mtu
-        min_mtu = '1400'
-        self.set(['ppp-options', 'min-mtu', min_mtu])
-
-        # mru
-        mru = '9000'
-        self.set(['ppp-options', 'mru', mru])
-
-        # interface-cache
-        interface_cache = '128000'
-        self.set(['ppp-options', 'interface-cache', interface_cache])
-
-        # ipv6
-        allow_ipv6 = 'allow'
-        random = 'random'
-        self.set(['ppp-options', 'ipv6', allow_ipv6])
-        self.set(['ppp-options', 'ipv6-intf-id', random])
-        self.set(['ppp-options', 'ipv6-accept-peer-intf-id'])
-        self.set(['ppp-options', 'ipv6-peer-intf-id', random])
-        # commit changes
         self.cli_commit()
-
-        # Validate configuration values
         conf = ConfigParser(allow_no_value=True, delimiters='=')
         conf.read(self._config_file)
-
-        # basic verification
-        self.verify(conf)
-
-        self.assertEqual(conf['chap-secrets']['gw-ip-address'], self._gateway)
-
-        # check ppp
-        self.assertEqual(conf['ppp']['mppe'], mppe)
-        self.assertEqual(conf['ppp']['min-mtu'], min_mtu)
-        self.assertEqual(conf['ppp']['mru'], mru)
-
-        self.assertTrue(conf['ppp'].getboolean('ccp'))
-
-        # check other settings
         self.assertEqual(conf['connlimit']['limit'], '20/min')
-
-        # check interface-cache
-        self.assertEqual(conf['ppp']['unit-cache'], interface_cache)
-
-        #check ipv6
-        for tmp in ['ipv6pool', 'ipv6_nd', 'ipv6_dhcp']:
-            self.assertEqual(conf['modules'][tmp], None)
-
-        self.assertEqual(conf['ppp']['ipv6'], allow_ipv6)
-        self.assertEqual(conf['ppp']['ipv6-intf-id'], random)
-        self.assertEqual(conf['ppp']['ipv6-peer-intf-id'], random)
-        self.assertTrue(conf['ppp'].getboolean('ipv6-accept-peer-intf-id'))
 
     def test_pppoe_server_authentication_protocols(self):
         # Test configuration of local authentication for PPPoE server

--- a/smoketest/scripts/cli/test_vpn_l2tp.py
+++ b/smoketest/scripts/cli/test_vpn_l2tp.py
@@ -38,58 +38,6 @@ class TestVPNL2TPServer(BasicAccelPPPTest.TestCase):
     def basic_protocol_specific_config(self):
         pass
 
-    def test_l2tp_server_ppp_options(self):
-        # Test configuration of local authentication for PPPoE server
-        self.basic_config()
-        mtu = '1425'
-        lcp_echo_failure = '5'
-        lcp_echo_interval = '40'
-        lcp_echo_timeout = '3000'
-        # other settings
-        mppe = 'require'
-        self.set(['ccp-disable'])
-        self.set(['ppp-options', 'mppe', mppe])
-        self.set(['authentication', 'radius', 'preallocate-vif'])
-        self.set(['mtu', mtu])
-        self.set(['ppp-options', 'lcp-echo-failure', lcp_echo_failure])
-        self.set(['ppp-options', 'lcp-echo-interval', lcp_echo_interval])
-        self.set(['ppp-options', 'lcp-echo-timeout', lcp_echo_timeout])
-
-        allow_ipv6 = 'allow'
-        random = 'random'
-        self.set(['ppp-options', 'ipv6', allow_ipv6])
-        self.set(['ppp-options', 'ipv6-intf-id', random])
-        self.set(['ppp-options', 'ipv6-accept-peer-intf-id'])
-        self.set(['ppp-options', 'ipv6-peer-intf-id', random])
-
-        # commit changes
-        self.cli_commit()
-
-        # Validate configuration values
-        conf = ConfigParser(allow_no_value=True, delimiters='=')
-        conf.read(self._config_file)
-
-        # basic verification
-        self.verify(conf)
-
-        # check ppp
-        self.assertEqual(conf['ppp']['mppe'], mppe)
-        self.assertFalse(conf['ppp'].getboolean('ccp'))
-        self.assertEqual(conf['ppp']['unit-preallocate'], '1')
-        self.assertTrue(conf['ppp'].getboolean('verbose'))
-        self.assertTrue(conf['ppp'].getboolean('check-ip'))
-        self.assertEqual(conf['ppp']['mtu'], mtu)
-        self.assertEqual(conf['ppp']['lcp-echo-interval'], lcp_echo_interval)
-        self.assertEqual(conf['ppp']['lcp-echo-timeout'], lcp_echo_timeout)
-        self.assertEqual(conf['ppp']['lcp-echo-failure'], lcp_echo_failure)
-
-        for tmp in ['ipv6pool', 'ipv6_nd', 'ipv6_dhcp']:
-            self.assertEqual(conf['modules'][tmp], None)
-        self.assertEqual(conf['ppp']['ipv6'], allow_ipv6)
-        self.assertEqual(conf['ppp']['ipv6-intf-id'], random)
-        self.assertEqual(conf['ppp']['ipv6-peer-intf-id'], random)
-        self.assertTrue(conf['ppp'].getboolean('ipv6-accept-peer-intf-id'))
-
     def test_l2tp_server_authentication_protocols(self):
         # Test configuration of local authentication for PPPoE server
         self.basic_config()

--- a/smoketest/scripts/cli/test_vpn_pptp.py
+++ b/smoketest/scripts/cli/test_vpn_pptp.py
@@ -40,25 +40,6 @@ class TestVPNPPTPServer(BasicAccelPPPTest.TestCase):
     def basic_protocol_specific_config(self):
         pass
 
-    def test_accel_name_servers(self):
-        # Verify proper Name-Server configuration for IPv4
-        self.basic_config()
-
-        nameserver = ["192.0.2.1", "192.0.2.2"]
-        for ns in nameserver:
-            self.set(["name-server", ns])
-
-        # commit changes
-        self.cli_commit()
-
-        # Validate configuration values
-        conf = ConfigParser(allow_no_value=True, delimiters="=", strict=False)
-        conf.read(self._config_file)
-
-        # IPv4 and IPv6 nameservers must be checked individually
-        for ns in nameserver:
-            self.assertIn(ns, [conf["dns"]["dns1"], conf["dns"]["dns2"]])
-
     def test_accel_local_authentication(self):
         # Test configuration of local authentication
         self.basic_config()
@@ -217,10 +198,6 @@ class TestVPNPPTPServer(BasicAccelPPPTest.TestCase):
         self.assertEqual(f"acct-port=0", server[3])
         self.assertEqual(f"req-limit=0", server[4])
         self.assertEqual(f"fail-time=0", server[5])
-
-    @unittest.skip("IPv6 is not implemented in PPTP")
-    def test_accel_ipv6_pool(self):
-        pass
 
 
 if __name__ == '__main__':

--- a/src/conf_mode/vpn_l2tp.py
+++ b/src/conf_mode/vpn_l2tp.py
@@ -51,11 +51,6 @@ def get_config(config=None):
         # Multiple named pools require ordered values T5099
         l2tp['ordered_named_pools'] = get_pools_in_order(
             dict_search('client_ip_pool', l2tp))
-    l2tp['ip6_column'] = []
-    if dict_search('client_ipv6_pool.prefix', l2tp):
-        l2tp['ip6_column'].append('ipv6')
-    if dict_search('client_ipv6_pool.delegate', l2tp):
-        l2tp['ip6_column'].append('ip6-db')
     l2tp['server_type'] = 'l2tp'
     return l2tp
 

--- a/src/conf_mode/vpn_sstp.py
+++ b/src/conf_mode/vpn_sstp.py
@@ -20,7 +20,6 @@ from sys import exit
 
 from vyos.config import Config
 from vyos.configdict import get_accel_dict
-from vyos.configdict import dict_merge
 from vyos.pki import wrap_certificate
 from vyos.pki import wrap_private_key
 from vyos.template import render

--- a/src/migration-scripts/l2tp/7-to-8
+++ b/src/migration-scripts/l2tp/7-to-8
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Migrate from 'ccp-disable' to 'ppp-options.disable-ccp'
+# Migration ipv6 options
+
+import os
+
+from sys import argv
+from sys import exit
+from vyos.configtree import ConfigTree
+
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+base = ['vpn', 'l2tp', 'remote-access']
+if not config.exists(base):
+    exit(0)
+
+#CCP migration
+if config.exists(base + ['ccp-disable']):
+    config.delete(base + ['ccp-disable'])
+    config.set(base + ['ppp-options', 'disable-ccp'])
+
+#IPV6 options migrations
+if config.exists(base + ['ppp-options','ipv6-peer-intf-id']):
+    intf_peer_id = config.return_value(base + ['ppp-options','ipv6-peer-intf-id'])
+    if intf_peer_id == 'ipv4':
+        intf_peer_id = 'ipv4-addr'
+    config.set(base + ['ppp-options','ipv6-peer-interface-id'], value=intf_peer_id, replace=True)
+    config.delete(base + ['ppp-options','ipv6-peer-intf-id'])
+
+if config.exists(base + ['ppp-options','ipv6-intf-id']):
+    intf_id = config.return_value(base + ['ppp-options','ipv6-intf-id'])
+    config.set(base + ['ppp-options','ipv6-interface-id'], value=intf_id, replace=True)
+    config.delete(base + ['ppp-options','ipv6-intf-id'])
+
+if config.exists(base + ['ppp-options','ipv6-accept-peer-intf-id']):
+    config.set(base + ['ppp-options','ipv6-accept-peer-interface-id'])
+    config.delete(base + ['ppp-options','ipv6-accept-peer-intf-id'])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)

--- a/src/migration-scripts/pppoe-server/8-to-9
+++ b/src/migration-scripts/pppoe-server/8-to-9
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Change from 'ccp' to 'disable-ccp' in ppp-option section
+# Migration ipv6 options
+
+import os
+
+from sys import argv
+from sys import exit
+from vyos.configtree import ConfigTree
+
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+base = ['service', 'pppoe-server']
+if not config.exists(base):
+    exit(0)
+
+#CCP migration
+if config.exists(base + ['ppp-options', 'ccp']):
+    config.delete(base + ['ppp-options', 'ccp'])
+else:
+    config.set(base + ['ppp-options', 'disable-ccp'])
+
+#IPV6 options migrations
+if config.exists(base + ['ppp-options','ipv6-peer-intf-id']):
+    intf_peer_id = config.return_value(base + ['ppp-options','ipv6-peer-intf-id'])
+    if intf_peer_id == 'ipv4':
+        intf_peer_id = 'ipv4-addr'
+    config.set(base + ['ppp-options','ipv6-peer-interface-id'], value=intf_peer_id, replace=True)
+    config.delete(base + ['ppp-options','ipv6-peer-intf-id'])
+
+if config.exists(base + ['ppp-options','ipv6-intf-id']):
+    intf_id = config.return_value(base + ['ppp-options','ipv6-intf-id'])
+    config.set(base + ['ppp-options','ipv6-interface-id'], value=intf_id, replace=True)
+    config.delete(base + ['ppp-options','ipv6-intf-id'])
+
+if config.exists(base + ['ppp-options','ipv6-accept-peer-intf-id']):
+    config.set(base + ['ppp-options','ipv6-accept-peer-interface-id'])
+    config.delete(base + ['ppp-options','ipv6-accept-peer-intf-id'])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)

--- a/src/migration-scripts/pptp/3-to-4
+++ b/src/migration-scripts/pptp/3-to-4
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# - Move 'mppe' from 'authentication' node to 'ppp-options'
+
+import os
+
+from sys import argv
+from sys import exit
+from vyos.configtree import ConfigTree
+
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+base = ['vpn', 'pptp', 'remote-access']
+
+if not config.exists(base):
+    exit(0)
+
+if config.exists(base + ['authentication','mppe']):
+    mppe = config.return_value(base + ['authentication','mppe'])
+    config.set(base + ['ppp-options', 'mppe'], value=mppe, replace=True)
+    config.delete(base + ['authentication','mppe'])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Rewritten 'ppp-options' to the same view in all accel-ppp services. Adding IPv6 support to PPTP.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5971

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe, l2tp, sstp, pptp

## Proposed changes
<!--- Describe your changes in detail -->
Rewritten 'ppp-options' to the same view in all accel-ppp services. Adding IPv6 support to PPTP.
```
vyos@vyos# set vpn sstp ppp-options
Possible completions:
   ccp-disable          Disable Compression Control Protocol (CCP)
   interface-cache      PPP interface cache
   ipv4                 IPv4 (IPCP) negotiation algorithm
   ipv6                 IPv6 (IPCP6) negotiation algorithm (default: deny)
   ipv6-accept-peer-intf-id
                        Accept peer interface identifier
   ipv6-intf-id         Fixed or random interface identifier for IPv6
   ipv6-peer-intf-id    Peer interface identifier for IPv6
   lcp-echo-failure     Maximum number of Echo-Requests may be sent without valid reply
                        (default: 3)
   lcp-echo-interval    LCP echo-requests/sec (default: 30)
   lcp-echo-timeout     Timeout in seconds to wait for any peer activity. If this option
                        specified it turns on adaptive lcp echo functionality and
                        "lcp-echo-failure" is not used. (default: 0)
   min-mtu              Minimum acceptable MTU (68-65535)
   mppe                 Specifies mppe negotiation preferences (default: prefer)
   mru                  Preferred MRU (68-65535)
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_ipoe-server.py
test_accel_ipv4_pool (__main__.TestServiceIPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServiceIPoEServer.test_accel_ipv6_pool) ...
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_local_authentication (__main__.TestServiceIPoEServer.test_accel_local_authentication) ...
No IPoE interface configured

ok
test_accel_name_servers (__main__.TestServiceIPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServiceIPoEServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_ppp_options (__main__.TestServiceIPoEServer.test_accel_ppp_options) ... skipped 'PPP is not a part of IPoE'
test_accel_radius_authentication (__main__.TestServiceIPoEServer.test_accel_radius_authentication) ... ok

----------------------------------------------------------------------
Ran 7 tests in 20.878s

OK (skipped=1)
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py
test_accel_ipv4_pool (__main__.TestServicePPPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServicePPPoEServer.test_accel_ipv6_pool) ...
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_local_authentication (__main__.TestServicePPPoEServer.test_accel_local_authentication) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_name_servers (__main__.TestServicePPPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServicePPPoEServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_ppp_options (__main__.TestServicePPPoEServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer.test_accel_radius_authentication) ... ok
test_pppoe_limits (__main__.TestServicePPPoEServer.test_pppoe_limits) ... ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer.test_pppoe_server_authentication_protocols) ... ok
test_pppoe_server_shaper (__main__.TestServicePPPoEServer.test_pppoe_server_shaper) ... ok
test_pppoe_server_vlan (__main__.TestServicePPPoEServer.test_pppoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 11 tests in 39.241s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_l2tp.py
test_accel_ipv4_pool (__main__.TestVPNL2TPServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestVPNL2TPServer.test_accel_ipv6_pool) ...
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_local_authentication (__main__.TestVPNL2TPServer.test_accel_local_authentication) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_name_servers (__main__.TestVPNL2TPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNL2TPServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_ppp_options (__main__.TestVPNL2TPServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestVPNL2TPServer.test_accel_radius_authentication) ... ok
test_l2tp_server_authentication_protocols (__main__.TestVPNL2TPServer.test_l2tp_server_authentication_protocols) ... ok

----------------------------------------------------------------------
Ran 8 tests in 29.922s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_pptp.py
test_accel_ipv4_pool (__main__.TestVPNPPTPServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestVPNPPTPServer.test_accel_ipv6_pool) ...
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_local_authentication (__main__.TestVPNPPTPServer.test_accel_local_authentication) ... ok
test_accel_name_servers (__main__.TestVPNPPTPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNPPTPServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_ppp_options (__main__.TestVPNPPTPServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestVPNPPTPServer.test_accel_radius_authentication) ... ok

----------------------------------------------------------------------
Ran 7 tests in 26.325s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_sstp.py
test_accel_ipv4_pool (__main__.TestVPNSSTPServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestVPNSSTPServer.test_accel_ipv6_pool) ...
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_local_authentication (__main__.TestVPNSSTPServer.test_accel_local_authentication) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_name_servers (__main__.TestVPNSSTPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNSSTPServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_ppp_options (__main__.TestVPNSSTPServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestVPNSSTPServer.test_accel_radius_authentication) ... ok

----------------------------------------------------------------------
Ran 7 tests in 28.384s

OK

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
