### PR TITLE
T6366: CGNAT add ability to get external and internal allocations

### DIFF
--- a/op-mode-definitions/nat.xml.in
+++ b/op-mode-definitions/nat.xml.in
@@ -16,6 +16,26 @@
                 <properties>
                   <help>Show allocated CGNAT parameters</help>
                 </properties>
+                <children>
+                  <tagNode name="external-address">
+                    <properties>
+                      <help>Show CGNAT allocations for an external IP address</help>
+                      <completionHelp>
+                        <list>&lt;x.x.x.x&gt;</list>
+                      </completionHelp>
+                    </properties>
+                    <command>sudo ${vyos_op_scripts_dir}/cgnat.py show_allocation --external-address "$6"</command>
+                  </tagNode>
+                  <tagNode name="internal-address">
+                    <properties>
+                      <help>Show CGNAT allocations for an internal IP address</help>
+                      <completionHelp>
+                        <list>&lt;x.x.x.x&gt;</list>
+                      </completionHelp>
+                    </properties>
+                    <command>sudo ${vyos_op_scripts_dir}/cgnat.py show_allocation --internal-address "$6"</command>
+                  </tagNode>
+                </children>
                 <command>sudo ${vyos_op_scripts_dir}/cgnat.py show_allocation</command>
               </node>
             </children>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add the ability to show port allocation per external or internal address. With huge entries of allocation, it is necessary to filter them by specific external/internal IP address
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Extend op-mode for CGN

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6366

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
cgnat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set nat cgnat pool external ext-01 external-port-range '40000-60000'
set nat cgnat pool external ext-01 per-user-limit port '5000'
set nat cgnat pool external ext-01 range 192.0.2.1-192.0.2.2
set nat cgnat pool external ext-01 range 192.0.2.11/32
set nat cgnat pool external vyos-ext-02 external-port-range '2000-22000'
set nat cgnat pool external vyos-ext-02 per-user-limit port '2000'
set nat cgnat pool external vyos-ext-02 range 203.0.113.55/32
set nat cgnat pool internal int-01 range '100.64.0.0/29'
set nat cgnat pool internal vyos-int-02 range '100.64.222.10-100.64.222.12'
set nat cgnat rule 100 source pool 'int-01'
set nat cgnat rule 100 translation pool 'ext-01'
set nat cgnat rule 120 source pool 'vyos-int-02'
set nat cgnat rule 120 translation pool 'vyos-ext-02'

```
Op-mode, check external/internal options
```
vyos@r4:~$ show nat cgnat allocation 
Internal IP    External IP    Port range
-------------  -------------  ------------
100.64.0.0     192.0.2.1      40000-44999
100.64.0.1     192.0.2.1      45000-49999
100.64.0.2     192.0.2.1      50000-54999
100.64.0.3     192.0.2.1      55000-59999
100.64.0.4     192.0.2.2      40000-44999
100.64.0.5     192.0.2.2      45000-49999
100.64.0.6     192.0.2.2      50000-54999
100.64.0.7     192.0.2.2      55000-59999
100.64.222.10  203.0.113.55   2000-3999
100.64.222.11  203.0.113.55   4000-5999
100.64.222.12  203.0.113.55   6000-7999
vyos@r4:~$ 
vyos@r4:~$ 
vyos@r4:~$ show nat cgnat allocation external-address 203.0.113.55
Internal IP    External IP    Port range
-------------  -------------  ------------
100.64.222.10  203.0.113.55   2000-3999
100.64.222.11  203.0.113.55   4000-5999
100.64.222.12  203.0.113.55   6000-7999
vyos@r4:~$ 
vyos@r4:~$ 
vyos@r4:~$ show nat cgnat allocation internal-address 100.64.0.2
Internal IP    External IP    Port range
-------------  -------------  ------------
100.64.0.2     192.0.2.1      50000-54999
vyos@r4:~$ 

```
Check the `raw` options:
```
vyos@r4:~$ sudo /usr/libexec/vyos/op_mode/cgnat.py show_allocation --internal-address 100.64.222.11 --raw
[
    {
        "internal_address": "100.64.222.11",
        "external_address": "203.0.113.55",
        "port_range": "4000-5999"
    }
]
vyos@r4:~$ 

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
