### PR TITLE
T3843: l2tp configuration is cleared after delete

### DIFF
--- a/data/config-mode-dependencies/vyos-1x.json
+++ b/data/config-mode-dependencies/vyos-1x.json
@@ -48,5 +48,8 @@
         "wireguard": ["interfaces_wireguard"],
         "wireless": ["interfaces_wireless"],
         "wwan": ["interfaces_wwan"]
+    },
+    "vpn_l2tp": {
+        "ipsec": ["vpn_ipsec"]
     }
 }

--- a/src/conf_mode/vpn_l2tp.py
+++ b/src/conf_mode/vpn_l2tp.py
@@ -19,6 +19,7 @@ import os
 from sys import exit
 
 from vyos.config import Config
+from vyos.configdep import set_dependents, call_dependents
 from vyos.configdict import get_accel_dict
 from vyos.template import render
 from vyos.utils.process import call
@@ -42,6 +43,9 @@ def get_config(config=None):
     else:
         conf = Config()
     base = ['vpn', 'l2tp', 'remote-access']
+
+    set_dependents("ipsec", conf)
+
     if not conf.exists(base):
         return None
 
@@ -94,10 +98,10 @@ def apply(l2tp):
         for file in [l2tp_chap_secrets, l2tp_conf]:
             if os.path.exists(file):
                 os.unlink(file)
+    else:
+        call('systemctl restart accel-ppp@l2tp.service')
 
-        return None
-
-    call('systemctl restart accel-ppp@l2tp.service')
+    call_dependents()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
l2tp configuration is cleared after delete

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3843
* https://vyos.dev/T5926

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vpn_l2tp

## Proposed changes
<!--- Describe your changes in detail -->
Added dependency between vpn_l2tp and vpn_ipsec

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
config
set vpn ipsec interface 'eth0'
commit
set vpn l2tp remote-access authentication local-users username alice password 'notsecure'
set vpn l2tp remote-access authentication mode 'local'
set vpn l2tp remote-access client-ip-pool test range '10.1.1.0/24'
set vpn l2tp remote-access gateway-address '10.1.1.1'
set vpn l2tp remote-access ipsec-settings authentication mode 'pre-shared-secret'
set vpn l2tp remote-access ipsec-settings authentication pre-shared-secret 'not-so-secret'
set vpn l2tp remote-access outside-address '192.168.1.1'
commit
sudo swanctl -L
delete vpn l2tp
commit
sudo swanctl -l
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ sudo nano /usr/libexec/vyos/tests/smoke/cli/test_vpn_l2tp.py
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_l2tp.py
test_accel_ipv4_pool (__main__.TestVPNL2TPServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestVPNL2TPServer.test_accel_ipv6_pool) ... ok
test_accel_local_authentication (__main__.TestVPNL2TPServer.test_accel_local_authentication) ... ok
test_accel_name_servers (__main__.TestVPNL2TPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNL2TPServer.test_accel_next_pool) ... ok
test_accel_ppp_options (__main__.TestVPNL2TPServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestVPNL2TPServer.test_accel_radius_authentication) ... ok
test_l2tp_config_apply_ipsec (__main__.TestVPNL2TPServer.test_l2tp_config_apply_ipsec) ... ok
test_l2tp_server_authentication_protocols (__main__.TestVPNL2TPServer.test_l2tp_server_authentication_protocols) ... ok

----------------------------------------------------------------------
Ran 9 tests in 51.269s

OK
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x ] I have linked this PR to one or more Phabricator Task(s)
- [x ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
