### PR TITLE
bgp: T5930: Denied using rt vpn 'export/import' with 'both' together

### DIFF
--- a/interface-definitions/include/version/bgp-version.xml.i
+++ b/interface-definitions/include/version/bgp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/bgp-version.xml.i -->
-<syntaxVersion component='bgp' version='4'></syntaxVersion>
+<syntaxVersion component='bgp' version='5'></syntaxVersion>
 <!-- include end -->

--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020-2023 VyOS maintainers and contributors
+# Copyright (C) 2020-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -509,6 +509,14 @@ def verify(bgp):
                     if verify_vrf_as_import(vrf_name, afi, bgp['dependent_vrfs']):
                         raise ConfigError(
                             'Command "import vrf" conflicts with "route-target vpn both" command!')
+                    if dict_search('route_target.vpn.export', afi_config):
+                        raise ConfigError(
+                            'Command "route-target vpn export" conflicts '\
+                            'with "route-target vpn both" command!')
+                    if dict_search('route_target.vpn.import', afi_config):
+                        raise ConfigError(
+                            'Command "route-target vpn import" conflicts '\
+                            'with "route-target vpn both" command!')
 
                 if dict_search('route_target.vpn.import', afi_config):
                     if verify_vrf_as_import(vrf_name, afi, bgp['dependent_vrfs']):

--- a/src/migration-scripts/bgp/4-to-5
+++ b/src/migration-scripts/bgp/4-to-5
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Delete 'protocols bgp address-family ipv6-unicast route-target vpn
+# import/export', if 'protocols bgp address-family ipv6-unicast
+# route-target vpn both' exists
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+
+bgp_base = ['protocols', 'bgp']
+# Delete 'import/export' in default vrf if 'both' exists
+if config.exists(bgp_base):
+    for address_family in ['ipv4-unicast', 'ipv6-unicast']:
+        rt_path = bgp_base + ['address-family', address_family, 'route-target',
+                              'vpn']
+        if config.exists(rt_path + ['both']):
+            if config.exists(rt_path + ['import']):
+                config.delete(rt_path + ['import'])
+            if config.exists(rt_path + ['export']):
+                config.delete(rt_path + ['export'])
+
+# Delete import/export in vrfs if both exists
+if config.exists(['vrf', 'name']):
+    for vrf in config.list_nodes(['vrf', 'name']):
+        vrf_base = ['vrf', 'name', vrf]
+        for address_family in ['ipv4-unicast', 'ipv6-unicast']:
+            rt_path = vrf_base + bgp_base + ['address-family', address_family,
+                                             'route-target', 'vpn']
+            if config.exists(rt_path + ['both']):
+                if config.exists(rt_path + ['import']):
+                    config.delete(rt_path + ['import'])
+                if config.exists(rt_path + ['export']):
+                    config.delete(rt_path + ['export'])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print(f'Failed to save the modified config: {e}')
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Denied using command 'route-target vpn export/import' with 'both' together in bgp configuration.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5930

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp

## Proposed changes
<!--- Describe your changes in detail -->
Denied using command 'route-target vpn export/import' with 'both' together in bgp configuration.


## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configuration before:
```
set protocols bgp address-family ipv4-unicast export vpn
set protocols bgp address-family ipv4-unicast import vpn
set protocols bgp address-family ipv4-unicast rd vpn export '64496:100'
set protocols bgp address-family ipv4-unicast redistribute connected
set protocols bgp address-family ipv4-unicast route-target vpn both '64496:100'
set protocols bgp address-family ipv4-unicast route-target vpn import '65500:200'
set protocols bgp parameters router-id '1.1.1.1'
set protocols bgp system-as '65000'
```
FRR Config:
```
router bgp 65000
 bgp router-id 1.1.1.1
 no bgp ebgp-requires-policy
 no bgp default ipv4-unicast
 no bgp network import-check
 !
 address-family ipv4 unicast
  redistribute connected
  rd vpn export 64496:100
  rt vpn both 64496:100
  export vpn
  import vpn
 exit-address-family
exit

```
After changing:

```
vyos@vyos# commit

Command "route-target vpn import" conflicts with "route-target vpn both"
command!

[[protocols bgp]] failed
Commit failed
[edit]
vyos@vyos#

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ...
BGP system-as number must be defined!

ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ...
Must either speficy exist-map or non-exist-map when conditionally-
advertise is in use!

ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ...
Must either speficy exist-map or non-exist-map when conditionally-
advertise is in use!

ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ...
Listen range for prefix "192.0.2.0/25" has no peer group configured.


Peer-group "listenfoobar" for listen range "192.0.2.0/25" does not
exist!


Peer-group "listenfoobar" for listen range "192.0.2.0/25" does not
exist!

ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ...
WARNING: BGP "router-id" is required when using "rd" and "route-
target"!


WARNING: BGP "router-id" is required when using "rd" and "route-
target"!

ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ...
WARNING: BGP neighbor "192.0.2.1" requires address-family!


Peer-group member "192.0.2.1" cannot override remote-as of peer-group
"bar"!


WARNING: BGP neighbor "192.0.2.1" requires address-family!


WARNING: BGP neighbor "eth0" requires address-family!


Peer-group member "eth0" cannot override remote-as of peer-group "bar"!


WARNING: BGP neighbor "192.0.2.1" requires address-family!


WARNING: BGP neighbor "eth0" requires address-family!


Peer-group member "eth0" cannot override remote-as of peer-group "bar"!


WARNING: BGP neighbor "192.0.2.1" requires address-family!


WARNING: BGP neighbor "eth0" requires address-family!

ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ...
WARNING: BGP neighbor "192.0.2.99" requires address-family!


local-as configured for "192.0.2.99", allowed only for eBGP peers!


WARNING: BGP neighbor "192.0.2.99" requires address-family!

ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ...
WARNING: BGP "router-id" is required when using "rd" and "route-
target"!


Please unconfigure "import vrf" commands before using vpn commands in
the same VRF!

ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ...
Command "import vrf" conflicts with "rd vpn export" command!

ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ...
Cannot delete VRF instance "red", unconfigure "import vrf" commands!

ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ...
Cannot delete default BGP instance, dependent VRF instance(s) exist!

ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ...
WARNING: BGP "router-id" is required when using "rd" and "route-
target"!


Please unconfigure import vrf commands before using vpn commands in
dependent VRFs!

ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ...
VRF "test" does not exist

ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok
test_bgp_24_srv6_sid (__main__.TestProtocolsBGP.test_bgp_24_srv6_sid) ...
SID per VRF and SID per address-family are mutually exclusive!

ok
test_bgp_25_ipv4_ipv6_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_25_ipv4_ipv6_labeled_unicast_peer_group) ... ok
test_bgp_99_bmp (__main__.TestProtocolsBGP.test_bgp_99_bmp) ...
BMP target "instance-bmp" address must be defined!

ok

----------------------------------------------------------------------
Ran 25 tests in 145.676s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
