### PR TITLE
T6254: Extend VRF table numbers

### DIFF
--- a/interface-definitions/vrf.xml.in
+++ b/interface-definitions/vrf.xml.in
@@ -111,13 +111,13 @@
             <properties>
               <help>Routing table associated with this instance</help>
               <valueHelp>
-                <format>u32:100-65535</format>
+                <format>u32:1-65535</format>
                 <description>Routing table ID</description>
               </valueHelp>
               <constraint>
-                <validator name="numeric" argument="--range 100-65535"/>
+                <validator name="numeric" argument="--range 1-65535"/>
               </constraint>
-              <constraintErrorMessage>VRF routing table must be in range from 100 to 65535</constraintErrorMessage>
+              <constraintErrorMessage>VRF routing table must be in range from 1 to 65535</constraintErrorMessage>
             </properties>
           </leafNode>
           <leafNode name="vni" owner="${vyos_conf_scripts_dir}/vrf_vni.py $VAR(../@)">


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Extend the table number that can be used for VRF to `1-65535`

The current limit `<200-65535>`
Actual kernel limit `<1-294967295>`

For now, we cannot use actual kernel limits and it should be fixed in another commit
The reason is it somehow related to nft conntrack rules
```
Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/vrf.py", line 351, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/vrf.py", line 308, in apply
    cmd(f'nft {nft_add_element}')
  File "/usr/lib/python3/dist-packages/vyos/utils/process.py", line 155, in cmd
    raise OSError(code, feedback)
PermissionError: [Errno 1] failed to run command: nft add element inet vrf_zones ct_iface_map { "blue" : 4294967295 }
returned: 
exit code: 1

noteworthy:
cmd 'nft add element inet vrf_zones ct_iface_map { "blue" : 4294967295 }'
returned (out):

returned (err):
Error: Value 4294967295 exceeds valid range 0-65535
add element inet vrf_zones ct_iface_map { blue : 4294967295 }
     
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Extend VRF table numbers

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6254

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrf
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add Table 1 for the VRF and check the actual table (expected `vrf table 1`)
```
set vrf name red table 1
commit

vyos@r4# sudo ip -d link show type vrf
228: red: <NOARP,MASTER,UP,LOWER_UP> mtu 65575 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether ea:20:1e:f9:0a:7e brd ff:ff:ff:ff:ff:ff promiscuity 0 allmulti 0 minmtu 1280 maxmtu 65575 
    vrf table 1 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 gso_ipv4_max_size 65536 gro_ipv4_max_size 65536 
[edit]
vyos@r4#
```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_vrf.py
test_vrf_assign_interface (__main__.VRFTest.test_vrf_assign_interface) ... ok
test_vrf_bind_all (__main__.VRFTest.test_vrf_bind_all) ... ok
test_vrf_conntrack (__main__.VRFTest.test_vrf_conntrack) ... ok
test_vrf_disable_forwarding (__main__.VRFTest.test_vrf_disable_forwarding) ... ok
test_vrf_ip_ipv6_nht (__main__.VRFTest.test_vrf_ip_ipv6_nht) ... ok
test_vrf_ip_ipv6_protocol_non_existing_route_map (__main__.VRFTest.test_vrf_ip_ipv6_protocol_non_existing_route_map) ... 
Specified route-map "v4-non-existing" does not exist!


Specified route-map "v6-non-existing" does not exist!

ok
test_vrf_ip_protocol_route_map (__main__.VRFTest.test_vrf_ip_protocol_route_map) ... ok
test_vrf_ipv6_protocol_route_map (__main__.VRFTest.test_vrf_ipv6_protocol_route_map) ... ok
test_vrf_link_local_ip_addresses (__main__.VRFTest.test_vrf_link_local_ip_addresses) ... ok
test_vrf_loopbacks_ips (__main__.VRFTest.test_vrf_loopbacks_ips) ... ok
test_vrf_static_route (__main__.VRFTest.test_vrf_static_route) ... 
VRF "red" table id is mandatory!


VRF "green" table id is mandatory!


VRF "blue" table id is mandatory!


VRF "foo-bar" table id is mandatory!


VRF "baz_foo" table id is mandatory!

ok
test_vrf_table_id_is_unalterable (__main__.VRFTest.test_vrf_table_id_is_unalterable) ... 
VRF "red" table id modification not possible!

ok
test_vrf_vni_add_change_remove (__main__.VRFTest.test_vrf_vni_add_change_remove) ... ok
test_vrf_vni_and_table_id (__main__.VRFTest.test_vrf_vni_and_table_id) ... 
VRF "red" table id is mandatory!


VRF "green" table id is mandatory!


VRF "blue" table id is mandatory!


VRF "foo-bar" table id is mandatory!


VRF "baz_foo" table id is mandatory!

ok
test_vrf_vni_duplicates (__main__.VRFTest.test_vrf_vni_duplicates) ... 
VRF "blue" VNI is not unique!


VRF "blue" VNI is not unique!


VRF "blue" VNI is not unique!


VRF "blue" VNI is not unique!


VRF "blue" VNI is not unique!

ok

----------------------------------------------------------------------
Ran 15 tests in 287.970s

OK
vyos@r4:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
