### PR TITLE
dhcp-server: T4718: Listen-address is not commit if the ip address is on the interface with vrf

### DIFF
--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -794,7 +794,7 @@ def kea_address_json(addresses):
     out = []
 
     for address in addresses:
-        ifname = is_addr_assigned(address, return_ifname=True)
+        ifname = is_addr_assigned(address, return_ifname=True, include_vrf=True)
 
         if not ifname:
             continue

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -310,7 +310,7 @@ def is_ipv6_link_local(addr):
 
     return False
 
-def is_addr_assigned(ip_address, vrf=None, return_ifname=False) -> bool | str:
+def is_addr_assigned(ip_address, vrf=None, return_ifname=False, include_vrf=False) -> bool | str:
     """ Verify if the given IPv4/IPv6 address is assigned to any interface """
     from netifaces import interfaces
     from vyos.utils.network import get_interface_config
@@ -321,7 +321,7 @@ def is_addr_assigned(ip_address, vrf=None, return_ifname=False) -> bool | str:
         # case there is no need to proceed with this data set - continue loop
         # with next element
         tmp = get_interface_config(interface)
-        if dict_search('master', tmp) != vrf:
+        if dict_search('master', tmp) != vrf and not include_vrf:
             continue
 
         if is_intf_addr_assigned(interface, ip_address):

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -316,7 +316,7 @@ def verify(dhcp):
                 raise ConfigError(f'Invalid CA certificate specified for DHCP high-availability')
 
     for address in (dict_search('listen_address', dhcp) or []):
-        if is_addr_assigned(address):
+        if is_addr_assigned(address, include_vrf=True):
             listen_ok = True
             # no need to probe further networks, we have one that is valid
             continue


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T4718

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set interfaces ethernet eth1 address 10.1.1.1/30
set interfaces ethernet eth1 vrf SMOKE-DHCP
set protocols static route 10.1.10.0/24 interface eth1 vrf SMOKE-DHCP
set vrf name SMOKE-DHCP protocols static route 10.1.10.0/24 next-hop 10.1.1.2
set vrf name SMOKE-DHCP table 1000
set service dhcp-server shared-network-name SMOKE-DHCP-NETWORK subnet 10.1.10.0/24 subnet-id 1
set service dhcp-server shared-network-name SMOKE-DHCP-NETWORK subnet 10.1.10.0/24 default-router 10.1.10.1
set service dhcp-server shared-network-name SMOKE-DHCP-NETWORK subnet 10.1.10.0/24 name-server 1.1.1.1
set service dhcp-server shared-network-name SMOKE-DHCP-NETWORK subnet 10.1.10.0/24 range 1 start 10.1.10.10
set service dhcp-server shared-network-name SMOKE-DHCP-NETWORK subnet 10.1.10.0/24 range 1 stop 10.1.10.20

set service dhcp-server listen-address 10.1.1.1
commit
```

```
cat /run/kea/kea-dhcp4.conf
{
    "Dhcp4": {
        "interfaces-config": {
            "interfaces": ["eth1/10.1.1.1"],
...
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_service_dh
test_service_dhcp-relay.py     test_service_dhcp-server.py    test_service_dhcpv6-relay.py   test_service_dhcpv6-server.py  
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py 
test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
test_dhcp_high_availability (__main__.TestServiceDHCPServer.test_dhcp_high_availability) ... ok
test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
test_dhcp_on_interface_with_vrf (__main__.TestServiceDHCPServer.test_dhcp_on_interface_with_vrf) ... ok
test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... ok
test_dhcp_single_pool_options_scoped (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options_scoped) ... ok
test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... ok
test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... ok

----------------------------------------------------------------------
Ran 10 tests in 52.150s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
