### PR TITLE
T6214: T6213: change constraint <alpha-numeric-hyphen-underscore-dot.xml.i>

### DIFF
--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -56,8 +56,9 @@
             <properties>
               <help>Firewall address-group</help>
               <constraint>
-                <regex>[a-zA-Z0-9][\w\-\.]*</regex>
+                #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
               </constraint>
+              <constraintErrorMessage>Name of firewall group can only contain alphanumeric letters, hyphen, underscores and dot</constraintErrorMessage>
             </properties>
             <children>
               <leafNode name="address">
@@ -96,7 +97,7 @@
               <constraint>
                 <regex>[a-zA-Z_][a-zA-Z0-9]?[\w\-\.]*</regex>
               </constraint>
-              <constraintErrorMessage>Name of domain-group can only contain alpha-numeric letters, hyphen, underscores and not start with numeric</constraintErrorMessage>
+              <constraintErrorMessage>Name of domain-group can only contain alphanumeric letters, hyphen, underscores and not start with numeric</constraintErrorMessage>
             </properties>
             <children>
               <leafNode name="address">
@@ -124,8 +125,9 @@
                 <properties>
                   <help>Firewall dynamic address group</help>
                   <constraint>
-                    <regex>[a-zA-Z0-9][\w\-\.]*</regex>
+                    #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
                   </constraint>
+                  <constraintErrorMessage>Name of firewall group can only contain alphanumeric letters, hyphen, underscores and dot</constraintErrorMessage>
                 </properties>
                 <children>
                   #include <include/generic-description.xml.i>
@@ -148,8 +150,9 @@
             <properties>
               <help>Firewall interface-group</help>
               <constraint>
-                <regex>[a-zA-Z0-9][\w\-\.]*</regex>
+                #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
               </constraint>
+              <constraintErrorMessage>Name of firewall group can only contain alphanumeric letters, hyphen, underscores and dot</constraintErrorMessage>
             </properties>
             <children>
               <leafNode name="interface">
@@ -177,8 +180,9 @@
             <properties>
               <help>Firewall ipv6-address-group</help>
               <constraint>
-                <regex>[a-zA-Z0-9][\w\-\.]*</regex>
+                #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
               </constraint>
+              <constraintErrorMessage>Name of firewall group can only contain alphanumeric letters, hyphen, underscores and dot</constraintErrorMessage>
             </properties>
             <children>
               <leafNode name="address">
@@ -215,8 +219,9 @@
             <properties>
               <help>Firewall ipv6-network-group</help>
               <constraint>
-                <regex>[a-zA-Z0-9][\w\-\.]*</regex>
+                #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
               </constraint>
+              <constraintErrorMessage>Name of firewall group can only contain alphanumeric letters, hyphen, underscores and dot</constraintErrorMessage>
             </properties>
             <children>
               #include <include/generic-description.xml.i>
@@ -248,8 +253,9 @@
             <properties>
               <help>Firewall mac-group</help>
               <constraint>
-                <regex>[a-zA-Z0-9][\w\-\.]*</regex>
+                #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
               </constraint>
+              <constraintErrorMessage>Name of firewall group can only contain alphanumeric letters, hyphen, underscores and dot</constraintErrorMessage>
             </properties>
             <children>
               #include <include/generic-description.xml.i>
@@ -281,8 +287,9 @@
             <properties>
               <help>Firewall network-group</help>
               <constraint>
-                <regex>[a-zA-Z0-9][\w\-\.]*</regex>
+                #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
               </constraint>
+              <constraintErrorMessage>Name of firewall group can only contain alphanumeric letters, hyphen, underscores and dot</constraintErrorMessage>
             </properties>
             <children>
               #include <include/generic-description.xml.i>
@@ -314,8 +321,9 @@
             <properties>
               <help>Firewall port-group</help>
               <constraint>
-                <regex>[a-zA-Z0-9][\w\-\.]*</regex>
+                #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
               </constraint>
+              <constraintErrorMessage>Name of firewall group can only contain alphanumeric letters, hyphen, underscores and dot</constraintErrorMessage>
             </properties>
             <children>
               #include <include/generic-description.xml.i>

--- a/interface-definitions/include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i
+++ b/interface-definitions/include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from constraint/alpha-numeric-hyphen-underscore-dot.xml.i -->
-<regex>[-_a-zA-Z0-9.]+</regex>
+<regex>[-_a-zA-Z0-9][\w\-\.\+]*</regex>
 <!-- include end -->


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Change constraint [alpha-numeric-hyphen-underscore-dot.xml.i](https://github.com/vyos/vyos-1x/blob/current/interface-definitions/include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i) in order to not allow string starting with dot character; use such constraint in firewall group definitions.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6214
* https://vyos.dev/T6213

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@Latest# compare commands 

set firewall group address-group -X_.Y address '198.51.100.3'
set firewall group address-group A.B_C-D address '198.51.100.1'
set firewall group address-group _aB-C. address '198.51.100.2'

[edit]
vyos@Latest# commit
[edit]
vyos@Latest# sudo nft list table ip vyos_filter | grep "set A"
        set A_-X_.Y {
        set A_A.B_C-D {
        set A__aB-C. {
[edit]
vyos@Latest# set firewall group port-group .PG01 port 22

  
  
  Name of firewall group con only contain alpha-numeric letters, hyphen, underscores and dot
  Value validation failed
  Set failed

[edit]
vyos@Latest# 
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Smoketest run during this change:
* test_firewall.py
* test_interfaces_pppoe.py
* test_service_pppoe-server.py
* test_protocols_bgp.py 
* test_service_dhcp-server.py
* test_service_dhcpv6-server.py
* test_pki.py

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
