### PR TITLE
dhcpv6-client: T2590: fix vyos-hostsd update for nameserver and search domains

### DIFF
--- a/data/templates/dhcp-client/dhcp6c-script.j2
+++ b/data/templates/dhcp-client/dhcp6c-script.j2
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Update DNS information for DHCPv6 clients
+# should be used only if vyos-hostsd is running
+
+if /usr/bin/systemctl -q is-active vyos-hostsd; then
+    hostsd_client="/usr/bin/vyos-hostsd-client"
+    hostsd_changes=
+
+    if [ -n "$new_domain_name" ]; then
+        logmsg info "Deleting search domains with tag \"dhcpv6-{{ ifname }}\" via vyos-hostsd-client"
+        $hostsd_client --delete-search-domains --tag "dhcpv6-{{ ifname }}"
+        logmsg info "Adding domain name \"$new_domain_name\" as search domain with tag \"dhcpv6-{{ ifname }}\" via vyos-hostsd-client"
+        $hostsd_client --add-search-domains "$new_domain_name" --tag "dhcpv6-{{ ifname }}"
+        hostsd_changes=y
+    fi
+
+    if [ -n "$new_domain_name_servers" ]; then
+        logmsg info "Deleting nameservers with tag \"dhcpv6-{{ ifname }}\" via vyos-hostsd-client"
+        $hostsd_client --delete-name-servers --tag "dhcpv6-{{ ifname }}"
+        logmsg info "Adding nameservers \"$new_domain_name_servers\" with tag \"dhcpv6-{{ ifname }}\" via vyos-hostsd-client"
+        $hostsd_client --add-name-servers $new_domain_name_servers --tag "dhcpv6-{{ ifname }}"
+        hostsd_changes=y
+    fi
+
+    if [ $hostsd_changes ]; then
+        logmsg info "Applying changes via vyos-hostsd-client"
+        $hostsd_client --apply
+    else
+        logmsg info "No changes to apply via vyos-hostsd-client"
+    fi
+fi

--- a/data/templates/dhcp-client/ipv6.j2
+++ b/data/templates/dhcp-client/ipv6.j2
@@ -23,6 +23,7 @@ interface {{ ifname }} {
     send ia-pd {{ pd }}; # prefix delegation #{{ pd }}
 {%     endfor %}
 {% endif %}
+    script "{{ dhcp6_script_file }}";
 };
 
 {% if address is vyos_defined and 'dhcpv6' in address %}
@@ -59,4 +60,3 @@ id-assoc pd {{ pd }} {
 };
 {%     endfor %}
 {% endif %}
-

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1375,15 +1375,19 @@ class Interface(Control):
         ifname = self.ifname
         config_base = directories['dhcp6_client_dir']
         config_file = f'{config_base}/dhcp6c.{ifname}.conf'
+        script_file = f'/etc/wide-dhcpv6/dhcp6c.{ifname}.script' # can not live under /run b/c of noexec mount option
         systemd_override_file = f'/run/systemd/system/dhcp6c@{ifname}.service.d/10-override.conf'
         systemd_service = f'dhcp6c@{ifname}.service'
 
-        # Rendered client configuration files require the apsolute config path
-        self.config['dhcp6_client_dir'] = directories['dhcp6_client_dir']
+        # Rendered client configuration files require additional settings
+        config = deepcopy(self.config)
+        config['dhcp6_client_dir'] = directories['dhcp6_client_dir']
+        config['dhcp6_script_file'] = script_file
 
-        if enable and 'disable' not in self.config:
-            render(systemd_override_file, 'dhcp-client/ipv6.override.conf.j2', self.config)
-            render(config_file, 'dhcp-client/ipv6.j2', self.config)
+        if enable and 'disable' not in config:
+            render(systemd_override_file, 'dhcp-client/ipv6.override.conf.j2', config)
+            render(config_file, 'dhcp-client/ipv6.j2', config)
+            render(script_file, 'dhcp-client/dhcp6c-script.j2', config, permission=0o755)
 
             # Reload systemd unit definitons as some options are dynamically generated
             self._cmd('systemctl daemon-reload')
