### PR TITLE
vrrp: T5504: Keepalived VRRP ability to set more than one peer-address

### DIFF
--- a/data/templates/vrrp/keepalived.conf.tmpl
+++ b/data/templates/vrrp/keepalived.conf.tmpl
@@ -83,7 +83,11 @@ vrrp_instance {{ name }} {
     nopreempt
 {%     endif %}
 {%     if group_config.peer_address is defined and group_config.peer_address is not none %}
-    unicast_peer { {{ group_config.peer_address }} }
+    unicast_peer {
+{%         for peer_address in group_config.peer_address %}
+        {{ peer_address }}
+{%         endfor %}
+    }
 {%     endif %}
 {%     if group_config.hello_source_address is defined and group_config.hello_source_address is not none %}
 {%       if group_config.peer_address is defined and group_config.peer_address is not none %}

--- a/interface-definitions/vrrp.xml.in
+++ b/interface-definitions/vrrp.xml.in
@@ -185,6 +185,7 @@
                     <validator name="ipv4-address"/>
                     <validator name="ipv6-address"/>
                   </constraint>
+                  <multi/>
                 </properties>
               </leafNode>
               <leafNode name="no-preempt">

--- a/smoketest/scripts/cli/test_ha_vrrp.py
+++ b/smoketest/scripts/cli/test_ha_vrrp.py
@@ -237,6 +237,33 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'track_interface', config)
         self.assertIn(f'    {none_vrrp_interface}', config)
 
+    def test_05_set_multiple_peer_address(self):
+        group = 'VyOS-WAN'
+        vlan_id = '24'
+        vip = '100.64.24.1/24'
+        peer_address_1 = '192.0.2.1'
+        peer_address_2 = '192.0.2.2'
+        vrid = '150'
+        group_base = base_path + ['group', group]
+
+        self.cli_set(['interfaces', 'ethernet', vrrp_interface, 'vif', vlan_id, 'address', '100.64.24.11/24'])
+        self.cli_set(group_base + ['interface', vrrp_interface])
+        self.cli_set(group_base + ['virtual-address', vip])
+        self.cli_set(group_base + ['peer-address', peer_address_1])
+        self.cli_set(group_base + ['peer-address', peer_address_2])
+        self.cli_set(group_base + ['vrid', vrid])
+
+        # commit changes
+        self.cli_commit()
+
+        config = getConfig(f'vrrp_instance {group}')
+
+        self.assertIn(f'interface {vrrp_interface}', config)
+        self.assertIn(f'virtual_router_id {vrid}', config)
+        self.assertIn(f'unicast_peer', config)
+        self.assertIn(f'    {peer_address_1}', config)
+        self.assertIn(f'    {peer_address_2}', config)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/vrrp.py
+++ b/src/conf_mode/vrrp.py
@@ -119,8 +119,9 @@ def verify(vrrp):
                         raise ConfigError(f'VRRP group "{group}" uses IPv4 but hello-source-address is IPv6!')
 
                 if 'peer_address' in group_config:
-                    if is_ipv6(group_config['peer_address']):
-                        raise ConfigError(f'VRRP group "{group}" uses IPv4 but peer-address is IPv6!')
+                    for peer_address in group_config['peer_address']:
+                        if is_ipv6(peer_address):
+                            raise ConfigError(f'VRRP group "{group}" uses IPv4 but peer-address is IPv6!')
 
             if vaddrs6:
                 if 'hello_source_address' in group_config:
@@ -128,8 +129,9 @@ def verify(vrrp):
                         raise ConfigError(f'VRRP group "{group}" uses IPv6 but hello-source-address is IPv4!')
 
                 if 'peer_address' in group_config:
-                    if is_ipv4(group_config['peer_address']):
-                        raise ConfigError(f'VRRP group "{group}" uses IPv6 but peer-address is IPv4!')
+                    for peer_address in group_config['peer_address']:
+                        if is_ipv4(peer_address):
+                            raise ConfigError(f'VRRP group "{group}" uses IPv6 but peer-address is IPv4!')
 
 
             # Warn the user about the deprecated mode-force option


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Keepalived VRRP ability to set more than one peer-address

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5504

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
high-availability vrrp

## Proposed changes
<!--- Describe your changes in detail -->
Added ability to set up more then 1 peer-address
```
vyos@vyos# cat /run/keepalived/keepalived.conf | sed -n "/^vrrp_instance foo/,/^}/p"
vrrp_instance foo {
    state BACKUP
    interface eth1
    virtual_router_id 101
    priority 123
    advert_int 1
    preempt_delay 0
    unicast_peer {
        192.0.2.2
        192.0.2.3
    }
    unicast_src_ip 192.0.2.1
    virtual_ipaddress {
        192.0.2.254/32
    }
}
```
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set high-availability vrrp group foo virtual-address 192.0.2.254/32
set high-availability vrrp group foo hello-source-address '192.0.2.1'
set high-availability vrrp group foo interface 'eth1'
set high-availability vrrp group foo peer-address '192.0.2.2'
set high-availability vrrp group foo peer-address '192.0.2.3'
set high-availability vrrp group foo priority '123'
set high-availability vrrp group foo vrid '101'
commit
```
Check unicast_peer configuration:
```
vyos@vyos# cat /run/keepalived/keepalived.conf | sed -n "/^vrrp_instance foo/,/^}/p"
vrrp_instance foo {
    state BACKUP
    interface eth1
    virtual_router_id 101
    priority 123
    advert_int 1
    preempt_delay 0
    unicast_peer {
        192.0.2.3
        192.0.2.2
    }
    unicast_src_ip 192.0.2.1
    virtual_ipaddress {
        192.0.2.254/32
    }
}
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$  /usr/libexec/vyos/tests/smoke/cli/test_ha_vrrp.py
test_01_default_values (__main__.TestVRRP) ... ok
test_02_simple_options (__main__.TestVRRP) ... ok
test_03_sync_group (__main__.TestVRRP) ... ok
test_04_exclude_vrrp_interface (__main__.TestVRRP) ... ok
test_05_set_multiple_peer_address (__main__.TestVRRP) ... ok

----------------------------------------------------------------------
Ran 5 tests in 34.384s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
