### PR TITLE
T6086: NAT: fix nat rules when using source-groups and translation address is a network.

### DIFF
--- a/python/vyos/nat.py
+++ b/python/vyos/nat.py
@@ -89,11 +89,14 @@ def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
             if addr and is_ip_network(addr):
                 if not ipv6:
                     map_addr =  dict_search_args(rule_conf, nat_type, 'address')
-                    if port:
-                        translation_output.append(f'{ip_prefix} prefix to {ip_prefix} {translation_prefix}addr map {{ {map_addr} : {addr} . {port} }}')
+                    if map_addr:
+                        if port:
+                            translation_output.append(f'{ip_prefix} prefix to {ip_prefix} {translation_prefix}addr map {{ {map_addr} : {addr} . {port} }}')
+                        else:
+                            translation_output.append(f'{ip_prefix} prefix to {ip_prefix} {translation_prefix}addr map {{ {map_addr} : {addr} }}')
+                        ignore_type_addr = True
                     else:
-                        translation_output.append(f'{ip_prefix} prefix to {ip_prefix} {translation_prefix}addr map {{ {map_addr} : {addr} }}')
-                    ignore_type_addr = True
+                        translation_output.append(f'prefix to {addr}')
                 else:
                     translation_output.append(f'prefix to {addr}')
             elif addr == 'masquerade':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6086

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@T6058:~$ show config comm | grep nat
set nat source rule 100 source group network-group 'NG1'
set nat source rule 100 translation address '192.0.2.248/32'
set nat source rule 110 source group address-group 'AG01'
set nat source rule 110 translation address '192.0.2.248/32'
set nat source rule 200 source group address-group 'AG01'
set nat source rule 200 translation address '203.0.113.15'

vyos@T6058:~$ sudo nft list chain ip vyos_nat POSTROUTING
table ip vyos_nat {
        chain POSTROUTING {
                type nat hook postrouting priority srcnat; policy accept;
                counter packets 3 bytes 228 jump VYOS_PRE_SNAT_HOOK
                ip saddr @N_NG1 counter packets 0 bytes 0 snat prefix to 192.0.2.248/32 comment "SRC-NAT-100"
                ip saddr @A_AG01 counter packets 0 bytes 0 snat prefix to 192.0.2.248/32 comment "SRC-NAT-110"
                ip saddr @A_AG01 counter packets 0 bytes 0 snat to 203.0.113.15 comment "SRC-NAT-200"
        }
}
vyos@T6058:~$ 

```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@T6058:/usr/libexec/vyos/tests/smoke/cli# ./test_nat.py 
test_dnat (__main__.TestNAT.test_dnat) ... ok
test_dnat_negated_addresses (__main__.TestNAT.test_dnat_negated_addresses) ... ok
test_dnat_redirect (__main__.TestNAT.test_dnat_redirect) ... ok
test_dnat_without_translation_address (__main__.TestNAT.test_dnat_without_translation_address) ... ok
test_nat_balance (__main__.TestNAT.test_nat_balance) ... ok
test_nat_no_rules (__main__.TestNAT.test_nat_no_rules) ... ok
test_snat (__main__.TestNAT.test_snat) ... ok
test_snat_groups (__main__.TestNAT.test_snat_groups) ... 
WARNING: IP address 203.0.113.1 does not exist on the system!

ok
test_snat_net_port_map (__main__.TestNAT.test_snat_net_port_map) ... ok
test_snat_required_translation_address (__main__.TestNAT.test_snat_required_translation_address) ... 
Source NAT configuration error in rule 5: translation requires address
and/or port

ok
test_static_nat (__main__.TestNAT.test_static_nat) ... ok

WARNING: IP address 203.0.113.15 does not exist on the system!


----------------------------------------------------------------------
Ran 11 tests in 20.974s

OK
root@T6058:/usr/libexec/vyos/tests/smoke/cli# 
```
Also, test for nat64 and nat66 were tested.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
