### PR TITLE
T6110: dhcp: add error check when fail-over is enabled on a subnet, but range is not defined.

### DIFF
--- a/src/conf_mode/dhcp_server.py
+++ b/src/conf_mode/dhcp_server.py
@@ -174,8 +174,11 @@ def verify(dhcp):
             # DHCP failover needs at least one subnet that uses it
             if 'enable_failover' in subnet_config:
                 if 'failover' not in dhcp:
-                    raise ConfigError(f'Can not enable failover for "{subnet}" in "{network}".\n' \
+                    raise ConfigError(f'Cannot enable failover for "{subnet}" in "{network}".\n' \
                                       'Failover is not configured globally!')
+                if 'range' not in subnet_config:
+                    raise ConfigError(f'Cannot enable failover for "{subnet}" in "{network}".\n' \
+                                      f'Range is not configured for "{subnet}"')
                 failover_ok = True
 
             # Check if DHCP address range is inside configured subnet declaration


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Catch error when configuration is wrong.
Fail-over feature for isc is tied to pool definitions. So If `enable-failover` is defined,  `range` is mandatory.  

More information: https://kb.isc.org/docs/aa-01356
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6110

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-server

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@136# compare commands 
set service dhcp-server failover name 'FOO'
set service dhcp-server failover remote '198.51.100.2'
set service dhcp-server failover source-address '198.51.100.1'
set service dhcp-server failover status 'primary'
set service dhcp-server listen-address '198.51.100.1'
set service dhcp-server shared-network-name TEST-NET subnet 198.51.100.0/24 default-router '198.51.100.1'
set service dhcp-server shared-network-name TEST-NET subnet 198.51.100.0/24 'enable-failover'
set service dhcp-server shared-network-name TEST-NET subnet 198.51.100.0/24 static-mapping customer1 ip-address '198.51.100.55'
set service dhcp-server shared-network-name TEST-NET subnet 198.51.100.0/24 static-mapping customer1 mac-address '00:11:22:33:44:55'
[edit]
vyos@136# commit
[ service dhcp-server ]
Can not enable failover for "198.51.100.0/24" in "TEST-NET". Range is
not configured for "198.51.100.0/24"

[[service dhcp-server]] failed
Commit failed
[edit]
vyos@136# 

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@136# sudo /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py 
test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer) ... ok
test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer) ... ok
test_dhcp_failover (__main__.TestServiceDHCPServer) ... ok
test_dhcp_invalid_raw_options (__main__.TestServiceDHCPServer) ... ok
test_dhcp_multiple_pools (__main__.TestServiceDHCPServer) ... ok
test_dhcp_relay_server (__main__.TestServiceDHCPServer) ... ok
test_dhcp_single_pool_options (__main__.TestServiceDHCPServer) ... ok
test_dhcp_single_pool_range (__main__.TestServiceDHCPServer) ... ok
test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer) ... ok

----------------------------------------------------------------------
Ran 9 tests in 19.499s

OK
[edit]
vyos@136# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
