### PR TITLE
vrrp: T6020: vrrp health-check script not applied correctly in keepal…

### DIFF
--- a/data/templates/high-availability/keepalived.conf.j2
+++ b/data/templates/high-availability/keepalived.conf.j2
@@ -33,6 +33,24 @@ global_defs {
     notify_fifo_script /usr/libexec/vyos/system/keepalived-fifo.py
 }
 
+{# Sync group has own health-check scripts T6020 #}
+{% if vrrp.sync_group is vyos_defined %}
+{%     for name, sync_group_config in vrrp.sync_group.items() if sync_group_config.disable is not vyos_defined %}
+{%         if sync_group_config.health_check is vyos_defined %}
+vrrp_script healthcheck_sg_{{ name }} {
+{%             if sync_group_config.health_check.script is vyos_defined %}
+    script "{{ sync_group_config.health_check.script }}"
+{%             elif sync_group_config.health_check.ping is vyos_defined %}
+    script "/usr/bin/ping -c1 {{ sync_group_config.health_check.ping }}"
+{%             endif %}
+    interval {{ sync_group_config.health_check.interval }}
+    fall {{ sync_group_config.health_check.failure_count }}
+    rise 1
+}
+{%         endif %}
+{%     endfor %}
+{% endif %}
+
 {% if vrrp.group is vyos_defined %}
 {%     for name, group_config in vrrp.group.items() if group_config.disable is not vyos_defined %}
 {%         if group_config.health_check is vyos_defined %}
@@ -132,7 +150,8 @@ vrrp_instance {{ name }} {
 {%             endfor %}
     }
 {%         endif %}
-{%         if group_config.health_check is vyos_defined %}
+{# Sync group member can't use own health check script #}
+{%         if group_config.health_check is vyos_defined and group_config._is_sync_group_member is not vyos_defined %}
     track_script {
         healthcheck_{{ name }}
     }
@@ -152,16 +171,12 @@ vrrp_sync_group {{ name }} {
 {%         endif %}
     }
 
-{# Health-check scripts should be in section sync-group if member is part of the sync-group T4081 #}
-{%         if vrrp.group is vyos_defined %}
-{%             for name, group_config in vrrp.group.items() if group_config.disable is not vyos_defined %}
-{%                 if group_config.health_check.script is vyos_defined and name in sync_group_config.member %}
+{%         if sync_group_config.health_check is vyos_defined %}
     track_script {
-        healthcheck_{{ name }}
+        healthcheck_sg_{{ name }}
     }
-{%                 endif %}
-{%             endfor %}
 {%         endif %}
+
 {%         if conntrack_sync_group is vyos_defined(name) %}
 {%             set vyos_helper = "/usr/libexec/vyos/vyos-vrrp-conntracksync.sh" %}
     notify_master "{{ vyos_helper }} master {{ name }}"

--- a/interface-definitions/high-availability.xml.in
+++ b/interface-definitions/high-availability.xml.in
@@ -345,6 +345,55 @@
                   </completionHelp>
                 </properties>
               </leafNode>
+              <node name="health-check">
+                <properties>
+                  <help>Health check</help>
+                </properties>
+                <children>
+                  <leafNode name="failure-count">
+                    <properties>
+                      <help>Health check failure count required for transition to fault</help>
+                      <constraint>
+                        <validator name="numeric" argument="--positive" />
+                      </constraint>
+                    </properties>
+                    <defaultValue>3</defaultValue>
+                  </leafNode>
+                  <leafNode name="interval">
+                    <properties>
+                      <help>Health check execution interval in seconds</help>
+                      <constraint>
+                        <validator name="numeric" argument="--positive"/>
+                      </constraint>
+                    </properties>
+                    <defaultValue>60</defaultValue>
+                  </leafNode>
+                  <leafNode name="ping">
+                    <properties>
+                      <help>ICMP ping health check</help>
+                      <valueHelp>
+                        <format>ipv4</format>
+                        <description>IPv4 ping target address</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>ipv6</format>
+                        <description>IPv6 ping target address</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="ip-address"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="script">
+                    <properties>
+                      <help>Health check script file</help>
+                      <constraint>
+                        <validator name="script"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
               #include <include/vrrp-transition-script.xml.i>
             </children>
           </tagNode>

--- a/smoketest/scripts/cli/test_high-availability_vrrp.py
+++ b/smoketest/scripts/cli/test_high-availability_vrrp.py
@@ -264,5 +264,58 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'    {peer_address_1}', config)
         self.assertIn(f'    {peer_address_2}', config)
 
+    def test_check_health_script(self):
+        sync_group = 'VyOS'
+
+        for group in groups:
+            vlan_id = group.lstrip('VLAN')
+            vip = f'100.64.{vlan_id}.1/24'
+            group_base = base_path + ['vrrp', 'group', group]
+
+            self.cli_set(['interfaces', 'ethernet', vrrp_interface, 'vif', vlan_id, 'address', inc_ip(vip, 1) + '/' + vip.split('/')[-1]])
+
+            self.cli_set(group_base + ['interface', f'{vrrp_interface}.{vlan_id}'])
+            self.cli_set(group_base + ['address', vip])
+            self.cli_set(group_base + ['vrid', vlan_id])
+
+            self.cli_set(group_base + ['health-check', 'ping', '127.0.0.1'])
+
+        # commit changes
+        self.cli_commit()
+
+        for group in groups:
+            config = getConfig(f'vrrp_instance {group}')
+            self.assertIn(f'track_script', config)
+
+        self.cli_set(base_path + ['vrrp', 'sync-group', sync_group, 'member', groups[0]])
+
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_delete(base_path + ['vrrp', 'group', groups[0], 'health-check'])
+        self.cli_commit()
+
+        for group in groups[1:]:
+            config = getConfig(f'vrrp_instance {group}')
+            self.assertIn(f'track_script', config)
+
+        config = getConfig(f'vrrp_instance {groups[0]}')
+        self.assertNotIn(f'track_script', config)
+
+        config = getConfig(f'vrrp_sync_group {sync_group}')
+        self.assertNotIn(f'track_script', config)
+
+        self.cli_set(base_path + ['vrrp', 'sync-group', sync_group, 'health-check', 'ping', '127.0.0.1'])
+
+        # commit changes
+        self.cli_commit()
+
+        config = getConfig(f'vrrp_instance {groups[0]}')
+        self.assertNotIn(f'track_script', config)
+
+        config = getConfig(f'vrrp_sync_group {sync_group}')
+        self.assertIn(f'track_script', config)
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/high-availability.py
+++ b/src/conf_mode/high-availability.py
@@ -86,16 +86,7 @@ def verify(ha):
                     raise ConfigError(f'Authentication requires both type and passwortd to be set in VRRP group "{group}"')
 
             if 'health_check' in group_config:
-                health_check_types = ["script", "ping"]
-                from vyos.utils.dict import check_mutually_exclusive_options
-                try:
-                    check_mutually_exclusive_options(group_config["health_check"], health_check_types, required=True)
-                except ValueError:
-                    Warning(f'Health check configuration for VRRP group "{group}" will remain unused ' \
-                            f'until it has one of the following options: {health_check_types}')
-                    # XXX: health check has default options so we need to remove it
-                    # to avoid generating useless config statements in keepalived.conf
-                    del group_config["health_check"]
+                _validate_health_check(group, group_config)
 
             # Keepalived doesn't allow mixing IPv4 and IPv6 in one group, so we mirror that restriction
             # We also need to make sure VRID is not used twice on the same interface with the
@@ -146,11 +137,22 @@ def verify(ha):
     # Check sync groups
     if 'vrrp' in ha and 'sync_group' in ha['vrrp']:
         for sync_group, sync_config in ha['vrrp']['sync_group'].items():
+            if 'health_check' in sync_config:
+                _validate_health_check(sync_group, sync_config)
+
             if 'member' in sync_config:
                 for member in sync_config['member']:
                     if member not in ha['vrrp']['group']:
                         raise ConfigError(f'VRRP sync-group "{sync_group}" refers to VRRP group "{member}", '\
                                           'but it does not exist!')
+                    else:
+                        ha['vrrp']['group'][member]['_is_sync_group_member'] = True
+                        if ha['vrrp']['group'][member].get('health_check') is not None:
+                            raise ConfigError(
+                                f'Health check configuration for VRRP group "{member}" will remain unused '
+                                f'while it has member of sync group "{sync_group}" '
+                                f'Only sync group health check will be used'
+                            )
 
     # Virtual-server
     if 'virtual_server' in ha:
@@ -170,6 +172,21 @@ def verify(ha):
         for rs, rs_config in vs_config['real_server'].items():
             if 'port' not in rs_config:
                 raise ConfigError(f'Port is required but not set for virtual-server "{vs}" real-server "{rs}"')
+
+
+def _validate_health_check(group, group_config):
+    health_check_types = ["script", "ping"]
+    from vyos.utils.dict import check_mutually_exclusive_options
+    try:
+        check_mutually_exclusive_options(group_config["health_check"],
+                                         health_check_types, required=True)
+    except ValueError:
+        Warning(
+            f'Health check configuration for VRRP group "{group}" will remain unused ' \
+            f'until it has one of the following options: {health_check_types}')
+        # XXX: health check has default options so we need to remove it
+        # to avoid generating useless config statements in keepalived.conf
+        del group_config["health_check"]
 
 
 def generate(ha):


### PR DESCRIPTION
[T6020](https://vyos.dev/T6020): vrrp health-check script not applied correctly in keepalived.conf

Added health check to sync-group in CLI
Don't use instance health-check when instance in sync group member
Warning notify for health-check config problem
New smoke test

It is a backport for PR https://github.com/vyos/vyos-1x/pull/2966

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added health check to sync-group in CLI
Don't use instance health-check when instance in sync group member
New smoke test

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): backport

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6020

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_high-availability_vrrp.py
test_01_default_values (__main__.TestVRRP.test_01_default_values) ... ok
test_02_simple_options (__main__.TestVRRP.test_02_simple_options) ... ok
test_03_sync_group (__main__.TestVRRP.test_03_sync_group) ... ok
test_04_exclude_vrrp_interface (__main__.TestVRRP.test_04_exclude_vrrp_interface) ... ok
test_05_set_multiple_peer_address (__main__.TestVRRP.test_05_set_multiple_peer_address) ... ok
test_check_health_script (__main__.TestVRRP.test_check_health_script) ... ok

----------------------------------------------------------------------
Ran 6 tests in 48.770s

OK
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
