### PR TITLE
isis: T6160: NameError: name 'process' is not defined

### DIFF
--- a/smoketest/scripts/cli/test_protocols_isis.py
+++ b/smoketest/scripts/cli/test_protocols_isis.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2023 VyOS maintainers and contributors
+# Copyright (C) 2021-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -73,6 +73,12 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
             self.cli_commit()
 
         self.isis_base_config()
+
+        self.cli_set(base_path + ['redistribute', 'ipv4', 'connected'])
+        # verify() - Redistribute level-1 or level-2 should be specified
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
         self.cli_set(base_path + ['redistribute', 'ipv4', 'connected', 'level-2', 'route-map', route_map])
         self.cli_set(base_path + ['log-adjacency-changes'])
 

--- a/src/conf_mode/protocols_isis.py
+++ b/src/conf_mode/protocols_isis.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020-2022 VyOS maintainers and contributors
+# Copyright (C) 2020-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -155,12 +155,12 @@ def verify(isis):
             for proto, proto_config in isis['redistribute'][afi].items():
                 if 'level_1' not in proto_config and 'level_2' not in proto_config:
                     raise ConfigError(f'Redistribute level-1 or level-2 should be specified in ' \
-                                      f'"protocols isis {process} redistribute {afi} {proto}"!')
+                                      f'"protocols isis redistribute {afi} {proto}"!')
 
                 for redistr_level, redistr_config in proto_config.items():
                     if proc_level and proc_level != 'level_1_2' and proc_level != redistr_level:
-                        raise ConfigError(f'"protocols isis {process} redistribute {afi} {proto} {redistr_level}" ' \
-                                          f'can not be used with \"protocols isis {process} level {proc_level}\"')
+                        raise ConfigError(f'"protocols isis redistribute {afi} {proto} {redistr_level}" ' \
+                                          f'can not be used with \"protocols isis level {proc_level}\"!')
 
     # Segment routing checks
     if dict_search('segment_routing.global_block', isis):
@@ -220,8 +220,8 @@ def verify(isis):
                 if ("explicit_null" in prefix_config['index']) and ("no_php_flag" in prefix_config['index']):
                     raise ConfigError(f'Segment routing prefix {prefix} cannot have both explicit-null '\
                                       f'and no-php-flag configured at the same time.')
- 
-    # Check for index ranges being larger than the segment routing global block    
+
+    # Check for index ranges being larger than the segment routing global block
     if dict_search('segment_routing.global_block', isis):
         g_high_label_value = dict_search('segment_routing.global_block.high_label_value', isis)
         g_low_label_value = dict_search('segment_routing.global_block.low_label_value', isis)
@@ -233,7 +233,7 @@ def verify(isis):
                     if int(index_size) > int(g_label_difference):
                         raise ConfigError(f'Segment routing prefix {prefix} cannot have an '\
                                           f'index base size larger than the SRGB label base.')
-            
+
     # Check for LFA tiebreaker index duplication
     if dict_search('fast_reroute.lfa.local.tiebreaker', isis):
         comparison_dictionary = {}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This is a leftover after commit 0e050cb35 (isis: T3417: drop artificial "domain" node identifying the IS-IS process name). Drop all references to "process" variable.

Specifying:

```
set protocols isis interface eth1
set protocols isis net '49.0001.1921.6825.5255.00'
set protocols isis redistribute ipv4 bgp
```

Triggered an exception

```
Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/protocols_isis.py", line 309, in <module>
    verify(c)
  File "/usr/libexec/vyos/conf_mode/protocols_isis.py", line 158, in verify
    f'"protocols isis {process} redistribute {afi} {proto}"!')
                       ^^^^^^^
NameError: name 'process' is not defined
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6160

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
IS-IS

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_isis.py
test_isis_01_redistribute (__main__.TestProtocolsISIS.test_isis_01_redistribute) ... ok
test_isis_02_vrfs (__main__.TestProtocolsISIS.test_isis_02_vrfs) ... ok
test_isis_04_default_information (__main__.TestProtocolsISIS.test_isis_04_default_information) ... ok
test_isis_05_password (__main__.TestProtocolsISIS.test_isis_05_password) ... ok
test_isis_06_spf_delay_bfd (__main__.TestProtocolsISIS.test_isis_06_spf_delay_bfd) ... ok
test_isis_07_segment_routing_configuration (__main__.TestProtocolsISIS.test_isis_07_segment_routing_configuration) ... ok
test_isis_08_ldp_sync (__main__.TestProtocolsISIS.test_isis_08_ldp_sync) ... ok
test_isis_09_lfa (__main__.TestProtocolsISIS.test_isis_09_lfa) ... ok

----------------------------------------------------------------------
Ran 8 tests in 129.315s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
