### PR TITLE
conntrack: T5080: Fix rule order for applied conntrack modules

### DIFF
--- a/src/conf_mode/system_conntrack.py
+++ b/src/conf_mode/system_conntrack.py
@@ -42,33 +42,33 @@ nftables_ct_file = r'/run/nftables-ct.conf'
 module_map = {
     'ftp': {
         'ko': ['nf_nat_ftp', 'nf_conntrack_ftp'],
-        'nftables': ['ct helper set "ftp_tcp" tcp dport {21} return']
+        'nftables': ['tcp dport {21} ct helper set "ftp_tcp" return']
     },
     'h323': {
         'ko': ['nf_nat_h323', 'nf_conntrack_h323'],
-        'nftables': ['ct helper set "ras_udp" udp dport {1719} return',
-                     'ct helper set "q931_tcp" tcp dport {1720} return']
+        'nftables': ['udp dport {1719} ct helper set "ras_udp" return',
+                     'tcp dport {1720} ct helper set "q931_tcp" return']
     },
     'nfs': {
-        'nftables': ['ct helper set "rpc_tcp" tcp dport {111} return',
-                     'ct helper set "rpc_udp" udp dport {111} return']
+        'nftables': ['tcp dport {111} ct helper set "rpc_tcp" return',
+                     'udp dport {111} ct helper set "rpc_udp" return']
     },
     'pptp': {
         'ko': ['nf_nat_pptp', 'nf_conntrack_pptp'],
-        'nftables': ['ct helper set "pptp_tcp" tcp dport {1723} return'],
+        'nftables': ['tcp dport {1723} ct helper set "pptp_tcp" return'],
         'ipv4': True
      },
     'sip': {
         'ko': ['nf_nat_sip', 'nf_conntrack_sip'],
-        'nftables': ['ct helper set "sip_tcp" tcp dport {5060,5061} return',
-                     'ct helper set "sip_udp" udp dport {5060,5061} return']
+        'nftables': ['tcp dport {5060,5061} ct helper set "sip_tcp" return',
+                     'udp dport {5060,5061} ct helper set "sip_udp" return']
      },
     'sqlnet': {
-        'nftables': ['ct helper set "tns_tcp" tcp dport {1521,1525,1536} return']
+        'nftables': ['tcp dport {1521,1525,1536} ct helper set "tns_tcp" return']
     },
     'tftp': {
         'ko': ['nf_nat_tftp', 'nf_conntrack_tftp'],
-        'nftables': ['ct helper set "tftp_udp" udp dport {69} return']
+        'nftables': ['udp dport {69} ct helper set "tftp_udp" return']
      },
 }
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixes order of matches for conntrack rules, thanks to @Ingramz

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5080

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
conntrack

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_system_conntrack.py
DEBUG - test_conntrack_hash_size (__main__.TestSystemConntrack.test_conntrack_hash_size) ... ok
DEBUG - test_conntrack_ignore (__main__.TestSystemConntrack.test_conntrack_ignore) ... ok
DEBUG - test_conntrack_module_enable (__main__.TestSystemConntrack.test_conntrack_module_enable) ... ok
DEBUG - test_conntrack_options (__main__.TestSystemConntrack.test_conntrack_options) ... ok
DEBUG - test_conntrack_timeout_custom (__main__.TestSystemConntrack.test_conntrack_timeout_custom) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 5 tests in 74.769s
DEBUG -
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
