### PR TITLE
strip-private: T6355: rework the strip-private filter

### DIFF
--- a/src/helpers/strip-private.py
+++ b/src/helpers/strip-private.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Copyright 2021-2023 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2021-2024 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -15,139 +15,191 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-import argparse
-import re
 import sys
+import copy
 
-from netaddr import IPNetwork, AddrFormatError
+import vyos.configtree
 
-parser = argparse.ArgumentParser(description='strip off private information from VyOS config')
 
-strictness = parser.add_mutually_exclusive_group()
-strictness.add_argument('--loose', action='store_true', help='remove only information specified as arguments')
-strictness.add_argument('--strict', action='store_true', help='remove any private information (implies all arguments below). This is the default behavior.')
+def anonymize_password(v):
+    return "<PASSWORD REDACTED>"
 
-parser.add_argument('--mac', action='store_true', help='strip off MAC addresses')
-parser.add_argument('--hostname', action='store_true', help='strip off system host and domain names')
-parser.add_argument('--username', action='store_true', help='strip off user names')
-parser.add_argument('--dhcp', action='store_true', help='strip off DHCP shared network and static mapping names')
-parser.add_argument('--domain', action='store_true', help='strip off domain names')
-parser.add_argument('--asn', action='store_true', help='strip off BGP ASNs')
-parser.add_argument('--snmp', action='store_true', help='strip off SNMP location information')
-parser.add_argument('--lldp', action='store_true', help='strip off LLDP location information')
+def anonymize_key(v):
+    return "<KEY DATA REDACTED>"
 
-address_preserval = parser.add_mutually_exclusive_group()
-address_preserval.add_argument('--address', action='store_true', help='strip off all IPv4 and IPv6 addresses')
-address_preserval.add_argument('--public-address', action='store_true', help='only strip off public IPv4 and IPv6 addresses')
-address_preserval.add_argument('--keep-address', action='store_true', help='preserve all IPv4 and IPv6 addresses')
+def anonymize_data(v):
+    return "<DATA REDACTED>"
 
-# Censor the first half of the address.
-ipv4_re = re.compile(r'(\d{1,3}\.){2}(\d{1,3}\.\d{1,3})')
-ipv4_subst = r'xxx.xxx.\2'
 
