### PR TITLE
T6196: Fixed applying parameters for aggregation in BGP

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -290,10 +290,7 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {%         endif %}
 {%         if afi_config.aggregate_address is vyos_defined %}
 {%             for aggregate, aggregate_config in afi_config.aggregate_address.items() %}
-  aggregate-address {{ aggregate }}{{ ' as-set' if aggregate_config.as_set is vyos_defined }}{{ ' summary-only' if aggregate_config.summary_only is vyos_defined }}
-{%                 if aggregate_config.route_map is vyos_defined %}
-  aggregate-address {{ aggregate }} route-map {{ aggregate_config.route_map }}
-{%                 endif %}
+  aggregate-address {{ aggregate }} {{ 'as-set' if aggregate_config.as_set is vyos_defined }} {{ 'summary-only' if aggregate_config.summary_only is vyos_defined }} {{ 'route-map ' ~ aggregate_config.route_map if aggregate_config.route_map is vyos_defined }}
 {%             endfor %}
 {%         endif %}
 {%         if afi_config.maximum_paths.ebgp is vyos_defined %}

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -630,6 +630,8 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         networks = {
             '10.0.0.0/8' : {
                 'as_set' : '',
+                'summary_only' : '',
+                'route_map' : route_map_in,
                 },
             '100.64.0.0/10' : {
                 'as_set' : '',
@@ -654,6 +656,9 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
             if 'summary_only' in network_config:
                 self.cli_set(base_path + ['address-family', 'ipv4-unicast',
                                               'aggregate-address', network, 'summary-only'])
+            if 'route_map' in network_config:
+                self.cli_set(base_path + ['address-family', 'ipv4-unicast',
+                                              'aggregate-address', network, 'route-map', network_config['route_map']])
 
         # commit changes
         self.cli_commit()
@@ -668,10 +673,14 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
 
         for network, network_config in networks.items():
             self.assertIn(f' network {network}', frrconfig)
+            command = f'aggregate-address {network}'
             if 'as_set' in network_config:
-                self.assertIn(f' aggregate-address {network} as-set', frrconfig)
+                command = f'{command} as-set'
             if 'summary_only' in network_config:
-                self.assertIn(f' aggregate-address {network} summary-only', frrconfig)
+                command = f'{command} summary-only'
+            if 'route_map' in network_config:
+                command = f'{command} route-map {network_config["route_map"]}'
+            self.assertIn(command, frrconfig)
 
     def test_bgp_05_afi_ipv6(self):
         networks = {


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed using 'route-map', 'as-set' and 'summary-only' together in aggregation in BGP

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6196 

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp

## Proposed changes
<!--- Describe your changes in detail -->
Fixed using 'route-map', 'as-set' and 'summary-only' together in aggregation in BGP

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configuration:
```
set policy route-map TEST-MAP rule 10 action 'permit'
set policy route-map TEST-MAP rule 10 set local-preference '200'
set protocols bgp address-family ipv4-unicast aggregate-address 192.168.0.0/24 as-set
set protocols bgp address-family ipv4-unicast aggregate-address 192.168.0.0/24 route-map 'TEST-MAP'
set protocols bgp address-family ipv4-unicast aggregate-address 192.168.0.0/24 summary-only
set protocols bgp address-family ipv4-unicast redistribute connected
set protocols bgp parameters router-id '1.1.1.1'
set protocols bgp system-as '65000'
```
FRR config:
Before
```
router bgp 65000
 bgp router-id 1.1.1.1
 no bgp ebgp-requires-policy
 no bgp default ipv4-unicast
 no bgp network import-check
 !
 address-family ipv4 unicast
  aggregate-address 192.168.0.0/24 route-map TEST-MAP
  redistribute connected
 exit-address-family
exit
```

After
```
router bgp 65000
 bgp router-id 1.1.1.1
 no bgp ebgp-requires-policy
 no bgp default ipv4-unicast
 no bgp network import-check
 !
 address-family ipv4 unicast
  aggregate-address 192.168.0.0/24 as-set summary-only route-map TEST-MAP
  redistribute connected
 exit-address-family
exit
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ...
BGP system-as number must be defined!

ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ...
Must either speficy exist-map or non-exist-map when conditionally-
advertise is in use!

ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ...
Must either speficy exist-map or non-exist-map when conditionally-
advertise is in use!

ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ...
Listen range for prefix "192.0.2.0/25" has no peer group configured.


Peer-group "listenfoobar" for listen range "192.0.2.0/25" does not
exist!


Peer-group "listenfoobar" for listen range "192.0.2.0/25" does not
exist!

ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ...
WARNING: BGP "router-id" is required when using "rd" and "route-
target"!


WARNING: BGP "router-id" is required when using "rd" and "route-
target"!

ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ...
WARNING: BGP neighbor "192.0.2.1" requires address-family!


Peer-group member "192.0.2.1" cannot override remote-as of peer-group
"bar"!


WARNING: BGP neighbor "192.0.2.1" requires address-family!


WARNING: BGP neighbor "eth0" requires address-family!


Peer-group member "eth0" cannot override remote-as of peer-group "bar"!


WARNING: BGP neighbor "192.0.2.1" requires address-family!


WARNING: BGP neighbor "eth0" requires address-family!


Peer-group member "eth0" cannot override remote-as of peer-group "bar"!


WARNING: BGP neighbor "192.0.2.1" requires address-family!


WARNING: BGP neighbor "eth0" requires address-family!

ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ...
WARNING: BGP neighbor "192.0.2.99" requires address-family!


local-as configured for "192.0.2.99", allowed only for eBGP peers!


WARNING: BGP neighbor "192.0.2.99" requires address-family!

ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ...
WARNING: BGP "router-id" is required when using "rd" and "route-
target"!


Please unconfigure "import vrf" commands before using vpn commands in
the same VRF!

ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ...
Command "import vrf" conflicts with "rd vpn export" command!

ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ...
Cannot delete VRF instance "red", unconfigure "import vrf" commands!

ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ...
Cannot delete default BGP instance, dependent VRF instance(s) exist!

ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ...
WARNING: BGP "router-id" is required when using "rd" and "route-
target"!


Please unconfigure import vrf commands before using vpn commands in
dependent VRFs!

ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ...
VRF "test" does not exist

ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok
test_bgp_24_srv6_sid (__main__.TestProtocolsBGP.test_bgp_24_srv6_sid) ...
SID per VRF and SID per address-family are mutually exclusive!

ok
test_bgp_25_ipv4_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_25_ipv4_labeled_unicast_peer_group) ... ok
test_bgp_26_ipv6_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_26_ipv6_labeled_unicast_peer_group) ... ok
test_bgp_27_route_reflector_client (__main__.TestProtocolsBGP.test_bgp_27_route_reflector_client) ...
route-reflector-client only supported for iBGP peers

ok
test_bgp_99_bmp (__main__.TestProtocolsBGP.test_bgp_99_bmp) ...
"bmp" flag is not found in bgpd. Configure "set system frr bmp" and
restart bgp process


WARNING: You need to reboot the router (preferred) or restart FRR to
apply changes in modules settings


BMP target "instance-bmp" address must be defined!

ok

----------------------------------------------------------------------
Ran 27 tests in 162.124s

OK

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
