### PR TITLE
dns forwarding: T5687: Implement ECS settings for PowerDNS recursor

### DIFF
--- a/data/templates/dns-forwarding/recursor.conf.j2
+++ b/data/templates/dns-forwarding/recursor.conf.j2
@@ -57,3 +57,17 @@ serve-rfc1918={{ 'no' if no_serve_rfc1918 is vyos_defined else 'yes' }}
 auth-zones={% for z in authoritative_zones %}{{ z.name }}={{ z.file }}{{- "," if not loop.last -}}{% endfor %}
 
 forward-zones-file={{ config_dir }}/recursor.forward-zones.conf
+
+#ecs
+{% if options.ecs_add_for is vyos_defined %}
+ecs-add-for={{ options.ecs_add_for | join(',') }}
+{% endif %}
+
+{% if options.ecs_ipv4_bits is vyos_defined %}
+ecs-ipv4-bits={{ options.ecs_ipv4_bits }}
+{% endif %}
+
+{% if options.edns_subnet_allow_list is vyos_defined %}
+edns-subnet-allow-list={{ options.edns_subnet_allow_list | join(',') }}
+{% endif %}
+

--- a/interface-definitions/service_dns_forwarding.xml.in
+++ b/interface-definitions/service_dns_forwarding.xml.in
@@ -745,12 +745,26 @@
                       <help>Client netmask for which EDNS Client Subnet will be added</help>
                       <valueHelp>
                         <format>ipv4net</format>
-                        <description>IP addresses or subnets, negation supported</description>
+                        <description>IPv4 prefix to match</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>!ipv4net</format>
+                        <description>Match everything except the specified IPv4 prefix</description>
                       </valueHelp>
                       <valueHelp>
                         <format>ipv6net</format>
-                        <description>IPv6 addresses or subnets, negation supported</description>
+                        <description>IPv6 prefix to match</description>
                       </valueHelp>
+                      <valueHelp>
+                        <format>!ipv6net</format>
+                        <description>Match everything except the specified IPv6 prefix</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="ipv4-prefix"/>
+                        <validator name="ipv4-prefix-exclude"/>
+                        <validator name="ipv6-prefix"/>
+                        <validator name="ipv6-prefix-exclude"/>
+                      </constraint>
                       <multi/>
                     </properties>
                   </leafNode>

--- a/interface-definitions/service_dns_forwarding.xml.in
+++ b/interface-definitions/service_dns_forwarding.xml.in
@@ -742,7 +742,7 @@
                 <children>
                   <leafNode name="ecs-add-for">
                     <properties>
-                      <help>List of client netmasks for which EDNS Client Subnet will be added</help>
+                      <help>Client netmask for which EDNS Client Subnet will be added</help>
                       <valueHelp>
                         <format>ipv4net</format>
                         <description>IP addresses or subnets, negation supported</description>
@@ -768,7 +768,7 @@
                   </leafNode>
                   <leafNode name="edns-subnet-allow-list">
                     <properties>
-                      <help>List of netmasks and domains that we should enable EDNS subnet for</help>
+                      <help>Netmask or domain that we should enable EDNS subnet for</help>
                       <valueHelp>
                         <format>txt</format>
                         <description>Netmask or domain</description>

--- a/interface-definitions/service_dns_forwarding.xml.in
+++ b/interface-definitions/service_dns_forwarding.xml.in
@@ -735,6 +735,49 @@
                   </constraint>
                 </properties>
               </leafNode>
+              <node name="options">
+                <properties>
+                  <help>DNS server options</help>
+                </properties>
+                <children>
+                  <leafNode name="ecs-add-for">
+                    <properties>
+                      <help>List of client netmasks for which EDNS Client Subnet will be added</help>
+                      <valueHelp>
+                        <format>ipv4net</format>
+                        <description>IP addresses or subnets, negation supported</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>ipv6net</format>
+                        <description>IPv6 addresses or subnets, negation supported</description>
+                      </valueHelp>
+                      <multi/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="ecs-ipv4-bits">
+                    <properties>
+                      <help>Number of bits of IPv4 address to pass for EDNS Client Subnet</help>
+                      <valueHelp>
+                        <format>u32:0-32</format>
+                        <description>Number of bits of IPv4 address</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-32"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="edns-subnet-allow-list">
+                    <properties>
+                      <help>List of netmasks and domains that we should enable EDNS subnet for</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Netmask or domain</description>
+                      </valueHelp>
+                      <multi/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
             </children>
           </node>
         </children>

--- a/smoketest/scripts/cli/test_service_dns_forwarding.py
+++ b/smoketest/scripts/cli/test_service_dns_forwarding.py
@@ -59,7 +59,9 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         # Check for running process
         self.assertFalse(process_named_running(PROCESS_NAME))
 
-    def _set_required_options(self):
+    def setUp(self):
+        # forward to base class
+        super().setUp()
         for network in allow_from:
             self.cli_set(base_path + ['allow-from', network])
         for address in listen_adress:
@@ -69,6 +71,10 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         # Check basic DNS forwarding settings
         cache_size = '20'
         negative_ttl = '120'
+
+        # remove code from setUp() as in this test-case we validate the proper
+        # handling of assertions when specific CLI nodes are missing
+        self.cli_delete(base_path)
 
         self.cli_set(base_path + ['cache-size', cache_size])
         self.cli_set(base_path + ['negative-ttl', negative_ttl])
@@ -124,12 +130,6 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
 
     def test_dnssec(self):
         # DNSSEC option testing
