### PR TITLE
T2447: add configurable kernel boot option 'disable-power-saving'

### DIFF
--- a/interface-definitions/system_option.xml.in
+++ b/interface-definitions/system_option.xml.in
@@ -43,6 +43,12 @@
                    <valueless/>
                  </properties>
                </leafNode>
+               <leafNode name="disable-power-saving">
+                <properties>
+                  <help>Disable CPU power saving mechanisms also known as C states</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
              </children>
            </node>
            <leafNode name="keyboard-layout">

--- a/src/conf_mode/system_option.py
+++ b/src/conf_mode/system_option.py
@@ -92,6 +92,8 @@ def generate(options):
     if 'kernel' in options:
         if 'disable_mitigations' in options['kernel']:
             cmdline_options.append('mitigations=off')
+        if 'disable_power_saving' in options['kernel']:
+            cmdline_options.append('intel_idle.max_cstate=0 processor.max_cstate=1')
     grub_util.update_kernel_cmdline_options(' '.join(cmdline_options))
 
     return None


### PR DESCRIPTION
Lower available CPU C states to a minimum if this option set.
This will set Kernel command-line options `intel_idle.max_cstate=0 processor.max_cstate=1`.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T2447

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/2886
* https://github.com/vyos/vyos-documentation/pull/1307

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
Kernel commandline options

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

* `set system option kernel disable-power-saving`



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
