### PR TITLE
T5872: ipsec remote access VPN: support dhcp-interface.

### DIFF
--- a/data/templates/ipsec/swanctl/peer.j2
+++ b/data/templates/ipsec/swanctl/peer.j2
@@ -8,7 +8,7 @@
 {% if peer_conf.virtual_address is vyos_defined %}
         vips = {{ peer_conf.virtual_address | join(', ') }}
 {% endif %}
-        local_addrs = {{ peer_conf.local_address if peer_conf.local_address != 'any' else '%any' }} # dhcp:{{ peer_conf.dhcp_interface if 'dhcp_interface' in peer_conf else 'no' }}
+        local_addrs = {{ peer_conf.local_address if peer_conf.local_address != 'any' else '%any' }} # dhcp:{{ peer_conf.dhcp_interface if 'dhcp_interface' in peer_conf else 'no' }} reset:{{ name }}
         remote_addrs = {{ peer_conf.remote_address | join(",") if peer_conf.remote_address is vyos_defined and 'any' not in peer_conf.remote_address else '%any' }}
 {% if peer_conf.authentication.mode is vyos_defined('x509') %}
         send_cert = always

--- a/data/templates/ipsec/swanctl/peer.j2
+++ b/data/templates/ipsec/swanctl/peer.j2
@@ -8,7 +8,7 @@
 {% if peer_conf.virtual_address is vyos_defined %}
         vips = {{ peer_conf.virtual_address | join(', ') }}
 {% endif %}
-        local_addrs = {{ peer_conf.local_address if peer_conf.local_address != 'any' else '%any' }} # dhcp:{{ peer_conf.dhcp_interface if 'dhcp_interface' in peer_conf else 'no' }} reset:{{ name }}
+        local_addrs = {{ peer_conf.local_address if peer_conf.local_address != 'any' else '%any' }} # dhcp:{{ peer_conf.dhcp_interface if 'dhcp_interface' in peer_conf else 'no' }}
         remote_addrs = {{ peer_conf.remote_address | join(",") if peer_conf.remote_address is vyos_defined and 'any' not in peer_conf.remote_address else '%any' }}
 {% if peer_conf.authentication.mode is vyos_defined('x509') %}
         send_cert = always

