### PR TITLE
conntrack-sync: T1244: Support for StartupResync in conntrackd

### DIFF
--- a/data/templates/conntrackd/conntrackd.conf.j2
+++ b/data/templates/conntrackd/conntrackd.conf.j2
@@ -4,7 +4,7 @@
 Sync {
     Mode FTFW {
         DisableExternalCache {{ 'on' if disable_external_cache is vyos_defined else 'off' }}
-        StartupResync {{ 'on' if enable_startup_resync is vyos_defined else 'off' }}
+        StartupResync {{ 'on' if startup_resync is vyos_defined else 'off' }}
     }
 {% for iface, iface_config in interface.items() %}
 {%     if iface_config.peer is vyos_defined %}

--- a/data/templates/conntrackd/conntrackd.conf.j2
+++ b/data/templates/conntrackd/conntrackd.conf.j2
@@ -4,6 +4,7 @@
 Sync {
     Mode FTFW {
         DisableExternalCache {{ 'on' if disable_external_cache is vyos_defined else 'off' }}
+        StartupResync {{ 'on' if enable_startup_resync is vyos_defined else 'off' }}
     }
 {% for iface, iface_config in interface.items() %}
 {%     if iface_config.peer is vyos_defined %}

--- a/interface-definitions/service_conntrack-sync.xml.in
+++ b/interface-definitions/service_conntrack-sync.xml.in
@@ -81,6 +81,12 @@
               <multi/>
             </properties>
           </leafNode>
+          <leafNode name="enable-startup-resync">
+            <properties>
+              <help>Order conntrackd to request a complete conntrack table resync against the other node at startup</help>
+              <valueless/>
+            </properties>
+          </leafNode>
           <node name="failover-mechanism">
             <properties>
               <help>Failover mechanism to use for conntrack-sync</help>

--- a/interface-definitions/service_conntrack-sync.xml.in
+++ b/interface-definitions/service_conntrack-sync.xml.in
@@ -81,7 +81,7 @@
               <multi/>
             </properties>
           </leafNode>
-          <leafNode name="enable-startup-resync">
+          <leafNode name="startup-resync">
             <properties>
               <help>Order conntrackd to request a complete conntrack table resync against the other node at startup</help>
               <valueless/>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added option for enabling startup resync

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
 * https://vyos.dev/T1244

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-documentation/pull/1352
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
conntrack-sync

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set high-availability vrrp group internal interface 'eth0'
set high-availability vrrp group internal virtual-address 10.0.0.10/24 interface 'eth0'
set high-availability vrrp group internal vrid '36'
set high-availability vrrp sync-group syncgrp member 'internal'
set service conntrack-sync failover-mechanism vrrp sync-group 'syncgrp'
set service conntrack-sync interface eth0
set service conntrack-sync startup-resync
commit

vyos@vyos# cat /run/conntrackd/conntrackd.conf | grep StartupResync
        StartupResync on
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
