### PR TITLE
container: T6210: add capability sys-nice

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -53,7 +53,7 @@
               </valueHelp>
               <valueHelp>
                 <format>sys-nice</format>
-                <description>Permissions to set process nice value</description>
+                <description>Permission to set process nice value</description>
               </valueHelp>
               <valueHelp>
                 <format>sys-time</format>

--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -25,7 +25,7 @@
             <properties>
               <help>Container capabilities/permissions</help>
               <completionHelp>
-                <list>net-admin net-bind-service net-raw setpcap sys-admin sys-module sys-time</list>
+                <list>net-admin net-bind-service net-raw setpcap sys-admin sys-module sys-nice sys-time</list>
               </completionHelp>
               <valueHelp>
                 <format>net-admin</format>
@@ -50,6 +50,10 @@
               <valueHelp>
                 <format>sys-module</format>
                 <description>Load, unload and delete kernel modules</description>
+              </valueHelp>
+              <valueHelp>
+                <format>sys-nice</format>
+                <description>Permissions to set process nice value</description>
               </valueHelp>
               <valueHelp>
                 <format>sys-time</format>

--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -56,7 +56,7 @@
                 <description>Permission to set system clock</description>
               </valueHelp>
               <constraint>
-                <regex>(net-admin|net-bind-service|net-raw|setpcap|sys-admin|sys-module|sys-time)</regex>
+                <regex>(net-admin|net-bind-service|net-raw|setpcap|sys-admin|sys-module|sys-nice|sys-time)</regex>
               </constraint>
               <multi/>
             </properties>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Adding sys-nice as an option for container cap-add configuration. This is needed for Suricata v7.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Just adding a Vyos config option for functionality that already exists in podman.

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6210

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
container

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configured container to run latest version of containerized Suricata. Running Vyos on my home router with Suricata v7 running as a container. Running on N305 Intel CPU with 32GB RAM.
```
container {
    name suricata {
        allow-host-networks
        arguments "-q 1 -q 2 -q 3 -q 4"
        cap-add net-admin
        cap-add sys-admin
        cap-add sys-nice
        image jasonish/suricata:latest
        memory 8192
        volume ETC {
            destination /etc/suricata
            source /config/suricata/etc
        }
        volume LOGS {
            destination /var/log/suricata
            source /config/suricata/logs
        }
        volume RULES {
            destination /var/lib/suricata
            source /config/suricata/rules
        }
    }
}
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
