### PR TITLE
T6068: dhcp-server: add command <set service dhcp-server high-availability mode>

### DIFF
--- a/interface-definitions/service_dhcp-server.xml.in
+++ b/interface-definitions/service_dhcp-server.xml.in
@@ -22,6 +22,27 @@
             </properties>
             <children>
               #include <include/source-address-ipv4.xml.i>
+              <leafNode name="mode">
+                <properties>
+                  <help>Configure high availability mode</help>
+                  <completionHelp>
+                    <list>active-active active-passive</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>active-active</format>
+                    <description>Both server attend DHCP requests</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>active-passive</format>
+                    <description>Only primary server attends DHCP requests</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(active-active|active-passive)</regex>
+                  </constraint>
+                  <constraintErrorMessage>Invalid DHCP high availability mode</constraintErrorMessage>
+                </properties>
+                <defaultValue>active-active</defaultValue>
+              </leafNode>
               <leafNode name="remote">
                 <properties>
                   <help>IPv4 remote address used for connection</help>

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -809,10 +809,19 @@ def kea_high_availability_json(config):
 
     source_addr = config['source_address']
     remote_addr = config['remote']
+    ha_mode = 'hot-standby' if config['mode'] == 'active-passive' else 'load-balancing'
+    ha_role = config['status']
+
+    if ha_role == 'primary':
+        peer1_role = 'primary'
+        peer2_role = 'standby' if ha_mode == 'hot-standby' else 'secondary'
+    else:
+        peer1_role = 'standby' if ha_mode == 'hot-standby' else 'secondary'
+        peer2_role = 'primary'
 
     data = {
         'this-server-name': os.uname()[1],
-        'mode': 'hot-standby',
+        'mode': ha_mode,
         'heartbeat-delay': 10000,
         'max-response-delay': 10000,
         'max-ack-delay': 5000,
@@ -821,13 +830,13 @@ def kea_high_availability_json(config):
         {
             'name': os.uname()[1],
             'url': f'http://{source_addr}:647/',
-            'role': 'standby' if config['status'] == 'secondary' else 'primary',
+            'role': peer1_role,
             'auto-failover': True
         },
         {
             'name': config['name'],
             'url': f'http://{remote_addr}:647/',
-            'role': 'primary' if config['status'] == 'secondary' else 'standby',
+            'role': peer2_role,
             'auto-failover': True
         }]
     }

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -143,8 +143,12 @@ def get_config(config=None):
                         dhcp['shared_network_name'][network]['subnet'][subnet].update(
                                 {'range' : new_range_dict})
 
-    if dict_search('high_availability.certificate', dhcp):
-        dhcp['pki'] = conf.get_config_dict(['pki'], key_mangling=('-', '_'), get_first_key=True, no_tag_node_value_mangle=True)
+    if len(dhcp['high_availability']) == 1:
+        ## only default value for mode is set, need to remove ha node
+        del dhcp['high_availability']
+    else:
+        if dict_search('high_availability.certificate', dhcp):
+            dhcp['pki'] = conf.get_config_dict(['pki'], key_mangling=('-', '_'), get_first_key=True, no_tag_node_value_mangle=True)
 
     return dhcp
 


