### PR TITLE
 pki: T6055: Cleanup unnecessary sudo, preserve env when sudo is needed

### DIFF
--- a/interface-definitions/include/pki/cli-private-key-base64.xml.i
+++ b/interface-definitions/include/pki/cli-private-key-base64.xml.i
@@ -1,4 +1,4 @@
-<!-- include start from pki/pki-cli-private-key.xml.i -->
+<!-- include start from pki/cli-private-key-base64.xml.i -->
 <leafNode name="key">
   <properties>
     <help>Private key in PEM format</help>

--- a/interface-definitions/include/pki/cli-public-key-base64.xml.i
+++ b/interface-definitions/include/pki/cli-public-key-base64.xml.i
@@ -1,11 +1,11 @@
-<!-- include start from pki/pki-cli-private-key.xml.i -->
+<!-- include start from pki/cli-public-key-base64.xml.i -->
 <leafNode name="key">
   <properties>
-    <help>Private key in PEM format</help>
+    <help>Public key in PEM format</help>
     <constraint>
       <validator name="base64"/>
     </constraint>
-    <constraintErrorMessage>Private key is not base64-encoded</constraintErrorMessage>
+    <constraintErrorMessage>Public key is not base64-encoded</constraintErrorMessage>
   </properties>
 </leafNode>
 <!-- include end -->

--- a/op-mode-definitions/pki.xml.in
+++ b/op-mode-definitions/pki.xml.in
@@ -27,7 +27,7 @@
                         <list>&lt;filename&gt;</list>
                       </completionHelp>
                     </properties>
-                    <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --ca "$7" --sign "$5" --file</command>
+                    <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action generate --ca "$7" --sign "$5" --file</command>
                   </tagNode>
                   <tagNode name="install">
                     <properties>
@@ -36,10 +36,10 @@
                         <list>&lt;certificate name&gt;</list>
                       </completionHelp>
                     </properties>
-                    <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --ca "$7" --sign "$5" --install</command>
+                    <command>${vyos_op_scripts_dir}/pki.py --action generate --ca "$7" --sign "$5" --install</command>
                   </tagNode>
                 </children>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --ca "noname" --sign "$5"</command>
+                <command>${vyos_op_scripts_dir}/pki.py --action generate --ca "noname" --sign "$5"</command>
               </tagNode>
               <tagNode name="file">
                 <properties>
@@ -48,7 +48,7 @@
                     <list>&lt;filename&gt;</list>
                   </completionHelp>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --ca "$5" --file</command>
+                <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action generate --ca "$5" --file</command>
               </tagNode>
               <tagNode name="install">
                 <properties>
@@ -57,10 +57,10 @@
                     <list>&lt;CA name&gt;</list>
                   </completionHelp>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --ca "$5" --install</command>
+                <command>${vyos_op_scripts_dir}/pki.py --action generate --ca "$5" --install</command>
               </tagNode>
             </children>
-            <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --ca "noname"</command>
+            <command>${vyos_op_scripts_dir}/pki.py --action generate --ca "noname"</command>
           </node>
           <node name="certificate">
             <properties>
@@ -79,7 +79,7 @@
                         <list>&lt;filename&gt;</list>
                       </completionHelp>
                     </properties>
-                    <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --certificate "$6" --self-sign --file</command>
+                    <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action generate --certificate "$6" --self-sign --file</command>
                   </tagNode>
                   <tagNode name="install">
                     <properties>
@@ -88,10 +88,10 @@
                         <list>&lt;certificate name&gt;</list>
                       </completionHelp>
                     </properties>
-                    <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --certificate "$6" --self-sign --install</command>
+                    <command>${vyos_op_scripts_dir}/pki.py --action generate --certificate "$6" --self-sign --install</command>
                   </tagNode>
                 </children>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --certificate "noname" --self-sign</command>
+                <command>${vyos_op_scripts_dir}/pki.py --action generate --certificate "noname" --self-sign</command>
               </node>
               <tagNode name="sign">
                 <properties>
@@ -108,7 +108,7 @@
                         <list>&lt;filename&gt;</list>
                       </completionHelp>
                     </properties>
-                    <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --certificate "$7" --sign "$5" --file</command>
+                    <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action generate --certificate "$7" --sign "$5" --file</command>
                   </tagNode>
                   <tagNode name="install">
                     <properties>
