### PR TITLE
Bond: T6303: add system mac address on interfaces bond

### DIFF
--- a/interface-definitions/interfaces_bonding.xml.in
+++ b/interface-definitions/interfaces_bonding.xml.in
@@ -176,6 +176,18 @@
             </properties>
             <defaultValue>0</defaultValue>
           </leafNode>
+          <leafNode name="system-mac">
+            <properties>
+              <help>System MAC address for 802.3ad</help>
+              <valueHelp>
+                <format>macaddr</format>
+                <description>MAC address</description>
+              </valueHelp>
+              <constraint>
+                <validator name="mac-address"/>
+              </constraint>
+            </properties>
+          </leafNode>
           <leafNode name="lacp-rate">
             <properties>
               <help>Rate in which we will ask our link partner to transmit LACPDU packets</help>

--- a/python/vyos/ifconfig/bond.py
+++ b/python/vyos/ifconfig/bond.py
@@ -449,18 +449,13 @@ class BondIf(Interface):
                     Interface(interface).set_admin_state('up')
 
             # Bonding policy/mode - default value, always present
-            mode = config.get('mode')
-            self.set_mode(mode)
+            self.set_mode(config['mode'])
 
             # LACPDU transmission rate - default value
-            if mode == '802.3ad':
+            if config['mode'] == '802.3ad':
                 self.set_lacp_rate(config.get('lacp_rate'))
 
-            # Add system mac address for 802.3ad
-            if mode == '802.3ad' and 'system_mac' in config:
-                self.set_system_mac(config.get('system_mac'))
-
-            if mode not in ['802.3ad', 'balance-tlb', 'balance-alb']:
+            if config['mode'] not in ['802.3ad', 'balance-tlb', 'balance-alb']:
                 tmp = dict_search('arp_monitor.interval', config)
                 value = tmp if (tmp != None) else '0'
                 self.set_arp_interval(value)
@@ -494,6 +489,14 @@ class BondIf(Interface):
                 # any remaining ones
                 Interface(interface).flush_addrs()
                 self.add_port(interface)
+
+        # Add system mac address for 802.3ad - default address is all zero
+        # mode is always present (defaultValue)
+        if config['mode'] == '802.3ad':
+            mac = '00:00:00:00:00:00'
+            if 'system_mac' in config:
+                mac = config['system_mac']
+            self.set_system_mac(mac)
 
         # Primary device interface - must be set after 'mode'
         value = config.get('primary')

