### PR TITLE
T6237: IPSec remote access VPN: ability to set EAP ID of clients

### DIFF
--- a/data/templates/ipsec/swanctl/remote_access.j2
+++ b/data/templates/ipsec/swanctl/remote_access.j2
@@ -33,7 +33,7 @@
             auth = pubkey
 {% elif rw_conf.authentication.client_mode.startswith("eap") %}
             auth = {{ rw_conf.authentication.client_mode }}
-            eap_id = %any
+            eap_id = {{ '%any' if rw_conf.authentication.eap_id == 'any' else rw_conf.authentication.eap_id }}
 {% endif %}
 {% if rw_conf.authentication.client_mode is vyos_defined('eap-tls') or rw_conf.authentication.client_mode is vyos_defined('x509') %}
 {#          pass all configured CAs as filenames, separated by commas #}

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -768,6 +768,26 @@
                     <children>
                       #include <include/ipsec/authentication-id.xml.i>
                       #include <include/ipsec/authentication-x509.xml.i>
+                      <leafNode name="eap-id">
+                        <properties>
+                          <help>Remote EAP ID for client authentication</help>
+                          <valueHelp>
+                            <format>txt</format>
+                            <description>Remote EAP ID for client authentication</description>
+                          </valueHelp>
+                          <completionHelp>
+                            <list>any</list>
+                          </completionHelp>
+                          <valueHelp>
+                            <format>any</format>
+                            <description>Allow any EAP ID</description>
+                          </valueHelp>
+                          <constraint>
+                            <regex>[[:ascii:]]{1,64}</regex>
+                          </constraint>
+                        </properties>
+                        <defaultValue>any</defaultValue>
+                      </leafNode>
                       <leafNode name="client-mode">
                         <properties>
                           <help>Client authentication mode</help>

--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -782,6 +782,11 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         self.assertTrue(os.path.exists(os.path.join(CA_PATH, f'{ca_name}.pem')))
         self.assertTrue(os.path.exists(os.path.join(CERT_PATH, f'{peer_name}.pem')))
 
+        # Test setting of custom EAP ID
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'eap-id', 'eap-user@vyos.net'])
+        self.cli_commit()
+        self.assertIn(r'eap_id = eap-user@vyos.net', read_file(swanctl_file))
+
         self.tearDownPKI()
 
     def test_remote_access_x509(self):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add the ability for VyOS IPSec remote-access connections to define acceptable EAP identify of connecting clients.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
[https://vyos.dev/T6237](https://vyos.dev/T6237)

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
VPN -> IPSec -> Remote Access
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

1. Create a VPN remote-access configuration using the new option:
```
set vpn ipsec esp-group ESP-RW lifetime '3600'
set vpn ipsec esp-group ESP-RW pfs 'disable'
set vpn ipsec esp-group ESP-RW proposal 10 encryption 'aes128gcm128'
set vpn ipsec esp-group ESP-RW proposal 10 hash 'sha256'
set vpn ipsec ike-group IKE-RW key-exchange 'ikev2'
set vpn ipsec ike-group IKE-RW lifetime '7200'
set vpn ipsec ike-group IKE-RW proposal 10 dh-group '14'
set vpn ipsec ike-group IKE-RW proposal 10 encryption 'aes128gcm128'
set vpn ipsec ike-group IKE-RW proposal 10 hash 'sha256'
set vpn ipsec remote-access connection rw authentication client-mode 'eap-tls'
set vpn ipsec remote-access connection rw authentication eap-id 'user@vyos.net'
set vpn ipsec remote-access connection rw authentication local-id '192.0.2.1'
set vpn ipsec remote-access connection rw authentication server-mode 'x509'
set vpn ipsec remote-access connection rw authentication x509 ca-certificate 'ca_root'
set vpn ipsec remote-access connection rw authentication x509 certificate 'server_cert'
set vpn ipsec remote-access connection rw esp-group 'ESP-RW'
set vpn ipsec remote-access connection rw ike-group 'IKE-RW'
set vpn ipsec remote-access connection rw local-address '192.0.2.1'
set vpn ipsec remote-access connection rw pool 'ra-rw-ipv4'
set vpn ipsec remote-access connection rw pool 'ra-rw-ipv6'
set vpn ipsec remote-access pool ra-rw-ipv4 name-server '192.0.2.1'
set vpn ipsec remote-access pool ra-rw-ipv4 prefix '192.0.2.128/25'
set vpn ipsec remote-access pool ra-rw-ipv6 name-server '2001:db8:1000::1'
set vpn ipsec remote-access pool ra-rw-ipv6 prefix '2001:db8:2000::/64'
```

2. Check the `swanctl.conf` configuration file is showing the correct options:
```
vyos@vyos:~$ cat /etc/swanctl/swanctl.conf  | grep "eap_id" -B 2 -A 2
        remote {
            auth = eap-tls
            eap_id = user@vyos.net
            cacerts = ca_root.pem
        }
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
test_dhcp_fail_handling (__main__.TestVPNIPsec.test_dhcp_fail_handling) ... You should set correct remote-address "peer main-branch remote-address x.x.x.x"

Failed to get address from dhcp-interface on site-to-site peer main-branch -- skipped
ok
test_dmvpn (__main__.TestVPNIPsec.test_dmvpn) ... ok
test_flex_vpn_vips (__main__.TestVPNIPsec.test_flex_vpn_vips) ... ok
test_remote_access (__main__.TestVPNIPsec.test_remote_access) ... PKI: Updating config: vpn ipsec remote_access connection vyos-rw authentication x509 certificate peer1

Missing local-address or dhcp-interface on remote-access connection
vyos-rw

ok
test_remote_access_dhcp_fail_handling (__main__.TestVPNIPsec.test_remote_access_dhcp_fail_handling) ... PKI: Updating config: vpn ipsec remote_access connection vyos-rw authentication x509 certificate peer1
PKI: Updating config: vpn ipsec remote_access connection vyos-rw authentication x509 ca_certificate MyVyOS-CA
Failed to get address from dhcp-interface on remote-access connection vyos-rw -- skipped
ok
test_remote_access_eap_tls (__main__.TestVPNIPsec.test_remote_access_eap_tls) ... PKI: Updating config: vpn ipsec remote_access connection vyos-rw authentication x509 certificate peer1

Missing local-address or dhcp-interface on remote-access connection
vyos-rw

ok
test_remote_access_x509 (__main__.TestVPNIPsec.test_remote_access_x509) ... PKI: Updating config: vpn ipsec remote_access connection vyos-rw authentication x509 certificate peer1

Missing local-address or dhcp-interface on remote-access connection
vyos-rw

ok
test_site_to_site (__main__.TestVPNIPsec.test_site_to_site) ... ok
test_site_to_site_vti (__main__.TestVPNIPsec.test_site_to_site_vti) ...
WARNING: It's recommended to use ipsec vti with the next command
[set vpn ipsec option disable-route-autoinstall]

ok
test_site_to_site_x509 (__main__.TestVPNIPsec.test_site_to_site_x509) ... PKI: Updating config: vpn ipsec site_to_site peer office authentication x509 certificate peer1
PKI: Updating config: vpn ipsec site_to_site peer office authentication x509 ca_certificate MyVyOS-CA
PKI: Updating config: vpn ipsec site_to_site peer office authentication x509 ca_certificate MyVyOS-IntCA

WARNING: It's recommended to use ipsec vti with the next command
[set vpn ipsec option disable-route-autoinstall]

ok

----------------------------------------------------------------------
Ran 10 tests in 41.977s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly