### PR TITLE
vyos-hostsd: T4270: do not resolve local router FQDN to 127.0.1.1

### DIFF
--- a/data/templates/vyos-hostsd/hosts.j2
+++ b/data/templates/vyos-hostsd/hosts.j2
@@ -4,7 +4,6 @@
 
 # Local host
 127.0.0.1       localhost
-127.0.1.1       {{ host_name }}{% if domain_name %}.{{ domain_name }} {{ host_name }}{% endif %}
 
 # The following lines are desirable for IPv6 capable hosts
 ::1             localhost ip6-localhost ip6-loopback


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Clients using VyOS as their DNS server and trying to resolve the FQDN of the router will receive 127.0.1.1 as answer.

```
set service dns forwarding allow-from '172.16.0.0/12'
set service dns forwarding listen-address '172.31.0.254'
set service dns forwarding negative-ttl '60'
set system domain-name 'vyos.net'
set system host-name 'R1'
```

Will return:
```
$ host R1.vyos.net 172.31.0.254
Using domain server:
Name: 172.31.0.254
Address: 172.31.0.254#53
Aliases:

R1.vyos.net has address 127.0.1.1
```

When it should rather return the real IP address assigned via DNS.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4270

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vyos-hostsd

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_dns_forwarding.py
test_basic_forwarding (__main__.TestServicePowerDNS.test_basic_forwarding) ... ok
test_dns64 (__main__.TestServicePowerDNS.test_dns64) ... ok
test_dnssec (__main__.TestServicePowerDNS.test_dnssec) ... ok
test_domain_forwarding (__main__.TestServicePowerDNS.test_domain_forwarding) ... ok
test_ecs_add_for (__main__.TestServicePowerDNS.test_ecs_add_for) ... ok
test_ecs_ipv4_bits (__main__.TestServicePowerDNS.test_ecs_ipv4_bits) ... ok
test_edns_subnet_allow_list (__main__.TestServicePowerDNS.test_edns_subnet_allow_list) ... ok
test_exclude_throttle_adress (__main__.TestServicePowerDNS.test_exclude_throttle_adress) ... ok
test_external_nameserver (__main__.TestServicePowerDNS.test_external_nameserver) ... ok
test_listening_port (__main__.TestServicePowerDNS.test_listening_port) ... ok
test_no_rfc1918_forwarding (__main__.TestServicePowerDNS.test_no_rfc1918_forwarding) ... ok
test_serve_stale_extension (__main__.TestServicePowerDNS.test_serve_stale_extension) ... ok

----------------------------------------------------------------------
Ran 12 tests in 61.189s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
