### PR TITLE
conntrack: T4022: add RTSP conntrack helper

### DIFF
--- a/data/templates/conntrack/nftables-helpers.j2
+++ b/data/templates/conntrack/nftables-helpers.j2
@@ -31,6 +31,12 @@
     }
 {% endif %}
 
+{% if modules.rtsp is vyos_defined and ipv4 %}
+    ct helper rtsp_tcp {
+        type "rtsp" protocol tcp;
+    }
+{% endif %}
+
 {% if modules.sip is vyos_defined %}
     ct helper sip_tcp {
         type "sip" protocol tcp;

--- a/debian/control
+++ b/debian/control
@@ -256,6 +256,9 @@ Depends:
 # For "nat64"
   jool,
 # End "nat64"
+# For "system conntrack modules rtsp"
+  nat-rtsp,
+# End "system conntrack modules rtsp"
 # For "system ntp"
   chrony,
 # End "system ntp"

--- a/interface-definitions/include/firewall/conntrack-helper.xml.i
+++ b/interface-definitions/include/firewall/conntrack-helper.xml.i
@@ -22,6 +22,10 @@
       <description>Related traffic from NFS helper</description>
     </valueHelp>
     <valueHelp>
+      <format>rtsp</format>
+      <description>Related traffic from RTSP helper</description>
+    </valueHelp>
+    <valueHelp>
       <format>sip</format>
       <description>Related traffic from SIP helper</description>
     </valueHelp>
@@ -34,7 +38,7 @@
       <description>Related traffic from SQLNet helper</description>
     </valueHelp>
     <constraint>
-      <regex>(ftp|h323|pptp|nfs|sip|tftp|sqlnet)</regex>
+      <regex>(ftp|h323|pptp|nfs|rtsp|sip|tftp|sqlnet)</regex>
     </constraint>
     <multi/>
   </properties>

--- a/interface-definitions/system_conntrack.xml.in
+++ b/interface-definitions/system_conntrack.xml.in
@@ -289,6 +289,12 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <leafNode name="rtsp">
+                <properties>
+                  <help>RTSP connection tracking</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
               <leafNode name="sip">
                 <properties>
                   <help>SIP connection tracking</help>

--- a/smoketest/scripts/cli/test_system_conntrack.py
+++ b/smoketest/scripts/cli/test_system_conntrack.py
@@ -174,12 +174,16 @@ class TestSystemConntrack(VyOSUnitTestSHIM.TestCase):
             'pptp': {
                 'driver': ['nf_nat_pptp', 'nf_conntrack_pptp'],
                 'nftables': ['ct helper set "pptp_tcp"']
-             },
+            },
+            'rtsp': {
+                'driver': ['nf_nat_rtsp', 'nf_conntrack_rtsp'],
+                'nftables': ['ct helper set "rtsp_tcp"']
+            },
             'sip': {
                 'driver': ['nf_nat_sip', 'nf_conntrack_sip'],
                 'nftables': ['ct helper set "sip_tcp"',
                              'ct helper set "sip_udp"']
-             },
+            },
             'sqlnet': {
                 'nftables': ['ct helper set "tns_tcp"']
             },

--- a/src/conf_mode/system_conntrack.py
+++ b/src/conf_mode/system_conntrack.py
@@ -58,6 +58,11 @@ module_map = {
         'nftables': ['tcp dport {1723} ct helper set "pptp_tcp" return'],
         'ipv4': True
      },
+    'rtsp': {
+        'ko': ['nf_nat_rtsp', 'nf_conntrack_rtsp'],
+        'nftables': ['tcp dport {554} ct helper set "rtsp_tcp" return'],
+        'ipv4': True
+    },
     'sip': {
         'ko': ['nf_nat_sip', 'nf_conntrack_sip'],
         'nftables': ['tcp dport {5060,5061} ct helper set "sip_tcp" return',
@@ -195,7 +200,7 @@ def generate(conntrack):
 def apply(conntrack):
     # Depending on the enable/disable state of the ALG (Application Layer Gateway)
     # modules we need to either insmod or rmmod the helpers.
-    
+
     add_modules = []
     rm_modules = []
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4022

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-build/pull/525

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
conntrack

## Proposed changes
<!--- Describe your changes in detail -->
Adds `system conntrack modules rtsp` configurable
Adds nat-rtsp package built in vyos-build to dependencies, containing accompanying kernel module

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
RTSP is generally used by ISP-s to provide on demand video service. Assuming the user has access to such service, they can simply initiate a RTSP stream by playing something from their set top box. Without a working helper, the server will not be able to send a stream to the client after the initial handshake.

`lsmod | grep rtsp` (empty, kernel module not loaded)
`configure`
`set system conntrack modules rtsp`
`commit`
`lsmod | grep rtsp` (nf_conntrack_rtsp and nf_nat_rtsp loaded)

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
$ /usr/libexec/vyos/tests/smoke/cli/test_system_conntrack.py
test_conntrack_hash_size (__main__.TestSystemConntrack.test_conntrack_hash_size) ... ok
test_conntrack_ignore (__main__.TestSystemConntrack.test_conntrack_ignore) ... ok
test_conntrack_module_enable (__main__.TestSystemConntrack.test_conntrack_module_enable) ... ok
test_conntrack_options (__main__.TestSystemConntrack.test_conntrack_options) ... ok
test_conntrack_timeout_custom (__main__.TestSystemConntrack.test_conntrack_timeout_custom) ... ok

----------------------------------------------------------------------
Ran 5 tests in 48.378s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
