### PR TITLE
image-tools: T6154: installer prompts to confirm password

### DIFF
--- a/python/vyos/utils/io.py
+++ b/python/vyos/utils/io.py
@@ -27,7 +27,7 @@ def print_error(str='', end='\n'):
     sys.stderr.flush()
 
 def ask_input(question, default='', numeric_only=False, valid_responses=[],
-              no_echo=False):
+              no_echo=False, non_empty=False):
     from getpass import getpass
     question_out = question
     if default:
@@ -47,6 +47,9 @@ def ask_input(question, default='', numeric_only=False, valid_responses=[],
             response = int(response)
         if valid_responses and response not in valid_responses:
             print("Invalid value, try again.")
+            continue
+        if non_empty and not response:
+            print("Non-empty value required; try again.")
             continue
         break
     return response

--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -60,7 +60,8 @@ MSG_INPUT_CONFIG_CHOICE: str = 'The following config files are available for boo
 MSG_INPUT_CONFIG_CHOOSE: str = 'Which file would you like as boot config?'
 MSG_INPUT_IMAGE_NAME: str = 'What would you like to name this image?'
 MSG_INPUT_IMAGE_DEFAULT: str = 'Would you like to set the new image as the default one for boot?'
-MSG_INPUT_PASSWORD: str = 'Please enter a password for the "vyos" user'
+MSG_INPUT_PASSWORD: str = 'Please enter a password for the "vyos" user:'
+MSG_INPUT_PASSWORD_CONFIRM: str = 'Please confirm password for the "vyos" user:'
 MSG_INPUT_ROOT_SIZE_ALL: str = 'Would you like to use all the free space on the drive?'
 MSG_INPUT_ROOT_SIZE_SET: str = 'Please specify the size (in GB) of the root partition (min is 1.5 GB)?'
 MSG_INPUT_CONSOLE_TYPE: str = 'What console should be used by default? (K: KVM, S: Serial, U: USB-Serial)?'
@@ -74,6 +75,7 @@ MSG_WARN_ROOT_SIZE_TOOBIG: str = 'The size is too big. Try again.'
 MSG_WARN_ROOT_SIZE_TOOSMALL: str = 'The size is too small. Try again'
 MSG_WARN_IMAGE_NAME_WRONG: str = 'The suggested name is unsupported!\n'\
 'It must be between 1 and 64 characters long and contains only the next characters: .+-_ a-z A-Z 0-9'
+MSG_WARN_PASSWORD_CONFIRM: str = 'The entered values did not match. Try again'
 CONST_MIN_DISK_SIZE: int = 2147483648  # 2 GB
 CONST_MIN_ROOT_SIZE: int = 1610612736  # 1.5 GB
 # a reserved space: 2MB for header, 1 MB for BIOS partition, 256 MB for EFI
@@ -695,8 +697,14 @@ def install_image() -> None:
         print(MSG_WARN_IMAGE_NAME_WRONG)
 
     # ask for password
-    user_password: str = ask_input(MSG_INPUT_PASSWORD, default='vyos',
-                                   no_echo=True)
+    while True:
+        user_password: str = ask_input(MSG_INPUT_PASSWORD, no_echo=True,
+                                       non_empty=True)
+        confirm: str = ask_input(MSG_INPUT_PASSWORD_CONFIRM, no_echo=True,
+                                 non_empty=True)
+        if user_password == confirm:
+            break
+        print(MSG_WARN_PASSWORD_CONFIRM)
 
     # ask for default console
     console_type: str = ask_input(MSG_INPUT_CONSOLE_TYPE,


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

NOTE: this requires: https://github.com/vyos/vyos-build/pull/569

QUESTION: This PR splits the difference suggested in T6154: it _requires_ confirmation of the password, while _retaining_ the prompted default 'vyos'. If the consensus is to drop the default as well, then I will pull in the change, along with the check for empty input string:
(https://github.com/vyos/vyos-1x/compare/current...jestabro:confirm-pass-no-default)
that will require a slight change to the accompanying PR 569.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-build/pull/569

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
