### PR TITLE
T5418: PPPoE allowed creating subnet started from any IP

### DIFF
--- a/interface-definitions/include/accel-ppp/client-ip-pool-subnet-single.xml.i
+++ b/interface-definitions/include/accel-ppp/client-ip-pool-subnet-single.xml.i
@@ -8,6 +8,7 @@
     </valueHelp>
     <constraint>
       <validator name="ipv4-prefix"/>
+      <validator name="ipv4-host"/>
     </constraint>
     <constraintErrorMessage>Not a valid CIDR formatted prefix</constraintErrorMessage>
   </properties>

--- a/interface-definitions/include/accel-ppp/client-ip-pool-subnet.xml.i
+++ b/interface-definitions/include/accel-ppp/client-ip-pool-subnet.xml.i
@@ -8,6 +8,7 @@
     </valueHelp>
     <constraint>
       <validator name="ipv4-prefix"/>
+      <validator name="ipv4-host"/>
     </constraint>
     <constraintErrorMessage>Not a valid CIDR formatted prefix</constraintErrorMessage>
     <multi />


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added the possibility of creating a subnet in PPPoE
client's IP pools started from any IP.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5418

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe
## Proposed changes
<!--- Describe your changes in detail -->
Added the possibility of creating a subnet in PPPoE
client's IP pools started from any IP.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Before:
```
vyos@vyos# set service pppoe-server client-ip-pool name TEST subnet 10.0.0.2/24




  Not a valid CIDR formatted prefix
  Value validation failed
  Set failed

[edit]
```
After:
```
vyos@vyos# set service pppoe-server client-ip-pool name TEST subnet 10.0.0.2/24
[edit]
vyos@vyos# set service pppoe-server client-ip-pool subnet 10.0.0.2/23
[edit]
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py
test_accel_local_authentication (__main__.TestServicePPPoEServer) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

Warning: No PPPoE client pool defined
Warning: No PPPoE client pool defined
ok
test_accel_name_servers (__main__.TestServicePPPoEServer) ... Warning: No PPPoE client pool defined
ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer) ... Warning: No PPPoE client pool defined
Warning: No PPPoE client pool defined
ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer) ... Warning: No PPPoE client pool defined
ok
test_pppoe_server_client_ip_pool (__main__.TestServicePPPoEServer) ... ok
test_pppoe_server_client_ip_pool_name (__main__.TestServicePPPoEServer) ... Warning: No PPPoE client pool defined
ok
test_pppoe_server_client_ipv6_pool (__main__.TestServicePPPoEServer) ... Warning: No PPPoE client pool defined
ok
test_pppoe_server_ppp_options (__main__.TestServicePPPoEServer) ... Warning: No PPPoE client pool defined
ok

----------------------------------------------------------------------
Ran 8 tests in 28.896s

OK

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
