### PR TITLE
T6026: QoS hide attempts to delete qdisc from devices

### DIFF
--- a/src/conf_mode/qos.py
+++ b/src/conf_mode/qos.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2023 VyOS maintainers and contributors
+# Copyright (C) 2023-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -36,7 +36,7 @@ from vyos.qos import RateLimiter
 from vyos.qos import RoundRobin
 from vyos.qos import TrafficShaper
 from vyos.qos import TrafficShaperHFSC
-from vyos.utils.process import call
+from vyos.utils.process import run
 from vyos.utils.dict import dict_search_recursive
 from vyos import ConfigError
 from vyos import airbag
@@ -205,8 +205,8 @@ def apply(qos):
     # Always delete "old" shapers first
     for interface in interfaces():
         # Ignore errors (may have no qdisc)
-        call(f'tc qdisc del dev {interface} parent ffff:')
-        call(f'tc qdisc del dev {interface} root')
+        run(f'tc qdisc del dev {interface} parent ffff:')
+        run(f'tc qdisc del dev {interface} root')
 
     call_dependents()
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Hide unexpected output by attempts to delete `qdisc` from interfaces.
```
[ qos ]
Error: Cannot find specified qdisc on specified device.
Error: Cannot delete qdisc with handle of zero.
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Cosmetic issue/bug

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6026

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
qos
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set qos policy shaper SHAPER bandwidth '1000mbit'
set qos policy shaper SHAPER class 10 bandwidth '70mbit'
set qos policy shaper SHAPER class 10 match SYN ip tcp syn
set qos policy shaper SHAPER default bandwidth '500mbit'
set qos interface eth1 egress SHAPER

```
Before the fix, we can see all attempts to delete `qdisc` from every interface
```

vyos@r4# commit
[ qos ]
Error: Cannot find specified qdisc on specified device.
Error: Cannot delete qdisc with handle of zero.
Error: Cannot find specified qdisc on specified device.
Error: Cannot delete qdisc with handle of zero.
Error: Cannot find specified qdisc on specified device.
Error: Cannot delete qdisc with handle of zero.
Error: Cannot find specified qdisc on specified device.
Error: Cannot delete qdisc with handle of zero.
Error: Cannot find specified qdisc on specified device.
Error: Cannot delete qdisc with handle of zero.
Error: Cannot find specified qdisc on specified device.
Error: Cannot delete qdisc with handle of zero.
Error: Cannot find specified qdisc on specified device.
Error: Cannot delete qdisc with handle of zero.
Error: Cannot find specified qdisc on specified device.
Error: Cannot delete qdisc with handle of zero.
Error: Cannot find specified qdisc on specified device.
Error: Cannot delete qdisc with handle of zero.
Error: Cannot find specified qdisc on specified device.
Error: Cannot delete qdisc with handle of zero.
Error: Cannot find specified qdisc on specified device.
Error: Cannot delete qdisc with handle of zero.

```
I.e. for every interface:
```
tc qdisc del dev lo parent ffff:
tc qdisc del dev lo root
tc qdisc del dev eth0 parent ffff:
tc qdisc del dev eth0 root
tc qdisc del dev eth1 parent ffff:
tc qdisc del dev eth1 root
tc qdisc del dev eth2 parent ffff:
tc qdisc del dev eth2 root
tc qdisc del dev eth3 parent ffff:
tc qdisc del dev eth3 root
tc qdisc del dev eth4 parent ffff:
tc qdisc del dev eth4 root
tc qdisc del dev eth5 parent ffff:
tc qdisc del dev eth5 root
tc qdisc del dev pim6reg parent ffff:
tc qdisc del dev pim6reg root
tc qdisc del dev pod-NET01 parent ffff:
tc qdisc del dev pod-NET01 root
tc qdisc del dev veth0 parent ffff:
tc qdisc del dev veth0 root
tc qdisc del dev veth1 parent ffff:
tc qdisc del dev veth1 root

```
After the fix:
```
set qos policy shaper SHAPER bandwidth '1000mbit'
set qos policy shaper SHAPER class 10 bandwidth '70mbit'
set qos policy shaper SHAPER class 10 match SYN ip tcp syn
set qos policy shaper SHAPER default bandwidth '500mbit'
set qos interface eth1 egress SHAPER

vyos@r4# commit
[edit]
vyos@r4# tc class show dev eth1
class htb 1:1 root rate 1Gbit ceil 1Gbit burst 1375b cburst 1375b
class htb 1:a parent 1:1 leaf 8099: prio 0 rate 70Mbit ceil 70Mbit burst 15Kb cburst 1583b
class htb 1:b parent 1:1 leaf 809a: prio 7 rate 500Mbit ceil 500Mbit burst 15250b cburst 1500b
[edit]
vyos@r4# 

```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_qos.py
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... skipped 'tc returns invalid JSON here - needs iproute2 fix'
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok

----------------------------------------------------------------------
Ran 11 tests in 85.724s

OK (skipped=1)
vyos@r4:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
