### PR TITLE
T5921: Fix OpenConnect verify for local users

### DIFF
--- a/src/conf_mode/vpn_openconnect.py
+++ b/src/conf_mode/vpn_openconnect.py
@@ -91,7 +91,7 @@ def verify(ocserv):
                 if not ocserv["authentication"]['radius']['server']:
                     raise ConfigError('Openconnect authentication mode radius requires at least one RADIUS server')
             if "local" in ocserv["authentication"]["mode"]:
-                if not ocserv["authentication"]["local_users"]:
+                if not ocserv.get("authentication", {}).get("local_users"):
                     raise ConfigError('openconnect mode local required at least one user')
                 if not ocserv["authentication"]["local_users"]["username"]:
                     raise ConfigError('openconnect mode local required at least one user')


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix verify error for the VPN OpenConnect configuration with local authentication and without any user
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5921

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openconnect
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Before the fix:
```
set vpn openconnect authentication mode local password
commit

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/vpn_openconnect.py", line 287, in <module>
    verify(c)
  File "/usr/libexec/vyos/conf_mode/vpn_openconnect.py", line 94, in verify
    if not ocserv["authentication"]["local_users"]:
           ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'local_users'
```
After the fix:
```
vyos@r4# set vpn openconnect authentication mode local password
[edit]
vyos@r4# commit
[ vpn openconnect ]
openconnect mode local required at least one user

[[vpn openconnect]] failed
Commit failed
[edit]
vyos@r4#
```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_openconnect.py
test_ocserv (__main__.TestVPNOpenConnect.test_ocserv) ... ok

----------------------------------------------------------------------
Ran 1 test in 18.098s

OK
vyos@r4:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