@@ -117,10 +117,10 @@
                         <list>&lt;certificate name&gt;</list>
                       </completionHelp>
                     </properties>
-                    <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --certificate "$7" --sign "$5" --install</command>
+                    <command>${vyos_op_scripts_dir}/pki.py --action generate --certificate "$7" --sign "$5" --install</command>
                   </tagNode>
                 </children>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --certificate "noname" --sign "$5"</command>
+                <command>${vyos_op_scripts_dir}/pki.py --action generate --certificate "noname" --sign "$5"</command>
               </tagNode>
               <tagNode name="file">
                 <properties>
@@ -129,7 +129,7 @@
                     <list>&lt;filename&gt;</list>
                   </completionHelp>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --certificate "$5" --file</command>
+                <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action generate --certificate "$5" --file</command>
               </tagNode>
               <tagNode name="install">
                 <properties>
@@ -138,10 +138,10 @@
                     <list>&lt;certificate name&gt;</list>
                   </completionHelp>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --certificate "$5" --install</command>
+                <command>${vyos_op_scripts_dir}/pki.py --action generate --certificate "$5" --install</command>
               </tagNode>
             </children>
-            <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --certificate "noname"</command>
+            <command>${vyos_op_scripts_dir}/pki.py --action generate --certificate "noname"</command>
           </node>
           <tagNode name="crl">
             <properties>
@@ -158,16 +158,16 @@
                     <list>&lt;filename&gt;</list>
                   </completionHelp>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --crl "$4" --file</command>
+                <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action generate --crl "$4" --file</command>
               </tagNode>
               <leafNode name="install">
                 <properties>
                   <help>Commands for installing generated CRL into running configuration</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --crl "$4" --install</command>
+                <command>${vyos_op_scripts_dir}/pki.py --action generate --crl "$4" --install</command>
               </leafNode>
             </children>
-            <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --crl "$4"</command>
+            <command>${vyos_op_scripts_dir}/pki.py --action generate --crl "$4"</command>
           </tagNode>
           <node name="dh">
             <properties>
@@ -181,7 +181,7 @@
                     <list>&lt;filename&gt;</list>
                   </completionHelp>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --dh "$5" --file</command>
+                <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action generate --dh "$5" --file</command>
               </tagNode>
               <tagNode name="install">
                 <properties>
@@ -190,10 +190,10 @@
                     <list>&lt;DH name&gt;</list>
                   </completionHelp>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --dh "$5" --install</command>
+                <command>${vyos_op_scripts_dir}/pki.py --action generate --dh "$5" --install</command>
               </tagNode>
             </children>
-            <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --dh "noname"</command>
+            <command>${vyos_op_scripts_dir}/pki.py --action generate --dh "noname"</command>
           </node>
           <node name="key-pair">
             <properties>
@@ -207,7 +207,7 @@
                     <list>&lt;filename&gt;</list>
                   </completionHelp>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --keypair "$5" --file</command>
+                <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action generate --keypair "$5" --file</command>
               </tagNode>
               <tagNode name="install">
                 <properties>
@@ -216,10 +216,10 @@
                     <list>&lt;key name&gt;</list>
                   </completionHelp>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --keypair "$5" --install</command>
+                <command>${vyos_op_scripts_dir}/pki.py --action generate --keypair "$5" --install</command>
               </tagNode>
             </children>
-            <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --keypair "noname"</command>
+            <command>${vyos_op_scripts_dir}/pki.py --action generate --keypair "noname"</command>
           </node>
           <node name="openvpn">
             <properties>
@@ -238,7 +238,7 @@
                         <list>&lt;filename&gt;</list>
                       </completionHelp>
                     </properties>
-                    <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --openvpn "$6" --file</command>
+                    <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action generate --openvpn "$6" --file</command>
                   </tagNode>
                   <tagNode name="install">
                     <properties>
@@ -247,10 +247,10 @@
                         <list>&lt;key name&gt;</list>
                       </completionHelp>
                     </properties>
-                    <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --openvpn "$6" --install</command>
+                    <command>${vyos_op_scripts_dir}/pki.py --action generate --openvpn "$6" --install</command>
                   </tagNode>
                 </children>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --openvpn "noname"</command>