-# Censor all but the first two fields.
-ipv6_re = re.compile(r'([0-9a-fA-F]{1,4}\:){2}([0-9a-fA-F:]+)')
-ipv6_subst = r'xxxx:xxxx:\2'
+secret_paths = [
+  # System user password hashes
+  {"base_path": ['system', 'login', 'user'], "secret_path": ["authentication", "encrypted-password"], "func": anonymize_password},
 
-def ip_match(match: re.Match, subst: str) -> str:
+  # PKI data
+  {"base_path": ["pki", "ca"], "secret_path": ["private", "key"], "func": anonymize_key},
+  {"base_path": ["pki", "ca"], "secret_path": ["certificate"], "func": anonymize_key},
+  {"base_path": ["pki", "ca"], "secret_path": ["crl"], "func": anonymize_key},
+  {"base_path": ["pki", "certificate"], "secret_path": ["private", "key"], "func": anonymize_key},
+  {"base_path": ["pki", "certificate"], "secret_path": ["certificate"], "func": anonymize_key},
+  {"base_path": ["pki", "certificate"], "secret_path": ["acme", "email"], "func": anonymize_data},
+  {"base_path": ["pki", "key-pair"], "secret_path": ["private", "key"], "func": anonymize_key},
+  {"base_path": ["pki", "key-pair"], "secret_path": ["public", "key"], "func": anonymize_key},
+  {"base_path": ["pki", "openssh"], "secret_path": ["private", "key"], "func": anonymize_key},
+  {"base_path": ["pki", "openssh"], "secret_path": ["public", "key"], "func": anonymize_key},
+  {"base_path": ["pki", "openvpn", "shared-secret"], "secret_path": ["key"], "func": anonymize_key},
+  {"base_path": ["pki", "dh"], "secret_path": ["parameters"], "func": anonymize_key},
+
+  # IPsec pre-shared secrets
+  {"base_path": ['vpn', 'ipsec', 'authentication', 'psk'], "secret_path": ["secret"], "func": anonymize_password},
+
+  # IPsec x509 passphrases
+  {"base_path": ['vpn', 'ipsec', 'site-to-site', 'peer'], "secret_path": ['authentication', 'x509'], "func": anonymize_password},
+
+  # IPsec remote-access secrets and passwords
+  {"base_path": ["vpn", "ipsec", "remote-access", "connection"], "secret_path": ["authentication", "pre-shared-secret"], "func": anonymize_password},
+  # Passwords in remote-access IPsec local users have their own fixup
+  # due to deeper nesting.
+
+  # PPTP passwords
+  {"base_path": ['vpn', 'pptp', 'remote-access', 'authentication', 'local-users', 'username'], "secret_path": ['password'], "func": anonymize_password},
+
+  # L2TP passwords
+  {"base_path": ['vpn', 'l2tp', 'remote-access', 'authentication', 'local-users', 'username'], "secret_path": ['password'], "func": anonymize_password},
+  {"path": ['vpn', 'l2tp', 'remote-access', 'ipsec-settings', 'authentication', 'pre-shared-secret'], "func": anonymize_password},
+
+  # SSTP passwords
+  {"base_path": ['vpn', 'sstp', 'remote-access', 'authentication', 'local-users', 'username'], "secret_path": ['password'], "func": anonymize_password},
+
+  # OpenConnect passwords
+  {"base_path": ['vpn', 'openconnect', 'authentication', 'local-users', 'username'], "secret_path": ['password'], "func": anonymize_password},
+
+  # PPPoE server passwords
+  {"base_path": ['service', 'pppoe-server', 'authentication', 'local-users', 'username'], "secret_path": ['password'], "func": anonymize_password},
+
+  # RADIUS PSKs for VPN services
+  {"base_path": ["vpn", "sstp", "authentication", "radius", "server"], "secret_path": ["key"], "func": anonymize_password},
+  {"base_path": ["vpn", "l2tp", "authentication", "radius", "server"], "secret_path": ["key"], "func": anonymize_password},
+  {"base_path": ["vpn", "pptp", "authentication", "radius", "server"], "secret_path": ["key"], "func": anonymize_password},
+  {"base_path": ["vpn", "openconnect", "authentication", "radius", "server"], "secret_path": ["key"], "func": anonymize_password},
+  {"base_path": ["service", "ipoe-server", "authentication", "radius", "server"], "secret_path": ["key"], "func": anonymize_password},
+  {"base_path": ["service", "pppoe-server", "authentication", "radius", "server"], "secret_path": ["key"], "func": anonymize_password},
+
+  # VRRP passwords
+  {"base_path": ['high-availability', 'vrrp', 'group'], "secret_path": ['authentication', 'password'], "func": anonymize_password},
+
+  # BGP neighbor and peer group passwords
+  {"base_path": ['protocols', 'bgp', 'neighbor'], "secret_path": ["password"], "func": anonymize_password},
+  {"base_path": ['protocols', 'bgp', 'peer-group'], "secret_path": ["password"], "func": anonymize_password},
+
+  # WireGuard private keys
+  {"base_path": ["interfaces", "wireguard"], "secret_path": ["private-key"], "func": anonymize_password},
+
+  # NHRP passwords
+  {"base_path": ["protocols", "nhrp", "tunnel"], "secret_path": ["cisco-authentication"], "func": anonymize_password},
+
+  # RIP passwords
+  {"base_path": ["protocols", "rip", "interface"], "secret_path": ["authentication", "plaintext-password"], "func": anonymize_password},
+
+  # IS-IS passwords
+  {"path": ["protocols", "isis", "area-password", "plaintext-password"], "func": anonymize_password},
+  {"base_path": ["protocols", "isis", "interface"], "secret_path": ["password", "plaintext-password"], "func": anonymize_password},
+
+  # HTTP API servers
+  {"base_path": ["service", "https", "api", "keys", "id"], "secret_path": ["key"], "func": anonymize_password},
+
+  # Telegraf
+  {"path": ["service", "monitoring", "telegraf", "prometheus-client", "authentication", "password"], "func": anonymize_password},
+  {"path": ["service", "monitoring", "telegraf", "influxdb", "authentication", "token"], "func": anonymize_password},
+  {"path": ["service", "monitoring", "telegraf", "azure-data-explorer", "authentication", "client-secret"], "func": anonymize_password},
+  {"path": ["service", "monitoring", "telegraf", "splunk", "authentication", "token"], "func": anonymize_password},
+
+  # SNMPv3 passwords
+  {"base_path": ["service", "snmp", "v3", "user"], "secret_path": ["privacy", "encrypted-password"], "func": anonymize_password},
+  {"base_path": ["service", "snmp", "v3", "user"], "secret_path": ["privacy", "plaintext-password"], "func": anonymize_password},
+  {"base_path": ["service", "snmp", "v3", "user"], "secret_path": ["auth", "encrypted-password"], "func": anonymize_password},
+  {"base_path": ["service", "snmp", "v3", "user"], "secret_path": ["auth", "encrypted-password"], "func": anonymize_password},
+]
+
+def prepare_secret_paths(config_tree, secret_paths):
+    """ Generate a list of secret paths for the current system,
+        adjusted for variable parts such as VRFs and remote access IPsec instances
     """
