### PR TITLE
vrf: T5973: module is now statically compiled into the kernel

### DIFF
--- a/smoketest/scripts/cli/test_vrf.py
+++ b/smoketest/scripts/cli/test_vrf.py
@@ -53,14 +53,17 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
         # call base-classes classmethod
         super(VRFTest, cls).setUpClass()
 
+    def setUp(self):
+        # VRF strict_most ist always enabled
+        tmp = read_file('/proc/sys/net/vrf/strict_mode')
+        self.assertEqual(tmp, '1')
+
     def tearDown(self):
         # delete all VRFs
         self.cli_delete(base_path)
         self.cli_commit()
         for vrf in vrfs:
             self.assertNotIn(vrf, interfaces())
-        # If there is no VRF defined, strict_mode should be off
-        self.assertEqual(sysctl_read('net.vrf.strict_mode'), '0')
 
     def test_vrf_vni_and_table_id(self):
         base_table = '1000'

--- a/src/conf_mode/vrf.py
+++ b/src/conf_mode/vrf.py
@@ -27,7 +27,6 @@ from vyos.ifconfig import Interface
 from vyos.template import render
 from vyos.template import render_to_string
 from vyos.utils.dict import dict_search
-from vyos.utils.kernel import check_kmod
 from vyos.utils.network import get_interface_config
 from vyos.utils.network import get_vrf_members
 from vyos.utils.network import interface_exists
@@ -223,18 +222,6 @@ def apply(vrf):
             # Delete the VRF Kernel interface
             call(f'ip link delete dev {tmp}')
 
-    # Enable/Disable VRF strict mode
-    # When net.vrf.strict_mode=0 (default) it is possible to associate multiple
-    # VRF devices to the same table. Conversely, when net.vrf.strict_mode=1 a
-    # table can be associated to a single VRF device.
-    #
-    # A VRF table can be used by the VyOS CLI only once (ensured by verify()),
-    # this simply adds an additional Kernel safety net
-    strict_mode = '0'
-    # Set to 1 if any VRF is defined
-    if 'name' in vrf: strict_mode = '1'
-    sysctl_write('net.vrf.strict_mode', strict_mode)
-
     if 'name' in vrf:
         # Linux routing uses rules to find tables - routing targets are then
         # looked up in those tables. If the lookup got a matching route, the
@@ -323,7 +310,6 @@ def apply(vrf):
 
 if __name__ == '__main__':
     try:
-        check_kmod(k_mod)
         c = get_config()
         verify(c)
         generate(c)

--- a/src/etc/sysctl.d/30-vyos-router.conf
+++ b/src/etc/sysctl.d/30-vyos-router.conf
@@ -108,3 +108,5 @@ net.ipv4.tcp_congestion_control=bbr
 # Disable IPv6 Segment Routing packets by default
 net.ipv6.conf.all.seg6_enabled = 0
 net.ipv6.conf.default.seg6_enabled = 0
+
+net.vrf.strict_mode = 1


### PR DESCRIPTION
Always enable VRF `strict_mode` on bootup as the module is now statically compiled into the Kernel

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5973

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
VRf

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_vrf.py
test_vrf_assign_interface (__main__.VRFTest.test_vrf_assign_interface) ... ok
test_vrf_bind_all (__main__.VRFTest.test_vrf_bind_all) ... ok
test_vrf_disable_forwarding (__main__.VRFTest.test_vrf_disable_forwarding) ... ok
test_vrf_ip_ipv6_protocol_non_existing_route_map (__main__.VRFTest.test_vrf_ip_ipv6_protocol_non_existing_route_map) ... ok
test_vrf_ip_protocol_route_map (__main__.VRFTest.test_vrf_ip_protocol_route_map) ... ok
test_vrf_ipv6_protocol_route_map (__main__.VRFTest.test_vrf_ipv6_protocol_route_map) ... ok
test_vrf_link_local_ip_addresses (__main__.VRFTest.test_vrf_link_local_ip_addresses) ... ok
test_vrf_loopbacks_ips (__main__.VRFTest.test_vrf_loopbacks_ips) ... ok
test_vrf_static_route (__main__.VRFTest.test_vrf_static_route) ... ok
test_vrf_table_id_is_unalterable (__main__.VRFTest.test_vrf_table_id_is_unalterable) ... ok
test_vrf_vni_add_change_remove (__main__.VRFTest.test_vrf_vni_add_change_remove) ... ok
test_vrf_vni_and_table_id (__main__.VRFTest.test_vrf_vni_and_table_id) ... ok
test_vrf_vni_duplicates (__main__.VRFTest.test_vrf_vni_duplicates) ... ok

----------------------------------------------------------------------
Ran 13 tests in 226.030s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
