### PR TITLE
T6255: static-routing: don't render whitespace from static table descriptions

### DIFF
--- a/data/templates/iproute2/static.conf.j2
+++ b/data/templates/iproute2/static.conf.j2
@@ -2,7 +2,7 @@
 {% if table is vyos_defined %}
 {%     for t, t_options in table.items() %}
 {%         if t_options.description is vyos_defined %}
-{{ "%-6s" | format(t) }} {{ "%-40s" | format(t_options.description) }}
+{{ "%-6s" | format(t) }} {{ "%-40s" | format(t_options.description | replace(" ", "_")) }}
 {%         endif %}
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
When rendering static-routing tables in `static.conf.j2` replace whitespace from table descriptions with underscores.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
[https://vyos.dev/T6255](https://vyos.dev/T6255)

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
protocol -> static-routing
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

1. Set a static table description containing whitespace:
```
[edit]
vyos@vyos# set protocols static table 100 description "table name with spaces"
[edit]
vyos@vyos# set protocols static table 100 route 192.168.1.1/32 blackhole
[edit]
vyos@vyos# commit ; save
[edit]
vyos@vyos# exit
```

2. Validate in rendered configuration file  whitespace has been replaced with underscores:
```
vyos@vyos:~$ cat /etc/iproute2/rt_tables.d/vyos-static.conf
# Generated by VyOS (protocols_static.py), do not edit by hand
100    table_name_with_spaces
```

3. Validate table is accessible via alias/description:
```
vyos@vyos:~$ sudo ip route show table table_name_with_spaces
blackhole 192.168.1.1 proto static metric 20
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly