### PR TITLE
T6364: CGNAT drop hard limit that allows only one translation rule

### DIFF
--- a/interface-definitions/nat_cgnat.xml.in
+++ b/interface-definitions/nat_cgnat.xml.in
@@ -123,6 +123,7 @@
                         <validator name="ipv4-host"/>
                         <validator name="ipv4-range"/>
                       </constraint>
+                      <multi/>
                     </properties>
                   </leafNode>
                 </children>

--- a/src/conf_mode/nat_cgnat.py
+++ b/src/conf_mode/nat_cgnat.py
@@ -189,11 +189,6 @@ def verify(config):
     if 'rule' not in config:
         raise ConfigError(f'Rule must be defined!')
 
-    # As PoC allow only one rule for CGNAT translations
-    # one internal pool and one external pool
-    if len(config['rule']) > 1:
-        raise ConfigError(f'Only one rule is allowed for translations!')
-
     for pool in ('external', 'internal'):
         if pool not in config['pool']:
             raise ConfigError(f'{pool} pool must be defined!')
@@ -208,6 +203,8 @@ def verify(config):
     internal_pools_query = "keys(pool.internal)"
     internal_pools: list = jmespath.search(internal_pools_query, config)
 
+    used_external_pools = {}
+    used_internal_pools = {}
     for rule, rule_config in config['rule'].items():
         if 'source' not in rule_config:
             raise ConfigError(f'Rule "{rule}" source pool must be defined!')
@@ -217,57 +214,82 @@ def verify(config):
         if 'translation' not in rule_config:
             raise ConfigError(f'Rule "{rule}" translation pool must be defined!')
 
+        # Check if pool exists
         internal_pool = rule_config['source']['pool']
         if internal_pool not in internal_pools:
             raise ConfigError(f'Internal pool "{internal_pool}" does not exist!')
-
         external_pool = rule_config['translation']['pool']
         if external_pool not in external_pools:
             raise ConfigError(f'External pool "{external_pool}" does not exist!')
+
+        # Check pool duplication in different rules
+        if external_pool in used_external_pools:
+            raise ConfigError(
+                f'External pool "{external_pool}" is already used in rule '
+                f'{used_external_pools[external_pool]} and cannot be used in '
+                f'rule {rule}!'
+            )
+
+        if internal_pool in used_internal_pools:
+            raise ConfigError(
+                f'Internal pool "{internal_pool}" is already used in rule '
+                f'{used_internal_pools[internal_pool]} and cannot be used in '
+                f'rule {rule}!'
+            )
+
+        used_external_pools[external_pool] = rule
+        used_internal_pools[internal_pool] = rule
 
 
 def generate(config):
     if not config:
         return None
-    # first external pool as we allow only one as PoC
-    ext_pool_name = jmespath.search("rule.*.translation | [0]", config).get('pool')
-    int_pool_name = jmespath.search("rule.*.source | [0]", config).get('pool')
-    ext_query = f'pool.external."{ext_pool_name}".range | keys(@)'
-    int_query = f'pool.internal."{int_pool_name}".range'
-    external_ranges = jmespath.search(ext_query, config)
-    internal_ranges = [jmespath.search(int_query, config)]
 
-    external_list_count = []
-    external_list_hosts = []
-    internal_list_count = []
-    internal_list_hosts = []
-    for ext_range in external_ranges:
-        # External hosts count
-        e_count = IPOperations(ext_range).get_ips_count()
-        external_list_count.append(e_count)
-        # External hosts list
-        e_hosts = IPOperations(ext_range).convert_prefix_to_list_ips()
-        external_list_hosts.extend(e_hosts)
-    for int_range in internal_ranges:
-        # Internal hosts count
-        i_count = IPOperations(int_range).get_ips_count()
-        internal_list_count.append(i_count)
-        # Internal hosts list
-        i_hosts = IPOperations(int_range).convert_prefix_to_list_ips()
-        internal_list_hosts.extend(i_hosts)
+    proto_maps = []
+    other_maps = []
 
-    external_host_count = sum(external_list_count)
-    internal_host_count = sum(internal_list_count)
-    ports_per_user = int(
-        jmespath.search(f'pool.external."{ext_pool_name}".per_user_limit.port', config)
-    )
-    external_port_range: str = jmespath.search(
-        f'pool.external."{ext_pool_name}".external_port_range', config
-    )
+    for rule, rule_config in config['rule'].items():
+        ext_pool_name: str = rule_config['translation']['pool']
+        int_pool_name: str = rule_config['source']['pool']
 
