### PR TITLE
T5535: firewall: migrate command <set system ip disable-directed-broadcast> to firewall global-optinos

### DIFF
--- a/interface-definitions/include/firewall/global-options.xml.i
+++ b/interface-definitions/include/firewall/global-options.xml.i
@@ -44,6 +44,26 @@
       </properties>
       <defaultValue>disable</defaultValue>
     </leafNode>
+    <leafNode name="directed-broadcast">
+      <properties>
+        <help>Policy for handling IPv4 directed broadcast forwarding on all interfaces</help>
+        <completionHelp>
+          <list>enable disable</list>
+        </completionHelp>
+        <valueHelp>
+          <format>enable</format>
+          <description>Enable IPv4 directed broadcast forwarding on all interfaces</description>
+        </valueHelp>
+        <valueHelp>
+          <format>disable</format>
+          <description>Disable IPv4 directed broadcast forwarding on all interfaces</description>
+        </valueHelp>
+        <constraint>
+          <regex>(enable|disable)</regex>
+        </constraint>
+      </properties>
+      <defaultValue>enable</defaultValue>
+    </leafNode>
     <leafNode name="ip-src-route">
       <properties>
         <help>Policy for handling IPv4 packets with source route option</help>

--- a/interface-definitions/include/version/firewall-version.xml.i
+++ b/interface-definitions/include/version/firewall-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/firewall-version.xml.i -->
-<syntaxVersion component='firewall' version='14'></syntaxVersion>
+<syntaxVersion component='firewall' version='15'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/system_ip.xml.in
+++ b/interface-definitions/system_ip.xml.in
@@ -23,12 +23,6 @@
               <valueless/>
             </properties>
           </leafNode>
-          <leafNode name="disable-directed-broadcast">
-            <properties>
-              <help>Disable IPv4 directed broadcast forwarding on all interfaces</help>
-              <valueless/>
-            </properties>
-          </leafNode>
           <node name="multipath">
             <properties>
               <help>IPv4 multipath settings</help>

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -27,6 +27,7 @@ from vyos.utils.process import run
 sysfs_config = {
     'all_ping': {'sysfs': '/proc/sys/net/ipv4/icmp_echo_ignore_all', 'default': '0', 'test_value': 'disable'},
     'broadcast_ping': {'sysfs': '/proc/sys/net/ipv4/icmp_echo_ignore_broadcasts', 'default': '1', 'test_value': 'enable'},
+    'directed_broadcast': {'sysfs': '/proc/sys/net/ipv4/conf/all/bc_forwarding', 'default': '1', 'test_value': 'disable'},
     'ip_src_route': {'sysfs': '/proc/sys/net/ipv4/conf/*/accept_source_route', 'default': '0', 'test_value': 'enable'},
     'ipv6_receive_redirects': {'sysfs': '/proc/sys/net/ipv6/conf/*/accept_redirects', 'default': '0', 'test_value': 'enable'},
     'ipv6_src_route': {'sysfs': '/proc/sys/net/ipv6/conf/*/accept_source_route', 'default': '-1', 'test_value': 'enable'},

--- a/smoketest/scripts/cli/test_system_ip.py
+++ b/smoketest/scripts/cli/test_system_ip.py
@@ -38,17 +38,6 @@ class TestSystemIP(VyOSUnitTestSHIM.TestCase):
 
         self.assertEqual(read_file(all_forwarding), '0')
 
-    def test_system_ip_directed_broadcast_forwarding(self):
-        # Test if IPv4 directed broadcast forwarding can be disabled globally,
-        # default is '1' which means forwarding enabled
-        bc_forwarding = '/proc/sys/net/ipv4/conf/all/bc_forwarding'
-        self.assertEqual(read_file(bc_forwarding), '1')
-
-        self.cli_set(base_path + ['disable-directed-broadcast'])
-        self.cli_commit()
-
-        self.assertEqual(read_file(bc_forwarding), '0')
-
     def test_system_ip_multipath(self):
         # Test IPv4 multipathing options, options default to off -> '0'
         use_neigh = '/proc/sys/net/ipv4/fib_multipath_use_neigh'

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -44,6 +44,7 @@ nftables_conf = '/run/nftables.conf'
 sysfs_config = {
     'all_ping': {'sysfs': '/proc/sys/net/ipv4/icmp_echo_ignore_all', 'enable': '0', 'disable': '1'},
     'broadcast_ping': {'sysfs': '/proc/sys/net/ipv4/icmp_echo_ignore_broadcasts', 'enable': '0', 'disable': '1'},
+    'directed_broadcast' : {'sysfs': '/proc/sys/net/ipv4/conf/all/bc_forwarding', 'enable': '1', 'disable': '0'},
     'ip_src_route': {'sysfs': '/proc/sys/net/ipv4/conf/*/accept_source_route'},
     'ipv6_receive_redirects': {'sysfs': '/proc/sys/net/ipv6/conf/*/accept_redirects'},
     'ipv6_src_route': {'sysfs': '/proc/sys/net/ipv6/conf/*/accept_source_route', 'enable': '0', 'disable': '-1'},

--- a/src/conf_mode/system_ip.py
+++ b/src/conf_mode/system_ip.py
@@ -81,11 +81,6 @@ def apply(opt):
     value = '0' if (tmp != None) else '1'
     write_file('/proc/sys/net/ipv4/conf/all/forwarding', value)
 
-    # enable/disable IPv4 directed broadcast forwarding
-    tmp = dict_search('disable_directed_broadcast', opt)
-    value = '0' if (tmp != None) else '1'
-    write_file('/proc/sys/net/ipv4/conf/all/bc_forwarding', value)
-
     # configure multipath
     tmp = dict_search('multipath.ignore_unreachable_nexthops', opt)
     value = '1' if (tmp != None) else '0'

--- a/src/migration-scripts/firewall/14-to-15
+++ b/src/migration-scripts/firewall/14-to-15
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022-2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T5535: Migrate <set system ip disable-directed-broadcast> to <set firewall global-options directed-broadcas [enable|disable]
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+
+base = ['firewall']
+
+if config.exists(['system', 'ip', 'disable-directed-broadcast']):
+    config.set(['firewall', 'global-options', 'directed-broadcast'], value='disable')
+    config.delete(['system', 'ip', 'disable-directed-broadcast'])
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Migrate command <set system ip disable-directed-broadcast> to firewall global-optinos

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T5535

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos# run show config comm | grep firewall
[edit]
vyos@vyos# sudo cat /proc/sys/net/ipv4/conf/all/bc_forwarding
1
[edit]
vyos@vyos# set firewall global-options directed-broadcast 
Possible completions:
   enable               Enable IPv4 directed broadcast forwarding on all interfaces (default)
   disable              Disable IPv4 directed broadcast forwarding on all interfaces
      
[edit]
vyos@vyos# set firewall global-options directed-broadcast disable 
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# sudo cat /proc/sys/net/ipv4/conf/all/bc_forwarding
0
[edit]
vyos@vyos# del firewall 
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# sudo cat /proc/sys/net/ipv4/conf/all/bc_forwarding
1
[edit]
vyos@vyos# 

```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
test_firewall.py -> OK
test_system_ip.py -> OK

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
