### PR TITLE
ospfv3: T6087: add support to redistribute IS-IS routes

### DIFF
--- a/interface-definitions/include/ospfv3/protocol-common-config.xml.i
+++ b/interface-definitions/include/ospfv3/protocol-common-config.xml.i
@@ -251,6 +251,16 @@
         #include <include/route-map.xml.i>
       </children>
     </node>
+    <node name="isis">
+      <properties>
+        <help>Redistribute IS-IS routes</help>
+      </properties>
+      <children>
+        #include <include/ospf/metric.xml.i>
+        #include <include/ospf/metric-type.xml.i>
+        #include <include/route-map.xml.i>
+      </children>
+    </node>
     <node name="kernel">
       <properties>
         <help>Redistribute kernel routes</help>

--- a/smoketest/scripts/cli/test_protocols_ospf.py
+++ b/smoketest/scripts/cli/test_protocols_ospf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2023 VyOS maintainers and contributors
+# Copyright (C) 2021-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -240,7 +240,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
     def test_ospf_07_redistribute(self):
         metric = '15'
         metric_type = '1'
-        redistribute = ['bgp', 'connected', 'isis', 'kernel', 'rip', 'static']
+        redistribute = ['babel', 'bgp', 'connected', 'isis', 'kernel', 'rip', 'static']
 
         for protocol in redistribute:
             self.cli_set(base_path + ['redistribute', protocol, 'metric', metric])

--- a/smoketest/scripts/cli/test_protocols_ospfv3.py
+++ b/smoketest/scripts/cli/test_protocols_ospfv3.py
@@ -118,7 +118,7 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         metric_type = '1'
         route_map = 'foo-bar'
         route_map_seq = '10'
-        redistribute = ['bgp', 'connected', 'kernel', 'ripng', 'static']
+        redistribute = ['babel', 'bgp', 'connected', 'isis', 'kernel', 'ripng', 'static']
 
         self.cli_set(['policy', 'route-map', route_map, 'rule', route_map_seq, 'action', 'permit'])
 

--- a/src/conf_mode/protocols_ospfv3.py
+++ b/src/conf_mode/protocols_ospfv3.py
@@ -85,7 +85,7 @@ def get_config(config=None):
     if 'graceful_restart' not in ospfv3:
         del default_values['graceful_restart']
 
-    for protocol in ['babel', 'bgp', 'connected', 'kernel', 'ripng', 'static']:
+    for protocol in ['babel', 'bgp', 'connected', 'isis', 'kernel', 'ripng', 'static']:
         if dict_search(f'redistribute.{protocol}', ospfv3) is None:
             del default_values['redistribute'][protocol]
     if not bool(default_values['redistribute']):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6087

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ospfv3

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_ospf.py
test_ospf_01_defaults (__main__.TestProtocolsOSPF.test_ospf_01_defaults) ... ok
test_ospf_02_simple (__main__.TestProtocolsOSPF.test_ospf_02_simple) ... ok
test_ospf_03_access_list (__main__.TestProtocolsOSPF.test_ospf_03_access_list) ... ok
test_ospf_04_default_originate (__main__.TestProtocolsOSPF.test_ospf_04_default_originate) ... ok
test_ospf_05_options (__main__.TestProtocolsOSPF.test_ospf_05_options) ... ok
test_ospf_06_neighbor (__main__.TestProtocolsOSPF.test_ospf_06_neighbor) ... ok
test_ospf_07_redistribute (__main__.TestProtocolsOSPF.test_ospf_07_redistribute) ... ok
test_ospf_08_virtual_link (__main__.TestProtocolsOSPF.test_ospf_08_virtual_link) ... ok
test_ospf_09_interface_configuration (__main__.TestProtocolsOSPF.test_ospf_09_interface_configuration) ... ok
test_ospf_11_interface_area (__main__.TestProtocolsOSPF.test_ospf_11_interface_area) ... ok
test_ospf_12_vrfs (__main__.TestProtocolsOSPF.test_ospf_12_vrfs) ... ok
test_ospf_13_export_list (__main__.TestProtocolsOSPF.test_ospf_13_export_list) ... ok
test_ospf_14_segment_routing_configuration (__main__.TestProtocolsOSPF.test_ospf_14_segment_routing_configuration) ... ok
test_ospf_15_ldp_sync (__main__.TestProtocolsOSPF.test_ospf_15_ldp_sync) ... ok
test_ospf_16_graceful_restart (__main__.TestProtocolsOSPF.test_ospf_16_graceful_restart) ... ok

----------------------------------------------------------------------
Ran 15 tests in 79.909s
```
```
OK
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_ospfv3.py
test_ospfv3_01_basic (__main__.TestProtocolsOSPFv3.test_ospfv3_01_basic) ... ok
test_ospfv3_02_distance (__main__.TestProtocolsOSPFv3.test_ospfv3_02_distance) ... ok
test_ospfv3_03_redistribute (__main__.TestProtocolsOSPFv3.test_ospfv3_03_redistribute) ... ok
test_ospfv3_04_interfaces (__main__.TestProtocolsOSPFv3.test_ospfv3_04_interfaces) ... ok
test_ospfv3_05_area_stub (__main__.TestProtocolsOSPFv3.test_ospfv3_05_area_stub) ... ok
test_ospfv3_06_area_nssa (__main__.TestProtocolsOSPFv3.test_ospfv3_06_area_nssa) ... ok
test_ospfv3_07_default_originate (__main__.TestProtocolsOSPFv3.test_ospfv3_07_default_originate) ... ok
test_ospfv3_08_vrfs (__main__.TestProtocolsOSPFv3.test_ospfv3_08_vrfs) ... ok
test_ospfv3_09_graceful_restart (__main__.TestProtocolsOSPFv3.test_ospfv3_09_graceful_restart) ... ok

----------------------------------------------------------------------
Ran 9 tests in 48.354s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
