### PR TITLE
T5833: Not all AFIs compatible with VRF add verify check

### DIFF
--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -473,6 +473,22 @@ def verify(bgp):
                             if peer_group_as is None or (peer_group_as != 'internal' and peer_group_as != bgp['system_as']):
                                 raise ConfigError('route-reflector-client only supported for iBGP peers')
 
+            # T5833 not all AFIs are supported for VRF
+            if 'vrf' in bgp and 'address_family' in peer_config:
+                unsupported_vrf_afi = {
+                    'ipv4_flowspec',
+                    'ipv6_flowspec',
+                    'ipv4_labeled_unicast',
+                    'ipv6_labeled_unicast',
+                    'ipv4_vpn',
+                    'ipv6_vpn',
+                }
+                for afi in peer_config['address_family']:
+                    if afi in unsupported_vrf_afi:
+                        raise ConfigError(
+                            f"VRF is not allowed for address-family '{afi.replace('_', '-')}'"
+                        )
+
     # Throw an error if a peer group is not configured for allow range
     for prefix in dict_search('listen.range', bgp) or []:
         # we can not use dict_search() here as prefix contains dots ...


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Not all FRR address-families compatible with VRF

```
r4# conf t
r4(config)# router bgp 65001 vrf bgp
r4(config-router)#

r4(config-router)# address-family ipv4 flowspec
Only Unicast/Multicast/EVPN SAFIs supported in non-core instances.
r4(config-router)#

r4(config-router)# address-family ipv4 labeled-unicast
Only Unicast/Multicast/EVPN SAFIs supported in non-core instances.
r4(config-router)#

r4(config-router)# address-family ipv4 vpn
Only Unicast/Multicast/EVPN SAFIs supported in non-core instances.
r4(config-router)#
```

Add verify AFI for VRF
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T5833

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set vrf name bgp table '1010'

set protocols bgp system-as '65001'
set vrf name bgp protocols bgp neighbor 10.1.1.2 address-family ipv4-unicast
set vrf name bgp protocols bgp neighbor 10.1.1.2 remote-as '65001'
set vrf name bgp protocols bgp system-as '65001'
commit

set vrf name bgp protocols bgp neighbor 10.1.1.2 address-family ipv4-flowspec
commit
```
Before the fix:
```
commit
[18690|mgmtd] sending configuration [18691|zebra] sending configuration
[18692|ripd] sending configuration [18693|ripngd] sending configuration
[18694|ospfd] sending configuration [18695|ospf6d] sending configuration
[18696|ldpd] sending configuration [18697|bgpd] sending configuration
[18698|isisd] sending configuration [18702|babeld] sending configuration
[18705|watchfrr] sending configuration [18707|staticd] sending
configuration [18691|zebra] done [18692|ripd] done [18708|bfdd] sending
configuration [18690|mgmtd] done [18695|ospf6d] done [18694|ospfd] done
Waiting for children to finish applying config... [18693|ripngd] done
[18711|pim6d] sending configuration [18698|isisd] done Only
Unicast/Multicast/EVPN SAFIs supported in non-core instances. line 6:
Failure to communicate[13] to bgpd, line:  address-family ipv4 labeled-
unicast  [18696|ldpd] done line 8: Warning[4]...: early exit from config
file [18697|bgpd] Configuration file[/etc/frr/frr.conf] processing
failure: 13 [18702|babeld] done [18705|watchfrr] done [18707|staticd]
done [18711|pim6d] done [18708|bfdd] done [18715|mgmtd] sending
configuration [18716|zebra] sending configuration [18717|ripd] sending
configuration [18718|ripngd] sending configuration [18719|ospfd] sending
configuration [18720|ospf6d] sending configuration [18721|ldpd] sending
configuration [18722|bgpd] sending configuration [18723|isisd] sending
configuration [18727|babeld] sending configuration [18730|watchfrr]
sending configuration [18718|ripngd] done [18732|staticd] sending
configuration [18733|bfdd] sending configuration Waiting for children to
finish applying config... [18736|pim6d] sending configuration
[18719|ospfd] done [18720|ospf6d] done Only Unicast/Multicast/EVPN SAFIs
supported in non-core instances. line 6: Failure to communicate[13] to
bgpd, line:  address-family ipv4 labeled-unicast  line 8: Warning[4]...:
early exit from config file [18716|zebra] done [18717|ripd] done
[18715|mgmtd] done [18722|bgpd] Configuration file[/etc/frr/frr.conf]
processing failure: 13 [18732|staticd] done [18733|bfdd] done
[18727|babeld] done [18730|watchfrr] done [18723|isisd] done
[18736|pim6d] done [18721|ldpd] done

```
After the fix:
```
vyos@r4# set vrf name bgp protocols bgp neighbor 10.1.1.2 address-family ipv4-flowspec
[edit]
vyos@r4# commit
[ vrf name bgp protocols bgp ]
VRF is not allowed for address-family 'ipv4-flowspec'

[[vrf name bgp protocols bgp]] failed
Commit failed
[edit]
vyos@r4# 

```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ... ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ... ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ... ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ... ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ... ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ... ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ... ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ... ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ... ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ... ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok
test_bgp_24_srv6_sid (__main__.TestProtocolsBGP.test_bgp_24_srv6_sid) ... ok
test_bgp_25_ipv4_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_25_ipv4_labeled_unicast_peer_group) ... ok
test_bgp_26_ipv6_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_26_ipv6_labeled_unicast_peer_group) ... ok
test_bgp_27_route_reflector_client (__main__.TestProtocolsBGP.test_bgp_27_route_reflector_client) ... ok
test_bgp_28_peer_group_member_all_internal_or_external (__main__.TestProtocolsBGP.test_bgp_28_peer_group_member_all_internal_or_external) ... ok
test_bgp_99_bmp (__main__.TestProtocolsBGP.test_bgp_99_bmp) ... ok

----------------------------------------------------------------------
Ran 28 tests in 300.721s

OK
vyos@r4:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
