### PR TITLE
reverse-proxy: T6370: Set custom HTTP headers in reverse-proxy responses

### DIFF
--- a/data/templates/load-balancing/haproxy.cfg.j2
+++ b/data/templates/load-balancing/haproxy.cfg.j2
@@ -81,6 +81,11 @@ frontend {{ front }}
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}
+{%             if front_config.http_response_headers is vyos_defined %}
+{%                 for header, header_config in front_config.http_response_headers.items() %}
+    http-response set-header {{ header }} '{{ header_config['value'] }}'
+{%                 endfor %}
+{%             endif %}
 {%         endif %}
 {%         if front_config.rule is vyos_defined %}
 {%             for rule, rule_config in front_config.rule.items() %}
@@ -158,6 +163,11 @@ backend {{ back }}
 {%         endif %}
 {%         if back_config.mode is vyos_defined %}
     mode {{ back_config.mode }}
+{%             if back_config.http_response_headers is vyos_defined %}
+{%                 for header, header_config in back_config.http_response_headers.items() %}
+    http-response set-header {{ header }} '{{ header_config['value'] }}'
+{%                 endfor %}
+{%             endif %}
 {%         endif %}
 {%         if back_config.rule is vyos_defined %}
 {%             for rule, rule_config in back_config.rule.items() %}

--- a/interface-definitions/include/haproxy/http-response-headers.xml.i
+++ b/interface-definitions/include/haproxy/http-response-headers.xml.i
@@ -1,0 +1,29 @@
+<!-- include start from haproxy/http-response-headers.xml.i -->
+<tagNode name="http-response-headers">
+  <properties>
+    <help>Headers to include in HTTP response</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>HTTP header name</description>
+    </valueHelp>
+    <constraint>
+      <regex>[-a-zA-Z]+</regex>
+    </constraint>
+    <constraintErrorMessage>Header names must only include alphabetical characters and hyphens</constraintErrorMessage>
+  </properties>
+  <children>
+    <leafNode name="value">
+      <properties>
+        <help>HTTP header value</help>
+        <valueHelp>
+          <format>txt</format>
+          <description>HTTP header value</description>
+        </valueHelp>
+        <constraint>
+          <regex>[[:ascii:]]{1,256}</regex>
+        </constraint>
+      </properties>
+    </leafNode>
+  </children>
+</tagNode>
+<!-- include end -->

--- a/interface-definitions/load-balancing_reverse-proxy.xml.in
+++ b/interface-definitions/load-balancing_reverse-proxy.xml.in
@@ -39,6 +39,7 @@
               #include <include/port-number.xml.i>
               #include <include/haproxy/rule-frontend.xml.i>
               #include <include/haproxy/tcp-request.xml.i>
+              #include <include/haproxy/http-response-headers.xml.i>
               <leafNode name="redirect-http-to-https">
                 <properties>
                   <help>Redirect HTTP to HTTPS</help>
@@ -90,6 +91,7 @@
               </leafNode>
               #include <include/generic-description.xml.i>
               #include <include/haproxy/mode.xml.i>
+              #include <include/haproxy/http-response-headers.xml.i>
               <node name="parameters">
                 <properties>
                   <help>Backend parameters</help>

--- a/src/conf_mode/load-balancing_reverse-proxy.py
+++ b/src/conf_mode/load-balancing_reverse-proxy.py
@@ -88,6 +88,12 @@ def verify(lb):
             if {'send_proxy', 'send_proxy_v2'} <= set(bk_server_conf):
                 raise ConfigError(f'Cannot use both "send-proxy" and "send-proxy-v2" for server "{bk_server}"')
 
+    # Check if http-response-headers are configured in any frontend/backend where mode != http
+    for group in ['service', 'backend']:
+        for config_name, config in lb[group].items():
+            if 'http_response_headers' in config and ('mode' not in config or config['mode'] != 'http'):
+                raise ConfigError(f'{group} {config_name} must be set to http mode to use http_response_headers!')
+
         if 'ssl' in back_config:
             if {'no_verify', 'ca_certificate'} <= set(back_config['ssl']):
                 raise ConfigError(f'backend {back} cannot have both ssl options no-verify and ca-certificate set!')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add the option to set custom HTTP headers in reverse-proxy responses.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
[https://vyos.dev/T6370](https://vyos.dev/T6370)

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
load-balancing -> reverse-proxy
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

1. Create a reverse-proxy configuration using the new options:
```
set load-balancing reverse-proxy backend bk-01 mode 'http'
set load-balancing reverse-proxy backend bk-01 server srv-01 address '192.0.2.12'
set load-balancing reverse-proxy backend bk-01 server srv-01 port '80'
set load-balancing reverse-proxy backend bk-01 http-response-headers Proxy-Backend-ID value bk-01

set load-balancing reverse-proxy service fe-https backend 'bk-01'
set load-balancing reverse-proxy service fe-https listen-address '192.0.2.11'
set load-balancing reverse-proxy service fe-https mode 'http'
set load-balancing reverse-proxy service fe-https port '443'
set load-balancing reverse-proxy service fe-https ssl certificate cert
set load-balancing reverse-proxy service fe-https http-response-headers Strict-Transport-Security value 'max-age=31536000; includeSubDomains;'
```

2. Check the HAProxy backend server configuration is showing the correct options:
```
vyos@vyos:~$ cat /var/run/haproxy/haproxy.cfg | grep 'Proxy-Backend-ID\|Strict-Transport-Security'
	http-response set-header Strict-Transport-Security 'max-age=31536000; includeSubDomains;'
	http-response set-header Proxy-Backend-ID 'bk-01'
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_load-balancing_reverse-proxy.py
test_01_lb_reverse_proxy_domain (__main__.TestLoadBalancingReverseProxy.test_01_lb_reverse_proxy_domain) ... ok
test_02_lb_reverse_proxy_cert_not_exists (__main__.TestLoadBalancingReverseProxy.test_02_lb_reverse_proxy_cert_not_exists) ...
PKI does not contain any certificates!


Certificate "cert" not found in configuration!

ok
test_03_lb_reverse_proxy_ca_not_exists (__main__.TestLoadBalancingReverseProxy.test_03_lb_reverse_proxy_ca_not_exists) ... ok
test_04_lb_reverse_proxy_backend_ssl_no_verify (__main__.TestLoadBalancingReverseProxy.test_04_lb_reverse_proxy_backend_ssl_no_verify) ...
backend bk-01 cannot have both ssl options no-verify and ca-certificate
set!

ok
test_05_lb_reverse_proxy_backend_http_check (__main__.TestLoadBalancingReverseProxy.test_05_lb_reverse_proxy_backend_http_check) ... ok
test_06_lb_reverse_proxy_tcp_mode (__main__.TestLoadBalancingReverseProxy.test_06_lb_reverse_proxy_tcp_mode) ... ok
test_07_lb_reverse_proxy_http_response_headers (__main__.TestLoadBalancingReverseProxy.test_07_lb_reverse_proxy_http_response_headers) ... ok

----------------------------------------------------------------------
Ran 7 tests in 29.581s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly