### PR TITLE
qos: T6035: QoS policy shaper queue-type random-detect requires limit avpkt

### DIFF
--- a/interface-definitions/include/qos/queue-average-packet.xml.i
+++ b/interface-definitions/include/qos/queue-average-packet.xml.i
@@ -1,0 +1,16 @@
+<!-- include start from qos/queue-average-packet.xml.i -->
+<leafNode name="average-packet">
+  <properties>
+    <help>Average packet size (bytes)</help>
+    <valueHelp>
+      <format>u32:16-10240</format>
+      <description>Average packet size in bytes</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 16-10240"/>
+    </constraint>
+    <constraintErrorMessage>Average packet size must be between 16 and 10240</constraintErrorMessage>
+  </properties>
+  <defaultValue>1024</defaultValue>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/qos/queue-mark-probability.xml.i
+++ b/interface-definitions/include/qos/queue-mark-probability.xml.i
@@ -1,0 +1,16 @@
+<!-- include start from qos/queue-mark-probability.xml.i -->
+<leafNode name="mark-probability">
+  <properties>
+    <help>Mark probability for random detection</help>
+    <valueHelp>
+      <format>u32</format>
+      <description>Numeric value (1/N)</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--positive"/>
+    </constraint>
+    <constraintErrorMessage>Mark probability must be greater than 0</constraintErrorMessage>
+  </properties>
+  <defaultValue>10</defaultValue>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/qos/queue-maximum-threshold.xml.i
+++ b/interface-definitions/include/qos/queue-maximum-threshold.xml.i
@@ -1,0 +1,16 @@
+<!-- include start from qos/queue-maximum-threshold.xml.i -->
+<leafNode name="maximum-threshold">
+  <properties>
+    <help>Maximum threshold for random detection</help>
+    <valueHelp>
+      <format>u32:0-4096</format>
+      <description>Maximum threshold in packets</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 0-4096"/>
+    </constraint>
+    <constraintErrorMessage>Threshold must be between 0 and 4096</constraintErrorMessage>
+  </properties>
+  <defaultValue>18</defaultValue>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/qos/queue-minimum-threshold.xml.i
+++ b/interface-definitions/include/qos/queue-minimum-threshold.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from qos/queue-minimum-threshold.xml.i -->
+<leafNode name="minimum-threshold">
+  <properties>
+    <help>Minimum threshold for random detection</help>
+    <valueHelp>
+      <format>u32:0-4096</format>
+      <description>Minimum threshold in packets</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 0-4096"/>
+    </constraint>
+    <constraintErrorMessage>Threshold must be between 0 and 4096</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/qos.xml.in
+++ b/interface-definitions/qos.xml.in
@@ -470,61 +470,10 @@
                 </properties>
                 <children>
                   #include <include/qos/queue-limit-1-4294967295.xml.i>
-                  <leafNode name="average-packet">
-                    <properties>
-                      <help>Average packet size (bytes)</help>
-                      <valueHelp>
-                        <format>u32:16-10240</format>
-                        <description>Average packet size in bytes</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 0-100"/>
-                      </constraint>
-                      <constraintErrorMessage>Average packet size must be between 16 and 10240</constraintErrorMessage>
-                    </properties>
-                    <defaultValue>1024</defaultValue>
-                  </leafNode>
-                  <leafNode name="mark-probability">
-                    <properties>
-                      <help>Mark probability for this precedence</help>
-                      <valueHelp>
-                        <format>&lt;number&gt;</format>
-                        <description>Numeric value (1/N)</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--positive"/>
-                      </constraint>
-                      <constraintErrorMessage>Mark probability must be greater than 0</constraintErrorMessage>
-                    </properties>
-                    <defaultValue>10</defaultValue>
-                  </leafNode>
-                  <leafNode name="maximum-threshold">
-                    <properties>
-                      <help>Maximum threshold for random detection</help>
-                      <valueHelp>
-                        <format>u32:0-4096</format>
-                        <description>Maximum Threshold in packets</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 0-4096"/>
-                      </constraint>
-                      <constraintErrorMessage>Threshold must be between 0 and 4096</constraintErrorMessage>
-                    </properties>
-                    <defaultValue>18</defaultValue>
-                  </leafNode>
-                  <leafNode name="minimum-threshold">
-                    <properties>
-                      <help>Minimum  threshold for random detection</help>
-                      <valueHelp>
-                        <format>u32:0-4096</format>
-                        <description>Maximum Threshold in packets</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 0-4096"/>
-                      </constraint>
-                      <constraintErrorMessage>Threshold must be between 0 and 4096</constraintErrorMessage>
-                    </properties>
-                  </leafNode>
+                  #include <include/qos/queue-average-packet.xml.i>
+                  #include <include/qos/queue-maximum-threshold.xml.i>
+                  #include <include/qos/queue-minimum-threshold.xml.i>
+                  #include <include/qos/queue-mark-probability.xml.i>
                 </children>
               </tagNode>
             </children>
