### PR TITLE
T6350: CGNAT add op-mode to show allocation

### DIFF
--- a/data/op-mode-standardized.json
+++ b/data/op-mode-standardized.json
@@ -3,6 +3,7 @@
 "bgp.py",
 "bonding.py",
 "bridge.py",
+"cgnat.py",
 "config_mgmt.py",
 "conntrack.py",
 "container.py",

--- a/op-mode-definitions/nat.xml.in
+++ b/op-mode-definitions/nat.xml.in
@@ -7,6 +7,19 @@
           <help>Show IPv4 Network Address Translation (NAT) information</help>
         </properties>
         <children>
+          <node name="cgnat">
+            <properties>
+              <help>Show Carrier-Grade Network Address Translation (CGNAT)</help>
+            </properties>
+            <children>
+              <node name="allocation">
+                <properties>
+                  <help>Show allocated CGNAT parameters</help>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/cgnat.py show_allocation</command>
+              </node>
+            </children>
+          </node>
           <node name="source">
             <properties>
               <help>Show source IPv4 to IPv4 Network Address Translation (NAT) information</help>

--- a/src/op_mode/cgnat.py
+++ b/src/op_mode/cgnat.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import sys
+import typing
+
+from tabulate import tabulate
+
+import vyos.opmode
+
+from vyos.configquery import ConfigTreeQuery
+from vyos.utils.process import cmd
+
+CGNAT_TABLE = 'cgnat'
+
+
+def _get_raw_data():
+    """ Get CGNAT dictionary
+    """
+    cmd_output = cmd(f'nft --json list table ip {CGNAT_TABLE}')
+    data = json.loads(cmd_output)
+    return data
+
+
+def _get_formatted_output(data):
+    elements = data['nftables'][2]['map']['elem']
+    allocations = []
+    for elem in elements:
+        internal = elem[0]  # internal
+        external = elem[1]['concat'][0]  # external
+        start_port = elem[1]['concat'][1]['range'][0]
+        end_port = elem[1]['concat'][1]['range'][1]
+        port_range = f'{start_port}-{end_port}'
+        allocations.append((internal, external, port_range))
+
+    headers = ['Internal IP', 'External IP', 'Port range']
+    output = tabulate(allocations, headers, numalign="left")
+    return output
+
+
+def show_allocation(raw: bool):
+    config = ConfigTreeQuery()
+    if not config.exists('nat cgnat'):
+        raise vyos.opmode.UnconfiguredSubsystem('CGNAT is not configured')
+
+    if raw:
+        return _get_raw_data()
+
+    else:
+        raw_data = _get_raw_data()
+        return _get_formatted_output(raw_data)
+
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except (ValueError, vyos.opmode.Error) as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add op-mode command `show nat cgnat allocation` to get CGNAT allocations (internal address, external address, port-range)
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6350

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
cgnat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set nat cgnat pool external ext01 external-port-range '1024-65535'
set nat cgnat pool external ext01 per-user-limit port '2000'
set nat cgnat pool external ext01 range 192.168.122.222/32
set nat cgnat pool internal int01 range '100.64.0.0/28'
set nat cgnat rule 10 source pool 'int01'
set nat cgnat rule 10 translation pool 'ext01'

```
Show allocation:
```
vyos@r4:~$ show nat cgnat allocation 
Internal IP    External IP      Port range
-------------  ---------------  ------------
100.64.0.0     192.168.122.222  1024-3023
100.64.0.1     192.168.122.222  3024-5023
100.64.0.2     192.168.122.222  5024-7023
100.64.0.3     192.168.122.222  7024-9023
100.64.0.4     192.168.122.222  9024-11023
100.64.0.5     192.168.122.222  11024-13023
100.64.0.6     192.168.122.222  13024-15023
100.64.0.7     192.168.122.222  15024-17023
100.64.0.8     192.168.122.222  17024-19023
100.64.0.9     192.168.122.222  19024-21023
100.64.0.10    192.168.122.222  21024-23023
100.64.0.11    192.168.122.222  23024-25023
100.64.0.12    192.168.122.222  25024-27023
100.64.0.13    192.168.122.222  27024-29023
100.64.0.14    192.168.122.222  29024-31023
100.64.0.15    192.168.122.222  31024-33023
vyos@r4:~$ 

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
