### PR TITLE
T6100: Added NAT migration from IP/Netmask to Network/Netmask

### DIFF
--- a/src/migration-scripts/nat/5-to-6
+++ b/src/migration-scripts/nat/5-to-6
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2023 VyOS maintainers and contributors
+# Copyright (C) 2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -18,46 +18,84 @@
 # to
 # 'set nat [source|destination] rule X [inbound-interface|outbound interface] interface-name <iface>'
 
+# T6100: Migration from 1.3.X to 1.4
+# Change IP/netmask to Network/netmask in
+#   'set nat [source|destination] rule X [source| destination| translation] address <IP/Netmask| !IP/Netmask>'
+
+import ipaddress
 from sys import argv,exit
 from vyos.configtree import ConfigTree
 
-if len(argv) < 2:
-    print("Must specify file name!")
-    exit(1)
 
-file_name = argv[1]
+def _func_T5643(conf, base_path):
+    for iface in ['inbound-interface', 'outbound-interface']:
+        if conf.exists(base_path + [iface]):
+            tmp = conf.return_value(base_path + [iface])
+            if tmp:
+                conf.delete(base_path + [iface])
+                conf.set(base_path + [iface, 'interface-name'], value=tmp)
+    return
 
-with open(file_name, 'r') as f:
-    config_file = f.read()
 
-config = ConfigTree(config_file)
+def _func_T6100(conf, base_path):
+    for addr_type in ['source', 'destination', 'translation']:
+        base_addr_type = base_path + [addr_type]
+        if not conf.exists(base_addr_type) or not conf.exists(
+                base_addr_type + ['address']):
+            continue
 
-if not config.exists(['nat']):
-    # Nothing to do
-    exit(0)
+        address = conf.return_value(base_addr_type + ['address'])
 
-for direction in ['source', 'destination']:
-    # If a node doesn't exist, we obviously have nothing to do.
-    if not config.exists(['nat', direction]):
-        continue
+        if not address or '/' not in address:
+            continue
 
-    # However, we also need to handle the case when a 'source' or 'destination' sub-node does exist,
-    # but there are no rules under it.
-    if not config.list_nodes(['nat', direction]):
-        continue
+        negative = ''
+        network = address
+        if '!' in address:
+            negative = '!'
+            network = str(address.split(negative)[1])
 
-    for rule in config.list_nodes(['nat', direction, 'rule']):
-        base = ['nat', direction, 'rule', rule]
-        for iface in ['inbound-interface','outbound-interface']:
-            if config.exists(base + [iface]):
-                tmp = config.return_value(base + [iface])
-                if tmp:
-                    config.delete(base + [iface])
-                    config.set(base + [iface, 'interface-name'], value=tmp)
+        network_ip = ipaddress.ip_network(network, strict=False)
+        if str(network_ip) != network:
+            network = f'{negative}{str(network_ip)}'
+            conf.set(base_addr_type + ['address'], value=network)
+    return
 
-try:
-    with open(file_name, 'w') as f:
-        f.write(config.to_string())
-except OSError as e:
-    print("Failed to save the modified config: {}".format(e))
-    exit(1)
+
+if __name__ == '__main__':
+    if len(argv) < 2:
+        print("Must specify file name!")
+        exit(1)
+
+    file_name = argv[1]
+
+    with open(file_name, 'r') as f:
+        config_file = f.read()
+
+    config = ConfigTree(config_file)
+
+    if not config.exists(['nat']):
+        # Nothing to do
+        exit(0)
+
+    for direction in ['source', 'destination']:
+        # If a node doesn't exist, we obviously have nothing to do.
+        if not config.exists(['nat', direction]):
+            continue
+
+        # However, we also need to handle the case when a 'source' or 'destination' sub-node does exist,
+        # but there are no rules under it.
+        if not config.list_nodes(['nat', direction]):
+            continue
+
+        for rule in config.list_nodes(['nat', direction, 'rule']):
+            base = ['nat', direction, 'rule', rule]
+            _func_T5643(config,base)
+            _func_T6100(config,base)
+
+    try:
+        with open(file_name, 'w') as f:
+            f.write(config.to_string())
+    except OSError as e:
+        print("Failed to save the modified config: {}".format(e))
+        exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added NAT migration from IP/Netmask to Network/Netmask.
In 1.3 allowed using IP/Netmask in Nat rules.
In 1.4 and 1.5 it is prohibited. Allowed Network/Netmask.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6100

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat

## Proposed changes
<!--- Describe your changes in detail -->
Added NAT migration from IP/Netmask to Network/Netmask.
In 1.3 allowed using IP/Netmask in Nat rules.
In 1.4 and 1.5 it is prohibited. Allowed Network/Netmask.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
For example:
VyOS 1.3.6 configuration:
```
set nat destination rule 2060 destination port '5060,10000-20000'
set nat destination rule 2060 inbound-interface 'eth4'
set nat destination rule 2060 protocol 'udp'
set nat destination rule 2060 source address '!192.0.2.226/27'
set nat destination rule 2060 translation address '10.250.1.3'
```

Netfilter config in 1.3.6
```
table ip nat {
        chain PREROUTING {
                type nat hook prerouting priority dstnat; policy accept;
                counter packets 411 bytes 72404 jump VYATTA_PRE_DNAT_HOOK
                iifname "eth4" meta l4proto udp ip saddr != 192.0.2.224/27 udp dport { 5060,10000-20000} counter packets 0 bytes 0 dnat to 10.250.1.3 comment "DST-NAT-2060"
        }
```
Migration to 1.4 or 1.5 fails, because
```
vyos@vyos# set nat destination rule 2060 source address '!192.0.2.226/27'

  Error: 192.0.2.226/27 is not a valid IPv4 address range

  Error: 192.0.2.226/27 is not a valid IPv4 prefix

  Error: 192.0.2.226/27 is not a valid IPv4 address

  Error: !192.0.2.226/27 is not a valid IPv4 address range

  Error: !192.0.2.226/27 is not a valid IPv4 prefix

  Error: !192.0.2.226/27 is not a valid IPv4 address



  Invalid value
  Value validation failed
  Set failed

[edit]
```
After changes:
After migration from 1.3 to 1.4 or 1.5. VyOS config looks
```
set nat destination rule 2060 destination port '5060,10000-20000'
set nat destination rule 2060 inbound-interface name 'eth4'
set nat destination rule 2060 protocol 'udp'
set nat destination rule 2060 source address '!192.0.2.224/27'
set nat destination rule 2060 translation address '10.250.1.3'
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
