### PR TITLE
ipsec: T5998: add replay-windows setting

### DIFF
--- a/data/templates/ipsec/swanctl/peer.j2
+++ b/data/templates/ipsec/swanctl/peer.j2
@@ -86,6 +86,9 @@
                 dpd_action = {{ ike.dead_peer_detection.action }}
 {%     endif %}
                 close_action = {{ ike.close_action }}
+{%     if peer_conf.replay_window is vyos_defined %}
+                replay_window = {{ peer_conf.replay_window }}
+{%     endif %}
             }
 {% elif peer_conf.tunnel is vyos_defined %}
 {%     for tunnel_id, tunnel_conf in peer_conf.tunnel.items() if tunnel_conf.disable is not defined %}
@@ -136,6 +139,9 @@
                 dpd_action = {{ ike.dead_peer_detection.action }}
 {%         endif %}
                 close_action = {{ ike.close_action }}
+{%         if peer_conf.replay_window is vyos_defined %}
+                replay_window = {{ peer_conf.replay_window }}
+{%         endif %}
 {%         if peer_conf.vti.bind is vyos_defined %}
 {#             The key defaults to 0 and will match any policies which similarly do not have a lookup key configuration. #}
 {#             Thus we simply shift the key by one to also support a vti0 interface #}

--- a/data/templates/ipsec/swanctl/remote_access.j2
+++ b/data/templates/ipsec/swanctl/remote_access.j2
@@ -43,6 +43,9 @@
                 rand_time = 540s
                 dpd_action = clear
                 inactivity = {{ rw_conf.timeout }}
+{% if rw_conf.replay_window is vyos_defined %}
+                replay_window = {{ rw_conf.replay_window }}
+{% endif %}
 {% set local_prefix = rw_conf.local.prefix if rw_conf.local.prefix is vyos_defined else ['0.0.0.0/0', '::/0'] %}
 {% set local_port = rw_conf.local.port if rw_conf.local.port is vyos_defined else '' %}
 {% set local_suffix = '[%any/{1}]'.format(local_port) if local_port else '' %}

--- a/interface-definitions/include/ipsec/replay-window.xml.i
+++ b/interface-definitions/include/ipsec/replay-window.xml.i
@@ -1,0 +1,19 @@
+<!-- include start from ipsec/replay-window.xml.i -->
+<leafNode name="replay-window">
+    <properties>
+      <help>IPsec replay window to configure for this CHILD_SA</help>
+      <valueHelp>
+        <format>u32:0</format>
+        <description>Disable IPsec replay protection</description>
+      </valueHelp>
+      <valueHelp>
+        <format>u32:1-2040</format>
+        <description>Replay window size in packets</description>
+      </valueHelp>
+      <constraint>
+        <validator name="numeric" argument="--range 0-2040"/>
+      </constraint>
+    </properties>
+    <defaultValue>32</defaultValue>
+  </leafNode>
+  <!-- include end -->

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -826,6 +826,7 @@
                   #include <include/ipsec/ike-group.xml.i>
                   #include <include/ipsec/local-address.xml.i>
                   #include <include/ipsec/local-traffic-selector.xml.i>
+                  #include <include/ipsec/replay-window.xml.i>
                   <leafNode name="timeout">
                     <properties>
                       <help>Timeout to close connection if no data is transmitted</help>
@@ -1100,6 +1101,7 @@
                   </leafNode>
                   #include <include/ipsec/local-address.xml.i>
                   #include <include/ipsec/remote-address.xml.i>
+                  #include <include/ipsec/replay-window.xml.i>
                   <tagNode name="tunnel">
                     <properties>
                       <help>Peer tunnel</help>

--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2023 VyOS maintainers and contributors
+# Copyright (C) 2021-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -155,7 +155,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
     def tearDownPKI(self):
         self.cli_delete(['pki'])
 
-    def test_01_dhcp_fail_handling(self):
+    def test_dhcp_fail_handling(self):
         # Skip process check - connection is not created for this test
         self.skip_process_check = True
 
@@ -185,7 +185,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         self.cli_delete(ethernet_path + [interface, 'vif', vif, 'address'])
 
-    def test_02_site_to_site(self):
+    def test_site_to_site(self):
         self.cli_set(base_path + ['ike-group', ike_group, 'key-exchange', 'ikev2'])
 
         local_address = '192.0.2.10'
@@ -248,6 +248,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             f'remote_ts = 10.2.0.0/16',
             f'priority = {priority}',
             f'mode = tunnel',
+            f'replay_window = 32',
         ]
         for line in swanctl_conf_lines:
             self.assertIn(line, swanctl_conf)
@@ -263,7 +264,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             self.assertRegex(swanctl_conf, fr'{line}')
 
 
-    def test_03_site_to_site_vti(self):
+    def test_site_to_site_vti(self):
         local_address = '192.0.2.10'
         vti = 'vti10'
         # IKE
@@ -317,6 +318,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             f'remote_ts = 172.17.10.0/24,172.17.11.0/24',
             f'ipcomp = yes',
             f'start_action = none',
+            f'replay_window = 32',
             f'if_id_in = {if_id}', # will be 11 for vti10 - shifted by one
             f'if_id_out = {if_id}',
             f'updown = "/etc/ipsec.d/vti-up-down {vti}"'
@@ -333,7 +335,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             self.assertRegex(swanctl_conf, fr'{line}')
 
 
-    def test_04_dmvpn(self):
+    def test_dmvpn(self):
         tunnel_if = 'tun100'
         nhrp_secret = 'secret'
         ike_lifetime = '3600'
@@ -396,7 +398,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         # There is only one NHRP test so no need to delete this globally in tearDown()
         self.cli_delete(nhrp_path)
 
-    def test_05_x509_site2site(self):
+    def test_site_to_site_x509(self):
         # Enable PKI
         self.setupPKI()
 
@@ -474,7 +476,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         self.tearDownPKI()
 
 
-    def test_06_flex_vpn_vips(self):
+    def test_flex_vpn_vips(self):
         local_address = '192.0.2.5'
         local_id = 'vyos-r1'
         remote_id = 'vyos-r2'
@@ -549,7 +551,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             self.assertIn(line, charon_conf)
 
 
-    def test_07_ikev2_road_warrior(self):
+    def test_remote_access(self):
         # This is a known to be good configuration for Microsoft Windows 10 and Apple iOS 17
         self.setupPKI()
 
@@ -640,6 +642,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             f'rekey_time = {eap_lifetime}s',
             f'rand_time = 540s',
             f'dpd_action = clear',
+            f'replay_window = 32',
             f'inactivity = 28800',
             f'local_ts = 0.0.0.0/0,::/0',
         ]
