### PR TITLE
T6265: firewall: allow only ethernet interfaces to flowtables.

### DIFF
--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -20,8 +20,13 @@
             <properties>
               <help>Interfaces to use this flowtable</help>
               <completionHelp>
-                <script>${vyos_completion_dir}/list_interfaces</script>
+                <path>interfaces ethernet</path>
+                <path>interfaces loopback</path>
               </completionHelp>
+               <constraint>
+                <regex>^(eth\d+|lo)$</regex>
+              </constraint>
+              <constraintErrorMessage>Only ethernet and loopback interfaces are allowed in flowtables</constraintErrorMessage>
               <multi/>
             </properties>
           </leafNode>

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -802,7 +802,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
     def test_flow_offload(self):
         self.cli_set(['interfaces', 'ethernet', 'eth0', 'vif', '10'])
-        self.cli_set(['firewall', 'flowtable', 'smoketest', 'interface', 'eth0.10'])
+        self.cli_set(['firewall', 'flowtable', 'smoketest', 'interface', 'eth0'])
         self.cli_set(['firewall', 'flowtable', 'smoketest', 'offload', 'hardware'])
 
         # QEMU virtual NIC does not support hw-tc-offload
@@ -828,7 +828,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         nftables_search = [
             ['flowtable VYOS_FLOWTABLE_smoketest'],
             ['hook ingress priority filter'],
-            ['devices = { eth0.10 }'],
+            ['devices = { eth0 }'],
             ['ct state { established, related }', 'meta l4proto { tcp, udp }', 'flow add @VYOS_FLOWTABLE_smoketest'],
         ]
 

--- a/src/migration-scripts/firewall/15-to-16
+++ b/src/migration-scripts/firewall/15-to-16
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022-2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T6265: allow only ethernet and loopback interface on firewall flowtables
+# If non ethernet|lo interface found in flowtables, remove it
+# If after removing flowtable is empty, add lo interface in order to keep it
+
+from sys import argv
+from sys import exit
+
+from vyos.configtree import ConfigTree
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+base = ['firewall', 'flowtable']
+
+if not config.exists(base):
+    # Nothing to do
+    exit(0)
+
+valid_str = ['eth','lo']
+invalid_arguments = ['.']
+
+for ft in config.list_nodes(base):
+    interfaces = config.return_values(base + [ft, 'interface'])
+    # Remove all node, and only add what is allowed
+    config.delete(base + [ft, 'interface'])
+    for iface in interfaces:
+        for aux in valid_str:
+            if aux in iface:
+                ## We may need to re-add it
+                for inv_arg in invalid_arguments:
+                    if inv_arg not in iface:
+                        # We need to re-add it
+                        config.set(base + [ft, 'interface'], value=iface, replace=False)
+
+    # Now we need to check that >ft interface> is not empty
+    if 'interface' not in config.list_nodes(base + [ft]):
+        config.set(base + [ft, 'interface'], value='lo')
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print("Failed to save the modified config: {}".format(e))
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow only ethernet interfaces to flowtables.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6265

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

-->
```
vyos@ftables# set firewall flowtable ft01 interface eth1
[edit]
vyos@ftables# commit
[edit]
vyos@ftables# set firewall flowtable ft02 interface 
Possible completions:
   <text>               Interfaces to use this flowtable
   eth0                 
   eth1                 
   eth2                 
   eth3                 
   lo                   

      
[edit]
vyos@ftables# set firewall flowtable ft02 interface br0

  
  
  Only ethernet and loopback interfaces are allowed in flowtables
  Value validation failed
  Set failed

[edit]
vyos@ftables# 

```
Example of migration:
```
root@latest:/home/vyos# show config comm | grep flowt
set firewall flowtable ft01 interface 'br0'
set firewall flowtable ft01 interface 'eth2'
set firewall flowtable ft01 interface 'eth3.33'
set firewall flowtable ft02 interface 'eth1'
set firewall flowtable ft03 interface 'lo'
set firewall flowtable ft04 interface 'eth0'
set firewall flowtable ft04 interface 'eth3'
set firewall flowtable ft05 interface 'vti0'
root@latest:/home/vyos# ./mig-test.sh config.boot
root@latest:/home/vyos# vyos-config-to-commands config.boot | grep flowt
set firewall flowtable ft01 interface 'eth2'
set firewall flowtable ft02 interface 'eth1'
set firewall flowtable ft03 interface 'lo'
set firewall flowtable ft04 interface 'eth0'
set firewall flowtable ft04 interface 'eth3'
set firewall flowtable ft05 interface 'lo'
root@latest:/home/vyos# 
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
test_firewall.py --> OK

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
