### PR TITLE
vrf: conntrack: T6073: Populate VRF zoning chains only while conntrack is required

### DIFF
--- a/data/config-mode-dependencies/vyos-1x.json
+++ b/data/config-mode-dependencies/vyos-1x.json
@@ -1,6 +1,7 @@
 {
     "system_conntrack": {
-        "conntrack_sync": ["service_conntrack-sync"]
+        "conntrack_sync": ["service_conntrack-sync"],
+        "vrf": ["vrf"]
     },
     "firewall": {
         "conntrack": ["system_conntrack"],

--- a/data/vyos-firewall-init.conf
+++ b/data/vyos-firewall-init.conf
@@ -65,11 +65,9 @@ table inet vrf_zones {
     # Chain for inbound traffic
     chain vrf_zones_ct_in {
         type filter hook prerouting priority raw; policy accept;
-        counter ct original zone set iifname map @ct_iface_map
     }
     # Chain for locally-generated traffic
     chain vrf_zones_ct_out {
         type filter hook output priority raw; policy accept;
-        counter ct original zone set oifname map @ct_iface_map
     }
 }

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -34,6 +34,24 @@ from vyos.utils.process import call
 from vyos.utils.process import cmd
 from vyos.utils.process import run
 
+# Conntrack
+
+def conntrack_required(conf):
+    required_nodes = ['nat', 'nat66', 'load-balancing wan']
+
+    for path in required_nodes:
+        if conf.exists(path):
+            return True
+
+    firewall = conf.get_config_dict(['firewall'], key_mangling=('-', '_'),
+                                    no_tag_node_value_mangle=True, get_first_key=True)
+
+    for rules, path in dict_search_recursive(firewall, 'rule'):
+        if any(('state' in rule_conf or 'connection_status' in rule_conf or 'offload_target' in rule_conf) for rule_conf in rules.values()):
+            return True
+
+    return False
+
 # Domain Resolver
 
 def fqdn_config_parse(firewall):

--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -102,6 +102,29 @@ class VyOSUnitTestSHIM:
             ssh_client.close()
             return output, error
 
+        # Verify nftables output
+        def verify_nftables(self, nftables_search, table, inverse=False, args=''):
+            nftables_output = cmd(f'sudo nft {args} list table {table}')
+
+            for search in nftables_search:
+                matched = False
+                for line in nftables_output.split("\n"):
+                    if all(item in line for item in search):
+                        matched = True
+                        break
+                self.assertTrue(not matched if inverse else matched, msg=search)
+
+        def verify_nftables_chain(self, nftables_search, table, chain, inverse=False, args=''):
+            nftables_output = cmd(f'sudo nft {args} list chain {table} {chain}')
+
+            for search in nftables_search:
+                matched = False
+                for line in nftables_output.split("\n"):
+                    if all(item in line for item in search):
+                        matched = True
+                        break
+                self.assertTrue(not matched if inverse else matched, msg=search)
+
 # standard construction; typing suggestion: https://stackoverflow.com/a/70292317
 def ignore_warning(warning: Type[Warning]):
     import warnings

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -22,7 +22,6 @@ from time import sleep
 from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.configsession import ConfigSessionError
-from vyos.utils.process import cmd
 from vyos.utils.process import run
 
 sysfs_config = {
@@ -66,28 +65,6 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         ]
 
         self.verify_nftables(nftables_search, 'ip vyos_filter', inverse=True)
-
-    def verify_nftables(self, nftables_search, table, inverse=False, args=''):
-        nftables_output = cmd(f'sudo nft {args} list table {table}')
-
-        for search in nftables_search:
-            matched = False
-            for line in nftables_output.split("\n"):
-                if all(item in line for item in search):
-                    matched = True
-                    break
-            self.assertTrue(not matched if inverse else matched, msg=search)
-
-    def verify_nftables_chain(self, nftables_search, table, chain, inverse=False, args=''):
-        nftables_output = cmd(f'sudo nft {args} list chain {table} {chain}')
-
-        for search in nftables_search:
-            matched = False
-            for line in nftables_output.split("\n"):
-                if all(item in line for item in search):
-                    matched = True
-                    break
-            self.assertTrue(not matched if inverse else matched, msg=search)
 
     def wait_for_domain_resolver(self, table, set_name, element, max_wait=10):
         # Resolver no longer blocks commit, need to wait for daemon to populate set
@@ -808,7 +785,6 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['ct state related', 'accept']
         ]
 
-        nftables_output = cmd('sudo nft list table ip vyos_filter')
         self.verify_nftables(nftables_search, 'ip vyos_filter')
         self.verify_nftables(nftables_search_v6, 'ip6 vyos_filter')
 

--- a/smoketest/scripts/cli/test_nat.py
+++ b/smoketest/scripts/cli/test_nat.py
@@ -21,8 +21,6 @@ import unittest
 
 from base_vyostest_shim import VyOSUnitTestSHIM
 from vyos.configsession import ConfigSessionError
-from vyos.utils.process import cmd
-from vyos.utils.dict import dict_search
 
 base_path = ['nat']
 src_path = base_path + ['source']
@@ -46,17 +44,6 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
         self.assertFalse(os.path.exists(nftables_nat_config))
         self.assertFalse(os.path.exists(nftables_static_nat_conf))
-
-    def verify_nftables(self, nftables_search, table, inverse=False, args=''):
-        nftables_output = cmd(f'sudo nft {args} list table {table}')
-
-        for search in nftables_search:
-            matched = False
-            for line in nftables_output.split("\n"):
-                if all(item in line for item in search):
-                    matched = True
-                    break
-            self.assertTrue(not matched if inverse else matched, msg=search)
 
     def wait_for_domain_resolver(self, table, set_name, element, max_wait=10):
         # Resolver no longer blocks commit, need to wait for daemon to populate set

--- a/smoketest/scripts/cli/test_nat66.py
+++ b/smoketest/scripts/cli/test_nat66.py
@@ -22,8 +22,6 @@ import unittest
 from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.configsession import ConfigSessionError
-from vyos.utils.process import cmd
-from vyos.utils.dict import dict_search
 
 base_path = ['nat66']
 src_path = base_path + ['source']
@@ -41,17 +39,6 @@ class TestNAT66(VyOSUnitTestSHIM.TestCase):
     def tearDown(self):
         self.cli_delete(base_path)
         self.cli_commit()
-
-    def verify_nftables(self, nftables_search, table, inverse=False, args=''):
-        nftables_output = cmd(f'sudo nft {args} list table {table}')
-
-        for search in nftables_search:
-            matched = False
-            for line in nftables_output.split("\n"):
-                if all(item in line for item in search):
-                    matched = True
-                    break
-            self.assertTrue(not matched if inverse else matched, msg=search)
 
     def test_source_nat66(self):
         source_prefix = 'fc00::/64'

--- a/smoketest/scripts/cli/test_policy_route.py
+++ b/smoketest/scripts/cli/test_policy_route.py
@@ -68,17 +68,6 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
 
         self.verify_rules(ip_rule_search, inverse=True)
 
-    def verify_nftables(self, nftables_search, table, inverse=False):
-        nftables_output = cmd(f'sudo nft list table {table}')
-
-        for search in nftables_search:
-            matched = False
-            for line in nftables_output.split("\n"):
-                if all(item in line for item in search):
-                    matched = True
-                    break
-            self.assertTrue(not matched if inverse else matched, msg=search)
-
     def verify_rules(self, rules_search, inverse=False):
         rule_output = cmd('ip rule show')
 

--- a/smoketest/scripts/cli/test_system_conntrack.py
+++ b/smoketest/scripts/cli/test_system_conntrack.py
@@ -21,7 +21,6 @@ import unittest
 from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.firewall import find_nftables_rule
-from vyos.utils.process import cmd
 from vyos.utils.file import read_file
 
 base_path = ['system', 'conntrack']
@@ -42,17 +41,6 @@ class TestSystemConntrack(VyOSUnitTestSHIM.TestCase):
     def tearDown(self):
         self.cli_delete(base_path)
         self.cli_commit()
-
-    def verify_nftables(self, nftables_search, table, inverse=False, args=''):
-        nftables_output = cmd(f'sudo nft {args} list table {table}')
-
-        for search in nftables_search:
-            matched = False
-            for line in nftables_output.split("\n"):
-                if all(item in line for item in search):
-                    matched = True
-                    break
-            self.assertTrue(not matched if inverse else matched, msg=search)
 
     def test_conntrack_options(self):
         conntrack_config = {

--- a/src/conf_mode/system_conntrack.py
+++ b/src/conf_mode/system_conntrack.py
@@ -104,6 +104,10 @@ def get_config(config=None):
     if conf.exists(['service', 'conntrack-sync']):
         set_dependents('conntrack_sync', conf)
 
+    # If conntrack status changes, VRF zone rules need updating
+    if conf.exists(['vrf']):
+        set_dependents('vrf', conf)
+
     return conntrack
 
 def verify(conntrack):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
- Remove VRF conntrack rules when conntrack is not in use
- Deduplicate nftables verify functions in smoketests, used by several tests

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6073

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
conntrack, vrf

## Proposed changes
<!--- Describe your changes in detail -->
- Adds `conntrack_required` function to vyos.firewall
- Remove VRF conntrack rules on boot, added later only if required
- Add conntrack dependency on vrf to ensure VRF rules are updated if conntrack status changes

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Added smoketest to verify nftables rules are only present based on conntrack requirements

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_vrf.py
DEBUG - test_vrf_assign_interface (__main__.VRFTest.test_vrf_assign_interface) ... ok
DEBUG - test_vrf_bind_all (__main__.VRFTest.test_vrf_bind_all) ... ok
DEBUG - test_vrf_conntrack (__main__.VRFTest.test_vrf_conntrack) ... ok
DEBUG - test_vrf_disable_forwarding (__main__.VRFTest.test_vrf_disable_forwarding) ... ok
DEBUG - test_vrf_ip_ipv6_nht (__main__.VRFTest.test_vrf_ip_ipv6_nht) ... ok
DEBUG - test_vrf_ip_ipv6_protocol_non_existing_route_map (__main__.VRFTest.test_vrf_ip_ipv6_protocol_non_existing_route_map) ... ok
DEBUG - test_vrf_ip_protocol_route_map (__main__.VRFTest.test_vrf_ip_protocol_route_map) ... ok
DEBUG - test_vrf_ipv6_protocol_route_map (__main__.VRFTest.test_vrf_ipv6_protocol_route_map) ... ok
DEBUG - test_vrf_link_local_ip_addresses (__main__.VRFTest.test_vrf_link_local_ip_addresses) ... ok
DEBUG - test_vrf_loopbacks_ips (__main__.VRFTest.test_vrf_loopbacks_ips) ... ok
DEBUG - test_vrf_static_route (__main__.VRFTest.test_vrf_static_route) ... ok
DEBUG - test_vrf_table_id_is_unalterable (__main__.VRFTest.test_vrf_table_id_is_unalterable) ... ok
DEBUG - test_vrf_vni_add_change_remove (__main__.VRFTest.test_vrf_vni_add_change_remove) ... ok
DEBUG - test_vrf_vni_and_table_id (__main__.VRFTest.test_vrf_vni_and_table_id) ... ok
DEBUG - test_vrf_vni_duplicates (__main__.VRFTest.test_vrf_vni_duplicates) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 15 tests in 239.216s
DEBUG -
DEBUG - OK
```

(Other `verify_nftables..` dependent smoketests were tested and passed after function move)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
