### PR TITLE
grub: T6165: increase service TimeoutSec from 5 -> 60

### DIFF
--- a/src/systemd/vyos-grub-update.service
+++ b/src/systemd/vyos-grub-update.service
@@ -6,7 +6,7 @@ Before=vyos-router.service
 [Service]
 Type=oneshot
 ExecStart=/usr/libexec/vyos/system/grub_update.py
-TimeoutSec=5
+TimeoutSec=60
 KillMode=process
 StandardOutput=journal+console
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The PCEngines APU2 systems with mSATA disks tend to be very slow. This results in a service startup error:

```
$ systemctl status vyos-grub-update
× vyos-grub-update.service - Update GRUB loader configuration structure
     Loaded: loaded (/lib/systemd/system/vyos-grub-update.service; enabled; preset: enabled)
     Active: failed (Result: timeout) since Sun 2024-03-24 08:48:10 UTC; 14min ago
   Main PID: 779 (code=killed, signal=TERM)
        CPU: 869ms

Mar 24 08:48:05 LR4.wue3 systemd[1]: Starting vyos-grub-update.service - Update GRUB loader configuration structure...
Mar 24 08:48:10 LR4.wue3 systemd[1]: vyos-grub-update.service: start operation timed out. Terminating.
Mar 24 08:48:10 LR4.wue3 systemd[1]: vyos-grub-update.service: Main process exited, code=killed, status=15/TERM
Mar 24 08:48:10 LR4.wue3 systemd[1]: vyos-grub-update.service: Failed with result 'timeout'.
Mar 24 08:48:10 LR4.wue3 systemd[1]: Failed to start vyos-grub-update.service - Update GRUB loader configuration structure.
```

Measunring on an APU2 system after boot and memory is "hot", it still needs almost 17 seconds to complete the job

```
cpo@LR4.wue3:~$ time sudo /usr/libexec/vyos/system/grub_update.py
real    0m16.803s
user    0m0.018s
sys     0m0.028s
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T4516

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vyos-grub-update.service

## Proposed changes
<!--- Describe your changes in detail -->

Increase startup timeout


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
