### PR TITLE
system: T6193: invalid warning "is not a DHCP interface but uses DHCP name-server option"

### DIFF
--- a/src/conf_mode/system_host-name.py
+++ b/src/conf_mode/system_host-name.py
@@ -71,9 +71,9 @@ def get_config(config=None):
                 hosts['nameserver'].append(ns)
             else:
                 tmp = ''
-                if_type = Section.section(ns)
-                if conf.exists(['interfaces', if_type, ns, 'address']):
-                    tmp = conf.return_values(['interfaces', if_type, ns, 'address'])
+                config_path = Section.get_config_path(ns)
+                if conf.exists(['interfaces', config_path, 'address']):
+                    tmp = conf.return_values(['interfaces', config_path, 'address'])
 
                 hosts['nameservers_dhcp_interfaces'].update({ ns : tmp })
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This fixes an invalid warning when using a DHCP VLAN interface to retrieve the system nameserver to be used. VLAN CLI config is not properly expanded leading to a false warning:

```
[ system name-server eth1.10 ]
WARNING: "eth1.10" is not a DHCP interface but uses DHCP name-server option!
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6193

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set interfaces ethernet eth1 vif 10 address 'dhcp'
set system name-server 'eth1.10'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
