### PR TITLE
vyos-event-handler.py: T6048: handling exception when _PID is not found

### DIFF
--- a/src/system/vyos-event-handler.py
+++ b/src/system/vyos-event-handler.py
@@ -153,7 +153,12 @@ if __name__ == '__main__':
             continue
         for entry in data:
             message = entry['MESSAGE']
-            pid = entry['_PID']
+            pid = -1
+            try:
+                pid = entry['_PID']
+            except Exception as ex:
+                journal.send(f'Unable to extract PID from message entry: {entry}', SYSLOG_IDENTIFIER=my_name)
+                continue            
             # Skip empty messages and messages from this process
             if message and pid != my_pid:
                 try:


### PR DESCRIPTION
Handling exception when _PID is not found

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Handling the case when ```_PID``` is not found in the following loop:

```
for entry in data:
    message = entry['MESSAGE']
    pid = entry['_PID']
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6048

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
Event handler.

## Proposed changes
<!--- Describe your changes in detail -->
The exception thrown when the ```_PID``` key is not found is handled and the loop continues without processing the concerned message.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
-->

When ```_PID``` cannot be extracted, the script does not exit anymore and prints the concerned message. For instance:

```
Feb 18 19:01:12 vyos vyos-event-handler[1564]: Unable to extract PID from message entry: {'_TRANSPORT': 'kernel', 'SYSLOG_FACILITY': 0, 'SYSLOG_IDENTIFIER': 'kernel', '_MACHINE_ID': UUID('b7091403-46e6-45c4-8fdf-4661a4c8b44c'), '_HOSTNAME': 'vyos', '_RUNTIME_SCOPE': 'system', 'PRIORITY': 6, 'MESSAGE': '8021q: adding VLAN 0 to HW filter on device eth2', '_BOOT_ID': UUID('dabb841c-6005-4662-b2d6-41cc4da08b10'), '_SOURCE_MONOTONIC_TIMESTAMP': datetime.timedelta(days=4, seconds=61864, microseconds=27675), '__REALTIME_TIMESTAMP': datetime.datetime(2024, 2, 18, 19, 1, 12, 245638, tzinfo=datetime.timezone(datetime.timedelta(seconds=3600), 'CET')), '__MONOTONIC_TIMESTAMP': journal.Monotonic(timestamp=datetime.timedelta(days=4, seconds=61867, microseconds=525194), bootid=UUID('dabb841c-6005-4662-b2d6-41cc4da08b10')), '__CURSOR': 's=704d11a86950461bb214afc68b9e8c37;i=568260;b=dabb841c60054662b2d641cc4da08b10;m=5edef5044a;t=611abc3330986;x=3902b6a3be371d1b'}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
