### PR TITLE
T5169: Add PoC for generating CGNAT rules rfc6888

### DIFF
--- a/data/templates/firewall/nftables-cgnat.j2
+++ b/data/templates/firewall/nftables-cgnat.j2
@@ -1,0 +1,47 @@
+#!/usr/sbin/nft -f
+
+add table ip cgnat
+flush table ip cgnat
+
+add map ip cgnat tcp_nat_map { type ipv4_addr: interval ipv4_addr . inet_service ; flags interval ;}
+add map ip cgnat udp_nat_map { type ipv4_addr: interval ipv4_addr . inet_service ; flags interval ;}
+add map ip cgnat icmp_nat_map { type ipv4_addr: interval ipv4_addr . inet_service ; flags interval ;}
+add map ip cgnat other_nat_map { type ipv4_addr: interval ipv4_addr ; flags interval ;}
+flush map ip cgnat tcp_nat_map
+flush map ip cgnat udp_nat_map
+flush map ip cgnat icmp_nat_map
+flush map ip cgnat other_nat_map
+
+table ip cgnat {
+    map tcp_nat_map {
+        type ipv4_addr : interval ipv4_addr . inet_service
+        flags interval
+        elements = { {{ proto_map_elements }} }
+    }
+
+    map udp_nat_map {
+        type ipv4_addr : interval ipv4_addr . inet_service
+        flags interval
+        elements = { {{ proto_map_elements }} }
+    }
+
+    map icmp_nat_map {
+        type ipv4_addr : interval ipv4_addr . inet_service
+        flags interval
+        elements = { {{ proto_map_elements }} }
+    }
+
+    map other_nat_map {
+        type ipv4_addr : interval ipv4_addr
+        flags interval
+        elements = { {{ other_map_elements }} }
+    }
+
+    chain POSTROUTING {
+        type nat hook postrouting priority srcnat; policy accept;
+        ip protocol tcp counter snat ip to ip saddr map @tcp_nat_map
+        ip protocol udp counter snat ip to ip saddr map @udp_nat_map
+        ip protocol icmp counter snat ip to ip saddr map @icmp_nat_map
+        counter snat ip to ip saddr map @other_nat_map
+    }
+}

