### PR TITLE
vyos.template: T3664: add an environment variable for template location

### DIFF
--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2019-2024 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -32,8 +32,21 @@ _TESTS = {}
 # reuse Environments with identical settings to improve performance
 @functools.lru_cache(maxsize=2)
 def _get_environment(location=None):
+    from os import getenv
+
     if location is None:
-        loc_loader=FileSystemLoader(directories["templates"])
+        # Sometimes functions that rely on templates need to be executed outside of VyOS installations:
+        # for example, installer functions are executed for image builds,
+        # and anything may be invoked for testing from a developer's machine.
+        # This environment variable allows running any unmodified code
+        # with a custom template location.
+        location_env_var = getenv("VYOS_TEMPLATE_DIR")
+        if location_env_var:
+            print(f"Using environment variable {location_env_var}")
+            template_dir = location_env_var
+        else:
+            template_dir = directories["templates"]
+        loc_loader=FileSystemLoader(template_dir)
     else:
         loc_loader=FileSystemLoader(location)
     env = Environment(


### PR DESCRIPTION
to allow unmodified code to be executed from anywhere, even outside of VyOS installations

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

By settings `VYOS_TEMPLATE_DIR` environment variable, anyone can run scripts that rely on template with any template dir location.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): internal API change


## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

`vyos.template`


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
