### PR TITLE
op mode: T6348: SNAT op-mode fails with flowtable offload entries

### DIFF
--- a/src/op_mode/nat.py
+++ b/src/op_mode/nat.py
@@ -263,7 +263,7 @@ def _get_formatted_translation(dict_data, nat_direction, family, verbose):
                     proto = meta['layer4']['protoname']
             if direction == 'independent':
                 conn_id = meta['id']
-                timeout = meta['timeout']
+                timeout = meta.get('timeout', 'n/a')
                 orig_src = f'{orig_src}:{orig_sport}' if orig_sport else orig_src
                 orig_dst = f'{orig_dst}:{orig_dport}' if orig_dport else orig_dst
                 reply_src = f'{reply_src}:{reply_sport}' if reply_sport else reply_src


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6348
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set firewall flowtable OFFLOAD interface 'eth0'
set firewall flowtable OFFLOAD interface 'eth1'
set firewall flowtable OFFLOAD offload 'software'

set firewall ipv4 forward filter default-action 'accept'
set firewall ipv4 forward filter rule 5 action 'offload'
set firewall ipv4 forward filter rule 5 offload-target 'OFFLOAD'
set firewall ipv4 forward filter rule 5 state 'established'
set firewall ipv4 forward filter rule 5 state 'related'

set nat cgnat pool external ext01 external-port-range '1024-65535'
set nat cgnat pool external ext01 per-user-limit port '2000'
set nat cgnat pool external ext01 range 192.168.122.222/32
set nat cgnat pool internal int01 range '100.64.0.0/28'
set nat cgnat rule 10 source pool 'int01'
set nat cgnat rule 10 translation pool 'ext01'

set nat source rule 100 outbound-interface name 'eth0'
set nat source rule 100 source address '10.0.0.0/24'
set nat source rule 100 translation address 'masquerade'

vyos@vyos# run show nat source translations
Pre-NAT           Post-NAT              Proto    Timeout    Mark    Zone
----------------  --------------------  -------  ---------  ------  ------
100.64.0.1:44704  192.168.122.222:4709  udp      27         0
100.64.0.1:47889  192.168.122.222:4038  udp      n/a         0
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
