### PR TITLE
T6068: dhcp-server: add split option to dhcp-server configuration.

### DIFF
--- a/data/templates/dhcp-server/dhcpd.conf.j2
+++ b/data/templates/dhcp-server/dhcpd.conf.j2
@@ -47,7 +47,11 @@ failover peer "{{ failover.name }}" {
 {%     if failover.status == 'primary' %}
     primary;
     mclt 1800;
+{%         if failover.split is vyos_defined %}
+    split {{ failover.split }};
+{%         else %}
     split 128;
+{%         endif %}
 {%     elif failover.status == 'secondary' %}
     secondary;
 {%     endif %}

--- a/interface-definitions/service_dhcp-server.xml.in
+++ b/interface-definitions/service_dhcp-server.xml.in
@@ -63,6 +63,18 @@
                   <constraintErrorMessage>Invalid DHCP failover peer status</constraintErrorMessage>
                 </properties>
               </leafNode>
+              <leafNode name="split">
+                <properties>
+                  <help>The split statement specifies the split between the primary and secondary for the purposes of load balancing.</help>
+                  <valueHelp>
+                    <format>u32:0-256</format>
+                    <description>Split value</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-256"/>
+                  </constraint>
+                </properties>
+              </leafNode>
             </children>
           </node>
           <leafNode name="global-parameters">

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -279,6 +279,9 @@ def verify(dhcp):
                 tmp = key.replace('_', '-')
                 raise ConfigError(f'DHCP failover requires "{tmp}" to be specified!')
 
+        if 'split' in dhcp['failover'] and dhcp['failover']['status'] != 'primary':
+            raise ConfigError('DHCP failover split parameter can only be used if status is primary')
+
     for address in (dict_search('listen_address', dhcp) or []):
         if is_addr_assigned(address):
             listen_ok = True


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add split option to dhcp-server configuration.This adds the hability to the user to specify load balancing towards dhcp servers defined in failover.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/T6068 -->
https://vyos.dev/T6068

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-server

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Config
```
set service dhcp-server failover name 'TEST'
set service dhcp-server failover remote '198.51.100.2'
set service dhcp-server failover source-address '198.51.100.1'
set service dhcp-server failover split '256'
set service dhcp-server failover status 'primary'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 default-router '198.51.100.1'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 enable-failover
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 name-server '8.8.8.8'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 range 0 start '198.51.100.101'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 range 0 stop '198.51.100.200'
```
Config file:
```
cat /run/dhcp-server/dhcpd.conf
...
failover peer "TEST" {
    primary;
    mclt 1800;
    split 256;
    address 198.51.100.1;
    port 647;
    peer address 198.51.100.2;
    peer port 647;
    max-response-delay 30;
    max-unacked-updates 10;
    load balance max seconds 3;
}
..
```
And error check if setting it to server `secondary` dhcp-server:
```
vyos@dhcp-sag-main# run show config comm | grep failover
set service dhcp-server failover name 'TEST'
set service dhcp-server failover remote '198.51.100.2'
set service dhcp-server failover source-address '198.51.100.1'
set service dhcp-server failover status 'secondary'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 enable-failover
[edit]
vyos@dhcp-sag-main# set service dhcp-server failover split 123
[edit]
vyos@dhcp-sag-main# commit

DHCP failover split parameter can only be used if status is primary

[[service dhcp-server]] failed
Commit failed
[edit]
vyos@dhcp-sag-main# 

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@dhcp-sag-main:/usr/libexec/vyos/tests/smoke/cli# ./test_service_dhcp-server.py                                                   

test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
test_dhcp_failover (__main__.TestServiceDHCPServer.test_dhcp_failover) ... 
No DHCP address range or active static-mapping configured within shared-
network "FAILOVER, 192.0.2.0/25"!


DHCP failover must be enabled for at least one subnet!

ok
test_dhcp_failover_split (__main__.TestServiceDHCPServer.test_dhcp_failover_split) ... ok
test_dhcp_invalid_raw_options (__main__.TestServiceDHCPServer.test_dhcp_invalid_raw_options) ... 
DEPRECATION WARNING: Additional global parameters are subject of
removal in VyOS 1.5! Please raise a feature request for proper CLI
nodes!


Configuration file errors encountered - check your options!

ok
test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... 
No DHCP address range or active static-mapping configured within shared-
network "SMOKE-0815, 192.0.2.0/25"!

ok
test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... 
No DHCP address range or active static-mapping configured within shared-
network "SMOKE-1, 192.0.2.0/25"!

ok
test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... 
No DHCP address range or active static-mapping configured within shared-
network "SMOKE-2, 192.0.2.0/25"!


Configured IP address for static mapping "dupe1" already exists on
another static mapping


Configured MAC address for static mapping "dupe2" already exists on
another static mapping

ok

----------------------------------------------------------------------
Ran 10 tests in 33.143s

OK
root@dhcp-sag-main:/usr/libexec/vyos/tests/smoke/cli# 

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
