### PR TITLE
bridge: T6125: support 802.1ad (ethertype 0x88a8) VLAN filtering

### DIFF
--- a/interface-definitions/include/interface/vif-s.xml.i
+++ b/interface-definitions/include/interface/vif-s.xml.i
@@ -18,27 +18,7 @@
     #include <include/interface/dhcpv6-options.xml.i>
     #include <include/interface/disable-link-detect.xml.i>
     #include <include/interface/disable.xml.i>
-    <leafNode name="protocol">
-      <properties>
-        <help>Protocol used for service VLAN (default: 802.1ad)</help>
-        <completionHelp>
-          <list>802.1ad 802.1q</list>
-        </completionHelp>
-        <valueHelp>
-          <format>802.1ad</format>
-          <description>Provider Bridging (IEEE 802.1ad, Q-inQ), ethertype 0x88a8</description>
-        </valueHelp>
-        <valueHelp>
-          <format>802.1q</format>
-          <description>VLAN-tagged frame (IEEE 802.1q), ethertype 0x8100</description>
-        </valueHelp>
-        <constraint>
-          <regex>(802.1q|802.1ad)</regex>
-        </constraint>
-        <constraintErrorMessage>Ethertype must be 802.1ad or 802.1q</constraintErrorMessage>
-      </properties>
-      <defaultValue>802.1ad</defaultValue>
-    </leafNode>
+    #include <include/interface/vlan-protocol.xml.i>
     #include <include/interface/ipv4-options.xml.i>
     #include <include/interface/ipv6-options.xml.i>
     #include <include/interface/mac.xml.i>

--- a/interface-definitions/include/interface/vlan-protocol.xml.i
+++ b/interface-definitions/include/interface/vlan-protocol.xml.i
@@ -1,0 +1,23 @@
+<!-- include start from interface/vif.xml.i -->
+<leafNode name="protocol">
+  <properties>
+    <help>Protocol used for service VLAN (default: 802.1ad)</help>
+    <completionHelp>
+      <list>802.1ad 802.1q</list>
+    </completionHelp>
+    <valueHelp>
+      <format>802.1ad</format>
+      <description>Provider Bridging (IEEE 802.1ad, Q-inQ), ethertype 0x88a8</description>
+    </valueHelp>
+    <valueHelp>
+      <format>802.1q</format>
+      <description>VLAN-tagged frame (IEEE 802.1q), ethertype 0x8100</description>
+    </valueHelp>
+    <constraint>
+      <regex>(802.1q|802.1ad)</regex>
+    </constraint>
+    <constraintErrorMessage>Ethertype must be 802.1ad or 802.1q</constraintErrorMessage>
+  </properties>
+  <defaultValue>802.1ad</defaultValue>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/interfaces_bridge.xml.in
+++ b/interface-definitions/interfaces_bridge.xml.in
@@ -98,6 +98,10 @@
               <valueless/>
             </properties>
           </leafNode>
+          #include <include/interface/vlan-protocol.xml.i>
+          <leafNode name="protocol">
+            <defaultValue>802.1q</defaultValue>
+          </leafNode>
           <leafNode name="max-age">
             <properties>
               <help>Interval at which neighbor bridges are removed</help>

--- a/smoketest/scripts/cli/test_interfaces_bridge.py
+++ b/smoketest/scripts/cli/test_interfaces_bridge.py
@@ -182,6 +182,10 @@ class BridgeInterfaceTest(BasicInterfaceTest.TestCase):
         for interface in self._interfaces:
             cost = 1000
             priority = 10
+
+            tmp = get_interface_config(interface)
+            self.assertEqual('802.1Q',  tmp['linkinfo']['info_data']['vlan_protocol']) # default VLAN protocol
+
             for member in self._members:
                 tmp = get_interface_config(member)
                 self.assertEqual(interface, tmp['master'])
@@ -441,6 +445,20 @@ class BridgeInterfaceTest(BasicInterfaceTest.TestCase):
         self.cli_delete(['interfaces', 'vxlan', vxlan_if])
         self.cli_delete(['interfaces', 'tunnel', tunnel_if])
         self.cli_delete(['interfaces', 'ethernet', 'eth0', 'address', eth0_addr])
+
+    def test_bridge_vlan_protocol(self):
+        protocol = '802.1ad'
+
+        # Add member interface to bridge and set VLAN filter
+        for interface in self._interfaces:
+            self.cli_set(self._base_path + [interface, 'protocol', protocol])
+
+        # commit config
+        self.cli_commit()
+
+        for interface in self._interfaces:
+            tmp = get_interface_config(interface)
+            self.assertEqual(protocol, tmp['linkinfo']['info_data']['vlan_protocol'])
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Linux bridge uses EtherType 0x8100 by default. In some scenarios, an EtherType value of 0x88A8 is required.

Reusing CLI command from VIF-S (QinQ) interfaces:
`set interfaces bridge br0 protocol 802.1ad`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6125

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-documentation/pull/1337

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Bridge

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Extended smoketests

* `set interfaces bridge br0 protocol 802.1ad`

Extended Smoketests `test_bridge_vlan_protocol`

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ TEST_ETH="eth1 eth2" /usr/libexec/vyos/tests/smoke/cli/test_interfaces_bridge.py
test_add_multiple_ip_addresses (__main__.BridgeInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_remove_bridge_member (__main__.BridgeInterfaceTest.test_add_remove_bridge_member) ... ok
test_add_single_ip_address (__main__.BridgeInterfaceTest.test_add_single_ip_address) ... ok
test_bridge_tunnel_vxlan_multicast (__main__.BridgeInterfaceTest.test_bridge_tunnel_vxlan_multicast) ... ok
test_bridge_vif_members (__main__.BridgeInterfaceTest.test_bridge_vif_members) ... ok
test_bridge_vif_s_vif_c_members (__main__.BridgeInterfaceTest.test_bridge_vif_s_vif_c_members) ... ok
test_bridge_vlan_filter (__main__.BridgeInterfaceTest.test_bridge_vlan_filter) ... ok
test_bridge_vlan_protocol (__main__.BridgeInterfaceTest.test_bridge_vlan_protocol) ... ok
test_dhcp_client_options (__main__.BridgeInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.BridgeInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.BridgeInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.BridgeInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.BridgeInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.BridgeInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.BridgeInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_igmp_querier_snooping (__main__.BridgeInterfaceTest.test_igmp_querier_snooping) ... ok
test_interface_description (__main__.BridgeInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.BridgeInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.BridgeInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.BridgeInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.BridgeInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.BridgeInterfaceTest.test_ipv6_link_local_address) ... ok
test_isolated_interfaces (__main__.BridgeInterfaceTest.test_isolated_interfaces) ... ok
test_mtu_1200_no_ipv6_interface (__main__.BridgeInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.BridgeInterfaceTest.test_span_mirror) ... ok
test_vif_8021q_interfaces (__main__.BridgeInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.BridgeInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.BridgeInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.BridgeInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.BridgeInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.BridgeInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 31 tests in 182.092s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