--- a/data/templates/ipsec/swanctl/remote_access.j2
+++ b/data/templates/ipsec/swanctl/remote_access.j2
@@ -4,7 +4,7 @@
 {% set esp = esp_group[rw_conf.esp_group] %}
     ra-{{ name }} {
         remote_addrs = %any
-        local_addrs = {{ rw_conf.local_address if rw_conf.local_address is vyos_defined else '%any' }}
+        local_addrs = {{ rw_conf.local_address if rw_conf.local_address is not vyos_defined('any') else '%any' }} # dhcp:{{ rw_conf.dhcp_interface if rw_conf.dhcp_interface is vyos_defined else 'no' }}
         proposals = {{ ike_group[rw_conf.ike_group] | get_esp_ike_cipher | join(',') }}
         version = {{ ike.key_exchange[4:] if ike.key_exchange is vyos_defined else "0" }}
         send_certreq = no

--- a/data/templates/ipsec/swanctl/remote_access.j2
+++ b/data/templates/ipsec/swanctl/remote_access.j2
@@ -4,7 +4,7 @@
 {% set esp = esp_group[rw_conf.esp_group] %}
     ra-{{ name }} {
         remote_addrs = %any
-        local_addrs = {{ rw_conf.local_address if rw_conf.local_address is not vyos_defined('any') else '%any' }} # dhcp:{{ rw_conf.dhcp_interface if rw_conf.dhcp_interface is vyos_defined else 'no' }} reset:ra-{{ name }}
+        local_addrs = {{ rw_conf.local_address if rw_conf.local_address is not vyos_defined('any') else '%any' }} # dhcp:{{ rw_conf.dhcp_interface if rw_conf.dhcp_interface is vyos_defined else 'no' }}
         proposals = {{ ike_group[rw_conf.ike_group] | get_esp_ike_cipher | join(',') }}
         version = {{ ike.key_exchange[4:] if ike.key_exchange is vyos_defined else "0" }}
         send_certreq = no

--- a/data/templates/ipsec/swanctl/remote_access.j2
+++ b/data/templates/ipsec/swanctl/remote_access.j2
@@ -4,7 +4,7 @@
 {% set esp = esp_group[rw_conf.esp_group] %}
     ra-{{ name }} {
         remote_addrs = %any
-        local_addrs = {{ rw_conf.local_address if rw_conf.local_address is not vyos_defined('any') else '%any' }} # dhcp:{{ rw_conf.dhcp_interface if rw_conf.dhcp_interface is vyos_defined else 'no' }}
+        local_addrs = {{ rw_conf.local_address if rw_conf.local_address is not vyos_defined('any') else '%any' }} # dhcp:{{ rw_conf.dhcp_interface if rw_conf.dhcp_interface is vyos_defined else 'no' }} reset:ra-{{ name }}
         proposals = {{ ike_group[rw_conf.ike_group] | get_esp_ike_cipher | join(',') }}
         version = {{ ike.key_exchange[4:] if ike.key_exchange is vyos_defined else "0" }}
         send_certreq = no

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -825,6 +825,7 @@
                   #include <include/ipsec/esp-group.xml.i>
                   #include <include/ipsec/ike-group.xml.i>
                   #include <include/ipsec/local-address.xml.i>
+                  #include <include/dhcp-interface.xml.i>
                   #include <include/ipsec/local-traffic-selector.xml.i>
                   #include <include/ipsec/replay-window.xml.i>
                   <leafNode name="timeout">

--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -31,7 +31,7 @@ nhrp_path = ['protocols', 'nhrp']
 base_path = ['vpn', 'ipsec']
 
 charon_file = '/etc/strongswan.d/charon.conf'
-dhcp_waiting_file = '/tmp/ipsec_dhcp_waiting'
+dhcp_interfaces_file = '/tmp/ipsec_dhcp_interfaces'
 swanctl_file = '/etc/swanctl/swanctl.conf'
 
 peer_ip = '203.0.113.45'
@@ -178,10 +178,10 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        self.assertTrue(os.path.exists(dhcp_waiting_file))
+        self.assertTrue(os.path.exists(dhcp_interfaces_file))
 
-        dhcp_waiting = read_file(dhcp_waiting_file)
-        self.assertIn(f'{interface}.{vif}', dhcp_waiting) # Ensure dhcp-failed interface was added for dhclient hook
+        dhcp_interfaces = read_file(dhcp_interfaces_file)
+        self.assertIn(f'{interface}.{vif}', dhcp_interfaces) # Ensure dhcp interface was added for dhclient hook
 
         self.cli_delete(ethernet_path + [interface, 'vif', vif, 'address'])
 
@@ -950,10 +950,10 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        self.assertTrue(os.path.exists(dhcp_waiting_file))
+        self.assertTrue(os.path.exists(dhcp_interfaces_file))
 
-        dhcp_waiting = read_file(dhcp_waiting_file)
-        self.assertIn(f'{interface}.{vif}', dhcp_waiting) # Ensure dhcp-failed interface was added for dhclient hook
+        dhcp_interfaces = read_file(dhcp_interfaces_file)
+        self.assertIn(f'{interface}.{vif}', dhcp_interfaces) # Ensure dhcp interface was added for dhclient hook
 
         self.cli_delete(ethernet_path + [interface, 'vif', vif, 'address'])
 

--- a/src/etc/dhcp/dhclient-exit-hooks.d/99-ipsec-dhclient-hook
+++ b/src/etc/dhcp/dhclient-exit-hooks.d/99-ipsec-dhclient-hook
@@ -14,60 +14,32 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-DHCP_HOOK_IFLIST="/tmp/ipsec_dhcp_waiting"
+DHCP_HOOK_IFLIST="/tmp/ipsec_dhcp_interfaces"
 
-if [ -f $DHCP_HOOK_IFLIST ] && [ "$reason" == "BOUND" ]; then
-    if grep -qw $interface $DHCP_HOOK_IFLIST; then
-        sudo rm $DHCP_HOOK_IFLIST
-        sudo /usr/libexec/vyos/conf_mode/vpn_ipsec.py
-        exit 0
-    fi
+if ! { [ -f $DHCP_HOOK_IFLIST ] && grep -qw $interface $DHCP_HOOK_IFLIST; }; then
+    exit 0
 fi
 
+# Re-generate the config on the following events:
+# - BOUND: always re-generate
+# - RENEW: re-generate if the IP address changed
+# - REBIND: re-generate if the IP address changed
 if [ "$reason" == "RENEW" ] || [ "$reason" == "REBIND" ]; then
     if [ "$old_ip_address" == "$new_ip_address" ]; then
         exit 0
     fi
-else
+elif [ "$reason" != "BOUND" ]; then
     exit 0
 fi
 
-python3 - <<PYEND
-import os
-import re
-
-from vyos.utils.process import call
-from vyos.utils.process import cmd
-from vyos.utils.file import read_file
-from vyos.utils.file import write_file
-
-SWANCTL_CONF="/etc/swanctl/swanctl.conf"
+# Best effort wait for any active commit to finish
+sudo python3 - <<PYEND
+from vyos.utils.commit import wait_for_commit_lock
 
 if __name__ == '__main__':
-    interface = os.getenv('interface')
-    new_ip = os.getenv('new_ip_address')
-    old_ip = os.getenv('old_ip_address')
-
-    if os.path.exists(SWANCTL_CONF):
-        conf_lines = read_file(SWANCTL_CONF).split("\n")
-        found = False
-        reset_conns = set()
-        to_match = f'# dhcp:{interface}'
-
-        for i, line in enumerate(conf_lines):
-            if line.find(to_match) > 0:
-                conf_lines[i] = line.replace(old_ip, new_ip)
-                found = True
-                regex_match = re.search(r'#.* reset:([-_a-zA-Z0-9|@]+)', line)
-                if regex_match:
-                   connection_name = regex_match[1]
-                   reset_conns.add(connection_name)
-
-        if found:
-            write_file(SWANCTL_CONF, "\n".join(conf_lines))
-            for connection_name in reset_conns:
-                call(f'sudo swanctl -t -i {connection_name}')
-            call('sudo swanctl -q')
-
+    wait_for_commit_lock()
     exit(0)
 PYEND
+
+# Now re-generate the config
+sudo /usr/libexec/vyos/conf_mode/vpn_ipsec.py

--- a/src/etc/dhcp/dhclient-exit-hooks.d/99-ipsec-dhclient-hook
+++ b/src/etc/dhcp/dhclient-exit-hooks.d/99-ipsec-dhclient-hook
@@ -14,22 +14,22 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-if [ "$reason" == "REBOOT" ] || [ "$reason" == "EXPIRE" ]; then
-    return 0
-fi
-
 DHCP_HOOK_IFLIST="/tmp/ipsec_dhcp_waiting"
 
 if [ -f $DHCP_HOOK_IFLIST ] && [ "$reason" == "BOUND" ]; then
     if grep -qw $interface $DHCP_HOOK_IFLIST; then
         sudo rm $DHCP_HOOK_IFLIST
         sudo /usr/libexec/vyos/conf_mode/vpn_ipsec.py
-        return 0
+        exit 0
     fi
 fi
 
-if [ "$old_ip_address" == "$new_ip_address" ] && [ "$reason" == "BOUND" ]; then
-    return 0
+if [ "$reason" == "RENEW" ] || [ "$reason" == "REBIND" ]; then
+    if [ "$old_ip_address" == "$new_ip_address" ]; then
+        exit 0
+    fi
+else
+    exit 0
 fi
 
 python3 - <<PYEND

--- a/src/etc/dhcp/dhclient-exit-hooks.d/99-ipsec-dhclient-hook
+++ b/src/etc/dhcp/dhclient-exit-hooks.d/99-ipsec-dhclient-hook
@@ -43,39 +43,30 @@ from vyos.utils.file import write_file
 
 SWANCTL_CONF="/etc/swanctl/swanctl.conf"
 
-def ipsec_down(ip_address):
-    # This prevents the need to restart ipsec and kill all active connections, only the stale connection is closed
-    status = cmd('sudo ipsec statusall')
-    connection_name = None
-    for line in status.split("\n"):
-        if line.find(ip_address) > 0:
-            regex_match = re.search(r'(peer_[^:\[]+)', line)
-            if regex_match:
-                connection_name = regex_match[1]
-                break
-    if connection_name:
-        call(f'sudo ipsec down {connection_name}')
-
 if __name__ == '__main__':
     interface = os.getenv('interface')
     new_ip = os.getenv('new_ip_address')
     old_ip = os.getenv('old_ip_address')
 
     if os.path.exists(SWANCTL_CONF):
-        conf_lines = read_file(SWANCTL_CONF)
+        conf_lines = read_file(SWANCTL_CONF).split("\n")
         found = False
+        reset_conns = set()
         to_match = f'# dhcp:{interface}'
 
         for i, line in enumerate(conf_lines):
             if line.find(to_match) > 0:
                 conf_lines[i] = line.replace(old_ip, new_ip)
                 found = True
+                regex_match = re.search(r'#.* reset:([-_a-zA-Z0-9|@]+)', line)
+                if regex_match:
+                   connection_name = regex_match[1]
+                   reset_conns.add(connection_name)
 
         if found:
-            write_file(SWANCTL_CONF, conf_lines)
-            ipsec_down(old_ip)
-            call('sudo ipsec rereadall')
-            call('sudo ipsec reload')
+            write_file(SWANCTL_CONF, "\n".join(conf_lines))
+            for connection_name in reset_conns:
+                call(f'sudo swanctl -t -i {connection_name}')
             call('sudo swanctl -q')
 
     exit(0)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Enables the `dhcp-interface` option to be used with ipsec remote-access VPNs.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5872

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec remote-access

## Proposed changes
<!--- Describe your changes in detail -->

This adds the ability to use `dhcp-interface` with the ipsec remote-access VPN. It works essentially the same way as the `dhcp-interface` behavior for the ipsec site-to-site VPN.

While most IKEv2 Remote Access ("Road Warrior") VPN setups will likely be at sites with a fixed IP, the DHCP functionality may be useful for isolated installs, say, at a small business or remote branch office that may be on an ISP package that only offers DHCP addressing. Combined with dynamic DNS, VyOS can still provide a one-stop routing and remote access solution.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Example configuration:
```
[edit vpn ipsec remote-access connection ClientVPN]
lucas@lcn-router# show
 authentication {
     client-mode eap-tls
     local-id <local id>
     server-mode x509
     x509 {
         ca-certificate <ca certificate name>
         certificate <server certificate name>
     }
 }
 dhcp-interface eth0
 ...
```

The ipsec daemon should start normally and accept connections.
If you inspect `/etc/swanctl/swanctl.conf` on the running router, you should see a peer configuration that begins with the following (replace `1.2.3.4` with the router's WAN interface IP on eth0):

```
    ra-ClientVPN {
        remote_addrs = %any
        local_addrs = 1.2.3.4 # dhcp:eth1
```

You can simulate the DHCP address change behavior by manually invoking the dhclient exit hook:
```
sudo interface=eth1 old_ip_address=1.2.3.4 new_ip_address=5.6.7.8 /etc/dhcp/dhclient-exit-hooks.d/99-ipsec-dhclient-hook
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
DEBUG - test_01_dhcp_fail_handling (__main__.TestVPNIPsec.test_01_dhcp_fail_handling) ... ok
DEBUG - test_02_site_to_site (__main__.TestVPNIPsec.test_02_site_to_site) ... ok
DEBUG - test_03_site_to_site_vti (__main__.TestVPNIPsec.test_03_site_to_site_vti) ... ok
DEBUG - test_04_dmvpn (__main__.TestVPNIPsec.test_04_dmvpn) ... ok
DEBUG - test_05_x509_site2site (__main__.TestVPNIPsec.test_05_x509_site2site) ... ok
DEBUG - test_06_flex_vpn_vips (__main__.TestVPNIPsec.test_06_flex_vpn_vips) ... ok
DEBUG - test_07_ikev2_road_warrior (__main__.TestVPNIPsec.test_07_ikev2_road_warrior) ... ok
DEBUG - test_08_ikev2_road_warrior_client_auth_eap_tls (__main__.TestVPNIPsec.test_08_ikev2_road_warrior_client_auth_eap_tls) ... ok
DEBUG - test_09_ikev2_road_warrior_client_auth_x509 (__main__.TestVPNIPsec.test_09_ikev2_road_warrior_client_auth_x509) ... ok
DEBUG - test_10_ikev2_road_warrior_dhcp_fail_handling (__main__.TestVPNIPsec.test_10_ikev2_road_warrior_dhcp_fail_handling) ... ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
