### PR TITLE
dhcpv6-server: T5993: Add subnet `interface` node, link subnet to locally connected interfaces

### DIFF
--- a/interface-definitions/include/version/dhcpv6-server-version.xml.i
+++ b/interface-definitions/include/version/dhcpv6-server-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/dhcpv6-server-version.xml.i -->
-<syntaxVersion component='dhcpv6-server' version='4'></syntaxVersion>
+<syntaxVersion component='dhcpv6-server' version='5'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/service_dhcpv6-server.xml.in
+++ b/interface-definitions/service_dhcpv6-server.xml.in
@@ -97,6 +97,21 @@
                 </properties>
                 <children>
                   #include <include/dhcp/option-v6.xml.i>
+                  <leafNode name="interface">
+                    <properties>
+                      <help>Optional interface for this subnet to accept requests from</help>
+                      <completionHelp>
+                        <script>${vyos_completion_dir}/list_interfaces</script>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Interface name</description>
+                      </valueHelp>
+                      <constraint>
+                        #include <include/constraint/interface-name.xml.i>
+                      </constraint>
+                    </properties>
+                  </leafNode>
                   <tagNode name="range">
                     <properties>
                       <help>Parameters setting ranges for assigning IPv6 addresses</help>

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -212,6 +212,9 @@ def kea6_parse_subnet(subnet, config):
     if 'option' in config:
         out['option-data'] = kea6_parse_options(config['option'])
 
+    if 'interface' in config:
+        out['interface'] = config['interface']
+
     if 'range' in config:
         pools = []
         for num, range_config in config['range'].items():

--- a/smoketest/scripts/cli/test_service_dhcpv6-server.py
+++ b/smoketest/scripts/cli/test_service_dhcpv6-server.py
@@ -102,6 +102,7 @@ class TestServiceDHCPv6Server(VyOSUnitTestSHIM.TestCase):
         pool = base_path + ['shared-network-name', shared_net_name, 'subnet', subnet]
 
         self.cli_set(base_path + ['preference', preference])
+        self.cli_set(pool + ['interface', interface])
         self.cli_set(pool + ['subnet-id', '1'])
         # we use the first subnet IP address as default gateway
         self.cli_set(pool + ['lease-time', 'default', lease_time])
@@ -146,6 +147,7 @@ class TestServiceDHCPv6Server(VyOSUnitTestSHIM.TestCase):
 
         self.verify_config_value(obj, ['Dhcp6', 'shared-networks'], 'name', shared_net_name)
         self.verify_config_value(obj, ['Dhcp6', 'shared-networks', 0, 'subnet6'], 'subnet', subnet)
+        self.verify_config_value(obj, ['Dhcp6', 'shared-networks', 0, 'subnet6'], 'interface', interface)
         self.verify_config_value(obj, ['Dhcp6', 'shared-networks', 0, 'subnet6'], 'id', 1)
         self.verify_config_value(obj, ['Dhcp6', 'shared-networks', 0, 'subnet6'], 'valid-lifetime', int(lease_time))
         self.verify_config_value(obj, ['Dhcp6', 'shared-networks', 0, 'subnet6'], 'min-valid-lifetime', int(min_lease_time))

--- a/src/migration-scripts/dhcpv6-server/4-to-5
+++ b/src/migration-scripts/dhcpv6-server/4-to-5
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T5993: Check if subnet is locally accessible and assign interface to subnet
+
+import sys
+from ipaddress import ip_network
+from vyos.configtree import ConfigTree
+
+if (len(sys.argv) < 1):
+    print("Must specify file name!")
+    sys.exit(1)
+
+file_name = sys.argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['service', 'dhcpv6-server', 'shared-network-name']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+
+def find_subnet_interface(subnet):
+    subnet_net = ip_network(subnet)
+
+    for iftype in config.list_nodes(['interfaces']):
+        for ifname in config.list_nodes(['interfaces', iftype]):
+            if_base = ['interfaces', iftype, ifname]
+
+            if config.exists(if_base + ['address']):
+                for addr in config.return_values(if_base + ['address']):
+                    if ip_network(addr, strict=False) == subnet_net:
+                        return ifname
+
+    return False
+
+for network in config.list_nodes(base):
+    if not config.exists(base + [network, 'subnet']):
+        continue
+
+    for subnet in config.list_nodes(base + [network, 'subnet']):
+        subnet_interface = find_subnet_interface(subnet)
+
+        if subnet_interface:
+            config.set(base + [network, 'subnet', subnet, 'interface'], value=subnet_interface)
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
* Add subnet `interface` node
* Migrate locally connected subnet to interface

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5993

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcpv6-server

## Proposed changes
<!--- Describe your changes in detail -->
* Add subnet `interface` node
* Migrate locally connected subnet to interface

Prior dhcpd behaviour implicitly handled requests for locally connected subnets. Kea requires an explicit link between subnets and an interface.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_service_dhcpv6-server.py
DEBUG - test_global_nameserver (__main__.TestServiceDHCPv6Server.test_global_nameserver) ... ok
DEBUG - test_prefix_delegation (__main__.TestServiceDHCPv6Server.test_prefix_delegation) ... ok
DEBUG - test_single_pool (__main__.TestServiceDHCPv6Server.test_single_pool) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 3 tests in 22.959s
DEBUG -
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