-    proto_maps, other_maps = generate_port_rules(
-        external_list_hosts, internal_list_hosts, ports_per_user, external_port_range
-    )
+        external_ranges: list = [range for range in config['pool']['external'][ext_pool_name]['range']]
+        internal_ranges: list = [config['pool']['internal'][int_pool_name]['range']]
+        external_list_hosts_count = []
+        external_list_hosts = []
+        internal_list_hosts_count = []
+        internal_list_hosts = []
+
+        for ext_range in external_ranges:
+            # External hosts count
+            e_count = IPOperations(ext_range).get_ips_count()
+            external_list_hosts_count.append(e_count)
+            # External hosts list
+            e_hosts = IPOperations(ext_range).convert_prefix_to_list_ips()
+            external_list_hosts.extend(e_hosts)
+
+        for int_range in internal_ranges:
+            # Internal hosts count
+            i_count = IPOperations(int_range).get_ips_count()
+            internal_list_hosts_count.append(i_count)
+            # Internal hosts list
+            i_hosts = IPOperations(int_range).convert_prefix_to_list_ips()
+            internal_list_hosts.extend(i_hosts)
+
+        external_host_count = sum(external_list_hosts_count)
+        internal_host_count = sum(internal_list_hosts_count)
+        ports_per_user = int(
+            jmespath.search(f'pool.external."{ext_pool_name}".per_user_limit.port', config)
+        )
+        external_port_range: str = jmespath.search(
+            f'pool.external."{ext_pool_name}".external_port_range', config
+        )
+
+        rule_proto_maps, rule_other_maps = generate_port_rules(
+            external_list_hosts, internal_list_hosts, ports_per_user, external_port_range
+        )
+
+        proto_maps.extend(rule_proto_maps)
+        other_maps.extend(rule_other_maps)
 
     config['proto_map_elements'] = ', '.join(proto_maps)
     config['other_map_elements'] = ', '.join(other_maps)

--- a/src/conf_mode/nat_cgnat.py
+++ b/src/conf_mode/nat_cgnat.py
@@ -253,7 +253,7 @@ def generate(config):
         int_pool_name: str = rule_config['source']['pool']
 
         external_ranges: list = [range for range in config['pool']['external'][ext_pool_name]['range']]
-        internal_ranges: list = [config['pool']['internal'][int_pool_name]['range']]
+        internal_ranges: list = [range for range in config['pool']['internal'][int_pool_name]['range']]
         external_list_hosts_count = []
         external_list_hosts = []
         internal_list_hosts_count = []


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
As PoC for CGNAT had a hard limit in using only one translation rule for one internal pool,
Drop this limit and extend the usage number of the rules.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6364

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
cgnat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
And configuration with several translation rules (before it was possible only one rule):
```
set nat cgnat pool external ext-01 external-port-range '40000-60000'
set nat cgnat pool external ext-01 per-user-limit port '5000'
set nat cgnat pool external ext-01 range 192.0.2.1-192.0.2.2
set nat cgnat pool external ext-01 range 192.0.2.11/32

set nat cgnat pool external vyos-ext-02 external-port-range '2000-22000'
set nat cgnat pool external vyos-ext-02 per-user-limit port '2000'
set nat cgnat pool external vyos-ext-02 range 203.0.113.55/32

set nat cgnat pool internal int-01 range '100.64.0.0/29'
set nat cgnat pool internal vyos-int-02 range '100.64.222.10-100.64.222.12'

set nat cgnat rule 100 source pool 'int-01'
set nat cgnat rule 100 translation pool 'ext-01'
set nat cgnat rule 120 source pool 'vyos-int-02'
set nat cgnat rule 120 translation pool 'vyos-ext-02'
```
Check allocation to be sure that we see addresses in both pools:
```
vyos@r4# run show nat cgnat allocation 
Internal IP    External IP    Port range
-------------  -------------  ------------
100.64.0.0     192.0.2.1      40000-44999
100.64.0.1     192.0.2.1      45000-49999
100.64.0.2     192.0.2.1      50000-54999
100.64.0.3     192.0.2.1      55000-59999
100.64.0.4     192.0.2.2      40000-44999
100.64.0.5     192.0.2.2      45000-49999
100.64.0.6     192.0.2.2      50000-54999
100.64.0.7     192.0.2.2      55000-59999
100.64.222.10  203.0.113.55   2000-3999
100.64.222.11  203.0.113.55   4000-5999
100.64.222.12  203.0.113.55   6000-7999
[edit]
vyos@r4# 

```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_cgnat.py
test_cgnat (__main__.TestCGNAT.test_cgnat) ... ok

----------------------------------------------------------------------
Ran 1 test in 20.654s

OK
vyos@r4:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
