### PR TITLE
T6068: T6171: change <fail-over> node to <high-availability>; add <mode> parameter

### DIFF
--- a/data/templates/dhcp-server/dhcpd.conf.j2
+++ b/data/templates/dhcp-server/dhcpd.conf.j2
@@ -41,19 +41,20 @@ class "ubnt" {
 {%     endfor %}
 
 {% endif %}
-{% if failover is vyos_defined %}
-# DHCP failover configuration
-failover peer "{{ failover.name }}" {
-{%     if failover.status == 'primary' %}
+{% if high_availability is vyos_defined %}
+# DHCP HA configuration
+{%     set split_value = '256' if high_availability.mode == 'active-passive' else '128' %}
+failover peer "{{ high_availability.name }}" {
+{%     if high_availability.status == 'primary' %}
     primary;
     mclt 1800;
-    split 128;
-{%     elif failover.status == 'secondary' %}
+    split {{ split_value }};
+{%     elif high_availability.status == 'secondary' %}
     secondary;
 {%     endif %}
-    address {{ failover.source_address }};
+    address {{ high_availability.source_address }};
     port 647;
-    peer address {{ failover.remote }};
+    peer address {{ high_availability.remote }};
     peer port 647;
     max-response-delay 30;
     max-unacked-updates 10;
@@ -215,7 +216,7 @@ shared-network {{ network }} {
         pool {
 {%                 endif %}
 {%                 if subnet_config.enable_failover is vyos_defined %}
-            failover peer "{{ failover.name }}";
+            failover peer "{{ high_availability.name }}";
             deny dynamic bootp clients;
 {%                 endif %}
 {%                 if subnet_config.range is vyos_defined %}

--- a/interface-definitions/include/version/dhcp-server-version.xml.i
+++ b/interface-definitions/include/version/dhcp-server-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/dhcp-server-version.xml.i -->
-<syntaxVersion component='dhcp-server' version='7'></syntaxVersion>
+<syntaxVersion component='dhcp-server' version='8'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/service_dhcp-server.xml.in
+++ b/interface-definitions/service_dhcp-server.xml.in
@@ -16,12 +16,33 @@
               <valueless/>
             </properties>
           </leafNode>
-          <node name="failover">
+          <node name="high-availability">
             <properties>
-              <help>DHCP failover configuration</help>
+              <help>DHCP high availability configuration</help>
             </properties>
             <children>
               #include <include/source-address-ipv4.xml.i>
+              <leafNode name="mode">
+                <properties>
+                  <help>Configure high availability mode</help>
+                  <completionHelp>
+                    <list>active-active active-passive</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>active-active</format>
+                    <description>Both server attend DHCP requests</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>active-passive</format>
+                    <description>Only primary server attends DHCP requests</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(active-active|active-passive)</regex>
+                  </constraint>
+                  <constraintErrorMessage>Invalid DHCP high availability mode</constraintErrorMessage>
+                </properties>
+                <defaultValue>active-active</defaultValue>
+              </leafNode>
               <leafNode name="remote">
                 <properties>
                   <help>IPv4 remote address used for connectio</help>

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -131,6 +131,10 @@ def get_config(config=None):
                         dhcp['shared_network_name'][network]['subnet'][subnet].update(
                                 {'range' : new_range_dict})
 
+    if len(dhcp['high_availability']) == 1:
+        ## only default value for mode is set, need to remove ha node
+        del dhcp['high_availability']
+
     return dhcp
 
 def verify(dhcp):
@@ -178,9 +182,9 @@ def verify(dhcp):
 
             # DHCP failover needs at least one subnet that uses it
             if 'enable_failover' in subnet_config:
-                if 'failover' not in dhcp:
-                    raise ConfigError(f'Can not enable failover for "{subnet}" in "{network}".\n' \
-                                      'Failover is not configured globally!')
+                if 'high_availability' not in dhcp:
+                    raise ConfigError(f'Can not enable high availability for "{subnet}" in "{network}".\n' \
+                                      'High availability is not configured globally!')
                 failover_ok = True
 
             # Check if DHCP address range is inside configured subnet declaration
@@ -270,12 +274,12 @@ def verify(dhcp):
     if (shared_networks - disabled_shared_networks) < 1:
         raise ConfigError(f'At least one shared network must be active!')
 
-    if 'failover' in dhcp:
+    if 'high_availability' in dhcp:
         if not failover_ok:
             raise ConfigError('DHCP failover must be enabled for at least one subnet!')
 
         for key in ['name', 'remote', 'source_address', 'status']:
-            if key not in dhcp['failover']:
+            if key not in dhcp['high_availability']:
                 tmp = key.replace('_', '-')
                 raise ConfigError(f'DHCP failover requires "{tmp}" to be specified!')
 

--- a/src/migration-scripts/dhcp-server/7-to-8
+++ b/src/migration-scripts/dhcp-server/7-to-8
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T6171: rename "service dhcp-server failover" to "service dhcp-server high-availability"
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+base = ['service', 'dhcp-server']
+config = ConfigTree(config_file)
+
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+
+if config.exists(base + ['failover']):
+    config.rename(base + ['failover'],'high-availability')
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print(f'Failed to save the modified config: {e}')
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Change <fail-over> node from dhcp-server to <high-availability>. Also, add <mode> parameter in order to configure active-active or active-passive behavior for HA.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6068
* https://vyos.dev/T6171
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-server

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Config on 1.3.0
```
vyos@130:~$ show config comm | grep dhcp
set interfaces ethernet eth0 address 'dhcp'
set service dhcp-server failover name 'FOO203'
set service dhcp-server failover remote '203.0.113.2'
set service dhcp-server failover source-address '203.0.113.1'
set service dhcp-server failover status 'primary'
set service dhcp-server shared-network-name LAN203 subnet 203.0.113.0/24 default-router '203.0.113.254'
set service dhcp-server shared-network-name LAN203 subnet 203.0.113.0/24 enable-failover
set service dhcp-server shared-network-name LAN203 subnet 203.0.113.0/24 name-server '203.0.113.254'
set service dhcp-server shared-network-name LAN203 subnet 203.0.113.0/24 range 0 start '203.0.113.101'
set service dhcp-server shared-network-name LAN203 subnet 203.0.113.0/24 range 0 stop '203.0.113.149'
vyos@130:~$ show ver | grep Ver
Version:          VyOS 1.3.0
```
Then after upgrade to custom image:
```
Welcome to VyOS!

   ┌── ┐
   . VyOS 1.4-rolling-202404031337
   └ ──┘  sagitta

 * Documentation:  https://docs.vyos.io/en/sagitta
 * Project news:   https://blog.vyos.io
 * Bug reports:    https://vyos.dev

You can change this banner using "set system login banner post-login" command.

VyOS is a free software distribution that includes multiple components,
you can check individual component licenses under /usr/share/doc/*/copyright
vyos@130:~$ show config comm | grep dhcp
set interfaces ethernet eth0 address 'dhcp'
set service dhcp-server high-availability name 'FOO203'
set service dhcp-server high-availability remote '203.0.113.2'
set service dhcp-server high-availability source-address '203.0.113.1'
set service dhcp-server high-availability status 'primary'
set service dhcp-server shared-network-name LAN203 subnet 203.0.113.0/24 default-router '203.0.113.254'
set service dhcp-server shared-network-name LAN203 subnet 203.0.113.0/24 enable-failover
set service dhcp-server shared-network-name LAN203 subnet 203.0.113.0/24 name-server '203.0.113.254'
set service dhcp-server shared-network-name LAN203 subnet 203.0.113.0/24 range 0 start '203.0.113.101'
set service dhcp-server shared-network-name LAN203 subnet 203.0.113.0/24 range 0 stop '203.0.113.149'
vyos@130:~$
vyos@130:~$ ps aux | grep dhcp
dhcpd       2375  0.0  0.6   9272  6916 ?        Ss   14:26   0:00 /usr/sbin/dhcpd -4 -q -user dhcpd -group vyattacfg -pf /run/dhcp-server/dhcpd.pid -cf /run/dhcp-server/dhcpd.conf -lf /config/dhcpd.leases
vyos        2894  0.0  0.2   6332  2048 ttyS0    S+   14:29   0:00 grep dhcp
vyos@130:~$ 

vyos@130:~$ cat /run/dhcp-server/dhcpd.conf
### Autogenerated by dhcp_server.py ###
...
...
# DHCP HA configuration
failover peer "FOO203" {
    primary;
    mclt 1800;
    split 128;
    address 203.0.113.1;
    port 647;
    peer address 203.0.113.2;
    peer port 647;
    max-response-delay 30;
    max-unacked-updates 10;
    load balance max seconds 3;
}

# Shared network configration(s)
shared-network LAN203 {
    subnet 203.0.113.0 netmask 255.255.255.0 {
        option domain-name-servers 203.0.113.254;
        option routers 203.0.113.254;
        default-lease-time 86400;
        max-lease-time 86400;
        pool {
            failover peer "FOO203";
            deny dynamic bootp clients;
            range 203.0.113.101 203.0.113.149;
        }
    }
    on commit {
        set shared-networkname = "LAN203";
    }                              
}

vyos@130:~$ 
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
root@130:/usr/libexec/vyos/tests/smoke/cli# ./test_service_dhcp-server.py 
test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
test_dhcp_high_availability (__main__.TestServiceDHCPServer.test_dhcp_high_availability) ... 
DHCP failover must be enabled for at least one subnet!

ok
test_dhcp_high_availability_mode (__main__.TestServiceDHCPServer.test_dhcp_high_availability_mode) ... ok
test_dhcp_invalid_raw_options (__main__.TestServiceDHCPServer.test_dhcp_invalid_raw_options) ... 
DEPRECATION WARNING: Additional global parameters are subject of
removal in VyOS 1.5! Please raise a feature request for proper CLI
nodes!


Configuration file errors encountered - check your options!

ok
test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
test_dhcp_on_interface_with_vrf (__main__.TestServiceDHCPServer.test_dhcp_on_interface_with_vrf) ... ok
test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... 
No DHCP address range or active static-mapping configured within shared-
network "SMOKE-0815, 192.0.2.0/25"!

ok
test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... 
No DHCP address range or active static-mapping configured within shared-
network "SMOKE-1, 192.0.2.0/25"!

ok
test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... 
No DHCP address range or active static-mapping configured within shared-
network "SMOKE-2, 192.0.2.0/25"!


Configured IP address for static mapping "dupe1" already exists on
another static mapping


Configured MAC address for static mapping "dupe2" already exists on
another static mapping

ok

----------------------------------------------------------------------
Ran 11 tests in 37.197s

OK
root@130:/usr/libexec/vyos/tests/smoke/cli# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
