### PR TITLE
op-mode: T6161: Show container details in JSON format

### DIFF
--- a/op-mode-definitions/container.xml.in
+++ b/op-mode-definitions/container.xml.in
@@ -103,12 +103,28 @@
         </properties>
         <command>sudo ${vyos_op_scripts_dir}/container.py show_container</command>
         <children>
-          <leafNode name="image">
+          <node name="json">
+            <properties>
+              <help>Show containers in JSON format</help>
+            </properties>
+            <!-- no admin check -->
+            <command>sudo ${vyos_op_scripts_dir}/container.py show_container --raw</command>
+          </node>
+          <node name="image">
             <properties>
               <help>Show container image</help>
             </properties>
             <command>sudo ${vyos_op_scripts_dir}/container.py show_image</command>
-          </leafNode>
+            <children>
+              <node name="json">
+                <properties>
+                  <help>Show container image in JSON format</help>
+                </properties>
+                <!-- no admin check -->
+                <command>sudo ${vyos_op_scripts_dir}/container.py show_image --raw</command>
+              </node>
+            </children>
+          </node>
           <tagNode name="log">
             <properties>
               <help>Show logs from a given container</help>
@@ -116,14 +132,25 @@
                 <path>container name</path>
               </completionHelp>
             </properties>
+            <!-- no admin check -->
             <command>sudo podman logs --names "$4"</command>
           </tagNode>
-          <leafNode name="network">
+          <node name="network">
             <properties>
               <help>Show available container networks</help>
             </properties>
+            <!-- no admin check -->
             <command>sudo ${vyos_op_scripts_dir}/container.py show_network</command>
-          </leafNode>
+            <children>
+              <node name="json">
+                <properties>
+                  <help>Show available container networks in JSON format</help>
+                </properties>
+                <!-- no admin check -->
+                <command>sudo ${vyos_op_scripts_dir}/container.py show_network --raw</command>
+              </node>
+            </children>
+          </node>
         </children>
       </node>
       <node name="log">


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Ability to get container details from op-mode in JSON format.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

https://vyos.dev/T6161

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

op-mode

## Proposed changes
<!--- Describe your changes in detail -->

Being able to get container information in a parseable format.  
This is on-par with other commands such as `show configuration json`.

I found that the "raw" versions of these commands already existed in the python scripts, so I just used the existing/unused flags.

I also made some assumptions about node types.

Should be backported to sagitta without any issue as it's non-breaking.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
show container json
show container image json
show container network json
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [?] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