+                <command>${vyos_op_scripts_dir}/pki.py --action generate --openvpn "noname"</command>
               </node>
             </children>
           </node>
@@ -266,7 +266,7 @@
                     <list>&lt;filename&gt;</list>
                   </completionHelp>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --ssh "$5" --file</command>
+                <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action generate --ssh "$5" --file</command>
               </tagNode>
               <tagNode name="install">
                 <properties>
@@ -275,10 +275,10 @@
                     <list>&lt;key name&gt;</list>
                   </completionHelp>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --ssh "$5" --install</command>
+                <command>${vyos_op_scripts_dir}/pki.py --action generate --ssh "$5" --install</command>
               </tagNode>
             </children>
-            <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --ssh "noname"</command>
+            <command>${vyos_op_scripts_dir}/pki.py --action generate --ssh "noname"</command>
           </node>
           <node name="wireguard">
             <properties>
@@ -302,12 +302,12 @@
                             <path>interfaces wireguard</path>
                           </completionHelp>
                         </properties>
-                        <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --wireguard --key --interface "$7" --install</command>
+                        <command>${vyos_op_scripts_dir}/pki.py --action generate --wireguard --key --interface "$7" --install</command>
                       </tagNode>
                     </children>
                   </node>
                 </children>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --wireguard --key</command>
+                <command>${vyos_op_scripts_dir}/pki.py --action generate --wireguard --key</command>
               </node>
               <node name="preshared-key">
                 <properties>
@@ -334,14 +334,14 @@
                                 <path>interfaces wireguard ${COMP_WORDS[COMP_CWORD-2]} peer</path>
                               </completionHelp>
                             </properties>
-                            <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --wireguard --psk --interface "$7" --peer "$9" --install</command>
+                            <command>${vyos_op_scripts_dir}/pki.py --action generate --wireguard --psk --interface "$7" --peer "$9" --install</command>
                           </tagNode>
                         </children>
                       </tagNode>
                     </children>
                   </node>
                 </children>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action generate --wireguard --psk</command>
+                <command>${vyos_op_scripts_dir}/pki.py --action generate --wireguard --psk</command>
               </node>
             </children>
           </node>
@@ -371,13 +371,13 @@
                 <properties>
                   <help>Path to CA certificate file</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action import --ca "$4" --filename "$6"</command>
+                <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action import --ca "$4" --filename "$6"</command>
               </tagNode>
               <tagNode name="key-file">
                 <properties>
                   <help>Path to private key file</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action import --ca "$4" --key-filename "$6"</command>
+                <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action import --ca "$4" --key-filename "$6"</command>
               </tagNode>
             </children>
           </tagNode>
@@ -393,13 +393,13 @@
                 <properties>
                   <help>Path to certificate file</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action import --certificate "$4" --filename "$6"</command>
+                <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action import --certificate "$4" --filename "$6"</command>
               </tagNode>
               <tagNode name="key-file">
                 <properties>
                   <help>Path to private key file</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action import --certificate "$4" --key-filename "$6"</command>
+                <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action import --certificate "$4" --key-filename "$6"</command>
               </tagNode>
             </children>
           </tagNode>
@@ -415,7 +415,7 @@
                 <properties>
                   <help>Path to CRL file</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action import --crl "$4" --filename "$6"</command>
+                <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action import --crl "$4" --filename "$6"</command>
               </tagNode>
             </children>
           </tagNode>
@@ -431,7 +431,7 @@
                 <properties>
                   <help>Path to DH parameters file</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action import --dh "$4" --filename "$6"</command>
+                <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action import --dh "$4" --filename "$6"</command>
               </tagNode>
             </children>
           </tagNode>
@@ -447,13 +447,13 @@
                 <properties>
                   <help>Path to public key file</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action import --keypair "$4" --filename "$6"</command>
+                <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action import --keypair "$4" --filename "$6"</command>
               </tagNode>
               <tagNode name="private-file">
                 <properties>
                   <help>Path to private key file</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action import --keypair "$4" --key-filename "$6"</command>
+                <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action import --keypair "$4" --key-filename "$6"</command>
               </tagNode>
             </children>
           </tagNode>
@@ -474,7 +474,7 @@
                     <properties>
                       <help>Path to shared secret key file</help>
                     </properties>