@@ -668,7 +671,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         self.tearDownPKI()
 
-    def test_08_ikev2_road_warrior_client_auth_eap_tls(self):
+    def test_remote_access_eap_tls(self):
         # This is a known to be good configuration for Microsoft Windows 10 and Apple iOS 17
         self.setupPKI()
 
@@ -780,7 +783,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         self.tearDownPKI()
 
-    def test_09_ikev2_road_warrior_client_auth_x509(self):
+    def test_remote_access_x509(self):
         # This is a known to be good configuration for Microsoft Windows 10 and Apple iOS 17
         self.setupPKI()
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The replay_window for child SA will always be 32 (hence enabled). Add a CLI node to explicitly change this.

* `set vpn ipsec site-to-site peer <name> replay-window <0-2040>`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5998

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
IPSec, strongswan

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
test_dhcp_fail_handling (__main__.TestVPNIPsec.test_dhcp_fail_handling) ... ok
test_dmvpn (__main__.TestVPNIPsec.test_dmvpn) ... ok
test_flex_vpn_vips (__main__.TestVPNIPsec.test_flex_vpn_vips) ... ok
test_remote_access (__main__.TestVPNIPsec.test_remote_access) ... ok
test_remote_access_eap_tls (__main__.TestVPNIPsec.test_remote_access_eap_tls) ... ok
test_remote_access_x509 (__main__.TestVPNIPsec.test_remote_access_x509) ... ok
test_site_to_site (__main__.TestVPNIPsec.test_site_to_site) ... ok
test_site_to_site_vti (__main__.TestVPNIPsec.test_site_to_site_vti) ... ok
test_site_to_site_x509 (__main__.TestVPNIPsec.test_site_to_site_x509) ... ok

----------------------------------------------------------------------
Ran 9 tests in 59.807s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
