### PR TITLE
bridge: T6317: add dependency call for wireless interfaces

### DIFF
--- a/data/config-mode-dependencies/vyos-1x.json
+++ b/data/config-mode-dependencies/vyos-1x.json
@@ -11,7 +11,8 @@
         "ethernet": ["interfaces_ethernet"]
     },
     "interfaces_bridge": {
-        "vxlan": ["interfaces_vxlan"]
+        "vxlan": ["interfaces_vxlan"],
+        "wlan": ["interfaces_wireless"]
     },
     "load_balancing_wan": {
         "conntrack": ["system_conntrack"]

--- a/data/templates/wifi/hostapd.conf.j2
+++ b/data/templates/wifi/hostapd.conf.j2
@@ -28,6 +28,12 @@ interface={{ ifname }}
 {%     for bridge in is_bridge_member %}
 bridge={{ bridge }}
 {%     endfor %}
+
+# WDS (4-address frame) mode with per-station virtual interfaces
+# (only supported with driver=nl80211)
+# This mode allows associated stations to use 4-address frames to allow layer 2
+# bridging to be used.
+wds_sta=1
 {% endif %}
 
 # Driver interface type (hostap/wired/none/nl80211/bsd);
@@ -739,4 +745,3 @@ wmm_ac_vo_cwmin=2
 wmm_ac_vo_cwmax=3
 wmm_ac_vo_txop_limit=47
 wmm_ac_vo_acm=0
-

--- a/smoketest/scripts/cli/test_interfaces_wireless.py
+++ b/smoketest/scripts/cli/test_interfaces_wireless.py
@@ -236,6 +236,17 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
 
         self.assertIn(interface, bridge_members)
 
+        # Now generate a VLAN on the bridge
+        self.cli_set(bridge_path + ['enable-vlan'])
+        self.cli_set(bridge_path + ['vif', '20', 'address', '10.0.0.1/24'])
+
+        self.cli_commit()
+
+        tmp = get_config_value(interface, 'bridge')
+        self.assertEqual(tmp, bridge)
+        tmp = get_config_value(interface, 'wds_sta')
+        self.assertEqual(tmp, '1')
+
         self.cli_delete(bridge_path)
 
     def test_wireless_security_station_address(self):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add missing code path to call dependencies when deleting bridge member interfaces.

Add dependency code path for wireless bridge members.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6317

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireless

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```console
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireless.py
test_add_multiple_ip_addresses (__main__.WirelessInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.WirelessInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.WirelessInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.WirelessInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.WirelessInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.WirelessInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.WirelessInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_interface_description (__main__.WirelessInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.WirelessInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.WirelessInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.WirelessInterfaceTest.test_interface_ipv6_options) ... skipped 'not supported'
test_interface_mtu (__main__.WirelessInterfaceTest.test_interface_mtu) ... skipped 'not supported'
test_ipv6_link_local_address (__main__.WirelessInterfaceTest.test_ipv6_link_local_address) ... skipped 'not supported'
test_mtu_1200_no_ipv6_interface (__main__.WirelessInterfaceTest.test_mtu_1200_no_ipv6_interface) ... skipped 'not supported'
test_span_mirror (__main__.WirelessInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.WirelessInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.WirelessInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.WirelessInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.WirelessInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.WirelessInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.WirelessInterfaceTest.test_vif_s_protocol_change) ... ok
test_wireless_access_point_bridge (__main__.WirelessInterfaceTest.test_wireless_access_point_bridge) ... ok
test_wireless_add_single_ip_address (__main__.WirelessInterfaceTest.test_wireless_add_single_ip_address) ... ok
test_wireless_hostapd_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_config) ... ok
test_wireless_hostapd_wpa_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_wpa_config) ... ok
test_wireless_security_station_address (__main__.WirelessInterfaceTest.test_wireless_security_station_address) ... ok

----------------------------------------------------------------------
Ran 28 tests in 206.892s

OK (skipped=9)
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
