### PR TITLE
T6287: Config-sync add the ability to configure API port

### DIFF
--- a/interface-definitions/service_config-sync.xml.in
+++ b/interface-definitions/service_config-sync.xml.in
@@ -34,6 +34,10 @@
                   </constraint>
                 </properties>
               </leafNode>
+              #include <include/port-number.xml.i>
+              <leafNode name="port">
+                <defaultValue>443</defaultValue>
+              </leafNode>
               <leafNode name="timeout">
                 <properties>
                   <help>Connection API timeout</help>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add the ability to configure the API port if the API on the secondary server works on a non-default port.
The primary node will connect to the configured port for config-sync

```
set service config-sync secondary port '8443'
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6287

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
config-sync
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure the `secondary` node API port (not default)
```
set service https api keys id KID key 'foo'
set service https port '8443'

```
On the `primary` node, use this port to connect to the `secondary` API for config-sync:
```
set service config-sync mode 'load'
set service config-sync secondary address '192.168.122.11'
set service config-sync secondary key 'foo'
set service config-sync secondary port '8443'
set service config-sync section protocols ospf
```
Change anything under protocol ospf on the `primary` node
```
vyos@r4# set protocols ospf area 0 network '192.0.2.0/30'
[edit]
vyos@r4# commit
INFO:vyos_config_sync:Config synchronization: Mode=load, Secondary=192.168.122.11
[edit]
vyos@r4# 

```
Check on the secondary node protocol ospf
```
vyos@r1-right# show protocols ospf 
 area 0 {
     network 192.0.2.0/30
 }
[edit]
vyos@r1-right# 

```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