--- a/python/vyos/ifconfig/bond.py
+++ b/python/vyos/ifconfig/bond.py
@@ -56,7 +56,7 @@ class BondIf(Interface):
             'location': '/sys/class/net/{ifname}/bonding/lacp_rate',
         },
         'bond_system_mac': {
-            'validate': assert_mac,
+            'validate': lambda v: assert_mac(v, test_all_zero=False),
             'location': '/sys/class/net/{ifname}/bonding/ad_actor_system',
         },
         'bond_miimon': {

--- a/python/vyos/utils/assertion.py
+++ b/python/vyos/utils/assertion.py
@@ -53,7 +53,7 @@ def assert_mtu(mtu, ifname):
     if (max_mtu and cur_mtu > max_mtu) or cur_mtu > 65536:
         raise ValueError(f'MTU is too small for interface "{ifname}": {mtu} > {max_mtu}')
 
-def assert_mac(m):
+def assert_mac(m, test_all_zero=True):
     split = m.split(':')
     size = len(split)
 
@@ -74,7 +74,7 @@ def assert_mac(m):
         raise ValueError(f'{m} is a multicast MAC address')
 
     # overall mac address is not allowed to be 00:00:00:00:00:00
-    if sum(octets) == 0:
+    if test_all_zero and sum(octets) == 0:
         raise ValueError('00:00:00:00:00:00 is not a valid MAC address')
 
     if octets[:5] == (0, 0, 94, 0, 1):

--- a/smoketest/scripts/cli/test_interfaces_bonding.py
+++ b/smoketest/scripts/cli/test_interfaces_bonding.py
@@ -241,6 +241,22 @@ class BondingInterfaceTest(BasicInterfaceTest.TestCase):
             for member in self._members:
                 self.assertIn(member, slaves)
 
+    def test_bonding_system_mac(self):
+        # configure member interfaces and system-mac
+        system_mac = '00:50:ab:cd:ef:11'
+        for interface in self._interfaces:
+            for option in self._options.get(interface, []):
+                self.cli_set(self._base_path + [interface] + option.split())
+
+            self.cli_set(self._base_path + [interface, 'system-mac', system_mac])
+
+        self.cli_commit()
+
+        # verify config
+        for interface in self._interfaces:
+            defined_mac = read_file(f'/sys/class/net/{interface}/bonding/ad_actor_system')
+            self.assertIn(defined_mac, system_mac)
+
     def test_bonding_evpn_multihoming(self):
         id = '5'
         for interface in self._interfaces:

--- a/smoketest/scripts/cli/test_interfaces_bonding.py
+++ b/smoketest/scripts/cli/test_interfaces_bonding.py
@@ -243,7 +243,9 @@ class BondingInterfaceTest(BasicInterfaceTest.TestCase):
 
     def test_bonding_system_mac(self):
         # configure member interfaces and system-mac
+        default_system_mac = '00:00:00:00:00:00' # default MAC is all zeroes
         system_mac = '00:50:ab:cd:ef:11'
+
         for interface in self._interfaces:
             for option in self._options.get(interface, []):
                 self.cli_set(self._base_path + [interface] + option.split())
@@ -254,8 +256,18 @@ class BondingInterfaceTest(BasicInterfaceTest.TestCase):
 
         # verify config
         for interface in self._interfaces:
-            defined_mac = read_file(f'/sys/class/net/{interface}/bonding/ad_actor_system')
-            self.assertIn(defined_mac, system_mac)
+            tmp = read_file(f'/sys/class/net/{interface}/bonding/ad_actor_system')
+            self.assertIn(tmp, system_mac)
+
+        for interface in self._interfaces:
+            self.cli_delete(self._base_path + [interface, 'system-mac'])
+
+        self.cli_commit()
+
+        # verify default value
+        for interface in self._interfaces:
+            tmp = read_file(f'/sys/class/net/{interface}/bonding/ad_actor_system')
+            self.assertIn(tmp, default_system_mac)
 
     def test_bonding_evpn_multihoming(self):
         id = '5'

--- a/src/conf_mode/interfaces_bonding.py
+++ b/src/conf_mode/interfaces_bonding.py
@@ -33,6 +33,7 @@ from vyos.ifconfig import BondIf
 from vyos.ifconfig.ethernet import EthernetIf
 from vyos.ifconfig import Section
 from vyos.template import render_to_string
+from vyos.utils.assertion import assert_mac
 from vyos.utils.dict import dict_search
 from vyos.utils.dict import dict_to_paths_values
 from vyos.utils.network import interface_exists
@@ -243,6 +244,16 @@ def verify(bond):
         if bond['mode'] not in ['active-backup', 'balance-tlb', 'balance-alb']:
             raise ConfigError('primary interface only works for mode active-backup, ' \
                               'transmit-load-balance or adaptive-load-balance')
+
+    if 'system_mac' in bond:
+        if bond['mode'] != '802.3ad':
+            raise ConfigError('Actor MAC address only available in 802.3ad mode!')
+
+        system_mac = bond['system_mac']
+        try:
+            assert_mac(system_mac, test_all_zero=False)
+        except:
+            raise ConfigError(f'Cannot use a multicast MAC address "{system_mac}" as system-mac!')
 
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->
some cases is necessary define system mac address where it allow belong to same group of system (lag system)
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6303
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bond
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
vyos bond configuration : 

```
set interfaces bonding bond0 description 'test'
set interfaces bonding bond0 member interface 'eth1'
set interfaces bonding bond0 system-mac '00:50:ab:cd:ef:cc'
```
bond information : 

```
vyos@vyos:~$ sudo cat /proc/net/bonding/bond0

Ethernet Channel Bonding Driver: v6.6.28-amd64-vyos

Bonding Mode: IEEE 802.3ad Dynamic link aggregation
Transmit Hash Policy: layer2 (0)
MII Status: up
MII Polling Interval (ms): 100
Up Delay (ms): 0
Down Delay (ms): 0
Peer Notification Delay (ms): 0

802.3ad info
LACP active: on
LACP rate: slow
Min links: 0
Aggregator selection policy (ad_select): stable
System priority: 65535
System MAC address: 00:50:ab:cd:ef:cc
Active Aggregator Info:
	Aggregator ID: 1
	Number of ports: 1
	Actor Key: 9
	Partner Key: 9
	Partner Mac Address: 22:29:a9:10:cc:ac

Slave Interface: eth1
MII Status: up
Speed: 1000 Mbps
Duplex: full
Link Failure Count: 0
Permanent HW addr: 50:00:00:04:00:01
Slave queue ID: 0
Aggregator ID: 1
Actor Churn State: monitoring
Partner Churn State: monitoring
Actor Churned Count: 0
Partner Churned Count: 0

```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
# /usr/libexec/vyos/tests/smoke/cli/test_interfaces_bonding.py
test_bonding_system_mac (__main__.BondingInterfaceTest.test_bonding_system_mac) ... ok
test_bonding_uniq_member_description (__main__.BondingInterfaceTest.test_bonding_uniq_member_description) ... ok
test_dhcp_client_options (__main__.BondingInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.BondingInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.BondingInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.BondingInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.BondingInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.BondingInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.BondingInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_interface_description (__main__.BondingInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.BondingInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.BondingInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.BondingInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.BondingInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.BondingInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.BondingInterfaceTest.test_mtu_1200_no_ipv6_interface) ...
link-local IPv6 address will be configured on interface "bond0", the
required minimum MTU is "1280"!
ok
test_span_mirror (__main__.BondingInterfaceTest.test_span_mirror) ... ok
test_vif_8021q_interfaces (__main__.BondingInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.BondingInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.BondingInterfaceTest.test_vif_8021q_mtu_limits) ...
Interface MTU "9000" too high, parent interface MTU is "1500"!
ok
test_vif_8021q_qos_change (__main__.BondingInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.BondingInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.BondingInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 34 tests in 180.785s
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
