### PR TITLE
snmp: T2998: SNMP v3 oid "exclude" option fix

### DIFF
--- a/data/templates/snmp/etc.snmpd.conf.j2
+++ b/data/templates/snmp/etc.snmpd.conf.j2
@@ -141,8 +141,13 @@ trap2sink {{ trap }}:{{ trap_config.port }} {{ trap_config.community }}
 # views
 {%         for view, view_config in v3.view.items() %}
 {%             if view_config.oid is vyos_defined %}
-{%                 for oid in view_config.oid %}
+{%                 for oid, oid_config in view_config.oid.items() %}
 view {{ view }} included .{{ oid }}
+{%                     if oid_config.exclude is vyos_defined %}
+{%                         for excluded in oid_config.exclude %}
+view {{ view }} excluded .{{ excluded }}
+{%                         endfor %}
+{%                     endif %}
 {%                 endfor %}
 {%             endif %}
 {%         endfor %}

--- a/interface-definitions/service_snmp.xml.in
+++ b/interface-definitions/service_snmp.xml.in
@@ -543,6 +543,7 @@
                       <leafNode name="exclude">
                         <properties>
                           <help>Exclude is an optional argument</help>
+                          <multi/>
                         </properties>
                       </leafNode>
                       <leafNode name="mask">

--- a/smoketest/scripts/cli/test_service_snmp.py
+++ b/smoketest/scripts/cli/test_service_snmp.py
@@ -229,5 +229,22 @@ class TestSNMPService(VyOSUnitTestSHIM.TestCase):
         tmp = call(f'snmpwalk -v 3 -u {snmpv3_user} -a MD5 -A {snmpv3_auth_pw} -x DES -X {snmpv3_priv_pw} -l authPriv 127.0.0.1', stdout=DEVNULL)
         self.assertEqual(tmp, 0)
 
+    def test_snmpv3_view_exclude(self):
+        snmpv3_view_oid_exclude = ['1.3.6.1.2.1.4.21', '1.3.6.1.2.1.4.24']
+
+        self.cli_set(base_path + ['v3', 'group', snmpv3_group, 'view', snmpv3_view])
+        self.cli_set(base_path + ['v3', 'view', snmpv3_view, 'oid', snmpv3_view_oid])
+
+        for excluded in snmpv3_view_oid_exclude:
+            self.cli_set(base_path + ['v3', 'view', snmpv3_view, 'oid', snmpv3_view_oid, 'exclude', excluded])
+
+        self.cli_commit()
+
+        tmp = read_file(SNMPD_CONF)
+        # views
+        self.assertIn(f'view {snmpv3_view} included .{snmpv3_view_oid}', tmp)
+        for excluded in snmpv3_view_oid_exclude:
+            self.assertIn(f'view {snmpv3_view} excluded .{excluded}', tmp)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
SNMP v3 oid "exclude" option fixed

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T2998

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
snmp

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set service snmp v3 group ipRoute view 'ipRoute'
set service snmp v3 view ipRoute oid 1.3.6.1.2.1 exclude '1.3.6.1.2.1.4.21'
set service snmp v3 view ipRoute oid 1.3.6.1.2.1 exclude '1.3.6.1.2.1.4.24'
commit
```
expected result:
```
vyos@vyos# show service snmp v3
 group ipRoute {
     view ipRoute
 }
 view ipRoute {
     oid 1.3.6.1.2.1 {
         exclude 1.3.6.1.2.1.4.21
         exclude 1.3.6.1.2.1.4.24
     }
 }

vyos@vyos# cat /etc/snmp/snmpd.conf | grep view
# views
view ipRoute included .1.3.6.1.2.1
view ipRoute excluded .1.3.6.1.2.1.4.21
view ipRoute excluded .1.3.6.1.2.1.4.24
[edit]
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ sudo nano /usr/libexec/vyos/tests/smoke/cli/test_service_snmp.py
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_snmp.py
test_snmp_basic (__main__.TestSNMPService.test_snmp_basic) ... ok
test_snmpv3_md5 (__main__.TestSNMPService.test_snmpv3_md5) ... ok
test_snmpv3_sha (__main__.TestSNMPService.test_snmpv3_sha) ... ok
test_snmpv3_view_exclude (__main__.TestSNMPService.test_snmpv3_view_exclude) ... ok

----------------------------------------------------------------------
Ran 4 tests in 33.594s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
