### PR TITLE
T6273: Allowed the use of "-" and "_" in PPPoE access-concentrator name

### DIFF
--- a/interface-definitions/include/pppoe-access-concentrator.xml.i
+++ b/interface-definitions/include/pppoe-access-concentrator.xml.i
@@ -3,9 +3,9 @@
   <properties>
     <help>Access concentrator name</help>
     <constraint>
-      <regex>[a-zA-Z0-9]{1,100}</regex>
+       #include <include/constraint/alpha-numeric-hyphen-underscore.xml.i>
     </constraint>
-    <constraintErrorMessage>Access-concentrator name must be alphanumerical only (max. 100 characters)</constraintErrorMessage>
+    <constraintErrorMessage>Access-concentrator name can only contain alpha-numeric letters, hyphen and underscores(max. 100 characters)</constraintErrorMessage>
   </properties>
 </leafNode>
 <!-- include end -->


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allowed the use of "-" and "_" in PPPoE access-concentrator name

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6273

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe
## Proposed changes
<!--- Describe your changes in detail -->
Allowed the use of "-" and "_" in PPPoE access-concentrator name

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
`vyos@vyos# set service pppoe-server access-concentrator first_concentrator`

```
vyos@vyos# set service pppoe-server access-concentrator first+concentrator



  Access-concentrator name can  only contain alpha-numeric letters, hyphen and underscores(max. 100 characters)
  Value validation failed
  Set failed

[edit]
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py
test_accel_ipv4_pool (__main__.TestServicePPPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServicePPPoEServer.test_accel_ipv6_pool) ...
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_limits (__main__.TestServicePPPoEServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestServicePPPoEServer.test_accel_local_authentication) ...
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_name_servers (__main__.TestServicePPPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServicePPPoEServer.test_accel_next_pool) ...
WARNING: 'default-pool' is not defined

ok
test_accel_ppp_options (__main__.TestServicePPPoEServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestServicePPPoEServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestServicePPPoEServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestServicePPPoEServer.test_accel_wins_server) ... ok
test_pppoe_limits (__main__.TestServicePPPoEServer.test_pppoe_limits) ... ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer.test_pppoe_server_authentication_protocols) ... ok
test_pppoe_server_pado_delay (__main__.TestServicePPPoEServer.test_pppoe_server_pado_delay) ... ok
test_pppoe_server_shaper (__main__.TestServicePPPoEServer.test_pppoe_server_shaper) ... ok
test_pppoe_server_vlan (__main__.TestServicePPPoEServer.test_pppoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 16 tests in 58.363s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
