### PR TITLE
T5873: ipsec remote access VPN: support VTI interfaces.

### DIFF
--- a/data/templates/ipsec/swanctl.conf.j2
+++ b/data/templates/ipsec/swanctl.conf.j2
@@ -31,6 +31,8 @@ pools {
     {{ pool }} {
 {%         if pool_config.prefix is vyos_defined %}
         addrs = {{ pool_config.prefix }}
+{%         elif pool_config.range is vyos_defined %}
+        addrs = {{ pool_config.range.start }}-{{ pool_config.range.stop }}
 {%         endif %}
 {%         if pool_config.name_server is vyos_defined %}
         dns = {{ pool_config.name_server | join(',') }}

--- a/data/templates/ipsec/swanctl/remote_access.j2
+++ b/data/templates/ipsec/swanctl/remote_access.j2
@@ -46,7 +46,7 @@
 {% endif %}
         }
         children {
-            ikev2-vpn  {
+            {{ name }}-client  {
                 esp_proposals = {{ esp | get_esp_ike_cipher(ike) | join(',') }}
 {% if esp.life_bytes is vyos_defined %}
                 life_bytes = {{ esp.life_bytes }}

--- a/data/templates/ipsec/swanctl/remote_access.j2
+++ b/data/templates/ipsec/swanctl/remote_access.j2
@@ -69,6 +69,13 @@
 {% set local_port = rw_conf.local.port if rw_conf.local.port is vyos_defined else '' %}
 {% set local_suffix = '[%any/{1}]'.format(local_port) if local_port else '' %}
                 local_ts = {{ local_prefix | join(local_suffix + ",") }}{{ local_suffix }}
+{% if rw_conf.bind is vyos_defined %}
+{#     The key defaults to 0 and will match any policies which similarly do not have a lookup key configuration. #}
+{#     Thus we simply shift the key by one to also support a vti0 interface #}
+{%     set if_id = rw_conf.bind | replace('vti', '') | int + 1 %}
+                if_id_in = {{ if_id }}
+                if_id_out = {{ if_id }}
+{% endif %}
             }
         }
     }

--- a/interface-definitions/include/ipsec/bind.xml.i
+++ b/interface-definitions/include/ipsec/bind.xml.i
@@ -1,0 +1,10 @@
+<!-- include start from ipsec/bind.xml.i -->
+<leafNode name="bind">
+  <properties>
+    <help>VTI tunnel interface associated with this configuration</help>
+    <completionHelp>
+      <path>interfaces vti</path>
+    </completionHelp>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -854,6 +854,7 @@
                   #include <include/dhcp-interface.xml.i>
                   #include <include/ipsec/local-traffic-selector.xml.i>
                   #include <include/ipsec/replay-window.xml.i>
+                  #include <include/ipsec/bind.xml.i>
                   <leafNode name="timeout">
                     <properties>
                       <help>Timeout to close connection if no data is transmitted</help>
@@ -978,6 +979,45 @@
                       </constraint>
                     </properties>
                   </leafNode>
+                  <node name="range">
+                    <properties>
+                      <help>Local IPv4 or IPv6 pool range</help>
+                    </properties>
+                    <children>
+                      <leafNode name="start">
+                        <properties>
+                          <help>First IP address for local pool range</help>
+                          <valueHelp>
+                            <format>ipv4</format>
+                            <description>IPv4 start address of pool</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>ipv6</format>
+                            <description>IPv6 start address of pool</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="ip-address"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="stop">
+                        <properties>
+                          <help>Last IP address for local pool range</help>
+                          <valueHelp>
+                            <format>ipv4</format>
+                            <description>IPv4 end address of pool</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>ipv6</format>
+                            <description>IPv6 end address of pool</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="ip-address"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </node>
                   #include <include/name-server-ipv4-ipv6.xml.i>
                 </children>
               </tagNode>
@@ -1201,14 +1241,7 @@
                       <help>Virtual tunnel interface</help>
                     </properties>
                     <children>
-                      <leafNode name="bind">
-                        <properties>
-                          <help>VTI tunnel interface associated with this configuration</help>
-                          <completionHelp>
-                            <path>interfaces vti</path>
-                          </completionHelp>
-                        </properties>
-                      </leafNode>
+                      #include <include/ipsec/bind.xml.i>
                       #include <include/ipsec/esp-group.xml.i>
                     </children>
                   </node>

--- a/python/vyos/utils/vti_updown_db.py
+++ b/python/vyos/utils/vti_updown_db.py
@@ -1,0 +1,194 @@
+# Copyright 2024 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from contextlib import contextmanager
+from syslog import syslog
+
+VTI_WANT_UP_IFLIST = '/tmp/ipsec_vti_interfaces'
+
+def vti_updown_db_exists():
+    """ Returns true if the database exists """
+    return os.path.exists(VTI_WANT_UP_IFLIST)
+
+@contextmanager
+def open_vti_updown_db_for_create_or_update():
+    """ Opens the database for reading and writing, creating the database if it does not exist """
+    if vti_updown_db_exists():
+        f = open(VTI_WANT_UP_IFLIST, 'r+')
+    else:
+        f = open(VTI_WANT_UP_IFLIST, 'x+')
+    try:
+        db = VTIUpDownDB(f)
+        yield db
+    finally:
+        f.close()
+
+@contextmanager
+def open_vti_updown_db_for_update():
+    """ Opens the database for reading and writing, returning an error if it does not exist """
+    f = open(VTI_WANT_UP_IFLIST, 'r+')
+    try:
+        db = VTIUpDownDB(f)
+        yield db
+    finally:
+        f.close()
+
+@contextmanager
+def open_vti_updown_db_readonly():
+    """ Opens the database for reading, returning an error if it does not exist """
+    f = open(VTI_WANT_UP_IFLIST, 'r')
+    try:
+        db = VTIUpDownDB(f)
+        yield db
+    finally:
+        f.close()
+
+def remove_vti_updown_db():
+    """ Brings down any interfaces referenced by the database and removes the database """
+    # We need to process the DB first to bring down any interfaces still up
+    with open_vti_updown_db_for_update() as db:
+        db.removeAllOtherInterfaces([])
+        # this usage of commit will only ever bring down interfaces,
+        # do not need to provide a functional interface dict supplier
+        db.commit(lambda _: None)
+
+    os.unlink(VTI_WANT_UP_IFLIST)
+
+class VTIUpDownDB:
+    # The VTI Up-Down DB is a text-based database of space-separated "ifspecs".
+    #
+    # ifspecs can come in one of the two following formats:
+    #
+    # persistent format: <interface name>
+    # indicates the named interface should always be up.
+    #
+    # connection format: <interface name>:<connection name>:<protocol>
+    # indicates the named interface wants to be up due to an established
+    # connection <connection name> using the <protocol> protocol.
+    #
+    # The configuration tree and ipsec daemon connection up-down hook
+    # modify this file as needed and use it to determine when a
+    # particular event or configuration change should lead to changing
+    # the interface state.
+
+    def __init__(self, f):
+        self._fileHandle = f
+        self._ifspecs = set([entry.strip() for entry in f.read().split(" ") if entry and not entry.isspace()])
+        self._ifsUp = set()
+        self._ifsDown = set()
+
+    def add(self, interface, connection = None, protocol = None):
+        """
+        Adds a new entry to the DB.
+
+        If an interface name, connection name, and protocol are supplied,
+        creates a connection entry.
+
+        If only an interface name is specified, creates a persistent entry
+        for the given interface.
+        """
+        ifspec = f"{interface}:{connection}:{protocol}" if (connection is not None and protocol is not None) else interface
+        if ifspec not in self._ifspecs:
+            self._ifspecs.add(ifspec)
+            self._ifsUp.add(interface)
+            self._ifsDown.discard(interface)
+
+    def remove(self, interface, connection = None, protocol = None):
+        """
+        Removes a matching entry from the DB.
+
+        If no matching entry can be fonud, the operation returns successfully.
+        """
+        ifspec = f"{interface}:{connection}:{protocol}" if (connection is not None and protocol is not None) else interface
+        if ifspec in self._ifspecs:
+            self._ifspecs.remove(ifspec)
+            interface_remains = False
+            for ifspec in self._ifspecs:
+                if ifspec.split(':')[0] == interface:
+                    interface_remains = True
+
+            if not interface_remains:
+                self._ifsDown.add(interface)
+                self._ifsUp.discard(interface)
+
+    def wantsInterfaceUp(self, interface):
+        """ Returns whether the DB contains at least one entry referencing the given interface """
+        for ifspec in self._ifspecs:
+                if ifspec.split(':')[0] == interface:
+                    return True
+
+        return False
+
+    def removeAllOtherInterfaces(self, interface_list):
+        """ Removes all interfaces not included in the given list from the DB """
+        updated_ifspecs = set([ifspec for ifspec in self._ifspecs if ifspec.split(':')[0] in interface_list])
+        removed_ifspecs = self._ifspecs - updated_ifspecs
+        self._ifspecs = updated_ifspecs
+        interfaces_to_bring_down = [ifspec.split(':')[0] for ifspec in removed_ifspecs]
+        self._ifsDown.update(interfaces_to_bring_down)
+        self._ifsUp.difference_update(interfaces_to_bring_down)
+
+    def setPersistentInterfaces(self, interface_list):
+        """ Updates the set of persistently up interfaces to match the given list """
+        new_presistent_interfaces = set(interface_list)
+        current_presistent_interfaces = set([ifspec for ifspec in self._ifspecs if ':' not in ifspec])
+        added_presistent_interfaces = new_presistent_interfaces - current_presistent_interfaces
+        removed_presistent_interfaces = current_presistent_interfaces - new_presistent_interfaces
+
+        for interface in added_presistent_interfaces:
+            self.add(interface)
+
+        for interface in removed_presistent_interfaces:
+            self.remove(interface)
+
+    def commit(self, interface_dict_supplier):
+        """
+        Writes the DB to disk and brings interfaces up and down as needed.
+
+        Only interfaces referenced by entries modified in this DB session
+        are manipulated. If an interface is called to be brought up, the
+        provided interface_config_supplier function is invoked and expected
+        to return the config dictionary for the interface.
+        """
+        from vyos.ifconfig import VTIIf
+        from vyos.utils.process import call
+        from vyos.utils.network import get_interface_config
+
+        self._fileHandle.seek(0)
+        self._fileHandle.write(' '.join(self._ifspecs))
+        self._fileHandle.truncate()
+
+        for interface in self._ifsDown:
+            vti_link = get_interface_config(interface)
+            vti_link_up = (vti_link['operstate'] != 'DOWN' if 'operstate' in vti_link else False)
+            if vti_link_up:
+                call(f'sudo ip link set {interface} down')
+                syslog(f'Interface {interface} is admin down ...')
+
+        self._ifsDown.clear()
+
+        for interface in self._ifsUp:
+            vti_link = get_interface_config(interface)
+            vti_link_up = (vti_link['operstate'] != 'DOWN' if 'operstate' in vti_link else False)
+            if not vti_link_up:
+                vti = interface_dict_supplier(interface)
+                if 'disable' not in vti:
+                    tmp = VTIIf(interface, bypass_vti_updown_db = True)
+                    tmp.update(vti)
+                    syslog(f'Interface {interface} is admin up ...')
+
+        self._ifsUp.clear()

--- a/smoketest/scripts/cli/test_interfaces_vti.py
+++ b/smoketest/scripts/cli/test_interfaces_vti.py
@@ -39,7 +39,8 @@ class VTIInterfaceTest(BasicInterfaceTest.TestCase):
 
         self.cli_commit()
 
-        # VTI interface are always down and only brought up by IPSec
+        # VTI interfaces are default down and only brought up when an
+        # IPSec connection is configured to use them
         for intf in self._interfaces:
             self.assertTrue(is_intf_addr_assigned(intf, addr))
             self.assertEqual(Interface(intf).get_admin_state(), 'down')

--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -1086,5 +1086,261 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         self.tearDownPKI()
 
+    def test_remote_access_pool_range(self):
+        # Same as test_remote_access but using an IP pool range instead of prefix
+        self.setupPKI()
+
+        ike_group = 'IKE-RW'
+        esp_group = 'ESP-RW'
+
+        conn_name = 'vyos-rw'
+        local_address = '192.0.2.1'
+        ip_pool_name = 'ra-rw-ipv4'
+        username = 'vyos'
+        password = 'secret'
+        ike_lifetime = '7200'
+        eap_lifetime = '3600'
+        local_id = 'ipsec.vyos.net'
+
+        name_servers = ['172.16.254.100', '172.16.254.101']
+        range_start = '172.16.250.2'
+        range_stop = '172.16.250.254'
+
+        # IKE
+        self.cli_set(base_path + ['ike-group', ike_group, 'key-exchange', 'ikev2'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'lifetime', ike_lifetime])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '1',  'dh-group', '14'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '1',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '1',  'hash', 'sha512'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '2',  'dh-group', '14'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '2',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '2',  'hash', 'sha256'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '3',  'dh-group', '2'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '3',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '3',  'hash', 'sha256'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '10', 'dh-group', '14'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '10', 'encryption', 'aes128gcm128'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '10', 'hash', 'sha256'])
+
+        # ESP
+        self.cli_set(base_path + ['esp-group', esp_group, 'lifetime', eap_lifetime])
+        self.cli_set(base_path + ['esp-group', esp_group, 'pfs', 'disable'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '1',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '1',  'hash', 'sha512'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '2',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '2',  'hash', 'sha384'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '3',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '3',  'hash', 'sha256'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '4',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '4',  'hash', 'sha1'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '10', 'encryption', 'aes128gcm128'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '10', 'hash', 'sha256'])
+
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'local-id', local_id])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'local-users', 'username', username, 'password', password])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'server-mode', 'x509'])
+
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'x509', 'certificate', peer_name])
+        # verify() - CA cert required for x509 auth
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'x509', 'ca-certificate', ca_name])
+
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'esp-group', esp_group])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'ike-group', ike_group])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'local-address', local_address])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'pool', ip_pool_name])
+
+        for ns in name_servers:
+            self.cli_set(base_path + ['remote-access', 'pool', ip_pool_name, 'name-server', ns])
+        self.cli_set(base_path + ['remote-access', 'pool', ip_pool_name, 'range', 'start', range_start])
+        self.cli_set(base_path + ['remote-access', 'pool', ip_pool_name, 'range', 'stop', range_stop])
+
+        self.cli_commit()
+
+        # verify applied configuration
+        swanctl_conf = read_file(swanctl_file)
+        swanctl_lines = [
+            f'{conn_name}',
+            f'remote_addrs = %any',
+            f'local_addrs = {local_address}',
+            f'proposals = aes256-sha512-modp2048,aes256-sha256-modp2048,aes256-sha256-modp1024,aes128gcm128-sha256-modp2048',
+            f'version = 2',
+            f'send_certreq = no',
+            f'rekey_time = {ike_lifetime}s',
+            f'keyingtries = 0',
+            f'pools = {ip_pool_name}',
+            f'id = "{local_id}"',
+            f'auth = pubkey',
+            f'certs = peer1.pem',
+            f'auth = eap-mschapv2',
+            f'eap_id = %any',
+            f'esp_proposals = aes256-sha512,aes256-sha384,aes256-sha256,aes256-sha1,aes128gcm128-sha256',
+            f'life_time = {eap_lifetime}s',
+            f'dpd_action = clear',
+            f'replay_window = 32',
+            f'inactivity = 28800',
+            f'local_ts = 0.0.0.0/0,::/0',
+        ]
+        for line in swanctl_lines:
+            self.assertIn(line, swanctl_conf)
+
+        swanctl_secrets_lines = [
+            f'eap-{conn_name}-{username}',
+            f'secret = "{password}"',
+            f'id-{conn_name}-{username} = "{username}"',
+        ]
+        for line in swanctl_secrets_lines:
+            self.assertIn(line, swanctl_conf)
+
+        swanctl_pool_lines = [
+            f'{ip_pool_name}',
+            f'addrs = {range_start}-{range_stop}',
+            f'dns = {",".join(name_servers)}',
+        ]
+        for line in swanctl_pool_lines:
+            self.assertIn(line, swanctl_conf)
+
+        # Check Root CA, Intermediate CA and Peer cert/key pair is present
+        self.assertTrue(os.path.exists(os.path.join(CA_PATH, f'{ca_name}.pem')))
+        self.assertTrue(os.path.exists(os.path.join(CERT_PATH, f'{peer_name}.pem')))
+
+        self.tearDownPKI()
+
+    def test_remote_access_vti(self):
+        # Set up and use a VTI interface for the remote access VPN
+        self.setupPKI()
+
+        ike_group = 'IKE-RW'
+        esp_group = 'ESP-RW'
+
+        conn_name = 'vyos-rw'
+        local_address = '192.0.2.1'
+        vti = 'vti10'
+        ip_pool_name = 'ra-rw-ipv4'
+        username = 'vyos'
+        password = 'secret'
+        ike_lifetime = '7200'
+        eap_lifetime = '3600'
+        local_id = 'ipsec.vyos.net'
+
+        name_servers = ['10.1.1.1']
+        range_start = '10.1.1.10'
+        range_stop = '10.1.1.254'
+
+        # VTI interface
+        self.cli_set(vti_path + [vti, 'address', '10.1.1.1/24'])
+
+        # IKE
+        self.cli_set(base_path + ['ike-group', ike_group, 'key-exchange', 'ikev2'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'lifetime', ike_lifetime])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '1',  'dh-group', '14'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '1',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '1',  'hash', 'sha512'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '2',  'dh-group', '14'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '2',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '2',  'hash', 'sha256'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '3',  'dh-group', '2'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '3',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '3',  'hash', 'sha256'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '10', 'dh-group', '14'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '10', 'encryption', 'aes128gcm128'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '10', 'hash', 'sha256'])
+
+        # ESP
+        self.cli_set(base_path + ['esp-group', esp_group, 'lifetime', eap_lifetime])
+        self.cli_set(base_path + ['esp-group', esp_group, 'pfs', 'disable'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '1',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '1',  'hash', 'sha512'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '2',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '2',  'hash', 'sha384'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '3',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '3',  'hash', 'sha256'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '4',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '4',  'hash', 'sha1'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '10', 'encryption', 'aes128gcm128'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '10', 'hash', 'sha256'])
+
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'local-id', local_id])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'local-users', 'username', username, 'password', password])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'server-mode', 'x509'])
+
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'x509', 'certificate', peer_name])
+        # verify() - CA cert required for x509 auth
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'x509', 'ca-certificate', ca_name])
+
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'esp-group', esp_group])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'ike-group', ike_group])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'bind', vti])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'local-address', local_address])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'pool', ip_pool_name])
+
+        for ns in name_servers:
+            self.cli_set(base_path + ['remote-access', 'pool', ip_pool_name, 'name-server', ns])
+        self.cli_set(base_path + ['remote-access', 'pool', ip_pool_name, 'range', 'start', range_start])
+        self.cli_set(base_path + ['remote-access', 'pool', ip_pool_name, 'range', 'stop', range_stop])
+
+        self.cli_commit()
+
+        # verify applied configuration
+        swanctl_conf = read_file(swanctl_file)
+
+        if_id = vti.lstrip('vti')
+        # The key defaults to 0 and will match any policies which similarly do
+        # not have a lookup key configuration - thus we shift the key by one
+        # to also support a vti0 interface
+        if_id = str(int(if_id) +1)
+
+        swanctl_lines = [
+            f'{conn_name}',
+            f'remote_addrs = %any',
+            f'local_addrs = {local_address}',
+            f'proposals = aes256-sha512-modp2048,aes256-sha256-modp2048,aes256-sha256-modp1024,aes128gcm128-sha256-modp2048',
+            f'version = 2',
+            f'send_certreq = no',
+            f'rekey_time = {ike_lifetime}s',
+            f'keyingtries = 0',
+            f'pools = {ip_pool_name}',
+            f'id = "{local_id}"',
+            f'auth = pubkey',
+            f'certs = peer1.pem',
+            f'auth = eap-mschapv2',
+            f'eap_id = %any',
+            f'esp_proposals = aes256-sha512,aes256-sha384,aes256-sha256,aes256-sha1,aes128gcm128-sha256',
+            f'life_time = {eap_lifetime}s',
+            f'dpd_action = clear',
+            f'replay_window = 32',
+            f'if_id_in = {if_id}', # will be 11 for vti10 - shifted by one
+            f'if_id_out = {if_id}',
+            f'inactivity = 28800',
+            f'local_ts = 0.0.0.0/0,::/0',
+        ]
+        for line in swanctl_lines:
+            self.assertIn(line, swanctl_conf)
+
+        swanctl_secrets_lines = [
+            f'eap-{conn_name}-{username}',
+            f'secret = "{password}"',
+            f'id-{conn_name}-{username} = "{username}"',
+        ]
+        for line in swanctl_secrets_lines:
+            self.assertIn(line, swanctl_conf)
+
+        swanctl_pool_lines = [
+            f'{ip_pool_name}',
+            f'addrs = {range_start}-{range_stop}',
+            f'dns = {",".join(name_servers)}',
+        ]
+        for line in swanctl_pool_lines:
+            self.assertIn(line, swanctl_conf)
+
+        # Check Root CA, Intermediate CA and Peer cert/key pair is present
+        self.assertTrue(os.path.exists(os.path.join(CA_PATH, f'{ca_name}.pem')))
+        self.assertTrue(os.path.exists(os.path.join(CERT_PATH, f'{peer_name}.pem')))
+
+        self.tearDownPKI()
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/vpn_ipsec.py
+++ b/src/conf_mode/vpn_ipsec.py
@@ -280,7 +280,8 @@ def verify(ipsec):
                     if not os.path.exists(f'{dhcp_base}/dhclient_{dhcp_interface}.conf'):
                         raise ConfigError(f"Invalid dhcp-interface on remote-access connection {name}")
 
