### PR TITLE
T6347: CGNAT fix error if pool contain dashes in the name

### DIFF
--- a/src/conf_mode/nat_cgnat.py
+++ b/src/conf_mode/nat_cgnat.py
@@ -219,8 +219,8 @@ def generate(config):
     # first external pool as we allow only one as PoC
     ext_pool_name = jmespath.search("rule.*.translation | [0]", config).get('pool')
     int_pool_name = jmespath.search("rule.*.source | [0]", config).get('pool')
-    ext_query = f"pool.external.{ext_pool_name}.range | keys(@)"
-    int_query = f"pool.internal.{int_pool_name}.range"
+    ext_query = f'pool.external."{ext_pool_name}".range | keys(@)'
+    int_query = f'pool.internal."{int_pool_name}".range'
     external_ranges = jmespath.search(ext_query, config)
     internal_ranges = [jmespath.search(int_query, config)]
 
@@ -246,10 +246,10 @@ def generate(config):
     external_host_count = sum(external_list_count)
     internal_host_count = sum(internal_list_count)
     ports_per_user = int(
-        jmespath.search(f'pool.external.{ext_pool_name}.per_user_limit.port', config)
+        jmespath.search(f'pool.external."{ext_pool_name}".per_user_limit.port', config)
     )
     external_port_range: str = jmespath.search(
-        f'pool.external.{ext_pool_name}.external_port_range', config
+        f'pool.external."{ext_pool_name}".external_port_range', config
     )
 
     proto_maps, other_maps = generate_port_rules(


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
CGNAT external pools containing dashes cause Traceback error
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6347

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
cgnat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add an external pool with dashes in the name
```
set nat cgnat pool external ext-01 external-port-range '1024-65535'
set nat cgnat pool external ext-01 per-user-limit port '2000'
set nat cgnat pool external ext-01 range 192.168.122.222/32
set nat cgnat pool internal int01 range '100.64.0.0/28'
set nat cgnat rule 10 source pool 'int01'
set nat cgnat rule 10 translation pool 'ext-01'
```
Before the fix:
```
vyos@r4# commit
[ nat cgnat ]
VyOS had an issue completing a command.

Report time:      2024-05-16 12:32:46
Image version:    VyOS 1.5-rolling-202405140019
Release train:    current

Built by:         autobuild@vyos.net
Built on:         Tue 14 May 2024 02:55 UTC
Build UUID:       c30a637d-f3c1-473e-8af6-03c9bfaf0729
Build commit ID:  3463386246a9ac

Architecture:     x86_64
Boot via:         installed image
System type:      KVM guest

Hardware vendor:  QEMU
Hardware model:   Standard PC (Q35 + ICH9, 2009)
Hardware S/N:     
Hardware UUID:    166cfd25-7d3a-4eca-9ef6-0b655c9acf0f

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/nat_cgnat.py", line 284, in <module>
    generate(c)
  File "/usr/libexec/vyos/conf_mode/nat_cgnat.py", line 224, in generate
    external_ranges = jmespath.search(ext_query, config)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/jmespath/__init__.py", line 12, in search
    return parser.Parser().parse(expression).search(data, options=options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/jmespath/parser.py", line 88, in parse
    parsed_result = self._do_parse(expression)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/jmespath/parser.py", line 96, in _do_parse
    return self._parse(expression)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/jmespath/parser.py", line 114, in _parse
    raise exceptions.ParseError(t['start'], t['value'], t['type'],
jmespath.exceptions.ParseError: Unexpected token: -1: Parse error at column 17, token "-1" (NUMBER), for expression:
"pool.external.ext-01.range | keys(@)"
                  ^



[[nat cgnat]] failed
Commit failed
```
After the fix:
```
vyos@r4# commit
[edit]
vyos@r4# sudo nft list table ip cgnat
table ip cgnat {
	map tcp_nat_map {
		type ipv4_addr : interval ipv4_addr . inet_service
		flags interval
		elements = { 100.64.0.0 : 192.168.122.222 . 1024-3023, 100.64.0.1 : 192.168.122.222 . 3024-5023,
			     100.64.0.2 : 192.168.122.222 . 5024-7023, 100.64.0.3 : 192.168.122.222 . 7024-9023,
			     100.64.0.4 : 192.168.122.222 . 9024-11023, 100.64.0.5 : 192.168.122.222 . 11024-13023,
			     100.64.0.6 : 192.168.122.222 . 13024-15023, 100.64.0.7 : 192.168.122.222 . 15024-17023,
			     100.64.0.8 : 192.168.122.222 . 17024-19023, 100.64.0.9 : 192.168.122.222 . 19024-21023,
			     100.64.0.10 : 192.168.122.222 . 21024-23023, 100.64.0.11 : 192.168.122.222 . 23024-25023,
			     100.64.0.12 : 192.168.122.222 . 25024-27023, 100.64.0.13 : 192.168.122.222 . 27024-29023,
			     100.64.0.14 : 192.168.122.222 . 29024-31023, 100.64.0.15 : 192.168.122.222 . 31024-33023 }
	}


```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
