### PR TITLE
T6329: firewall: add a patch for op-mode command <show firewall group>

### DIFF
--- a/src/op_mode/firewall.py
+++ b/src/op_mode/firewall.py
@@ -531,9 +531,15 @@ def show_firewall_group(name=None):
                             continue
 
                         for idx, member in enumerate(members):
-                            val = member.get('val', 'N/D')
-                            timeout = str(member.get('timeout', 'N/D'))
-                            expires = str(member.get('expires', 'N/D'))
+                            if type(member) == str:
+                                # Only member, and no timeout:
+                                val = member
+                                timeout = "N/D"
+                                expires = "N/D"
+                            else:
+                                val = member.get('val', 'N/D')
+                                timeout = str(member.get('timeout', 'N/D'))
+                                expires = str(member.get('expires', 'N/D'))
 
                             if args.detail:
                                 row.append(f'{val} (timeout: {timeout}, expires: {expires})')

--- a/src/op_mode/firewall.py
+++ b/src/op_mode/firewall.py
@@ -531,7 +531,7 @@ def show_firewall_group(name=None):
                             continue
 
                         for idx, member in enumerate(members):
-                            if type(member) == str:
+                            if isinstance(member, str):
                                 # Only member, and no timeout:
                                 val = member
                                 timeout = "N/D"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add a patch for op-mode command <show firewall group>

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6329

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Define firewall groups
```
set firewall group address-group SERVERS address '198.51.100.101'
set firewall group address-group SERVERS address '198.51.100.102'
set firewall group dynamic-group address-group ALLOWED
set firewall group dynamic-group address-group PN_01
set firewall group dynamic-group address-group PN_02
set firewall group dynamic-group address-group TEST
set firewall group interface-group LAN interface 'eth2.2001'
set firewall group interface-group LAN interface 'bon0'
set firewall group ipv6-network-group TRUSTEDv6 network '2001:db8::/64'
set firewall group network-group TRUSTEDv4 network '192.0.2.0/30'
set firewall group network-group TRUSTEDv4 network '203.0.113.128/25'
set firewall group port-group PORT-SERVERS port 'http'
set firewall group port-group PORT-SERVERS port '443'
set firewall group port-group PORT-SERVERS port '5000-5010'
```
Firewall rules that uses  groups:
```
set firewall ipv4 forward filter rule 20 action 'accept'
set firewall ipv4 forward filter rule 20 source group network-group 'TRUSTEDv4'
set firewall ipv4 forward filter rule 99921 action 'drop'
set firewall ipv4 forward filter rule 99921 source group dynamic-address-group '!ALLOWED'
set firewall ipv4 input filter default-action 'drop'
set firewall ipv4 input filter rule 2 action 'drop'
set firewall ipv4 input filter rule 2 add-address-to-group source-address address-group 'TEST'
set firewall ipv4 input filter rule 2 destination port '7777'
set firewall ipv4 input filter rule 2 protocol 'tcp'
set firewall ipv4 input filter rule 5 action 'accept'
set firewall ipv4 input filter rule 5 protocol 'icmp'
set firewall ipv4 input filter rule 10 action 'drop'
set firewall ipv4 input filter rule 10 add-address-to-group source-address address-group 'PN_01'
set firewall ipv4 input filter rule 10 add-address-to-group source-address timeout '2m'
set firewall ipv4 input filter rule 10 description 'Port_nock 01'
set firewall ipv4 input filter rule 10 destination port '9990'
set firewall ipv4 input filter rule 10 protocol 'tcp'
set firewall ipv4 input filter rule 20 action 'drop'
set firewall ipv4 input filter rule 20 add-address-to-group source-address address-group 'PN_02'
set firewall ipv4 input filter rule 20 add-address-to-group source-address timeout '3m'
set firewall ipv4 input filter rule 20 description 'Port_nock 02'
set firewall ipv4 input filter rule 20 destination port '9991'
set firewall ipv4 input filter rule 20 protocol 'tcp'
set firewall ipv4 input filter rule 20 source group dynamic-address-group 'PN_01'
set firewall ipv4 input filter rule 30 action 'drop'
set firewall ipv4 input filter rule 30 add-address-to-group source-address address-group 'ALLOWED'
set firewall ipv4 input filter rule 30 add-address-to-group source-address timeout '2h'
set firewall ipv4 input filter rule 30 description 'Port_nock 03'
set firewall ipv4 input filter rule 30 destination port '9992'
set firewall ipv4 input filter rule 30 protocol 'tcp'
set firewall ipv4 input filter rule 30 source group dynamic-address-group 'PN_02'
set firewall ipv4 input filter rule 99 action 'accept'
set firewall ipv4 input filter rule 99 description 'Port_nock 04 - Allow ssh'
set firewall ipv4 input filter rule 99 destination port '22'
set firewall ipv4 input filter rule 99 protocol 'tcp'
set firewall ipv4 input filter rule 99 source group dynamic-address-group 'ALLOWED'
set firewall ipv4 output filter rule 10 action 'accept'
set firewall ipv4 output filter rule 10 outbound-interface group '!LAN'
set firewall ipv6 input filter rule 10 action 'accept'
set firewall ipv6 input filter rule 10 source group network-group 'TRUSTEDv6'
```
After testing connections to ensure dynamic elements were added to groups, check op-mode command:
```
vyos@clear:~$ show firewall group 
Firewall Groups

Name          Type                    References              Members           Timeout    Expires
------------  ----------------------  ----------------------  ----------------  ---------  ---------
SERVERS       address_group           nat-destination-101     198.51.100.101
                                                              198.51.100.102
ALLOWED       address_group(dynamic)  ipv4-input-filter-30    192.168.0.245     7200       3973
                                                              192.168.77.39     7200       3645
PN_01         address_group(dynamic)  ipv4-input-filter-10    192.168.77.39     120        97
PN_02         address_group(dynamic)  ipv4-input-filter-20    N/D               N/D        N/D
TEST          address_group(dynamic)  ipv4-input-filter-2     192.168.0.245     N/D        N/D
                                                              192.168.77.39     N/D        N/D
LAN           interface_group         ipv4-output-filter-10   bon0
                                      nat-destination-101     eth2.2001
TRUSTEDv6     ipv6_network_group      ipv6-input-filter-10    2001:db8::/64
TRUSTEDv4     network_group           ipv4-forward-filter-20  192.0.2.0/30
                                                              203.0.113.128/25
PORT-SERVERS  port_group              route-PBR-201           443
                                      route-PBR-201           5000-5010
                                      nat-destination-101     http
vyos@clear:~$ 

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
