### PR TITLE
T6090: policy: fix migration script

### DIFF
--- a/src/migration-scripts/policy/1-to-2
+++ b/src/migration-scripts/policy/1-to-2
@@ -32,23 +32,23 @@ file_name = argv[1]
 with open(file_name, 'r') as f:
     config_file = f.read()
 
-base = ['policy', 'ipv6-route']
+base = ['policy']
 config = ConfigTree(config_file)
 
 if not config.exists(base):
     # Nothing to do
     exit(0)
 
-config.rename(base, 'route6')
-config.set_tag(['policy', 'route6'])
+if config.exists(base + ['ipv6-route']):
+    config.rename(base + ['ipv6-route'],'route6')
+    config.set_tag(['policy', 'route6'])
 
 for route in ['route', 'route6']:
-    route_path = ['policy', route]
-    if config.exists(route_path):
-        for name in config.list_nodes(route_path):
-            if config.exists(route_path + [name, 'rule']):
-                for rule in config.list_nodes(route_path + [name, 'rule']):
-                    rule_tcp_flags = route_path + [name, 'rule', rule, 'tcp', 'flags']
+    if config.exists(base + [route]):
+        for name in config.list_nodes(base + [route]):
+            if config.exists(base + [route, name, 'rule']):
+                for rule in config.list_nodes(base + [route, name, 'rule']):
+                    rule_tcp_flags = base + [route, name, 'rule', rule, 'tcp', 'flags']
 
                     if config.exists(rule_tcp_flags):
                         tmp = config.return_value(rule_tcp_flags)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Migration script did not run if `policy ipv6-route` wasn't defined.
Now it's called properly.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6090

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
policy

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
First test:
```
vyos@136:~$ show config comm | grep policy
set interfaces ethernet eth3 policy route 'FOO'
set policy route FOO rule 10 protocol 'tcp'
set policy route FOO rule 10 set tcp-mss '1436'
set policy route FOO rule 10 tcp flags 'SYN'
vyos@136:~$ add system image vyos-1.5-rolling-202403151830-amd64.iso
Checking SHA256 checksums of files on the ISO image... OK.
Done!
What would you like to name this image? [1.5-rolling-202403151830]: 
OK.  This image will be named: 1.5-rolling-202403151830
Installing "1.5-rolling-202403151830" image.
Copying new release files...
Would you like to save the current configuration 
directory and config file? (Yes/No) [Yes]: Yes
Copying current configuration...
Would you like to save the SSH host keys from your 
current configuration? (Yes/No) [Yes]: 
Copying SSH keys...
Running post-install script...
Setting up grub configuration...
Done.
vyos@136:~$ 

....
After reboot:
....
[   30.772139] vyos-router[1087]: Mounting VyOS Config...done.
[   41.947427] vyos-router[1087]: Starting VyOS router: migrate configure.
[   42.640205] vyos-config[1093]: Configuration success

Welcome to VyOS - 136 ttyS0

136 login: vyos
Password: 
Welcome to VyOS!

   ┌── ┐
   . VyOS 1.5-rolling-202403151830
   └ ──┘  current

 * Documentation:  https://docs.vyos.io/en/latest
 * Project news:   https://blog.vyos.io
 * Bug reports:    https://vyos.dev

You can change this banner using "set system login banner post-login" command.

VyOS is a free software distribution that includes multiple components,
you can check individual component licenses under /usr/share/doc/*/copyright
vyos@136:~$ show config comm | grep policy
set policy route FOO interface 'eth3'
set policy route FOO rule 10 protocol 'tcp'
set policy route FOO rule 10 set tcp-mss '1436'
set policy route FOO rule 10 tcp flags syn
vyos@136:~$ 

```
And second test, also defining ipv6 route:
```
vyos@136:~$ show config comm | grep policy
set interfaces ethernet eth3 policy ipv6-route 'FOO6'
set interfaces ethernet eth3 policy route 'FOO'
set policy ipv6-route FOO6 rule 10 action 'drop'
set policy ipv6-route FOO6 rule 10 protocol 'udp'
set policy ipv6-route FOO6 rule 17 protocol 'tcp'
set policy ipv6-route FOO6 rule 17 set tcp-mss '1234'
set policy ipv6-route FOO6 rule 17 tcp flags 'SYN,ACK,FIN,RST'
set policy ipv6-route FOO6 rule 21 action 'drop'
set policy ipv6-route FOO6 rule 21 protocol 'tcp'
set policy ipv6-route FOO6 rule 21 tcp flags '!RST,ACK'
set policy route FOO rule 10 protocol 'tcp'
set policy route FOO rule 10 set tcp-mss '1436'
set policy route FOO rule 10 tcp flags 'SYN'
vyos@136:~$ 
vyos@136:~$ show version | grep Version
Version:          VyOS 1.3.6
vyos@136:~$ 

And after upgrade+reboot:
vyos@136:~$ show config comm | grep policy
set policy route FOO interface 'eth3'
set policy route FOO rule 10 protocol 'tcp'
set policy route FOO rule 10 set tcp-mss '1436'
set policy route FOO rule 10 tcp flags syn
set policy route6 FOO6 interface 'eth3'
set policy route6 FOO6 rule 10 action 'drop'
set policy route6 FOO6 rule 10 protocol 'udp'
set policy route6 FOO6 rule 17 protocol 'tcp'
set policy route6 FOO6 rule 17 set tcp-mss '1234'
set policy route6 FOO6 rule 17 tcp flags ack
set policy route6 FOO6 rule 17 tcp flags fin
set policy route6 FOO6 rule 17 tcp flags rst
set policy route6 FOO6 rule 17 tcp flags syn
set policy route6 FOO6 rule 21 action 'drop'
set policy route6 FOO6 rule 21 protocol 'tcp'
set policy route6 FOO6 rule 21 tcp flags ack
set policy route6 FOO6 rule 21 tcp flags not rst
vyos@136:~$ 

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
