### PR TITLE
T6169: DNS forwarding should allow underscore for srv record

### DIFF
--- a/interface-definitions/service_dns_forwarding.xml.in
+++ b/interface-definitions/service_dns_forwarding.xml.in
@@ -115,7 +115,7 @@
                     <description>An absolute DNS domain name</description>
                   </valueHelp>
                   <constraint>
-                    <validator name="fqdn"/>
+                    <regex>((?!-)[-_a-zA-Z0-9.]{1,63}|@|any)(?&lt;!\.)</regex>
                   </constraint>
                 </properties>
                 <children>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This SRV record looks valid:
```
set service dns forwarding authoritative-domain _tcp.db.mongors1.example.com records srv _mongodb entry 0 hostname 'mongors1.example.com'
```
But the FQDN validator cannot validate it correctly; use regex to fix.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6169

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service dns forwarding authoritative-domain _tcp.db.mongors1.example.com records srv _mongodb entry 0 hostname 'mongors1.example.com'
set service dns forwarding authoritative-domain _tcp.db.mongors1.example.com records srv _mongodb entry 0 port '2555'

```
Before the fix:
```
# set service dns forwarding authoritative-domain _tcp.db.mongors1.example.com records srv _mongodb entry 0 hostname 'mongors1.example.com'
  
  Invalid value
  Value validation failed
  Set failed

[edit]

```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_dns_forwarding.py
test_basic_forwarding (__main__.TestServicePowerDNS.test_basic_forwarding) ... ok
test_dns64 (__main__.TestServicePowerDNS.test_dns64) ... ok
test_dnssec (__main__.TestServicePowerDNS.test_dnssec) ... ok
test_domain_forwarding (__main__.TestServicePowerDNS.test_domain_forwarding) ... ok
test_ecs_add_for (__main__.TestServicePowerDNS.test_ecs_add_for) ... ok
test_ecs_ipv4_bits (__main__.TestServicePowerDNS.test_ecs_ipv4_bits) ... ok
test_edns_subnet_allow_list (__main__.TestServicePowerDNS.test_edns_subnet_allow_list) ... ok
test_exclude_throttle_adress (__main__.TestServicePowerDNS.test_exclude_throttle_adress) ... ok
test_external_nameserver (__main__.TestServicePowerDNS.test_external_nameserver) ... ok
test_listening_port (__main__.TestServicePowerDNS.test_listening_port) ... ok
test_no_rfc1918_forwarding (__main__.TestServicePowerDNS.test_no_rfc1918_forwarding) ... ok
test_serve_stale_extension (__main__.TestServicePowerDNS.test_serve_stale_extension) ... ok

----------------------------------------------------------------------
Ran 12 tests in 133.439s

OK
vyos@r4:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
