### PR TITLE
T6136: add error checks when using dynamic firewall groups

### DIFF
--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -268,6 +268,18 @@ def verify_rule(firewall, rule_conf, ipv6):
             if 'port' in side_conf and dict_search_args(side_conf, 'group', 'port_group'):
                 raise ConfigError(f'{side} port-group and port cannot both be defined')
 
+    if 'add_address_to_group' in rule_conf:
+        for type in ['destination_address', 'source_address']:
+            if type in rule_conf['add_address_to_group']:
+                if 'address_group' not in rule_conf['add_address_to_group'][type]:
+                    raise ConfigError(f'Dynamic address group must be defined.')
+                else:
+                    target = rule_conf['add_address_to_group'][type]['address_group']
+                    fwall_group = 'ipv6_address_group' if ipv6 else 'address_group'
+                    group_obj = dict_search_args(firewall, 'group', 'dynamic_group', fwall_group, target)
+                    if group_obj is None:
+                            raise ConfigError(f'Invalid dynamic address group on firewall rule')
+
     if 'log_options' in rule_conf:
         if 'log' not in rule_conf:
             raise ConfigError('log-options defined, but log is not enable')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6136

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Ipv4 error checks:
```
### 1: no address-group defined
vyos@T6136# compare commands 

set firewall ipv4 input filter rule 10 action 'continue'
set firewall ipv4 input filter rule 10 add-address-to-group source-address timeout '1m'
set firewall ipv4 input filter rule 10 packet-length '1052'
set firewall ipv4 input filter rule 10 protocol 'icmp'

[edit]
vyos@T6136# commit

Dynamic address group must be defined.

[[firewall]] failed
Commit failed
[edit]
vyos@T6136#


### 2: use unexistent address group
vyos@T6136# compare commands 

set firewall ipv4 input filter rule 10 action 'continue'
set firewall ipv4 input filter rule 10 add-address-to-group source-address address-group 'FOO'
set firewall ipv4 input filter rule 10 add-address-to-group source-address timeout '1m'
set firewall ipv4 input filter rule 10 packet-length '1052'
set firewall ipv4 input filter rule 10 protocol 'icmp'

[edit]
vyos@T6136# commit

Invalid dynamic address group on firewall rule

[[firewall]] failed
Commit failed
[edit]
vyos@T6136# 

### Last, working:
vyos@T6136# compare commands 

set firewall group dynamic-group address-group FOO
set firewall ipv4 input filter rule 10 action 'continue'
set firewall ipv4 input filter rule 10 add-address-to-group source-address address-group 'FOO'
set firewall ipv4 input filter rule 10 add-address-to-group source-address timeout '1m'
set firewall ipv4 input filter rule 10 packet-length '1052'
set firewall ipv4 input filter rule 10 protocol 'icmp'

[edit]
vyos@T6136# commit
[edit]
vyos@T6136# 
```
And ipv6:
```
### 1: no address-group defined
vyos@T6136# compare commands 

set firewall ipv6 input filter rule 10 action 'continue'
set firewall ipv6 input filter rule 10 add-address-to-group source-address timeout '1m'
set firewall ipv6 input filter rule 10 packet-length '1052'
set firewall ipv6 input filter rule 10 protocol 'ipv6-icmp'

[edit]
vyos@T6136# commit

Dynamic address group must be defined.

[[firewall]] failed
Commit failed
[edit]
vyos@T6136#

### 2: use unexistent address group
vyos@T6136# compare commands 

set firewall ipv6 input filter rule 10 action 'continue'
set firewall ipv6 input filter rule 10 add-address-to-group source-address address-group 'AUXv6'
set firewall ipv6 input filter rule 10 add-address-to-group source-address timeout '1m'
set firewall ipv6 input filter rule 10 packet-length '1052'
set firewall ipv6 input filter rule 10 protocol 'ipv6-icmp'

[edit]
vyos@T6136# commit

Invalid dynamic address group on firewall rule

[[firewall]] failed
Commit failed
[edit]
vyos@T6136# 

### Last, working:

set firewall group dynamic-group ipv6-address-group AUXv6
set firewall ipv6 input filter rule 10 action 'continue'
set firewall ipv6 input filter rule 10 add-address-to-group source-address address-group 'AUXv6'
set firewall ipv6 input filter rule 10 add-address-to-group source-address timeout '1m'
set firewall ipv6 input filter rule 10 packet-length '1052'
set firewall ipv6 input filter rule 10 protocol 'ipv6-icmp'

[edit]
vyos@T6136# commit
[edit]
vyos@T6136#
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
