### PR TITLE
nat: T6365: remove warnings for negated interface selections by name

### DIFF
--- a/src/conf_mode/nat.py
+++ b/src/conf_mode/nat.py
@@ -151,7 +151,7 @@ def verify(nat):
                 elif 'name' in config['outbound_interface']:
                     interface_name = config['outbound_interface']['name']
                     if interface_name not in 'any':
-                        if interface_name[0] == '!':
+                        if interface_name.startswith('!'):
                             interface_name = interface_name[1:]
                         if interface_name not in interfaces():
                             Warning(f'NAT interface "{interface_name}" for source NAT rule "{rule}" does not exist!')
@@ -188,7 +188,7 @@ def verify(nat):
                 elif 'name' in config['inbound_interface']:
                     interface_name = config['inbound_interface']['name']
                     if interface_name not in 'any':
-                        if interface_name[0] == '!':
+                        if interface_name.startswith('!'):
                             interface_name = interface_name[1:]
                         if interface_name not in interfaces():
                             Warning(f'NAT interface "{interface_name}" for destination NAT rule "{rule}" does not exist!')

--- a/src/conf_mode/nat.py
+++ b/src/conf_mode/nat.py
@@ -149,8 +149,12 @@ def verify(nat):
                 if 'name' in config['outbound_interface'] and 'group' in config['outbound_interface']:
                     raise ConfigError(f'{err_msg} cannot specify both interface group and interface name for nat source rule "{rule}"')
                 elif 'name' in config['outbound_interface']:
-                    if config['outbound_interface']['name'] not in 'any' and config['outbound_interface']['name'] not in interfaces():
-                        Warning(f'NAT interface "{config["outbound_interface"]["name"]}" for source NAT rule "{rule}" does not exist!')
+                    interface_name = config['outbound_interface']['name']
+                    if interface_name not in 'any':
+                        if interface_name[0] == '!':
+                            interface_name = interface_name[1:]
+                        if interface_name not in interfaces():
+                            Warning(f'NAT interface "{interface_name}" for source NAT rule "{rule}" does not exist!')
                 else:
                     group_name = config['outbound_interface']['group']
                     if group_name[0] == '!':
@@ -182,8 +186,12 @@ def verify(nat):
                 if 'name' in config['inbound_interface'] and 'group' in config['inbound_interface']:
                     raise ConfigError(f'{err_msg} cannot specify both interface group and interface name for destination nat rule "{rule}"')
                 elif 'name' in config['inbound_interface']:
-                    if config['inbound_interface']['name'] not in 'any' and config['inbound_interface']['name'] not in interfaces():
-                        Warning(f'NAT interface "{config["inbound_interface"]["name"]}" for destination NAT rule "{rule}" does not exist!')
+                    interface_name = config['inbound_interface']['name']
+                    if interface_name not in 'any':
+                        if interface_name[0] == '!':
+                            interface_name = interface_name[1:]
+                        if interface_name not in interfaces():
+                            Warning(f'NAT interface "{interface_name}" for destination NAT rule "{rule}" does not exist!')
                 else:
                     group_name = config['inbound_interface']['group']
                     if group_name[0] == '!':

--- a/src/conf_mode/nat.py
+++ b/src/conf_mode/nat.py
@@ -17,7 +17,6 @@
 import os
 
 from sys import exit
-from netifaces import interfaces
 
 from vyos.base import Warning
 from vyos.config import Config
@@ -30,6 +29,7 @@ from vyos.utils.dict import dict_search_args
 from vyos.utils.process import cmd
 from vyos.utils.process import run
 from vyos.utils.network import is_addr_assigned
+from vyos.utils.network import interface_exists
 from vyos import ConfigError
 
 from vyos import airbag
@@ -153,8 +153,8 @@ def verify(nat):
                     if interface_name not in 'any':
                         if interface_name.startswith('!'):
                             interface_name = interface_name[1:]
-                        if interface_name not in interfaces():
-                            Warning(f'NAT interface "{interface_name}" for source NAT rule "{rule}" does not exist!')
+                        if not interface_exists(interface_name):
+                            Warning(f'Interface "{interface_name}" for source NAT rule "{rule}" does not exist!')
                 else:
                     group_name = config['outbound_interface']['group']
                     if group_name[0] == '!':
@@ -190,8 +190,8 @@ def verify(nat):
                     if interface_name not in 'any':
                         if interface_name.startswith('!'):
                             interface_name = interface_name[1:]
-                        if interface_name not in interfaces():
-                            Warning(f'NAT interface "{interface_name}" for destination NAT rule "{rule}" does not exist!')
+                        if not interface_exists(interface_name):
+                            Warning(f'Interface "{interface_name}" for destination NAT rule "{rule}" does not exist!')
                 else:
                     group_name = config['inbound_interface']['group']
                     if group_name[0] == '!':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

Avoids spam of invalid warnings when a negated interface name is used.

```
...
WARNING: NAT interface "!bond0.2" for destination NAT rule "430" does
not exist!
WARNING: NAT interface "!bond0.2" for destination NAT rule "450" does
not exist!
WARNING: NAT interface "!bond0.2" for destination NAT rule "470" does
not exist!
WARNING: NAT interface "!bond0.2" for destination NAT rule "490" does
not exist!
WARNING: NAT interface "!bond0.2" for destination NAT rule "510" does
not exist!
...
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6365

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
_none_

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
- nat source
- nat destination

## Proposed changes
Added code to parse negation (in a similar manner groups are used).

## How to test

```
set nat destination rule 10 description 'DNS'
set nat destination rule 10 destination address 10.0.0.1
set nat destination rule 10 destination port 53
set nat destination rule 10 inbound-interface name '!eth0'
set nat destination rule 10 protocol 'tcp_udp'
set nat destination rule 10 translation address 172.16.0.1
```

And perform a `commit`.

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] ~My change requires a change to the documentation~
- [ ] ~I have updated the documentation accordingly~
