### PR TITLE
conntrack-sync: T6057: Add ability to disable syslog for conntrackd

### DIFF
--- a/data/templates/conntrackd/conntrackd.conf.j2
+++ b/data/templates/conntrackd/conntrackd.conf.j2
@@ -76,7 +76,7 @@ General {
     HashSize {{ hash_size }}
     HashLimit {{ table_size | int *2 }}
     LogFile off
-    Syslog on
+    Syslog {{ 'off' if disable_syslog is vyos_defined else 'on' }}
     LockFile /var/lock/conntrack.lock
     UNIX {
         Path /var/run/conntrackd.ctl

--- a/interface-definitions/service_conntrack-sync.xml.in
+++ b/interface-definitions/service_conntrack-sync.xml.in
@@ -52,6 +52,12 @@
               <valueless/>
             </properties>
           </leafNode>
+          <leafNode name="disable-syslog">
+            <properties>
+              <help>Disable connection logging via Syslog</help>
+              <valueless/>
+            </properties>
+          </leafNode>
           <leafNode name="event-listen-queue-size">
             <properties>
               <help>Queue size for local conntrack events</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to disable syslog for conntrackd

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6057

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-documentation/pull/1312

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
conntrack-sync

## Proposed changes
<!--- Describe your changes in detail -->
Ability to disable syslog for conntrackd

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set high-availability vrrp group internal address 10.0.0.10 interface 'eth0'
set high-availability vrrp group internal interface 'eth0'
set high-availability vrrp group internal vrid '36'
set high-availability vrrp sync-group syncgrp member 'internal'
set service conntrack-sync failover-mechanism vrrp sync-group 'syncgrp'
set service conntrack-sync interface eth0
set service conntrack-sync disable-syslog
commit
```
Expected result:
```
vyos@vyos:~$ cat /run/conntrackd/conntrackd.conf | grep Syslog
    Syslog off
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
