### PR TITLE
T6150: Fixed setting a static IP address by Radius in IPoE

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.tmpl
+++ b/data/templates/accel-ppp/ipoe.config.tmpl
@@ -32,20 +32,29 @@ interface={{ ifname }},shared={{ interface.shared }},mode={{ interface.mode }},i
 {% endfor %}
 {% if auth_mode == 'noauth' %}
 noauth=1
-{%   if client_named_ip_pool %}
-{%     for pool in client_named_ip_pool %}
-{%       if pool.subnet is defined  %}
-ip-pool={{ pool.name }}
-{%       endif %}
-{%       if pool.gateway_address is defined %}
-gw-ip-address={{ pool.gateway_address }}/{{ pool.subnet.split('/')[1] }}
-{%       endif %}
-{%     endfor%}
-{%   endif %}
 {% elif auth_mode == 'local' %}
 username=ifname
 password=csid
+{% elif auth_mode == 'radius' %}
+attr-dhcp-client-ip=Framed-IP-Address
+attr-dhcp-mask=Framed-IP-Netmask
 {% endif %}
+{% if gateway_address %}
+{%   for gw in gateway_address %}
+gw-ip-address={{ gw }}
+{%   endfor %}
+{% endif %}
+{% if client_named_ip_pool %}
+{%   for pool in client_named_ip_pool %}
+{%     if pool.subnet is defined  %}
+ip-pool={{ pool.name }}
+{%     endif %}
+{%     if pool.gateway_address is defined %}
+gw-ip-address={{ pool.gateway_address }}/{{ pool.subnet.split('/')[1] }}
+{%     endif %}
+{%   endfor%}
+{% endif %}
+
 proxy-arp=1
 
 {% for interface in interfaces %}

--- a/interface-definitions/include/accel-ppp/gateway-address-multi.xml.i
+++ b/interface-definitions/include/accel-ppp/gateway-address-multi.xml.i
@@ -1,0 +1,17 @@
+<!-- include start from accel-ppp/gateway-address-multi.xml.i -->
+<leafNode name="gateway-address">
+  <properties>
+    <help>Gateway IP address</help>
+    <constraintErrorMessage>invalid IPv4 address</constraintErrorMessage>
+    <valueHelp>
+      <format>ipv4net</format>
+      <description>Default Gateway, mask send to the client</description>
+    </valueHelp>
+    <constraint>
+      <validator name="ipv4-prefix"/>
+      <validator name="ipv4-host"/>
+    </constraint>
+    <multi/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/service_ipoe-server.xml.in
+++ b/interface-definitions/service_ipoe-server.xml.in
@@ -121,6 +121,7 @@
             </children>
           </node>
           #include <include/accel-ppp/client-ipv6-pool.xml.i>
+          #include <include/accel-ppp/gateway-address-multi.xml.i>
           <node name="authentication">
             <properties>
               <help>Client authentication methods</help>

--- a/src/conf_mode/service_ipoe-server.py
+++ b/src/conf_mode/service_ipoe-server.py
@@ -44,6 +44,7 @@ default_config_data = {
     'client_named_ip_pool': [],
     'client_ipv6_pool': [],
     'client_ipv6_delegate_prefix': [],
+    'gateway_address':[],
     'radius_server': [],
     'radius_acct_inter_jitter': '',
     'radius_acct_tmo': '3',
@@ -275,7 +276,12 @@ def get_config(config=None):
 
             ipoe['client_ipv6_delegate_prefix'].append(tmp)
 
+    if conf.exists(['gateway-address']):
+        for gw in conf.return_values(['gateway-address']):
+            ipoe['gateway_address'].append(gw)
+
     return ipoe
+
 
 
 def verify(ipoe):
@@ -303,6 +309,13 @@ def verify(ipoe):
     if ipoe['client_ipv6_delegate_prefix'] and not ipoe['client_ipv6_pool']:
         raise ConfigError('IPoE IPv6 deletate-prefix requires IPv6 prefix to be configured!')
 
+    if ipoe['gateway_address']:
+        if ipoe['client_named_ip_pool']:
+            ipoe_gateways = ' '.join(ipoe['gateway_address'])
+            for pool in ipoe['client_named_ip_pool']:
+                if f'{pool["gateway_address"]}/' in ipoe_gateways:
+                        raise ConfigError(
+                            'IPoE "gateway-address" exists in IPoE "client-ip-pool"!')
     return None
 
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed setting a static IP address by Radius in IPoE.
Allowing using named pools by default.
Allowed adding 'gateway-address' without named pool.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/T6150 -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipoe

## Proposed changes
<!--- Describe your changes in detail -->
Fixed setting a static IP address by Radius in IPoE.
Allowing using named pools by default.
Allowed adding 'gateway-address' without named pool.


## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
VyOS Configuration:
```
set service ipoe-server authentication mode 'radius'
set service ipoe-server authentication radius server 192.168.139.100 key 'gns3'
set service ipoe-server client-ip-pool name TEST gateway-address '192.168.0.1'
set service ipoe-server client-ip-pool name TEST subnet '192.168.0.0/24'
set service ipoe-server interface eth1
```
Radius configuration
```
eth1     Cleartext-Password := "eth1"
         Framed-IP-Address = 192.168.0.10,
         Framed-IP-Netmask = 255.255.255.0
```
A client obtains IP 192.168.0.10
Before changes, a client cannot receive any IP.

Allowed adding 'gateway-address' without named pool.
```
set service ipoe-server authentication mode 'radius'
set service ipoe-server authentication radius server 192.168.139.100 key 'gns3'
set service ipoe-server gateway-address '192.168.0.1/24'
set service ipoe-server interface eth1 client-subnet '192.168.0.0/24'
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