--- a/interface-definitions/nat_cgnat.xml.in
+++ b/interface-definitions/nat_cgnat.xml.in
@@ -1,0 +1,197 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="nat">
+    <children>
+      <node name="cgnat" owner="${vyos_conf_scripts_dir}/nat_cgnat.py">
+        <properties>
+          <help>Carrier-grade NAT (CGNAT) parameters</help>
+          <priority>221</priority>
+        </properties>
+        <children>
+          <node name="pool">
+            <properties>
+              <help>External and internal pool parameters</help>
+            </properties>
+            <children>
+              <tagNode name="external">
+                <properties>
+                  <help>External pool name</help>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>External pool name</description>
+                  </valueHelp>
+                  <constraint>
+                    #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+                  </constraint>
+                  <constraintErrorMessage>Name of pool can only contain alpha-numeric letters, hyphen and underscores</constraintErrorMessage>
+                </properties>
+                <children>
+                  <leafNode name="external-port-range">
+                    <properties>
+                      <help>Port range</help>
+                      <valueHelp>
+                        <format>range</format>
+                        <description>Numbered port range (e.g., 1001-1005)</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="port-range"/>
+                      </constraint>
+                    </properties>
+                    <defaultValue>1024-65535</defaultValue>
+                  </leafNode>
+                  <node name="per-user-limit">
+                    <properties>
+                      <help>Per user limits for the pool</help>
+                    </properties>
+                    <children>
+                      <leafNode name="port">
+                        <properties>
+                          <help>Ports per user</help>
+                          <valueHelp>
+                            <format>u32:1-65535</format>
+                            <description>Numeric IP port</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-65535"/>
+                          </constraint>
+                        </properties>
+                        <defaultValue>2000</defaultValue>
+                      </leafNode>
+                    </children>
+                  </node>
+                  <tagNode name="range">
+                    <properties>
+                      <help>Range of IP addresses</help>
+                      <valueHelp>
+                        <format>ipv4net</format>
+                        <description>IPv4 prefix</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>ipv4range</format>
+                        <description>IPv4 address range</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="ipv4-prefix"/>
+                        <validator name="ipv4-host"/>
+                        <validator name="ipv4-range"/>
+                      </constraint>
+                    </properties>
+                    <children>
+                      <leafNode name="seq">
+                        <properties>
+                          <help>Sequence</help>
+                          <valueHelp>
+                            <format>u32:1-999999</format>
+                            <description>Sequence number</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-999999"/>
+                          </constraint>
+                          <constraintErrorMessage>Sequence number must be between 1 and 999999</constraintErrorMessage>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </tagNode>
+                </children>
+              </tagNode>
+              <tagNode name="internal">
+                <properties>
+                  <help>Internal pool name</help>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>Internal pool name</description>
+                  </valueHelp>
+                  <constraint>
+                    #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+                  </constraint>
+                  <constraintErrorMessage>Name of pool can only contain alpha-numeric letters, hyphen and underscores</constraintErrorMessage>
+                </properties>
+                <children>
+                  <leafNode name="range">
+                    <properties>
+                      <help>Range of IP addresses</help>
+                      <valueHelp>
+                        <format>ipv4net</format>
+                        <description>IPv4 prefix</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>ipv4range</format>
+                        <description>IPv4 address range</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="ipv4-prefix"/>
+                        <validator name="ipv4-host"/>
+                        <validator name="ipv4-range"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                </children>
+              </tagNode>
+            </children>
+          </node>
+          <tagNode name="rule">
+            <properties>
+              <help>Rule</help>
+              <valueHelp>
+                <format>u32:1-999999</format>
+                <description>Number for this CGNAT rule</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 1-999999"/>
+              </constraint>
+              <constraintErrorMessage>Rule number must be between 1 and 999999</constraintErrorMessage>
+            </properties>
+            <children>
+              <node name="source">
+                <properties>
+                  <help>Source parameters</help>
+                </properties>
+                <children>
+                  <leafNode name="pool">
+                    <properties>
+                      <help>Source internal pool</help>
+                      <completionHelp>
+                        <path>nat cgnat pool internal</path>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Source internal pool name</description>
+                      </valueHelp>
+                      <constraint>
+                        #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+                      </constraint>
+                      <constraintErrorMessage>Name of pool can only contain alpha-numeric letters, hyphen and underscores</constraintErrorMessage>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+              <node name="translation">
+                <properties>
+                  <help>Translation parameters</help>
+                </properties>
+                <children>
+                  <leafNode name="pool">
+                    <properties>
+                      <help>Translation external pool</help>
+                      <completionHelp>
+                        <path>nat cgnat pool external</path>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Translation external pool name</description>
+                      </valueHelp>
+                      <constraint>
+                        #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+                      </constraint>
+                      <constraintErrorMessage>Name of pool can only contain alpha-numeric letters, hyphen and underscores</constraintErrorMessage>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+            </children>
+          </tagNode>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/src/conf_mode/nat_cgnat.py
+++ b/src/conf_mode/nat_cgnat.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import ipaddress
+import jmespath
+import os
+
+from sys import exit
+
+from vyos.config import Config
+from vyos.template import render
+from vyos.utils.process import cmd
+from vyos.utils.process import run
+from vyos import ConfigError
+from vyos import airbag
+
+airbag.enable()
+
+
+nftables_cgnat_config = '/run/nftables-cgnat.nft'
+
+
+class IPOperations:
+    def __init__(self, ip_prefix: str):
+        self.ip_prefix = ip_prefix
+        self.ip_network = ipaddress.ip_network(ip_prefix) if '/' in ip_prefix else None
+
+    def get_ips_count(self) -> int:
+        """Returns the number of IPs in a prefix or range.
+
+        Example:
+        % ip = IPOperations('192.0.2.0/30')
+        % ip.get_ips_count()
+        4
+        % ip = IPOperations('192.0.2.0-192.0.2.2')
+        % ip.get_ips_count()
+        3
+        """
+        if '-' in self.ip_prefix:
+            start_ip, end_ip = self.ip_prefix.split('-')
+            start_ip = ipaddress.ip_address(start_ip)
+            end_ip = ipaddress.ip_address(end_ip)
+            return int(end_ip) - int(start_ip) + 1
+        elif '/31' in self.ip_prefix:
+            return 2
+        elif '/32' in self.ip_prefix:
+            return 1
+        else:
+            return sum(
+                1
+                for _ in [self.ip_network.network_address]
+                + list(self.ip_network.hosts())
+                + [self.ip_network.broadcast_address]
+            )
+
+    def convert_prefix_to_list_ips(self) -> list:
+        """Converts a prefix or IP range to a list of IPs including the network and broadcast addresses.
+
+        Example:
+        % ip = IPOperations('192.0.2.0/30')
+        % ip.convert_prefix_to_list_ips()
+        ['192.0.2.0', '192.0.2.1', '192.0.2.2', '192.0.2.3']
+        %
+        % ip = IPOperations('192.0.0.1-192.0.2.5')
+        % ip.convert_prefix_to_list_ips()
+        ['192.0.2.1', '192.0.2.2', '192.0.2.3', '192.0.2.4', '192.0.2.5']
+        """
+        if '-' in self.ip_prefix:
+            start_ip, end_ip = self.ip_prefix.split('-')
+            start_ip = ipaddress.ip_address(start_ip)
+            end_ip = ipaddress.ip_address(end_ip)
+            return [
+                str(ipaddress.ip_address(ip))
+                for ip in range(int(start_ip), int(end_ip) + 1)
+            ]
+        elif '/31' in self.ip_prefix:
+            return [
+                str(ip)
+                for ip in [
+                    self.ip_network.network_address,
+                    self.ip_network.broadcast_address,
+                ]
+            ]
+        elif '/32' in self.ip_prefix:
+            return [str(self.ip_network.network_address)]
+        else:
+            return [
+                str(ip)
+                for ip in [self.ip_network.network_address]
+                + list(self.ip_network.hosts())
+                + [self.ip_network.broadcast_address]
+            ]
+
+
+def generate_port_rules(
+    external_hosts: list,
+    internal_hosts: list,
+    port_count: int,
+    global_port_range: str = '1024-65535',
+) -> list:
+    """Generates list of nftables rules for the batch file."""
+    rules = []
+    proto_map_elements = []
+    other_map_elements = []
+    start_port, end_port = map(int, global_port_range.split('-'))
+    total_possible_ports = (end_port - start_port) + 1
+
+    # Calculate the required number of ports per host
+    required_ports_per_host = port_count
+
+    # Check if there are enough external addresses for all internal hosts
+    if required_ports_per_host * len(internal_hosts) > total_possible_ports * len(
+        external_hosts
+    ):
+        raise ConfigError("Not enough ports available for the specified parameters!")
+
+    current_port = start_port
+    current_external_index = 0
+
+    for internal_host in internal_hosts:
+        external_host = external_hosts[current_external_index]
+        next_end_port = current_port + required_ports_per_host - 1
+
+        # If the port range exceeds the end_port, move to the next external host
+        while next_end_port > end_port:
+            current_external_index = (current_external_index + 1) % len(external_hosts)
+            external_host = external_hosts[current_external_index]
+            current_port = start_port
+            next_end_port = current_port + required_ports_per_host - 1
+
+        # Ensure the same port is not assigned to the same external host
+        if any(
+            rule.endswith(f'{external_host}:{current_port}-{next_end_port}')
+            for rule in rules
+        ):
+            raise ConfigError("Not enough ports available for the specified parameters")
+
+        proto_map_elements.append(
+            f'{internal_host} : {external_host} . {current_port}-{next_end_port}'
+        )
+        other_map_elements.append(f'{internal_host} : {external_host}')
+
+        current_port = next_end_port + 1
+        if current_port > end_port:
+            current_port = start_port
+            current_external_index += 1  # Move to the next external host
+
+    return [proto_map_elements, other_map_elements]
+
+
+def get_config(config=None):
+    if config:
+        conf = config
+    else:
+        conf = Config()
+
+    base = ['nat', 'cgnat']
+    config = conf.get_config_dict(
+        base,
+        get_first_key=True,
+        key_mangling=('-', '_'),
+        no_tag_node_value_mangle=True,
+        with_recursive_defaults=True,
+    )
+
+    return config
+
+
+def verify(config):
+    # bail out early - looks like removal from running config
+    if not config:
+        return None
+
+    if 'pool' not in config:
+        raise ConfigError(f'Pool must be defined!')
+    if 'rule' not in config:
+        raise ConfigError(f'Rule must be defined!')
+
+    # As PoC allow only one rule for CGNAT translations
+    # one internal pool and one external pool
+    if len(config['rule']) > 1:
+        raise ConfigError(f'Only one rule is allowed for translations!')
+
+    for pool in ('external', 'internal'):
+        if pool not in config['pool']:
+            raise ConfigError(f'{pool} pool must be defined!')
+        for pool_name, pool_config in config['pool'][pool].items():
+            if 'range' not in pool_config:
+                raise ConfigError(
+                    f'Range for "{pool} pool {pool_name}" must be defined!'
+                )
+
+    for rule, rule_config in config['rule'].items():
+        if 'source' not in rule_config:
+            raise ConfigError(f'Rule "{rule}" source pool must be defined!')
+        if 'pool' not in rule_config['source']:
+            raise ConfigError(f'Rule "{rule}" source pool must be defined!')
+
+        if 'translation' not in rule_config:
+            raise ConfigError(f'Rule "{rule}" translation pool must be defined!')
+
+
+def generate(config):
+    if not config:
+        return None
+    # first external pool as we allow only one as PoC
+    ext_pool_name = jmespath.search("rule.*.translation | [0]", config).get('pool')
+    int_pool_name = jmespath.search("rule.*.source | [0]", config).get('pool')
+    ext_query = f"pool.external.{ext_pool_name}.range | keys(@)"
+    int_query = f"pool.internal.{int_pool_name}.range"
+    external_ranges = jmespath.search(ext_query, config)
+    internal_ranges = [jmespath.search(int_query, config)]
+
+    external_list_count = []
+    external_list_hosts = []
+    internal_list_count = []
+    internal_list_hosts = []
+    for ext_range in external_ranges:
+        # External hosts count
+        e_count = IPOperations(ext_range).get_ips_count()
+        external_list_count.append(e_count)
+        # External hosts list
+        e_hosts = IPOperations(ext_range).convert_prefix_to_list_ips()
+        external_list_hosts.extend(e_hosts)
+    for int_range in internal_ranges:
+        # Internal hosts count
+        i_count = IPOperations(int_range).get_ips_count()
+        internal_list_count.append(i_count)
+        # Internal hosts list
+        i_hosts = IPOperations(int_range).convert_prefix_to_list_ips()
+        internal_list_hosts.extend(i_hosts)
+
+    external_host_count = sum(external_list_count)
+    internal_host_count = sum(internal_list_count)
+    ports_per_user = int(
+        jmespath.search(f'pool.external.{ext_pool_name}.per_user_limit.port', config)
+    )
+    external_port_range: str = jmespath.search(
+        f'pool.external.{ext_pool_name}.external_port_range', config
+    )
+
+    proto_maps, other_maps = generate_port_rules(
+        external_list_hosts, internal_list_hosts, ports_per_user, external_port_range
+    )
+
+    config['proto_map_elements'] = ', '.join(proto_maps)
+    config['other_map_elements'] = ', '.join(other_maps)
+
+    render(nftables_cgnat_config, 'firewall/nftables-cgnat.j2', config)
+
+    # dry-run newly generated configuration
+    tmp = run(f'nft --check --file {nftables_cgnat_config}')
+    if tmp > 0:
+        raise ConfigError('Configuration file errors encountered!')
+
+
+def apply(config):
+    if not config:
+        # Cleanup cgnat
+        cmd('nft delete table ip cgnat')
+        if os.path.isfile(nftables_cgnat_config):
+            os.unlink(nftables_cgnat_config)
+        return None
+    cmd(f'nft --file {nftables_cgnat_config}')
+
+
+if __name__ == '__main__':
+    try:
+        c = get_config()
+        verify(c)
+        generate(c)
+        apply(c)
+    except ConfigError as e:
+        print(e)
+        exit(1)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add PoC to generate CGNAT rules (that's why classes and templates are in the same file now).

https://datatracker.ietf.org/doc/html/rfc6888
Not all requirements are implemented, but some of them. Implemented:

REQ-2
```
A CGN MUST have a default "IP address pooling" behavior of "Paired"
CGN must use the same external IP
      address mapping for all sessions associated with the same internal
      IP address, be they TCP, UDP, ICMP, something else, or a mix of
      different protocols.
```

REQ-3
```
The CGN function SHOULD NOT have any limitations on the size
      or the contiguity of the external address pool
```

REQ-4
```
A CGN MUST support limiting the number of external ports (or,
      equivalently, "identifiers" for ICMP) that are assigned per
      subscriber
```


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T5169

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
cgnat, nat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Example with prefixes:
```
set nat cgnat pool external ext1 external-port-range '1024-65535'
set nat cgnat pool external ext1 per-user-limit port '1000'
set nat cgnat pool external ext1 range 192.0.2.222/32
set nat cgnat pool internal int1 range '100.64.0.0/28'
set nat cgnat rule 10 source pool 'int1'
set nat cgnat rule 10 translation pool 'ext1'

```
Check nftables:
```
vyos@r4# sudo nft -s list table ip cgnat
table ip cgnat {
	map tcp_nat_map {
		type ipv4_addr : interval ipv4_addr . inet_service
		flags interval
		elements = { 100.64.0.0 : 192.0.2.222 . 1024-2023, 100.64.0.1 : 192.0.2.222 . 2024-3023,
			     100.64.0.2 : 192.0.2.222 . 3024-4023, 100.64.0.3 : 192.0.2.222 . 4024-5023,
			     100.64.0.4 : 192.0.2.222 . 5024-6023, 100.64.0.5 : 192.0.2.222 . 6024-7023,
			     100.64.0.6 : 192.0.2.222 . 7024-8023, 100.64.0.7 : 192.0.2.222 . 8024-9023,
			     100.64.0.8 : 192.0.2.222 . 9024-10023, 100.64.0.9 : 192.0.2.222 . 10024-11023,
			     100.64.0.10 : 192.0.2.222 . 11024-12023, 100.64.0.11 : 192.0.2.222 . 12024-13023,
			     100.64.0.12 : 192.0.2.222 . 13024-14023, 100.64.0.13 : 192.0.2.222 . 14024-15023,
			     100.64.0.14 : 192.0.2.222 . 15024-16023, 100.64.0.15 : 192.0.2.222 . 16024-17023 }
	}

	map udp_nat_map {
		type ipv4_addr : interval ipv4_addr . inet_service
		flags interval
		elements = { 100.64.0.0 : 192.0.2.222 . 1024-2023, 100.64.0.1 : 192.0.2.222 . 2024-3023,
			     100.64.0.2 : 192.0.2.222 . 3024-4023, 100.64.0.3 : 192.0.2.222 . 4024-5023,
			     100.64.0.4 : 192.0.2.222 . 5024-6023, 100.64.0.5 : 192.0.2.222 . 6024-7023,
			     100.64.0.6 : 192.0.2.222 . 7024-8023, 100.64.0.7 : 192.0.2.222 . 8024-9023,
			     100.64.0.8 : 192.0.2.222 . 9024-10023, 100.64.0.9 : 192.0.2.222 . 10024-11023,
			     100.64.0.10 : 192.0.2.222 . 11024-12023, 100.64.0.11 : 192.0.2.222 . 12024-13023,
			     100.64.0.12 : 192.0.2.222 . 13024-14023, 100.64.0.13 : 192.0.2.222 . 14024-15023,
			     100.64.0.14 : 192.0.2.222 . 15024-16023, 100.64.0.15 : 192.0.2.222 . 16024-17023 }
	}

	map icmp_nat_map {
		type ipv4_addr : interval ipv4_addr . inet_service
		flags interval
		elements = { 100.64.0.0 : 192.0.2.222 . 1024-2023, 100.64.0.1 : 192.0.2.222 . 2024-3023,
			     100.64.0.2 : 192.0.2.222 . 3024-4023, 100.64.0.3 : 192.0.2.222 . 4024-5023,
			     100.64.0.4 : 192.0.2.222 . 5024-6023, 100.64.0.5 : 192.0.2.222 . 6024-7023,
			     100.64.0.6 : 192.0.2.222 . 7024-8023, 100.64.0.7 : 192.0.2.222 . 8024-9023,
			     100.64.0.8 : 192.0.2.222 . 9024-10023, 100.64.0.9 : 192.0.2.222 . 10024-11023,
			     100.64.0.10 : 192.0.2.222 . 11024-12023, 100.64.0.11 : 192.0.2.222 . 12024-13023,
			     100.64.0.12 : 192.0.2.222 . 13024-14023, 100.64.0.13 : 192.0.2.222 . 14024-15023,
			     100.64.0.14 : 192.0.2.222 . 15024-16023, 100.64.0.15 : 192.0.2.222 . 16024-17023 }
	}

	map other_nat_map {
		type ipv4_addr : interval ipv4_addr
		flags interval
		elements = { 100.64.0.0 : 192.0.2.222/32, 100.64.0.1 : 192.0.2.222/32,
			     100.64.0.2 : 192.0.2.222/32, 100.64.0.3 : 192.0.2.222/32,
			     100.64.0.4 : 192.0.2.222/32, 100.64.0.5 : 192.0.2.222/32,
			     100.64.0.6 : 192.0.2.222/32, 100.64.0.7 : 192.0.2.222/32,
			     100.64.0.8 : 192.0.2.222/32, 100.64.0.9 : 192.0.2.222/32,
			     100.64.0.10 : 192.0.2.222/32, 100.64.0.11 : 192.0.2.222/32,
			     100.64.0.12 : 192.0.2.222/32, 100.64.0.13 : 192.0.2.222/32,
			     100.64.0.14 : 192.0.2.222/32, 100.64.0.15 : 192.0.2.222/32 }
	}

	chain POSTROUTING {
		type nat hook postrouting priority srcnat; policy accept;
		ip protocol tcp counter snat ip to ip saddr map @tcp_nat_map
		ip protocol udp counter snat ip to ip saddr map @udp_nat_map
		ip protocol icmp counter snat ip to ip saddr map @icmp_nat_map
		counter snat ip to ip saddr map @other_nat_map
	}
}

```
Example with ranges:
```
set nat cgnat pool external ext1 external-port-range '1024-65535'
set nat cgnat pool external ext1 per-user-limit port '8000'
set nat cgnat pool external ext1 range 192.0.2.1-192.0.2.2
set nat cgnat pool internal int1 range '100.64.0.1-100.64.0.16'
set nat cgnat rule 10 source pool 'int1'
set nat cgnat rule 10 translation pool 'ext1'
```
Check nft for ranges:
```
vyos@r4# sudo nft -s list table ip cgnat
table ip cgnat {
	map tcp_nat_map {
		type ipv4_addr : interval ipv4_addr . inet_service
		flags interval
		elements = { 100.64.0.1 : 192.0.2.1 . 1024-9023, 100.64.0.2 : 192.0.2.1 . 9024-17023,
			     100.64.0.3 : 192.0.2.1 . 17024-25023, 100.64.0.4 : 192.0.2.1 . 25024-33023,
			     100.64.0.5 : 192.0.2.1 . 33024-41023, 100.64.0.6 : 192.0.2.1 . 41024-49023,
			     100.64.0.7 : 192.0.2.1 . 49024-57023, 100.64.0.8 : 192.0.2.1 . 57024-65023,
			     100.64.0.9 : 192.0.2.2 . 1024-9023, 100.64.0.10 : 192.0.2.2 . 9024-17023,
			     100.64.0.11 : 192.0.2.2 . 17024-25023, 100.64.0.12 : 192.0.2.2 . 25024-33023,
			     100.64.0.13 : 192.0.2.2 . 33024-41023, 100.64.0.14 : 192.0.2.2 . 41024-49023,
			     100.64.0.15 : 192.0.2.2 . 49024-57023, 100.64.0.16 : 192.0.2.2 . 57024-65023 }
	}

	map udp_nat_map {
		type ipv4_addr : interval ipv4_addr . inet_service
		flags interval
		elements = { 100.64.0.1 : 192.0.2.1 . 1024-9023, 100.64.0.2 : 192.0.2.1 . 9024-17023,
			     100.64.0.3 : 192.0.2.1 . 17024-25023, 100.64.0.4 : 192.0.2.1 . 25024-33023,
			     100.64.0.5 : 192.0.2.1 . 33024-41023, 100.64.0.6 : 192.0.2.1 . 41024-49023,
			     100.64.0.7 : 192.0.2.1 . 49024-57023, 100.64.0.8 : 192.0.2.1 . 57024-65023,
			     100.64.0.9 : 192.0.2.2 . 1024-9023, 100.64.0.10 : 192.0.2.2 . 9024-17023,
			     100.64.0.11 : 192.0.2.2 . 17024-25023, 100.64.0.12 : 192.0.2.2 . 25024-33023,
			     100.64.0.13 : 192.0.2.2 . 33024-41023, 100.64.0.14 : 192.0.2.2 . 41024-49023,
			     100.64.0.15 : 192.0.2.2 . 49024-57023, 100.64.0.16 : 192.0.2.2 . 57024-65023 }
	}

	map icmp_nat_map {
		type ipv4_addr : interval ipv4_addr . inet_service
		flags interval
		elements = { 100.64.0.1 : 192.0.2.1 . 1024-9023, 100.64.0.2 : 192.0.2.1 . 9024-17023,
			     100.64.0.3 : 192.0.2.1 . 17024-25023, 100.64.0.4 : 192.0.2.1 . 25024-33023,
			     100.64.0.5 : 192.0.2.1 . 33024-41023, 100.64.0.6 : 192.0.2.1 . 41024-49023,
			     100.64.0.7 : 192.0.2.1 . 49024-57023, 100.64.0.8 : 192.0.2.1 . 57024-65023,
			     100.64.0.9 : 192.0.2.2 . 1024-9023, 100.64.0.10 : 192.0.2.2 . 9024-17023,
			     100.64.0.11 : 192.0.2.2 . 17024-25023, 100.64.0.12 : 192.0.2.2 . 25024-33023,
			     100.64.0.13 : 192.0.2.2 . 33024-41023, 100.64.0.14 : 192.0.2.2 . 41024-49023,
			     100.64.0.15 : 192.0.2.2 . 49024-57023, 100.64.0.16 : 192.0.2.2 . 57024-65023 }
	}

	map other_nat_map {
		type ipv4_addr : interval ipv4_addr
		flags interval
		elements = { 100.64.0.1 : 192.0.2.1/32, 100.64.0.2 : 192.0.2.1/32,
			     100.64.0.3 : 192.0.2.1/32, 100.64.0.4 : 192.0.2.1/32,
			     100.64.0.5 : 192.0.2.1/32, 100.64.0.6 : 192.0.2.1/32,
			     100.64.0.7 : 192.0.2.1/32, 100.64.0.8 : 192.0.2.1/32,
			     100.64.0.9 : 192.0.2.2/32, 100.64.0.10 : 192.0.2.2/32,
			     100.64.0.11 : 192.0.2.2/32, 100.64.0.12 : 192.0.2.2/32,
			     100.64.0.13 : 192.0.2.2/32, 100.64.0.14 : 192.0.2.2/32,
			     100.64.0.15 : 192.0.2.2/32, 100.64.0.16 : 192.0.2.2/32 }
	}

	chain POSTROUTING {
		type nat hook postrouting priority srcnat; policy accept;
		ip protocol tcp counter snat ip to ip saddr map @tcp_nat_map
		ip protocol udp counter snat ip to ip saddr map @udp_nat_map
		ip protocol icmp counter snat ip to ip saddr map @icmp_nat_map
		counter snat ip to ip saddr map @other_nat_map
	}
}

```
Try out of the range (ports in config more than available external-addresses/ports):
```
vyos@r4# set nat cgnat pool external ext1 per-user-limit port '16000'
[edit]
vyos@r4# commit
[ cgnat ]
Not enough ports available for the specified parameters!

[[cgnat]] failed
Commit failed
[edit]
vyos@r4# 

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
