### PR TITLE
op mode: T3355: remove the mention of legacy non-image installations

### DIFF
--- a/python/vyos/version.py
+++ b/python/vyos/version.py
@@ -81,16 +81,14 @@ def get_full_version_data(fname=version_file):
     else:
         version_data['system_type'] = f"{hypervisor} guest"
 
-    # Get boot type, it can be livecd, installed image, or, possible, a system installed
-    # via legacy "install system" mechanism
+    # Get boot type, it can be livecd or installed image
     # In installed images, the squashfs image file is named after its image version,
     # while on livecd it's just "filesystem.squashfs", that's how we tell a livecd boot
     # from an installed image
-    boot_via = "installed image"
-    if run(""" grep -e '^overlay.*/filesystem.squashfs' /proc/mounts >/dev/null""") == 0:
+    if run(""" grep -e '^overlay.*/filesystem.squashfs' /proc/mounts >/dev/null """) == 0:
         boot_via = "livecd"
-    elif run(""" grep '^overlay /' /proc/mounts >/dev/null """) != 0:
-        boot_via = "legacy non-image installation"
+    else:
+        boot_via = "installed image"
     version_data['boot_via'] = boot_via
 
     # Get hardware details from DMI


### PR DESCRIPTION
We still have a conditional for detecting "legacy non-image installations" in `show version`. Such installations were never supported by VyOS — that check was only relevant for very old systems upgraded from Vyatta Core instances that were created with `install system` instead of `install image`. Even Vyatta Core itself dropped support for that post 6.1 (or so), so such systems certainly don't exist in the wild now.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): legacy code removal

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