-                    <command>sudo ${vyos_op_scripts_dir}/pki.py --action import --openvpn "$5" --filename "$7"</command>
+                    <command>sudo -E ${vyos_op_scripts_dir}/pki.py --action import --openvpn "$5" --filename "$7"</command>
                   </tagNode>
                 </children>
               </tagNode>
@@ -495,7 +495,7 @@
             <properties>
               <help>Show x509 CA certificates</help>
             </properties>
-            <command>sudo ${vyos_op_scripts_dir}/pki.py --action show --ca "all"</command>
+            <command>${vyos_op_scripts_dir}/pki.py --action show --ca "all"</command>
           </leafNode>
           <tagNode name="ca">
             <properties>
@@ -504,13 +504,13 @@
                 <path>pki ca</path>
               </completionHelp>
             </properties>
-            <command>sudo ${vyos_op_scripts_dir}/pki.py --action show --ca "$4"</command>
+            <command>${vyos_op_scripts_dir}/pki.py --action show --ca "$4"</command>
             <children>
               <leafNode name="pem">
                 <properties>
                   <help>Show x509 CA certificate in PEM format</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action show --ca "$4" --pem</command>
+                <command>${vyos_op_scripts_dir}/pki.py --action show --ca "$4" --pem</command>
               </leafNode>
             </children>
           </tagNode>
@@ -518,7 +518,7 @@
             <properties>
               <help>Show x509 certificates</help>
             </properties>
-            <command>sudo ${vyos_op_scripts_dir}/pki.py --action show --certificate "all"</command>
+            <command>${vyos_op_scripts_dir}/pki.py --action show --certificate "all"</command>
           </leafNode>
           <tagNode name="certificate">
             <properties>
@@ -527,7 +527,7 @@
                 <path>pki certificate</path>
               </completionHelp>
             </properties>
-            <command>sudo ${vyos_op_scripts_dir}/pki.py --action show --certificate "$4"</command>
+            <command>${vyos_op_scripts_dir}/pki.py --action show --certificate "$4"</command>
             <children>
               <leafNode name="pem">
                 <properties>
@@ -542,7 +542,7 @@
                     <list>sha256 sha384 sha512</list>
                   </completionHelp>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action show --certificate "$4" --fingerprint "$6"</command>
+                <command>${vyos_op_scripts_dir}/pki.py --action show --certificate "$4" --fingerprint "$6"</command>
               </tagNode>
             </children>
           </tagNode>
@@ -550,7 +550,7 @@
             <properties>
               <help>Show x509 certificate revocation lists</help>
             </properties>
-            <command>sudo ${vyos_op_scripts_dir}/pki.py --action show --crl "all"</command>
+            <command>${vyos_op_scripts_dir}/pki.py --action show --crl "all"</command>
           </leafNode>
           <tagNode name="crl">
             <properties>
@@ -559,18 +559,18 @@
                 <path>pki ca</path>
               </completionHelp>
             </properties>
-            <command>sudo ${vyos_op_scripts_dir}/pki.py --action show --crl "$4"</command>
+            <command>${vyos_op_scripts_dir}/pki.py --action show --crl "$4"</command>
             <children>
               <leafNode name="pem">
                 <properties>
                   <help>Show x509 certificate revocation lists by CA name in PEM format</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/pki.py --action show --crl "$4" --pem</command>
+                <command>${vyos_op_scripts_dir}/pki.py --action show --crl "$4" --pem</command>
               </leafNode>
             </children>
           </tagNode>
         </children>
-        <command>sudo ${vyos_op_scripts_dir}/pki.py --action show</command>
+        <command>${vyos_op_scripts_dir}/pki.py --action show</command>
       </node>
     </children>
   </node>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
- Fixes PKI install issue. Caused by environment variables not present under sudo
- Fix typo in PKI xml includes

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6055

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pki

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos# run generate pki key-pair install rsa-keys
Enter private key type: [rsa, dsa, ec] (Default: rsa)
Enter private key bits: (Default: 2048)
Note: If you plan to use the generated key on this router, do not encrypt the private key.
Do you want to encrypt the private key with a passphrase? [y/N] y
Enter passphrase: vyos
Do you want to install the public key? [Y/n]
Do you want to install the private key? [Y/n]
3 value(s) installed. Use "compare" to see the pending changes, and "commit" to apply.
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