-                    ipsec['dhcp_interfaces'].add(dhcp_interface)
+                    if 'disable' not in ra_conf:
+                        ipsec['dhcp_interfaces'].add(dhcp_interface)
 
                     address = get_dhcp_address(dhcp_interface)
                     count = 0
@@ -340,9 +341,10 @@ def verify(ipsec):
                     if not interface_exists(vti_interface):
                         raise ConfigError(f'VTI interface {vti_interface} for remote-access connection {name} does not exist!')
 
-                    ipsec['enabled_vti_interfaces'].add(vti_interface)
-                    # remote access VPN interfaces are always up regardless of whether clients are connected
-                    ipsec['persistent_vti_interfaces'].add(vti_interface)
+                    if 'disable' not in ra_conf:
+                        ipsec['enabled_vti_interfaces'].add(vti_interface)
+                        # remote access VPN interfaces are always up regardless of whether clients are connected
+                        ipsec['persistent_vti_interfaces'].add(vti_interface)
 
                 if 'pool' in ra_conf:
                     if {'dhcp', 'radius'} <= set(ra_conf['pool']):
@@ -507,7 +509,8 @@ def verify(ipsec):
                 if not os.path.exists(f'{dhcp_base}/dhclient_{dhcp_interface}.conf'):
                     raise ConfigError(f"Invalid dhcp-interface on site-to-site peer {peer}")
 
