### PR TITLE
T6121: Extend config-sync for QoS and system options

### DIFF
--- a/interface-definitions/service_config-sync.xml.in
+++ b/interface-definitions/service_config-sync.xml.in
@@ -344,6 +344,25 @@
                   </leafNode>
                 </children>
               </node>
+              <node name="qos">
+                <properties>
+                  <help>Quality of Service (QoS)</help>
+                </properties>
+                <children>
+                  <leafNode name="interface">
+                    <properties>
+                      <help>Interface to apply QoS policy</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="policy">
+                    <properties>
+                      <help>Service Policy definitions</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
               <node name="service">
                 <properties>
                   <help>System services</help>
@@ -430,6 +449,49 @@
                   <leafNode name="webproxy">
                     <properties>
                       <help>Webproxy service settings</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+              <node name="system">
+                <properties>
+                  <help>System parameters</help>
+                </properties>
+                <children>
+                  <leafNode name="conntrack">
+                    <properties>
+                      <help>Connection Tracking</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="flow-accounting">
+                    <properties>
+                      <help>Flow accounting</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="option">
+                    <properties>
+                      <help>System Options</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="sflow">
+                    <properties>
+                      <help>sFlow</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="static-host-mapping">
+                    <properties>
+                      <help>Map host names to addresses</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="sysctl">
+                    <properties>
+                      <help>Configure kernel parameters at runtime</help>
                       <valueless/>
                     </properties>
                   </leafNode>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Extent the service config-sync for sections:
 - qos interface
 - qos policy
 - system conntrack
 - system flow-accounting
 - system option
 - system sflow
 - system static-host-mapping
 - system sysctl
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6121

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
config-sync
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add desired sections for sync
```
set service config-sync mode 'load'
set service config-sync secondary address '192.168.122.11'
set service config-sync secondary key 'foo'
set service config-sync section qos policy
set service config-sync section system static-host-mapping
```
change any option in those sections:
```
set qos policy shaper SHAPE bandwidth '1000mbit'
set qos policy shaper SHAPE class 10 bandwidth '200mbit'
set qos policy shaper SHAPE class 10 match IP ip destination address '192.0.2.1'
set system static-host-mapping host-name 2.example.local inet '192.0.2.2'
set system static-host-mapping host-name example.local inet '192.0.2.1'

vyos@r4# commit
INFO:vyos_config_sync:Config synchronization: Mode=load, Secondary=192.168.122.11
[edit]
vyos@r4# 

```
Check those sections on the `secondary` node (be sure all config in sections is present):
```
vyos@r1-right# show qos 
 policy {
     shaper SHAPE {
         bandwidth 1000mbit
         class 10 {
             bandwidth 200mbit
             match IP {
                 ip {
                     destination {
                         address 192.0.2.1
                     }
                 }
             }
         }
     }
 }
[edit]
vyos@r1-right# show system static-host-mapping 
 host-name 2.example.local {
     inet 192.0.2.2
 }
 host-name example.local {
     inet 192.0.2.1
 }
[edit]
vyos@r1-right# 
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
