### PR TITLE
haproxy: T6179: fix rule generation

### DIFF
--- a/data/templates/load-balancing/haproxy.cfg.j2
+++ b/data/templates/load-balancing/haproxy.cfg.j2
@@ -85,7 +85,7 @@ frontend {{ front }}
 {%         if front_config.rule is vyos_defined %}
 {%             for rule, rule_config in front_config.rule.items() %}
     # rule {{ rule }}
-{%                 if rule_config.domain_name is vyos_defined and rule_config.set.backend is vyos_defined %}
+{%                 if rule_config.domain_name is vyos_defined %}
 {%                     set rule_options = 'hdr(host)' %}
 {%                     if rule_config.ssl is vyos_defined %}
 {%                         set ssl_rule_translate = {'req-ssl-sni': 'req_ssl_sni', 'ssl-fc-sni': 'ssl_fc_sni', 'ssl-fc-sni-end': 'ssl_fc_sni_end'} %}
@@ -94,16 +94,20 @@ frontend {{ front }}
 {%                     for domain in rule_config.domain_name %}
     acl {{ rule }} {{ rule_options }} -i {{ domain }}
 {%                     endfor %}
-    use_backend {{ rule_config.set.backend }} if {{ rule }}
 {%                 endif %}
 {# path url #}
-{%                 if rule_config.url_path is vyos_defined and rule_config.set.redirect_location is vyos_defined %}
+{%                 if rule_config.url_path is vyos_defined %}
 {%                     set path_mod_translate = {'begin': '-i -m beg', 'end': '-i -m end', 'exact': ''} %}
 {%                     for path, path_config in rule_config.url_path.items() %}
 {%                         for url in path_config %}
     acl {{ rule }} path {{ path_mod_translate[path] }} {{ url }}
 {%                         endfor %}
 {%                     endfor %}
+{%                 endif %}
+{%                 if rule_config.set.backend is vyos_defined %}
+    use_backend {{ rule_config.set.backend }} if {{ rule }}
+{%                 endif %}
+{%                 if rule_config.set.redirect_location is vyos_defined %}
     http-request redirect location {{ rule_config.set.redirect_location }} code 301 if {{ rule }}
 {%                 endif %}
 {# endpath #}

--- a/smoketest/scripts/cli/test_load-balancing_reverse-proxy.py
+++ b/smoketest/scripts/cli/test_load-balancing_reverse-proxy.py
@@ -180,6 +180,7 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
         mode = 'http'
         rule_ten = '10'
         rule_twenty = '20'
+        rule_thirty = '30'
         send_proxy = 'send-proxy'
         max_connections = '1000'
 
@@ -192,6 +193,8 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['service', frontend, 'rule', rule_ten, 'set', 'backend', bk_first_name])
         self.cli_set(base_path + ['service', frontend, 'rule', rule_twenty, 'domain-name', domain_bk_second])
         self.cli_set(base_path + ['service', frontend, 'rule', rule_twenty, 'set', 'backend', bk_second_name])
+        self.cli_set(base_path + ['service', frontend, 'rule', rule_thirty, 'url-path', 'end', '/test'])
+        self.cli_set(base_path + ['service', frontend, 'rule', rule_thirty, 'set', 'backend', bk_second_name])
 
         self.cli_set(back_base + [bk_first_name, 'mode', mode])
         self.cli_set(back_base + [bk_first_name, 'server', bk_first_name, 'address', bk_server_first])
@@ -222,6 +225,8 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'use_backend {bk_first_name} if {rule_ten}', config)
         self.assertIn(f'acl {rule_twenty} hdr(host) -i {domain_bk_second}', config)
         self.assertIn(f'use_backend {bk_second_name} if {rule_twenty}', config)
+        self.assertIn(f'acl {rule_thirty} path -i -m end /test', config)
+        self.assertIn(f'use_backend {bk_second_name} if {rule_thirty}', config)
 
         # Backend
         self.assertIn(f'backend {bk_first_name}', config)


### PR DESCRIPTION
## Change Summary
Fix config generation for different combinations of set-backend/redirect-location

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6179

## Related PR(s)
None

## Component(s) name
load-balancing

## Proposed changes
`path` acl rules (and domain_name for that matter) can be used with both `set-backend` or `redirect-location`
(https://www.haproxy.com/blog/path-based-routing-with-haproxy has an example with set-backend)

## How to test
```
set load-balancing reverse-proxy service foo port '4443'
set load-balancing reverse-proxy service foo rule 10 set backend 'bk01'
set load-balancing reverse-proxy service foo rule 10 url-path end '/local'
set load-balancing reverse-proxy backend bk01 server s1 address '192.0.2.1'
set load-balancing reverse-proxy backend bk01 server s1 port '4443'
```
should yield the frontend config config:
```
# Frontend
frontend foo
    bind :::4443 v4v6  
    # rule 10
    acl 10 path -i -m end /local
    use_backend bk01 if 10
```

## Smoketest result
```
$ /usr/libexec/vyos/tests/smoke/cli/test_load-balancing_reverse-proxy.py
test_01_lb_reverse_proxy_domain (__main__.TestLoadBalancingReverseProxy.test_01_lb_reverse_proxy_domain) ... ok
test_02_lb_reverse_proxy_cert_not_exists (__main__.TestLoadBalancingReverseProxy.test_02_lb_reverse_proxy_cert_not_exists) ... 
PKI does not contain any certificates!


Certificate "cert" not found in configuration!

ok
test_03_lb_reverse_proxy_ca_not_exists (__main__.TestLoadBalancingReverseProxy.test_03_lb_reverse_proxy_ca_not_exists) ... ok
test_04_lb_reverse_proxy_backend_ssl_no_verify (__main__.TestLoadBalancingReverseProxy.test_04_lb_reverse_proxy_backend_ssl_no_verify) ... 
backend bk-01 cannot have both ssl options no-verify and ca-certificate
set!

ok
test_05_lb_reverse_proxy_backend_http_check (__main__.TestLoadBalancingReverseProxy.test_05_lb_reverse_proxy_backend_http_check) ... ok
test_06_lb_reverse_proxy_tcp_mode (__main__.TestLoadBalancingReverseProxy.test_06_lb_reverse_proxy_tcp_mode) ... ok

----------------------------------------------------------------------
Ran 6 tests in 86.712s

OK
```

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
