### PR TITLE
vti: T6085: bring VTI interfaces up only when the IPsec tunnel is up

### DIFF
--- a/python/vyos/ifconfig/vti.py
+++ b/python/vyos/ifconfig/vti.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2022 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2021-2024 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -52,7 +52,13 @@ class VTIIf(Interface):
                 cmd += f' {iproute2_key} {tmp}'
 
         self._cmd(cmd.format(**self.config))
+
+        # interface is always A/D down. It needs to be enabled explicitly
         self.set_interface('admin_state', 'down')
+
+    def set_admin_state(self, state):
+        """ Handled outside by /etc/ipsec.d/vti-up-down """
+        pass
 
     def get_mac(self):
         """ Get a synthetic MAC address. """

--- a/src/etc/ipsec.d/vti-up-down
+++ b/src/etc/ipsec.d/vti-up-down
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2023 VyOS maintainers and contributors
+# Copyright (C) 2021-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -57,7 +57,9 @@ if __name__ == '__main__':
             if 'disable' not in vti:
                 tmp = VTIIf(interface)
                 tmp.update(vti)
+                call(f'sudo ip link set {interface} up')
             else:
+                call(f'sudo ip link set {interface} down')
                 syslog(f'Interface {interface} is admin down ...')
     elif verb in ['down-client', 'down-host']:
         if vti_link_up:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

When a VTI interface is just created, it is in ADMIN UP state by default, even if an IPSec peer is not connected. After the peer is disconnected the interface goes to DOWN state as expected.

This breaks routing logic - for example, static routes through VTI interfaces will be active even if a peer is not connected.

This changes to logic so ADMIN UP/DOWN state can only be changed by the vti-up-down helper script.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6085

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
`vyos.ifconfig.vti`

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_vti.py
test_add_multiple_ip_addresses (__main__.VTIInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.VTIInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.VTIInterfaceTest.test_dhcp_client_options) ... skipped 'not supported'
test_dhcp_disable_interface (__main__.VTIInterfaceTest.test_dhcp_disable_interface) ... skipped 'not supported'
test_dhcp_vrf (__main__.VTIInterfaceTest.test_dhcp_vrf) ... skipped 'not supported'
test_dhcpv6_client_options (__main__.VTIInterfaceTest.test_dhcpv6_client_options) ... skipped 'not supported'
test_dhcpv6_vrf (__main__.VTIInterfaceTest.test_dhcpv6_vrf) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.VTIInterfaceTest.test_dhcpv6pd_auto_sla_id) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.VTIInterfaceTest.test_dhcpv6pd_manual_sla_id) ... skipped 'not supported'
test_interface_description (__main__.VTIInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.VTIInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.VTIInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.VTIInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.VTIInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.VTIInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.VTIInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.VTIInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.VTIInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.VTIInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.VTIInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.VTIInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.VTIInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.VTIInterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'

----------------------------------------------------------------------
Ran 23 tests in 125.563s

OK (skipped=14)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
