### PR TITLE
conntrack: T5376: Fix priority for CT helpers

### DIFF
--- a/data/templates/conntrack/nftables-ct.j2
+++ b/data/templates/conntrack/nftables-ct.j2
@@ -40,9 +40,6 @@ table ip vyos_conntrack {
 
     chain PREROUTING {
         type filter hook prerouting priority -300; policy accept;
-{% if ipv4_firewall_action == 'accept' or ipv4_nat_action == 'accept' %}
-        counter jump VYOS_CT_HELPER
-{% endif %}
         counter jump VYOS_CT_IGNORE
         counter jump VYOS_CT_TIMEOUT
         counter jump FW_CONNTRACK
@@ -51,11 +48,15 @@ table ip vyos_conntrack {
         notrack
     }
 
+{% if ipv4_firewall_action == 'accept' or ipv4_nat_action == 'accept' %}
+    chain PREROUTING_HELPER {
+        type filter hook prerouting priority -5; policy accept;
+        counter jump VYOS_CT_HELPER
+    }
+{% endif %}
+
     chain OUTPUT {
         type filter hook output priority -300; policy accept;
-{% if ipv4_firewall_action == 'accept' or ipv4_nat_action == 'accept' %}
-        counter jump VYOS_CT_HELPER
-{% endif %}
         counter jump VYOS_CT_IGNORE
         counter jump VYOS_CT_TIMEOUT
         counter jump FW_CONNTRACK
@@ -65,6 +66,13 @@ table ip vyos_conntrack {
 {% endif %}
         notrack
     }
+
+{% if ipv4_firewall_action == 'accept' or ipv4_nat_action == 'accept' %}
+    chain OUTPUT_HELPER {
+        type filter hook output priority -5; policy accept;
+        counter jump VYOS_CT_HELPER
+    }
+{% endif %}
 
 {{ helper_tmpl.conntrack_helpers(module_map, modules, ipv4=True) }}
 
@@ -122,9 +130,6 @@ table ip6 vyos_conntrack {
 
     chain PREROUTING {
         type filter hook prerouting priority -300; policy accept;
-{% if ipv6_firewall_action == 'accept' or ipv6_nat_action == 'accept' %}
-        counter jump VYOS_CT_HELPER
-{% endif %}
         counter jump VYOS_CT_IGNORE
         counter jump VYOS_CT_TIMEOUT
         counter jump FW_CONNTRACK
@@ -132,17 +137,28 @@ table ip6 vyos_conntrack {
         notrack
     }
 
+{% if ipv6_firewall_action == 'accept' or ipv6_nat_action == 'accept' %}
+    chain PREROUTING_HELPER {
+        type filter hook prerouting priority -5; policy accept;
+        counter jump VYOS_CT_HELPER
+    }
+{% endif %}
+
     chain OUTPUT {
         type filter hook output priority -300; policy accept;
-{% if ipv6_firewall_action == 'accept' or ipv6_nat_action == 'accept' %}
-        counter jump VYOS_CT_HELPER
-{% endif %}
         counter jump VYOS_CT_IGNORE
         counter jump VYOS_CT_TIMEOUT
         counter jump FW_CONNTRACK
         counter jump NAT_CONNTRACK
         notrack
     }
+
+{% if ipv6_firewall_action == 'accept' or ipv6_nat_action == 'accept' %}
+    chain OUTPUT_HELPER {
+        type filter hook output priority -5; policy accept;
+        counter jump VYOS_CT_HELPER
+    }
+{% endif %}
 
 {{ helper_tmpl.conntrack_helpers(module_map, modules, ipv4=False) }}
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix priority required for CT helpers to function

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5376

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
conntrack

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Tested FTP helper as described in task, now working.

```
vyos@vyos# sudo conntrack -L expect
298 proto=6 src=192.168.15.3 dst=192.168.20.209 sport=0 dport=62262 mask-src=255.255.255.255 mask-dst=255.255.255.255 sport=0 dport=65535 master-src=192.168.15.3 master-dst=192.168.20.209 sport=51566 dport=21 class=0 helper=ftp
conntrack v1.4.6 (conntrack-tools): 1 expectations have been shown.
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
