### PR TITLE
ethernet: T6306: add support for EVPN MH uplink/core tracking

### DIFF
--- a/interface-definitions/include/interface/evpn-mh-uplink.xml.i
+++ b/interface-definitions/include/interface/evpn-mh-uplink.xml.i
@@ -1,0 +1,8 @@
+<!-- include start from interface/evpn-mh-uplink.xml.i -->
+<leafNode name="uplink">
+  <properties>
+    <help>Uplink to the VXLAN core</help>
+    <valueless/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/interfaces_bonding.xml.in
+++ b/interface-definitions/interfaces_bonding.xml.in
@@ -102,12 +102,7 @@
                   </constraint>
                 </properties>
               </leafNode>
-              <leafNode name="uplink">
-                <properties>
-                  <help>Uplink to the VXLAN core</help>
-                  <valueless/>
-                </properties>
-              </leafNode>
+              #include <include/interface/evpn-mh-uplink.xml.i>
             </children>
           </node>
           <leafNode name="hash-policy">

--- a/interface-definitions/interfaces_ethernet.xml.in
+++ b/interface-definitions/interfaces_ethernet.xml.in
@@ -57,6 +57,14 @@
             <defaultValue>auto</defaultValue>
           </leafNode>
           #include <include/interface/eapol.xml.i>
+          <node name="evpn">
+            <properties>
+              <help>EVPN Multihoming</help>
+            </properties>
+            <children>
+              #include <include/interface/evpn-mh-uplink.xml.i>
+            </children>
+          </node>
           #include <include/interface/hw-id.xml.i>
           #include <include/interface/ipv4-options.xml.i>
           #include <include/interface/ipv6-options.xml.i>

--- a/smoketest/scripts/cli/test_interfaces_ethernet.py
+++ b/smoketest/scripts/cli/test_interfaces_ethernet.py
@@ -354,5 +354,15 @@ class EthernetInterfaceTest(BasicInterfaceTest.TestCase):
                 out = loads(out)
                 self.assertFalse(out[0]['autonegotiate'])
 
+    def test_ethtool_evpn_uplink_tarcking(self):
+        for interface in self._interfaces:
+            self.cli_set(self._base_path + [interface, 'evpn', 'uplink'])
+
+        self.cli_commit()
+
+        for interface in self._interfaces:
+            frrconfig = self.getFRRconfig(f'interface {interface}', daemon='zebra')
+            self.assertIn(f' evpn mh uplink', frrconfig)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

When all the underlay links go down the PE no longer has access to the VxLAN +overlay.

To prevent blackholing of traffic the server/ES links are protodowned on the PE. A link can be setup for uplink tracking via the following configuration:

`set interfaces ethernet eth0 evpn uplink`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6306

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/2416
* https://github.com/vyos/vyos-documentation/pull/1443

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* ethernet interface
* frr

## Proposed changes
<!--- Describe your changes in detail -->
New CLI command `set interfaces ethernet eth0 evpn uplink`

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result

<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
test_add_multiple_ip_addresses (__main__.EthernetInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.EthernetInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.EthernetInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.EthernetInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.EthernetInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.EthernetInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.EthernetInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol_support (__main__.EthernetInterfaceTest.test_eapol_support) ... ok
test_ethtool_evpn_uplink_tarcking (__main__.EthernetInterfaceTest.test_ethtool_evpn_uplink_tarcking) ... ok <-- NEW!
test_ethtool_flow_control (__main__.EthernetInterfaceTest.test_ethtool_flow_control) ... ok
test_ethtool_ring_buffer (__main__.EthernetInterfaceTest.test_ethtool_ring_buffer) ... ok
test_interface_description (__main__.EthernetInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.EthernetInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.EthernetInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.EthernetInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.EthernetInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.EthernetInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.EthernetInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_non_existing_interface (__main__.EthernetInterfaceTest.test_non_existing_interface) ... ok
test_offloading_rfs (__main__.EthernetInterfaceTest.test_offloading_rfs) ... ok
test_offloading_rps (__main__.EthernetInterfaceTest.test_offloading_rps) ... ok
test_span_mirror (__main__.EthernetInterfaceTest.test_span_mirror) ... ok
test_speed_duplex_verify (__main__.EthernetInterfaceTest.test_speed_duplex_verify) ... ok
test_vif_8021q_interfaces (__main__.EthernetInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.EthernetInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.EthernetInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.EthernetInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.EthernetInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.EthernetInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 31 tests in 299.546s

OK
```

![image](https://github.com/vyos/vyos-1x/assets/25299219/7187f65a-5614-477c-9c24-7b7cc259b1b3)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
