### PR TITLE
container: T6060: support removing all container images at once via op-mode

### DIFF
--- a/op-mode-definitions/container.xml.in
+++ b/op-mode-definitions/container.xml.in
@@ -41,6 +41,7 @@
             <properties>
               <help>Delete container image</help>
               <completionHelp>
+                <list>all</list>
                 <script>sudo podman image ls -q</script>
               </completionHelp>
             </properties>

--- a/src/op_mode/container.py
+++ b/src/op_mode/container.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022 VyOS maintainers and contributors
+# Copyright (C) 2022-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -29,7 +29,6 @@ def _get_json_data(command: str) -> list:
     """
     return cmd(f'{command} --format json')
 
-
 def _get_raw_data(command: str) -> list:
     json_data = _get_json_data(command)
     data = json.loads(json_data)
@@ -45,6 +44,13 @@ def add_image(name: str):
 def delete_image(name: str):
     from vyos.utils.process import rc_cmd
 
+    if name == 'all':
+        # gather list of all images and pass them to the removal list
+        name = cmd('sudo podman image ls --quiet')
+        # If there are no container images left, we can not delete them all
+        if not name: return
+        # replace newline with whitespace
+        name = name.replace('\n', ' ')
     rc, output = rc_cmd(f'podman image rm --force {name}')
     if rc != 0:
         raise vyos.opmode.InternalError(output)
@@ -57,7 +63,6 @@ def show_container(raw: bool):
     else:
         return cmd(command)
 
-
 def show_image(raw: bool):
     command = 'podman image ls'
     container_data = _get_raw_data('podman image ls')
@@ -66,7 +71,6 @@ def show_image(raw: bool):
     else:
         return cmd(command)
 
-
 def show_network(raw: bool):
     command = 'podman network ls'
     container_data = _get_raw_data(command)
@@ -74,7 +78,6 @@ def show_network(raw: bool):
         return container_data
     else:
         return cmd(command)
-
 
 def restart(name: str):
     from vyos.utils.process import rc_cmd
@@ -85,7 +88,6 @@ def restart(name: str):
         return None
     print(f'Container "{name}" restarted!')
     return output
-
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add 'all'  completion helper for op-mode command `delete container image`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6060

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
cpo@LR1.wue3:~$ show container image
REPOSITORY                    TAG         IMAGE ID      CREATED       SIZE
docker.io/library/busybox     latest      3f57d9401f8d  5 weeks ago   4.5 MB
docker.io/jacobalberty/unifi  v7.5        f6df690d6c67  4 months ago  827 MB
docker.io/jacobalberty/unifi  v7.4        7838b75ef7b9  7 months ago  786 MB

cpo@LR1.wue3:~$ delete container image ?
Possible completions:
  3f57d9401f8d          Delete container image
  7838b75ef7b9
  all
  f6df690d6c67

cpo@LR1.wue3:~$ delete container image all

cpo@LR1.wue3:~$ show container image
REPOSITORY  TAG         IMAGE ID    CREATED     SIZE
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
