### PR TITLE
qos: T6225: Fix QoS random-detect policy

### DIFF
--- a/python/vyos/qos/base.py
+++ b/python/vyos/qos/base.py
@@ -90,13 +90,14 @@ class QoSBase:
         else:
             return value
 
-    def _calc_random_detect_queue_params(self, avg_pkt, max_thr, limit=None, min_thr=None, mark_probability=None):
+    def _calc_random_detect_queue_params(self, avg_pkt, max_thr, limit=None, min_thr=None,
+                                         mark_probability=None, precedence=0):
         params = dict()
         avg_pkt = int(avg_pkt)
         max_thr = int(max_thr)
         mark_probability = int(mark_probability)
         limit = int(limit) if limit else 4 * max_thr
-        min_thr = int(min_thr) if min_thr else (9 * max_thr) // 18
+        min_thr = int(min_thr) if min_thr else ((9 + precedence) * max_thr) // 18
 
         params['avg_pkt'] = avg_pkt
         params['limit'] = limit * avg_pkt

--- a/smoketest/scripts/cli/test_qos.py
+++ b/smoketest/scripts/cli/test_qos.py
@@ -441,7 +441,6 @@ class TestQoS(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
     def test_08_random_detect(self):
-        self.skipTest('tc returns invalid JSON here - needs iproute2 fix')
         bandwidth = 5000
 
         first = True
@@ -467,8 +466,11 @@ class TestQoS(VyOSUnitTestSHIM.TestCase):
         bandwidth = 5000
         for interface in self._interfaces:
             tmp = get_tc_qdisc_json(interface)
-            import pprint
-            pprint.pprint(tmp)
+            self.assertTrue('gred' in tmp.get('kind'))
+            self.assertEqual(8, len(tmp.get('options', {}).get('vqs')))
+            self.assertEqual(8, tmp.get('options', {}).get('dp_cnt'))
+            self.assertEqual(0, tmp.get('options', {}).get('dp_default'))
+            self.assertTrue(tmp.get('options', {}).get('grio'))
 
     def test_09_rate_control(self):
         bandwidth = 5000


### PR DESCRIPTION
Fix default values for random-detect
Remove dsmark qdisc from gred cofig because dsmark was deleted from kernel

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix getting default values for random detect policy
Remove dsmark qdisc.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6225

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
qos
## Proposed changes
<!--- Describe your changes in detail -->
dsmark was removed from the kernel and iproute2
https://patchwork.kernel.org/project/netdevbpf/patch/20231030184100.30264-5-stephen@networkplumber.org/

Currently we cannot use it, but looks like gred doesn't distribute traffic by virtual queues automatically therefore we lose behavior similar to WRED which we had in the vyos version 1.3

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
conf
set qos interface eth0 egress qos-policy-eth0
set qos policy random-detect qos-policy-eth0 bandwidth 5000
commit
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_qos.py
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok
test_12_shaper_with_red_queue (__main__.TestQoS.test_12_shaper_with_red_queue) ... ok
test_13_shaper_delete_only_rule (__main__.TestQoS.test_13_shaper_delete_only_rule) ... ok

----------------------------------------------------------------------
Ran 13 tests in 44.034s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
