### PR TITLE
T6121: Extend service config-sync to new sections

### DIFF
--- a/interface-definitions/service_config-sync.xml.in
+++ b/interface-definitions/service_config-sync.xml.in
@@ -73,30 +73,382 @@
               </constraint>
             </properties>
           </leafNode>
-          <leafNode name="section">
+          <node name="section">
             <properties>
               <help>Section for synchronization</help>
-              <completionHelp>
-                <list>nat nat66 firewall</list>
-              </completionHelp>
-              <valueHelp>
-                <format>nat</format>
-                <description>NAT</description>
-              </valueHelp>
-              <valueHelp>
-                <format>nat66</format>
-                <description>NAT66</description>
-              </valueHelp>
-              <valueHelp>
-                <format>firewall</format>
-                <description>firewall</description>
-              </valueHelp>
-              <constraint>
-                <regex>(nat|nat66|firewall)</regex>
-              </constraint>
-              <multi/>
             </properties>
-          </leafNode>
+            <children>
+              <leafNode name="firewall">
+                <properties>
+                  <help>Firewall</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <node name="interfaces">
+                <properties>
+                  <help>Interfaces</help>
+                </properties>
+                <children>
+                  <leafNode name="bonding">
+                    <properties>
+                      <help>Bonding interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="bridge">
+                    <properties>
+                      <help>Bridge interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="dummy">
+                    <properties>
+                      <help>Dummy interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="ethernet">
+                    <properties>
+                      <help>Ethernet interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="geneve">
+                    <properties>
+                      <help>GENEVE interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="input">
+                    <properties>
+                      <help>Input interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="l2tpv3">
+                    <properties>
+                      <help>L2TPv3 interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="loopback">
+                    <properties>
+                      <help>Loopback interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="macsec">
+                    <properties>
+                      <help>MACsec interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="openvpn">
+                    <properties>
+                      <help>OpenVPN interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="pppoe">
+                    <properties>
+                      <help>PPPoE interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="pseudo-ethernet">
+                    <properties>
+                      <help>Pseudo-Ethernet interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="sstpc">
+                    <properties>
+                      <help>SSTP client interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="tunnel">
+                    <properties>
+                      <help>Tunnel interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="virtual-ethernet">
+                    <properties>
+                      <help>Virtual Ethernet interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="vti">
+                    <properties>
+                      <help>Virtual tunnel interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="vxlan">
+                    <properties>
+                      <help>VXLAN interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="wireguard">
+                    <properties>
+                      <help>Wireguard interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="wireless">
+                    <properties>
+                      <help>Wireless interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="wwan">
+                    <properties>
+                      <help>WWAN interface</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+              <leafNode name="nat">
+                <properties>
+                  <help>NAT</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="nat66">
+                <properties>
+                  <help>NAT66</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="pki">
+                <properties>
+                  <help>Public key infrastructure (PKI)</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="policy">
+                <properties>
+                  <help>Routing policy</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <node name="protocols">
+                <properties>
+                  <help>Routing protocols</help>
+                </properties>
+                <children>
+                  <leafNode name="babel">
+                    <properties>
+                      <help>Babel Routing Protocol</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="bfd">
+                    <properties>
+                      <help>Bidirectional Forwarding Detection (BFD)</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="bgp">
+                    <properties>
+                      <help>Border Gateway Protocol (BGP)</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="failover">
+                    <properties>
+                      <help>Failover route</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="igmp-proxy">
+                    <properties>
+                      <help>Internet Group Management Protocol (IGMP) proxy</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="isis">
+                    <properties>
+                      <help>Intermediate System to Intermediate System (IS-IS)</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="mpls">
+                    <properties>
+                      <help>Multiprotocol Label Switching (MPLS)</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="nhrp">
+                    <properties>
+                      <help>Next Hop Resolution Protocol (NHRP) parameters</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="ospf">
+                    <properties>
+                      <help>Open Shortest Path First (OSPF)</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="ospfv3">
+                    <properties>
+                      <help>Open Shortest Path First (OSPF) for IPv6</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="pim">
+                    <properties>
+                      <help>Protocol Independent Multicast (PIM) and IGMP</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="pim6">
+                    <properties>
+                      <help>Protocol Independent Multicast for IPv6 (PIMv6) and MLD</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="rip">
+                    <properties>
+                      <help>Routing Information Protocol (RIP) parameters</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="ripng">
+                    <properties>
+                      <help>Routing Information Protocol (RIPng) parameters</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="rpki">
+                    <properties>
+                      <help>Resource Public Key Infrastructure (RPKI)</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="segment-routing">
+                    <properties>
+                      <help>Segment Routing</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="static">
+                    <properties>
+                      <help>Static Routing</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+              <node name="service">
+                <properties>
+                  <help>System services</help>
+                </properties>
+                <children>
+                  <leafNode name="console-server">
+                    <properties>
+                      <help>Serial Console Server</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="dhcp-relay">
+                    <properties>
+                      <help>Host Configuration Protocol (DHCP) relay agent</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="dhcp-server">
+                    <properties>
+                      <help>Dynamic Host Configuration Protocol (DHCP) for DHCP server</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="dhcpv6-relay">
+                    <properties>
+                      <help>DHCPv6 Relay Agent parameters</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="dhcpv6-server">
+                    <properties>
+                      <help>DHCP for IPv6 (DHCPv6) server</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="dns">
+                    <properties>
+                      <help>Domain Name System (DNS) related services</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="lldp">
+                    <properties>
+                      <help>LLDP settings</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="mdns">
+                    <properties>
+                      <help>Multicast DNS (mDNS) parameters</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="monitoring">
+                    <properties>
+                      <help>Monitoring services</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="ndp-proxy">
+                    <properties>
+                      <help>Neighbor Discovery Protocol (NDP) Proxy</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="ntp">
+                    <properties>
+                      <help>Network Time Protocol (NTP) configuration</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="snmp">
+                    <properties>
+                      <help>Simple Network Management Protocol (SNMP)</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="tftp-server">
+                    <properties>
+                      <help>Trivial File Transfer Protocol (TFTP) server</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="webproxy">
+                    <properties>
+                      <help>Webproxy service settings</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+              <leafNode name="vpn">
+                <properties>
+                  <help>Virtual Private Network (VPN)</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="vrf">
+                <properties>
+                  <help>Virtual Routing and Forwarding</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+            </children>
+          </node>
         </children>
       </node>
     </children>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Extend `service config-sync` with new sections:
 - LeafNodes: pki, policy, vpn, vrf (syncs the whole sections)
 - Nodes: interfaces, protocols, service (syncs subsections)

