### PR TITLE
T6222: VRRP show prefix for long rfc3768-compatibility interfaces allow prefix vrrp

### DIFF
--- a/python/vyos/ifconfig/section.py
+++ b/python/vyos/ifconfig/section.py
@@ -97,7 +97,7 @@ class Section:
 
         for ifname in interfaces:
             ifsection = cls.section(ifname)
-            if not ifsection:
+            if not ifsection and not ifname.startswith('vrrp'):
                 continue
 
             if section and ifsection != section:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
If we use rfc3768-compatibility with long interface names like eth1.100.200 it converts the VRRP interface name name to `<interface>v<VRID><IP version>`
For example `eth2.100.200v10v4`

The limit for interface name is 15 symbols and it causes that interface name is ignoring by keepalived

VMAC interface name 'eth2.100.200v10v4' too long or invalid characters - ignoring And it uses the default prefix `vrrp` for such cases. It works fine, but such interfaces are not displayed in the op-mode

Allow prefix `vrrp` for the op-mode for `show interfaces`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6222

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces ethernet eth2 vif-s 100 vif-c 200 address '10.0.1.1/30'

set high-availability vrrp group FIRST address 203.0.113.1/24
set high-availability vrrp group FIRST interface 'eth2.100.200'
set high-availability vrrp group FIRST no-preempt
set high-availability vrrp group FIRST priority '250'
set high-availability vrrp group FIRST rfc3768-compatibility
set high-availability vrrp group FIRST vrid '10'
```
Before the fix we don't see interface with address `203.0.113.1`
```
vyos@r4:~$ show interfaces 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface     IP Address         MAC                VRF        MTU  S/L    Description
------------  -----------------  -----------------  -------  -----  -----  -------------
eth0          192.168.122.14/24  52:54:00:f1:fd:77  default   1500  u/u    WAN
eth1          -                  52:54:00:04:33:2b  default   1500  u/u    WAN
eth2          -                  52:54:00:40:2e:af  default   1500  u/u    sync
eth2.100      -                  52:54:00:40:2e:af  default   1500  u/u
eth2.100.200  10.0.1.1/30        52:54:00:40:2e:af  default   1500  u/u
eth3          -                  52:54:00:09:a4:b4  default   1500  A/D
eth4          -                  52:54:00:2c:51:09  default   1500  A/D
eth5          -                  52:54:00:f3:1d:e8  default   1500  A/D
lo            127.0.0.1/8        00:00:00:00:00:00  default  65536  u/u
              ::1/128
vti10         -                  n/a                default   1500  A/D
vyos@r4:~$ 
```
But actually address exits
```
vyos@r4:~$ ip addres show dev vrrp.10
49: vrrp.10@eth2.100.200: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 00:00:5e:00:01:0a brd ff:ff:ff:ff:ff:ff
    inet 203.0.113.1/24 scope global vrrp.10
       valid_lft forever preferred_lft forever
vyos@r4:~$ 

```


After the fix, the expected interface if showing with the prefix `vrrp`
```
vyos@r4:~$ show interfaces 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface     IP Address         MAC                VRF        MTU  S/L    Description
------------  -----------------  -----------------  -------  -----  -----  -------------
eth0          192.168.122.14/24  52:54:00:f1:fd:77  default   1500  u/u    WAN
eth1          -                  52:54:00:04:33:2b  default   1500  u/u    WAN
eth2          -                  52:54:00:40:2e:af  default   1500  u/u    sync
eth2.100      -                  52:54:00:40:2e:af  default   1500  u/u
eth2.100.200  10.0.1.1/30        52:54:00:40:2e:af  default   1500  u/u
eth3          -                  52:54:00:09:a4:b4  default   1500  A/D
eth4          -                  52:54:00:2c:51:09  default   1500  A/D
eth5          -                  52:54:00:f3:1d:e8  default   1500  A/D
lo            127.0.0.1/8        00:00:00:00:00:00  default  65536  u/u
              ::1/128
vrrp.10       203.0.113.1/24     00:00:5e:00:01:0a  default   1500  u/u
vti10         -                  n/a                default   1500  A/D
vyos@r4:~$ 

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
