### PR TITLE
smoketest: T6199: remove redundant code when unpacking Kernel GZ config

### DIFF
--- a/smoketest/scripts/system/test_kernel_options.py
+++ b/smoketest/scripts/system/test_kernel_options.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020-2023 VyOS maintainers and contributors
+# Copyright (C) 2020-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -14,28 +14,38 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import gzip
 import re
 import os
 import platform
 import unittest
 
-from vyos.utils.process import call
-from vyos.utils.file import read_file
-
 kernel = platform.release()
-config = read_file(f'/boot/config-{kernel}')
-CONFIG = '/proc/config.gz'
 
 class TestKernelModules(unittest.TestCase):
     """ VyOS makes use of a lot of Kernel drivers, modules and features. The
     required modules which are essential for VyOS should be tested that they are
     available in the Kernel that is run. """
 
+    _config_data = None
+
+    @classmethod
+    def setUpClass(cls):
+        import gzip
+        from vyos.utils.process import call
+
+        super(TestKernelModules, cls).setUpClass()
+        CONFIG = '/proc/config.gz'
+
+        if not os.path.isfile(CONFIG):
+            call('sudo modprobe configs')
+
+        with gzip.open(CONFIG, 'rt') as f:
+            cls._config_data = f.read()
+
     def test_bond_interface(self):
         # The bond/lacp interface must be enabled in the OS Kernel
         for option in ['CONFIG_BONDING']:
-            tmp = re.findall(f'{option}=(y|m)', config)
+            tmp = re.findall(f'{option}=(y|m)', self._config_data)
             self.assertTrue(tmp)
 
     def test_bridge_interface(self):
@@ -43,7 +53,7 @@ class TestKernelModules(unittest.TestCase):
         for option in ['CONFIG_BRIDGE',
                        'CONFIG_BRIDGE_IGMP_SNOOPING',
                        'CONFIG_BRIDGE_VLAN_FILTERING']:
-            tmp = re.findall(f'{option}=(y|m)', config)
+            tmp = re.findall(f'{option}=(y|m)', self._config_data)
             self.assertTrue(tmp)
 
     def test_dropmon_enabled(self):
@@ -53,47 +63,53 @@ class TestKernelModules(unittest.TestCase):
             'CONFIG_BPF_EVENTS=y',
             'CONFIG_TRACEPOINTS=y'
         ]
-        if not os.path.isfile(CONFIG):
-            call('sudo modprobe configs')
 
-        with gzip.open(CONFIG, 'rt') as f:
-            config_data = f.read()
         for option in options_to_check:
-            self.assertIn(option, config_data,
-                          f"Option {option} is not present in /proc/config.gz")
+            self.assertIn(option, self._config_data)
 
     def test_synproxy_enabled(self):
         options_to_check = [
             'CONFIG_NFT_SYNPROXY',
             'CONFIG_IP_NF_TARGET_SYNPROXY'
         ]
-        if not os.path.isfile(CONFIG):
-            call('sudo modprobe configs')
-        with gzip.open(CONFIG, 'rt') as f:
-            config_data = f.read()
         for option in options_to_check:
-            tmp = re.findall(f'{option}=(y|m)', config_data)
+            tmp = re.findall(f'{option}=(y|m)', self._config_data)
             self.assertTrue(tmp)
 
     def test_qemu_support(self):
-        for option in ['CONFIG_VIRTIO_BLK', 'CONFIG_SCSI_VIRTIO',
-                       'CONFIG_VIRTIO_NET', 'CONFIG_VIRTIO_CONSOLE',
-                       'CONFIG_VIRTIO', 'CONFIG_VIRTIO_PCI',
-                       'CONFIG_VIRTIO_BALLOON', 'CONFIG_CRYPTO_DEV_VIRTIO',
-                       'CONFIG_X86_PLATFORM_DEVICES']:
-            tmp = re.findall(f'{option}=(y|m)', config)
+        options_to_check = [
+            'CONFIG_VIRTIO_BLK', 'CONFIG_SCSI_VIRTIO',
+            'CONFIG_VIRTIO_NET', 'CONFIG_VIRTIO_CONSOLE',
+            'CONFIG_VIRTIO', 'CONFIG_VIRTIO_PCI',
+            'CONFIG_VIRTIO_BALLOON', 'CONFIG_CRYPTO_DEV_VIRTIO',
+            'CONFIG_X86_PLATFORM_DEVICES'
+            ]
+        for option in options_to_check:
+            tmp = re.findall(f'{option}=(y|m)', self._config_data)
             self.assertTrue(tmp)
 
     def test_vmware_support(self):
         for option in ['CONFIG_VMXNET3']:
-            tmp = re.findall(f'{option}=(y|m)', config)
+            tmp = re.findall(f'{option}=(y|m)', self._config_data)
             self.assertTrue(tmp)
 
     def test_container_cgroup_support(self):
-        for option in ['CONFIG_CGROUPS', 'CONFIG_MEMCG', 'CONFIG_CGROUP_PIDS', 'CONFIG_CGROUP_BPF']:
-            tmp = re.findall(f'{option}=(y|m)', config)
+        options_to_check = [
+            'CONFIG_CGROUPS', 'CONFIG_MEMCG',
+            'CONFIG_CGROUP_PIDS', 'CONFIG_CGROUP_BPF'
+            ]
+        for option in options_to_check:
+            tmp = re.findall(f'{option}=(y|m)', self._config_data)
+            self.assertTrue(tmp)
+
+    def test_ip_routing_support(self):
+        options_to_check = [
+            'CONFIG_IP_ADVANCED_ROUTER', 'CONFIG_IP_MULTIPLE_TABLES',
+            'CONFIG_IP_ROUTE_MULTIPATH'
+            ]
+        for option in options_to_check:
+            tmp = re.findall(f'{option}=(y|m)', self._config_data)
             self.assertTrue(tmp)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)
-


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Remove redundant code when unpacking Kernel GZ config

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6199

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/system/test_kernel_options.py
test_bond_interface (__main__.TestKernelModules.test_bond_interface) ... ok
test_bridge_interface (__main__.TestKernelModules.test_bridge_interface) ... ok
test_container_cgroup_support (__main__.TestKernelModules.test_container_cgroup_support) ... ok
test_dropmon_enabled (__main__.TestKernelModules.test_dropmon_enabled) ... ok
test_ip_routing_support (__main__.TestKernelModules.test_ip_routing_support) ... ok
test_qemu_support (__main__.TestKernelModules.test_qemu_support) ... ok
test_synproxy_enabled (__main__.TestKernelModules.test_synproxy_enabled) ... ok
test_vmware_support (__main__.TestKernelModules.test_vmware_support) ... ok

----------------------------------------------------------------------
Ran 8 tests in 0.017s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
