### PR TITLE
T6096: Config commits are not synced properly because 00vyos-sync is deleted by vyos-router

### DIFF
--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -218,8 +218,8 @@ cleanup_post_commit_hooks () {
     # note that this approach only supports hooks that are "configured",
     # i.e., it does not support hooks that need to always be present.
     cpostdir=$(cli-shell-api getPostCommitHookDir)
-    # exclude commits hooks from vyatta-cfg
-    excluded="10vyatta-log-commit.pl 99vyos-user-postcommit-hooks"
+    # exclude commit hooks that need to always be present
+    excluded="00vyos-sync 10vyatta-log-commit.pl 99vyos-user-postcommit-hooks"
     if [ -d "$cpostdir" ]; then
 	    for f in $cpostdir/*; do
 	        if [[ ! $excluded =~ $(basename $f) ]]; then


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

00vyos-sync was missing from excludelist in vyos-router init-script.

The above resulted in that sync to storage was never performed during commits because `/etc/commit/post-commit.d/00vyos-sync` was deleted during boot.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6096

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
boot, config, commit

## Proposed changes
<!--- Describe your changes in detail -->

At approx line 222 in vyos-router init-script:

```
https://github.com/vyos/vyos-1x/blob/current/src/init/vyos-router#L222
```

The excludelist in the function cleanup_post_commit_hooks is missing `00vyos-sync`.

Before fix:

```
excluded="10vyatta-log-commit.pl 99vyos-user-postcommit-hooks"
```

After fix:

```
excluded="00vyos-sync 10vyatta-log-commit.pl 99vyos-user-postcommit-hooks"
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Compare output of `ls -la /etc/commit/post-commit.d` before and after the fix.

The error is that the function cleanup_post_commit_hooks in vyos-router deletes all files and links except those in the exceludelist.

The deletion of the 00vyos-sync makes it show through `sudo find / -iname "00vyos-sync"` but in a deleted state due to the use of overlay fs. That is the 00vyos-sync exists in the filesystem.squashfs but is not visible after boot.

By adding 00vyos-sync to the excludelist the file is no longer deleted by vyos-router during boot.

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

No smoketest have been runned at this moment.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
