### PR TITLE
T6246: improve haproxy http check configuration

### DIFF
--- a/data/templates/load-balancing/haproxy.cfg.j2
+++ b/data/templates/load-balancing/haproxy.cfg.j2
@@ -113,11 +113,22 @@ backend {{ back }}
 {%         if back_config.http_check is vyos_defined %}
     option httpchk
 {%         endif %}
-{%         if back_config.http_check.uri is vyos_defined and back_config.http_check.method is vyos_defined %}
-    http-check send meth {{ back_config.http_check.method | upper }} uri {{ back_config.http_check.uri }}
+{%         set send = '' %}
+{%         if back_config.http_check.method is vyos_defined %}
+{%             set send = send + ' meth ' + back_config.http_check.method | upper %}
+{%         endif %}
+{%         if back_config.http_check.uri is vyos_defined %}
+{%             set send = send + ' uri ' + back_config.http_check.uri %}
+{%         endif %}
+{%         if send != '' %}
+    http-check send{{ send }}
 {%         endif %}
 {%         if back_config.http_check.expect is vyos_defined %}
-    http-check expect {{ back_config.http_check.expect }}
+{%             if back_config.http_check.expect.status is vyos_defined %}
+    http-check expect status {{ back_config.http_check.expect.status }}
+{%             elif back_config.http_check.expect.string is vyos_defined %}
+    http-check expect string {{ back_config.http_check.expect.string }}
+{%             endif %}
 {%         endif %}
 {%         if back_config.balance is vyos_defined %}
 {%             set balance_translate = {'least-connection': 'leastconn', 'round-robin': 'roundrobin', 'source-address': 'source'} %}

--- a/interface-definitions/load-balancing_reverse-proxy.xml.in
+++ b/interface-definitions/load-balancing_reverse-proxy.xml.in
@@ -110,29 +110,55 @@
                   <leafNode name="method">
                     <properties>
                       <help>HTTP method used for health check</help>
+                      <completionHelp>
+                        <list>options head get post put</list>
+                      </completionHelp>
                       <valueHelp>
-                        <format>options|get|post|put</format>
+                        <format>options|head|get|post|put</format>
                         <description>HTTP method used for health checking</description>
                       </valueHelp>
                       <constraint>
-                        <regex>options|get|post|put</regex>
+                        <regex>(options|head|get|post|put)</regex>
                       </constraint>
                     </properties>
                   </leafNode>
                   <leafNode name="uri">
                     <properties>
                       <help>URI used for HTTP health check (Example: '/' or '/health')</help>
