### PR TITLE
T6358: Container config option to enable host pid

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -15,9 +15,15 @@
           <constraintErrorMessage>Container name must be alphanumeric and can contain hyphens</constraintErrorMessage>
         </properties>
         <children>
+          <leafNode name="allow-host-pid">
+            <properties>
+              <help>Allow sharing host process namespace with container</help>
+              <valueless/>
+            </properties>
+          </leafNode>
           <leafNode name="allow-host-networks">
             <properties>
-              <help>Allow host networks in container</help>
+              <help>Allow sharing host networking with container</help>
               <valueless/>
             </properties>
           </leafNode>

--- a/smoketest/config-tests/container-simple
+++ b/smoketest/config-tests/container-simple
@@ -8,5 +8,6 @@ set container name c01 capability 'net-bind-service'
 set container name c01 capability 'net-raw'
 set container name c01 image 'busybox:stable'
 set container name c02 allow-host-networks
+set container name c02 allow-host-pid
 set container name c02 capability 'sys-time'
 set container name c02 image 'busybox:stable'

--- a/smoketest/configs/container-simple
+++ b/smoketest/configs/container-simple
@@ -7,6 +7,7 @@ container {
     }
     name c02 {
         allow-host-networks
+        allow-host-pid
         cap-add sys-time
         image busybox:stable
     }

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -339,11 +339,6 @@ def generate_run_arguments(name, container_config):
         entrypoint = json_write(container_config['entrypoint'].split()).replace('"', "&quot;")
         entrypoint = f'--entrypoint &apos;{entrypoint}&apos;'
 
-    hostname = ''
-    if 'host_name' in container_config:
-        hostname = container_config['host_name']
-        hostname = f'--hostname {hostname}'
-
     command = ''
     if 'command' in container_config:
         command = container_config['command'].strip()

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -329,9 +329,13 @@ def generate_run_arguments(name, container_config):
             prop = vol_config['propagation']
             volume += f' --volume {svol}:{dvol}:{mode},{prop}'
 
+    host_pid = ''
+    if 'allow_host_pid' in container_config:
+      host_pid = '--pid host'
+
     container_base_cmd = f'--detach --interactive --tty --replace {capabilities} ' \
                          f'--memory {memory}m --shm-size {shared_memory}m --memory-swap 0 --restart {restart} ' \
-                         f'--name {name} {hostname} {device} {port} {volume} {env_opt} {label} {uid}'
+                         f'--name {name} {hostname} {device} {port} {volume} {env_opt} {label} {uid} {host_pid}'
 
     entrypoint = ''
     if 'entrypoint' in container_config:


### PR DESCRIPTION
## Change Summary
Container config option `allow-host-pid` to enable host pid

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6358

## Component(s) name
container

## How to test
Create a container with option `allow-host-pid` which should add `--pid host` to the run commands.
```
set container name c02 allow-host-networks
set container name c02 allow-host-pid
set container name c02 image 'busybox:stable'
```

## Smoketest result
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_container.py
test_basic (__main__.TestContainer.test_basic) ... ok
test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... 
IP address "192.0.2.1" can not be used for a container, reserved for the
container engine!

ok
test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... 
IP address "192.0.2.1" can not be used for a container, reserved for the
container engine!

ok
test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... 
IP address "2001:db8::1" can not be used for a container, reserved for
the container engine!

ok
test_uid_gid (__main__.TestContainer.test_uid_gid) ... 
Cannot set "gid" without "uid" for container

ok

----------------------------------------------------------------------
Ran 5 tests in 165.785s

OK
```

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
