### PR TITLE
container: T6218: fix host IPv6 link-local address for VRF networks

### DIFF
--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -473,8 +473,8 @@ def apply(container):
             # it to a VRF as there's no consumer, yet.
             if interface_exists(network_name):
                 tmp = Interface(network_name)
-                tmp.add_ipv6_eui64_address('fe80::/64')
                 tmp.set_vrf(network_config.get('vrf', ''))
+                tmp.add_ipv6_eui64_address('fe80::/64')
 
     return None
 


### PR DESCRIPTION
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Fix IPv6 EUI64 link-local address generation for host (`pod-`) interfaces assigned to a VRF.

Currently, container networks that are assigned to a VRF result in not having a valid IPv6 link-local address on the host. This is due to the address being assigned and then the VRF being changed resulting in the loss of the link-local address.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6218

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* container

## Proposed changes
<!--- Describe your changes in detail -->
Correct the ordering of the VRF assignment and link-local address generation logic. (Swap lines 476 and 477).

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Create a container network that is assigned to any VRF other than default and ensure an IPv6 EUI64 link-local address is generated:

Configuration:
```
set container network TEST prefix '169.254.1.0/24'
set container network TEST prefix 'fd00:169:254:1::/64'
set container network TEST vrf TESTVRF
set container name SERVICE1 network TEST
```

Verification:
```
6: pod-SERVICES: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master SERVICE state UP group default qlen 1000
    link/ether 8a:61:51:a0:21:09 brd ff:ff:ff:ff:ff:ff
    inet 169.254.1.1/24 brd 169.254.1.255 scope global pod-SERVICES
       valid_lft forever preferred_lft forever
    inet6 fd00:169:254:1::1/64 scope global
       valid_lft forever preferred_lft forever
    inet6 fe80::8861:51ff:fea0:2109/64 scope link
       valid_lft forever preferred_lft forever
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
