### PR TITLE
T6019: Fix smoketest test_system_conntrack custom timeout

### DIFF
--- a/smoketest/scripts/cli/test_system_conntrack.py
+++ b/smoketest/scripts/cli/test_system_conntrack.py
@@ -328,10 +328,10 @@ class TestSystemConntrack(VyOSUnitTestSHIM.TestCase):
         nftables_search = [
             ['ct timeout ct-timeout-1 {'],
             ['protocol tcp'],
-            ['policy = { syn_sent : 77, established : 99, close : 88 }'],
+            ['policy = { syn_sent : 1m17s, established : 1m39s, close : 1m28s }'],
             ['ct timeout ct-timeout-2 {'],
             ['protocol udp'],
-            ['policy = { unreplied : 55 }'],
+            ['policy = { unreplied : 55s }'],
             ['chain VYOS_CT_TIMEOUT {'],
             ['ip saddr 192.0.2.1', 'ip daddr 192.0.2.2', 'tcp dport 22', 'ct timeout set "ct-timeout-1"'],
             ['iifname "eth1"', 'meta l4proto udp', 'ip saddr 198.51.100.1', 'ct timeout set "ct-timeout-2"']
@@ -340,7 +340,7 @@ class TestSystemConntrack(VyOSUnitTestSHIM.TestCase):
         nftables6_search = [
             ['ct timeout ct-timeout-1 {'],
             ['protocol tcp'],
-            ['policy = { last_ack : 33, time_wait : 22 }'],
+            ['policy = { last_ack : 33s, time_wait : 22s }'],
             ['chain VYOS_CT_TIMEOUT {'],
             ['iifname "eth2"', 'meta l4proto tcp', 'ip6 saddr 2001:db8::1', 'ct timeout set "ct-timeout-1"']
         ]


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
After updating netfilter in the commit https://github.com/vyos/vyos-build/commit/b31f5fe934bcb37534d49acdb5f7756bf05422e8 The nftables format for conntrack timeouts is different. Fix this.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Fix smoketest

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6019

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
smoketest
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Before the fix
```
DEBUG - test_conntrack_timeout_custom (__main__.TestSystemConntrack.test_conntrack_timeout_custom) ... FAIL
DEBUG - 
DEBUG - ======================================================================
DEBUG - FAIL: test_conntrack_timeout_custom (__main__.TestSystemConntrack.test_conntrack_timeout_custom)
DEBUG - ----------------------------------------------------------------------
DEBUG - Traceback (most recent call last):
DEBUG -   File "/usr/libexec/vyos/tests/smoke/cli/test_system_conntrack.py", line 348, in test_conntrack_timeout_custom
DEBUG -     self.verify_nftables(nftables_search, 'ip vyos_conntrack')
DEBUG -   File "/usr/libexec/vyos/tests/smoke/cli/test_system_conntrack.py", line 55, in verify_nftables
DEBUG -     self.assertTrue(not matched if inverse else matched, msg=search)
DEBUG - AssertionError: False is not true : ['policy = { syn_sent : 77, established : 99, close : 88 }']
DEBUG - 
DEBUG - ----------------------------------------------------------------------
```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_conntrack.py
test_conntrack_hash_size (__main__.TestSystemConntrack.test_conntrack_hash_size) ... ok
test_conntrack_ignore (__main__.TestSystemConntrack.test_conntrack_ignore) ... ok
test_conntrack_module_enable (__main__.TestSystemConntrack.test_conntrack_module_enable) ... ok
test_conntrack_options (__main__.TestSystemConntrack.test_conntrack_options) ... ok
test_conntrack_timeout_custom (__main__.TestSystemConntrack.test_conntrack_timeout_custom) ... ok

----------------------------------------------------------------------
Ran 5 tests in 64.699s

OK
vyos@r4:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
