### PR TITLE
configdep: T6276: do not call dependencies on script error

### DIFF
--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -236,7 +236,7 @@ def process_node_data(config, data, last: bool = False) -> int:
     with stdout_redirected(session_out, session_mode):
         result = run_script(conf_mode_scripts[script_name], config, args)
 
-    if last:
+    if last and result == R_SUCCESS:
         call_dependents(dependent_func=config.dependent_func)
 
     return result


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

NOTE: this should not be automatically backported, as it depends on the changes of T5839 and T5660, not yet in 1.4. Instead, all changes for T5839, T5660, T6206, T6276 will be backported in single PRs for vyatta-cfg, respectively, vyos-1x.

This fixes a simple bug in the removal of config dependency redundancies when running under vyos-configd: do not call the list of redundancies if the script returns an error (the case of a pass-through script, i.e., one returned to CLI for execution, was already handled in the original).

Test by smoketests running under configd, both 1.5 and 1.4 (output 1.5 below):

```
vyos_bld@514b6dccae9c:/vyos$ sudo make iso && make testd 2>&1|tee out.testd-configdep
vyos_bld@514b6dccae9c:/vyos$ tail -n 12 out.testd-configdep
DEBUG - echo EXITCODE:$?
 INFO - Smoketest finished successfully!
 INFO - Powering off system
DEBUG - EXITCODE:0poweroff now
 INFO - Shutting down virtual machine
 INFO - Waiting for shutdown...
DEBUG - poweroff now
 INFO - Waiting for shutdown...
DEBUG - poweroff now
 INFO - VM is shut down!
 INFO - Cleaning up
 INFO - Removing disk file: testinstall-20240428-201259-c043.img

```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T5839
* https://vyos.dev/T5660

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
