### PR TITLE
T6029: Rewritten Accel-PPP services to an identical feature set

### DIFF
--- a/data/templates/accel-ppp/config_extended_scripts.j2
+++ b/data/templates/accel-ppp/config_extended_scripts.j2
@@ -1,0 +1,9 @@
+{% if extended_scripts is vyos_defined %}
+[pppd-compat]
+verbose=1
+radattr-prefix=/run/accel-pppd/radattr
+{%     set script_name = {'on_up': 'ip-up', 'on_down': 'ip-down', 'on_change':'ip-change', 'on_pre_up':'ip-pre-up'} %}
+{%     for script in extended_scripts %}
+{{ script_name[script] }}={{ extended_scripts[script] }}
+{%     endfor %}
+{% endif %}

--- a/data/templates/accel-ppp/config_limits.j2
+++ b/data/templates/accel-ppp/config_limits.j2
@@ -1,0 +1,12 @@
+{% if limits is vyos_defined %}
+[connlimit]
+{%     if limits.connection_limit is vyos_defined %}
+limit={{ limits.connection_limit }}
+{%     endif %}
+{%     if limits.burst is vyos_defined %}
+burst={{ limits.burst }}
+{%     endif %}
+{%     if limits.timeout is vyos_defined %}
+timeout={{ limits.timeout }}
+{%     endif %}
+{% endif %}

--- a/data/templates/accel-ppp/config_snmp.j2
+++ b/data/templates/accel-ppp/config_snmp.j2
@@ -1,0 +1,4 @@
+{% if snmp.master_agent is vyos_defined %}
+[snmp]
+master=1
+{% endif %}

--- a/data/templates/accel-ppp/config_wins_server.j2
+++ b/data/templates/accel-ppp/config_wins_server.j2
@@ -1,0 +1,6 @@
+{% if wins_server is vyos_defined %}
+[wins]
+{%     for server in wins_server %}
+wins{{ loop.index }}={{ server }}
+{%     endfor %}
+{% endif %}

