### PR TITLE
T5832: VRRP allow set interface for exluded-address

### DIFF
--- a/data/templates/high-availability/keepalived.conf.j2
+++ b/data/templates/high-availability/keepalived.conf.j2
@@ -138,8 +138,8 @@ vrrp_instance {{ name }} {
 {%         endif %}
 {%         if group_config.excluded_address is vyos_defined %}
     virtual_ipaddress_excluded {
-{%             for addr in group_config.excluded_address %}
-        {{ addr }}
+{%             for addr, addr_config in group_config.excluded_address.items() %}
+        {{ addr }}{{ ' dev ' + addr_config.interface if addr_config.interface is vyos_defined }}
 {%             endfor %}
     }
 {%         endif %}

--- a/interface-definitions/high-availability.xml.in
+++ b/interface-definitions/high-availability.xml.in
@@ -294,25 +294,34 @@
                   #include <include/generic-interface-broadcast.xml.i>
                 </children>
               </tagNode>
-              <leafNode name="excluded-address">
+              <tagNode name="excluded-address">
                 <properties>
                   <help>Virtual address (If you need additional IPv4 and IPv6 in same group)</help>
                   <valueHelp>
+                    <format>ipv4net</format>
+                    <description>IPv4 address and prefix length</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ipv6net</format>
+                    <description>IPv6 address and prefix length</description>
+                  </valueHelp>
+                  <valueHelp>
                     <format>ipv4</format>
-                    <description>IP address</description>
+                    <description>IPv4 address</description>
                   </valueHelp>
                   <valueHelp>
                     <format>ipv6</format>
                     <description>IPv6 address</description>
                   </valueHelp>
-                  <multi/>
                   <constraint>
-                    <validator name="ipv4-host"/>
-                    <validator name="ipv6-host"/>
+                    <validator name="ip-host"/>
+                    <validator name="ip-address"/>
                   </constraint>
-                  <constraintErrorMessage>Virtual address must be a valid IPv4 or IPv6 address with prefix length (e.g. 192.0.2.3/24 or 2001:db8:ff::10/64)</constraintErrorMessage>
                 </properties>
-              </leafNode>
+                <children>
+                  #include <include/generic-interface-broadcast.xml.i>
+                </children>
+              </tagNode>
               <leafNode name="vrid">
                 <properties>
                   <help>Virtual router identifier</help>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Ability to set interface for `excluded-address`
The excluded-addresses are not listed in the VRRP packet (adverts packets). We have this ability for `address`, add the same feature for the excluded-address

```
set high-availability vrrp group GRP-01 excluded-address 192.0.2.202 interface 'dum2'
set high-availability vrrp group GRP-01 excluded-address 192.0.2.203 interface 'dum3'
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T5832

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrrp, keepalived
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add excluded-address for an interface:
```
set high-availability vrrp group GRP-01 address 100.64.0.5
set high-availability vrrp group GRP-01 address 192.0.2.5
set high-availability vrrp group GRP-01 excluded-address 100.64.0.5
set high-availability vrrp group GRP-01 excluded-address 192.0.2.201
set high-availability vrrp group GRP-01 excluded-address 192.0.2.202 interface 'dum2'
set high-availability vrrp group GRP-01 excluded-address 192.0.2.203 interface 'dum3'
set high-availability vrrp group GRP-01 excluded-address 192.0.2.222/24
set high-availability vrrp group GRP-01 interface 'eth1'
set high-availability vrrp group GRP-01 vrid '123'
```
Check that address is assigned by Keepalived to dummy interface:
```
vyos@r4# show interfaces dummy 
 dummy dum2 {
 }
 dummy dum3 {
 }
[edit]
vyos@r4# 
[edit]
vyos@r4# run show interfaces dummy 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
dum2             192.0.2.202/32                    u/u  
dum3             192.0.2.203/32                    u/u  
[edit]
vyos@r4# 

```

## Smoketest result
```
vyos@r4:~$ 
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_high-availability_vrrp.py
test_01_default_values (__main__.TestVRRP.test_01_default_values) ... ok
test_02_simple_options (__main__.TestVRRP.test_02_simple_options) ... ok
test_03_sync_group (__main__.TestVRRP.test_03_sync_group) ... ok
test_04_exclude_vrrp_interface (__main__.TestVRRP.test_04_exclude_vrrp_interface) ... ok
test_05_set_multiple_peer_address (__main__.TestVRRP.test_05_set_multiple_peer_address) ... ok
test_check_health_script (__main__.TestVRRP.test_check_health_script) ... ok

----------------------------------------------------------------------
Ran 6 tests in 70.262s

OK
vyos@r4:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