-                ipsec['dhcp_interfaces'].add(dhcp_interface)
+                if 'disable' not in peer_conf:
+                    ipsec['dhcp_interfaces'].add(dhcp_interface)
 
                 address = get_dhcp_address(dhcp_interface)
                 count = 0
@@ -529,7 +532,8 @@ def verify(ipsec):
                     vti_interface = peer_conf['vti']['bind']
                     if not interface_exists(vti_interface):
                         raise ConfigError(f'VTI interface {vti_interface} for site-to-site peer {peer} does not exist!')
-                    ipsec['enabled_vti_interfaces'].add(vti_interface)
+                    if 'disable' not in peer_conf:
+                        ipsec['enabled_vti_interfaces'].add(vti_interface)
 
             if 'vti' not in peer_conf and 'tunnel' not in peer_conf:
                 raise ConfigError(f"No VTI or tunnel specified on site-to-site peer {peer}")

--- a/src/etc/ipsec.d/vti-up-down
+++ b/src/etc/ipsec.d/vti-up-down
@@ -27,40 +27,41 @@ from syslog import LOG_INFO
 
 from vyos.configquery import ConfigTreeQuery
 from vyos.configdict import get_interface_dict
-from vyos.ifconfig import VTIIf
+from vyos.utils.commit import wait_for_commit_lock
 from vyos.utils.process import call
