### PR TITLE
vyos.utils: T6244: add whitespace after time unit in uptime

### DIFF
--- a/python/vyos/utils/convert.py
+++ b/python/vyos/utils/convert.py
@@ -1,4 +1,4 @@
-# Copyright 2023 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2023-2024 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -23,34 +23,34 @@ def seconds_to_human(s, separator=""):
     day = 60 * 60 * 24
     hour = 60 * 60
 
-    remainder = 0
-    result = ""
+    result = []
+
 
     weeks = s // week
     if weeks > 0:
-        result = "{0}w".format(weeks)
+        result.append(f'{weeks}w')
         s = s % week
 
     days = s // day
     if days > 0:
-        result = "{0}{1}{2}d".format(result, separator, days)
+        result.append(f'{days}d')
         s = s % day
 
     hours = s // hour
     if hours > 0:
-        result = "{0}{1}{2}h".format(result, separator, hours)
+        result.append(f'{hours}h')
         s = s % hour
 
     minutes = s // 60
     if minutes > 0:
-        result = "{0}{1}{2}m".format(result, separator, minutes)
+        result.append(f'{minutes}m')
         s = s % 60
 
     seconds = s
     if seconds > 0:
-        result = "{0}{1}{2}s".format(result, separator, seconds)
+        result.append(f'{seconds}s')
 
-    return result
+    return separator.join(result)
 
 def bytes_to_human(bytes, initial_exponent=0, precision=2,
                    int_below_exponent=0):

--- a/python/vyos/utils/convert.py
+++ b/python/vyos/utils/convert.py
@@ -19,12 +19,17 @@ def seconds_to_human(s, separator=""):
     """
     s = int(s)
 
+    year = 60 * 60 * 24 * 365.25
     week = 60 * 60 * 24 * 7
     day = 60 * 60 * 24
     hour = 60 * 60
 
     result = []
 
+    years = s // year
+    if years > 0:
+        result.append(f'{int(years)}y')
+        s = int(s % year)
 
     weeks = s // week
     if weeks > 0:

--- a/src/op_mode/uptime.py
+++ b/src/op_mode/uptime.py
@@ -49,7 +49,7 @@ def _get_raw_data():
 
     res = {}
     res["uptime_seconds"] = _get_uptime_seconds()
-    res["uptime"] = seconds_to_human(_get_uptime_seconds())
+    res["uptime"] = seconds_to_human(_get_uptime_seconds(), separator=' ')
     res["load_average"] = _get_load_averages()
 
     return res


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

We only supported calculating seconds to weeks but not seconds to years. This has been added.

In addition when handling optional separators rather build up a list and join

This PR thus changes the result of  "show system uptime" `2w4d22h54m9s` to a more human readable string `2w 4d 22h 54m 9s`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6244

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vyos.utils

## Proposed changes
<!--- Describe your changes in detail -->

## How to test

```python3
#!/usr/bin/env python3
from vyos.utils.convert import seconds_to_human

minute = 60
hour = minute * 60
day = hour * 24
week = day * 7
year = day * 365.25

for separator in ['', ' ', '-', '/']:
  print(f'----- Using separator "{separator}" -----')
  print(seconds_to_human(10, separator))
  print(seconds_to_human(5* minute, separator))
  print(seconds_to_human(3* hour, separator))
  print(seconds_to_human(4* day, separator))
  print(seconds_to_human(7 * week, separator))
  print(seconds_to_human(10 * year, separator))
  print(seconds_to_human(5*year + 4*week + 3*day + 2*hour + minute + 5, separator))
  print()
```

yields:

```console
cpo@LR1.wue3:~$ ./foo.py
----- Using separator "" -----
10s
5m
3h
4d
7w
10y
5y4w3d2h1m5s

----- Using separator " " -----
10s
5m
3h
4d
7w
10y
5y 4w 3d 2h 1m 5s

----- Using separator "-" -----
10s
5m
3h
4d
7w
10y
5y-4w-3d-2h-1m-5s

----- Using separator "/" -----
10s
5m
3h
4d
7w
10y
5y/4w/3d/2h/1m/5s
```

```console
cpo@LR1.wue3:~$ show system uptime
Uptime: 4d 19h 8m 51s

Load averages:
1  minute:   0.0%
5  minutes:  0.0%
15 minutes:  0.0%
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
