### PR TITLE
T6207: restore ability to copy config.boot.default on image install

### DIFF
--- a/python/vyos/utils/io.py
+++ b/python/vyos/utils/io.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
+from typing import Callable, Optional
 
 def print_error(str='', end='\n'):
     """
@@ -81,7 +81,8 @@ def is_dumb_terminal():
     return os.getenv('TERM') in ['vt100', 'dumb']
 
 def select_entry(l: list, list_msg: str = '', prompt_msg: str = '',
-                 list_format: Callable = None,) -> str:
+                 list_format: Optional[Callable] = None,
+                 default_entry: Optional[int] = None) -> str:
     """Select an entry from a list
 
     Args:
@@ -99,6 +100,9 @@ def select_entry(l: list, list_msg: str = '', prompt_msg: str = '',
             print(f'\t{i}: {list_format(e)}')
         else:
             print(f'\t{i}: {e}')
-    select = ask_input(prompt_msg, numeric_only=True,
-                       valid_responses=range(1, len(l)+1))
+    valid_entry = range(1, len(l)+1)
+    if default_entry and default_entry not in valid_entry:
+        default_entry = None
+    select = ask_input(prompt_msg, default=default_entry, numeric_only=True,
+                       valid_responses=valid_entry)
     return next(filter(lambda x: x[0] == select, en))[1]

--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -56,6 +56,8 @@ MSG_INFO_INSTALL_DISK_CONFIRM: str = 'Installation will delete all data on the d
 MSG_INFO_INSTALL_RAID_CONFIRM: str = 'Installation will delete all data on both drives. Continue?'
 MSG_INFO_INSTALL_PARTITONING: str = 'Creating partition table...'
 MSG_INPUT_CONFIG_FOUND: str = 'An active configuration was found. Would you like to copy it to the new image?'
+MSG_INPUT_CONFIG_CHOICE: str = 'The following config files are available for boot:'
+MSG_INPUT_CONFIG_CHOOSE: str = 'Which file would you like as boot config?'
 MSG_INPUT_IMAGE_NAME: str = 'What would you like to name this image?'
 MSG_INPUT_IMAGE_DEFAULT: str = 'Would you like to set the new image as the default one for boot?'
 MSG_INPUT_PASSWORD: str = 'Please enter a password for the "vyos" user'
@@ -702,6 +704,10 @@ def install_image() -> None:
                                   valid_responses=['K', 'S', 'U'])
     console_dict: dict[str, str] = {'K': 'tty', 'S': 'ttyS', 'U': 'ttyUSB'}
 
+    config_boot_list = ['/opt/vyatta/etc/config/config.boot',
+                        '/opt/vyatta/etc/config.boot.default']
+    default_config = config_boot_list[0]
+
     disks: dict[str, int] = find_disks()
 
     install_target: Union[disk.DiskDetails, raid.RaidDetails, None] = None
@@ -709,6 +715,14 @@ def install_image() -> None:
         install_target = check_raid_install(disks)
         if install_target is None:
             install_target = ask_single_disk(disks)
+
+        # if previous install was selected in search_previous_installation,
+        # directory /mnt/config was prepared for copy below; if not, prompt:
+        if not Path('/mnt/config').exists():
+            default_config: str = select_entry(config_boot_list,
+                                               MSG_INPUT_CONFIG_CHOICE,
+                                               MSG_INPUT_CONFIG_CHOOSE,
+                                               default_entry=1) # select_entry indexes from 1
 
         # create directories for installation media
         prepare_tmp_disr()
@@ -731,7 +745,7 @@ def install_image() -> None:
         chown(target_config_dir, group='vyattacfg')
         chmod_2775(target_config_dir)
         # copy config
-        copy('/opt/vyatta/etc/config/config.boot', target_config_dir)
+        copy(default_config, f'{target_config_dir}/config.boot')
         configure_authentication(f'{target_config_dir}/config.boot',
                                  user_password)
         Path(f'{target_config_dir}/.vyatta_config').touch()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

NOTE: this requires the companion PR https://github.com/vyos/vyos-build/pull/551 to adjust the test script for added prompt.

The option to use config.boot.default was unfortunately dropped during development of the revised image-tools; this is a problem, for example, for EVE-NG installs:
https://www.eve-ng.net/index.php/documentation/howtos/howto-add-vyos-vyatta/

Restore option.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-build/pull/551

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
