### PR TITLE
T6171: migrate <set service dhcp-server failover> to <set service dhcp-server high-availability>

### DIFF
--- a/data/templates/dhcp-server/kea-ctrl-agent.conf.j2
+++ b/data/templates/dhcp-server/kea-ctrl-agent.conf.j2
@@ -1,7 +1,7 @@
 {
     "Control-agent": {
-{% if failover is vyos_defined %}
-        "http-host": "{{ failover.source_address }}",
+{% if high_availability is vyos_defined %}
+        "http-host": "{{ high_availability.source_address }}",
         "http-port": 647,
         "control-sockets": {
             "dhcp4": {

--- a/data/templates/dhcp-server/kea-dhcp4.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp4.conf.j2
@@ -51,11 +51,11 @@
             }
         ],
         "hooks-libraries": [
-{% if failover is vyos_defined %}
+{% if high_availability is vyos_defined %}
             {
                 "library": "/usr/lib/{{ machine }}-linux-gnu/kea/hooks/libdhcp_ha.so",
                 "parameters": {
-                    "high-availability": [{{ failover | kea_failover_json }}]
+                    "high-availability": [{{ high_availability | kea_high_availability_json }}]
                 }
             },
 {% endif %}

--- a/interface-definitions/include/version/dhcp-server-version.xml.i
+++ b/interface-definitions/include/version/dhcp-server-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/dhcp-server-version.xml.i -->
-<syntaxVersion component='dhcp-server' version='10'></syntaxVersion>
+<syntaxVersion component='dhcp-server' version='11'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/service_dhcp-server.xml.in
+++ b/interface-definitions/service_dhcp-server.xml.in
@@ -16,18 +16,18 @@
               <valueless/>
             </properties>
           </leafNode>
-          <node name="failover">
+          <node name="high-availability">
             <properties>
-              <help>DHCP failover configuration</help>
+              <help>DHCP high availability configuration</help>
             </properties>
             <children>
               #include <include/source-address-ipv4.xml.i>
               <leafNode name="remote">
                 <properties>
-                  <help>IPv4 remote address used for connectio</help>
+                  <help>IPv4 remote address used for connection</help>
                   <valueHelp>
                     <format>ipv4</format>
-                    <description>IPv4 address of failover peer</description>
+                    <description>IPv4 address of high availability peer</description>
                   </valueHelp>
                   <constraint>
                     <validator name="ipv4-address"/>
@@ -45,7 +45,7 @@
               </leafNode>
               <leafNode name="status">
                 <properties>
-                  <help>Failover hierarchy</help>
+                  <help>High availability hierarchy</help>
                   <completionHelp>
                     <list>primary secondary</list>
                   </completionHelp>
@@ -60,7 +60,7 @@
                   <constraint>
                     <regex>(primary|secondary)</regex>
                   </constraint>
-                  <constraintErrorMessage>Invalid DHCP failover peer status</constraintErrorMessage>
+                  <constraintErrorMessage>Invalid DHCP high availability peer status</constraintErrorMessage>
                 </properties>
               </leafNode>
               #include <include/pki/ca-certificate.xml.i>

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -803,8 +803,8 @@ def kea_address_json(addresses):
 
     return dumps(out)
 
-@register_filter('kea_failover_json')
-def kea_failover_json(config):
+@register_filter('kea_high_availability_json')
+def kea_high_availability_json(config):
     from json import dumps
 
     source_addr = config['source_address']

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -673,7 +673,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         # Check for running process
         self.assertTrue(process_named_running(PROCESS_NAME))
 
-    def test_dhcp_failover(self):
+    def test_dhcp_high_availability(self):
         shared_net_name = 'FAILOVER'
         failover_name = 'VyOS-Failover'
 
@@ -695,10 +695,10 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         failover_local = router
         failover_remote = inc_ip(router, 1)
 
-        self.cli_set(base_path + ['failover', 'source-address', failover_local])
-        self.cli_set(base_path + ['failover', 'name', failover_name])
-        self.cli_set(base_path + ['failover', 'remote', failover_remote])
-        self.cli_set(base_path + ['failover', 'status', 'primary'])
+        self.cli_set(base_path + ['high-availability', 'source-address', failover_local])
+        self.cli_set(base_path + ['high-availability', 'name', failover_name])
+        self.cli_set(base_path + ['high-availability', 'remote', failover_remote])
+        self.cli_set(base_path + ['high-availability', 'status', 'primary'])
 
         # commit changes
         self.cli_commit()

--- a/src/migration-scripts/dhcp-server/10-to-11
+++ b/src/migration-scripts/dhcp-server/10-to-11
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T6171: rename "service dhcp-server failover" to "service dhcp-server high-availability"
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['service', 'dhcp-server']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+
+if config.exists(base + ['failover']):
+    config.rename(base + ['failover'],'high-availability')
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print(f'Failed to save the modified config: {e}')
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
failover -> Word regularly used for active-backup scenarios.
In dhcp-server, we can support active-active and active-backup scenario.
This migration is mandatory for a clear definition of this feature, and necessary to later add an option for what kind of high-availability the user wants

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6171

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Config running on 1.4.0-epa2
```
vyos@dhcp-sag-main:~$ show config comm | grep dhcp
set interfaces ethernet eth0 address 'dhcp'
set service dhcp-server failover name 'TEST'
set service dhcp-server failover remote '198.51.100.2'
set service dhcp-server failover source-address '198.51.100.1'
set service dhcp-server failover status 'primary'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 default-router '198.51.100.1'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 enable-failover
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 name-server '8.8.8.8'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 range 0 start '198.51.100.101'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 range 0 stop '198.51.100.200'
vyos@dhcp-sag-main:~$ 
```
And after migration to custom image generated for testing:
```
vyos@dhcp-sag-main:~$ show config comm | grep dhcp
set interfaces ethernet eth0 address 'dhcp'
set service dhcp-server high-availability name 'TEST'
set service dhcp-server high-availability remote '198.51.100.2'
set service dhcp-server high-availability source-address '198.51.100.1'
set service dhcp-server high-availability status 'primary'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 option default-router '198.51.100.1'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 option name-server '8.8.8.8'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 range 0 start '198.51.100.101'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 range 0 stop '198.51.100.200'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 subnet-id '1'

## Check process
vyos@dhcp-sag-main:~$ sudo ps aux | grep kea
_kea        2365  0.4  2.3  51704 11648 ?        Ssl  18:29   0:00 /usr/sbin/kea-ctrl-agent -c /run/kea/kea-ctrl-agent.conf
_kea        2369  0.9  5.1 216608 25288 ?        Ssl  18:29   0:00 /usr/sbin/kea-dhcp4 -c /run/kea/kea-dhcp4.conf
vyos        2739  0.0  0.4   6332  2048 ttyS0    S+   18:30   0:00 grep kea
vyos@dhcp-sag-main:~$
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@dhcp-sag-backup:/usr/libexec/vyos/tests/smoke/cli# ./test_service_dhcp-server.py
test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
test_dhcp_high_availability (__main__.TestServiceDHCPServer.test_dhcp_high_availability) ... 
No DHCP address range or active static-mapping configured within shared-
network "FAILOVER, 192.0.2.0/25"!

ok
test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... ok
test_dhcp_single_pool_options_scoped (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options_scoped) ... ok
test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... 
No DHCP address range or active static-mapping configured within shared-
network "SMOKE-1, 192.0.2.0/25"!

ok
test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... 
No DHCP address range or active static-mapping configured within shared-
network "SMOKE-2, 192.0.2.0/25"!


Either MAC address or Client identifier (DUID) is required for static
mapping "client1" within shared-network "SMOKE-2, 192.0.2.0/25"!


Configured IP address for static mapping "dupe1" already exists on
another static mapping


Configured MAC address for static mapping "dupe2" already exists on
another static mapping


Configured IP address for static mapping "dupe4" already exists on
another static mapping

ok

----------------------------------------------------------------------
Ran 9 tests in 23.140s

OK
root@dhcp-sag-backup:/usr/libexec/vyos/tests/smoke/cli#
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
