### PR TITLE
qos: T1871: add MTU option when configure limiter traffic-policy

### DIFF
--- a/interface-definitions/include/qos/mtu.xml.i
+++ b/interface-definitions/include/qos/mtu.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from qos/mtu.xml.i -->
+<leafNode name="mtu">
+  <properties>
+    <help>MTU size for this class</help>
+    <valueHelp>
+      <format>u32:256-65535</format>
+      <description>Bytes</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 256-65535"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/qos.xml.in
+++ b/interface-definitions/qos.xml.in
@@ -278,6 +278,7 @@
                   #include <include/generic-description.xml.i>
                   #include <include/qos/bandwidth.xml.i>
                   #include <include/qos/burst.xml.i>
+                  #include <include/qos/mtu.xml.i>
                   #include <include/qos/class-police-exceed.xml.i>
                   #include <include/qos/class-match.xml.i>
                   #include <include/qos/class-priority.xml.i>
@@ -293,6 +294,7 @@
                 <children>
                   #include <include/qos/bandwidth.xml.i>
                   #include <include/qos/burst.xml.i>
+                  #include <include/qos/mtu.xml.i>
                   #include <include/qos/class-police-exceed.xml.i>
                 </children>
               </node>

--- a/python/vyos/qos/base.py
+++ b/python/vyos/qos/base.py
@@ -324,6 +324,11 @@ class QoSBase:
                             if 'burst' in cls_config:
                                 burst = cls_config['burst']
                                 filter_cmd += f' burst {burst}'
+
+                            if 'mtu' in cls_config:
+                                mtu = cls_config['mtu']
+                                filter_cmd += f' mtu {mtu}'
+
                         cls = int(cls)
                         filter_cmd += f' flowid {self._parent:x}:{cls:x}'
                         self._cmd(filter_cmd)
@@ -386,6 +391,10 @@ class QoSBase:
                 if 'burst' in config['default']:
                     burst = config['default']['burst']
                     filter_cmd += f' burst {burst}'
+
+                if 'mtu' in config['default']:
+                    mtu = config['default']['mtu']
+                    filter_cmd += f' mtu {mtu}'
 
                 if 'class' in config:
                     filter_cmd += f' flowid {self._parent:x}:{default_cls_id:x}'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added MTU option for qos limiter traffic policy
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T1871

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set qos policy limiter T1871 default bandwidth '10mbit'
set qos policy limiter T1871 default burst '100kb'
set qos policy limiter T1871 default mtu 10000
set qos interface eth0 ingress T1871 
```

## Smoketest result
<!-- Provide the output of the smoketest
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_qos.py 
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... skipped 'tc returns invalid JSON here - needs iproute2 fix'
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok

----------------------------------------------------------------------
Ran 11 tests in 40.376s

OK (skipped=1)

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