+                      <constraint>
+                        <regex>^\/([^?#\s]*)(\?[^#\s]*)?$</regex>
+                      </constraint>
                     </properties>
                   </leafNode>
-                  <leafNode name="expect">
+                  <node name="expect">
                     <properties>
                       <help>Expected response for the health check to pass</help>
-                      <valueHelp>
-                        <format>txt</format>
-                        <description>expected response (Example: 'status 200-299' or 'string success')</description>
-                      </valueHelp>
                     </properties>
-                  </leafNode>
+                    <children>
+                      <leafNode name="status">
+                        <properties>
+                          <help>Expected response status code for the health check to pass</help>
+                          <valueHelp>
+                            <format>u32:200-399</format>
+                            <description>Expected response code</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 200-399"/>
+                          </constraint>
+                          <constraintErrorMessage>Status code must be in range 200-399</constraintErrorMessage>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="string">
+                        <properties>
+                          <help>Expected to be in response body for the health check to pass</help>
+                          <valueHelp>
+                            <format>txt</format>
+                            <description>A string expected to be in the response</description>
+                          </valueHelp>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </node>
                 </children>
               </node>
               #include <include/haproxy/rule-backend.xml.i>

--- a/smoketest/scripts/cli/test_load-balancing_reverse-proxy.py
+++ b/smoketest/scripts/cli/test_load-balancing_reverse-proxy.py
@@ -304,15 +304,34 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
 
       # Set http-check
       self.cli_set(base_path + ['backend', 'bk-01', 'http-check', 'method', 'get'])
-      self.cli_set(base_path + ['backend', 'bk-01', 'http-check', 'uri', '/health'])
-      self.cli_set(base_path + ['backend', 'bk-01', 'http-check', 'expect', 'status 200'])
       self.cli_commit()
 
       # Test http-check
       config = read_file(HAPROXY_CONF)
       self.assertIn('option httpchk', config)
+      self.assertIn('http-check send meth GET', config)
+
+      # Set http-check with uri and status
+      self.cli_set(base_path + ['backend', 'bk-01', 'http-check', 'uri', '/health'])
+      self.cli_set(base_path + ['backend', 'bk-01', 'http-check', 'expect', 'status', '200'])
+      self.cli_commit()
+
+      # Test http-check with uri and status
+      config = read_file(HAPROXY_CONF)
+      self.assertIn('option httpchk', config)
       self.assertIn('http-check send meth GET uri /health', config)
       self.assertIn('http-check expect status 200', config)
+
+      # Set http-check with string
+      self.cli_delete(base_path + ['backend', 'bk-01', 'http-check', 'expect', 'status', '200'])
+      self.cli_set(base_path + ['backend', 'bk-01', 'http-check', 'expect', 'string', 'success'])
+      self.cli_commit()
+
+      # Test http-check with string
+      config = read_file(HAPROXY_CONF)
+      self.assertIn('option httpchk', config)
+      self.assertIn('http-check send meth GET uri /health', config)
+      self.assertIn('http-check expect string success', config)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/load-balancing_reverse-proxy.py
+++ b/src/conf_mode/load-balancing_reverse-proxy.py
@@ -75,6 +75,10 @@ def verify(lb):
             raise ConfigError(f'"TCP" port "{tmp_port}" is used by another service')
 
     for back, back_config in lb['backend'].items():
+        if 'http-check' in back_config:
+            http_check = back_config['http-check']
+            if 'expect' in http_check and 'status' in http_check['expect'] and 'string' in http_check['expect']:
+                raise ConfigError(f'"expect status" and "expect string" can not be configured together!')
         if 'server' not in back_config:
             raise ConfigError(f'"{back} server" must be configured!')
         for bk_server, bk_server_conf in back_config['server'].items():


### PR DESCRIPTION
## Change Summary
Improve upon issues raised in backport PR #3332

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6246

## Related PR(s)
#3325
#3332

## Component(s) name
load-balancing

## Proposed changes
Improve

## How to test
```
set load-balancing reverse-proxy service front port 4433
set load-balancing reverse-proxy service front backend bk-01

set load-balancing reverse-proxy backend bk-01 mode tcp
set load-balancing reverse-proxy backend bk-01 server s01 address 192.0.2.11
set load-balancing reverse-proxy backend bk-01 server s01 port 4438


set load-balancing reverse-proxy backend bk-01 http-check method get
set load-balancing reverse-proxy backend bk-01 http-check uri /health

set load-balancing reverse-proxy backend bk-01 http-check expect status 200
```
Should result in a config `/run/haproxy/haproxy.cfg `
```
# Frontend
frontend front
    bind :::4433 v4v6  
    default_backend bk-01


# Backend
backend bk-01
    option httpchk
    http-check send meth GET uri /health
    http-check expect status 200
    balance roundrobin
    mode tcp
    server s01 192.0.2.11:4438 
```

## Smoketest result
```
$ /usr/libexec/vyos/tests/smoke/cli/test_load-balancing_reverse-proxy.py
test_01_lb_reverse_proxy_domain (__main__.TestLoadBalancingReverseProxy.test_01_lb_reverse_proxy_domain) ... ok
test_02_lb_reverse_proxy_cert_not_exists (__main__.TestLoadBalancingReverseProxy.test_02_lb_reverse_proxy_cert_not_exists) ... 
PKI does not contain any certificates!


Certificate "cert" not found in configuration!

ok
test_03_lb_reverse_proxy_ca_not_exists (__main__.TestLoadBalancingReverseProxy.test_03_lb_reverse_proxy_ca_not_exists) ... ok
test_04_lb_reverse_proxy_backend_ssl_no_verify (__main__.TestLoadBalancingReverseProxy.test_04_lb_reverse_proxy_backend_ssl_no_verify) ... 
backend bk-01 cannot have both ssl options no-verify and ca-certificate
set!

ok
test_05_lb_reverse_proxy_backend_http_check (__main__.TestLoadBalancingReverseProxy.test_05_lb_reverse_proxy_backend_http_check) ... ok

----------------------------------------------------------------------
Ran 5 tests in 82.459s

OK

```

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