-from vyos.utils.network import get_interface_config
+from vyos.utils.vti_updown_db import open_vti_updown_db_for_update
+
+def supply_interface_dict(interface):
+    # Lazy-load the running config on first invocation
+    try:
+        conf = supply_interface_dict.cached_config
+    except AttributeError:
+        conf = ConfigTreeQuery()
+        supply_interface_dict.cached_config = conf
+
+    _, vti = get_interface_dict(conf.config, ['interfaces', 'vti'], interface)
+    return vti
 
 if __name__ == '__main__':
     verb = os.getenv('PLUTO_VERB')
     connection = os.getenv('PLUTO_CONNECTION')
     interface = sys.argv[1]
 
+    if verb.endswith('-v6'):
+        protocol = 'v6'
+    else:
+        protocol = 'v4'
+
     openlog(ident=f'vti-up-down', logoption=LOG_PID, facility=LOG_INFO)
     syslog(f'Interface {interface} {verb} {connection}')
 
-    if verb in ['up-client', 'up-host']:
-        call('sudo ip route delete default table 220')
+    wait_for_commit_lock()
 
-    vti_link = get_interface_config(interface)
-
-    if not vti_link:
-        syslog(f'Interface {interface} not found')
-        sys.exit(0)
-
-    vti_link_up = (vti_link['operstate'] != 'DOWN' if 'operstate' in vti_link else False)
-
-    if verb in ['up-client', 'up-host']:
-        if not vti_link_up:
-            conf = ConfigTreeQuery()
-            _, vti = get_interface_dict(conf.config, ['interfaces', 'vti'], interface)
-            if 'disable' not in vti:
-                tmp = VTIIf(interface)
-                tmp.update(vti)
-                call(f'sudo ip link set {interface} up')
-            else:
-                call(f'sudo ip link set {interface} down')
-                syslog(f'Interface {interface} is admin down ...')
-    elif verb in ['down-client', 'down-host']:
-        if vti_link_up:
-            call(f'sudo ip link set {interface} down')
+    if verb in ['up-client', 'up-client-v6', 'up-host', 'up-host-v6']:
+        with open_vti_updown_db_for_update() as db:
+            db.add(interface, connection, protocol)
+            db.commit(supply_interface_dict)
+    elif verb in ['down-client', 'down-client-v6', 'down-host', 'down-host-v6']:
+        with open_vti_updown_db_for_update() as db:
+            db.remove(interface, connection, protocol)
+            db.commit(supply_interface_dict)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Route-based VPNs can be more convenient to configure and tie in nicely with existing routing protocols, zone-based firewalls, and other common network configurations. OpenVPN users are already quite familiar with this pattern. This PR extends the IPsec (IKEv2) Remote Access VPN to support "virtual tunnel interfaces" enabling similar usage patterns.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
https://vyos.dev/T5873
also lays some groundwork needed to complete https://vyos.dev/T5874

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec

