### PR TITLE
T6061: fix rule parsing when connection-status is used

### DIFF
--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -136,10 +136,10 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
     if 'connection_status' in rule_conf and rule_conf['connection_status']:
         status = rule_conf['connection_status']
         if status['nat'] == 'destination':
-            nat_status = '{dnat}'
+            nat_status = 'dnat'
             output.append(f'ct status {nat_status}')
         if status['nat'] == 'source':
-            nat_status = '{snat}'
+            nat_status = 'snat'
             output.append(f'ct status {nat_status}')
 
     if 'protocol' in rule_conf and rule_conf['protocol'] != 'all':

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -629,8 +629,8 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         nftables_search = [
             ['ct state { established, related }', 'accept'],
             ['ct state invalid', 'reject'],
-            ['ct state new', 'ct status == dnat', 'accept'],
-            ['ct state { established, new }', 'ct status == snat', 'accept'],
+            ['ct state new', 'ct status dnat', 'accept'],
+            ['ct state { established, new }', 'ct status snat', 'accept'],
             ['ct state related', 'ct helper { "ftp", "pptp" }', 'accept'],
             ['drop', f'comment "{name} default-action drop"'],
             ['jump VYOS_STATE_POLICY'],


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6061
* https://vyos.dev/T6094

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@T6058:~$ show config comm | grep "nat\|firewall"
set firewall global-options state-policy established action 'accept'
set firewall global-options state-policy invalid action 'drop'
set firewall global-options state-policy related action 'accept'
set firewall ipv4 forward filter default-action 'drop'
set firewall ipv4 forward filter rule 10 action 'accept'
set firewall ipv4 forward filter rule 10 connection-status nat 'destination'
set firewall ipv4 forward filter rule 10 log
set nat destination rule 10 destination port '9999'
set nat destination rule 10 inbound-interface name 'eth0'
set nat destination rule 10 log
set nat destination rule 10 protocol 'tcp'
set nat destination rule 10 translation address '198.51.100.1'
set nat destination rule 10 translation port '22'
set nat source rule 10 outbound-interface name 'eth0'
set nat source rule 10 translation address 'masquerade'
vyos@T6058:~$ sudo nft list chain ip vyos_filter VYOS_FORWARD_filter
table ip vyos_filter {
        chain VYOS_FORWARD_filter {
                type filter hook forward priority filter; policy accept;
                jump VYOS_STATE_POLICY
                ct status dnat log prefix "[ipv4-FWD-filter-10-A]" counter packets 2 bytes 148 accept comment "ipv4-FWD-filter-10"
                counter packets 4 bytes 304 drop comment "FWD-filter default-action drop"
        }
}
vyos@T6058:~$ sudo conntrack -L | grep tcp
conntrack v1.4.6 (conntrack-tools): 7 flow entries have been shown.
tcp      6 103 TIME_WAIT src=192.168.77.39 dst=192.168.0.141 sport=57776 dport=9999 src=198.51.100.1 dst=192.168.77.39 sport=22 dport=57776 [ASSURED] mark=0 helper=ftp use=1
tcp      6 431986 ESTABLISHED src=192.168.77.39 dst=192.168.0.141 sport=40018 dport=9999 src=198.51.100.1 dst=192.168.77.39 sport=22 dport=40018 [ASSURED] mark=0 helper=ftp use=1
vyos@T6058:~$ 
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
From firewall.py smoketest:
```
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
