### PR TITLE
T5722: Failover route add option onlink

### DIFF
--- a/interface-definitions/protocols_failover.xml.in
+++ b/interface-definitions/protocols_failover.xml.in
@@ -124,6 +124,12 @@
                     </properties>
                     <defaultValue>1</defaultValue>
                   </leafNode>
+                  <leafNode name="onlink">
+                    <properties>
+                      <help>The next hop is directly connected to the interface, even if it does not match interface prefix</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
                 </children>
               </tagNode>
             </children>

--- a/src/helpers/vyos-failover.py
+++ b/src/helpers/vyos-failover.py
@@ -197,6 +197,7 @@ if __name__ == '__main__':
                 proto = nexthop_config.get('check').get('type')
                 target = nexthop_config.get('check').get('target')
                 timeout = nexthop_config.get('check').get('timeout')
+                onlink = 'onlink' if 'onlink' in nexthop_config else ''
 
                 # Route not found in the current routing table
                 if not is_route_exists(route, next_hop, conf_iface, conf_metric):
@@ -206,14 +207,14 @@ if __name__ == '__main__':
                         if debug: print(f'    [ ADD ] -- ip route add {route} via {next_hop} dev {conf_iface} '
                                         f'metric {conf_metric} proto failover\n###')
                         rc, command = rc_cmd(f'ip route add {route} via {next_hop} dev {conf_iface} '
-                                             f'metric {conf_metric} proto failover')
+                                             f'{onlink} metric {conf_metric} proto failover')
                         # If something is wrong and gateway not added
                         # Example: Error: Next-hop has invalid gateway.
                         if rc !=0:
                             if debug: print(f'{command} -- return-code [RC: {rc}] {next_hop} dev {conf_iface}')
                         else:
                             journal.send(f'ip route add {route} via {next_hop} dev {conf_iface} '
-                                         f'metric {conf_metric} proto failover', SYSLOG_IDENTIFIER=my_name)
+                                         f'{onlink} metric {conf_metric} proto failover', SYSLOG_IDENTIFIER=my_name)
                     else:
                         if debug: print(f'    [ TARGET_FAIL ] target checks fails for [{target}], do nothing')
                         journal.send(f'Check fail for route {route} target {target} proto {proto} '


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
onlink pretend that the nexthop is directly attached to this link, even if it does not match any interface prefix.

Useful when the gateway is not in the same interface network

```
vyos@r4# sudo ip route add 192.0.2.111/32 via 10.20.30.0 dev eth0.10 metric 1 proto failover
Error: Nexthop has invalid gateway.
[edit]
vyos@r4#
[edit]
vyos@r4# sudo ip route add 192.0.2.111/32 via 10.20.30.0 dev eth0.10 onlink metric 1 proto failover
[edit]
vyos@r4#
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): New option some kind of bugfix

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T5722

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
routing, failover route
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces ethernet eth0 vif 10 address '10.20.30.1/32'
set protocols static route 10.20.30.0/32 interface eth0.10

set protocols failover route 192.0.2.11/32 next-hop 10.20.30.0 check target '10.20.30.0'
set protocols failover route 192.0.2.11/32 next-hop 10.20.30.0 check timeout '5'
set protocols failover route 192.0.2.11/32 next-hop 10.20.30.0 check type 'icmp'
set protocols failover route 192.0.2.11/32 next-hop 10.20.30.0 interface 'eth0.10'
set protocols failover route 192.0.2.11/32 next-hop 10.20.30.0 metric '1'
commit

```
Before, this route cannot be added due to gateway and interface not in the same network
```
Route 192.0.2.11/32 for protocol failover was not found
    [NEW_ROUTE_DETECTED] route: [192.0.2.11/32]
    [ CHECK-TARGET ]: [/usr/bin/ping -q 10.20.30.0 -I eth0.10 -n -c 2 -W 1] -- return-code [RC: 0]
    [ ADD ] -- ip route add 192.0.2.11/32 via 10.20.30.0 dev eth0.10 metric 1 proto failover
Error: Nexthop has invalid gateway. -- return-code [RC: 2] 10.20.30.0 dev eth0.10


vyos@r4# sudo ip route add 192.0.2.11/32 via 10.20.30.0 dev eth0.10 metric 1 proto failover
Error: Nexthop has invalid gateway.
[edit]
vyos@r4# 

```
The  iproute2 option `onlink` fixes these cases
```

set protocols failover route 192.0.2.11/32 next-hop 10.20.30.0 onlink
commit

vyos@r4# run show ip route kernel 
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

K>* 192.0.2.11/32 [0/1] via 10.20.30.0, eth0.10 onlink, 00:00:03
[edit]
vyos@r4# 

```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