## Proposed changes
<!--- Describe your changes in detail -->

This PR includes several changes to enable VTI-based remote access VPNs.

### remote-access pool range block

The `remote-access pool` configuration block has been extended to accept a `range` block, as an alternative to the current CIDR `prefix` attribute. This allows defining a more granular range for assigning VPN client IPs, which is helpful if you want to reserve one or more IPs at the start of a CIDR block for the router itself on the VTI interface.

### remote-access `bind` attribute

The `remote-access connection` accepts a new `bind` attribute. This works identically to the `peer <peer> vti bind`  attribute (for site-to-site peers you either define one or more `tunnel`s, or a `vti` block—there is no equivalent of `tunnel` for remote-access connections hence the decision not to nest it under `vti` here). Once defined, all traffic to/from connected peers uses the specified VTI interface, as opposed to being routed by kernel policies. This change is enabled by the internal change in VyOS 1.4 that switched from the legacy `vti` interface type to the newer `xfrm` interface type, which happily multiple tunnels with different local/remote traffic selectors, e.g. for each connected VPN client.

### vti-up-down hook revamp

To facilitate the use of the `bind` attribute with remote-access connections, a revamp of the `vti-up-down` hook was also required. The hook is called by the ipsec daemon to dynamically bring VTI interfaces up and down.

