### PR TITLE
T5996: selectively escape and restore single backslashes in config

### DIFF
--- a/smoketest/scripts/cli/test_backslash_escape.py
+++ b/smoketest/scripts/cli/test_backslash_escape.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from base_vyostest_shim import VyOSUnitTestSHIM
+from vyos.configtree import ConfigTree
+
+base_path = ['interfaces', 'ethernet', 'eth0', 'description']
+
+cases_word = [r'fo\o', r'fo\\o', r'foço\o', r'foço\\o']
+# legacy CLI output quotes only if whitespace present; this is a notable
+# difference that confounds the translation legacy -> modern, hence
+# determines the regex used in function replace_backslash
+cases_phrase = [r'some fo\o', r'some fo\\o', r'some foço\o', r'some foço\\o']
+
+case_save_config = '/tmp/smoketest-case-save'
+
+class TestBackslashEscape(VyOSUnitTestSHIM.TestCase):
+    def test_backslash_escape_word(self):
+        for case in cases_word:
+            self.cli_set(base_path + [case])
+            self.cli_commit()
+            # save_config tests translation though subsystems:
+            # legacy output -> config -> configtree -> file
+            self._session.save_config(case_save_config)
+            # reload to configtree and confirm:
+            with open(case_save_config) as f:
+                config_string = f.read()
+            ct = ConfigTree(config_string)
+            res = ct.return_value(base_path)
+            self.assertEqual(case, res, msg=res)
+            print(f'description: {res}')
+            self.cli_delete(base_path)
+            self.cli_commit()
+
+    def test_backslash_escape_phrase(self):
+        for case in cases_phrase:
+            self.cli_set(base_path + [case])
+            self.cli_commit()
+            # save_config tests translation though subsystems:
+            # legacy output -> config -> configtree -> file
+            self._session.save_config(case_save_config)
+            # reload to configtree and confirm:
+            with open(case_save_config) as f:
+                config_string = f.read()
+            ct = ConfigTree(config_string)
+            res = ct.return_value(base_path)
+            self.assertEqual(case, res, msg=res)
+            print(f'description: {res}')
+            self.cli_delete(base_path)
+            self.cli_commit()
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Gory details are summarized in the task, but the short story is that the legacy and modern parser and config output have conflicting practices in handling unescaped backslashes --- the existing filter to allow parsing of legacy output requires a refinement, in order to maintain the occasional use of single backslashes in values.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5996

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
vyos@vyos# set interfaces ethernet eth0 description 'fo\o'
[edit]
vyos@vyos# compare
[interfaces ethernet eth0]
+ description "fo\o"

[edit]
vyos@vyos# commit
[edit]
vyos@vyos# run show configuration commands |match desc
set interfaces ethernet eth0 description 'fo\o'
[edit]
vyos@vyos# set interfaces ethernet eth0 description 'fo\\o'
[edit]
vyos@vyos# compare
[interfaces ethernet eth0]
- description "fo\o"
+ description "fo\\o"

[edit]
vyos@vyos# commit
[edit]
vyos@vyos# run show configuration commands |match desc
set interfaces ethernet eth0 description 'fo\\o'
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
