### PR TITLE
T6019: fix smoketest after upgrading nftables and libnftnl packages.

### DIFF
--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -652,8 +652,8 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         nftables_search = [
             ['ct state { established, related }', 'accept'],
             ['ct state invalid', 'reject'],
-            ['ct state new', 'ct status dnat', 'accept'],
-            ['ct state { established, new }', 'ct status snat', 'accept'],
+            ['ct state new', 'ct status == dnat', 'accept'],
+            ['ct state { established, new }', 'ct status == snat', 'accept'],
             ['ct state related', 'ct helper { "ftp", "pptp" }', 'accept'],
             ['drop', f'comment "{name} default-action drop"'],
             ['jump VYOS_STATE_POLICY'],


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
fix smoketest after upgrading nftables and libnftnl packages.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6019

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-build/pull/501

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos:~$ show config comm | grep firewall
set firewall ipv4 input filter rule 1 action 'accept'
set firewall ipv4 input filter rule 1 description 'Good'
set firewall ipv4 input filter rule 1 time starttime '00:00:00'
set firewall ipv4 input filter rule 1 time stoptime '15:00:25'
set firewall ipv4 input filter rule 2 action 'accept'
set firewall ipv4 input filter rule 2 description 'Good, using latest value accepted'
set firewall ipv4 input filter rule 2 time starttime '17:00:01'
set firewall ipv4 input filter rule 2 time stoptime '20:59:59'
set firewall ipv4 input filter rule 3 action 'accept'
set firewall ipv4 input filter rule 3 description 'StopTime 23 plus utc 3 >> than 24. not ok'
set firewall ipv4 input filter rule 3 time starttime '06:00:00'
set firewall ipv4 input filter rule 3 time stoptime '23:00:00'
set firewall ipv4 input filter rule 4 action 'accept'
set firewall ipv4 input filter rule 4 description 'Both time would be bigger than 24 in UTC.. Not OK'
set firewall ipv4 input filter rule 4 time starttime '21:00:00'
set firewall ipv4 input filter rule 4 time stoptime '23:30:00'
set firewall ipv4 input filter rule 10 action 'accept'
vyos@vyos:~$ sudo nft -s list chain ip vyos_filter VYOS_INPUT_filter
table ip vyos_filter {
(reversechain VYOS_INPUT_filter { -s list chain ip vyos_filter VYOS_INPUT_filter 
                type filter hook input priority filter; policy accept;
                meta hour >= "00:00" meta hour < "15:00:25" counter accept comment "ipv4-INP-filter-1"
                meta hour >= "17:00:01" meta hour < "20:59:59" counter accept comment "ipv4-INP-filter-2"
                meta hour >= "06:00" meta hour < "23:00" counter accept comment "ipv4-INP-filter-3"
                meta hour >= "21:00" meta hour < "23:30" counter accept comment "ipv4-INP-filter-4"
                ct state new ct status == dnat counter accept comment "ipv4-INP-filter-10"
                counter accept comment "INP-filter default-action accept"
        }
}
vyos@vyos:~$ date
Mon Feb 12 08:51:45 AM -03 2024
vyos@vyos:~$ show config comm | grep zone
set system time-zone 'America/Argentina/Buenos_Aires'
vyos@vyos:~$ 

```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@vyos:/usr/libexec/vyos/tests/smoke/cli# ./test_firewall.py
test_bridge_basic_rules (__main__.TestFirewall.test_bridge_basic_rules) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ...
Interface "eth0" does not support hardware offload

ok
test_geoip (__main__.TestFirewall.test_geoip) ... Updating GeoIP. Please wait...
Updating GeoIP. Please wait...
ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_dynamic_groups (__main__.TestFirewall.test_ipv4_dynamic_groups) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ...
"synproxy" option allowed only for action synproxy

ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_dynamic_groups (__main__.TestFirewall.test_ipv6_dynamic_groups) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ...
Group "smoketest_network1" has a circular reference

ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ...
Interface "eth0" does not support hardware offload

ok

----------------------------------------------------------------------
Ran 19 tests in 48.442s

OK
root@vyos:/usr/libexec/vyos/tests/smoke/cli#
```
Smoketests that were also tested:
* policy_route
* nat
* nat66

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
