### PR TITLE
op mode: T4519: Show DUID instead of IAID_DUID

### DIFF
--- a/op-mode-definitions/dhcp.xml.in
+++ b/op-mode-definitions/dhcp.xml.in
@@ -130,7 +130,7 @@
                     <properties>
                       <help>Show DHCPv6 server leases sorted by the specified key</help>
                       <completionHelp>
-                        <list>end iaid_duid ip last_communication pool remaining state type</list>
+                        <list>end duid ip last_communication pool remaining state type</list>
                       </completionHelp>
                     </properties>
                     <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet6 --sort $6</command>

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -37,7 +37,7 @@ time_string = "%a %b %d %H:%M:%S %Z %Y"
 config = ConfigTreeQuery()
 lease_valid_states = ['all', 'active', 'free', 'expired', 'released', 'abandoned', 'reset', 'backup']
 sort_valid_inet = ['end', 'mac', 'hostname', 'ip', 'pool', 'remaining', 'start', 'state']
-sort_valid_inet6 = ['end', 'iaid_duid', 'ip', 'last_communication', 'pool', 'remaining', 'state', 'type']
+sort_valid_inet6 = ['end', 'duid', 'ip', 'last_communication', 'pool', 'remaining', 'state', 'type']
 
 ArgFamily = typing.Literal['inet', 'inet6']
 ArgState = typing.Literal['all', 'active', 'free', 'expired', 'released', 'abandoned', 'reset', 'backup']
@@ -105,7 +105,7 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[], orig
 
                 if family == 'inet6':
                     data_lease['last_communication'] = lease.last_communication.timestamp()
-                    data_lease['iaid_duid'] = _format_hex_string(lease.host_identifier_string)
+                    data_lease['duid'] = _format_hex_string(lease.duid)
                     lease_types_long = {'na': 'non-temporary', 'ta': 'temporary', 'pd': 'prefix delegation'}
                     data_lease['type'] = lease_types_long[lease.type]
 
@@ -175,11 +175,11 @@ def _get_formatted_server_leases(raw_data, family='inet'):
             remain = lease.get('remaining')
             lease_type = lease.get('type')
             pool = lease.get('pool')
-            host_identifier = lease.get('iaid_duid')
+            host_identifier = lease.get('duid')
             data_entries.append([ipaddr, state, start, end, remain, lease_type, pool, host_identifier])
 
         headers = ['IPv6 address', 'State', 'Last communication', 'Lease expiration', 'Remaining', 'Type', 'Pool',
-                   'IAID_DUID']
+                   'DUID']
 
     output = tabulate(data_entries, headers, numalign='left')
     return output


### PR DESCRIPTION
## Change Summary
Replace IAID_DUID with DUID in op command `show dhcpv6 server lease` like current does.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): change to command output

## Related Task(s)
https://vyos.dev/T4519

## Component(s) name
dhcp

## Proposed changes
List DUID instead of IAID_DUID in leases overview to make adding static mappings easier.

## How to test
Aquire a DHCPv6 lease and list the current leases with `show dhcpv6 server lease`.
Last column should be the DUID instead of IAID_DUID

## Smoketest result
Couldn't really test it as I can't custom build Sagitta anymore

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