The existing logic was build for site-to-site connections with the assumption every VTI interface maps 1:1 to a single ipsec connection. These assumptions were already outdated for dual-stack site-to-site connections (the existing hook ignored events for the IPv6 side of the connection). Remote access configurations further expose this limitation, as each VPN client establishes its own connection.

This PR introduces a new hook mechanism that relies on a plaintext DB file (`/tmp/ipsec_vti_interfaces`). When ipsec connections come up and down, the DB file is updated with the list of connections that "want" a particular VTI interface to come up. Interfaces are brought up when referenced by at least one entry in the DB and taken down if there are no references. If a remote access connection is configured, a persistent reference is placed for the connection, since clients can connect at any time (I see little value in having the interface go down when no client are connected). Modifications to the interface `disable` config now take effect immediately—removing `disable` brings the interface up _if and only if_ it is referenced by an entry in the DB.

### Miscellaneous cleanup

The old `vti-up-down` hook had some code around deleting route table 220. This was also tied to warnings issued at config time if VTI is used without the `disable-route-autoinstall` option. These are leftover from the previous `vti`  interface type implementation and not relevant to the `xfrm` implementation.

Naming of remote-access child ESP sessions is improved (making the output of `show vpn ipsec sa` more useful).

Certain vestiges of ipsec config (such as DHCP interface references) are still written even if the peer or connection is disabled.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
 
