### PR TITLE
srv6: T5849: add segment support to "protocols static route6"

### DIFF
--- a/data/templates/frr/static_routes_macro.j2
+++ b/data/templates/frr/static_routes_macro.j2
@@ -13,17 +13,17 @@
 {% endif %}
 {% if prefix_config.interface is vyos_defined %}
 {%     for interface, interface_config in prefix_config.interface.items() if interface_config.disable is not defined %}
-{{ ip_ipv6 }} route {{ prefix }} {{ interface }} {{ interface_config.distance if interface_config.distance is vyos_defined }} {{ 'nexthop-vrf ' ~ interface_config.vrf if interface_config.vrf is vyos_defined }} {{ 'table ' ~ table if table is vyos_defined }}
+{{ ip_ipv6 }} route {{ prefix }} {{ interface }} {{ interface_config.distance if interface_config.distance is vyos_defined }} {{ 'nexthop-vrf ' ~ interface_config.vrf if interface_config.vrf is vyos_defined }} {{ 'segments ' ~ interface_config.segments if interface_config.segments is vyos_defined }} {{ 'table ' ~ table if table is vyos_defined }}
 {%     endfor %}
 {% endif %}
 {% if prefix_config.next_hop is vyos_defined and prefix_config.next_hop is not none %}
 {%     for next_hop, next_hop_config in prefix_config.next_hop.items() if next_hop_config.disable is not defined %}
-{{ ip_ipv6 }} route {{ prefix }} {{ next_hop }} {{ next_hop_config.interface if next_hop_config.interface is vyos_defined }} {{ next_hop_config.distance if next_hop_config.distance is vyos_defined }} {{ 'nexthop-vrf ' ~ next_hop_config.vrf if next_hop_config.vrf is vyos_defined }} {{ 'bfd profile ' ~ next_hop_config.bfd.profile if next_hop_config.bfd.profile is vyos_defined }} {{ 'table ' ~ table if table is vyos_defined }} 
+{{ ip_ipv6 }} route {{ prefix }} {{ next_hop }} {{ next_hop_config.interface if next_hop_config.interface is vyos_defined }} {{ next_hop_config.distance if next_hop_config.distance is vyos_defined }} {{ 'nexthop-vrf ' ~ next_hop_config.vrf if next_hop_config.vrf is vyos_defined }} {{ 'bfd profile ' ~ next_hop_config.bfd.profile if next_hop_config.bfd.profile is vyos_defined }} {{ 'segments ' ~ next_hop_config.segments if next_hop_config.segments is vyos_defined }} {{ 'table ' ~ table if table is vyos_defined }}
 {%         if next_hop_config.bfd.multi_hop.source is vyos_defined %}
 {%             for source, source_config in next_hop_config.bfd.multi_hop.source.items() %}
 {{ ip_ipv6 }} route {{ prefix }} {{ next_hop }} bfd multi-hop source {{ source }} profile {{ source_config.profile }}
 {%             endfor %}
-{%         endif %} 
+{%         endif %}
 {%     endfor %}
 {% endif %}
 {% endmacro %}

--- a/interface-definitions/include/static/static-route-reject.xml.i
+++ b/interface-definitions/include/static/static-route-reject.xml.i
@@ -9,4 +9,3 @@
   </children>
 </node>
 <!-- include end -->
-

--- a/interface-definitions/include/static/static-route-segments.xml.i
+++ b/interface-definitions/include/static/static-route-segments.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from static/static-route-segments.xml.i -->
+<leafNode name="segments">
+    <properties>
+      <help>SRv6 segments</help>
+      <valueHelp>
+        <format>txt</format>
+        <description>Segs (SIDs)</description>
+      </valueHelp>
+      <constraint>
+        <validator name="ipv6-srv6-segments"/>
+      </constraint>
+    </properties>
+  </leafNode>
+  <!-- include end -->

--- a/interface-definitions/include/static/static-route6.xml.i
+++ b/interface-definitions/include/static/static-route6.xml.i
@@ -31,6 +31,7 @@
       <children>
         #include <include/generic-disable-node.xml.i>
         #include <include/static/static-route-distance.xml.i>
+        #include <include/static/static-route-segments.xml.i>
         #include <include/static/static-route-vrf.xml.i>
       </children>
     </tagNode>
@@ -47,13 +48,13 @@
       </properties>
       <children>
         #include <include/generic-disable-node.xml.i>
+        #include <include/static/static-route-bfd.xml.i>
         #include <include/static/static-route-distance.xml.i>
         #include <include/static/static-route-interface.xml.i>
+        #include <include/static/static-route-segments.xml.i>
         #include <include/static/static-route-vrf.xml.i>
-        #include <include/static/static-route-bfd.xml.i>
       </children>
     </tagNode>
   </children>
 </tagNode>
 <!-- include end -->
-

--- a/src/validators/ipv6-srv6-segments
+++ b/src/validators/ipv6-srv6-segments
@@ -1,0 +1,13 @@
+#!/bin/sh
+segments="$1"
+export IFS="/"
+
+for ipv6addr in $segments; do
+    ipaddrcheck --is-ipv6-single $ipv6addr
+    if [ $? -gt 0 ]; then
+        echo "Error: $1 is not a valid IPv6 address"
+        exit 1
+    fi
+done
+exit 0
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

```
set protocols static route6 <prefix> next-hop <address> segments 'x:x::x:x/y:y::y/z::z'
set protocols static route6 <prefix> interface <interface> segments 'x:x::x:x/y:y::y/z::z'
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5849

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-documentation/pull/1275

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_static.py
test_01_static (__main__.TestProtocolsStatic.test_01_static) ... ok
test_02_static_table (__main__.TestProtocolsStatic.test_02_static_table) ... ok
test_03_static_vrf (__main__.TestProtocolsStatic.test_03_static_vrf) ... ok

----------------------------------------------------------------------
Ran 3 tests in 46.329s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
