### PR TITLE
radvd: T6118: add nat64prefix support RFC8781

### DIFF
--- a/data/templates/router-advert/radvd.conf.j2
+++ b/data/templates/router-advert/radvd.conf.j2
@@ -50,6 +50,13 @@ interface {{ iface }} {
 {%             endfor %}
     };
 {%         endif %}
+{%         if iface_config.nat64prefix is vyos_defined %}
+{%             for nat64prefix, nat64prefix_options in iface_config.nat64prefix.items() %}
+    nat64prefix {{ nat64prefix }} {
+        AdvValidLifetime {{ nat64prefix_options.valid_lifetime }};
+    };
+{%             endfor %}
+{%         endif %}
 {%         if iface_config.prefix is vyos_defined %}
 {%             for prefix, prefix_options in iface_config.prefix.items() %}
     prefix {{ prefix }} {

--- a/interface-definitions/service_router-advert.xml.in
+++ b/interface-definitions/service_router-advert.xml.in
@@ -225,6 +225,36 @@
                   </leafNode>
                 </children>
               </tagNode>
+              <tagNode name="nat64prefix">
+                <properties>
+                  <help>NAT64 prefix included in the router advertisements</help>
+                  <valueHelp>
+                    <format>ipv6net</format>
+                    <description>IPv6 prefix to be advertized</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="ipv6-prefix"/>
+                  </constraint>
+                </properties>
+                <children>
+                  <leafNode name="valid-lifetime">
+                    <properties>
+                      <help>Time in seconds that the prefix will remain valid</help>
+                      <completionHelp>
+                        <list>infinity</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>u32:4-65528</format>
+                        <description>Time in seconds that the prefix will remain valid</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 4-65528"/>
+                      </constraint>
+                    </properties>
+                    <defaultValue>65528</defaultValue>
+                  </leafNode>
+                </children>
+              </tagNode>
               <tagNode name="prefix">
                 <properties>
                   <help>IPv6 prefix to be advertised in Router Advertisements (RAs)</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add support for pref64 option, as defined in RFC8781. The prefix valid lifetime must not be smaller than the "interface interval max" definition which defaults to 600.

* `set service router-advert interface eth1 nat64prefix 64:ff9b::/96`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6118

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
radvd

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Extended build in smoketests

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_router-advert.py
test_common (__main__.TestServiceRADVD.test_common) ... ok
test_deprecate_prefix (__main__.TestServiceRADVD.test_deprecate_prefix) ... ok
test_dns (__main__.TestServiceRADVD.test_dns) ... ok
test_nat64prefix (__main__.TestServiceRADVD.test_nat64prefix) ... ok
test_rasrcaddress (__main__.TestServiceRADVD.test_rasrcaddress) ... ok
test_route (__main__.TestServiceRADVD.test_route) ... ok

----------------------------------------------------------------------
Ran 6 tests in 20.868s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