-    Take a Match and a substitution pattern, check if the match contains a valid IP address, strip
-    information if it is. This routine is intended to be passed to `re.sub' as a replacement pattern.
-    """
-    result = match.group(0)
-    # Is this a valid IP address?
+
+    # Fixup for remote-access IPsec local users that are nested under two tag nodes
+    # We generate the list of their paths dynamically
+    ipsec_ra_base = {"base_path": ["vpn", "ipsec", "remote-access", "connection"], "func": anonymize_password}
+    if config_tree.exists(ipsec_ra_base["base_path"]):
+        for conn in config_tree.list_nodes(ipsec_ra_base["base_path"]):
+            if config_tree.exists(ipsec_ra_base["base_path"] + [conn] + ["authentication", "local-users", "username"]):
+                for u in config_tree.list_nodes(ipsec_ra_base["base_path"] + [conn] + ["authentication", "local-users", "username"]):
+                    p = copy.copy(ipsec_ra_base)
+                    p["base_path"] = p["base_path"] + [conn] + ["authentication", "local-users", "username"]
+                    p["secret_path"] = ["password"]
+                    secret_paths.append(p)
+
+    # Fixup for VRFs that may contain routing protocols and other nodes nested under them
+    vrf_paths = []
+    vrf_base_path = ["vrf", "name"]
+    if config_tree.exists(vrf_base_path):
+        for v in config_tree.list_nodes(vrf_base_path):
+            vrf_secret_paths = copy.deepcopy(secret_paths)
+            for sp in vrf_secret_paths:
+                if "base_path" in sp:
+                    sp["base_path"] = vrf_base_path + [v] + sp["base_path"]
+                elif "path" in sp:
+                    sp["path"] = vrf_base_path + [v] + sp["path"]
+                vrf_paths.append(sp)
+
+    secret_paths = secret_paths + vrf_paths
+
+    # Fixup for user SSH keys, that are nested under a tag node
+    #ssh_key_base_path = {"base_path": ['system', 'login', 'user'], "secret_path": ["authentication", "encrypted-password"], "func": anonymize_password},
+    user_base_path = ['system', 'login', 'user']
+    ssh_key_paths = []
+    if config_tree.exists(user_base_path):
+        for u in config_tree.list_nodes(user_base_path):
+            kp = {"base_path": user_base_path + [u, "authentication", "public-keys"], "secret_path": ["key"], "func": anonymize_key}
+            ssh_key_paths.append(kp)
+
+    secret_paths = secret_paths + ssh_key_paths
+
+    return secret_paths
+
+def strip_private(ct, secret_paths):
+    for sp in secret_paths:
+        if "base_path" in sp:
+            if ct.exists(sp["base_path"]):
+                for n in ct.list_nodes(sp["base_path"]):
+                    if ct.exists(sp["base_path"] + [n] + sp["secret_path"]):
+                        secret = ct.return_value(sp["base_path"] + [n] + sp["secret_path"])
+                        ct.set(sp["base_path"] + [n] + sp["secret_path"], value=sp["func"](secret))
+        elif "path" in sp:
+            if ct.exists(sp["path"]):
+                secret = ct.return_value(sp["path"])
+                ct.set(sp["path"], value=sp["func"](secret))
+        else:
+            raise ValueError("Malformed secret path dict, has neither base_path nor path in it ")
+
+
+    return ct.to_string()
+
+def read_input():
     try:
-        addr = IPNetwork(result).ip
-    # No? Then we've got nothing to do with it.
-    except AddrFormatError:
-        return result
-    # Should we strip it?
-    if args.address or (args.public_address and not addr.is_private()):
-        return match.expand(subst)
-    # No? Then we'll leave it as is.
-    else:
-        return result
-
-def strip_address(line: str) -> str:
-    """
-    Strip IPv4 and IPv6 addresses from the given string.
-    """
-    return ipv4_re.sub(lambda match: ip_match(match, ipv4_subst), ipv6_re.sub(lambda match: ip_match(match, ipv6_subst), line))
-
-def strip_lines(rules: tuple) -> None:
-    """
-    Read stdin line by line and apply the given stripping rules.
-    """
-    try:
-        for line in sys.stdin:
-            if not args.keep_address:
-                line = strip_address(line)
-            for (condition, regexp, subst) in rules:
-                if condition:
-                    line = regexp.sub(subst, line)
-            print(line, end='')
+        return sys.stdin.read()
     # stdin can be cut for any reason, such as user interrupt or the pager terminating before the text can be read.
     # All we can do is gracefully exit.
     except (BrokenPipeError, EOFError, KeyboardInterrupt):
         sys.exit(1)
 
 if __name__ == "__main__":
-    args = parser.parse_args()
-    # Strict mode is the default and the absence of loose mode implies presence of strict mode.
-    if not args.loose:
-        args.mac = args.domain = args.hostname = args.username = args.dhcp = args.asn = args.snmp = args.lldp = True
-        if not args.public_address and not args.keep_address:
-            args.address = True
-    elif not args.address and not args.public_address:
-        args.keep_address = True
-
-    # (condition, precompiled regexp, substitution string)
-    stripping_rules = [
-        # Strip passwords
-        (True, re.compile(r'password \S+'), 'password xxxxxx'),
-        (True, re.compile(r'cisco-authentication \S+'), 'cisco-authentication xxxxxx'),
-        # Strip public key information
-        (True, re.compile(r'public-keys \S+'), 'public-keys xxxx@xxx.xxx'),
-        (True, re.compile(r'type \'ssh-(rsa|dss)\''), 'type ssh-xxx'),
-        (True, re.compile(r' key \S+'), ' key xxxxxx'),
-        # Strip bucket
-        (True, re.compile(r' bucket \S+'), ' bucket xxxxxx'),
-        # Strip tokens
-        (True, re.compile(r' token \S+'), ' token xxxxxx'),
-        # Strip OpenVPN secrets
-        (True, re.compile(r'(shared-secret-key-file|ca-cert-file|cert-file|dh-file|key-file|client) (\S+)'), r'\1 xxxxxx'),
-        # Strip IPSEC secrets
-        (True, re.compile(r'pre-shared-secret \S+'), 'pre-shared-secret xxxxxx'),
-        (True, re.compile(r'secret \S+'), 'secret xxxxxx'),
-        # Strip OSPF md5-key
-        (True, re.compile(r'md5-key \S+'), 'md5-key xxxxxx'),
-        # Strip WireGuard private-key
-        (True, re.compile(r'private-key \S+'), 'private-key xxxxxx'),
-
-        # Strip MAC addresses
-        (args.mac, re.compile(r'([0-9a-fA-F]{2}\:){5}([0-9a-fA-F]{2}((\:{0,1})){3})'), r'xx:xx:xx:xx:xx:\2'),
-
-        # Strip host-name, domain-name, domain-search and url
-        (args.hostname, re.compile(r'(host-name|domain-name|domain-search|url) \S+'), r'\1 xxxxxx'),
-
-        # Strip user-names
-        (args.username, re.compile(r'(user|username|user-id) \S+'), r'\1 xxxxxx'),
-        # Strip full-name
-        (args.username, re.compile(r'(full-name) [ -_A-Z a-z]+'), r'\1 xxxxxx'),
-
-        # Strip DHCP static-mapping and shared network names
-        (args.dhcp, re.compile(r'(shared-network-name|static-mapping) \S+'), r'\1 xxxxxx'),
-
-        # Strip host/domain names
-        (args.domain, re.compile(r' (peer|remote-host|local-host|server) ([\w-]+\.)+[\w-]+'), r' \1 xxxxx.tld'),
-
-        # Strip BGP ASNs
-        (args.asn, re.compile(r'(bgp|remote-as) (\d+)'), r'\1 XXXXXX'),
-
-        # Strip LLDP location parameters
-        (args.lldp, re.compile(r'(altitude|datum|latitude|longitude|ca-value|country-code) (\S+)'), r'\1 xxxxxx'),
-
-        # Strip SNMP location
-        (args.snmp, re.compile(r'(location) \S+'), r'\1 xxxxxx'),
-    ]
-    strip_lines(stripping_rules)
+    try:
+        config_source = read_input()
+        config_tree = vyos.configtree.ConfigTree(config_source)
+        secret_paths = prepare_secret_paths(config_tree, secret_paths)
+        stripped_config = strip_private(config_tree, secret_paths)
+        print(stripped_config)
+    except ValueError:
+        # Most definitely caused by trying to run the filter
+        # on something else than a config
+        print('strip-private filter error: could not parse the input as a VyOS config', file=sys.stderr)
+        print('Hint: if want to see your config as commands, run "show | strip-private | commands"', file=sys.stderr)


### PR DESCRIPTION
The original `| strip-private` has two issues:

1. It removes _way_ too much: replacing every IP address with `xx.xx.10.20` makes it impossible to make any sense of what's going on. The script has options to only strip specific things, but they were never exposed in the CLI.
2. It uses regexes, which can lead to false positives and unintentionally remove absolutely non-secret data.

In the future, "secret" will be a property of the node in the config tree and "strip private" will be a feature of the config rendered. But for now we can at least:

* Only remove passwords and private keys.
* Use an explicit list of secret paths.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): behavior change.


## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

strip-private filter.

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

My test config:

```
vyos@vyos# show | strip-private 
high-availability {
    vrrp {
        group Foo {
            address 10.4.0.1/24 {
            }
            authentication {
                password "<PASSWORD REDACTED>"
                type "plaintext-password"
            }
            interface "eth0"
            vrid "100"
        }
    }
}
interfaces {
    ethernet eth0 {
        address "dhcp"
        hw-id "08:00:27:64:ce:12"
    }
    ethernet eth1 {
        hw-id "08:00:27:7b:d1:70"
    }
    ethernet eth2 {
        hw-id "08:00:27:0c:45:17"
    }
    loopback lo {
    }
}
pki {
    ca foo {
        certificate "MIIDnTCCAoWgAwIBAgIUFG50M50A+IY23eL0LbAWClg8nqEwDQYJKoZIhvcNAQELBQAwVzELMAkGA1UEBhMCR0IxEzARBgNVBAgMClNvbWUtU3RhdGUxEjAQBgNVBAcMCVNvbWUtQ2l0eTENMAsGA1UECgwEVnlPUzEQMA4GA1UEAwwHdnlvcy5pbzAeFw0yNDA1MTYyMjEzMjhaFw0yOTA1MTUyMjEzMjhaMFcxCzAJBgNVBAYTAkdCMRMwEQYDVQQIDApTb21lLVN0YXRlMRIwEAYDVQQHDAlTb21lLUNpdHkxDTALBgNVBAoMBFZ5T1MxEDAOBgNVBAMMB3Z5b3MuaW8wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDBaO/ljzvAhPpk56owvQJu0Cmz/1wxY/ap3zBofSBq00zXfaZwO6xSS5ekjp/xhq1vyJ5Nfv03cVlq3prW4yN8fo6vel1MdWmxXVGMtstHb+7DRgLK/hgfnk0M2qbl9XIonTMP9tX1c6N8vbtUgOcaHUNVYeygezC145kTjS5uo24RRYWeJXakITYcYIrGU5UUVNGAx+cJpAz4DPR3LJAT1WWhWMW0jkIDXuIj8BmrHgyvlrTXmj1XvXcBQ1j3M/vwbLYPhcJnzwfgjwD37H6Z/Al2RReynYDSsxN4UcZE5IE0sUeGWdfdqZmhpdFMol9Gv72IKXxGrBc4t7QyYXq5AgMBAAGjYTBfMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgGGMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAdBgNVHQ4EFgQUBeNzDtl5bcr/CeGBGuFROABPpIkwDQYJKoZIhvcNAQELBQADggEBABMW74QnzBgmOHGmxtTpmehSAgBGSSpghgYw9mlLdY7cIJ4rRSp1jVcU0yaiBKjkzfMRTuuVzXV7O2Ux1J2HsmSQYHfpAL/H0CIu87is0DiAuFAhaBRyWirccipL27M4BikFGLuAfpo2gB+aBNYDXl6e7cAR4YeQvENp2K1iOe8iT5CheQgHUKpsXo0UYKv6+a+WxMpkAxY/a7onUjP4sh/8Swi0c4bYvJupbbSzgCYr09hgBCLRQjzA8tcWsmG3iCzvfs48h0/uXmS6e/qsAPykjTHF26pnzGr9/cyUnNURgQrOXGsQGmqMkUVy5tIMnUTE2bKPBQ///fTl6eGU6NI="
        private {
            key "<KEY DATA REDACTED>"
        }
    }
    key-pair test {
        private {
            key "<KEY DATA REDACTED>"
        }
        public {
            key "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAw1SxRlVk11uAMirhE3vlDXT8rtCDNDZW2k3qidZ8dvYiXkUlEhEntAGwQSTD7uH62jZm+NDipH4SlHES+vcFF9EnkKF/pDvIpt6hYHrkU+pylyH23QjLkV/OE05xhkMqw+eU47Te6MZj4YM0pIk3HdoYDmbYGCI4qXN04tV1IYrYNg0rWALRSI5vR680iamAUTWJAuCA7d0k3uenD+5qNAGqeXbD5+X8DzP/+dEu4zsBNC9zk/oN+uWBhC3OZElVAgMTDszvISimpffmV+QEWSO+1hc9Yl/WRMN6pwD0peqi4BMAp4UnpZLcRARBusQgXSdho4esXxizNTYsbe0kRQIDAQAB"
        }
    }
    openvpn {
        shared-secret ovpn-test {
            key "<KEY DATA REDACTED>"
            version "1"
        }
    }
}
protocols {
    isis {
        area-password {
            plaintext-password "<PASSWORD REDACTED>"
        }
        interface eth0 {
            password {
                plaintext-password "<PASSWORD REDACTED>"
            }
        }
        net "49.0001.1921.6800.1002.00"
    }
    rip {
        interface eth0 {
            authentication {
                plaintext-password "<PASSWORD REDACTED>"
            }
        }
    }
}
service {
    https {
        api {
            keys {
                id Foo {
                    key "<PASSWORD REDACTED>"
                }
            }
        }
    }
    monitoring {
        telegraf {
            prometheus-client {
                authentication {
                    password "<PASSWORD REDACTED>"
                    username "admin"
                }
            }
        }
    }
    ntp {
        allow-client {
            address "127.0.0.0/8"
            address "169.254.0.0/16"
            address "10.0.0.0/8"
            address "172.16.0.0/12"
            address "192.168.0.0/16"
            address "::1/128"
            address "fe80::/10"
            address "fc00::/7"
        }
        server time1.vyos.net {
        }
        server time2.vyos.net {
        }
        server time3.vyos.net {
        }
    }
    pppoe-server {
        authentication {
            local-users {
                username user {
                    password "<PASSWORD REDACTED>"
                }
            }
        }
        client-ip-pool Foo {
            range "10.4.0.0-10.4.0.10"
        }
        default-pool "Foo"
        interface eth1 {
        }
    }
    ssh
}
system {
    config-management {
        commit-revisions "100"
    }
    conntrack {
        modules {
            ftp
            h323
            nfs
            pptp
            sip
            sqlnet
            tftp
        }
    }
    console {
        device ttyS0 {
            speed "115200"
        }
    }
    host-name "vyos"
    login {
        user vyos {
            authentication {
                encrypted-password "<PASSWORD REDACTED>"
                plaintext-password ""
                public-keys ssh-test {
                    key "AAAAB3NzaC1yc2EAAAADAQABAAABAQCzWd3tvQlzPo68BFQzJ4iEDHH94D0x2c0MT5+9F0qPZuJyEV+ATyRf7Z80ijLxNHeoIE/bBkQVpL84a8FJO0DRqbzxt/oFi88ZPlrqhcjpj39q92a3ZAh2FGq5wEQ1HQ2zjSrLEKhSMqgSipr+iR8Kaazyv8tZ1m8yNchA0G33uxSf8dahJXfbmPA2vEsH0CiwuEpLpZXbNY2W3EFcwwuz+K5Lln+zWBlizytjbUSQGWmmcGFLKQ8YdSLtFz/PxRhBuk9ja74a36XZeZvC9E77Zmdbh1qsGEaW5SYozJS+jSOUCeY9MBEMPkGSC745Bmu6+yngmBxdYLPwkl0S1hOb"
                    type "ssh-rsa"
                }
                public-keys ssh-test-2 {
                    key "AAAAB3NzaC1yc2EAAAADAQABAAABAQCrohI5nQ3CDc6eFMZn2Zzrks1Yl4cz6DvJPD4vni8vXJCo89Oc8bdTTvkUTPVmMligqYzsYfTPv9WoD8dP5RT4FR/4ZUCAwWz2xwqwi07e3fu/qbMYOYzPbqHHwYsMzsKzgXgjSnFKyj8MAIJQs2QX4GbsxF71kQI/zukWNlArK10nCLOWZFCAllUvXOr9bbSezM18Q362nzhxuGucBPjyZJhL8WOMHTVWT85e5KYshT110oo3FWC5ahulfbi805BldJRZuu9loTOAgENai9Jl8ARxD9vC8pTJtakaDn3tnQd09F1OCOGni6aSvw0X0IipnfFzezMtcJitkL0FZRIb"
                    type "ssh-rsa"
                }
            }
        }
    }
    syslog {
        global {
            facility all {
                level "info"
            }
            facility local7 {
                level "debug"
            }
        }
    }
}
vpn {
    ipsec {
        authentication {
            psk Foo {
                id "192.0.2.1"
                secret "<PASSWORD REDACTED>"
            }
        }
        esp-group Foo {
            proposal 1 {
                encryption "3des"
                hash "md5"
            }
        }
        ike-group Foo {
            key-exchange "ikev2"
            proposal 1 {
                encryption "3des"
                hash "md5"
            }
        }
        remote-access {
            connection Bar {
                authentication {
                    local-users {
                        username dmb {
                            password "<PASSWORD REDACTED>"
                        }
                    }
                    pre-shared-secret "<PASSWORD REDACTED>"
                    server-mode "pre-shared-secret"
                }
                esp-group "Foo"
                ike-group "Foo"
                local-address "192.168.56.107"
            }
        }
    }
    l2tp {
        remote-access {
            authentication {
                local-users {
                    username dmbaturin {
                        password "<PASSWORD REDACTED>"
                    }
                }
            }
            client-ip-pool Foo {
                range "10.2.0.0-10.2.0.10"
            }
            default-pool "Foo"
            ipsec-settings {
                authentication {
                    mode "pre-shared-secret"
                    pre-shared-secret "<PASSWORD REDACTED>"
                }
                esp-group "Foo"
                ike-group "Foo"
            }
            outside-address "192.168.56.107"
        }
    }
    pptp {
        remote-access {
            authentication {
                local-users {
                    username dmbaturin {
                        password "<PASSWORD REDACTED>"
                    }
                }
            }
            client-ip-pool Foo {
                range "10.0.0.0-10.0.0.10"
            }
            default-pool "Foo"
        }
    }
}
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
