### PR TITLE
bgp: T6106: fix test and verify()

### DIFF
--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -1236,12 +1236,10 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'  neighbor {pg_ipv6} activate', afiv6_config)
         self.assertIn(f'  neighbor {pg_ipv6} maximum-prefix {ipv6_max_prefix}', afiv6_config)
 
-    def test_bgp_26_commit_error(self):
+    def test_bgp_27_route_reflector_client(self):
         self.cli_set(base_path + ['peer-group', 'peer1', 'address-family', 'l2vpn-evpn', 'route-reflector-client'])
         with self.assertRaises(ConfigSessionError) as e:
             self.cli_commit()
-
-        self.assertTrue("% Invalid command. Not an internal neighbor" in str(e.exception))
 
     def test_bgp_99_bmp(self):
         target_name = 'instance-bmp'

--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -457,6 +457,8 @@ def verify(bgp):
                             peer_group_as = dict_search(f'peer_group.{peer_group}.remote_as', bgp)
                             if peer_group_as != None and peer_group_as != 'internal' and peer_group_as != bgp['system_as']:
                                 raise ConfigError('route-reflector-client only supported for iBGP peers')
+                        else:
+                            raise ConfigError('route-reflector-client only supported for iBGP peers')
 
     # Throw an error if a peer group is not configured for allow range
     for prefix in dict_search('listen.range', bgp) or []:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6106

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py 
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ... ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ... ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ... ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ... ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ... ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ... ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ... ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ... ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ... ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ... ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok
test_bgp_24_srv6_sid (__main__.TestProtocolsBGP.test_bgp_24_srv6_sid) ... ok
test_bgp_25_ipv4_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_25_ipv4_labeled_unicast_peer_group) ... ok
test_bgp_26_ipv6_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_26_ipv6_labeled_unicast_peer_group) ... ok
test_bgp_27_route_reflector_client (__main__.TestProtocolsBGP.test_bgp_26_route_reflector_client) ... ok
test_bgp_99_bmp (__main__.TestProtocolsBGP.test_bgp_99_bmp) ... ok

----------------------------------------------------------------------
Ran 27 tests in 182.978s

OK

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
