### PR TITLE
op-mode: T6175: "renew dhcp interface <name>" does not check for DHCP interface

### DIFF
--- a/data/templates/dhcp-client/override.conf.j2
+++ b/data/templates/dhcp-client/override.conf.j2
@@ -3,9 +3,6 @@
 {% set if_metric = '-e IF_METRIC=' ~ dhcp_options.default_route_distance if dhcp_options.default_route_distance is vyos_defined else '' %}
 {% set dhclient_options = '-d -nw -cf ' ~ isc_dhclient_dir ~ '/dhclient_' ~ ifname ~ '.conf -pf ' ~ isc_dhclient_dir ~ '/dhclient_' ~ ifname  ~ '.pid -lf ' ~ isc_dhclient_dir ~ '/dhclient_' ~ ifname ~ '.leases ' ~ if_metric %}
 
-[Unit]
-ConditionPathExists={{ isc_dhclient_dir }}/dhclient_%i.conf
-
 [Service]
 ExecStart=
 ExecStart={{ vrf_command }}/sbin/dhclient -4 {{ dhclient_options }} {{ ifname }}

--- a/op-mode-definitions/dhcp.xml.in
+++ b/op-mode-definitions/dhcp.xml.in
@@ -293,7 +293,7 @@
                 <script>${vyos_completion_dir}/list_interfaces</script>
               </completionHelp>
             </properties>
-            <command>sudo systemctl restart "dhclient@$4.service"</command>
+            <command>sudo ${vyos_op_scripts_dir}/dhcp.py renew_client_lease --family inet --interface "$4"</command>
           </tagNode>
         </children>
       </node>
@@ -309,7 +309,7 @@
                 <script>${vyos_completion_dir}/list_interfaces</script>
               </completionHelp>
             </properties>
-            <command>sudo systemctl restart "dhcp6c@$4.service"</command>
+            <command>sudo ${vyos_op_scripts_dir}/dhcp.py renew_client_lease --family inet6 --interface "$4"</command>
           </tagNode>
         </children>
       </node>

--- a/python/vyos/opmode.py
+++ b/python/vyos/opmode.py
@@ -81,7 +81,7 @@ class InternalError(Error):
 
 
 def _is_op_mode_function_name(name):
-    if re.match(r"^(show|clear|reset|restart|add|update|delete|generate|set)", name):
+    if re.match(r"^(show|clear|reset|restart|add|update|delete|generate|set|renew)", name):
         return True
     else:
         return False

--- a/src/systemd/dhclient@.service
+++ b/src/systemd/dhclient@.service
@@ -3,6 +3,7 @@ Description=DHCP client on %i
 Documentation=man:dhclient(8)
 StartLimitIntervalSec=0
 After=vyos-router.service
+ConditionPathExists=/run/dhclient/dhclient_%i.conf
 
 [Service]
 Type=exec


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The current op-mode script simply calls sudo systemctl restart "dhclient@$4.service" with no additional information about a client interface at all.

This results in useless dhclient processes
```
root  47812  4.7  0.0   5848  3584 ?  Ss 00:30   0:00 /sbin/dhclient -4 -d
root  48121  0.0  0.0   4188  3072 ?  S  00:30   0:00  \_ /bin/sh /sbin/dhclient-script
root  48148 50.0  0.2  18776 11264 ?  R  00:30   0:00      \_ python3 -
```

Which also assign client leases to all local interfaces, if we receive one valid DHCPOFFER

```
vyos@vyos:~$ show interfaces
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address         MAC                VRF        MTU  S/L    Description
-----------  -----------------  -----------------  -------  -----  -----  -------------
eth0         -                  00:50:56:bf:c5:6d  default   1500  u/u
eth0.10      172.16.33.102/24   00:50:56:bf:c5:6d  default   1500  u/u
eth1         172.16.33.131/24   00:50:56:b3:38:c5  default   1500  u/u
```

`172.16.33.102/24` and `172.16.33.131/24` are stray DHCP addresses.

This commit moved the renew command to the DHCP op-mode script to properly validate if the interface we request a renew for, has actually a dhcp address configured. In additional this exposes the renew feature to the API.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6175

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
vyos@vyos:~$ renew dhcp interface eth3
DHCP client not configured on interface eth3!
```
```
vyos@vyos:~$ renew dhcpv6 interface eth3
DHCPv6 client not configured on interface eth3!
```
```
vyos@vyos:~$ renew dhcp interface eth3.10
Restarting DHCP client on interface eth3.10...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
