### PR TITLE
ospfv3: allow metric and metric-type on redistributed routes

### DIFF
--- a/data/templates/frr/ospf6d.frr.j2
+++ b/data/templates/frr/ospf6d.frr.j2
@@ -109,7 +109,7 @@ router ospf6 {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {% endif %}
 {% if redistribute is vyos_defined %}
 {%     for protocol, options in redistribute.items() %}
- redistribute {{ protocol }} {{ 'route-map ' ~ options.route_map if options.route_map is vyos_defined }}
+ redistribute {{ protocol }} {{ 'metric ' ~ options.metric if options.metric is vyos_defined }} {{ 'metric-type ' ~ options.metric_type if options.metric_type is vyos_defined }} {{ 'route-map ' ~ options.route_map if options.route_map is vyos_defined }}
 {%     endfor %}
 {% endif %}
 exit

--- a/data/templates/frr/ospfd.frr.j2
+++ b/data/templates/frr/ospfd.frr.j2
@@ -214,13 +214,13 @@ router ospf {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
  passive-interface default
 {% endif %}
 {% if redistribute is vyos_defined %}
-{%     for protocol, protocols_options in redistribute.items() %}
+{%     for protocol, options in redistribute.items() %}
 {%         if protocol == 'table' %}
-{%             for table, table_options in protocols_options.items() %}
- redistribute {{ protocol }} {{ table }} {{ 'metric ' + table_options.metric if table_options.metric is vyos_defined }} {{ 'metric-type ' + table_options.metric_type if table_options.metric_type is vyos_defined }} {{ 'route-map ' + table_options.route_map if table_options.route_map is vyos_defined }}
+{%             for table, table_options in options.items() %}
+ redistribute {{ protocol }} {{ table }} {{ 'metric ' ~ table_options.metric if table_options.metric is vyos_defined }} {{ 'metric-type ' ~ table_options.metric_type if table_options.metric_type is vyos_defined }} {{ 'route-map ' ~ table_options.route_map if table_options.route_map is vyos_defined }}
 {%             endfor %}
 {%         else %}
- redistribute {{ protocol }} {{ 'metric ' + protocols_options.metric if protocols_options.metric is vyos_defined }} {{ 'metric-type ' + protocols_options.metric_type if protocols_options.metric_type is vyos_defined }} {{ 'route-map ' + protocols_options.route_map if protocols_options.route_map is vyos_defined }}
+ redistribute {{ protocol }} {{ 'metric ' ~ options.metric if options.metric is vyos_defined }} {{ 'metric-type ' ~ options.metric_type if options.metric_type is vyos_defined }} {{ 'route-map ' ~ options.route_map if options.route_map is vyos_defined }}
 {%         endif %}
 {%     endfor %}
 {% endif %}

--- a/interface-definitions/include/ospfv3/protocol-common-config.xml.i
+++ b/interface-definitions/include/ospfv3/protocol-common-config.xml.i
@@ -221,11 +221,23 @@
     <help>Redistribute information from another routing protocol</help>
   </properties>
   <children>
+    <node name="babel">
+      <properties>
+        <help>Redistribute Babel routes</help>
+      </properties>
+      <children>
+        #include <include/ospf/metric.xml.i>
+        #include <include/ospf/metric-type.xml.i>
+        #include <include/route-map.xml.i>
+      </children>
+    </node>
     <node name="bgp">
       <properties>
         <help>Redistribute BGP routes</help>
       </properties>
       <children>
+        #include <include/ospf/metric.xml.i>
+        #include <include/ospf/metric-type.xml.i>
         #include <include/route-map.xml.i>
       </children>
     </node>
@@ -234,6 +246,8 @@
         <help>Redistribute connected routes</help>
       </properties>
       <children>
+        #include <include/ospf/metric.xml.i>
+        #include <include/ospf/metric-type.xml.i>
         #include <include/route-map.xml.i>
       </children>
     </node>
@@ -242,6 +256,8 @@
         <help>Redistribute kernel routes</help>
       </properties>
       <children>
+        #include <include/ospf/metric.xml.i>
+        #include <include/ospf/metric-type.xml.i>
         #include <include/route-map.xml.i>
       </children>
     </node>
@@ -250,14 +266,8 @@
         <help>Redistribute RIPNG routes</help>
       </properties>
       <children>
-        #include <include/route-map.xml.i>
-      </children>
-    </node>
-    <node name="babel">
-      <properties>
-        <help>Redistribute Babel routes</help>
-      </properties>
-      <children>
+        #include <include/ospf/metric.xml.i>
+        #include <include/ospf/metric-type.xml.i>
         #include <include/route-map.xml.i>
       </children>
     </node>
@@ -266,6 +276,8 @@
         <help>Redistribute static routes</help>
       </properties>
       <children>
+        #include <include/ospf/metric.xml.i>
+        #include <include/ospf/metric-type.xml.i>
         #include <include/route-map.xml.i>
       </children>
     </node>

--- a/smoketest/scripts/cli/test_protocols_ospfv3.py
+++ b/smoketest/scripts/cli/test_protocols_ospfv3.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2023 VyOS maintainers and contributors
+# Copyright (C) 2021-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -114,6 +114,8 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
 
 
     def test_ospfv3_03_redistribute(self):
+        metric = '15'
+        metric_type = '1'
         route_map = 'foo-bar'
         route_map_seq = '10'
         redistribute = ['bgp', 'connected', 'kernel', 'ripng', 'static']
@@ -121,7 +123,9 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['policy', 'route-map', route_map, 'rule', route_map_seq, 'action', 'permit'])
 
         for protocol in redistribute:
+            self.cli_set(base_path + ['redistribute', protocol, 'metric', metric])
             self.cli_set(base_path + ['redistribute', protocol, 'route-map', route_map])
+            self.cli_set(base_path + ['redistribute', protocol, 'metric-type', metric_type])
 
         # commit changes
         self.cli_commit()
@@ -130,7 +134,7 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         frrconfig = self.getFRRconfig('router ospf6', daemon=PROCESS_NAME)
         self.assertIn(f'router ospf6', frrconfig)
         for protocol in redistribute:
-            self.assertIn(f' redistribute {protocol} route-map {route_map}', frrconfig)
+            self.assertIn(f' redistribute {protocol} metric {metric} metric-type {metric_type} route-map {route_map}', frrconfig)
 
 
     def test_ospfv3_04_interfaces(self):

--- a/src/conf_mode/protocols_ospf.py
+++ b/src/conf_mode/protocols_ospf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2023 VyOS maintainers and contributors
+# Copyright (C) 2021-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -91,6 +91,8 @@ def get_config(config=None):
     for protocol in ['babel', 'bgp', 'connected', 'isis', 'kernel', 'rip', 'static']:
         if dict_search(f'redistribute.{protocol}', ospf) is None:
             del default_values['redistribute'][protocol]
+    if not bool(default_values['redistribute']):
+        del default_values['redistribute']
 
     for interface in ospf.get('interface', []):
         # We need to reload the defaults on every pass b/c of
@@ -213,7 +215,7 @@ def verify(ospf):
                     raise ConfigError(f'Segment routing prefix {prefix} cannot have both explicit-null '\
                                       f'and no-php-flag configured at the same time.')
 
-    # Check for index ranges being larger than the segment routing global block    
+    # Check for index ranges being larger than the segment routing global block
     if dict_search('segment_routing.global_block', ospf):
         g_high_label_value = dict_search('segment_routing.global_block.high_label_value', ospf)
         g_low_label_value = dict_search('segment_routing.global_block.low_label_value', ospf)

--- a/src/conf_mode/protocols_ospfv3.py
+++ b/src/conf_mode/protocols_ospfv3.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2023 VyOS maintainers and contributors
+# Copyright (C) 2021-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -84,6 +84,12 @@ def get_config(config=None):
         del default_values['default_information']
     if 'graceful_restart' not in ospfv3:
         del default_values['graceful_restart']
+
+    for protocol in ['babel', 'bgp', 'connected', 'kernel', 'ripng', 'static']:
+        if dict_search(f'redistribute.{protocol}', ospfv3) is None:
+            del default_values['redistribute'][protocol]
+    if not bool(default_values['redistribute']):
+        del default_values['redistribute']
 
     default_values.pop('interface', {})
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Allow metric and metric-type on redistributed routes

```
vyos@vyos# set protocols ospfv3 redistribute bgp
Possible completions:
   metric               OSPF default metric
   metric-type          OSPF metric type for default routes (default: 2)
   route-map            Specify route-map name to use
```

https://docs.frrouting.org/en/stable-9.1/ospf6d.html#redistribute-routes-to-ospf6

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5717

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Extended Smoketests

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_ospfv3.py
test_ospfv3_01_basic (__main__.TestProtocolsOSPFv3.test_ospfv3_01_basic) ... ok
test_ospfv3_02_distance (__main__.TestProtocolsOSPFv3.test_ospfv3_02_distance) ... ok
test_ospfv3_03_redistribute (__main__.TestProtocolsOSPFv3.test_ospfv3_03_redistribute) ... ok
test_ospfv3_04_interfaces (__main__.TestProtocolsOSPFv3.test_ospfv3_04_interfaces) ... ok
test_ospfv3_05_area_stub (__main__.TestProtocolsOSPFv3.test_ospfv3_05_area_stub) ... ok
test_ospfv3_06_area_nssa (__main__.TestProtocolsOSPFv3.test_ospfv3_06_area_nssa) ... ok
test_ospfv3_07_default_originate (__main__.TestProtocolsOSPFv3.test_ospfv3_07_default_originate) ... ok
test_ospfv3_08_vrfs (__main__.TestProtocolsOSPFv3.test_ospfv3_08_vrfs) ... ok
test_ospfv3_09_graceful_restart (__main__.TestProtocolsOSPFv3.test_ospfv3_09_graceful_restart) ... ok

----------------------------------------------------------------------
Ran 9 tests in 47.773s

OK
```

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_ospf.py
test_ospf_01_defaults (__main__.TestProtocolsOSPF.test_ospf_01_defaults) ... ok
test_ospf_02_simple (__main__.TestProtocolsOSPF.test_ospf_02_simple) ... ok
test_ospf_03_access_list (__main__.TestProtocolsOSPF.test_ospf_03_access_list) ... ok
test_ospf_04_default_originate (__main__.TestProtocolsOSPF.test_ospf_04_default_originate) ... ok
test_ospf_05_options (__main__.TestProtocolsOSPF.test_ospf_05_options) ... ok
test_ospf_06_neighbor (__main__.TestProtocolsOSPF.test_ospf_06_neighbor) ... ok
test_ospf_07_redistribute (__main__.TestProtocolsOSPF.test_ospf_07_redistribute) ... ok
test_ospf_08_virtual_link (__main__.TestProtocolsOSPF.test_ospf_08_virtual_link) ... ok
test_ospf_09_interface_configuration (__main__.TestProtocolsOSPF.test_ospf_09_interface_configuration) ... ok
test_ospf_11_interface_area (__main__.TestProtocolsOSPF.test_ospf_11_interface_area) ... ok
test_ospf_12_vrfs (__main__.TestProtocolsOSPF.test_ospf_12_vrfs) ... ok
test_ospf_13_export_list (__main__.TestProtocolsOSPF.test_ospf_13_export_list) ... ok
test_ospf_14_segment_routing_configuration (__main__.TestProtocolsOSPF.test_ospf_14_segment_routing_configuration) ... ok
test_ospf_15_ldp_sync (__main__.TestProtocolsOSPF.test_ospf_15_ldp_sync) ... ok
test_ospf_16_graceful_restart (__main__.TestProtocolsOSPF.test_ospf_16_graceful_restart) ... ok

----------------------------------------------------------------------
Ran 15 tests in 80.585s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
