### PR TITLE
dhcpv6-server: T5992: Fix op-mode DHCP lease output + updates

### DIFF
--- a/op-mode-definitions/dhcp.xml.in
+++ b/op-mode-definitions/dhcp.xml.in
@@ -130,7 +130,7 @@
                     <properties>
                       <help>Show DHCPv6 server leases sorted by the specified key</help>
                       <completionHelp>
-                        <list>end iaid_duid ip last_communication pool remaining state type</list>
+                        <list>end duid ip last_communication pool remaining state type</list>
                       </completionHelp>
                     </properties>
                     <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet6 --sort $6</command>

--- a/op-mode-definitions/dhcp.xml.in
+++ b/op-mode-definitions/dhcp.xml.in
@@ -80,6 +80,32 @@
                   </tagNode>
                 </children>
               </node>
+              <node name="static-mappings">
+                <properties>
+                  <help>Show DHCP server static mappings</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet</command>
+                <children>
+                  <tagNode name="pool">
+                    <properties>
+                      <help>Show DHCP server static mappings for a specific pool</help>
+                      <completionHelp>
+                        <path>service dhcp-server shared-network-name</path>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet --pool $6</command>
+                  </tagNode>
+                  <tagNode name="sort">
+                    <properties>
+                      <help>Show DHCP server static mappings sorted by the specified key</help>
+                      <completionHelp>
+                        <list>ip mac duid pool</list>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet --sort $6</command>
+                  </tagNode>
+                </children>
+              </node>
               <node name="statistics">
                 <properties>
                   <help>Show DHCP server statistics</help>
@@ -143,6 +169,32 @@
                       </completionHelp>
                     </properties>
                     <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet6 --state $6</command>
+                  </tagNode>
+                </children>
+              </node>
+              <node name="static-mappings">
+                <properties>
+                  <help>Show DHCPv6 server static mappings</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet6</command>
+                <children>
+                  <tagNode name="pool">
+                    <properties>
+                      <help>Show DHCPv6 server static mappings for a specific pool</help>
+                      <completionHelp>
+                        <path>service dhcp-server shared-network-name</path>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet6 --pool $6</command>
+                  </tagNode>
+                  <tagNode name="sort">
+                    <properties>
+                      <help>Show DHCPv6 server static mappings sorted by the specified key</help>
+                      <completionHelp>
+                        <list>ip mac duid pool</list>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet6 --sort $6</command>
                   </tagNode>
                 </children>
               </node>

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -112,6 +112,10 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[], orig
             data_lease['duid'] = _format_hex_string(lease['duid'])
             data_lease['type'] = lease['type']
 
+            if lease['type'] == 'IA_PD':
+                prefix_len = lease['prefix-len']
+                data_lease['ip'] += f'/{prefix_len}'
+
         data_lease['remaining'] = '-'
 
         if lease['valid-lft'] > 0:

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -39,6 +39,7 @@ config = ConfigTreeQuery()
 lease_valid_states = ['all', 'active', 'free', 'expired', 'released', 'abandoned', 'reset', 'backup']
 sort_valid_inet = ['end', 'mac', 'hostname', 'ip', 'pool', 'remaining', 'start', 'state']
 sort_valid_inet6 = ['end', 'duid', 'ip', 'last_communication', 'pool', 'remaining', 'state', 'type']
+mapping_sort_valid = ['mac', 'ip', 'pool', 'duid']
 
 ArgFamily = typing.Literal['inet', 'inet6']
 ArgState = typing.Literal['all', 'active', 'free', 'expired', 'released', 'abandoned', 'reset', 'backup']
@@ -249,6 +250,47 @@ def _get_formatted_pool_statistics(pool_data, family='inet'):
     output = tabulate(data_entries, headers, numalign='left')
     return output
 
+def _get_raw_server_static_mappings(family='inet', pool=None, sorted=None):
+    if pool is None:
+        pool = _get_dhcp_pools(family=family)
+    else:
+        pool = [pool]
+
+    v = 'v6' if family == 'inet6' else ''
+    mappings = []
+    for p in pool:
+        pool_config = config.get_config_dict(['service', f'dhcp{v}-server', 'shared-network-name', p],
+                                             get_first_key=True)
+        if 'subnet' in pool_config:
+            for subnet, subnet_config in pool_config['subnet'].items():
+                if 'static-mapping' in subnet_config:
+                    for name, mapping_config in subnet_config['static-mapping'].items():
+                        mapping = {'pool': p, 'subnet': subnet, 'name': name}
+                        mapping.update(mapping_config)
+                        mappings.append(mapping)
+
+    if sorted:
+        if sorted == 'ip':
+            data.sort(key = lambda x:ip_address(x['ip-address']))
+        else:
+            data.sort(key = lambda x:x[sorted])
+    return mappings
+
+def _get_formatted_server_static_mappings(raw_data, family='inet'):
+    data_entries = []
+    for entry in raw_data:
+        pool = entry.get('pool')
+        subnet = entry.get('subnet')
+        name = entry.get('name')
+        ip_addr = entry.get('ip-address', 'N/A')
+        mac_addr = entry.get('mac', 'N/A')
+        duid = entry.get('duid', 'N/A')
+        description = entry.get('description', 'N/A')
+        data_entries.append([pool, subnet, name, ip_addr, mac_addr, duid, description])
+
+    headers = ['Pool', 'Subnet', 'Name', 'IP Address', 'MAC Address', 'DUID', 'Description']
+    output = tabulate(data_entries, headers, numalign='left')
+    return output
 
 def _verify(func):
     """Decorator checks if DHCP(v6) config exists"""
@@ -302,6 +344,21 @@ def show_server_leases(raw: bool, family: ArgFamily, pool: typing.Optional[str],
     else:
         return _get_formatted_server_leases(lease_data, family=family)
 
+@_verify
+def show_server_static_mappings(raw: bool, family: ArgFamily, pool: typing.Optional[str],
+                                sorted: typing.Optional[str]):
+    v = 'v6' if family == 'inet6' else ''
+    if pool and pool not in _get_dhcp_pools(family=family):
+        raise vyos.opmode.IncorrectValue(f'DHCP{v} pool "{pool}" does not exist!')
+
+    if sorted and sorted not in mapping_sort_valid:
+        raise vyos.opmode.IncorrectValue(f'DHCP{v} sort "{sorted}" is invalid!')
+
+    static_mappings = _get_raw_server_static_mappings(family=family, pool=pool, sorted=sorted)
+    if raw:
+        return static_mappings
+    else:
+        return _get_formatted_server_static_mappings(static_mappings, family=family)
 
 def _get_raw_client_leases(family='inet', interface=None):
     from time import mktime


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
* Fix op-mode lease output
* Show PD prefix length in lease
* Add `show dhcp(v6) server static-mappings` op-mode

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5992
* https://vyos.dev/T3316

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-server, dhcpv6-server

## Proposed changes
<!--- Describe your changes in detail -->
* Fix op-mode lease output by using Kea control socket for current lease information instead of relying on the inconsistent CSV files under /config/dhcp
* For PD leases, append the prefix length to the output
* Adds `show dhcp(v6) server static-mappings` op-mode to display static-mappings from config

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
