### PR TITLE
vyos.system.grub: T3664: add chroot argument to the GRUB install function

### DIFF
--- a/python/vyos/system/grub.py
+++ b/python/vyos/system/grub.py
@@ -56,7 +56,7 @@ REGEX_KERNEL_CMDLINE: str = r'^BOOT_IMAGE=/(?P<boot_type>boot|live)/((?P<image_v
 REGEX_GRUB_BOOT_OPTS: str = r'^\s*set boot_opts="(?P<boot_opts>[^$]+)"$'
 
 
-def install(drive_path: str, boot_dir: str, efi_dir: str, id: str = 'VyOS') -> None:
+def install(drive_path: str, boot_dir: str, efi_dir: str, id: str = 'VyOS', chroot : str = "") -> None:
     """Install GRUB for both BIOS and EFI modes (hybrid boot)
 
     Args:
@@ -65,17 +65,22 @@ def install(drive_path: str, boot_dir: str, efi_dir: str, id: str = 'VyOS') -> N
         efi_dir (str): a path to '/boot/efi' directory
     """
 
+    if chroot:
+        chroot_cmd = f"chroot {chroot}"
+    else:
+        chroot_cmd = ""
+
     efi_installation_arch = "x86_64"
     if platform.machine() == "aarch64":
         efi_installation_arch = "arm64"
     elif platform.machine() == "x86_64":
         cmd(
-            f'grub-install --no-floppy --target=i386-pc \
+            f'{chroot_cmd} grub-install --no-floppy --target=i386-pc \
             --boot-directory={boot_dir}  {drive_path} --force'
         )
 
     cmd(
-        f'grub-install --no-floppy --recheck --target={efi_installation_arch}-efi \
+        f'{chroot_cmd} grub-install --no-floppy --recheck --target={efi_installation_arch}-efi \
             --force-extra-removable --boot-directory={boot_dir} \
             --efi-directory={efi_dir} --bootloader-id="{id}" \
             --no-uefi-secure-boot'
@@ -458,3 +463,4 @@ def sort_inodes(dir_path: str) -> None:
     for item in temp_list_new:
         new_name = Path(f'{item.as_posix()[0:-4]}')
         item.rename(new_name)
+


### PR DESCRIPTION
Add chroot argument to the GRUB install function to faciliate running it outside of a VyOS installation.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): internal API change

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

`vyos.system.grub`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
