### PR TITLE
T6138: Fix op-mode show conntrack table with flowtable offloads

### DIFF
--- a/src/op_mode/conntrack.py
+++ b/src/op_mode/conntrack.py
@@ -112,7 +112,8 @@ def get_formatted_output(dict_data):
                     proto = meta['layer4']['protoname']
             if direction == 'independent':
                 conn_id = meta['id']
-                timeout = meta['timeout']
+                # T6138 flowtable offload conntrack entries without 'timeout'
+                timeout = meta.get('timeout', 'n/a')
                 orig_src = f'{orig_src}:{orig_sport}' if orig_sport else orig_src
                 orig_dst = f'{orig_dst}:{orig_dport}' if orig_dport else orig_dst
                 reply_src = f'{reply_src}:{reply_sport}' if reply_sport else reply_src


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The op-mode command `show conntrack table ipv4` fails if it gets a conntrack entry with `flowtable` offload. 
Those entries do not have the key `timeout`

```
  File "/usr/libexec/vyos/op_mode/conntrack.py", line 115, in get_formatted_output
    timeout = meta['timeout']
              ~~~~^^^^^^^^^^^
```

Use the timeout `n/a` for those offload conntrack entries
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6138

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
conntrack
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
To reproduce, add firewall with flowtable offload

set firewall flowtable FLOW interface 'eth0'
set firewall flowtable FLOW interface 'eth1'
set firewall flowtable FLOW interface 'lo'
set firewall ipv4 forward filter default-action 'accept'
set firewall ipv4 forward filter rule 10 action 'offload'
set firewall ipv4 forward filter rule 10 offload-target 'FLOW'
```
Wait for conntrack entries for forward with offload.
Before the fix:
```
vyos@r4:~$ show conntrack table ipv4 
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/conntrack.py", line 150, in <module>
    res = vyos.opmode.run(sys.modules[__name__])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/opmode.py", line 263, in run
    res = func(**args)
          ^^^^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/conntrack.py", line 137, in show
    return get_formatted_output(conntrack_data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/conntrack.py", line 115, in get_formatted_output
    timeout = meta['timeout']
              ~~~~^^^^^^^^^^^
KeyError: 'timeout'
vyos@r4:~$ 
vyos@r4:~$ sudo conntrack -L | grep -i off
udp      17 src=192.0.2.14 dst=1.1.1.1 sport=38006 dport=53 src=1.1.1.1 dst=192.168.122.14 sport=53 dport=38006 [OFFLOAD] mark=0 use=2
conntrack v1.4.6 (conntrack-tools): 12 flow entries have been shown.
vyos@r4:~$
```

After the fix:
```
vyos@r4:~$ show conntrack table ipv4 
Id          Original src       Original dst         Reply src            Reply dst             Protocol    State        Timeout    Mark    Zone
----------  -----------------  -------------------  -------------------  --------------------  ----------  -----------  ---------  ------  ------
2589405901  192.0.2.14:37122   34.206.168.146:123   34.206.168.146:123   192.168.122.14:37122  udp                      99         0
931438034   192.168.122.14:22  192.168.122.1:56010  192.168.122.1:56010  192.168.122.14:22     tcp         ESTABLISHED  431999     0
4269448361  192.0.2.14:43882   34.117.118.44:80     34.117.118.44:80     192.168.122.14:43882  tcp         TIME_WAIT    116        0
821718377   192.0.2.14:36208   1.1.1.1:53           1.1.1.1:53           192.168.122.14:36208  udp                      n/a        0
vyos@r4:~$ 
vyos@r4:~$
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
