### PR TITLE
T6354: Get rid of the custom boot type check in version.py

### DIFF
--- a/python/vyos/version.py
+++ b/python/vyos/version.py
@@ -33,11 +33,11 @@ import os
 
 import requests
 import vyos.defaults
+from vyos.system.image import is_live_boot
 
 from vyos.utils.file import read_file
 from vyos.utils.file import read_json
 from vyos.utils.process import popen
-from vyos.utils.process import run
 from vyos.utils.process import DEVNULL
 
 version_file = os.path.join(vyos.defaults.directories['data'], 'version.json')
@@ -85,7 +85,7 @@ def get_full_version_data(fname=version_file):
     # In installed images, the squashfs image file is named after its image version,
     # while on livecd it's just "filesystem.squashfs", that's how we tell a livecd boot
     # from an installed image
-    if run(""" grep -e '^overlay.*/filesystem.squashfs' /proc/mounts >/dev/null """) == 0:
+    if is_live_boot():
         boot_via = "livecd"
     else:
         boot_via = "installed image"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6354

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos:~$ show version 
Version:          VyOS 1.5-rolling-202405080016
Release train:    current

Built by:         autobuild@vyos.net
Built on:         Wed 08 May 2024 02:49 UTC
Build UUID:       c2dc10d6-bfe8-4443-8e86-b32ff261a25d
Build commit ID:  bdde6daecd46f3

Architecture:     x86_64
Boot via:         installed image
System type:      KVM guest

Hardware vendor:  QEMU
Hardware model:   Standard PC (i440FX + PIIX, 1996)
Hardware S/N:     
Hardware UUID:    a265716d-3af6-452f-bc42-a9448452fb54

Copyright:        VyOS maintainers and contributors
```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
