### PR TITLE
ntp: T4909 rewrite NTP op mode in the new format

### DIFF
--- a/op-mode-definitions/ntp.xml.in
+++ b/op-mode-definitions/ntp.xml.in
@@ -6,13 +6,25 @@
         <properties>
           <help>Show peer status of NTP daemon</help>
         </properties>
-        <command>${vyos_op_scripts_dir}/show_ntp.sh --sourcestats</command>
+        <command>${vyos_op_scripts_dir}/ntp.py show_sourcestats</command>
         <children>
+          <node name="activity">
+            <properties>
+              <help>Report the number of servers and peers that are online and offline</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/ntp.py show_activity</command>
+          </node>
+          <node name="sources">
+            <properties>
+              <help>Show information about the current time sources being accessed</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/ntp.py show_sources</command>
+          </node>
           <node name="system">
             <properties>
               <help>Show parameters about the system clock performance</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/show_ntp.sh --tracking</command>
+            <command>${vyos_op_scripts_dir}/ntp.py show_tracking</command>
           </node>
         </children>
       </node>

--- a/src/op_mode/ntp.py
+++ b/src/op_mode/ntp.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import csv
+import sys
+from itertools import chain
+
+import vyos.opmode
+from vyos.configquery import ConfigTreeQuery
+from vyos.utils.process import cmd
+
+def _get_raw_data(command: str) -> dict:
+    # Returns returns chronyc output as a dictionary
+
+    # Initialize dictionary keys to align with output of
+    # chrony -c. From some commands, its -c switch outputs
+    # more parameters, make sure to include them all below.
+    # See to chronyc(1) for definition of key variables
+    match command:
+        case "chronyc -c activity":
+            keys: list = [
+            'sources_online',
+            'sources_offline',
+            'sources_doing_burst_return_online',
+            'sources_doing_burst_return_offline',
+            'sources_with_unknown_address'
+            ]
+
+        case "chronyc -c sources":
+            keys: list = [
+            'm',
+            's',
+            'name_ip_address',
+            'stratum',
+            'poll',
+            'reach',
+            'last_rx',
+            'last_sample_adj_offset',
+            'last_sample_mes_offset',
+            'last_sample_est_error'
+            ]
+
+        case "chronyc -c sourcestats":
+            keys: list = [
+            'name_ip_address',
+            'np',
+            'nr',
+            'span',
+            'frequency',
+            'freq_skew',
+            'offset',
+            'std_dev'
+            ]
+
+        case "chronyc -c tracking":
+            keys: list = [
+            'ref_id',
+            'ref_id_name',
+            'stratum',
+            'ref_time',
+            'system_time',
+            'last_offset',
+            'rms_offset',
+            'frequency',
+            'residual_freq',
+            'skew',
+            'root_delay',
+            'root_dispersion',
+            'update_interval',
+            'leap_status'
+            ]
+
+        case _:
+            raise ValueError(f"Raw mode: of {command} is not implemented")
+
+    # Get -c option command line output, splitlines,
+    # and save comma-separated values as a flat list
+    output = cmd(command).splitlines()
+    values = csv.reader(output)
+    values = list(chain.from_iterable(values))
+
+    # Divide values into chunks of size keys and transpose
+    if len(values) > len(keys):
+       values = _chunk_list(values,keys)
+       values = zip(*values)
+
+    return dict(zip(keys, values))
+
+def _chunk_list(in_list, n):
+    # Yields successive n-sized chunks from in_list
+    for i in range(0, len(in_list), len(n)):
+        yield in_list[i:i + len(n)]
+
+def _is_configured():
+    # Check if ntp is configured
+    config = ConfigTreeQuery()
+    if not config.exists("service ntp"):
+        raise vyos.opmode.UnconfiguredSubsystem("NTP service is not enabled.")
+
+def show_activity(raw: bool):
+    _is_configured()
+    command = f'chronyc'
+
+    if raw:
+       command += f" -c activity"
+       return _get_raw_data(command)
+    else:
+       command += f" activity"
+       return cmd(command)
+
+def show_sources(raw: bool):
+    _is_configured()
+    command = f'chronyc'
+
+    if raw:
+       command += f" -c sources"
+       return _get_raw_data(command)
+    else:
+       command += f" sources -v"
+       return cmd(command)
+
+def show_tracking(raw: bool):
+    _is_configured()
+    command = f'chronyc'
+
+    if raw:
+       command += f" -c tracking"
+       return _get_raw_data(command)
+    else:
+       command += f" tracking"
+       return cmd(command)
+
+def show_sourcestats(raw: bool):
+    _is_configured()
+    command = f'chronyc'
+
+    if raw:
+       command += f" -c sourcestats"
+       return _get_raw_data(command)
+    else:
+       command += f" sourcestats -v"
+       return cmd(command)
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except (ValueError, vyos.opmode.Error) as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Op commands are rewritten in Python and encompasses the existing chronyc calls that were in show_ntp.sh. 

Have also added two additional functions. Op-mode definition has been updated accordingly and follows the chronyc command language so that there's alignment between xml and python source. 

Op commands consist of:
    show ntp
    show ntp activity
    show ntp sources
    show ntp tracking
note: show ntp activity and sources are new additions, while tracking has been renamed from previous system.

See task in Maniphest for additional info,

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [X] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T4909

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly -> will do as subsequent step
