### PR TITLE
T6226: add HAPROXY tcp-request related block to load-balancing reverse proxy config

### DIFF
--- a/data/templates/load-balancing/haproxy.cfg.j2
+++ b/data/templates/load-balancing/haproxy.cfg.j2
@@ -69,6 +69,18 @@ frontend {{ front }}
 {%         endif %}
 {%         if front_config.mode is vyos_defined %}
     mode {{ front_config.mode }}
+{%             if front_config.tcp_request.inspect_delay is vyos_defined %}
+    tcp-request inspect-delay {{ front_config.tcp_request.inspect_delay }}
+{%             endif %}
+{# add tcp-request related directive if ssl is configed #}
+{%             if front_config.mode is vyos_defined('tcp') and front_config.rule is vyos_defined %}
+{%                 for rule, rule_config in front_config.rule.items() %}
+{%                     if rule_config.ssl is vyos_defined %}
+    tcp-request content accept if { req_ssl_hello_type 1 }
+{%                         break %}
+{%                     endif %}
+{%                 endfor %}
+{%             endif %}
 {%         endif %}
 {%         if front_config.rule is vyos_defined %}
 {%             for rule, rule_config in front_config.rule.items() %}

--- a/interface-definitions/include/haproxy/tcp-request.xml.i
+++ b/interface-definitions/include/haproxy/tcp-request.xml.i
@@ -1,0 +1,22 @@
+<!-- include start from haproxy/tcp-request.xml.i -->
+<node name="tcp-request">
+  <properties>
+    <help>TCP request directive</help>
+  </properties>
+  <children>
+    <leafNode name="inspect-delay">
+      <properties>
+        <help>Set the maximum allowed time to wait for data during content inspection</help>
+        <valueHelp>
+          <format>u32:1-65535</format>
+          <description>The timeout value specified in milliseconds</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-65535"/>
+        </constraint>
+        <constraintErrorMessage>The timeout value must be in range 1 to 65535 milliseconds</constraintErrorMessage>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/load-balancing_reverse-proxy.xml.in
+++ b/interface-definitions/load-balancing_reverse-proxy.xml.in
@@ -38,6 +38,7 @@
               #include <include/haproxy/mode.xml.i>
               #include <include/port-number.xml.i>
               #include <include/haproxy/rule-frontend.xml.i>
+              #include <include/haproxy/tcp-request.xml.i>
               <leafNode name="redirect-http-to-https">
                 <properties>
                   <help>Redirect HTTP to HTTPS</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add tcp-request related directive in haproxy.cfg.j2 template and haproxy interface definitions, for service in tcp mode.
Add tcp mode related test case in test_load-balancing_reverse-proxy.py

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

https://vyos.dev/T6226

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

load-balancing reverse-proxy

## Proposed changes
<!--- Describe your changes in detail -->
Add tcp-request related directive in haproxy.cfg.j2 template, for service in tcp mode.
Add tcp mode related test case in test_load-balancing_reverse-proxy.py

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Build the new vyos-1x deb package from my fork repo, then install it the instance build from vyos-1.5-rolling-202404130016-amd64.iso 

```
set load-balancing reverse-proxy service tcp443 listen-address '192.168.255.1'
set load-balancing reverse-proxy service tcp443 port '443'
set load-balancing reverse-proxy service tcp443 mode 'tcp'
set load-balancing reverse-proxy service tcp443 tcp-request inspect-delay '5000'
set load-balancing reverse-proxy service tcp443 rule 10 ssl 'req-ssl-sni'
set load-balancing reverse-proxy service tcp443 rule 10 domain-name 'vyos-api.mgmt.domain'
set load-balancing reverse-proxy service tcp443 rule 10 set backend 'vyos-api'
set load-balancing reverse-proxy backend vyos-api balance 'round-robin'
set load-balancing reverse-proxy backend vyos-api mode 'tcp'
set load-balancing reverse-proxy backend vyos-api server vyos address '192.168.255.1'
set load-balancing reverse-proxy backend vyos-api server vyos port '8443'
commit
save
```
validate the haproxy config in `/run/haproxy/haproxy.cfg`, in frontend `tcp443` block, the content below should exist.
```
tcp-request inspect-delay 5000
tcp-request content accept if { req_ssl_hello_type 1 }
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos-test:~$ /usr/libexec/vyos/tests/smoke/cli/test_load-balancing_reverse-proxy.py
test_01_lb_reverse_proxy_domain (__main__.TestLoadBalancingReverseProxy.test_01_lb_reverse_proxy_domain) ... ok
test_02_lb_reverse_proxy_cert_not_exists (__main__.TestLoadBalancingReverseProxy.test_02_lb_reverse_proxy_cert_not_exists) ...
PKI does not contain any certificates!


Certificate "cert" not found in configuration!

ok
test_03_lb_reverse_proxy_ca_not_exists (__main__.TestLoadBalancingReverseProxy.test_03_lb_reverse_proxy_ca_not_exists) ... ok
test_04_lb_reverse_proxy_backend_ssl_no_verify (__main__.TestLoadBalancingReverseProxy.test_04_lb_reverse_proxy_backend_ssl_no_verify) ...
backend bk-01 cannot have both ssl options no-verify and ca-certificate
set!

ok
test_05_lb_reverse_proxy_backend_http_check (__main__.TestLoadBalancingReverseProxy.test_05_lb_reverse_proxy_backend_http_check) ... ok
test_06_lb_reverse_proxy_tcp_mode (__main__.TestLoadBalancingReverseProxy.test_06_lb_reverse_proxy_tcp_mode) ... ok

----------------------------------------------------------------------
Ran 6 tests in 33.206s
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