Example configuration:
```
 interfaces {
     ethernet eth0 {
         ...
     }
     vti vti1 {
         address 10.23.58.1/24
         address fdcc:2200:a8ee:2358::1/64
         description "Client VPN"
         mtu 1436
     }
 }
 vpn {
     ipsec {
         esp-group ClientVPN-Client {
             lifetime 3600
             pfs enable
             proposal 1 {
                 encryption aes256gcm128
                 hash sha256
             }
         }
         ike-group ClientVPN-Client {
             key-exchange ikev2
             lifetime 7200
             proposal 1 {
                 dh-group 21
                 encryption aes256gcm128
                 hash sha256
             }
         }
         options {
             disable-route-autoinstall
         }
         remote-access {
             connection ClientVPN {
                 authentication {
                     client-mode x509
                     local-id <local id>
                     server-mode x509
                     x509 {
                         ca-certificate <ca cert name>
                         certificate <cert name>
                     }
                 }
                 bind vti1
                 dhcp-interface eth0
                 esp-group ClientVPN-Client
                 ike-group ClientVPN-Client
                 pool Client-Pool-v4
                 pool Client-Pool-v6
             }
             pool Client-Pool-v4 {
                 name-server 10.23.58.1
                 range {
                     start 10.23.58.2
                     stop 10.23.58.254
                 }
             }
             pool Client-Pool-v6 {
                 name-server fdcc:2200:a8ee:2358::1
                 range {
                     start fdcc:2200:a8ee:2358::2
                     stop fdcc:2200:a8ee:2358::ffff
                 }
             }
         }
     }
 }
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
 INFO - Executing VyOS smoketests
DEBUG - vyos@vyos:~$ /usr/bin/vyos-smoketest
DEBUG - /usr/bin/vyos-smoketest
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
DEBUG - test_dhcp_fail_handling (__main__.TestVPNIPsec.test_dhcp_fail_handling) ... ok
DEBUG - test_dmvpn (__main__.TestVPNIPsec.test_dmvpn) ... ok
DEBUG - test_flex_vpn_vips (__main__.TestVPNIPsec.test_flex_vpn_vips) ... ok
DEBUG - test_remote_access (__main__.TestVPNIPsec.test_remote_access) ... ok
DEBUG - test_remote_access_dhcp_fail_handling (__main__.TestVPNIPsec.test_remote_access_dhcp_fail_handling) ... ok
DEBUG - test_remote_access_eap_tls (__main__.TestVPNIPsec.test_remote_access_eap_tls) ... ok
DEBUG - test_remote_access_pool_range (__main__.TestVPNIPsec.test_remote_access_pool_range) ... ok
DEBUG - test_remote_access_vti (__main__.TestVPNIPsec.test_remote_access_vti) ... ok
DEBUG - test_remote_access_x509 (__main__.TestVPNIPsec.test_remote_access_x509) ... ok
DEBUG - test_site_to_site (__main__.TestVPNIPsec.test_site_to_site) ... ok
DEBUG - test_site_to_site_vti (__main__.TestVPNIPsec.test_site_to_site_vti) ... ok
DEBUG - test_site_to_site_x509 (__main__.TestVPNIPsec.test_site_to_site_x509) ... ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
