### PR TITLE
T5858: Fix op-mode format for show conntrack statistics

### DIFF
--- a/src/op_mode/conntrack.py
+++ b/src/op_mode/conntrack.py
@@ -62,7 +62,7 @@ def _get_raw_data(family):
 
 def _get_raw_statistics():
     entries = []
-    data = cmd('sudo conntrack -S')
+    data = cmd('sudo conntrack --stats')
     data = data.replace('  \t', '').split('\n')
     for entry in data:
         entries.append(entry.split())
@@ -70,8 +70,25 @@ def _get_raw_statistics():
 
 
 def get_formatted_statistics(entries):
-    headers = ["CPU", "Found", "Invalid", "Insert", "Insert fail", "Drop", "Early drop", "Errors", "Search restart"]
-    output = tabulate(entries, headers, numalign="left")
+    headers = [
+        "CPU",
+        "Found",
+        "Invalid",
+        "Insert",
+        "Insert fail",
+        "Drop",
+        "Early drop",
+        "Errors",
+        "Search restart",
+        "",
+        "",
+    ]
+    # Process each entry to extract and format the values after '='
+    processed_entries = [
+        [value.split('=')[-1] for value in entry]
+        for entry in entries
+    ]
+    output = tabulate(processed_entries, headers, numalign="left")
     return output
 
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T5858

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
conntrack
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Before the fix, the output looks bad formated:
```
vyos@r15-left:~$ show conntrack statistics 
                CPU          Found     Invalid          Insert    Insert fail    Drop       Early drop        Errors    Search restart
-----  -------  -----------  --------  ---------------  --------  -------------  ---------  ----------------  --------  ----------------
cpu=0  found=0  invalid=174  insert=0  insert_failed=1  drop=1    early_drop=0   error=1    search_restart=0  (null)=2  (null)=0
cpu=1  found=0  invalid=73   insert=0  insert_failed=0  drop=0    early_drop=0   error=126  search_restart=0  (null)=1  (null)=0
vyos@r15-left:~$ 
```
After the fix:
```
vyos@r15-left:~$ show conntrack statistics 
CPU    Found    Invalid    Insert    Insert fail    Drop    Early drop    Errors    Search restart
-----  -------  ---------  --------  -------------  ------  ------------  --------  ----------------  --  --
0      0        174        0         1              1       0             1         0                 2   0
1      0        73         0         0              0       0             126       0                 1   0
vyos@r15-left:~$ 

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
