### PR TITLE
pppoe-server: T6141: T5364: PPPoE-server add pado-delay without sessions fails

### DIFF
--- a/data/templates/accel-ppp/pppoe.config.j2
+++ b/data/templates/accel-ppp/pppoe.config.j2
@@ -68,9 +68,9 @@ service-name={{ service_name | join(',') }}
 {%     set pado_delay_param = namespace(value=delay_without_sessions) %}
 {%     for delay, sessions in pado_delay.delays_with_sessions | sort(attribute='1') %}
 {%         if not loop.last %}
-{%             set pado_delay_param.value = pado_delay_param.value + ',' + delay + ':' + sessions|string %}
+{%             set pado_delay_param.value = pado_delay_param.value + ',' + delay + ':' + sessions | string %}
 {%         else %}
-{%             set pado_delay_param.value = pado_delay_param.value + ',-1:' + sessions|string %}
+{%             set pado_delay_param.value = pado_delay_param.value + ',-1:' + sessions | string %}
 {%         endif %}
 {%     endfor %}
 pado-delay={{ pado_delay_param.value }}

--- a/data/templates/accel-ppp/pppoe.config.j2
+++ b/data/templates/accel-ppp/pppoe.config.j2
@@ -64,12 +64,13 @@ vlan-mon={{ iface }},{{ iface_config.vlan | join(',') }}
 service-name={{ service_name | join(',') }}
 {% endif %}
 {% if pado_delay %}
-{%     set pado_delay_param = namespace(value='0') %}
-{%     for delay in pado_delay | sort(attribute='0') %}
+{%     set delay_without_sessions = pado_delay.delays_without_sessions[0] | default('0') %}
+{%     set pado_delay_param = namespace(value=delay_without_sessions) %}
+{%     for delay, sessions in pado_delay.delays_with_sessions | sort(attribute='1') %}
 {%         if not loop.last %}
-{%             set pado_delay_param.value = pado_delay_param.value + ',' + delay + ':' + pado_delay[delay].sessions %}
+{%             set pado_delay_param.value = pado_delay_param.value + ',' + delay + ':' + sessions|string %}
 {%         else %}
-{%             set pado_delay_param.value = pado_delay_param.value + ',-1:' + pado_delay[delay].sessions %}
+{%             set pado_delay_param.value = pado_delay_param.value + ',-1:' + sessions|string %}
 {%         endif %}
 {%     endfor %}
 pado-delay={{ pado_delay_param.value }}

--- a/smoketest/scripts/cli/test_service_pppoe-server.py
+++ b/smoketest/scripts/cli/test_service_pppoe-server.py
@@ -148,6 +148,28 @@ class TestServicePPPoEServer(BasicAccelPPPTest.TestCase):
         tmp = ','.join(vlans)
         self.assertIn(f'vlan-mon={interface},{tmp}', config)
 
+    def test_pppoe_server_pado_delay(self):
+        delay_without_sessions = '10'
+        delays = {'20': '200', '30': '300'}
+
+        self.basic_config()
+
+        self.set(['pado-delay', delay_without_sessions])
+        self.cli_commit()
+
+        conf = ConfigParser(allow_no_value=True, delimiters='=')
+        conf.read(self._config_file)
+        self.assertEqual(conf['pppoe']['pado-delay'], delay_without_sessions)
+
+        for delay, sessions in delays.items():
+            self.set(['pado-delay', delay, 'sessions', sessions])
+        self.cli_commit()
+
+        conf = ConfigParser(allow_no_value=True, delimiters='=')
+        conf.read(self._config_file)
+
+        self.assertEqual(conf['pppoe']['pado-delay'], '10,20:200,-1:300')
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed:
```
set service pppoe-server pado-delay 10
```
Also changed sorting by delays to sorting by sessions as the documentation requires
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6141
* https://vyos.dev/T5364
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe-server
## Proposed changes
<!--- Describe your changes in detail -->
Now can add pado-delay without sessions
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set service pppoe-server authentication local-users username user1 password 'user1'
set service pppoe-server authentication mode 'local'
set service pppoe-server client-ip-pool first range '100.64.0.1-100.64.0.100'
set service pppoe-server default-pool 'first'
set service pppoe-server gateway-address '100.64.0.1'
set service pppoe-server interface eth1
commit

set service pppoe-server pado-delay 10
commit

vyos@vyos# cat /run/accel-pppd/pppoe.conf | grep pado-delay
pado-delay=10

set service pppoe-server pado-delay 20 sessions 200
commit

vyos@vyos# cat /run/accel-pppd/pppoe.conf | grep pado-delay
pado-delay=10,-1:200
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py
test_accel_ipv4_pool (__main__.TestServicePPPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServicePPPoEServer.test_accel_ipv6_pool) ... ok
test_accel_limits (__main__.TestServicePPPoEServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestServicePPPoEServer.test_accel_local_authentication) ... ok
test_accel_name_servers (__main__.TestServicePPPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServicePPPoEServer.test_accel_next_pool) ... ok
test_accel_ppp_options (__main__.TestServicePPPoEServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestServicePPPoEServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestServicePPPoEServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestServicePPPoEServer.test_accel_wins_server) ... ok
test_pppoe_limits (__main__.TestServicePPPoEServer.test_pppoe_limits) ... ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer.test_pppoe_server_authentication_protocols) ... ok
test_pppoe_server_pado_delay (__main__.TestServicePPPoEServer.test_pppoe_server_pado_delay) ... ok
test_pppoe_server_shaper (__main__.TestServicePPPoEServer.test_pppoe_server_shaper) ... ok
test_pppoe_server_vlan (__main__.TestServicePPPoEServer.test_pppoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 16 tests in 234.722s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
