### PR TITLE
GRE : T6252: fix issues when set mtu higher than 8024

### DIFF
--- a/interface-definitions/interfaces_tunnel.xml.in
+++ b/interface-definitions/interfaces_tunnel.xml.in
@@ -20,7 +20,7 @@
           #include <include/interface/address-ipv4-ipv6.xml.i>
           #include <include/interface/disable.xml.i>
           #include <include/interface/disable-link-detect.xml.i>
-          #include <include/interface/mtu-64-8024.xml.i>
+          #include <include/interface/mtu-68-16000.xml.i>
           <leafNode name="mtu">
             <defaultValue>1476</defaultValue>
           </leafNode>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
there is an issues when we want to set a MTU higher than 8024 (it doesn't allow) , it is supported on linux
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6252
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
gre
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
vyos : 
`set interfaces tunnel tun1 mtu '8972'`

```
10: tun1@NONE: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 8972 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/gre 10.243.100.21 peer 10.243.100.22 promiscuity 0 allmulti 0 minmtu 68 maxmtu 65511
    gre remote 10.243.100.22 local 10.243.100.21 ttl 64 tos inherit numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 gso_ipv4_max_size 65536 gro_ipv4_max_size 65536
```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
