### PR TITLE
container: T5909: move registry login to op-mode

### DIFF
--- a/src/op_mode/container.py
+++ b/src/op_mode/container.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022 VyOS maintainers and contributors
+# Copyright (C) 2022-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -20,6 +20,8 @@ import sys
 from sys import exit
 
 from vyos.utils.process import cmd
+from vyos.utils.process import call
+from vyos.utils.process import rc_cmd
 
 import vyos.opmode
 
@@ -36,11 +38,33 @@ def _get_raw_data(command: str) -> list:
     return data
 
 def add_image(name: str):
-    from vyos.utils.process import rc_cmd
+    """ Pull image from container registry. If registry authentication
+    is defined within VyOS CLI, credentials are used to login befroe pull """
+    from vyos.configquery import ConfigTreeQuery
+
+    conf = ConfigTreeQuery()
+    container = conf.get_config_dict(['container', 'registry'])
+
+    do_logout = False
+    if 'registry' in container:
+        for registry, registry_config in container['registry'].items():
+            if 'disable' in registry_config:
+                continue
+            if 'authentication' in registry_config:
+                do_logout = True
+                if {'username', 'password'} <= set(registry_config['authentication']):
+                    username = registry_config['authentication']['username']
+                    password = registry_config['authentication']['password']
+                    cmd = f'podman login --username {username} --password {password} {registry}'
+                    rc, out = rc_cmd(cmd)
+                    if rc != 0: raise vyos.opmode.InternalError(out)
 
     rc, output = rc_cmd(f'podman image pull {name}')
     if rc != 0:
         raise vyos.opmode.InternalError(output)
+
+    if do_logout:
+        rc_cmd('podman logout --all')
 
 def delete_image(name: str):
     from vyos.utils.process import rc_cmd


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
It does not make sense to perform the `podman login` command when setting up containers, as images are not automatically pulled in from the registry - due to issues with the default route during startup.

The same issue manifests in `podman login` where we can not login to a registry unless there is a default route present.

This commit changes the behavior that the container registry is part of the configuration, but it is only referenced during "add container image" and thus never during system boot.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5909

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/2775

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_container.py
test_basic (__main__.TestContainer.test_basic) ... ok
test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... ok
test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... ok
test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... ok
test_uid_gid (__main__.TestContainer.test_uid_gid) ... ok

----------------------------------------------------------------------
Ran 5 tests in 106.476s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
