### PR TITLE
T6075: firewall and NAT: check if interface-group exists when using them in firewall|nat rules.

### DIFF
--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -282,6 +282,15 @@ def verify_rule(firewall, rule_conf, ipv6):
         if direction in rule_conf:
             if 'name' in rule_conf[direction] and 'group' in rule_conf[direction]:
                 raise ConfigError(f'Cannot specify both interface group and interface name for {direction}')
+            if 'group' in rule_conf[direction]:
+                group_name = rule_conf[direction]['group']
+                if group_name[0] == '!':
+                    group_name = group_name[1:]
+                group_obj = dict_search_args(firewall, 'group', 'interface_group', group_name)
+                if group_obj is None:
+                    raise ConfigError(f'Invalid interface group "{group_name}" on firewall rule')
+                if not group_obj:
+                    Warning(f'interface-group "{group_name}" has no members!')
 
 def verify_nested_group(group_name, group, groups, seen):
     if 'include' not in group:

--- a/src/conf_mode/nat.py
+++ b/src/conf_mode/nat.py
@@ -153,6 +153,15 @@ def verify(nat):
                 elif 'name' in config['outbound_interface']:
                     if config['outbound_interface']['name'] not in 'any' and config['outbound_interface']['name'] not in interfaces():
                         Warning(f'NAT interface "{config["outbound_interface"]["name"]}" for source NAT rule "{rule}" does not exist!')
+                else:
+                    group_name = config['outbound_interface']['group']
+                    if group_name[0] == '!':
+                        group_name = group_name[1:]
+                    group_obj = dict_search_args(nat['firewall_group'], 'interface_group', group_name)
+                    if group_obj is None:
+                        raise ConfigError(f'Invalid interface group "{group_name}" on source nat rule')
+                    if not group_obj:
+                        Warning(f'interface-group "{group_name}" has no members!')
 
             if not dict_search('translation.address', config) and not dict_search('translation.port', config):
                 if 'exclude' not in config and 'backend' not in config['load_balance']:
@@ -177,6 +186,15 @@ def verify(nat):
                 elif 'name' in config['inbound_interface']:
                     if config['inbound_interface']['name'] not in 'any' and config['inbound_interface']['name'] not in interfaces():
                         Warning(f'NAT interface "{config["inbound_interface"]["name"]}" for destination NAT rule "{rule}" does not exist!')
+                else:
+                    group_name = config['inbound_interface']['group']
+                    if group_name[0] == '!':
+                        group_name = group_name[1:]
+                    group_obj = dict_search_args(nat['firewall_group'], 'interface_group', group_name)
+                    if group_obj is None:
+                        raise ConfigError(f'Invalid interface group "{group_name}" on destination nat rule')
+                    if not group_obj:
+                        Warning(f'interface-group "{group_name}" has no members!')
 
             if not dict_search('translation.address', config) and not dict_search('translation.port', config) and 'redirect' not in config['translation']:
                 if 'exclude' not in config and 'backend' not in config['load_balance']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Check existence of firewall interface-group when using them in firewall and nat rules
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6075

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall, nat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Firewall Test:
```
vyos@T6075# compare commands 

set firewall ipv6 name FOO6 rule 10 action 'accept'
set firewall ipv6 name FOO6 rule 10 outbound-interface group 'AUX'

[edit]
vyos@T6075# commit

Invalid interface group "AUX" on firewall rule

[[firewall]] failed
Commit failed
[edit]
vyos@T6075# set firewall group interface-group AUX 
[edit]
vyos@T6075# commit

WARNING: interface-group "AUX" has no members!

[edit]
vyos@T6075# 
```
NAT Test:
```
vyos@T6075# compare commands 

set nat source rule 10 outbound-interface group 'BAR'
set nat source rule 10 translation address 'masquerade'

[edit]
vyos@T6075# commit

Invalid interface group "BAR" on source nat rule

[[nat]] failed
Commit failed
[edit]
vyos@T6075# set firewall group interface-group BAR interface eth0
[edit]
vyos@T6075# commit

WARNING: interface-group "AUX" has no members!

[edit]

```
Final config:
```
vyos@T6075:~$ show config comm | grep "firewall\|nat"
set firewall group interface-group AUX
set firewall group interface-group BAR interface 'eth0'
set firewall ipv6 name FOO6 rule 10 action 'accept'
set firewall ipv6 name FOO6 rule 10 outbound-interface group 'AUX'
set nat source rule 10 outbound-interface group 'BAR'
set nat source rule 10 translation address 'masquerade'
vyos@T6075:~$ 

```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@T6075:~$ /usr/libexec/vyos/tests/smoke/cli/test_firewall.py
test_bridge_basic_rules (__main__.TestFirewall.test_bridge_basic_rules) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... 
Interface "eth0.10" does not support hardware offload

ok
test_geoip (__main__.TestFirewall.test_geoip) ... Updating GeoIP. Please wait...
Updating GeoIP. Please wait...
ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_dynamic_groups (__main__.TestFirewall.test_ipv4_dynamic_groups) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... 
"synproxy" option allowed only for action synproxy

ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_dynamic_groups (__main__.TestFirewall.test_ipv6_dynamic_groups) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... 
Interface "eth0" does not support hardware offload

ok

----------------------------------------------------------------------
Ran 18 tests in 51.521s

OK
vyos@T6075:~$ /usr/libexec/vyos/tests/smoke/cli/test_nat.py
test_dnat (__main__.TestNAT.test_dnat) ... ok
test_dnat_negated_addresses (__main__.TestNAT.test_dnat_negated_addresses) ... ok
test_dnat_redirect (__main__.TestNAT.test_dnat_redirect) ... ok
test_dnat_without_translation_address (__main__.TestNAT.test_dnat_without_translation_address) ... ok
test_nat_balance (__main__.TestNAT.test_nat_balance) ... ok
test_nat_no_rules (__main__.TestNAT.test_nat_no_rules) ... ok
test_snat (__main__.TestNAT.test_snat) ... ok
test_snat_groups (__main__.TestNAT.test_snat_groups) ... 
WARNING: IP address 203.0.113.1 does not exist on the system!

ok
test_snat_net_port_map (__main__.TestNAT.test_snat_net_port_map) ... ok
test_snat_required_translation_address (__main__.TestNAT.test_snat_required_translation_address) ... 
Source NAT configuration error in rule 5: translation requires address
and/or port

ok
test_static_nat (__main__.TestNAT.test_static_nat) ... ok

----------------------------------------------------------------------
Ran 11 tests in 31.450s

OK
vyos@T6075:~$ 
```
NOTE about smoketests: I have skipped test  [test_nested_groups](https://github.com/vyos/vyos-1x/blob/current/smoketest/scripts/cli/test_firewall.py#L151C8-L151C27) because, at least on local environment, it's not working and hangs out forever.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
