### PR TITLE
pki: T6105: load ACME fullchain into PKI instead of cert

### DIFF
--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -110,7 +110,7 @@ def config_dict_mangle_acme(name, cli_dict):
         vyos_certbot_dir = directories['certbot']
 
         if 'acme' in cli_dict:
-            tmp = read_file(f'{vyos_certbot_dir}/live/{name}/cert.pem')
+            tmp = read_file(f'{vyos_certbot_dir}/live/{name}/fullchain.pem')
             tmp = load_certificate(tmp, wrap_tags=False)
             cert_base64 = "".join(encode_certificate(tmp).strip().split("\n")[1:-1])
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Load the `fullchain.pem` from ACME/Let's encrypt instead of only the `chain.pem`. This allows nginx to serve the entire certificate chain instead of just the server certificate. Clients are unable to verify the certificate because the chain is not presented

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6105

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pki

## Proposed changes
<!--- Describe your changes in detail -->

Load the `fullchain.pem` from ACME/Let's encrypt instead of only the `chain.pem`. This allows nginx to serve the entire certificate chain instead of just the server certificate. Clients are unable to verify the certificate because the chain is not presented

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

TODO

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
