### PR TITLE
ospf: T6089: fix invalid "ospf passive-interface default"

### DIFF
--- a/smoketest/config-tests/ospf-simple
+++ b/smoketest/config-tests/ospf-simple
@@ -1,0 +1,20 @@
+set interfaces ethernet eth0 vif 20 address '193.201.42.173/28'
+set interfaces ethernet eth0 vif 666 address '10.66.66.1/24'
+set interfaces loopback lo
+set protocols ospf area 0 network '10.66.66.0/24'
+set protocols ospf area 0 network '193.201.42.160/28'
+set protocols ospf area 0 area-type normal
+set protocols ospf interface eth0.20 cost '999'
+set protocols ospf interface eth0.20 dead-interval '4'
+set protocols ospf interface eth0.20 hello-interval '1'
+set protocols ospf interface eth0.20 priority '255'
+set protocols ospf interface eth0.20 retransmit-interval '5'
+set protocols ospf interface eth0.20 transmit-delay '1'
+set protocols ospf interface eth0.666 passive
+set protocols ospf log-adjacency-changes detail
+set protocols static route 0.0.0.0/0 next-hop 193.201.42.170 distance '130'
+set system config-management commit-revisions '100'
+set system host-name 'lab-vyos-r1'
+set system login user vyos authentication encrypted-password '$6$R.OnGzfXSfl6J$Iba/hl9bmjBs0VPtZ2zdW.Snh/nHuvxUwi0R6ruypgW63iKEbicJH.uUst8xZCyByURblxRtjAC1lAnYfIt.b0'
+set system login user vyos authentication plaintext-password ''
+set system console device ttyS0 speed '115200'

--- a/smoketest/configs/ospf-simple
+++ b/smoketest/configs/ospf-simple
@@ -1,0 +1,81 @@
+interfaces {
+    ethernet eth0 {
+        vif 20 {
+            address 193.201.42.173/28
+            ip {
+                ospf {
+                    cost 999
+                    dead-interval 4
+                    hello-interval 1
+                    priority 255
+                    retransmit-interval 5
+                    transmit-delay 1
+                }
+            }
+        }
+        vif 666 {
+            address 10.66.66.1/24
+        }
+    }
+    ethernet eth1 {
+    }
+    ethernet eth2 {
+    }
+    loopback lo {
+    }
+}
+protocols {
+    ospf {
+        area 0 {
+            area-type {
+                normal
+            }
+            network 193.201.42.160/28
+            network 10.66.66.0/24
+        }
+        log-adjacency-changes {
+            detail
+        }
+        passive-interface eth0.666
+    }
+    static {
+        route 0.0.0.0/0 {
+            next-hop 193.201.42.170 {
+                distance 130
+            }
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions 100
+    }
+    console {
+        device ttyS0 {
+            speed 115200
+        }
+    }
+    host-name lab-vyos-r1
+    login {
+        user vyos {
+            authentication {
+                encrypted-password $6$R.OnGzfXSfl6J$Iba/hl9bmjBs0VPtZ2zdW.Snh/nHuvxUwi0R6ruypgW63iKEbicJH.uUst8xZCyByURblxRtjAC1lAnYfIt.b0
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level info
+            }
+            facility protocols {
+                level debug
+            }
+        }
+    }
+}
+
+// Warning: Do not remove the following line.
+// vyos-config-version: "broadcast-relay@1:cluster@1:config-management@1:conntrack@3:conntrack-sync@2:container@1:dhcp-relay@2:dhcp-server@6:dhcpv6-server@1:dns-forwarding@3:firewall@5:https@2:interfaces@22:ipoe-server@1:ipsec@5:isis@1:l2tp@3:lldp@1:mdns@1:nat@5:ntp@1:pppoe-server@5:pptp@2:qos@1:quagga@8:rpki@1:salt@1:snmp@2:ssh@2:sstp@3:system@21:vrrp@2:vyos-accel-ppp@2:wanloadbalance@3:webproxy@2:zone-policy@1"
+// Release version: 1.3.4

--- a/src/migration-scripts/ospf/0-to-1
+++ b/src/migration-scripts/ospf/0-to-1
@@ -31,7 +31,8 @@ def ospf_passive_migration(config, ospf_base):
                 config.set_tag(ospf_base + ['interface'])
 
             config.delete(ospf_base + ['passive-interface'])
-            config.set(ospf_base + ['passive-interface'], value='default')
+            if default:
+                config.set(ospf_base + ['passive-interface'], value='default')
 
         if config.exists(ospf_base + ['passive-interface-exclude']):
             for interface in config.return_values(ospf_base + ['passive-interface-exclude']):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The option "passive-interface default" was set even if it was not present in the previous version we are migrating from. Fix migration script to handle this with a conditional path.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6089

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

Conditional code path for default with a new config test added to check the migrator


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
