### PR TITLE
T6084: Add NHRP dependency for IPsec and fix NHRP empty config bug

### DIFF
--- a/data/config-mode-dependencies/vyos-1x.json
+++ b/data/config-mode-dependencies/vyos-1x.json
@@ -31,6 +31,9 @@
         "rpki": ["protocols_rpki"],
         "sstp": ["vpn_sstp"]
     },
+    "vpn_ipsec": {
+        "nhrp": ["protocols_nhrp"]
+    },
     "vpn_l2tp": {
         "ipsec": ["vpn_ipsec"]
     },


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
If we have any `vpn ipsec` and `protocol nhrp` configuration, we get the empty configuration file `/run/opennhrp/opennhrp.conf` after rebooting the system.

Using config dependency instead of the old `resync_nhrp` function fixes this issue
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6084

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nhrp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add this configuration and reboot the system
```
set interfaces ethernet eth1 address '192.0.2.14/24'
set interfaces ethernet eth1 description 'WAN'

set vpn ipsec esp-group group-ESP lifetime '3600'
set vpn ipsec esp-group group-ESP mode 'tunnel'
set vpn ipsec esp-group group-ESP pfs 'dh-group14'
set vpn ipsec esp-group group-ESP proposal 10 encryption 'aes128'
set vpn ipsec esp-group group-ESP proposal 10 hash 'sha1'
set vpn ipsec ike-group group-IKE close-action 'none'
set vpn ipsec ike-group group-IKE disable-mobike
set vpn ipsec ike-group group-IKE key-exchange 'ikev2'
set vpn ipsec ike-group group-IKE lifetime '28000'
set vpn ipsec ike-group group-IKE proposal 10 dh-group '14'
set vpn ipsec ike-group group-IKE proposal 10 encryption 'aes256gcm128'
set vpn ipsec ike-group group-IKE proposal 10 hash 'sha1'
set vpn ipsec interface 'eth1'

set interfaces tunnel tun100 address '192.168.250.4/24'
set interfaces tunnel tun100 encapsulation 'gre'
set interfaces tunnel tun100 parameters ip key '1'
set interfaces tunnel tun100 source-address '192.0.2.14'

set protocols nhrp tunnel tun100 cisco-authentication 'secret'
set protocols nhrp tunnel tun100 holding-time '30'
set protocols nhrp tunnel tun100 multicast 'dynamic'
set protocols nhrp tunnel tun100 redirect
set protocols nhrp tunnel tun100 shortcut
```
Before the fix we have empty `opennhrp.conf` file:
```
vyos@r1-right:~$ cat /run/opennhrp/opennhrp.conf 
# Created by VyOS - manual changes will be overwritten

vyos@r1-right:~$
```

After the fix, we have correct config:
```
vyos@r4:~$ cat /run/opennhrp/opennhrp.conf 
# Created by VyOS - manual changes will be overwritten

interface tun100 #hub 
    cisco-authentication secret
    holding-time 30
    multicast dynamic
    redirect
    shortcut

vyos@r4:~$ 

```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_nhrp.py
test_config (__main__.TestProtocolsNHRP.test_config) ... ok

----------------------------------------------------------------------
Ran 1 test in 8.666s

OK


vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
test_dhcp_fail_handling (__main__.TestVPNIPsec.test_dhcp_fail_handling) ... You should set correct remote-address "peer main-branch remote-address x.x.x.x"

Failed to get address from dhcp-interface on site-to-site peer main-branch -- skipped
ok
test_dmvpn (__main__.TestVPNIPsec.test_dmvpn) ... ok
test_flex_vpn_vips (__main__.TestVPNIPsec.test_flex_vpn_vips) ... ok
test_remote_access (__main__.TestVPNIPsec.test_remote_access) ... 
Missing esp-group on vyos-rw remote-access config

ok
test_remote_access_eap_tls (__main__.TestVPNIPsec.test_remote_access_eap_tls) ... 
Missing esp-group on vyos-rw remote-access config

ok
test_remote_access_x509 (__main__.TestVPNIPsec.test_remote_access_x509) ... 
Missing esp-group on vyos-rw remote-access config

ok
test_site_to_site (__main__.TestVPNIPsec.test_site_to_site) ... ok
test_site_to_site_vti (__main__.TestVPNIPsec.test_site_to_site_vti) ... 
WARNING: It's recommended to use ipsec vti with the next command
[set vpn ipsec option disable-route-autoinstall]

ok
test_site_to_site_x509 (__main__.TestVPNIPsec.test_site_to_site_x509) ... 
WARNING: It's recommended to use ipsec vti with the next command
[set vpn ipsec option disable-route-autoinstall]

ok

----------------------------------------------------------------------
Ran 9 tests in 62.948s

OK
vyos@r4:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
