### PR TITLE
T5734: OpenVPN check PKI DH name exists if DH configured

### DIFF
--- a/src/conf_mode/interfaces_openvpn.py
+++ b/src/conf_mode/interfaces_openvpn.py
@@ -198,6 +198,12 @@ def verify_pki(openvpn):
                 raise ConfigError(f'Cannot use encrypted private key on openvpn interface {interface}')
 
         if 'dh_params' in tls:
+            if 'dh' not in pki:
+                raise ConfigError(f'pki dh is not configured')
+            proposed_dh = tls['dh_params']
+            if proposed_dh not in pki['dh'].keys():
+                raise ConfigError(f"pki dh '{proposed_dh}' is not configured")
+
             pki_dh = pki['dh'][tls['dh_params']]
             dh_params = load_dh_parameters(pki_dh['parameters'])
             dh_numbers = dh_params.parameter_numbers()


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Check if DH is configured for OpenVPN but does not exist in the PKI section

```
set pki dh dh-correct parameters 'xxxx'
set interfaces openvpn vtun10 tls dh-params 'dh-fake'

  File "/usr/libexec/vyos/conf_mode/interfaces_openvpn.py", line 208, in verify_pki
    pki_dh = pki['dh'][tls['dh_params']]
             ~~~~~~~~~^^^^^^^^^^^^^^^^^^
KeyError: 'dh-fake'
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T5734

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
OpenVPN
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Use not exist `dh` for OpenVPN configuration

```
set pki dh dh-correct parameters 'xxxx'

set interfaces openvpn vtun10 encryption cipher 'aes256'
set interfaces openvpn vtun10 hash 'sha512'
set interfaces openvpn vtun10 local-host '203.0.113.1'
set interfaces openvpn vtun10 local-port '1194'
set interfaces openvpn vtun10 mode 'server'
set interfaces openvpn vtun10 persistent-tunnel
set interfaces openvpn vtun10 protocol 'udp'
set interfaces openvpn vtun10 server client client1 ip '10.10.0.10'
set interfaces openvpn vtun10 server domain-name 'vyos.net'
set interfaces openvpn vtun10 server max-connections '250'
set interfaces openvpn vtun10 server mfa totp
set interfaces openvpn vtun10 server name-server '172.16.254.30'
set interfaces openvpn vtun10 server subnet '10.10.0.0/24'
set interfaces openvpn vtun10 server topology 'subnet'
set interfaces openvpn vtun10 tls ca-certificate 'ca'
set interfaces openvpn vtun10 tls certificate 'cert'
set interfaces openvpn vtun10 tls dh-params 'dh-fake'
set interfaces openvpn vtun10 tls tls-version-min '1.0'
set interfaces openvpn vtun10 use-lzo-compression

```
Before the fix:
```
Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/interfaces-openvpn.py", line 726, in <module>
    verify(c)
  File "/usr/libexec/vyos/conf_mode/interfaces-openvpn.py", line 513, in verify
    verify_pki(openvpn)
  File "/usr/libexec/vyos/conf_mode/interfaces-openvpn.py", line 205, in verify_pki
    pki_dh = pki['dh'][tls['dh_params']]
             ~~~^^^^^^
KeyError: 'dh-fake'



[[interfaces openvpn vtun10]] failed
Commit failed
[edit]
vyos@r4#
```
After the fix:
```
vyos@r4# commit
[ interfaces openvpn vtun10 ]
pki dh 'dh-fake' is not configured

[[interfaces openvpn vtun10]] failed
Commit failed
[edit]
vyos@r4# 

```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py
test_openvpn_client_interfaces (__main__.TestInterfacesOpenVPN.test_openvpn_client_interfaces) ... ok
test_openvpn_client_verify (__main__.TestInterfacesOpenVPN.test_openvpn_client_verify) ... ok
test_openvpn_options (__main__.TestInterfacesOpenVPN.test_openvpn_options) ... ok
test_openvpn_server_subnet_topology (__main__.TestInterfacesOpenVPN.test_openvpn_server_subnet_topology) ... ok
test_openvpn_server_verify (__main__.TestInterfacesOpenVPN.test_openvpn_server_verify) ... ok
test_openvpn_site2site_interfaces_tun (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_interfaces_tun) ... ok
test_openvpn_site2site_verify (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_verify) ... ok

----------------------------------------------------------------------
Ran 7 tests in 167.585s

OK
vyos@r4:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