@@ -1396,6 +1400,8 @@ class Interface(Control):
                 self._cmd(f'systemctl stop {systemd_service}')
             if os.path.isfile(config_file):
                 os.remove(config_file)
+            if os.path.isfile(script_file):
+                os.remove(script_file)
 
         return None
 

--- a/src/etc/dhcp/dhclient-enter-hooks.d/04-vyos-resolvconf
+++ b/src/etc/dhcp/dhclient-enter-hooks.d/04-vyos-resolvconf
@@ -14,27 +14,11 @@ if /usr/bin/systemctl -q is-active vyos-hostsd; then
             hostsd_changes=y
         fi
 
-        if [ -n "$new_dhcp6_domain_search" ]; then
-            logmsg info "Deleting search domains with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
-            $hostsd_client --delete-search-domains --tag "dhcpv6-$interface"
-            logmsg info "Adding search domain \"$new_dhcp6_domain_search\" with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
-            $hostsd_client --add-search-domains "$new_dhcp6_domain_search" --tag "dhcpv6-$interface"
-            hostsd_changes=y
-        fi
-
         if [ -n "$new_domain_name_servers" ]; then
             logmsg info "Deleting nameservers with tag \"dhcp-$interface\" via vyos-hostsd-client"
             $hostsd_client --delete-name-servers --tag "dhcp-$interface"
             logmsg info "Adding nameservers \"$new_domain_name_servers\" with tag \"dhcp-$interface\" via vyos-hostsd-client"
             $hostsd_client --add-name-servers $new_domain_name_servers --tag "dhcp-$interface"
-            hostsd_changes=y
-        fi
-
-        if [ -n "$new_dhcp6_name_servers" ]; then
-            logmsg info "Deleting nameservers with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
-            $hostsd_client --delete-name-servers --tag "dhcpv6-$interface"
-            logmsg info "Adding nameservers \"$new_dhcp6_name_servers\" with tag \"dhcpv6-$interface\" via vyos-hostsd-client"
-            $hostsd_client --add-name-servers $new_dhcp6_name_servers --tag "dhcpv6-$interface"
             hostsd_changes=y
         fi
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

After migrating from ISC DHCLIENT for IPv6 to wide-dhcp-client the logic which was present to update /etc/resolv.conf with the DHCP specified nameservers and also the search domain list was no longer present.

This commit adds a per interface rendered script to inform vyos-hostsd about the received IPv6 nameservers and search domains.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T2590

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wide-dhcp-client

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set interfaces ethernet eth0 address 'dhcpv6'
set system name-server 'eth0'
```

```console
$ cat /etc/resolv.conf
### Autogenerated by VyOS ###
### Do not edit, your changes will get overwritten ###

# dhcpv6-eth0
nameserver 2001:db8::8888
nameserver 2001:db8::4444

# dhcpv6-eth0
search vyos.net.
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```console
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_ethernet.py
test_add_multiple_ip_addresses (__main__.EthernetInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.EthernetInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.EthernetInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.EthernetInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.EthernetInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.EthernetInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.EthernetInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol_support (__main__.EthernetInterfaceTest.test_eapol_support) ... ok
test_ethtool_flow_control (__main__.EthernetInterfaceTest.test_ethtool_flow_control) ... ok
test_ethtool_ring_buffer (__main__.EthernetInterfaceTest.test_ethtool_ring_buffer) ... ok
test_interface_description (__main__.EthernetInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.EthernetInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.EthernetInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.EthernetInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.EthernetInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.EthernetInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.EthernetInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_non_existing_interface (__main__.EthernetInterfaceTest.test_non_existing_interface) ... ok
test_offloading_rfs (__main__.EthernetInterfaceTest.test_offloading_rfs) ... ok
test_offloading_rps (__main__.EthernetInterfaceTest.test_offloading_rps) ... ok
test_span_mirror (__main__.EthernetInterfaceTest.test_span_mirror) ... ok
test_speed_duplex_verify (__main__.EthernetInterfaceTest.test_speed_duplex_verify) ... ok
test_vif_8021q_interfaces (__main__.EthernetInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.EthernetInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.EthernetInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.EthernetInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.EthernetInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.EthernetInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 30 tests in 206.851s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
