### PR TITLE
PKI: T6259: Support RFC822 names in certificate generation

### DIFF
--- a/python/vyos/pki.py
+++ b/python/vyos/pki.py
@@ -146,7 +146,7 @@ def create_certificate_request(subject, private_key, subject_alt_names=[]):
             if isinstance(obj, ipaddress.IPv4Address) or isinstance(obj, ipaddress.IPv6Address):
                 alt_names.append(x509.IPAddress(obj))
             elif isinstance(obj, str):
-                alt_names.append(x509.DNSName(obj))
+                alt_names.append(x509.RFC822Name(obj) if '@' in obj else x509.DNSName(obj))
         if alt_names:
             builder = builder.add_extension(x509.SubjectAlternativeName(alt_names), critical=False)
 

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -306,7 +306,7 @@ def parse_san_string(san_string):
             output.append(ipaddress.IPv4Address(value))
         elif tag == 'ipv6':
             output.append(ipaddress.IPv6Address(value))
-        elif tag == 'dns':
+        elif tag == 'dns' or tag == 'rfc822':
             output.append(value)
     return output
 
@@ -324,7 +324,7 @@ def generate_certificate_request(private_key=None, key_type=None, return_request
     subject_alt_names = None
 
     if ask_san and ask_yes_no('Do you want to configure Subject Alternative Names?'):
-        print("Enter alternative names in a comma separate list, example: ipv4:1.1.1.1,ipv6:fe80::1,dns:vyos.net")
+        print("Enter alternative names in a comma separate list, example: ipv4:1.1.1.1,ipv6:fe80::1,dns:vyos.net,rfc822:user@vyos.net")
         san_string = ask_input('Enter Subject Alternative Names:')
         subject_alt_names = parse_san_string(san_string)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add the ability to specific RFC822 (email) names as Subject Alternative Names in x509 certificates generated via the PKI system.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
[https://vyos.dev/T6259](https://vyos.dev/T6259)

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
PKI
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

1. Generate a new certificate using the PKI system that contains an RFC822 SAN:
```
vyos@vyos:~$ generate pki certificate self-signed file test-t6259
Enter private key type: [rsa, dsa, ec] (Default: rsa) rsa
Enter private key bits: (Default: 2048) 2048
Enter country code: (Default: GB) GB
Enter state: (Default: Some-State) Some-State
Enter locality: (Default: Some-City) Some-City
Enter organization name: (Default: VyOS) VyOS
Enter common name: (Default: vyos.io) vyos.net
Do you want to configure Subject Alternative Names? [y/N] y
Enter alternative names in a comma separate list, example: ipv4:1.1.1.1,ipv6:fe80::1,dns:vyos.net,rfc822:user@vyos.net
Enter Subject Alternative Names: dns:vyos.net,rfc822:exampleuser@vyos.net
Enter how many days certificate will be valid: (Default: 365) 365
Enter certificate type: (client, server) (Default: server) server
Note: If you plan to use the generated key on this router, do not encrypt the private key.
Do you want to encrypt the private key with a passphrase? [y/N] n
File written to /config/auth/test-t6259.pem
File written to /config/auth/test-t6259.key
```

2. Validate that the SAN extension contains the requested names: 
```
vyos@vyos:~$ openssl x509 -inform pem -noout -text -in "/config/auth/test-t6259.pem" | grep "Subject Alternative Name" -A 1
            X509v3 Subject Alternative Name:
                DNS:vyos.net, email:exampleuser@vyos.net
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly