### PR TITLE
ethernet: T5862: default MTU is not acceptable in some environments

### DIFF
--- a/interface-definitions/include/interface/mtu-68-16000.xml.i
+++ b/interface-definitions/include/interface/mtu-68-16000.xml.i
@@ -11,6 +11,5 @@
     </constraint>
     <constraintErrorMessage>MTU must be between 68 and 16000</constraintErrorMessage>
   </properties>
-  <defaultValue>1500</defaultValue>
 </leafNode>
 <!-- include end -->

--- a/interface-definitions/interfaces_bonding.xml.in
+++ b/interface-definitions/interfaces_bonding.xml.in
@@ -261,6 +261,9 @@
             </children>
           </node>
           #include <include/interface/mtu-68-16000.xml.i>
+          <leafNode name="mtu">
+            <defaultValue>1500</defaultValue>
+          </leafNode>
           <leafNode name="primary">
             <properties>
               <help>Primary device interface</help>

--- a/interface-definitions/interfaces_bridge.xml.in
+++ b/interface-definitions/interfaces_bridge.xml.in
@@ -41,6 +41,9 @@
           #include <include/interface/disable.xml.i>
           #include <include/interface/vrf.xml.i>
           #include <include/interface/mtu-68-16000.xml.i>
+          <leafNode name="mtu">
+            <defaultValue>1500</defaultValue>
+          </leafNode>
           <leafNode name="forwarding-delay">
             <properties>
               <help>Forwarding delay</help>

--- a/interface-definitions/interfaces_dummy.xml.in
+++ b/interface-definitions/interfaces_dummy.xml.in
@@ -46,6 +46,9 @@
             </children>
           </node>
           #include <include/interface/mtu-68-16000.xml.i>
+          <leafNode name="mtu">
+            <defaultValue>1500</defaultValue>
+          </leafNode>
           #include <include/interface/mirror.xml.i>
           #include <include/interface/netns.xml.i>
           #include <include/interface/redirect.xml.i>

--- a/interface-definitions/interfaces_vti.xml.in
+++ b/interface-definitions/interfaces_vti.xml.in
@@ -22,6 +22,9 @@
           #include <include/interface/ipv4-options.xml.i>
           #include <include/interface/ipv6-options.xml.i>
           #include <include/interface/mtu-68-16000.xml.i>
+          <leafNode name="mtu">
+            <defaultValue>1500</defaultValue>
+          </leafNode>
           #include <include/interface/mirror.xml.i>
           #include <include/interface/redirect.xml.i>
           #include <include/interface/vrf.xml.i>

--- a/interface-definitions/interfaces_wireguard.xml.in
+++ b/interface-definitions/interfaces_wireguard.xml.in
@@ -21,10 +21,10 @@
           #include <include/interface/disable.xml.i>
           #include <include/port-number.xml.i>
           #include <include/interface/mtu-68-16000.xml.i>
-          #include <include/interface/mirror.xml.i>
           <leafNode name="mtu">
             <defaultValue>1420</defaultValue>
           </leafNode>
+          #include <include/interface/mirror.xml.i>
           #include <include/interface/ipv4-options.xml.i>
           #include <include/interface/ipv6-options.xml.i>
           <leafNode name="fwmark">

--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -60,8 +60,8 @@ def verify_mtu_parent(config, parent):
     mtu = int(config['mtu'])
     parent_mtu = int(parent['mtu'])
     if mtu > parent_mtu:
-        raise ConfigError(f'Interface MTU ({mtu}) too high, ' \
-                          f'parent interface MTU is {parent_mtu}!')
+        raise ConfigError(f'Interface MTU "{mtu}" too high, ' \
+                          f'parent interface MTU is "{parent_mtu}"!')
 
 def verify_mtu_ipv6(config):
     """
@@ -76,7 +76,7 @@ def verify_mtu_ipv6(config):
         if int(config['mtu']) < min_mtu:
             interface = config['ifname']
             error_msg = f'IPv6 address will be configured on interface "{interface}",\n' \
-                        f'the required minimum MTU is {min_mtu}!'
+                        f'the required minimum MTU is "{min_mtu}"!'
 
             if 'address' in config:
                 for address in config['address']:

--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -519,8 +519,7 @@ class BasicInterfaceTest:
                     base = self._base_path + [interface, 'vif', vlan]
                     self.cli_set(base + ['mtu', mtu_9000])
 
-            # check validate() - VIF MTU must not be larger the parent interface
-            # MTU size.
+            # check validate() - Interface MTU "9000" too high, parent interface MTU is "1500"!
             with self.assertRaises(ConfigSessionError):
                 self.cli_commit()
 

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -152,6 +152,19 @@ def get_config(config=None):
     base = ['interfaces', 'ethernet']
     ifname, ethernet = get_interface_dict(conf, base, with_pki=True)
 
+    # T5862 - default MTU is not acceptable in some environments
+    # There are cloud environments available where the maximum supported
+    # ethernet MTU is e.g. 1450 bytes, thus we clamp this to the adapters
+    # maximum MTU value or 1500 bytes - whatever is lower
+    if 'mtu' not in ethernet:
+        try:
+            ethernet['mtu'] = '1500'
+            max_mtu = EthernetIf(ifname).get_max_mtu()
+            if max_mtu < int(ethernet['mtu']):
+                ethernet['mtu'] = str(max_mtu)
+        except:
+            pass
+
     if 'is_bond_member' in ethernet:
         update_bond_options(conf, ethernet)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

There are cloud environments available where the maximum supported ethernet MTU is e.g. 1450 bytes, thus we clamp this to the adapters maximum MTU value or 1500 bytes - whatever is lower.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T5862

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
Ethernet

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_ethernet.py
test_add_multiple_ip_addresses (__main__.EthernetInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.EthernetInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.EthernetInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.EthernetInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.EthernetInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.EthernetInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.EthernetInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol_support (__main__.EthernetInterfaceTest.test_eapol_support) ... ok
test_ethtool_flow_control (__main__.EthernetInterfaceTest.test_ethtool_flow_control) ... ok
test_ethtool_ring_buffer (__main__.EthernetInterfaceTest.test_ethtool_ring_buffer) ... ok
test_interface_description (__main__.EthernetInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.EthernetInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.EthernetInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.EthernetInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.EthernetInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.EthernetInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.EthernetInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_non_existing_interface (__main__.EthernetInterfaceTest.test_non_existing_interface) ... ok
test_offloading_rfs (__main__.EthernetInterfaceTest.test_offloading_rfs) ... ok
test_offloading_rps (__main__.EthernetInterfaceTest.test_offloading_rps) ... ok
test_span_mirror (__main__.EthernetInterfaceTest.test_span_mirror) ... ok
test_speed_duplex_verify (__main__.EthernetInterfaceTest.test_speed_duplex_verify) ... ok
test_vif_8021q_interfaces (__main__.EthernetInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.EthernetInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.EthernetInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.EthernetInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.EthernetInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.EthernetInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 30 tests in 141.876s

OK
```

![image](https://github.com/vyos/vyos-1x/assets/25299219/4fa30b65-1fba-4d6a-9444-1707b58b66ec)



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
