### PR TITLE
T6050: Fixed descriptions of 'extended-scripts' commands in accel-ppp

### DIFF
--- a/interface-definitions/include/accel-ppp/extended-scripts.xml.i
+++ b/interface-definitions/include/accel-ppp/extended-scripts.xml.i
@@ -6,7 +6,7 @@
   <children>
     <leafNode name="on-pre-up">
       <properties>
-        <help>Script to run before PPPoE session interface comes up</help>
+        <help>Script to run before session interface comes up</help>
           <constraint>
             <validator name="script"/>
           </constraint>
@@ -14,7 +14,7 @@
     </leafNode>
     <leafNode name="on-up">
       <properties>
-        <help>Script to run when PPPoE session interface is completely configured and started</help>
+        <help>Script to run when session interface is completely configured and started</help>
           <constraint>
             <validator name="script"/>
           </constraint>
@@ -22,7 +22,7 @@
     </leafNode>
     <leafNode name="on-down">
       <properties>
-        <help>Script to run when PPPoE session interface going to terminate</help>
+        <help>Script to run when session interface going to terminate</help>
           <constraint>
             <validator name="script"/>
           </constraint>
@@ -30,7 +30,7 @@
     </leafNode>
     <leafNode name="on-change">
       <properties>
-        <help>Script to run when PPPoE session interface changed by RADIUS CoA handling</help>
+        <help>Script to run when session interface changed by RADIUS CoA handling</help>
           <constraint>
             <validator name="script"/>
           </constraint>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Removed word 'PPPoE' from descriptions in common template for all accel-ppp services.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6050

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
l2tp, sstp, pptp, ipoe, pppoe

## Proposed changes
<!--- Describe your changes in detail -->
Removed word 'PPPoE' from descriptions in common template for all accel-ppp services.

```
vyos@vyos# set vpn l2tp remote-access extended-scripts
Possible completions:
   on-change            Script to run when session interface changed by RADIUS CoA
                        handling
   on-down              Script to run when session interface going to terminate
   on-pre-up            Script to run before session interface comes up
   on-up                Script to run when session interface is completely
                        configured and started
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
