### PR TITLE
bgp: T6024: add additional missing FRR features

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -225,10 +225,10 @@
   neighbor {{ neighbor }} route-map {{ afi_config.route_map.import }} in
 {%         endif %}
 {%         if afi_config.prefix_list.export is vyos_defined %}
-  neighbor {{ neighbor }} prefix-list  {{ afi_config.prefix_list.export }} out
+  neighbor {{ neighbor }} prefix-list {{ afi_config.prefix_list.export }} out
 {%         endif %}
 {%         if afi_config.prefix_list.import is vyos_defined %}
-  neighbor {{ neighbor }} prefix-list  {{ afi_config.prefix_list.import }} in
+  neighbor {{ neighbor }} prefix-list {{ afi_config.prefix_list.import }} in
 {%         endif %}
 {%         if afi_config.soft_reconfiguration.inbound is vyos_defined %}
   neighbor {{ neighbor }} soft-reconfiguration inbound
@@ -237,10 +237,10 @@
   neighbor {{ neighbor }} unsuppress-map {{ afi_config.unsuppress_map }}
 {%         endif %}
 {%         if afi_config.disable_send_community.extended is vyos_defined %}
- no neighbor {{ neighbor }} send-community extended
+  no neighbor {{ neighbor }} send-community extended
 {%         endif %}
 {%         if afi_config.disable_send_community.standard is vyos_defined %}
- no neighbor {{ neighbor }} send-community standard
+  no neighbor {{ neighbor }} send-community standard
 {%         endif %}
   neighbor {{ neighbor }} activate
  exit-address-family
@@ -473,6 +473,7 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {%             endfor %}
 {%         endif %}
  exit-address-family
+ !
 {%     endfor %}
 {% endif %}
  !
@@ -529,6 +530,9 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
  bgp listen range {{ prefix }} peer-group {{ options.peer_group }}
 {%         endif %}
 {%     endfor %}
+{% endif %}
+{% if parameters.allow_martian_nexthop is vyos_defined %}
+ bgp allow-martian-nexthop
 {% endif %}
 {% if parameters.always_compare_med is vyos_defined %}
  bgp always-compare-med
@@ -589,6 +593,12 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {% endif %}
 {% if parameters.graceful_shutdown is vyos_defined %}
  bgp graceful-shutdown
+{% endif %}
+{% if parameters.no_hard_administrative_reset is vyos_defined %}
+ no bgp hard-administrative-reset
+{% endif %}
+{% if parameters.labeled_unicast is vyos_defined %}
+ bgp labeled-unicast {{ parameters.labeled_unicast }}
 {% endif %}
 {% if parameters.log_neighbor_changes is vyos_defined %}
  bgp log-neighbor-changes

--- a/interface-definitions/include/bgp/neighbor-afi-ipv4-ipv6-common.xml.i
+++ b/interface-definitions/include/bgp/neighbor-afi-ipv4-ipv6-common.xml.i
@@ -1,5 +1,4 @@
 <!-- include start from bgp/neighbor-afi-ipv4-ipv6-common.xml.i -->
-
 <leafNode name="addpath-tx-all">
   <properties>
     <help>Use addpath to advertise all paths to a neighbor</help>

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -1219,6 +1219,12 @@
     <help>BGP parameters</help>
   </properties>
   <children>
+    <leafNode name="allow-martian-nexthop">
+      <properties>
+        <help>Allow Martian nexthops to be received in the NLRI from a peer</help>
+        <valueless/>
+      </properties>
+    </leafNode>
     <leafNode name="always-compare-med">
       <properties>
         <help>Always compare MEDs from different neighbors</help>
@@ -1574,6 +1580,35 @@
       <properties>
         <help>Graceful shutdown</help>
         <valueless/>
+      </properties>
+    </leafNode>
+    <leafNode name="no-hard-administrative-reset">
+      <properties>
+        <help>Do not send hard reset CEASE Notification for 'Administrative Reset'</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+    <leafNode name="labeled-unicast">
+      <properties>
+        <help>BGP Labeled-unicast options</help>
+        <completionHelp>
+          <list>explicit-null ipv4-explicit-null ipv6-explicit-null</list>
+        </completionHelp>
+        <valueHelp>
+          <format>explicit-null</format>
+          <description>Use explicit-null label values for all local prefixes</description>
+        </valueHelp>
+        <valueHelp>
+          <format>ipv4-explicit-null</format>
+          <description>Use IPv4 explicit-null label value for IPv4 local prefixes</description>
+        </valueHelp>
+        <valueHelp>
+          <format>ipv6-explicit-null</format>
+          <description>Use IPv6 explicit-null label value for IPv4 local prefixes</description>
+        </valueHelp>
+        <constraint>
+          <regex>(explicit-null|ipv4-explicit-null|ipv6-explicit-null)</regex>
+        </constraint>
       </properties>
     </leafNode>
     <leafNode name="log-neighbor-changes">


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

* set protocols bgp parameters labeled-unicast <explicit-null | ipv4-explicit-null | ipv6-explicit-null>
* set protocols bgp parameters allow-martian-nexthop
* set protocols bgp parameters no-hard-administrative-reset"

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6024

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-documentation/pull/1267

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ... ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ... ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ... ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ... ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ... ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ... ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ... ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ... ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ... ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ... ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok
test_bgp_24_srv6_sid (__main__.TestProtocolsBGP.test_bgp_24_srv6_sid) ... ok
test_bgp_25_ipv4_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_25_ipv4_labeled_unicast_peer_group) ... ok
test_bgp_26_ipv6_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_26_ipv6_labeled_unicast_peer_group) ... ok
test_bgp_99_bmp (__main__.TestProtocolsBGP.test_bgp_99_bmp) ... ok

----------------------------------------------------------------------
Ran 26 tests in 195.114s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
