### PR TITLE
login: T5972: add possibility to disable individual local user accounts

### DIFF
--- a/interface-definitions/system_login.xml.in
+++ b/interface-definitions/system_login.xml.in
@@ -172,6 +172,7 @@
                   </tagNode>
                 </children>
               </node>
+              #include <include/generic-disable-node.xml.i>
               <leafNode name="full-name">
                 <properties>
                   <help>Full name of the user (use quotes for names with spaces)</help>

--- a/src/conf_mode/system_login.py
+++ b/src/conf_mode/system_login.py
@@ -367,6 +367,12 @@ def apply(login):
                 if os.path.exists(f'{home_dir}/.google_authenticator'):
                     os.remove(f'{home_dir}/.google_authenticator')
 
+            # Lock/Unlock local user account
+            lock_unlock = '--unlock'
+            if 'disable' in user_config:
+                lock_unlock = '--lock'
+            cmd(f'usermod {lock_unlock} {user}')
+
     if 'rm_users' in login:
         for user in login['rm_users']:
             try:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

* `set system login user <name> disable`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5972

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-documentation/pull/1283

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set system login user vyos2 authentication plaintext-password vyos2
set system login user vyos2 disable
```

Now `sudo passwd -S vyos2` must return `vyos2 L` L is for Locked


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_system_login.py
DEBUG - test_add_linux_system_user (__main__.TestSystemLogin.test_add_linux_system_user) ... ok
DEBUG - test_radius_kernel_features (__main__.TestSystemLogin.test_radius_kernel_features) ... ok
DEBUG - test_system_login_max_login_session (__main__.TestSystemLogin.test_system_login_max_login_session) ... ok
DEBUG - test_system_login_otp (__main__.TestSystemLogin.test_system_login_otp) ... ok
DEBUG - test_system_login_radius_ipv4 (__main__.TestSystemLogin.test_system_login_radius_ipv4) ... ok
DEBUG - test_system_login_radius_ipv6 (__main__.TestSystemLogin.test_system_login_radius_ipv6) ... ok
DEBUG - test_system_login_tacacs (__main__.TestSystemLogin.test_system_login_tacacs) ... ok
DEBUG - test_system_login_user (__main__.TestSystemLogin.test_system_login_user) ... ok
DEBUG - test_system_user_ssh_key (__main__.TestSystemLogin.test_system_user_ssh_key) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 9 tests in 42.178s
DEBUG -
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
