### PR TITLE
connect_disconnect: T6261: correction to typo in check_ppp_running

### DIFF
--- a/src/op_mode/connect_disconnect.py
+++ b/src/op_mode/connect_disconnect.py
@@ -48,7 +48,7 @@ def connect(interface):
         if os.path.isdir(f'/sys/class/net/{interface}'):
             print(f'Interface {interface}: already connected!')
         elif check_ppp_running(interface):
-            print(f'Interface {interface}: connection is beeing established!')
+            print(f'Interface {interface}: connection is being established!')
         else:
             print(f'Interface {interface}: connecting...')
             call(f'systemctl restart ppp@{interface}.service')
@@ -58,7 +58,7 @@ def connect(interface):
         else:
             call(f'VYOS_TAGNODE_VALUE={interface} /usr/libexec/vyos/conf_mode/interfaces_wwan.py')
     else:
-        print(f'Unknown interface {interface}, can not connect. Aborting!')
+        print(f'Unknown interface {interface}, cannot connect. Aborting!')
 
     # Reaply QoS configuration
     config = ConfigTreeQuery()
@@ -90,7 +90,7 @@ def disconnect(interface):
             modem = interface.lstrip('wwan')
             call(f'mmcli --modem {modem} --simple-disconnect', stdout=DEVNULL)
     else:
-        print(f'Unknown interface {interface}, can not disconnect. Aborting!')
+        print(f'Unknown interface {interface}, cannot disconnect. Aborting!')
 
 def main():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Connect_disconnect: T6261: correction to typo in check_ppp_running function

Changes include:
1. Replaces "beeing" -> being in print statement for check_ppp_running
2. Replaces "can not" -> cannot in print statement on lines 61 and 93

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6261

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
N/A

## Proposed changes
<!--- Describe your changes in detail -->
N/A

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [N/A] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [N/A] My change requires a change to the documentation
- [N/A] I have updated the documentation accordingly