### PR DESCRIPTION
…
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add command <set service dhcp-server high-availability mode> so user can define what type of ha use: active-active or active-passive

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6068

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Main config:
```
vyos@dhcp-sag-main:~$ show config comm | grep dhcp
set service dhcp-server high-availability mode 'active-active'
set service dhcp-server high-availability name 'TEST'
set service dhcp-server high-availability remote '198.51.100.2'
set service dhcp-server high-availability source-address '198.51.100.1'
set service dhcp-server high-availability status 'primary'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 option default-router '198.51.100.1'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 option name-server '8.8.8.8'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 range 0 start '198.51.100.101'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 range 0 stop '198.51.100.200'
set service dhcp-server shared-network-name LAN subnet 198.51.100.0/24 subnet-id '1'
set system host-name 'dhcp-sag-main'
```
## mode=active-active and status=primary
```
vyos@dhcp-sag-main:~$ sudo ps aux | grep kea
_kea        2050  0.0  1.1  51800 11776 ?        Ssl  22:06   0:00 /usr/sbin/kea-ctrl-agent -c /run/kea/kea-ctrl-agent.conf
_kea        2053  0.1  2.5 216708 25856 ?        Ssl  22:06   0:00 /usr/sbin/kea-dhcp4 -c /run/kea/kea-dhcp4.conf
vyos        2395  0.0  0.2   6332  2176 ttyS0    S+   22:08   0:00 grep kea
vyos@dhcp-sag-main:~$ cat /run/kea/kea-dhcp4.conf | grep high-av
                    "high-availability": [{"this-server-name": "dhcp-sag-main", "mode": "load-balancing", "heartbeat-delay": 10000, "max-response-delay": 10000, "max-ack-delay": 5000, "max-unacked-clients": 0, "peers": [{"name": "dhcp-sag-main", "url": "http://198.51.100.1:647/", "role": "primary", "auto-failover": true}, {"name": "TEST", "url": "http://198.51.100.2:647/", "role": "secondary", "auto-failover": true}]}]
vyos@dhcp-sag-main:~$ 
```
## mode=active-active and status=secondary
```
vyos@dhcp-sag-main# sudo ps aux | grep kea
_kea        2638  0.2  1.1  51704 11904 ?        Ssl  22:09   0:00 /usr/sbin/kea-ctrl-agent -c /run/kea/kea-ctrl-agent.conf
_kea        2641  0.8  2.9 151072 29240 ?        Ssl  22:09   0:00 /usr/sbin/kea-dhcp4 -c /run/kea/kea-dhcp4.conf
vyos        2696  0.0  0.2   6332  2176 ttyS0    S+   22:09   0:00 grep kea
[edit]
vyos@dhcp-sag-main# cat /run/kea/kea-dhcp4.conf | grep high-av
                    "high-availability": [{"this-server-name": "dhcp-sag-main", "mode": "load-balancing", "heartbeat-delay": 10000, "max-response-delay": 10000, "max-ack-delay": 5000, "max-unacked-clients": 0, "peers": [{"name": "dhcp-sag-main", "url": "http://198.51.100.1:647/", "role": "secondary", "auto-failover": true}, {"name": "TEST", "url": "http://198.51.100.2:647/", "role": "primary", "auto-failover": true}]}]
[edit]
vyos@dhcp-sag-main# 
```
## mode=active-passive and status=secondary
```
vyos@dhcp-sag-main# sudo ps aux | grep kea
_kea        2826  0.0  1.1  51704 11648 ?        Ssl  22:10   0:00 /usr/sbin/kea-ctrl-agent -c /run/kea/kea-ctrl-agent.conf
_kea        2833  0.4  2.5  85536 25452 ?        Ssl  22:10   0:00 /usr/sbin/kea-dhcp4 -c /run/kea/kea-dhcp4.conf
vyos        2889  0.0  0.2   6332  2048 ttyS0    S+   22:10   0:00 grep kea
[edit]
vyos@dhcp-sag-main# cat /run/kea/kea-dhcp4.conf | grep high-av
                    "high-availability": [{"this-server-name": "dhcp-sag-main", "mode": "hot-standby", "heartbeat-delay": 10000, "max-response-delay": 10000, "max-ack-delay": 5000, "max-unacked-clients": 0, "peers": [{"name": "dhcp-sag-main", "url": "http://198.51.100.1:647/", "role": "standby", "auto-failover": true}, {"name": "TEST", "url": "http://198.51.100.2:647/", "role": "primary", "auto-failover": true}]}]
[edit]
vyos@dhcp-sag-main#
```
## mode=active-passive and status=primary
```
vyos@dhcp-sag-main# sudo ps aux | grep kea                                                                        
_kea        2995  0.0  1.1  51704 11776 ?        Ssl  22:11   0:00 /usr/sbin/kea-ctrl-agent -c /run/kea/kea-ctrl-agent.conf
_kea        3004  0.2  2.5  85536 25564 ?        Ssl  22:11   0:00 /usr/sbin/kea-dhcp4 -c /run/kea/kea-dhcp4.conf
vyos        3066  0.0  0.2   6332  2176 ttyS0    S+   22:11   0:00 grep kea
[edit]
vyos@dhcp-sag-main# cat /run/kea/kea-dhcp4.conf | grep high-av
                    "high-availability": [{"this-server-name": "dhcp-sag-main", "mode": "hot-standby", "heartbeat-delay": 10000, "max-response-delay": 10000, "max-ack-delay": 5000, "max-unacked-clients": 0, "peers": [{"name": "dhcp-sag-main", "url": "http://198.51.100.1:647/", "role": "primary", "auto-failover": true}, {"name": "TEST", "url": "http://198.51.100.2:647/", "role": "standby", "auto-failover": true}]}]
[edit]
vyos@dhcp-sag-main# 
```
## mode=not-defined (default value is active=active) and status=primary

