### PR TITLE
xml: T5738: use common constraint include for container network

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -211,6 +211,7 @@
               <completionHelp>
                 <path>container network</path>
               </completionHelp>
+              #include <include/constraint/container-network.xml.i>
             </properties>
             <children>
               <leafNode name="address">
@@ -426,10 +427,7 @@
       <tagNode name="network">
         <properties>
           <help>Network name</help>
-          <constraint>
-            <regex>[-_a-zA-Z0-9]{1,11}</regex>
-          </constraint>
-          <constraintErrorMessage>Network name cannot be longer than 11 characters</constraintErrorMessage>
+          #include <include/constraint/container-network.xml.i>
         </properties>
         <children>
           #include <include/generic-description.xml.i>

--- a/interface-definitions/include/constraint/container-network.xml.i
+++ b/interface-definitions/include/constraint/container-network.xml.i
@@ -1,0 +1,6 @@
+<!-- include start from constraint/container-network.xml.i -->
+<constraint>
+  <regex>[-_a-zA-Z0-9]{1,11}</regex>
+</constraint>
+<constraintErrorMessage>Network name cannot be longer than 11 characters</constraintErrorMessage>
+<!-- include end -->


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T5738

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
XML definition


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
