### PR TITLE
qos: T4248: Allow to remove the only rule from the qos class

### DIFF
--- a/python/vyos/qos/base.py
+++ b/python/vyos/qos/base.py
@@ -246,6 +246,7 @@ class QoSBase:
                 filter_cmd_base += ' protocol all'
 
                 if 'match' in cls_config:
+                    is_filtered = False
                     for index, (match, match_config) in enumerate(cls_config['match'].items(), start=1):
                         filter_cmd = filter_cmd_base
                         if self.qostype == 'shaper' and 'prio ' not in filter_cmd:
@@ -330,11 +331,13 @@ class QoSBase:
                                 cls = int(cls)
                                 filter_cmd += f' flowid {self._parent:x}:{cls:x}'
                                 self._cmd(filter_cmd)
+                                is_filtered = True
 
                     vlan_expression = "match.*.vif"
                     match_vlan = jmespath.search(vlan_expression, cls_config)
 
-                    if any(tmp in ['exceed', 'bandwidth', 'burst'] for tmp in cls_config):
+                    if any(tmp in ['exceed', 'bandwidth', 'burst'] for tmp in cls_config) \
+                        and is_filtered:
                         # For "vif" "basic match" is used instead of "action police" T5961
                         if not match_vlan:
                             filter_cmd += f' action police'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T4248

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
single rule:
```
set qos interface eth0 egress qos-shaper-eth0
set qos policy shaper qos-shaper-eth0 bandwidth 10mbit
set qos policy shaper qos-shaper-eth0 default bandwidth 100mbit
set qos policy shaper qos-shaper-eth0 default burst 100
set qos policy shaper qos-shaper-eth0 class 30 bandwidth 50mbit
set qos policy shaper qos-shaper-eth0 class 30 ceiling 5mbit
set qos policy shaper qos-shaper-eth0 class 30 match ADDRESS30 ip source address 10.1.1.0/24
set qos policy shaper qos-shaper-eth0 class 30 priority 5
set qos policy shaper qos-shaper-eth0 class 30 queue-type fair-queue
commit
del qos policy shaper qos-shaper-eth0 class 30 match ADDRESS30 ip source address 10.1.1.0/24
commit
```

two rules:
```
conf
set qos interface eth1 egress MY-HTB
set qos policy shaper MY-HTB default bandwidth '10mbit'
set qos policy shaper MY-HTB class 40 bandwidth '90%'
set qos policy shaper MY-HTB class 40 ceiling '100%'
set qos policy shaper MY-HTB class 40 match ADDRESS40 ip source address '10.2.1.0/24'
set qos policy shaper MY-HTB class 40 match ADDRESS40 ip dscp CS4
set qos policy shaper MY-HTB class 40 priority '5'
set qos policy shaper MY-HTB class 40 queue-type 'fair-queue'
commit
del qos policy shaper MY-HTB class 40 match ADDRESS40 ip source address '10.2.1.0/24'
commit
del qos policy shaper MY-HTB class 40 match ADDRESS40 ip dscp CS4
commit
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_qos.py 
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... skipped 'tc returns invalid JSON here - needs iproute2 fix'
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok
test_12_shaper_with_red_queue (__main__.TestQoS.test_12_shaper_with_red_queue) ... ok
test_13_shaper_delete_only_rule (__main__.TestQoS.test_13_shaper_delete_only_rule) ... ok

----------------------------------------------------------------------
Ran 13 tests in 41.900s

OK (skipped=1)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