```
vyos@dhcp-sag-main# sudo ps aux | grep kea
_kea        3157  0.0  1.1  51704 11392 ?        Ssl  22:12   0:00 /usr/sbin/kea-ctrl-agent -c /run/kea/kea-ctrl-agent.conf
_kea        3164  0.2  2.4  85536 24936 ?        Ssl  22:12   0:00 /usr/sbin/kea-dhcp4 -c /run/kea/kea-dhcp4.conf
vyos        3221  0.0  0.2   6332  2048 ttyS0    S+   22:12   0:00 grep kea
[edit]
vyos@dhcp-sag-main# cat /run/kea/kea-dhcp4.conf | grep high-av
                    "high-availability": [{"this-server-name": "dhcp-sag-main", "mode": "load-balancing", "heartbeat-delay": 10000, "max-response-delay": 10000, "max-ack-delay": 5000, "max-unacked-clients": 0, "peers": [{"name": "dhcp-sag-main", "url": "http://198.51.100.1:647/", "role": "primary", "auto-failover": true}, {"name": "TEST", "url": "http://198.51.100.2:647/", "role": "secondary", "auto-failover": true}]}]
[edit]
vyos@dhcp-sag-main# 
```
### And last config, without using high availability:
```
vyos@dhcp-sag-main# del serv dhcp-server high-availability 
[edit]
vyos@dhcp-sag-main# commit
[edit]
vyos@dhcp-sag-main# sudo ps aux | grep kea
_kea        3277  0.1  2.3 142160 23860 ?        Ssl  22:13   0:00 /usr/sbin/kea-dhcp4 -c /run/kea/kea-dhcp4.conf
vyos        3333  0.0  0.2   6332  2176 ttyS0    S+   22:13   0:00 grep kea
[edit]
vyos@dhcp-sag-main# cat /run/kea/kea-dhcp4.conf | grep high-av
[edit]
vyos@dhcp-sag-main# 
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@dhcp-sag-main:/usr/libexec/vyos/tests/smoke/cli# ./test_service_dhcp-server.py 
test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
test_dhcp_high_availability (__main__.TestServiceDHCPServer.test_dhcp_high_availability) ... 
No DHCP address range or active static-mapping configured within shared-
network "FAILOVER, 192.0.2.0/25"!

ok
test_dhcp_high_availability_standby (__main__.TestServiceDHCPServer.test_dhcp_high_availability_standby) ... ok
test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... ok
test_dhcp_single_pool_options_scoped (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options_scoped) ... ok
test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... 
No DHCP address range or active static-mapping configured within shared-
network "SMOKE-1, 192.0.2.0/25"!

ok
test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... 
No DHCP address range or active static-mapping configured within shared-
network "SMOKE-2, 192.0.2.0/25"!


Either MAC address or Client identifier (DUID) is required for static
mapping "client1" within shared-network "SMOKE-2, 192.0.2.0/25"!


Configured IP address for static mapping "dupe1" already exists on
another static mapping


Configured MAC address for static mapping "dupe2" already exists on
another static mapping


Configured IP address for static mapping "dupe4" already exists on
another static mapping

ok

----------------------------------------------------------------------
Ran 10 tests in 26.717s

OK
root@dhcp-sag-main:/usr/libexec/vyos/tests/smoke/cli# 
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