@@ -697,6 +646,10 @@
                   #include <include/qos/interval.xml.i>
                   #include <include/qos/class-match.xml.i>
                   #include <include/qos/class-priority.xml.i>
+                  #include <include/qos/queue-average-packet.xml.i>
+                  #include <include/qos/queue-maximum-threshold.xml.i>
+                  #include <include/qos/queue-minimum-threshold.xml.i>
+                  #include <include/qos/queue-mark-probability.xml.i>
                   #include <include/qos/queue-limit-1-4294967295.xml.i>
                   #include <include/qos/queue-type.xml.i>
                   <leafNode name="queue-type">
@@ -759,6 +712,10 @@
                     </properties>
                     <defaultValue>20</defaultValue>
                   </leafNode>
+                  #include <include/qos/queue-average-packet.xml.i>
+                  #include <include/qos/queue-maximum-threshold.xml.i>
+                  #include <include/qos/queue-minimum-threshold.xml.i>
+                  #include <include/qos/queue-mark-probability.xml.i>
                   #include <include/qos/queue-limit-1-4294967295.xml.i>
                   #include <include/qos/queue-type.xml.i>
                   <leafNode name="queue-type">

--- a/python/vyos/qos/base.py
+++ b/python/vyos/qos/base.py
@@ -90,6 +90,23 @@ class QoSBase:
         else:
             return value
 
+    def _calc_random_detect_queue_params(self, avg_pkt, max_thr, limit=None, min_thr=None, mark_probability=None):
+        params = dict()
+        avg_pkt = int(avg_pkt)
+        max_thr = int(max_thr)
+        mark_probability = int(mark_probability)
+        limit = int(limit) if limit else 4 * max_thr
+        min_thr = int(min_thr) if min_thr else (9 * max_thr) // 18
+
+        params['avg_pkt'] = avg_pkt
+        params['limit'] = limit * avg_pkt
+        params['min_val'] = min_thr * avg_pkt
+        params['max_val'] = max_thr * avg_pkt
+        params['burst'] = (2 * min_thr + max_thr) // 3
+        params['probability'] = 1 / mark_probability
+
+        return params
+
     def _build_base_qdisc(self, config : dict, cls_id : int):
         """
         Add/replace qdisc for every class (also default is a class). This is
@@ -143,6 +160,18 @@ class QoSBase:
 
         elif queue_type == 'random-detect':
             default_tc += f' red'
+
+            qparams = self._calc_random_detect_queue_params(
+                avg_pkt=dict_search('average_packet', config),
+                max_thr=dict_search('maximum_threshold', config),
+                limit=dict_search('queue_limit', config),
+                min_thr=dict_search('minimum_threshold', config),
+                mark_probability=dict_search('mark_probability', config)
+            )
+
+            default_tc += f' limit {qparams["limit"]} avpkt {qparams["avg_pkt"]}'
+            default_tc += f' max {qparams["max_val"]} min {qparams["min_val"]}'
+            default_tc += f' burst {qparams["burst"]} probability {qparams["probability"]}'
 
             self._cmd(default_tc)
 


### PR DESCRIPTION
Added params for configuration red on the shaper policy

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6035

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
example from task:
```
set qos policy shaper QOS bandwidth 100mbit
set qos policy shaper QOS default bandwidth 100%
set qos policy shaper QOS default burst 10
set qos policy shaper QOS default queue-type random-detect
set qos interface eth1 egress QOS
```

example with additional params and non default policy:
```
set qos interface eth0 egress qos-shaper-eth0
set qos policy shaper qos-shaper-eth0 bandwidth 100mbit
set qos policy shaper qos-shaper-eth0 default bandwidth 100%
set qos policy shaper qos-shaper-eth0 default burst 100
set qos policy shaper qos-shaper-eth0 default queue-type random-detect
set qos policy shaper qos-shaper-eth0 class 2 bandwidth 50mbit
set qos policy shaper qos-shaper-eth0 class 2 match 10 ip destination address 192.0.2.8/32
set qos policy shaper qos-shaper-eth0 class 2 queue-type random-detect
set qos policy shaper qos-shaper-eth0 default queue-limit 1024
set qos policy shaper qos-shaper-eth0 default average-packet 1024
set qos policy shaper qos-shaper-eth0 default maximum-threshold 32
set qos policy shaper qos-shaper-eth0 default minimum-threshold 16
set qos policy shaper qos-shaper-eth0 class 2 queue-limit 1024
set qos policy shaper qos-shaper-eth0 class 2 average-packet 512
set qos policy shaper qos-shaper-eth0 class 2 maximum-threshold 32
set qos policy shaper qos-shaper-eth0 class 2 minimum-threshold 16
set qos policy shaper qos-shaper-eth0 class 2 mark-probability 20
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_qos.py 
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... skipped 'tc returns invalid JSON here - needs iproute2 fix'
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok
test_12_shaper_with_red_queue (__main__.TestQoS.test_12_shaper_with_red_queue) ... ok

----------------------------------------------------------------------
Ran 12 tests in 37.756s

OK (skipped=1)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
