### PR TITLE
T6028: Fix QoS policy shaper wrong class_id_max and default_minor_id

### DIFF
--- a/python/vyos/qos/trafficshaper.py
+++ b/python/vyos/qos/trafficshaper.py
@@ -29,8 +29,9 @@ class TrafficShaper(QoSBase):
         class_id_max = 0
         if 'class' in config:
             tmp = list(config['class'])
-            tmp.sort()
-            class_id_max = tmp[-1]
+            # Convert strings to integers
+            tmp = [int(x) for x in tmp]
+            class_id_max = max(tmp)
 
         r2q = 10
         # bandwidth is a mandatory CLI node


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The `class_id_max` is wrong due to `tmp.sort` list of Strings.
If we have class 5 and class 10, we get sorted max value **5**, expected **10**

```
>>> tmp = ['5', '10']
>>> tmp.sort()
>>> tmp
['10', '5']
>>>

>>> hex(5+1)
'0x6'
>>>
>>> hex(10+1)
'0xb'
>>>
```

This way we get wrong default maximum class value:
```
tc qdisc replace dev eth1 root handle 1: htb r2q 444 default 6
```
Expect:
```
tc qdisc replace dev eth1 root handle 1: htb r2q 444 default b
```

Fix this converting Strings to Integers and get max value.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6028

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
qos
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set qos policy shaper SHAPE bandwidth '710mbit'
set qos policy shaper SHAPE class 5 bandwidth '2%'
set qos policy shaper SHAPE class 5 match tiny4 ip tcp syn

set qos policy shaper SHAPE class 10 bandwidth '1%'
set qos policy shaper SHAPE class 10 match dns ip protocol 'udp'

set qos policy shaper SHAPE default bandwidth '95%'
set qos policy shaper SHAPE default ceiling '100%'
set qos policy shaper SHAPE default codel-quantum '8000'

set qos interface eth1 egress SHAPE
commit

```
Before the fix we get default class **6** but `tc qsidc` expected `b`:
```


commit

DEBUG/QoS: tc qdisc replace dev eth1 root handle 1: htb r2q 444 default 6

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/qos.py", line 240, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/qos.py", line 231, in apply
    tmp.update(shaper_config, direction)
  File "/usr/lib/python3/dist-packages/vyos/qos/trafficshaper.py", line 129, in update
    super().update(config, direction)
  File "/usr/lib/python3/dist-packages/vyos/qos/base.py", line 375, in update
    self._build_base_qdisc(config['default'], default_cls_id)
  File "/usr/lib/python3/dist-packages/vyos/qos/base.py", line 147, in _build_base_qdisc
    self._cmd(default_tc)
  File "/usr/lib/python3/dist-packages/vyos/qos/base.py", line 75, in _cmd
    return cmd(command)
           ^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/utils/process.py", line 155, in cmd
    raise OSError(code, feedback)
FileNotFoundError: [Errno 2] failed to run command: tc qdisc replace dev eth1 parent 1:b fq_codel quantum 8000 flows 1024 interval 100 interval 100 target 5 noecn
returned: 
exit code: 2



returned (err):
Error: Cannot delete qdisc with handle of zero.
cmd 'tc qdisc replace dev eth1 parent 1:b fq_codel quantum 8000 flows 1024 interval 100 interval 100 target 5 noecn'
returned (out):

```
After the fix:
```
vyos@r4# commit
[ qos ]
DEBUG/QoS: tc qdisc replace dev eth1 root handle 1: htb r2q 444 default b
DEBUG/QoS: tc class replace dev eth1 parent 1: classid 1:1 htb rate 710000000
DEBUG/QoS: tc class replace dev eth1 parent 1:1 classid 1:5 htb rate 14200000 burst 15k quantum 1514
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:5 sfq
DEBUG/QoS: tc class replace dev eth1 parent 1:1 classid 1:a htb rate 7100000 burst 15k quantum 1514
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:a sfq
DEBUG/QoS: tc class replace dev eth1 parent 1:1 classid 1:b htb rate 674500000 burst 15k quantum 8000 prio 20 ceil 710000000
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:b sfq
{'bandwidth': '710mbit',
 'class': {'10': {'bandwidth': '1%',
                  'burst': '15k',
                  'codel_quantum': '1514',
                  'flows': '1024',
                  'interval': '100',
                  'match': {'dns': {'ip': {'protocol': 'udp'}}},
                  'queue_type': 'fq-codel',
                  'target': '5'},
           '5': {'bandwidth': '2%',
                 'burst': '15k',
                 'codel_quantum': '1514',
                 'flows': '1024',
                 'interval': '100',
                 'match': {'tiny4': {'ip': {'tcp': {'syn': {}}}}},
                 'queue_type': 'fq-codel',
                 'target': '5'}},
 'default': {'bandwidth': '95%',
             'burst': '15k',
             'ceiling': '100%',
             'codel_quantum': '8000',
             'flows': '1024',
             'interval': '100',
             'priority': '20',
             'queue_type': 'fq-codel',
             'target': '5'}}
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:5 fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5 noecn
DEBUG/QoS: tc filter add dev eth1 parent 1: protocol all prio 1 u32 match u8 0x2 0x2 at 33 flowid 1:5

WARNING: Interface speed cannot be determined (assuming 1000 Mbit/s)

DEBUG/QoS: tc filter add dev eth1 parent 1: protocol all prio 1 u32 match u8 0x2 0x2 at 33 flowid 1:5 action police rate 20000000 burst 15k flowid 1:5
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:a fq_codel quantum 1514 flows 1024 interval 100 interval 100 target 5 noecn
DEBUG/QoS: tc filter add dev eth1 parent 1: protocol all prio 1 u32 match ip protocol 17 0xff flowid 1:a

WARNING: Interface speed cannot be determined (assuming 1000 Mbit/s)

DEBUG/QoS: tc filter add dev eth1 parent 1: protocol all prio 1 u32 match ip protocol 17 0xff flowid 1:a action police rate 10000000 burst 15k flowid 1:a
DEBUG/QoS: tc qdisc replace dev eth1 parent 1:b fq_codel quantum 8000 flows 1024 interval 100 interval 100 target 5 noecn

[edit]
vyos@r4#
```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_qos.py
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... skipped 'tc returns invalid JSON here - needs iproute2 fix'
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok

----------------------------------------------------------------------
Ran 11 tests in 85.659s

OK (skipped=1)
vyos@r4:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
