### PR TITLE
T6127: Fixed show log firewall for rule with offload

### DIFF
--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -322,7 +322,7 @@
                                 <path>firewall ipv6 forward filter rule</path>
                               </completionHelp>
                             </properties>
-                            <command>journalctl --no-hostname --boot -k | egrep "\[ipv6-FWD-filter-$8-[ADRJC]\]"</command>
+                            <command>journalctl --no-hostname --boot -k | egrep "\[ipv6-FWD-filter-$8-[ADRJCO]\]"</command>
                           </tagNode>
                         </children>
                       </node>

--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -188,7 +188,7 @@
                             <path>firewall bridge name ${COMP_WORDS[5]} rule</path>
                           </completionHelp>
                         </properties>
-                        <command>journalctl --no-hostname --boot -k | egrep "\[bri-NAM-$6-$8-[ADRJC]\]"</command>
+                        <command>journalctl --no-hostname --boot -k | egrep "\[bri-NAM-$6-$8-[ADRJCO]\]"</command>
                       </tagNode>
                     </children>
                   </tagNode>

--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -188,7 +188,7 @@
                             <path>firewall bridge name ${COMP_WORDS[5]} rule</path>
                           </completionHelp>
                         </properties>
-                        <command>journalctl --no-hostname --boot -k | egrep "\[bri-NAM-$6-$8-[ADRJCO]\]"</command>
+                        <command>journalctl --no-hostname --boot -k | egrep "\[bri-NAM-$6-$8-[ADRJC]\]"</command>
                       </tagNode>
                     </children>
                   </tagNode>
@@ -219,7 +219,7 @@
                                 <path>firewall ipv4 forward filter rule</path>
                               </completionHelp>
                             </properties>
-                            <command>journalctl --no-hostname --boot -k | egrep "\[ipv4-FWD-filter-$8-[ADRJC]\]"</command>
+                            <command>journalctl --no-hostname --boot -k | egrep "\[ipv4-FWD-filter-$8-[ADRJCO]\]"</command>
                           </tagNode>
                         </children>
                       </node>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6127

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
show log ```show log firewall ipv4 forward filter rule```
show log ```show log firewall ipv6 forward filter rule```
## Proposed changes
<!--- Describe your changes in detail -->
Added the '0' character to the egrep regex for this command:
```journalctl --no-hostname --boot -k | egrep "\[ipv4-FWD-filter-$8-[ADRJCO]\]"```

This allows the user to view logs for specific rule entries that have an action of offload
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Config a firewall rule with an action of offload:
```
set firewall ipv4 forward filter rule 1 action 'offload'
set firewall ipv4 forward filter rule 1 log
set firewall ipv4 forward filter rule 1 offload-target 'OT1'
set firewall ipv4 forward filter rule 1 state 'established'
set firewall ipv4 forward filter rule 1 state 'related'
```
View the logs for that rule:
```
l0crian@R86S:~$ show log firewall ipv4 forward filter rule 1
Mar 15 21:59:28 kernel: [ipv4-FWD-filter-1-O]IN=eth0.4040 OUT=eth6 
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
