### PR TITLE
sstp: T4393: Add support to configure host-name (SNI)

### DIFF
--- a/data/templates/accel-ppp/sstp.config.j2
+++ b/data/templates/accel-ppp/sstp.config.j2
@@ -42,6 +42,9 @@ accept=ssl
 ssl-ca-file=/run/accel-pppd/sstp-ca.pem
 ssl-pemfile=/run/accel-pppd/sstp-cert.pem
 ssl-keyfile=/run/accel-pppd/sstp-cert.key
+{% if host_name is vyos_defined %}
+host-name={{ host_name }}
+{% endif %}
 {% if default_pool is vyos_defined %}
 ip-pool={{ default_pool }}
 {% endif %}

--- a/interface-definitions/vpn_sstp.xml.in
+++ b/interface-definitions/vpn_sstp.xml.in
@@ -53,6 +53,15 @@
           #include <include/accel-ppp/wins-server.xml.i>
           #include <include/generic-description.xml.i>
           #include <include/name-server-ipv4-ipv6.xml.i>
+          <leafNode name="host-name">
+            <properties>
+              <help>Only allow connection to specified host with the same TLS SNI</help>
+              <constraint>
+                #include <include/constraint/host-name.xml.i>
+              </constraint>
+              <constraintErrorMessage>Host-name must be alphanumeric and can contain hyphens</constraintErrorMessage>
+            </properties>
+          </leafNode>
         </children>
       </node>
     </children>

--- a/smoketest/scripts/cli/test_vpn_sstp.py
+++ b/smoketest/scripts/cli/test_vpn_sstp.py
@@ -75,6 +75,16 @@ class TestVPNSSTPServer(BasicAccelPPPTest.TestCase):
         config = read_file(self._config_file)
         self.assertIn(f'port={port}', config)
 
+    def test_sstp_host_name(self):
+        host_name = 'test.vyos.io'
+        self.set(['host-name', host_name])
+
+        self.basic_config()
+        self.cli_commit()
+
+        config = read_file(self._config_file)
+        self.assertIn(f'host-name={host_name}', config)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
sstp: Add support to configure host-name (SNI)
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T4393

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-documentation/pull/1432
 
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vpn sstp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set vpn sstp host-name example.vyos.io
commit

vyos@vyos# cat /run/accel-pppd/sstp.conf | grep host-name
host-name=example.vyos.io
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# /usr/libexec/vyos/tests/smoke/cli/test_vpn_sstp.py
test_accel_ipv4_pool (__main__.TestVPNSSTPServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestVPNSSTPServer.test_accel_ipv6_pool) ... ok
test_accel_limits (__main__.TestVPNSSTPServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestVPNSSTPServer.test_accel_local_authentication) ... ok
test_accel_name_servers (__main__.TestVPNSSTPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNSSTPServer.test_accel_next_pool) ... ok
test_accel_ppp_options (__main__.TestVPNSSTPServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestVPNSSTPServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestVPNSSTPServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestVPNSSTPServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestVPNSSTPServer.test_accel_wins_server) ... ok
test_sstp_host_name (__main__.TestVPNSSTPServer.test_sstp_host_name) ... ok

----------------------------------------------------------------------
Ran 12 tests in 67.336s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
