### PR TITLE
http-api: T6069: fix concurrent configure requests

### DIFF
--- a/src/services/vyos-http-api-server
+++ b/src/services/vyos-http-api-server
@@ -546,7 +546,7 @@ def _configure_op(data: Union[ConfigureModel, ConfigureListModel,
     return success(msg)
 
 @app.post('/configure')
-def configure_op(data: Union[ConfigureModel,
+async def configure_op(data: Union[ConfigureModel,
                              ConfigureListModel],
                        request: Request, background_tasks: BackgroundTasks):
     return _configure_op(data, request, background_tasks)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
fix concurrent configure requests via api

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6069
* https://vyos.dev/T5006
* https://vyos.dev/T5305

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/1823

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* http-api

## Proposed changes
<!--- Describe your changes in detail -->
Defining configure endpoint as async stops api server from segfaulting during multiple concurrent requests. This is a more conservative than previous attempts to fix this issue and only targets the configure  endpoint.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```bash
#!/bin/bash

[ "$VYOS_HOST" == "" ] && echo "VYOS_HOST must be set to the dns or ip of your box"
[ "$VYOS_KEY" == "" ] && echo "VYOS_KEY must be set to your api key"

for i in {0..200}; do
    echo -n "$i/200 ";

    curl -k --fail --location --request POST "https://$VYOS_HOST/configure" --form key="$VYOS_KEY" --form data='[
        {"op":"delete","path":["firewall","ipv4","name","example1","default-action","accept"]},
        {"op":"set","path":["firewall","ipv4","name","example1","default-action","accept"]}
    ]' &
    pid1=$!

    curl -k --fail --location --request POST "https://$VYOS_HOST/configure" --form key="$VYOS_KEY" --form data='[
        {"op":"delete","path":["firewall","ipv4","name","example2","default-action","accept"]},
        {"op":"set","path":["firewall","ipv4","name","example2","default-action","accept"]}
    ]' &
    pid2=$!

    echo -n "Result: "

    wait $pid1
    ret1=$?
    wait $pid2
    ret2=$?

    echo

    [ $(($ret1 + $ret2)) != 0 ] && exit $(($ret1 + $ret2))
done
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Unable to find documentation on how to run it.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
