### PR TITLE
configverify: T3992: fix KeyError in verify_address()

### DIFF
--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -203,10 +203,9 @@ def verify_address(config):
     of a bridge or bond.
     """
     if {'is_bridge_member', 'address'} <= set(config):
-        interface = config['ifname']
         bridge_name = next(iter(config['is_bridge_member']))
-        raise ConfigError(f'Cannot assign address to interface "{interface}" '
-                          f'as it is a member of bridge "{bridge_name}"!')
+        raise ConfigError(f'Cannot assign address to interface which '
+                          f'is a member of bridge "{bridge_name}"!')
 
 def verify_bridge_delete(config):
     """


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Reproducible by:
set interfaces bridge br0 member interface eth1.10 set interfaces ethernet eth1 vif 10 address 100.64.0.1/24

```
File "/usr/lib/python3/dist-packages/vyos/configverify.py", line 314, in verify_vlan_config
  verify_address(vlan)
File "/usr/lib/python3/dist-packages/vyos/configverify.py", line 206, in verify_address
  interface = config['ifname']
KeyError: 'ifname'
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3992

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR3.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_ethernet.py
test_add_multiple_ip_addresses (__main__.EthernetInterfaceTest) ... ok
test_add_single_ip_address (__main__.EthernetInterfaceTest) ... ok
test_dhcp_disable_interface (__main__.EthernetInterfaceTest) ... ok
test_dhcp_vrf (__main__.EthernetInterfaceTest) ... ok
test_dhcpv6_client_options (__main__.EthernetInterfaceTest) ... ok
test_dhcpv6_vrf (__main__.EthernetInterfaceTest) ... ok
test_dhcpv6pd_auto_sla_id (__main__.EthernetInterfaceTest) ... ok
test_dhcpv6pd_manual_sla_id (__main__.EthernetInterfaceTest) ... ok
test_eapol_support (__main__.EthernetInterfaceTest) ... ok
test_interface_description (__main__.EthernetInterfaceTest) ... ok
test_interface_disable (__main__.EthernetInterfaceTest) ... ok
test_interface_ip_options (__main__.EthernetInterfaceTest) ... ok
test_interface_ipv6_options (__main__.EthernetInterfaceTest) ... ok
test_interface_mtu (__main__.EthernetInterfaceTest) ... ok
test_ipv6_link_local_address (__main__.EthernetInterfaceTest) ... ok
test_mtu_1200_no_ipv6_interface (__main__.EthernetInterfaceTest) ... ok
test_non_existing_interface (__main__.EthernetInterfaceTest) ... ok
test_offloading_rps (__main__.EthernetInterfaceTest) ... ok
test_span_mirror (__main__.EthernetInterfaceTest) ... ok
test_speed_duplex_verify (__main__.EthernetInterfaceTest) ... ok
test_vif_8021q_interfaces (__main__.EthernetInterfaceTest) ... ok
test_vif_8021q_lower_up_down (__main__.EthernetInterfaceTest) ... ok
test_vif_8021q_mtu_limits (__main__.EthernetInterfaceTest) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.EthernetInterfaceTest) ... ok

----------------------------------------------------------------------
Ran 24 tests in 116.823s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
