### PR TITLE
bgp: T6151: Allow configuration of disable-ebgp-connected-route-check

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -537,6 +537,9 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {% if parameters.allow_martian_nexthop is vyos_defined %}
  bgp allow-martian-nexthop
 {% endif %}
+{% if parameters.disable_ebgp_connected_route_check is vyos_defined %}
+ bgp disable-ebgp-connected-route-check
+{% endif %}
 {% if parameters.always_compare_med is vyos_defined %}
  bgp always-compare-med
 {% endif %}

--- a/interface-definitions/include/bgp/neighbor-disable-connected-check.xml.i
+++ b/interface-definitions/include/bgp/neighbor-disable-connected-check.xml.i
@@ -1,7 +1,7 @@
 <!-- include start from bgp/neighbor-disable-connected-check.xml.i -->
 <leafNode name="disable-connected-check">
   <properties>
-    <help>Disable check to see if eBGP peer address is a connected route</help>
+    <help>Allow peerings between eBGP peer using loopback address</help>
     <valueless/>
   </properties>
 </leafNode>

--- a/interface-definitions/include/bgp/neighbor-disable-connected-check.xml.i
+++ b/interface-definitions/include/bgp/neighbor-disable-connected-check.xml.i
@@ -1,7 +1,7 @@
 <!-- include start from bgp/neighbor-disable-connected-check.xml.i -->
 <leafNode name="disable-connected-check">
   <properties>
-    <help>Allow peerings between eBGP peer using loopback address</help>
+    <help>Allow peerings between eBGP peer using loopback/dummy address</help>
     <valueless/>
   </properties>
 </leafNode>

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -1251,7 +1251,7 @@
     </leafNode>
     <leafNode name="disable-ebgp-connected-route-check">
       <properties>
-        <help>Disable checking if nexthop is connected on ebgp session</help>
+        <help>Disable checking if nexthop is connected on eBGP session</help>
         <valueless/>
       </properties>
     </leafNode>

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -1249,6 +1249,12 @@
         <valueless/>
       </properties>
     </leafNode>
+    <leafNode name="disable-ebgp-connected-route-check">
+      <properties>
+        <help>Disable checking if nexthop is connected on ebgp session</help>
+        <valueless/>
+      </properties>
+    </leafNode>
     <leafNode name="always-compare-med">
       <properties>
         <help>Always compare MEDs from different neighbors</help>

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -321,6 +321,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         tcp_keepalive_probes = '22'
 
         self.cli_set(base_path + ['parameters', 'allow-martian-nexthop'])
+        self.cli_set(base_path + ['parameters', 'disable-ebgp-connected-route-check'])
         self.cli_set(base_path + ['parameters', 'no-hard-administrative-reset'])
         self.cli_set(base_path + ['parameters', 'log-neighbor-changes'])
         self.cli_set(base_path + ['parameters', 'labeled-unicast', 'explicit-null'])
@@ -372,6 +373,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f' bgp router-id {router_id}', frrconfig)
         self.assertIn(f' bgp allow-martian-nexthop', frrconfig)
+        self.assertIn(f' bgp disable-ebgp-connected-route-check', frrconfig)
         self.assertIn(f' bgp log-neighbor-changes', frrconfig)
         self.assertIn(f' bgp default local-preference {local_pref}', frrconfig)
         self.assertIn(f' bgp conditional-advertisement timer {cond_adv_timer}', frrconfig)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

Allow configuration of disable-ebgp-connected-route-check when the next-hop is learned not connected.

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6151
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
vyos command : 
```
set protocols bgp parameters disable-ebgp-connected-route-check
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```

vyos@vrf-test:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ...

ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ...

ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ...

ok
----------------------------------------------------------------------
Ran 27 tests in 128.218s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
