### PR TITLE
T6199: start validating smoketests against real CLI defaultValues

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_pppoe.py
+++ b/smoketest/scripts/cli/test_interfaces_pppoe.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2023 VyOS maintainers and contributors
+# Copyright (C) 2019-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -20,6 +20,7 @@ from psutil import process_iter
 from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.configsession import ConfigSessionError
+from vyos.xml_ref import default_value
 
 config_file = '/etc/ppp/peers/{}'
 base_path = ['interfaces', 'pppoe']
@@ -169,10 +170,10 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
         for interface in self._interfaces:
             user = f'VyOS-user-{interface}'
             passwd = f'VyOS-passwd-{interface}'
+            mtu_default = default_value(base_path + [interface, 'mtu'])
 
-            # verify "normal" PPPoE value - 1492 is default MTU
             tmp = get_config_value(interface, 'mtu')[1]
-            self.assertEqual(tmp, '1492')
+            self.assertEqual(tmp, mtu_default)
             tmp = get_config_value(interface, 'user')[1].replace('"', '')
             self.assertEqual(tmp, user)
             tmp = get_config_value(interface, 'password')[1].replace('"', '')

--- a/smoketest/scripts/cli/test_interfaces_wireless.py
+++ b/smoketest/scripts/cli/test_interfaces_wireless.py
@@ -25,6 +25,7 @@ from vyos.configsession import ConfigSessionError
 from vyos.utils.process import process_named_running
 from vyos.utils.kernel import check_kmod
 from vyos.utils.file import read_file
+from vyos.xml_ref import default_value
 
 def get_config_value(interface, key):
     tmp = read_file(f'/run/hostapd/{interface}.conf')
@@ -127,7 +128,8 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
 
         # channel
         tmp = get_config_value(interface, 'channel')
-        self.assertEqual('0', tmp) # default is channel 0
+        cli_default = default_value(self._base_path + [interface, 'channel'])
+        self.assertEqual(cli_default, tmp)
 
         # auto-powersave is special
         tmp = get_config_value(interface, 'uapsd_advertisement_enabled')

--- a/smoketest/scripts/cli/test_service_https.py
+++ b/smoketest/scripts/cli/test_service_https.py
@@ -27,6 +27,7 @@ from vyos.utils.file import read_file
 from vyos.utils.file import write_file
 from vyos.utils.process import call
 from vyos.utils.process import process_named_running
+from vyos.xml_ref import default_value
 
 from vyos.configsession import ConfigSessionError
 
@@ -147,10 +148,8 @@ class TestHTTPSService(VyOSUnitTestSHIM.TestCase):
 
     @ignore_warning(InsecureRequestWarning)
     def test_api_auth(self):
-        vhost_id = 'example'
         address = '127.0.0.1'
-        port = '443' # default value
-        name = 'localhost'
+        port = default_value(base_path + ['port'])
 
         key = 'MySuperSecretVyOS'
         self.cli_set(base_path + ['api', 'keys', 'id', 'key-01', 'key', key])
@@ -420,7 +419,6 @@ class TestHTTPSService(VyOSUnitTestSHIM.TestCase):
         url = f'https://{address}/config-file'
         url_config = f'https://{address}/configure'
         headers = {}
-        tmp_file = 'tmp-config.boot'
 
         self.cli_set(base_path + ['api', 'keys', 'id', 'key-01', 'key', key])
         self.cli_commit()

--- a/smoketest/scripts/cli/test_service_ssh.py
+++ b/smoketest/scripts/cli/test_service_ssh.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2022 VyOS maintainers and contributors
+# Copyright (C) 2019-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -28,6 +28,7 @@ from vyos.utils.process import cmd
 from vyos.utils.process import is_systemd_service_running
 from vyos.utils.process import process_named_running
 from vyos.utils.file import read_file
+from vyos.xml_ref import default_value
 
 PROCESS_NAME = 'sshd'
 SSHD_CONF = '/run/sshd/sshd_config'
@@ -78,9 +79,10 @@ class TestServiceSSH(VyOSUnitTestSHIM.TestCase):
         # commit changes
         self.cli_commit()
 
-        # Check configured port
-        port = get_config_value('Port')[0]
-        self.assertEqual('22', port) # default value
+        # Check configured port agains CLI default value
+        port = get_config_value('Port')
+        cli_default = default_value(base_path + ['port'])
+        self.assertEqual(port, cli_default)
 
     def test_ssh_single_listen_address(self):
         # Check if SSH service can be configured and runs


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Use `vyos.xml_ref.default_value` to query XML default values and take them into account when validating properly applied defaults in individual smoketests instead of using hardcoded values like 443 for https port.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/T6199-->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
Smoketests

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->