-
-        for network in allow_from:
-            self.cli_set(base_path + ['allow-from', network])
-        for address in listen_adress:
-            self.cli_set(base_path + ['listen-address', address])
-
         options = ['off', 'process-no-validate', 'process', 'log-fail', 'validate']
         for option in options:
             self.cli_set(base_path + ['dnssec', option])
@@ -142,12 +142,6 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
 
     def test_external_nameserver(self):
         # Externe Domain Name Servers (DNS) addresses
-
-        for network in allow_from:
-            self.cli_set(base_path + ['allow-from', network])
-        for address in listen_adress:
-            self.cli_set(base_path + ['listen-address', address])
-
         nameservers = {'192.0.2.1': {}, '192.0.2.2': {'port': '53'}, '2001:db8::1': {'port': '853'}}
         for h,p in nameservers.items():
             if 'port' in p:
@@ -169,11 +163,6 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         self.assertEqual(tmp, 'yes')
 
     def test_domain_forwarding(self):
-        for network in allow_from:
-            self.cli_set(base_path + ['allow-from', network])
-        for address in listen_adress:
-            self.cli_set(base_path + ['listen-address', address])
-
         domains = ['vyos.io', 'vyos.net', 'vyos.com']
         nameservers = {'192.0.2.1': {}, '192.0.2.2': {'port': '53'}, '2001:db8::1': {'port': '853'}}
         for domain in domains:
@@ -210,11 +199,6 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
                 self.assertIn(f'addNTA("{domain}", "static")', hosts_conf)
 
     def test_no_rfc1918_forwarding(self):
-        for network in allow_from:
-            self.cli_set(base_path + ['allow-from', network])
-        for address in listen_adress:
-            self.cli_set(base_path + ['listen-address', address])
-
         self.cli_set(base_path + ['no-serve-rfc1918'])
 
         # commit changes
@@ -226,12 +210,6 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
 
     def test_dns64(self):
         dns_prefix = '64:ff9b::/96'
-
-        for network in allow_from:
-            self.cli_set(base_path + ['allow-from', network])
-        for address in listen_adress:
-            self.cli_set(base_path + ['listen-address', address])
-
         # Check dns64-prefix - must be prefix /96
         self.cli_set(base_path + ['dns64-prefix', '2001:db8:aabb::/64'])
         with self.assertRaises(ConfigSessionError):
@@ -252,12 +230,6 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
             '2001:db8:85a3:8d3:1319:8a2e:370:7348',
             '64:ff9b::/96'
         ]
-
-        for network in allow_from:
-            self.cli_set(base_path + ['allow-from', network])
-        for address in listen_adress:
-            self.cli_set(base_path + ['listen-address', address])
-
         for exclude_throttle_adress in exclude_throttle_adress_examples:
             self.cli_set(base_path + ['exclude-throttle-address', exclude_throttle_adress])
 
@@ -270,16 +242,9 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
 
     def test_serve_stale_extension(self):
         server_stale = '20'
-        for network in allow_from:
-            self.cli_set(base_path + ['allow-from', network])
-        for address in listen_adress:
-            self.cli_set(base_path + ['listen-address', address])
-
         self.cli_set(base_path + ['serve-stale-extension', server_stale])
-
         # commit changes
         self.cli_commit()
-
         # verify configuration
         tmp = get_config_value('serve-stale-extensions')
         self.assertEqual(tmp, server_stale)
@@ -288,48 +253,33 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         # We can listen on a different port compared to '53' but only one at a time
         for port in ['10053', '10054']:
             self.cli_set(base_path + ['port', port])
-            for network in allow_from:
-                self.cli_set(base_path + ['allow-from', network])
-            for address in listen_adress:
-                self.cli_set(base_path + ['listen-address', address])
-
             # commit changes
             self.cli_commit()
-
             # verify local-port configuration
             tmp = get_config_value('local-port')
             self.assertEqual(tmp, port)
 
     def test_ecs_add_for(self):
-        self._set_required_options()
-
         options = ['0.0.0.0/0', '!10.0.0.0/8', 'fc00::/7', '!fe80::/10']
         for param in options:
             self.cli_set(base_path + ['options', 'ecs-add-for', param])
 
         # commit changes
         self.cli_commit()
-
         # verify ecs_add_for configuration
         tmp = get_config_value('ecs-add-for')
         self.assertEqual(tmp, ','.join(options))
 
     def test_ecs_ipv4_bits(self):
-        self._set_required_options()
-
         option_value = '24'
         self.cli_set(base_path + ['options', 'ecs-ipv4-bits', option_value])
-
         # commit changes
         self.cli_commit()
-
         # verify ecs_ipv4_bits configuration
         tmp = get_config_value('ecs-ipv4-bits')
         self.assertEqual(tmp, option_value)
 
     def test_edns_subnet_allow_list(self):
-        self._set_required_options()
-
         options = ['192.0.2.1/32', 'example.com', 'fe80::/10']
         for param in options:
             self.cli_set(base_path + ['options', 'edns-subnet-allow-list', param])
@@ -340,7 +290,6 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         # verify edns_subnet_allow_list configuration
         tmp = get_config_value('edns-subnet-allow-list')
         self.assertEqual(tmp, ','.join(options))
-
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Implement ECS settings for PowerDNS recursor

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5687

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dns forwarding
## Proposed changes
<!--- Describe your changes in detail -->
Add new params to `/run/powerdns/recursor.conf` and new CLI commands.
```
set service dns forwarding options ecs-add-for 
set service dns forwarding options ecs-ipv4-bits 
set service dns forwarding options edns-subnet-allow-list 
```
Add smoke test for this CLI command

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
