### PR TITLE
T6258: Add sysctl base-reachable-time for IPv6

### DIFF
--- a/interface-definitions/include/interface/base-reachable-time.xml.i
+++ b/interface-definitions/include/interface/base-reachable-time.xml.i
@@ -1,0 +1,16 @@
+<!-- include start from interface/base-reachable-time.xml.i -->
+<leafNode name="base-reachable-time">
+  <properties>
+    <help>Base reachable time in seconds</help>
+    <valueHelp>
+      <format>u32:1-86400</format>
+      <description>Base reachable time in seconds</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-86400"/>
+    </constraint>
+    <constraintErrorMessage>Base reachable time must be between 1 and 86400 seconds</constraintErrorMessage>
+  </properties>
+  <defaultValue>30</defaultValue>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/interface/ipv6-options.xml.i
+++ b/interface-definitions/include/interface/ipv6-options.xml.i
@@ -5,6 +5,7 @@
   </properties>
   <children>
     #include <include/interface/adjust-mss.xml.i>
+    #include <include/interface/base-reachable-time.xml.i>
     #include <include/interface/disable-forwarding.xml.i>
     #include <include/interface/ipv6-accept-dad.xml.i>
     #include <include/interface/ipv6-address.xml.i>

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2019-2024 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -193,6 +193,9 @@ class Interface(Control):
             'validate': assert_positive,
             'location': '/proc/sys/net/ipv6/conf/{ifname}/dad_transmits',
         },
+        'ipv6_cache_tmo': {
+            'location': '/proc/sys/net/ipv6/neigh/{ifname}/base_reachable_time_ms',
+        },
         'path_cost': {
             # XXX: we should set a maximum
             'validate': assert_positive,
@@ -260,6 +263,9 @@ class Interface(Control):
         },
         'ipv6_dad_transmits': {
             'location': '/proc/sys/net/ipv6/conf/{ifname}/dad_transmits',
+        },
+        'ipv6_cache_tmo': {
+            'location': '/proc/sys/net/ipv6/neigh/{ifname}/base_reachable_time_ms',
         },
         'proxy_arp': {
             'location': '/proc/sys/net/ipv4/conf/{ifname}/proxy_arp',
@@ -612,6 +618,21 @@ class Interface(Control):
         if tmp == tmo:
             return None
         return self.set_interface('arp_cache_tmo', tmo)
+
+    def set_ipv6_cache_tmo(self, tmo):
+        """
+        Set IPv6 cache timeout value in seconds. Internal Kernel representation
+        is in milliseconds.
+
+        Example:
+        >>> from vyos.ifconfig import Interface
+        >>> Interface('eth0').set_ipv6_cache_tmo(40)
+        """
+        tmo = str(int(tmo) * 1000)
+        tmp = self.get_interface('ipv6_cache_tmo')
+        if tmp == tmo:
+            return None
+        return self.set_interface('ipv6_cache_tmo', tmo)
 
     def _cleanup_mss_rules(self, table, ifname):
         commands = []
@@ -1697,6 +1718,11 @@ class Interface(Control):
         if tmp:
             for addr in tmp:
                 self.add_ipv6_eui64_address(addr)
+
+        # Configure IPv6 base time in milliseconds - has default value
+        tmp = dict_search('ipv6.base_reachable_time', config)
+        value = tmp if (tmp != None) else '30'
+        self.set_ipv6_cache_tmo(value)
 
         # re-add ourselves to any bridge we might have fallen out of
         if 'is_bridge_member' in config:


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add ability to change `base_reachable_time_ms` option 
`/proc/sys/net/ipv6/neigh/{ifname}/base_reachable_time_ms`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6258

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
sysctl
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure the option and check that the value is applied:
```
vyos@r4# sudo sysctl net.ipv6.neigh.eth2.base_reachable_time_ms
net.ipv6.neigh.eth2.base_reachable_time_ms = 30000
[edit]
vyos@r4# 

vyos@r4# set interfaces ethernet eth2 ipv6 base-reachable-time 28
[edit]
vyos@r4# commit
[edit]
vyos@r4# 
[edit]
vyos@r4# sudo sysctl net.ipv6.neigh.eth2.base_reachable_time_ms
net.ipv6.neigh.eth2.base_reachable_time_ms = 28000
[edit]
vyos@r4# 
vyos@r4# cat /proc/sys/net/ipv6/neigh/eth2/base_reachable_time_ms 
28000
[edit]
vyos@r4# 


vyos@r4# del interfaces ethernet eth2 ipv6 base-reachable-time 28
[edit]
vyos@r4# commit
[edit]
vyos@r4# sudo sysctl net.ipv6.neigh.eth2.base_reachable_time_ms
net.ipv6.neigh.eth2.base_reachable_time_ms = 30000
[edit]
vyos@r4# 
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
