### PR TITLE
grub: T4548: Fixed GRUB configuration files order

### DIFF
--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -786,6 +786,10 @@ def install_image() -> None:
             grub.install(install_target.name, f'{DIR_DST_ROOT}/boot/',
                          f'{DIR_DST_ROOT}/boot/efi')
 
+        # sort inodes (to make GRUB read config files in alphabetical order)
+        grub.sort_inodes(f'{DIR_DST_ROOT}/{grub.GRUB_DIR_VYOS}')
+        grub.sort_inodes(f'{DIR_DST_ROOT}/{grub.GRUB_DIR_VYOS_VERS}')
+
         # umount filesystems and remove temporary files
         if is_raid_install(install_target):
             cleanup([install_target.name],

--- a/src/system/grub_update.py
+++ b/src/system/grub_update.py
@@ -105,4 +105,8 @@ if __name__ == '__main__':
     else:
         render(grub_cfg_main, grub.TMPL_GRUB_MAIN, {})
 
+    # sort inodes (to make GRUB read config files in alphabetical order)
+    grub.sort_inodes(f'{root_dir}/{grub.GRUB_DIR_VYOS}')
+    grub.sort_inodes(f'{root_dir}/{grub.GRUB_DIR_VYOS_VERS}')
+
     exit(0)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed GRUB configuration files order

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4548
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
GRUB

## Proposed changes
<!--- Describe your changes in detail -->
To iterate files on ext* file systems GRUB reads their inodes one by one, ignoring names. This breaks our configuration logic that relies on proper loading order.

This commit adds a helper `sort_inodes()` that needs to be used whenever GRUB configuration files are created. It recreates files, changing their inodes in a way where inodes order matches alphabetical order.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Before:

```
vyos@vyos:~$ ls -li /lib/live/mount/persistence/boot/grub/grub.cfg.d/
total 24
36 -rw-r--r-- 1 root root   41 Mar 12 22:50 00-vyos-header.cfg
35 -rw-r--r-- 1 root root    0 Mar 12 22:50 10-vyos-modules-autoload.cfg
34 -rw-r--r-- 1 root root  272 Mar 12 22:50 20-vyos-defaults-autoload.cfg
33 -rw-r--r-- 1 root root  607 Mar 12 22:50 25-vyos-common-autoload.cfg
37 -rw-r--r-- 1 root root  133 Mar 12 22:50 40-vyos-menu-autoload.cfg
38 -rw-r--r-- 1 root root 1668 Mar 12 22:50 50-vyos-options.cfg
39 drwxr-xr-x 2 root root 4096 Mar 12 22:50 vyos-versions
```

After:

```
vyos@vyos:~$ ls -li /lib/live/mount/persistence/boot/grub/grub.cfg.d/
total 24
612 -rw-r--r-- 1 root root   41 Mar 12 23:01 00-vyos-header.cfg
613 -rw-r--r-- 1 root root    0 Mar 12 23:01 10-vyos-modules-autoload.cfg
614 -rw-r--r-- 1 root root  272 Mar 12 23:01 20-vyos-defaults-autoload.cfg
615 -rw-r--r-- 1 root root  607 Mar 12 23:01 25-vyos-common-autoload.cfg
616 -rw-r--r-- 1 root root  133 Mar 12 23:01 40-vyos-menu-autoload.cfg
617 -rw-r--r-- 1 root root 1668 Mar 12 23:01 50-vyos-options.cfg
 39 drwxr-xr-x 2 root root 4096 Mar 12 23:01 vyos-versions
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
