### PR TITLE
T6351: CGNAT add verification if the pool exists

### DIFF
--- a/src/conf_mode/nat_cgnat.py
+++ b/src/conf_mode/nat_cgnat.py
@@ -203,6 +203,11 @@ def verify(config):
                     f'Range for "{pool} pool {pool_name}" must be defined!'
                 )
 
+    external_pools_query = "keys(pool.external)"
+    external_pools: list = jmespath.search(external_pools_query, config)
+    internal_pools_query = "keys(pool.internal)"
+    internal_pools: list = jmespath.search(internal_pools_query, config)
+
     for rule, rule_config in config['rule'].items():
         if 'source' not in rule_config:
             raise ConfigError(f'Rule "{rule}" source pool must be defined!')
@@ -211,6 +216,14 @@ def verify(config):
 
         if 'translation' not in rule_config:
             raise ConfigError(f'Rule "{rule}" translation pool must be defined!')
+
+        internal_pool = rule_config['source']['pool']
+        if internal_pool not in internal_pools:
+            raise ConfigError(f'Internal pool "{internal_pool}" does not exist!')
+
+        external_pool = rule_config['translation']['pool']
+        if external_pool not in external_pools:
+            raise ConfigError(f'External pool "{external_pool}" does not exist!')
 
 
 def generate(config):


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add verification if the external/internal pools are exists before we can use them in the source and translation rules
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6351

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
cgnat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Use not exists pool name in the rules (in this example `fake-pool`):
```
set nat cgnat pool external ext1 external-port-range '1024-65535'
set nat cgnat pool external ext1 per-user-limit port '2000'
set nat cgnat pool external ext1 range 192.168.122.222/32
set nat cgnat pool internal int1 range '100.64.0.0/28'

set nat cgnat rule 10 source pool 'fake-pool'
set nat cgnat rule 10 translation pool 'ext1'
```
Before the fix:
```
vyos@r4# commit
[ nat cgnat ]
VyOS had an issue completing a command.

Report time:      2024-05-16 15:23:29
Image version:    VyOS 1.5-rolling-202405140019
Release train:    current

Built by:         autobuild@vyos.net
Built on:         Tue 14 May 2024 02:55 UTC
Build UUID:       c30a637d-f3c1-473e-8af6-03c9bfaf0729
Build commit ID:  3463386246a9ac

Architecture:     x86_64
Boot via:         installed image
System type:      KVM guest

Hardware vendor:  QEMU
Hardware model:   Standard PC (Q35 + ICH9, 2009)
Hardware S/N:     
Hardware UUID:    166cfd25-7d3a-4eca-9ef6-0b655c9acf0f

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/nat_cgnat.py", line 284, in <module>
    generate(c)
  File "/usr/libexec/vyos/conf_mode/nat_cgnat.py", line 240, in generate
    i_count = IPOperations(int_range).get_ips_count()
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/libexec/vyos/conf_mode/nat_cgnat.py", line 39, in __init__
    self.ip_network = ipaddress.ip_network(ip_prefix) if '/' in ip_prefix else None
                                                         ^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable



[[nat cgnat]] failed
Commit failed
[edit]
vyos@r4#
```
After the fix:
```
vyos@r4# commit
[ nat cgnat ]
Internal pool "fake-pool" does not exist!

[[nat cgnat]] failed
Commit failed
[edit]
vyos@r4# 
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
