### PR TITLE
dhcp-client: T6093: extend regex for client class-id's with DOT (backport #3117) 

### DIFF
--- a/interface-definitions/include/constraint/dhcp-client-string-option.xml.i
+++ b/interface-definitions/include/constraint/dhcp-client-string-option.xml.i
@@ -1,4 +1,4 @@
 <!-- include start from constraint/dhcp-client-string-option.xml.i -->
-<regex>[-_a-zA-Z0-9\s]+</regex>
+<regex>[-_a-zA-Z0-9.\s]+</regex>
 <regex>([a-fA-F0-9][a-fA-F0-9]:){2,}[a-fA-F0-9][a-fA-F0-9]</regex>
 <!-- include end -->


### PR DESCRIPTION
This is a manual backport of pull request https://github.com/vyos/vyos-1x/pull/3117