In this case, the Node allows the use the next level section i.e., subsection

For example, any of the subsections of the node `interfaces`:
  - set service config-sync section interfaces pseudo-ethernet
  - set service config-sync section interfaces virtual-ethernet


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6121

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
config-sync
## Proposed changes
<!--- Describe your changes in detail -->

## How to test

Example of the config:
```
set service config-sync mode 'load'
set service config-sync secondary address '192.168.122.11'
set service config-sync secondary key 'xxx'
set service config-sync section firewall
set service config-sync section interfaces pseudo-ethernet
set service config-sync section interfaces virtual-ethernet
set service config-sync section nat
set service config-sync section nat66
set service config-sync section protocols static
set service config-sync section pki
set service config-sync section service ntp
set service config-sync section vrf
```
configure any section, for example `nat`:
```
vyos@r4# set nat source rule 100 outbound-interface name 'eth0'
[edit]
vyos@r4# set nat source rule 100 source address '10.0.0.0/24'
[edit]
vyos@r4# set nat source rule 100 translation address 'masquerade'
[edit]
vyos@r4# commit
INFO:vyos_config_sync:Config synchronization: Mode=load, Secondary=192.168.122.11
[edit]
vyos@r4# 

```
Be sure that configuration is applied on the `secondary node` for those sections:
```
vyos@r1-right# run show conf com | match "nat|static|virt|pseu"
set interfaces pseudo-ethernet peth0 description '2321'
set interfaces pseudo-ethernet peth0 source-interface 'eth0'
set interfaces virtual-ethernet veth10 description 'foo'
set interfaces virtual-ethernet veth10 peer-name 'veth11'
set interfaces virtual-ethernet veth11 peer-name 'veth10'
set nat source rule 100 outbound-interface name 'eth0'
set nat source rule 100 source address '10.0.0.0/24'
set nat source rule 100 translation address 'masquerade'
set protocols static route 0.0.0.0/0 next-hop 192.168.122.1

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
