### PR TITLE
T6114: fix broken migration dhcpv6-server 4-to-5

### DIFF
--- a/src/migration-scripts/dhcpv6-server/4-to-5
+++ b/src/migration-scripts/dhcpv6-server/4-to-5
@@ -42,8 +42,11 @@ def find_subnet_interface(subnet):
     def check_addr(if_path):
         if config.exists(if_path + ['address']):
             for addr in config.return_values(if_path + ['address']):
-                if ip_network(addr, strict=False) == subnet_net:
-                    return True
+                try:
+                    if ip_network(addr, strict=False) == subnet_net:
+                        return True
+                except:
+                    pass # interface address was probably "dhcp" or other magic string
         return None
 
     for iftype in config.list_nodes(['interfaces']):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The migration script seems to choke on `address dhcp` (or any `address` line that does not contain a valid IPv4 or IPv6 address). This PR fixes by catching the ip_network class exception and ignoring the address value.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6114

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcpv6-server

## Proposed changes
<!--- Describe your changes in detail -->
See summary/ticket.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Load a configuration from a vyos build prior to Feb. 12th 2024 that contains an interface using `address dhcp` and a dhcpv6-server configuration that references a subnet configured on another interface. Confirm the migration runs successfully and adds the `interface` option.

Example configuration:
```
 interfaces {
     ethernet eth0 {
         address dhcp
         address dhcpv6
         description WAN
         dhcpv6-options {
             pd 0 {
                 interface eth1 {
                     address 1
                     sla-id 2
                 }
                 interface eth2 {
                     address 1
                     sla-id 1
                 }
                 length 56
             }
             rapid-commit
         }
     }
     ethernet eth1 {
         address 10.23.55.1/24
         address fdcc:2200:a8ee:2355::1/64
         description LAN1
     }
     ethernet eth2 {
         address 10.23.56.1/24
         address fdcc:2200:a8ee:2356::1/64
         description LAN2
     }
     loopback lo {
     }
 }
 service {
     dhcp-server {
         shared-network-name LAN1 {
             authoritative
             description LAN1
             subnet 10.23.55.0/24 {
                 lease 86400
                 option {
                     default-router 10.23.55.1
                     name-server 10.23.55.1
                 }
                 range 0 {
                     start 10.23.55.15
                     stop 10.23.55.254
                 }
                 subnet-id 1
             }
         }
         shared-network-name LAN2 {
             authoritative
             description LAN2
             subnet 10.23.56.0/24 {
                 lease 86400
                 option {
                     default-router 10.23.56.1
                     name-server 10.23.56.1
                 }
                 range 0 {
                     start 10.23.56.10
                     stop 10.23.56.255
                 }
                 subnet-id 2
             }
         }
     }
     dhcpv6-server {
         shared-network-name LAN1 {
             common-options {
                 name-server fdcc:2200:a8ee:2355::1
             }
             subnet fdcc:2200:a8ee:2355::0/64 {
                 subnet-id 1
             }
         }
         shared-network-name LAN2 {
             common-options {
                 name-server fdcc:2200:a8ee:2356::1
             }
             subnet fdcc:2200:a8ee:2356::0/64 {
                 subnet-id 2
             }
         }
     }
}
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
N/A (smoketest does not cover migration)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
