### PR TITLE
T6054: WLB: fix rules parsing when using multiple ports in one rule

### DIFF
--- a/data/templates/load-balancing/wlb.conf.j2
+++ b/data/templates/load-balancing/wlb.conf.j2
@@ -93,6 +93,8 @@ rule {{ rule }} {
 {%             if rule_config.destination.port is vyos_defined  %}
 {%                 if '-' in rule_config.destination.port %}
         port-ipt "-m multiport  --dports {{ rule_config.destination.port | replace('-', ':') }}"
+{%                 elif ',' in rule_config.destination.port %}
+        port-ipt "-m multiport  --dports {{ rule_config.destination.port }}"
 {%                 else %}
         port-ipt " --dport {{ rule_config.destination.port }}"
 {%                 endif %}
@@ -107,6 +109,8 @@ rule {{ rule }} {
 {%             if rule_config.source.port is vyos_defined  %}
 {%                 if '-' in rule_config.source.port %}
         port-ipt "-m multiport  --sports {{ rule_config.source.port | replace('-', ':') }}"
+{%                 elif ',' in rule_config.destination.port %}
+        port-ipt "-m multiport  --sports {{ rule_config.source.port }}"
 {%                 else %}
         port.ipt " --sport {{ rule_config.source.port }}"
 {%                 endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6054

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
load-balancing-wan

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos:~$ show config comm | grep wan
set load-balancing wan disable-source-nat
set load-balancing wan flush-connections
set load-balancing wan interface-health eth1 failure-count '3'
set load-balancing wan interface-health eth1 nexthop '198.51.100.2'
set load-balancing wan interface-health eth2 failure-count '3'
set load-balancing wan interface-health eth2 nexthop '192.0.2.2'
set load-balancing wan rule 10 destination port '80,443'
set load-balancing wan rule 10 inbound-interface 'eth3'
set load-balancing wan rule 10 interface eth1 weight '2'
set load-balancing wan rule 10 interface eth2 weight '1'
set load-balancing wan rule 10 protocol 'tcp'
set load-balancing wan rule 10 source port '20000-30000'
set load-balancing wan rule 20 destination port '22'
set load-balancing wan rule 20 inbound-interface 'eth3'
set load-balancing wan rule 20 interface eth1 weight '2'
set load-balancing wan rule 20 interface eth2 weight '1'
set load-balancing wan rule 20 protocol 'tcp'
vyos@vyos:~$ sudo nft list table ip mangle
# Warning: table ip mangle is managed by iptables-nft, do not touch!
table ip mangle {
        chain WANLOADBALANCE_PRE {
                iifname "eth3" meta l4proto tcp tcp sport 20000-30000 tcp dport { 80, 443 } ct state new meta random & 2147483647 < 1431656481 counter packets 0 bytes 0 jump ISP_eth1
                iifname "eth3" meta l4proto tcp tcp sport 20000-30000 tcp dport { 80, 443 } ct state new counter packets 0 bytes 0 jump ISP_eth2
                iifname "eth3" meta l4proto tcp tcp sport 20000-30000 tcp dport { 80, 443 } counter packets 0 bytes 0 meta mark set ct mark
                iifname "eth3" tcp dport 22 ct state new meta random & 2147483647 < 1431656481 counter packets 0 bytes 0 jump ISP_eth1
                iifname "eth3" tcp dport 22 ct state new counter packets 0 bytes 0 jump ISP_eth2
                iifname "eth3" tcp dport 22 counter packets 0 bytes 0 meta mark set ct mark
        }

        chain PREROUTING {
                type filter hook prerouting priority mangle; policy accept;
                counter packets 20 bytes 2808 jump WANLOADBALANCE_PRE
        }

        chain ISP_eth1 {
                counter packets 0 bytes 0 ct mark set 0xc9
                counter packets 0 bytes 0 meta mark set 0xc9
                counter packets 0 bytes 0 accept
        }

        chain ISP_eth2 {
                counter packets 0 bytes 0 ct mark set 0xca
                counter packets 0 bytes 0 meta mark set 0xca
                counter packets 0 bytes 0 accept
        }
}
vyos@vyos:~$ 
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Smoketest for WLB failed locally. This may be a time condition, because if adding and extra delay with `time.sleep(5)` before [Line-240](https://github.com/vyos/vyos-1x/blob/current/smoketest/scripts/cli/test_load-balancing_wan.py#L240), smoketest runs successfully.  

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
