### PR TITLE
op-mode: T6284: IPoE-server op-mode does not show IPv6 address field

### DIFF
--- a/src/op_mode/ipoe-control.py
+++ b/src/op_mode/ipoe-control.py
@@ -56,7 +56,11 @@ def main():
         if args.selector in cmd_dict['selector'] and args.target:
             run(cmd_dict['cmd_base'] + "{0} {1} {2}".format(args.action, args.selector, args.target))
         else:
-            output, err = popen(cmd_dict['cmd_base'] + cmd_dict['actions'][args.action], decode='utf-8')
+            if args.action == "show_sessions":
+                ses_pattern = " ifname,username,calling-sid,ip,ip6,ip6-dp,rate-limit,type,comp,state,uptime"
+            else:
+                ses_pattern = ""
+            output, err = popen(cmd_dict['cmd_base'] + cmd_dict['actions'][args.action] + ses_pattern, decode='utf-8')
             if not err:
                 print(output)
             else:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6284
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
op_mode  ipoe_server
## Proposed changes
<!--- Describe your changes in detail -->
Added  IPv6 address fields ``` ip6 | ip6-dp ``` to ``` show ipoe-service sessions ``` output
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set service ipoe-server authentication mode 'noauth'
set service ipoe-server client-ip-pool ONE range '100.64.0.1-100.64.0.10'
set service ipoe-server client-ipv6-pool POOL-v6 delegate 2001:db8:8003::/48 delegation-prefix '56'
set service ipoe-server client-ipv6-pool POOL-v6 prefix 2001:db8::/64
set service ipoe-server default-ipv6-pool 'POOL-v6'
set service ipoe-server default-pool 'ONE'
set service ipoe-server gateway-address '100.64.0.14/28'
set service ipoe-server interface eth1 network 'shared'
set service ipoe-server name-server '1.1.1.1'
set service ipoe-server name-server '100.64.0.14'
set service ipoe-server name-server '2001:db8::1'

vyos@vyos# run show ipoe-server sessions
ifname | username |    calling-sid    |     ip     |              ip6             | ip6-dp | rate-limit | type | comp | state  |  uptime
--------+----------+-------------------+------------+------------------------------+--------+------------+------+------+--------+----------
 ipoe0  |          | 0c:08:3f:03:00:00 | 100.64.0.1 | 2001:db8::e08:3fff:fe03:0/64 |        |            | ipoe |      | active | 00:18:32
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