```console
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireless.py
test_add_multiple_ip_addresses (__main__.WirelessInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.WirelessInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.WirelessInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.WirelessInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.WirelessInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.WirelessInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.WirelessInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_interface_description (__main__.WirelessInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.WirelessInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.WirelessInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.WirelessInterfaceTest.test_interface_ipv6_options) ... skipped 'not supported'
test_interface_mtu (__main__.WirelessInterfaceTest.test_interface_mtu) ... skipped 'not supported'
test_ipv6_link_local_address (__main__.WirelessInterfaceTest.test_ipv6_link_local_address) ... skipped 'not supported'
test_mtu_1200_no_ipv6_interface (__main__.WirelessInterfaceTest.test_mtu_1200_no_ipv6_interface) ... skipped 'not supported'
test_span_mirror (__main__.WirelessInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.WirelessInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.WirelessInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.WirelessInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.WirelessInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.WirelessInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.WirelessInterfaceTest.test_vif_s_protocol_change) ... ok
test_wireless_access_point_bridge (__main__.WirelessInterfaceTest.test_wireless_access_point_bridge) ... ok
test_wireless_add_single_ip_address (__main__.WirelessInterfaceTest.test_wireless_add_single_ip_address) ... ok
test_wireless_hostapd_config (__main__.WirelessInterfaceTest.test_01wireless_hostapd_config) ... ok
test_wireless_hostapd_wpa_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_wpa_config) ... ok
test_wireless_security_station_address (__main__.WirelessInterfaceTest.test_wireless_security_station_address) ... ok

----------------------------------------------------------------------
Ran 28 tests in 229.349s

OK (skipped=9)
```

```console
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_pppoe.py
test_pppoe_authentication (__main__.PPPoEInterfaceTest.test_pppoe_authentication) ... ok
test_pppoe_client (__main__.PPPoEInterfaceTest.test_pppoe_client) ... ok
test_pppoe_client_disabled_interface (__main__.PPPoEInterfaceTest.test_pppoe_client_disabled_interface) ... ok
test_pppoe_dhcpv6pd (__main__.PPPoEInterfaceTest.test_pppoe_dhcpv6pd) ... ok
test_pppoe_mtu_mru (__main__.PPPoEInterfaceTest.test_pppoe_mtu_mru) ... ok
test_pppoe_options (__main__.PPPoEInterfaceTest.test_pppoe_options) ... ok

----------------------------------------------------------------------
Ran 6 tests in 44.452s

OK
```

```console
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_https.py
test_api_add_delete (__main__.TestHTTPSService.test_api_add_delete) ... ok
test_api_auth (__main__.TestHTTPSService.test_api_auth) ... ok
test_api_config_file (__main__.TestHTTPSService.test_api_config_file) ... ok
test_api_config_file_load_http (__main__.TestHTTPSService.test_api_config_file_load_http) ... ok
test_api_configure (__main__.TestHTTPSService.test_api_configure) ... ok
test_api_generate (__main__.TestHTTPSService.test_api_generate) ... ok
test_api_incomplete_key (__main__.TestHTTPSService.test_api_incomplete_key) ... ok
test_api_missing_keys (__main__.TestHTTPSService.test_api_missing_keys) ... ok
test_api_reset (__main__.TestHTTPSService.test_api_reset) ... ok
test_api_show (__main__.TestHTTPSService.test_api_show) ... ok
test_certificate (__main__.TestHTTPSService.test_certificate) ... ok

----------------------------------------------------------------------
Ran 11 tests in 87.941s

OK
```

```console
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_ssh.py
test_ssh_default (__main__.TestServiceSSH.test_ssh_default) ... ok
test_ssh_dynamic_protection (__main__.TestServiceSSH.test_ssh_dynamic_protection) ... ok
test_ssh_login (__main__.TestServiceSSH.test_ssh_login) ... ok
test_ssh_multiple_listen_addresses (__main__.TestServiceSSH.test_ssh_multiple_listen_addresses) ... ok
test_ssh_ndcpp (__main__.TestServiceSSH.test_ssh_ndcpp) ... ok
test_ssh_single_listen_address (__main__.TestServiceSSH.test_ssh_single_listen_address) ... ok
test_ssh_vrf_multi (__main__.TestServiceSSH.test_ssh_vrf_multi) ... ok
test_ssh_vrf_single (__main__.TestServiceSSH.test_ssh_vrf_single) ... ok

----------------------------------------------------------------------
Ran 8 tests in 43.881s

OK
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
