### PR TITLE
vpn: T3843: l2tp configuration not cleared after delete

### DIFF
--- a/data/config-mode-dependencies/vyos-1x.json
+++ b/data/config-mode-dependencies/vyos-1x.json
@@ -29,6 +29,9 @@
         "openconnect": ["vpn_openconnect"],
         "sstp": ["vpn_sstp"]
     },
+    "vpn_l2tp": {
+        "ipsec": ["vpn_ipsec"]
+    },
     "qos": {
         "bonding": ["interfaces_bonding"],
         "bridge": ["interfaces_bridge"],

--- a/smoketest/scripts/cli/test_vpn_l2tp.py
+++ b/smoketest/scripts/cli/test_vpn_l2tp.py
@@ -54,6 +54,47 @@ class TestVPNL2TPServer(BasicAccelPPPTest.TestCase):
 
         self.assertEqual(conf['modules']['auth_mschap_v2'], None)
 
+    def test_vpn_l2tp_dependence_ipsec_swanctl(self):
+        # Test config vpn for tasks T3843 and T5926
+
+        base_path = ['vpn', 'l2tp', 'remote-access']
+        # make precondition
+        self.cli_set(['interfaces', 'dummy', 'dum0', 'address', '203.0.113.1/32'])
+        self.cli_set(['vpn', 'ipsec', 'interface', 'dum0'])
+
+        self.cli_commit()
+        # check ipsec apply to swanctl
+        self.assertEqual('', cmd('echo vyos | sudo -S swanctl -L '))
+
+        self.cli_set(base_path + ['authentication', 'local-users', 'username', 'foo', 'password', 'bar'])
+        self.cli_set(base_path + ['authentication', 'mode', 'local'])
+        self.cli_set(base_path + ['authentication', 'protocols', 'chap'])
+        self.cli_set(base_path + ['client-ip-pool', 'first', 'range', '10.200.100.100-10.200.100.110'])
+        self.cli_set(base_path + ['description', 'VPN - REMOTE'])
+        self.cli_set(base_path + ['name-server', '1.1.1.1'])
+        self.cli_set(base_path + ['ipsec-settings', 'authentication', 'mode', 'pre-shared-secret'])
+        self.cli_set(base_path + ['ipsec-settings', 'authentication', 'pre-shared-secret', 'SeCret'])
+        self.cli_set(base_path + ['ipsec-settings', 'ike-lifetime', '8600'])
+        self.cli_set(base_path + ['ipsec-settings', 'lifetime', '3600'])
+        self.cli_set(base_path + ['outside-address', '203.0.113.1'])
+        self.cli_set(base_path + ['gateway-address', '203.0.113.1'])
+
+        self.cli_commit()
+
+        # check l2tp apply to swanctl
+        self.assertTrue('l2tp_remote_access:' in cmd('echo vyos | sudo -S swanctl -L '))
+
+        self.cli_delete(['vpn', 'l2tp'])
+        self.cli_commit()
+
+        # check l2tp apply to swanctl after delete config
+        self.assertEqual('', cmd('echo vyos | sudo -S swanctl -L '))
+
+        # need to correct tearDown test
+        self.basic_config()
+        self.cli_set(base_path + ['authentication', 'protocols', 'chap'])
+        self.cli_commit()
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/vpn_l2tp.py
+++ b/src/conf_mode/vpn_l2tp.py
@@ -19,6 +19,7 @@ import os
 from sys import exit
 
 from vyos.config import Config
+from vyos.configdep import call_dependents, set_dependents
 from vyos.configdict import get_accel_dict
 from vyos.template import render
 from vyos.utils.process import call
@@ -42,6 +43,9 @@ def get_config(config=None):
     else:
         conf = Config()
     base = ['vpn', 'l2tp', 'remote-access']
+
+    set_dependents('ipsec', conf)
+
     if not conf.exists(base):
         return None
 
@@ -94,10 +98,10 @@ def apply(l2tp):
         for file in [l2tp_chap_secrets, l2tp_conf]:
             if os.path.exists(file):
                 os.unlink(file)
+    else:
+        call('systemctl restart accel-ppp@l2tp.service')
 
-        return None
-
-    call('systemctl restart accel-ppp@l2tp.service')
+    call_dependents()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
vpn: T3843: l2tp configuration not cleared after delete
vpn: T5926: IPSEC does not apply after l2tp configuration was changed

added dependency between l2tp and ipsec conf
added test for apply config to swanctl

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3843
* https://vyos.dev/T5926

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
l2tp, ipsec

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
sudo swanctl -L
configure
set interfaces dummy dum0 address 203.0.113.1/32
set vpn ipsec interface dum0
commit
sudo swanctl -L
set vpn l2tp remote-access authentication local-users username foo password bar
set vpn l2tp remote-access authentication mode 'local'
set vpn l2tp remote-access authentication protocols chap
set vpn l2tp remote-access client-ip-pool first range  10.200.100.100-10.200.100.110
set vpn l2tp remote-access description 'VPN-REMOTE'
set vpn l2tp remote-access name-server 1.1.1.1
set vpn l2tp remote-access ipsec-settings authentication mode pre-shared-secret
set vpn l2tp remote-access ipsec-settings authentication pre-shared-secret SeCret
set vpn l2tp remote-access ipsec-settings ike-lifetime '8600'
set vpn l2tp remote-access ipsec-settings lifetime '3600'
set vpn l2tp remote-access outside-address 203.0.113.1
set vpn l2tp remote-access gateway-address 203.0.113.1
commit
sudo swanctl -L
delete vpn l2tp
commit
sudo swanctl -L
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_vpn_l2tp.py 
test_accel_ipv4_pool (__main__.TestVPNL2TPServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestVPNL2TPServer.test_accel_ipv6_pool) ... ok
test_accel_local_authentication (__main__.TestVPNL2TPServer.test_accel_local_authentication) ... ok
test_accel_name_servers (__main__.TestVPNL2TPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNL2TPServer.test_accel_next_pool) ... ok
test_accel_ppp_options (__main__.TestVPNL2TPServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestVPNL2TPServer.test_accel_radius_authentication) ... ok
test_l2tp_server_authentication_protocols (__main__.TestVPNL2TPServer.test_l2tp_server_authentication_protocols) ... ok
test_vpn_l2tp_dependence_ipsec_swanctl (__main__.TestVPNL2TPServer.test_vpn_l2tp_dependence_ipsec_swanctl) ... ok

----------------------------------------------------------------------
Ran 9 tests in 62.270s

OK
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py 
test_dhcp_fail_handling (__main__.TestVPNIPsec.test_dhcp_fail_handling) ... ok
test_dmvpn (__main__.TestVPNIPsec.test_dmvpn) ... ok
test_flex_vpn_vips (__main__.TestVPNIPsec.test_flex_vpn_vips) ... ok
test_remote_access (__main__.TestVPNIPsec.test_remote_access) ... ok
test_remote_access_eap_tls (__main__.TestVPNIPsec.test_remote_access_eap_tls) ... ok
test_remote_access_x509 (__main__.TestVPNIPsec.test_remote_access_x509) ... ok
test_site_to_site (__main__.TestVPNIPsec.test_site_to_site) ... ok
test_site_to_site_vti (__main__.TestVPNIPsec.test_site_to_site_vti) ... ok
test_site_to_site_x509 (__main__.TestVPNIPsec.test_site_to_site_x509) ... ok

----------------------------------------------------------------------
Ran 9 tests in 67.923s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