--- a/data/templates/accel-ppp/ipoe.config.j2
+++ b/data/templates/accel-ppp/ipoe.config.j2
@@ -6,10 +6,16 @@ ipoe
 shaper
 {# Common authentication backend definitions #}
 {% include 'accel-ppp/config_modules_auth_mode.j2' %}
+ippool
 ipv6pool
 ipv6_nd
 ipv6_dhcp
-ippool
+{% if snmp is vyos_defined %}
+net-snmp
+{% endif %}
+{% if limits is vyos_defined %}
+connlimit
+{% endif %}
 
 [core]
 thread-count={{ thread_count }}
@@ -18,6 +24,7 @@ thread-count={{ thread_count }}
 {% if max_concurrent_sessions is vyos_defined %}
 max-starting={{ max_concurrent_sessions }}
 {% endif %}
+
 
 [log]
 syslog=accel-ipoe,daemon
@@ -83,6 +90,15 @@ proxy-arp=1
 
 {# Common RADIUS shaper configuration #}
 {% include 'accel-ppp/config_shaper_radius.j2' %}
+
+{# Common Extended scripts configuration #}
+{% include 'accel-ppp/config_extended_scripts.j2' %}
+
+{# Common Limits configuration #}
+{% include 'accel-ppp/config_limits.j2' %}
+
+{# Common SNMP definitions #}
+{% include 'accel-ppp/config_snmp.j2' %}
 
 [cli]
 tcp=127.0.0.1:2002

--- a/data/templates/accel-ppp/l2tp.config.j2
+++ b/data/templates/accel-ppp/l2tp.config.j2
@@ -10,6 +10,12 @@ ippool
 {% include 'accel-ppp/config_modules_ipv6.j2' %}
 {# Common authentication protocols (pap, chap ...) #}
 {% include 'accel-ppp/config_modules_auth_protocols.j2' %}
+{% if snmp is vyos_defined %}
+net-snmp
+{% endif %}
+{% if limits is vyos_defined %}
+connlimit
+{% endif %}
 
 [core]
 thread-count={{ thread_count }}
@@ -24,15 +30,8 @@ syslog=accel-l2tp,daemon
 copy=1
 level=5
 
-{# Common DNS name-server definition #}
-{% include 'accel-ppp/config_name_server.j2' %}
-
-{% if wins_server is vyos_defined %}
-[wins]
-{%     for server in wins_server %}
-wins{{ loop.index }}={{ server }}
-{%     endfor %}
-{% endif %}
+[client-ip-range]
+0.0.0.0/0
 
 [l2tp]
 verbose=1
@@ -56,11 +55,17 @@ ipv6-pool={{ default_ipv6_pool }}
 ipv6-pool-delegate={{ default_ipv6_pool }}
 {% endif %}
 
-[client-ip-range]
-0.0.0.0/0
-
 {# Common IP pool definitions #}
 {% include 'accel-ppp/config_ip_pool.j2' %}
+
+{# Common IPv6 pool definitions #}
+{% include 'accel-ppp/config_ipv6_pool.j2' %}
+
+{# Common DNS name-server definition #}
+{% include 'accel-ppp/config_name_server.j2' %}
+
+{# Common wins-server definition #}
+{% include 'accel-ppp/config_wins_server.j2' %}
 
 {# Common chap-secrets and RADIUS server/option definitions #}
 {% include 'accel-ppp/config_chap_secrets_radius.j2' %}
@@ -68,11 +73,17 @@ ipv6-pool-delegate={{ default_ipv6_pool }}
 {# Common ppp-options definitions #}
 {% include 'accel-ppp/ppp-options.j2' %}
 
-{# Common IPv6 pool definitions #}
-{% include 'accel-ppp/config_ipv6_pool.j2' %}
-
 {# Common RADIUS shaper configuration #}
 {% include 'accel-ppp/config_shaper_radius.j2' %}
+
+{# Common Extended scripts configuration #}
+{% include 'accel-ppp/config_extended_scripts.j2' %}
+
+{# Common Limits configuration #}
+{% include 'accel-ppp/config_limits.j2' %}
+
+{# Common SNMP definitions #}
+{% include 'accel-ppp/config_snmp.j2' %}
 
 [cli]
 tcp=127.0.0.1:2004

--- a/data/templates/accel-ppp/pppoe.config.j2
+++ b/data/templates/accel-ppp/pppoe.config.j2
@@ -10,7 +10,6 @@ ippool
 {% include 'accel-ppp/config_modules_ipv6.j2' %}
 {# Common authentication protocols (pap, chap ...) #}
 {% include 'accel-ppp/config_modules_auth_protocols.j2' %}
-
 {% if snmp is vyos_defined %}
 net-snmp
 {% endif %}
@@ -35,32 +34,8 @@ level=5
 noauth=1
 {% endif %}
 
-{% if snmp.master_agent is vyos_defined %}
-[snmp]
-master=1
-{% endif %}
-
 [client-ip-range]
-disable
-
-{# Common IP pool definitions #}
-{% include 'accel-ppp/config_ip_pool.j2' %}
-
-{# Common IPv6 pool definitions #}
-{% include 'accel-ppp/config_ipv6_pool.j2' %}
-
-{# Common DNS name-server definition #}
-{% include 'accel-ppp/config_name_server.j2' %}
-
-{% if wins_server is vyos_defined %}
-[wins]
-{%     for server in wins_server %}
-wins{{ loop.index }}={{ server }}
-{%     endfor %}
-{% endif %}
-
-{# Common chap-secrets and RADIUS server/option definitions #}
-{% include 'accel-ppp/config_chap_secrets_radius.j2' %}
+0.0.0.0/0
 
 [common]
 {% if session_control is vyos_defined and session_control is not vyos_defined('disable') %}
@@ -69,9 +44,6 @@ single-session={{ session_control }}
 {% if max_concurrent_sessions is vyos_defined %}
 max-starting={{ max_concurrent_sessions }}
 {% endif %}
-
-{# Common ppp-options definitions #}
-{% include 'accel-ppp/ppp-options.j2' %}
 
 [pppoe]
 verbose=1
@@ -116,31 +88,35 @@ ipv6-pool={{ default_ipv6_pool }}
 ipv6-pool-delegate={{ default_ipv6_pool }}
 {% endif %}
 
-{% if limits is vyos_defined %}
-[connlimit]
-{%     if limits.connection_limit is vyos_defined %}
-limit={{ limits.connection_limit }}
-{%     endif %}
-{%     if limits.burst is vyos_defined %}
-burst={{ limits.burst }}
-{%     endif %}
-{%     if limits.timeout is vyos_defined %}
-timeout={{ limits.timeout }}
-{%     endif %}
-{% endif %}
+{# Common IP pool definitions #}
+{% include 'accel-ppp/config_ip_pool.j2' %}
+
+{# Common IPv6 pool definitions #}
+{% include 'accel-ppp/config_ipv6_pool.j2' %}
+
+{# Common DNS name-server definition #}
+{% include 'accel-ppp/config_name_server.j2' %}
+
+{# Common wins-server definition #}
+{% include 'accel-ppp/config_wins_server.j2' %}
+
+{# Common chap-secrets and RADIUS server/option definitions #}
+{% include 'accel-ppp/config_chap_secrets_radius.j2' %}
+
+{# Common ppp-options definitions #}
+{% include 'accel-ppp/ppp-options.j2' %}
 
 {# Common RADIUS shaper configuration #}
 {% include 'accel-ppp/config_shaper_radius.j2' %}
 
-{% if extended_scripts is vyos_defined %}
-[pppd-compat]
-verbose=1
-radattr-prefix=/run/accel-pppd/radattr
-{%     set script_name = {'on_up': 'ip-up', 'on_down': 'ip-down', 'on_change':'ip-change', 'on_pre_up':'ip-pre-up'} %}
-{%     for script in extended_scripts %}
-{{ script_name[script] }}={{ extended_scripts[script] }}
-{%     endfor %}
-{% endif %}
+{# Common Extended scripts configuration #}
+{% include 'accel-ppp/config_extended_scripts.j2' %}
+
+{# Common Limits configuration #}
+{% include 'accel-ppp/config_limits.j2' %}
+
+{# Common SNMP definitions #}
+{% include 'accel-ppp/config_snmp.j2' %}
 
 [cli]
 tcp=127.0.0.1:2001

--- a/data/templates/accel-ppp/pptp.config.j2
+++ b/data/templates/accel-ppp/pptp.config.j2
@@ -10,6 +10,12 @@ ippool
 {% include 'accel-ppp/config_modules_ipv6.j2' %}
 {# Common authentication protocols (pap, chap ...) #}
 {% include 'accel-ppp/config_modules_auth_protocols.j2' %}
+{% if snmp is vyos_defined %}
+net-snmp
+{% endif %}
+{% if limits is vyos_defined %}
+connlimit
+{% endif %}
 
 [core]
 thread-count={{ thread_count }}
@@ -24,15 +30,8 @@ syslog=accel-pptp,daemon
 copy=1
 level=5
 
-{# Common DNS name-server definition #}
-{% include 'accel-ppp/config_name_server.j2' %}
-
-{% if wins_server is vyos_defined %}
-[wins]
-{%     for server in wins_server %}
-wins{{ loop.index }}={{ server }}
-{%     endfor %}
-{% endif %}
+[client-ip-range]
+0.0.0.0/0
 
 [pptp]
 ifname=pptp%d
@@ -52,23 +51,35 @@ ipv6-pool={{ default_ipv6_pool }}
 ipv6-pool-delegate={{ default_ipv6_pool }}
 {% endif %}
 
-[client-ip-range]
-0.0.0.0/0
-
 {# Common IP pool definitions #}
 {% include 'accel-ppp/config_ip_pool.j2' %}
 
 {# Common IPv6 pool definitions #}
 {% include 'accel-ppp/config_ipv6_pool.j2' %}
 
-{# Common ppp-options definitions #}
-{% include 'accel-ppp/ppp-options.j2' %}
+{# Common DNS name-server definition #}
+{% include 'accel-ppp/config_name_server.j2' %}
+
+{# Common wins-server definition #}
+{% include 'accel-ppp/config_wins_server.j2' %}
 
 {# Common chap-secrets and RADIUS server/option definitions #}
 {% include 'accel-ppp/config_chap_secrets_radius.j2' %}
 
+{# Common ppp-options definitions #}
+{% include 'accel-ppp/ppp-options.j2' %}
+
 {# Common RADIUS shaper configuration #}
 {% include 'accel-ppp/config_shaper_radius.j2' %}
+
+{# Common Extended scripts configuration #}
+{% include 'accel-ppp/config_extended_scripts.j2' %}
+
+{# Common Limits configuration #}
+{% include 'accel-ppp/config_limits.j2' %}
+
+{# Common SNMP definitions #}
+{% include 'accel-ppp/config_snmp.j2' %}
 
 [cli]
 tcp=127.0.0.1:2003

--- a/data/templates/accel-ppp/sstp.config.j2
+++ b/data/templates/accel-ppp/sstp.config.j2
@@ -10,6 +10,12 @@ ippool
 {% include 'accel-ppp/config_modules_ipv6.j2' %}
 {# Common authentication protocols (pap, chap ...) #}
 {% include 'accel-ppp/config_modules_auth_protocols.j2' %}
+{% if snmp is vyos_defined %}
+net-snmp
+{% endif %}
+{% if limits is vyos_defined %}
+connlimit
+{% endif %}
 
 [core]
 thread-count={{ thread_count }}
@@ -26,7 +32,7 @@ copy=1
 level=5
 
 [client-ip-range]
-disable
+0.0.0.0/0
 
 [sstp]
 verbose=1
@@ -53,6 +59,9 @@ ipv6-pool-delegate={{ default_ipv6_pool }}
 {# Common DNS name-server definition #}
 {% include 'accel-ppp/config_name_server.j2' %}
 
+{# Common wins-server definition #}
+{% include 'accel-ppp/config_wins_server.j2' %}
+
 {# Common chap-secrets and RADIUS server/option definitions #}
 {% include 'accel-ppp/config_chap_secrets_radius.j2' %}
 
@@ -61,6 +70,15 @@ ipv6-pool-delegate={{ default_ipv6_pool }}
 
 {# Common RADIUS shaper configuration #}
 {% include 'accel-ppp/config_shaper_radius.j2' %}
+
+{# Common Extended scripts configuration #}
+{% include 'accel-ppp/config_extended_scripts.j2' %}
+
+{# Common Limits configuration #}
+{% include 'accel-ppp/config_limits.j2' %}
+
+{# Common SNMP definitions #}
+{% include 'accel-ppp/config_snmp.j2' %}
 
 [cli]
 tcp=127.0.0.1:2005

--- a/interface-definitions/include/accel-ppp/extended-scripts.xml.i
+++ b/interface-definitions/include/accel-ppp/extended-scripts.xml.i
@@ -1,0 +1,41 @@
+<!-- include start from accel-ppp/extended-scripts.xml.i -->
+<node name="extended-scripts">
+  <properties>
+    <help>Extended script execution</help>
+  </properties>
+  <children>
+    <leafNode name="on-pre-up">
+      <properties>
+        <help>Script to run before PPPoE session interface comes up</help>
+          <constraint>
+            <validator name="script"/>
+          </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="on-up">
+      <properties>
+        <help>Script to run when PPPoE session interface is completely configured and started</help>
+          <constraint>
+            <validator name="script"/>
+          </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="on-down">
+      <properties>
+        <help>Script to run when PPPoE session interface going to terminate</help>
+          <constraint>
+            <validator name="script"/>
+          </constraint>
+      </properties>
+    </leafNode>
+    <leafNode name="on-change">
+      <properties>
+        <help>Script to run when PPPoE session interface changed by RADIUS CoA handling</help>
+          <constraint>
+            <validator name="script"/>
+          </constraint>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/accel-ppp/limits.xml.i
+++ b/interface-definitions/include/accel-ppp/limits.xml.i
@@ -1,0 +1,28 @@
+<!-- include start from accel-ppp/limits.xml.i -->
+<node name="limits">
+  <properties>
+    <help>Limits the connection rate from a single source</help>
+  </properties>
+  <children>
+    <leafNode name="connection-limit">
+      <properties>
+        <help>Acceptable rate of connections (e.g. 1/min, 60/sec)</help>
+        <constraint>
+          <regex>[0-9]+\/(min|sec)</regex>
+        </constraint>
+        <constraintErrorMessage>illegal value</constraintErrorMessage>
+      </properties>
+    </leafNode>
+    <leafNode name="burst">
+      <properties>
+        <help>Burst count</help>
+      </properties>
+    </leafNode>
+    <leafNode name="timeout">
+      <properties>
+        <help>Timeout in seconds</help>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/accel-ppp/snmp.xml.i
+++ b/interface-definitions/include/accel-ppp/snmp.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from accel-ppp/snmp.xml.i -->
+<node name="snmp">
+  <properties>
+    <help>Enable SNMP</help>
+  </properties>
+  <children>
+    <leafNode name="master-agent">
+      <properties>
+        <help>Enable SNMP master agent mode</help>
+        <valueless />
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/version/l2tp-version.xml.i
+++ b/interface-definitions/include/version/l2tp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/l2tp-version.xml.i -->
-<syntaxVersion component='l2tp' version='8'></syntaxVersion>
+<syntaxVersion component='l2tp' version='9'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/service_ipoe-server.xml.in
+++ b/interface-definitions/service_ipoe-server.xml.in
@@ -177,13 +177,18 @@
               #include <include/accel-ppp/vlan.xml.i>
             </children>
           </tagNode>
-          #include <include/accel-ppp/max-concurrent-sessions.xml.i>
-          #include <include/name-server-ipv4-ipv6.xml.i>
           #include <include/accel-ppp/client-ip-pool.xml.i>
-          #include <include/accel-ppp/gateway-address-multi.xml.i>
           #include <include/accel-ppp/client-ipv6-pool.xml.i>
           #include <include/accel-ppp/default-pool.xml.i>
           #include <include/accel-ppp/default-ipv6-pool.xml.i>
+          #include <include/accel-ppp/extended-scripts.xml.i>
+          #include <include/accel-ppp/gateway-address-multi.xml.i>
+          #include <include/accel-ppp/limits.xml.i>
+          #include <include/accel-ppp/max-concurrent-sessions.xml.i>
+          #include <include/accel-ppp/shaper.xml.i>
+          #include <include/accel-ppp/snmp.xml.i>
+          #include <include/generic-description.xml.i>
+          #include <include/name-server-ipv4-ipv6.xml.i>
         </children>
       </node>
     </children>

--- a/interface-definitions/service_pppoe-server.xml.in
+++ b/interface-definitions/service_pppoe-server.xml.in
@@ -49,9 +49,6 @@
               </node>
             </children>
           </node>
-          #include <include/accel-ppp/client-ip-pool.xml.i>
-          #include <include/accel-ppp/client-ipv6-pool.xml.i>
-          #include <include/name-server-ipv4-ipv6.xml.i>
           <tagNode name="interface">
             <properties>
               <help>interface(s) to listen on</help>
@@ -63,35 +60,6 @@
               #include <include/accel-ppp/vlan.xml.i>
             </children>
           </tagNode>
-          #include <include/accel-ppp/gateway-address.xml.i>
-          #include <include/accel-ppp/max-concurrent-sessions.xml.i>
-          #include <include/accel-ppp/mtu-128-16384.xml.i>
-          <node name="limits">
-            <properties>
-              <help>Limits the connection rate from a single source</help>
-            </properties>
-            <children>
-              <leafNode name="connection-limit">
-                <properties>
-                  <help>Acceptable rate of connections (e.g. 1/min, 60/sec)</help>
-                  <constraint>
-                    <regex>[0-9]+\/(min|sec)</regex>
-                  </constraint>
-                  <constraintErrorMessage>illegal value</constraintErrorMessage>
-                </properties>
-              </leafNode>
-              <leafNode name="burst">
-                <properties>
-                  <help>Burst count</help>
-                </properties>
-              </leafNode>
-              <leafNode name="timeout">
-                <properties>
-                  <help>Timeout in seconds</help>
-                </properties>
-              </leafNode>
-            </children>
-          </node>
           <leafNode name="service-name">
             <properties>
               <help>Service name</help>
@@ -102,15 +70,6 @@
               <multi/>
             </properties>
           </leafNode>
-          #include <include/accel-ppp/wins-server.xml.i>
-          #include <include/accel-ppp/ppp-options.xml.i>
-          <node name="ppp-options">
-            <children>
-              <leafNode name="min-mtu">
-                <defaultValue>1280</defaultValue>
-              </leafNode>
-            </children>
-          </node>
           <tagNode name="pado-delay">
             <properties>
               <help>PADO delays</help>
@@ -164,61 +123,28 @@
             </properties>
             <defaultValue>replace</defaultValue>
           </leafNode>
-          #include <include/accel-ppp/shaper.xml.i>
-          <node name="snmp">
-            <properties>
-              <help>Enable SNMP</help>
-            </properties>
-            <children>
-              <leafNode name="master-agent">
-                <properties>
-                  <help>enable SNMP master agent mode</help>
-                  <valueless />
-                </properties>
-              </leafNode>
-            </children>
-          </node>
-          <node name="extended-scripts">
-            <properties>
-              <help>Extended script execution</help>
-            </properties>
-            <children>
-              <leafNode name="on-pre-up">
-                <properties>
-                  <help>Script to run before PPPoE session interface comes up</help>
-                    <constraint>
-                      <validator name="script"/>
-                    </constraint>
-                </properties>
-              </leafNode>
-              <leafNode name="on-up">
-                <properties>
-                  <help>Script to run when PPPoE session interface is completely configured and started</help>
-                    <constraint>
-                      <validator name="script"/>
-                    </constraint>
-                </properties>
-              </leafNode>
-              <leafNode name="on-down">
-                <properties>
-                  <help>Script to run when PPPoE session interface going to terminate</help>
-                    <constraint>
-                      <validator name="script"/>
-                    </constraint>
-                </properties>
-              </leafNode>
-              <leafNode name="on-change">
-                <properties>
-                  <help>Script to run when PPPoE session interface changed by RADIUS CoA handling</help>
-                    <constraint>
-                      <validator name="script"/>
-                    </constraint>
-                </properties>
-              </leafNode>
-            </children>
-          </node>
+          #include <include/accel-ppp/client-ip-pool.xml.i>
+          #include <include/accel-ppp/client-ipv6-pool.xml.i>
           #include <include/accel-ppp/default-pool.xml.i>
           #include <include/accel-ppp/default-ipv6-pool.xml.i>
+          #include <include/accel-ppp/extended-scripts.xml.i>
+          #include <include/accel-ppp/gateway-address.xml.i>
+          #include <include/accel-ppp/limits.xml.i>
+          #include <include/accel-ppp/max-concurrent-sessions.xml.i>
+          #include <include/accel-ppp/mtu-128-16384.xml.i>
+          #include <include/accel-ppp/ppp-options.xml.i>
+          <node name="ppp-options">
+            <children>
+              <leafNode name="min-mtu">
+                <defaultValue>1280</defaultValue>
+              </leafNode>
+            </children>
+          </node>
+          #include <include/accel-ppp/shaper.xml.i>
+          #include <include/accel-ppp/snmp.xml.i>
+          #include <include/accel-ppp/wins-server.xml.i>
+          #include <include/generic-description.xml.i>
+          #include <include/name-server-ipv4-ipv6.xml.i>
         </children>
       </node>
     </children>

--- a/interface-definitions/vpn_l2tp.xml.in
+++ b/interface-definitions/vpn_l2tp.xml.in
@@ -30,42 +30,6 @@
                   </node>
                 </children>
               </node>
-              #include <include/accel-ppp/max-concurrent-sessions.xml.i>
-              #include <include/accel-ppp/mtu-128-16384.xml.i>
-              <leafNode name="mtu">
-                <defaultValue>1436</defaultValue>
-              </leafNode>
-              <leafNode name="outside-address">
-                <properties>
-                  <help>External IP address to which VPN clients will connect</help>
-                  <constraint>
-                    <validator name="ipv4-address"/>
-                  </constraint>
-                </properties>
-              </leafNode>
-              #include <include/accel-ppp/gateway-address.xml.i>
-              #include <include/name-server-ipv4-ipv6.xml.i>
-              <node name="lns">
-                <properties>
-                  <help>L2TP Network Server (LNS)</help>
-                </properties>
-                <children>
-                  <leafNode name="shared-secret">
-                    <properties>
-                      <help>Tunnel password used to authenticate the client (LAC)</help>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="host-name">
-                    <properties>
-                      <help>Sent to the client (LAC) in the Host-Name attribute</help>
-                      <constraint>
-                        #include <include/constraint/host-name.xml.i>
-                      </constraint>
-                      <constraintErrorMessage>Host-name must be alphanumeric and can contain hyphens</constraintErrorMessage>
-                    </properties>
-                  </leafNode>
-                </children>
-              </node>
               <node name="ipsec-settings">
                 <properties>
                   <help>Internet Protocol Security (IPsec) for remote access L2TP VPN</help>
@@ -129,14 +93,53 @@
                   #include <include/ipsec/ike-group.xml.i>
                 </children>
               </node>
-              #include <include/accel-ppp/wins-server.xml.i>
+              <node name="lns">
+                <properties>
+                  <help>L2TP Network Server (LNS)</help>
+                </properties>
+                <children>
+                  <leafNode name="shared-secret">
+                    <properties>
+                      <help>Tunnel password used to authenticate the client (LAC)</help>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="host-name">
+                    <properties>
+                      <help>Sent to the client (LAC) in the Host-Name attribute</help>
+                      <constraint>
+                        #include <include/constraint/host-name.xml.i>
+                      </constraint>
+                      <constraintErrorMessage>Host-name must be alphanumeric and can contain hyphens</constraintErrorMessage>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+              <leafNode name="outside-address">
+                <properties>
+                  <help>External IP address to which VPN clients will connect</help>
+                  <constraint>
+                    <validator name="ipv4-address"/>
+                  </constraint>
+                </properties>
+              </leafNode>
               #include <include/accel-ppp/client-ip-pool.xml.i>
               #include <include/accel-ppp/client-ipv6-pool.xml.i>
-              #include <include/generic-description.xml.i>
-              #include <include/dhcp-interface.xml.i>
-              #include <include/accel-ppp/ppp-options.xml.i>
               #include <include/accel-ppp/default-pool.xml.i>
               #include <include/accel-ppp/default-ipv6-pool.xml.i>
+              #include <include/accel-ppp/extended-scripts.xml.i>
+              #include <include/accel-ppp/gateway-address.xml.i>
+              #include <include/accel-ppp/limits.xml.i>
+              #include <include/accel-ppp/max-concurrent-sessions.xml.i>
+              #include <include/accel-ppp/mtu-128-16384.xml.i>
+              <leafNode name="mtu">
+                <defaultValue>1436</defaultValue>
+              </leafNode>
+              #include <include/accel-ppp/ppp-options.xml.i>
+              #include <include/accel-ppp/shaper.xml.i>
+              #include <include/accel-ppp/snmp.xml.i>
+              #include <include/accel-ppp/wins-server.xml.i>
+              #include <include/generic-description.xml.i>
+              #include <include/name-server-ipv4-ipv6.xml.i>
             </children>
           </node>
         </children>

--- a/interface-definitions/vpn_pptp.xml.in
+++ b/interface-definitions/vpn_pptp.xml.in
@@ -30,11 +30,6 @@
                   </node>
                 </children>
               </node>
-              #include <include/accel-ppp/max-concurrent-sessions.xml.i>
-              #include <include/accel-ppp/mtu-128-16384.xml.i>
-              <leafNode name="mtu">
-                <defaultValue>1436</defaultValue>
-              </leafNode>
               <leafNode name="outside-address">
                 <properties>
                   <help>External IP address to which VPN clients will connect</help>
@@ -43,14 +38,24 @@
                   </constraint>
                 </properties>
               </leafNode>
-              #include <include/accel-ppp/gateway-address.xml.i>
-              #include <include/name-server-ipv4-ipv6.xml.i>
-              #include <include/accel-ppp/wins-server.xml.i>
               #include <include/accel-ppp/client-ip-pool.xml.i>
-              #include <include/accel-ppp/default-pool.xml.i>
               #include <include/accel-ppp/client-ipv6-pool.xml.i>
+              #include <include/accel-ppp/default-pool.xml.i>
               #include <include/accel-ppp/default-ipv6-pool.xml.i>
+              #include <include/accel-ppp/extended-scripts.xml.i>
+              #include <include/accel-ppp/gateway-address.xml.i>
+              #include <include/accel-ppp/limits.xml.i>
+              #include <include/accel-ppp/max-concurrent-sessions.xml.i>
+              #include <include/accel-ppp/mtu-128-16384.xml.i>
+              <leafNode name="mtu">
+                <defaultValue>1436</defaultValue>
+              </leafNode>
               #include <include/accel-ppp/ppp-options.xml.i>
+              #include <include/accel-ppp/shaper.xml.i>
+              #include <include/accel-ppp/snmp.xml.i>
+              #include <include/accel-ppp/wins-server.xml.i>
+              #include <include/generic-description.xml.i>
+              #include <include/name-server-ipv4-ipv6.xml.i>
             </children>
           </node>
         </children>

--- a/interface-definitions/vpn_sstp.xml.in
+++ b/interface-definitions/vpn_sstp.xml.in
@@ -25,19 +25,6 @@
               </node>
             </children>
           </node>
-          #include <include/accel-ppp/max-concurrent-sessions.xml.i>
-          #include <include/interface/mtu-68-1500.xml.i>
-          #include <include/accel-ppp/gateway-address.xml.i>
-          #include <include/name-server-ipv4-ipv6.xml.i>
-          #include <include/accel-ppp/client-ip-pool.xml.i>
-          #include <include/accel-ppp/client-ipv6-pool.xml.i>
-          #include <include/port-number.xml.i>
-          <leafNode name="port">
-            <defaultValue>443</defaultValue>
-          </leafNode>
-          #include <include/accel-ppp/default-pool.xml.i>
-          #include <include/accel-ppp/default-ipv6-pool.xml.i>
-          #include <include/accel-ppp/ppp-options.xml.i>
           <node name="ssl">
             <properties>
               <help>SSL Certificate, SSL Key and CA</help>
@@ -47,6 +34,25 @@
               #include <include/pki/certificate.xml.i>
             </children>
           </node>
+          #include <include/accel-ppp/client-ip-pool.xml.i>
+          #include <include/accel-ppp/client-ipv6-pool.xml.i>
+          #include <include/accel-ppp/default-pool.xml.i>
+          #include <include/accel-ppp/default-ipv6-pool.xml.i>
+          #include <include/accel-ppp/extended-scripts.xml.i>
+          #include <include/accel-ppp/gateway-address.xml.i>
+          #include <include/accel-ppp/limits.xml.i>
+          #include <include/accel-ppp/max-concurrent-sessions.xml.i>
+          #include <include/interface/mtu-68-1500.xml.i>
+          #include <include/port-number.xml.i>
+          <leafNode name="port">
+            <defaultValue>443</defaultValue>
+          </leafNode>
+          #include <include/accel-ppp/ppp-options.xml.i>
+          #include <include/accel-ppp/shaper.xml.i>
+          #include <include/accel-ppp/snmp.xml.i>
+          #include <include/accel-ppp/wins-server.xml.i>
+          #include <include/generic-description.xml.i>
+          #include <include/name-server-ipv4-ipv6.xml.i>
         </children>
       </node>
     </children>

--- a/python/vyos/accel_ppp_util.py
+++ b/python/vyos/accel_ppp_util.py
@@ -106,7 +106,26 @@ def get_pools_in_order(data: dict) -> list:
     return pools
 
 
-def verify_accel_ppp_base_service(config, local_users=True):
+def verify_accel_ppp_name_servers(config):
+    if "name_server_ipv4" in config:
+        if len(config["name_server_ipv4"]) > 2:
+            raise ConfigError(
+                "Not more then two IPv4 DNS name-servers " "can be configured"
+            )
+    if "name_server_ipv6" in config:
+        if len(config["name_server_ipv6"]) > 3:
+            raise ConfigError(
+                "Not more then three IPv6 DNS name-servers " "can be configured"
+            )
+
+
+def verify_accel_ppp_wins_servers(config):
+    if 'wins_server' in config and len(config['wins_server']) > 2:
+        raise ConfigError(
+            'Not more then two WINS name-servers can be configured')
+
+
+def verify_accel_ppp_authentication(config, local_users=True):
     """
     Common helper function which must be used by all Accel-PPP services based
     on get_config_dict()
@@ -148,17 +167,6 @@ def verify_accel_ppp_base_service(config, local_users=True):
         if not dict_search('authentication.radius.dynamic_author.key', config):
             raise ConfigError('DAE/CoA server key required!')
 
-    if "name_server_ipv4" in config:
-        if len(config["name_server_ipv4"]) > 2:
-            raise ConfigError(
-                "Not more then two IPv4 DNS name-servers " "can be configured"
-            )
-
-    if "name_server_ipv6" in config:
-        if len(config["name_server_ipv6"]) > 3:
-            raise ConfigError(
-                "Not more then three IPv6 DNS name-servers " "can be configured"
-            )
 
 
 

--- a/smoketest/scripts/cli/base_accel_ppp_test.py
+++ b/smoketest/scripts/cli/base_accel_ppp_test.py
@@ -559,3 +559,52 @@ delegate={delegate_2_prefix},{delegate_mask},name={pool_name}"""
             self.assertEqual(conf['ppp']['lcp-echo-failure'], lcp_failure)
             self.assertEqual(conf['ppp']['lcp-echo-interval'], lcp_interval)
             self.assertEqual(conf['ppp']['lcp-echo-timeout'], lcp_timeout)
+
+
+        def test_accel_wins_server(self):
+            self.basic_config()
+            winsservers = ["192.0.2.1", "192.0.2.2"]
+            for wins in winsservers:
+                self.set(["wins-server", wins])
+            self.cli_commit()
+            conf = ConfigParser(allow_no_value=True, delimiters="=", strict=False)
+            conf.read(self._config_file)
+            for ws in winsservers:
+                self.assertIn(ws, [conf["wins"]["wins1"], conf["wins"]["wins2"]])
+
+        def test_accel_snmp(self):
+            self.basic_config()
+            self.set(['snmp', 'master-agent'])
+            self.cli_commit()
+            conf = ConfigParser(allow_no_value=True, delimiters="=", strict=False)
+            conf.read(self._config_file)
+            self.assertEqual(conf['modules']['net-snmp'], None)
+            self.assertEqual(conf['snmp']['master'],'1')
+
+        def test_accel_shaper(self):
+            self.basic_config()
+            fwmark = '2'
+            self.set(['shaper', 'fwmark', fwmark])
+            self.cli_commit()
+            conf = ConfigParser(allow_no_value=True, delimiters="=", strict=False)
+            conf.read(self._config_file)
+            self.assertEqual(conf['modules']['shaper'], None)
+            self.assertEqual(conf['shaper']['verbose'], '1')
+            self.assertEqual(conf['shaper']['down-limiter'], 'tbf')
+            self.assertEqual(conf['shaper']['fwmark'], fwmark)
+
+        def test_accel_limits(self):
+            self.basic_config()
+            burst = '100'
+            timeout = '20'
+            limits = '1/min'
+            self.set(['limits', 'connection-limit', limits])
+            self.set(['limits', 'timeout', timeout])
+            self.set(['limits', 'burst', burst])
+            self.cli_commit()
+            conf = ConfigParser(allow_no_value=True, delimiters="=", strict=False)
+            conf.read(self._config_file)
+            self.assertEqual(conf['modules']['connlimit'], None)
+            self.assertEqual(conf['connlimit']['limit'], limits)
+            self.assertEqual(conf['connlimit']['burst'], burst)
+            self.assertEqual(conf['connlimit']['timeout'], timeout)

--- a/smoketest/scripts/cli/test_service_ipoe-server.py
+++ b/smoketest/scripts/cli/test_service_ipoe-server.py
@@ -232,5 +232,9 @@ delegate={delegate_2_prefix},{delegate_mask},name={pool_name}"""
     def test_accel_ppp_options(self):
         pass
 
+    @unittest.skip("WINS server is not used in IPoE")
+    def test_accel_wins_server(self):
+        pass
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/src/conf_mode/service_ipoe-server.py
+++ b/src/conf_mode/service_ipoe-server.py
@@ -25,8 +25,10 @@ from vyos.template import render
 from vyos.utils.process import call
 from vyos.utils.dict import dict_search
 from vyos.accel_ppp_util import get_pools_in_order
+from vyos.accel_ppp_util import verify_accel_ppp_name_servers
+from vyos.accel_ppp_util import verify_accel_ppp_wins_servers
 from vyos.accel_ppp_util import verify_accel_ppp_ip_pool
-from vyos.accel_ppp_util import verify_accel_ppp_base_service
+from vyos.accel_ppp_util import verify_accel_ppp_authentication
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -69,8 +71,10 @@ def verify(ipoe):
             raise ConfigError('Option "client-subnet" incompatible with "vlan"!'
                               'Use "ipoe client-ip-pool" instead.')
 
-    verify_accel_ppp_base_service(ipoe, local_users=False)
+    verify_accel_ppp_authentication(ipoe, local_users=False)
     verify_accel_ppp_ip_pool(ipoe)
+    verify_accel_ppp_name_servers(ipoe)
+    verify_accel_ppp_wins_servers(ipoe)
 
     return None
 

--- a/src/conf_mode/service_pppoe-server.py
+++ b/src/conf_mode/service_pppoe-server.py
@@ -25,7 +25,9 @@ from vyos.configverify import verify_interface_exists
 from vyos.template import render
 from vyos.utils.process import call
 from vyos.utils.dict import dict_search
-from vyos.accel_ppp_util import verify_accel_ppp_base_service
+from vyos.accel_ppp_util import verify_accel_ppp_name_servers
+from vyos.accel_ppp_util import verify_accel_ppp_wins_servers
+from vyos.accel_ppp_util import verify_accel_ppp_authentication
 from vyos.accel_ppp_util import verify_accel_ppp_ip_pool
 from vyos.accel_ppp_util import get_pools_in_order
 from vyos import ConfigError
@@ -67,11 +69,11 @@ def verify(pppoe):
     if not pppoe:
         return None
 
-    verify_accel_ppp_base_service(pppoe)
+    verify_accel_ppp_authentication(pppoe)
     verify_accel_ppp_ip_pool(pppoe)
+    verify_accel_ppp_name_servers(pppoe)
+    verify_accel_ppp_wins_servers(pppoe)
 
-    if 'wins_server' in pppoe and len(pppoe['wins_server']) > 2:
-        raise ConfigError('Not more then two WINS name-servers can be configured')
 
     if 'interface' not in pppoe:
         raise ConfigError('At least one listen interface must be defined!')

--- a/src/conf_mode/vpn_l2tp.py
+++ b/src/conf_mode/vpn_l2tp.py
@@ -24,7 +24,9 @@ from vyos.configdict import get_accel_dict
 from vyos.template import render
 from vyos.utils.process import call
 from vyos.utils.dict import dict_search
-from vyos.accel_ppp_util import verify_accel_ppp_base_service
+from vyos.accel_ppp_util import verify_accel_ppp_name_servers
+from vyos.accel_ppp_util import verify_accel_ppp_wins_servers
+from vyos.accel_ppp_util import verify_accel_ppp_authentication
 from vyos.accel_ppp_util import verify_accel_ppp_ip_pool
 from vyos.accel_ppp_util import get_pools_in_order
 from vyos import ConfigError
@@ -62,12 +64,10 @@ def verify(l2tp):
     if not l2tp:
         return None
 
-    verify_accel_ppp_base_service(l2tp)
+    verify_accel_ppp_authentication(l2tp)
     verify_accel_ppp_ip_pool(l2tp)
-
-    if 'wins_server' in l2tp and len(l2tp['wins_server']) > 2:
-        raise ConfigError(
-            'Not more then two WINS name-servers can be configured')
+    verify_accel_ppp_name_servers(l2tp)
+    verify_accel_ppp_wins_servers(l2tp)
 
     return None
 

--- a/src/conf_mode/vpn_pptp.py
+++ b/src/conf_mode/vpn_pptp.py
@@ -22,7 +22,9 @@ from vyos.config import Config
 from vyos.template import render
 from vyos.utils.process import call
 from vyos.utils.dict import dict_search
-from vyos.accel_ppp_util import verify_accel_ppp_base_service
+from vyos.accel_ppp_util import verify_accel_ppp_name_servers
+from vyos.accel_ppp_util import verify_accel_ppp_wins_servers
+from vyos.accel_ppp_util import verify_accel_ppp_authentication
 from vyos.accel_ppp_util import verify_accel_ppp_ip_pool
 from vyos.accel_ppp_util import get_pools_in_order
 from vyos import ConfigError
@@ -60,12 +62,10 @@ def verify(pptp):
     if not pptp:
         return None
 
-    verify_accel_ppp_base_service(pptp)
+    verify_accel_ppp_authentication(pptp)
     verify_accel_ppp_ip_pool(pptp)
-
-    if 'wins_server' in pptp and len(pptp['wins_server']) > 2:
-        raise ConfigError(
-            'Not more then two WINS name-servers can be configured')
+    verify_accel_ppp_name_servers(pptp)
+    verify_accel_ppp_wins_servers(pptp)
 
 
 def generate(pptp):

--- a/src/migration-scripts/l2tp/8-to-9
+++ b/src/migration-scripts/l2tp/8-to-9
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Deleted 'dhcp-interface' from l2tp
+
+import os
+
+from sys import argv
+from sys import exit
+from vyos.configtree import ConfigTree
+
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+base = ['vpn', 'l2tp', 'remote-access']
+if not config.exists(base):
+    exit(0)
+
+#deleting unused dhcp-interface
+if config.exists(base + ['dhcp-interface']):
+    config.delete(base + ['dhcp-interface'])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Removed dhcp-interface option (l2tp)
Added wins-server (sstp)
Added description (ipoe, pppoe, sstp, pptp)
Added exteded-script (l2tp, sstp, pptp)
Added shaper (ipoe, pptp, sstp, l2tp)
Added limits (ipoe, pptp, sstp, l2tp)
Added snmp ( ipoe, pptp,sstp, l2tp)
Refactoring and reformated code.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6029

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->
Removed dhcp-interface option (l2tp)
Added wins-server (sstp)
Added description (ipoe, pppoe, sstp, pptp)
Added exteded-script (l2tp, sstp, pptp)
Added shaper (ipoe, pptp, sstp, l2tp)
Added limits (ipoe, pptp, sstp, l2tp)
Added snmp ( ipoe, pptp,sstp, l2tp)
Refactoring and reformated code.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_ipoe-server.py
test_accel_ipv4_pool (__main__.TestServiceIPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServiceIPoEServer.test_accel_ipv6_pool) ...
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_limits (__main__.TestServiceIPoEServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestServiceIPoEServer.test_accel_local_authentication) ...
No IPoE interface configured

ok
test_accel_name_servers (__main__.TestServiceIPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServiceIPoEServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_ppp_options (__main__.TestServiceIPoEServer.test_accel_ppp_options) ... skipped 'PPP is not a part of IPoE'
test_accel_radius_authentication (__main__.TestServiceIPoEServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestServiceIPoEServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestServiceIPoEServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestServiceIPoEServer.test_accel_wins_server) ... skipped 'WINS server is not used in IPoE'

----------------------------------------------------------------------
Ran 11 tests in 29.626s

OK (skipped=2)
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py
test_accel_ipv4_pool (__main__.TestServicePPPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServicePPPoEServer.test_accel_ipv6_pool) ...
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_limits (__main__.TestServicePPPoEServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestServicePPPoEServer.test_accel_local_authentication) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_name_servers (__main__.TestServicePPPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServicePPPoEServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_ppp_options (__main__.TestServicePPPoEServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestServicePPPoEServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestServicePPPoEServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestServicePPPoEServer.test_accel_wins_server) ... ok
test_pppoe_limits (__main__.TestServicePPPoEServer.test_pppoe_limits) ... ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer.test_pppoe_server_authentication_protocols) ... ok
test_pppoe_server_shaper (__main__.TestServicePPPoEServer.test_pppoe_server_shaper) ... ok
test_pppoe_server_vlan (__main__.TestServicePPPoEServer.test_pppoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 15 tests in 53.114s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_l2tp.py
test_accel_ipv4_pool (__main__.TestVPNL2TPServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestVPNL2TPServer.test_accel_ipv6_pool) ...
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_limits (__main__.TestVPNL2TPServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestVPNL2TPServer.test_accel_local_authentication) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_name_servers (__main__.TestVPNL2TPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNL2TPServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_ppp_options (__main__.TestVPNL2TPServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestVPNL2TPServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestVPNL2TPServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestVPNL2TPServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestVPNL2TPServer.test_accel_wins_server) ... ok
test_l2tp_server_authentication_protocols (__main__.TestVPNL2TPServer.test_l2tp_server_authentication_protocols) ... ok
test_vpn_l2tp_dependence_ipsec_swanctl (__main__.TestVPNL2TPServer.test_vpn_l2tp_dependence_ipsec_swanctl) ...
WARNING: 'default-pool' is not defined

ok

----------------------------------------------------------------------
Ran 13 tests in 58.854s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_pptp.py
test_accel_ipv4_pool (__main__.TestVPNPPTPServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestVPNPPTPServer.test_accel_ipv6_pool) ...
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_limits (__main__.TestVPNPPTPServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestVPNPPTPServer.test_accel_local_authentication) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_name_servers (__main__.TestVPNPPTPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNPPTPServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_ppp_options (__main__.TestVPNPPTPServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestVPNPPTPServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestVPNPPTPServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestVPNPPTPServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestVPNPPTPServer.test_accel_wins_server) ... ok

----------------------------------------------------------------------
Ran 11 tests in 38.991s

OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_sstp.py
test_accel_ipv4_pool (__main__.TestVPNSSTPServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestVPNSSTPServer.test_accel_ipv6_pool) ...
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_limits (__main__.TestVPNSSTPServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestVPNSSTPServer.test_accel_local_authentication) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_name_servers (__main__.TestVPNSSTPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNSSTPServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_ppp_options (__main__.TestVPNSSTPServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestVPNSSTPServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestVPNSSTPServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestVPNSSTPServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestVPNSSTPServer.test_accel_wins_server) ... ok

----------------------------------------------------------------------
Ran 11 tests in 40.321s

OK

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
