### PR TITLE
snmp: T2998: SNMP v3 oid "exclude" option fix

### DIFF
--- a/data/templates/snmp/etc.snmpd.conf.tmpl
+++ b/data/templates/snmp/etc.snmpd.conf.tmpl
@@ -91,6 +91,11 @@ trap2sink {{ trap.target }}{{ ":" + trap.port if trap.port is defined }} {{ trap
 {%   for view in v3_views %}
 {%     for oid in view.oids %}
 view {{ view.name }} included .{{ oid.oid }}
+{%         if oid.exclude %}
+{%             for excl in oid.exclude %}
+view {{ view.name }} excluded .{{ excl }}
+{%             endfor %}
+{%         endif %}
 {%     endfor %}
 {%   endfor %}
 

--- a/interface-definitions/snmp.xml.in
+++ b/interface-definitions/snmp.xml.in
@@ -599,6 +599,7 @@
                       <leafNode name="exclude">
                         <properties>
                           <help>Exclude is an optional argument</help>
+                          <multi/>
                         </properties>
                       </leafNode>
                       <leafNode name="mask">

--- a/smoketest/scripts/cli/test_service_snmp.py
+++ b/smoketest/scripts/cli/test_service_snmp.py
@@ -225,5 +225,25 @@ class TestSNMPService(VyOSUnitTestSHIM.TestCase):
         # Check for running process
         self.assertTrue(process_named_running(PROCESS_NAME))
 
+    def test_snmpv3_view_exclude(self):
+        snmpv3_group = 'default_group'
+        snmpv3_view = 'default_view'
+        snmpv3_view_oid = '1'
+        snmpv3_view_oid_exclude = ['1.3.6.1.2.1.4.21', '1.3.6.1.2.1.4.24']
+
+        self.cli_set(base_path + ['v3', 'group', snmpv3_group, 'view', snmpv3_view])
+        self.cli_set(base_path + ['v3', 'view', snmpv3_view, 'oid', snmpv3_view_oid])
+
+        for excluded in snmpv3_view_oid_exclude:
+            self.cli_set(base_path + ['v3', 'view', snmpv3_view, 'oid', snmpv3_view_oid, 'exclude', excluded])
+
+        self.cli_commit()
+
+        tmp = read_file(SNMPD_CONF)
+        # views
+        self.assertIn(f'view {snmpv3_view} included .{snmpv3_view_oid}', tmp)
+        for excluded in snmpv3_view_oid_exclude:
+            self.assertIn(f'view {snmpv3_view} excluded .{excluded}', tmp)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/snmp.py
+++ b/src/conf_mode/snmp.py
@@ -384,9 +384,7 @@ def get_config():
                         'oid': oid
                     }
                     if conf.exists('v3 view {0} oid {1} exclude'.format(view, oid)):
-                        oid_cfg['exclude'] = []
-                        for exclude in conf.return_values('v3 view {0} oid {1} exclude'.format(view, oid)):
-                            oid_cfg['exclude'].append(exclude)
+                        oid_cfg['exclude'] = conf.return_values('v3 view {0} oid {1} exclude'.format(view, oid))
                     view_cfg['oids'].append(oid_cfg)
             snmp['v3_views'].append(view_cfg)
 

--- a/src/conf_mode/snmp.py
+++ b/src/conf_mode/snmp.py
@@ -383,6 +383,10 @@ def get_config():
                     oid_cfg = {
                         'oid': oid
                     }
+                    if conf.exists('v3 view {0} oid {1} exclude'.format(view, oid)):
+                        oid_cfg['exclude'] = []
+                        for exclude in conf.return_values('v3 view {0} oid {1} exclude'.format(view, oid)):
+                            oid_cfg['exclude'].append(exclude)
                     view_cfg['oids'].append(oid_cfg)
             snmp['v3_views'].append(view_cfg)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
SNMP v3 oid "exclude" option fixed

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T2998

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
snmp

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set service snmp v3 group ipRoute view 'ipRoute'
set service snmp v3 view ipRoute oid 1.3.6.1.2.1 exclude '1.3.6.1.2.1.4.21'
set service snmp v3 view ipRoute oid 1.3.6.1.2.1 exclude '1.3.6.1.2.1.4.24'
commit
```
expected result:
```
vyos@vyos# show service snmp v3
 group ipRoute {
     view ipRoute
 }
 view ipRoute {
     oid 1.3.6.1.2.1 {
         exclude 1.3.6.1.2.1.4.21
         exclude 1.3.6.1.2.1.4.24
     }
 }

vyos@vyos# cat /etc/snmp/snmpd.conf | grep view
# views
view ipRoute included .1.3.6.1.2.1
view ipRoute excluded .1.3.6.1.2.1.4.21
view ipRoute excluded .1.3.6.1.2.1.4.24
[edit]
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/bin/env python3 /usr/libexec/vyos/tests/smoke/cli/test_service_snmp.py
test_snmp_basic (__main__.TestSNMPService) ... ok
test_snmp_tcp (__main__.TestSNMPService) ... ok
test_snmpv3_md5 (__main__.TestSNMPService) ... ok
test_snmpv3_sha (__main__.TestSNMPService) ... ok
test_snmpv3_view_exclude (__main__.TestSNMPService) ... ok

----------------------------------------------------------------------
Ran 5 tests in 17.545s

OK

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
