### PR TITLE
remote: T6104: fix logic of failure case in MissingHostKeyPolicy

### DIFF
--- a/python/vyos/remote.py
+++ b/python/vyos/remote.py
@@ -43,6 +43,7 @@ from vyos.utils.io import print_error
 from vyos.utils.misc import begin
 from vyos.utils.process import cmd, rc_cmd
 from vyos.version import get_version
+from vyos.base import Warning
 
 CHUNK_SIZE = 8192
 
@@ -54,13 +55,16 @@ class InteractivePolicy(MissingHostKeyPolicy):
     def missing_host_key(self, client, hostname, key):
         print_error(f"Host '{hostname}' not found in known hosts.")
         print_error('Fingerprint: ' + key.get_fingerprint().hex())
-        if sys.stdin.isatty() and ask_yes_no('Do you wish to continue?'):
-            if client._host_keys_filename\
-               and ask_yes_no('Do you wish to permanently add this host/key pair to known hosts?'):
-                client._host_keys.add(hostname, key.get_name(), key)
-                client.save_host_keys(client._host_keys_filename)
-        else:
+        if not sys.stdin.isatty():
+            return
+        if not ask_yes_no('Do you wish to continue?'):
             raise SSHException(f"Cannot connect to unknown host '{hostname}'.")
+        if client._host_keys_filename is None:
+            Warning('no \'known_hosts\' file; create to store keys permanently')
+            return
+        if ask_yes_no('Do you wish to permanently add this host/key pair to known_hosts file?'):
+            client._host_keys.add(hostname, key.get_name(), key)
+            client.save_host_keys(client._host_keys_filename)
 
 class SourceAdapter(HTTPAdapter):
     """


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

N.B.: this _should_ be backported to Sagitta, but can not be cherry-picked, as some minor changes for T4038 will not be backported yet, as discussed. A 'mergifyio' can be added with manual intervention, or an independent PR will be submitted.

Clean up logic of remote upload in non-interactive case, for example, via http-api. Previously, it would silently fail. As this had not always been the case, it was introduced somewhere along recent development; an earlier version appeared to have caused the config-sync lockup in https://vyos.dev/T5348, which (1) was a non-issue, of course, once the silent failure was introduced (2) is no longer an issue after this PR.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6104
* https://vyos.dev/T5348

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
