### PR TITLE
webproxy: T6328: Add a warning message about deprecation of web proxy URL filtering

### DIFF
--- a/src/conf_mode/service_webproxy.py
+++ b/src/conf_mode/service_webproxy.py
@@ -27,7 +27,7 @@ from vyos.utils.permission import chmod_755
 from vyos.utils.dict import dict_search
 from vyos.utils.file import write_file
 from vyos.utils.network import is_addr_assigned
-from vyos.base import Warning
+from vyos.base import Warning, DeprecationWarning
 from vyos import ConfigError
 from vyos import airbag
 
@@ -219,6 +219,9 @@ def generate(proxy):
                 for category, list_type in cat_dict.items():
                     generate_sg_rule_localdb(category, list_type, rule, proxy)
                 check_blacklist_categorydb(rule_config_section)
+
+        DeprecationWarning('URL filtering with SquidGuard is deprecated and '
+                           'will be removed in the future VyOS versions.')
 
     return None
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add a warning message about deprecation of web proxy URL filtering
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Deprecation warning

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6328
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
service webproxy
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set service webproxy listen-address 192.168.122.14
set service webproxy url-filtering squidguard block-category 'ads'
commit

vyos@vyos# commit
[ service webproxy ]

WARNING: DB of category ads does not exist.
 Use [update webproxy blacklists] or delete undefined category!


DEPRECATION WARNING: URL filtering with SquidGuard is deprecated and
will be removed in the future VyOS versions.

```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# /usr/libexec/vyos/tests/smoke/cli/test_service_webproxy.py
test_01_basic_proxy (__main__.TestServiceWebProxy.test_01_basic_proxy) ... ok
test_02_advanced_proxy (__main__.TestServiceWebProxy.test_02_advanced_proxy) ... ok
test_03_ldap_proxy_auth (__main__.TestServiceWebProxy.test_03_ldap_proxy_auth) ... ok
test_04_cache_peer (__main__.TestServiceWebProxy.test_04_cache_peer) ... ok
test_05_basic_squidguard (__main__.TestServiceWebProxy.test_05_basic_squidguard) ... ok

----------------------------------------------------------------------
Ran 5 tests in 184.114s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
