### PR TITLE
T5307: QoS - traffic-class-map services

### DIFF
--- a/interface-definitions/include/qos/class-match-group.xml.i
+++ b/interface-definitions/include/qos/class-match-group.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from qos/class-match-group.xml.i -->
+<leafNode name="match-group">
+  <properties>
+    <help>Filter group for QoS policy</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>Match group name</description>
+    </valueHelp>
+    <completionHelp>
+      <script>${vyos_completion_dir}/qos/list_traffic_match_group.py</script>
+    </completionHelp>
+    <multi/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/qos/class-match-ipv4.xml.i
+++ b/interface-definitions/include/qos/class-match-ipv4.xml.i
@@ -1,0 +1,31 @@
+<!-- include start from qos/class-match-ipv4.xml.i -->
+<node name="ip">
+  <properties>
+    <help>Match IP protocol header</help>
+  </properties>
+  <children>
+    <node name="destination">
+      <properties>
+        <help>Match on destination port or address</help>
+      </properties>
+      <children>
+        #include <include/qos/class-match-ipv4-address.xml.i>
+        #include <include/port-number.xml.i>
+      </children>
+    </node>
+    #include <include/qos/match-dscp.xml.i>
+    #include <include/qos/max-length.xml.i>
+    #include <include/ip-protocol.xml.i>
+    <node name="source">
+      <properties>
+        <help>Match on source port or address</help>
+      </properties>
+      <children>
+        #include <include/qos/class-match-ipv4-address.xml.i>
+        #include <include/port-number.xml.i>
+      </children>
+    </node>
+    #include <include/qos/tcp-flags.xml.i>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/qos/class-match-ipv6.xml.i
+++ b/interface-definitions/include/qos/class-match-ipv6.xml.i
@@ -1,0 +1,31 @@
+<!-- include start from qos/class-match-ipv6.xml.i -->
+<node name="ipv6">
+  <properties>
+    <help>Match IPv6 protocol header</help>
+  </properties>
+  <children>
+    <node name="destination">
+      <properties>
+        <help>Match on destination port or address</help>
+      </properties>
+      <children>
+        #include <include/qos/class-match-ipv6-address.xml.i>
+        #include <include/port-number.xml.i>
+      </children>
+    </node>
+    #include <include/qos/match-dscp.xml.i>
+    #include <include/qos/max-length.xml.i>
+    #include <include/ip-protocol.xml.i>
+    <node name="source">
+      <properties>
+        <help>Match on source port or address</help>
+      </properties>
+      <children>
+        #include <include/qos/class-match-ipv6-address.xml.i>
+        #include <include/port-number.xml.i>
+      </children>
+    </node>
+    #include <include/qos/tcp-flags.xml.i>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/qos/class-match-mark.xml.i
+++ b/interface-definitions/include/qos/class-match-mark.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from qos/class-match-mark.xml.i -->
+<leafNode name="mark">
+  <properties>
+    <help>Match on mark applied by firewall</help>
+    <valueHelp>
+      <format>u32</format>
+      <description>FW mark to match</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 0-4294967295"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/qos/class-match-vif.xml.i
+++ b/interface-definitions/include/qos/class-match-vif.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from qos/class-match-vif.xml.i -->
+<leafNode name="vif">
+  <properties>
+    <help>Virtual Local Area Network (VLAN) ID for this match</help>
+    <valueHelp>
+      <format>u32:0-4095</format>
+      <description>Virtual Local Area Network (VLAN) tag </description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 0-4095"/>
+    </constraint>
+    <constraintErrorMessage>VLAN ID must be between 0 and 4095</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/qos/class-match.xml.i
+++ b/interface-definitions/include/qos/class-match.xml.i
@@ -5,7 +5,7 @@
     <constraint>
       <regex>[^-].*</regex>
     </constraint>
-    <constraintErrorMessage>Match queue name cannot start with hyphen (-)</constraintErrorMessage>
+    <constraintErrorMessage>Match queue name cannot start with hyphen</constraintErrorMessage>
   </properties>
   <children>
     #include <include/generic-description.xml.i>
@@ -89,89 +89,10 @@
       </children>
     </node>
     #include <include/generic-interface.xml.i>
-    <node name="ip">
-      <properties>
-        <help>Match IP protocol header</help>
-      </properties>
-      <children>
-        <node name="destination">
-          <properties>
-            <help>Match on destination port or address</help>
-          </properties>
-          <children>
-            #include <include/qos/class-match-ipv4-address.xml.i>
-            #include <include/port-number.xml.i>
-          </children>
-        </node>
-        #include <include/qos/match-dscp.xml.i>
-        #include <include/qos/max-length.xml.i>
-        #include <include/ip-protocol.xml.i>
-        <node name="source">
-          <properties>
-            <help>Match on source port or address</help>
-          </properties>
-          <children>
-            #include <include/qos/class-match-ipv4-address.xml.i>
-            #include <include/port-number.xml.i>
-          </children>
-        </node>
-        #include <include/qos/tcp-flags.xml.i>
-      </children>
-    </node>
-    <node name="ipv6">
-      <properties>
-        <help>Match IPv6 protocol header</help>
-      </properties>
-      <children>
-        <node name="destination">
-          <properties>
-            <help>Match on destination port or address</help>
-          </properties>
-          <children>
-            #include <include/qos/class-match-ipv6-address.xml.i>
-            #include <include/port-number.xml.i>
-          </children>
-        </node>
-        #include <include/qos/match-dscp.xml.i>
-        #include <include/qos/max-length.xml.i>
-        #include <include/ip-protocol.xml.i>
-        <node name="source">
-          <properties>
-            <help>Match on source port or address</help>
-          </properties>
-          <children>
-            #include <include/qos/class-match-ipv6-address.xml.i>
-            #include <include/port-number.xml.i>
-          </children>
-        </node>
-        #include <include/qos/tcp-flags.xml.i>
-      </children>
-    </node>
-    <leafNode name="mark">
-      <properties>
-        <help>Match on mark applied by firewall</help>
-        <valueHelp>
-          <format>u32</format>
-          <description>FW mark to match</description>
-        </valueHelp>
-        <constraint>
-          <validator name="numeric" argument="--range 0-4294967295"/>
-        </constraint>
-      </properties>
-    </leafNode>
-    <leafNode name="vif">
-      <properties>
-        <help>Virtual Local Area Network (VLAN) ID for this match</help>
-        <valueHelp>
-          <format>u32:0-4095</format>
-          <description>Virtual Local Area Network (VLAN) tag </description>
-        </valueHelp>
-        <constraint>
-          <validator name="numeric" argument="--range 0-4095"/>
-        </constraint>
-        <constraintErrorMessage>VLAN ID must be between 0 and 4095</constraintErrorMessage>
-      </properties>
-    </leafNode>
+    #include <include/qos/class-match-ipv4.xml.i>
+    #include <include/qos/class-match-ipv6.xml.i>
+    #include <include/qos/class-match-mark.xml.i>
+    #include <include/qos/class-match-vif.xml.i>
   </children>
 </tagNode>
 <!-- include end -->

--- a/interface-definitions/qos.xml.in
+++ b/interface-definitions/qos.xml.in
@@ -281,6 +281,7 @@
                   #include <include/qos/mtu.xml.i>
                   #include <include/qos/class-police-exceed.xml.i>
                   #include <include/qos/class-match.xml.i>
+                  #include <include/qos/class-match-group.xml.i>
                   #include <include/qos/class-priority.xml.i>
                   <leafNode name="priority">
                     <defaultValue>20</defaultValue>
@@ -415,6 +416,7 @@
                   #include <include/qos/flows.xml.i>
                   #include <include/qos/interval.xml.i>
                   #include <include/qos/class-match.xml.i>
+                  #include <include/qos/class-match-group.xml.i>
                   #include <include/qos/queue-limit-1-4294967295.xml.i>
                   #include <include/qos/queue-type.xml.i>
                   <leafNode name="queue-type">
@@ -542,6 +544,8 @@
                   #include <include/qos/flows.xml.i>
                   #include <include/qos/interval.xml.i>
                   #include <include/qos/class-match.xml.i>
+                  #include <include/qos/class-match-group.xml.i>
+
                   <leafNode name="quantum">
                     <properties>
                       <help>Packet scheduling quantum</help>
@@ -645,6 +649,7 @@
                   #include <include/qos/flows.xml.i>
                   #include <include/qos/interval.xml.i>
                   #include <include/qos/class-match.xml.i>
+                  #include <include/qos/class-match-group.xml.i>
                   #include <include/qos/class-priority.xml.i>
                   #include <include/qos/queue-average-packet.xml.i>
                   #include <include/qos/queue-maximum-threshold.xml.i>
@@ -767,6 +772,7 @@
                     </children>
                   </node>
                   #include <include/qos/class-match.xml.i>
+                  #include <include/qos/class-match-group.xml.i>
                   <node name="realtime">
                     <properties>
                       <help>Realtime class settings</help>
@@ -830,6 +836,39 @@
           </tagNode>
         </children>
       </node>
+      <tagNode name="traffic-match-group">
+        <properties>
+          <help>Filter group for QoS policy</help>
+          <valueHelp>
+            <format>txt</format>
+            <description>Match group name</description>
+          </valueHelp>
+          <constraint>
+            <regex>[^-].*</regex>
+          </constraint>
+          <constraintErrorMessage>Match group name cannot start with hyphen</constraintErrorMessage>
+        </properties>
+          <children>
+            #include <include/generic-description.xml.i>
+            <tagNode name="match">
+              <properties>
+                <help>Class matching rule name</help>
+                <constraint>
+                  <regex>[^-].*</regex>
+                </constraint>
+                <constraintErrorMessage>Match queue name cannot start with hyphen</constraintErrorMessage>
+              </properties>
+              <children>
+                #include <include/generic-description.xml.i>
+                #include <include/qos/class-match-ipv4.xml.i>
+                #include <include/qos/class-match-ipv6.xml.i>
+                #include <include/qos/class-match-mark.xml.i>
+                #include <include/qos/class-match-vif.xml.i>
+              </children>
+            </tagNode>
+            #include <include/qos/class-match-group.xml.i>
+          </children>
+      </tagNode>
     </children>
   </node>
 </interfaceDefinition>

--- a/src/completion/qos/list_traffic_match_group.py
+++ b/src/completion/qos/list_traffic_match_group.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from vyos.config import Config
+
+
+def get_qos_traffic_match_group():
+    config = Config()
+    base = ['qos', 'traffic-match-group']
+    conf = config.get_config_dict(base, key_mangling=('-', '_'))
+    groups = []
+
+    for group in conf.get('traffic_match_group', []):
+        groups.append(group)
+
+    return groups
+
+
+if __name__ == "__main__":
+    groups = get_qos_traffic_match_group()
+    print(" ".join(groups))
+


### PR DESCRIPTION
added new syntax to work with class match filters in QoS policy

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
 * https://vyos.dev/T5307 
 
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
QoS
## Proposed changes
<!--- Describe your changes in detail -->
Implemented the ability to create named match group and use this in QoS policy classes
Old match syntax is kept and tc filters from the `match` node are created first then tc filters from the `match-group` node
new syntax to work with group:
```
set qos policy ... match-group <match_group_name> # add group to the class by group name
# create\change match group
set qos traffic-match-group <group_name> description <value>
set qos traffic-match-group <group_name> match <match_name> [description | ip | ipv6| mark | vif ] ...
set qos traffic-match-group <group_name> match-group <match_group_name> # inherit matches from another group
```
Every policy class or traffic match group can contain several groups
Every group can contain several matches
Match in the group configured the same as match in the class excluded nodes `ether`  `interface`


## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Create policy using old syntax:
```
set qos interface eth0 egress VyOS-HTB
set qos policy shaper VyOS-HTB bandwidth 100mbit
set qos policy shaper VyOS-HTB class 10 bandwidth 40%
set qos policy shaper VyOS-HTB class 10 match AF11 ip dscp AF11
set qos policy shaper VyOS-HTB class 10 match AF41 ip dscp AF41
set qos policy shaper VyOS-HTB class 10 match AF43 ip dscp AF43
set qos policy shaper VyOS-HTB class 10 match CS4 ip dscp CS4
set qos policy shaper VyOS-HTB class 10 priority 1
set qos policy shaper VyOS-HTB class 10 queue-type fair-queue
set qos policy shaper VyOS-HTB class 20 bandwidth 30%
set qos policy shaper VyOS-HTB class 20 match EF ip dscp EF
set qos policy shaper VyOS-HTB class 20 match CS5 ip dscp CS5
set qos policy shaper VyOS-HTB class 20 priority 2
set qos policy shaper VyOS-HTB class 20 queue-type fair-queue
set qos policy shaper VyOS-HTB default bandwidth 20%
set qos policy shaper VyOS-HTB default queue-type fair-queue
commit
tc filter show dev eth0
```

delete existing policy
```
del qos policy shaper VyOS-HTB
del qos interface eth0 egress VyOS-HTB
commit
tc filter show dev eth0
```

create same policy using new syntax
```
set qos interface eth0 egress VyOS-HTB
# prepare new match group
set qos traffic-match-group VOICE description 'voice shaper'
set qos traffic-match-group VOICE match EF ip dscp EF
set qos traffic-match-group VOICE match CS5 ip dscp CS5
set qos traffic-match-group REAL_TIME_COMMON description 'real time common filters'
set qos traffic-match-group REAL_TIME_COMMON match AF43 ip dscp AF43
set qos traffic-match-group REAL_TIME_COMMON match CS4 ip dscp CS4
set qos traffic-match-group REAL_TIME description 'real time shaper'
set qos traffic-match-group REAL_TIME match AF41 ip dscp AF41
set qos traffic-match-group REAL_TIME match-group REAL_TIME_COMMON
# create same policy using new match groups
set qos policy shaper VyOS-HTB bandwidth 100mbit
set qos policy shaper VyOS-HTB class 10 bandwidth 40%
# old match and new match group can work together
set qos policy shaper VyOS-HTB class 10 match AF11 ip dscp AF11
set qos policy shaper VyOS-HTB class 10 match-group REAL_TIME

set qos policy shaper VyOS-HTB class 10 priority 1
set qos policy shaper VyOS-HTB class 10 queue-type fair-queue
set qos policy shaper VyOS-HTB class 20 bandwidth 30%
# also we can use only match group
set qos policy shaper VyOS-HTB class 20 match-group VOICE

set qos policy shaper VyOS-HTB class 20 priority 2
set qos policy shaper VyOS-HTB class 20 queue-type fair-queue
set qos policy shaper VyOS-HTB default bandwidth 20%
set qos policy shaper VyOS-HTB default queue-type fair-queue
commit
tc filter show dev eth0
```

compare tc filters after old and new syntax
new:
```
vyos@vyos# tc filter show dev eth0
filter parent 1: protocol all pref 1 u32 chain 0
filter parent 1: protocol all pref 1 u32 chain 0 fh 800: ht divisor 1
filter parent 1: protocol all pref 1 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 flowid 1:a not_in_hw
  match 00280000/00ff0000 at 0
filter parent 1: protocol all pref 1 u32 chain 0 fh 800::801 order 2049 key ht 800 bkt 0 flowid 1:a not_in_hw
  match 00880000/00ff0000 at 0
filter parent 1: protocol all pref 1 u32 chain 0 fh 800::802 order 2050 key ht 800 bkt 0 flowid 1:a not_in_hw
  match 00980000/00ff0000 at 0
filter parent 1: protocol all pref 1 u32 chain 0 fh 800::803 order 2051 key ht 800 bkt 0 flowid 1:a not_in_hw
  match 00800000/00ff0000 at 0
filter parent 1: protocol all pref 1 u32 chain 0 fh 800::804 order 2052 key ht 800 bkt 0 flowid 1:a not_in_hw
  match 00800000/00ff0000 at 0
        action order 1:  police 0x1 rate 4Gbit burst 14500b mtu 2Kb action reclassify overhead 0b
        ref 1 bind 1

filter parent 1: protocol all pref 2 u32 chain 0
filter parent 1: protocol all pref 2 u32 chain 0 fh 801: ht divisor 1
filter parent 1: protocol all pref 2 u32 chain 0 fh 801::800 order 2048 key ht 801 bkt 0 flowid 1:14 not_in_hw
  match 00a00000/00ff0000 at 0
filter parent 1: protocol all pref 2 u32 chain 0 fh 801::801 order 2049 key ht 801 bkt 0 flowid 1:14 not_in_hw
  match 00b80000/00ff0000 at 0
filter parent 1: protocol all pref 2 u32 chain 0 fh 801::802 order 2050 key ht 801 bkt 0 flowid 1:14 not_in_hw
  match 00b80000/00ff0000 at 0
        action order 1:  police 0x2 rate 3Gbit burst 15000b mtu 2Kb action reclassify overhead 0b
        ref 1 bind 1
```

old:
```
vyos@vyos# tc filter show dev eth0
filter parent 1: protocol all pref 1 u32 chain 0 
filter parent 1: protocol all pref 1 u32 chain 0 fh 800: ht divisor 1 
filter parent 1: protocol all pref 1 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 flowid 1:a not_in_hw 
  match 00280000/00ff0000 at 0
filter parent 1: protocol all pref 1 u32 chain 0 fh 800::801 order 2049 key ht 800 bkt 0 flowid 1:a not_in_hw 
  match 00880000/00ff0000 at 0
filter parent 1: protocol all pref 1 u32 chain 0 fh 800::802 order 2050 key ht 800 bkt 0 flowid 1:a not_in_hw 
  match 00980000/00ff0000 at 0
filter parent 1: protocol all pref 1 u32 chain 0 fh 800::803 order 2051 key ht 800 bkt 0 flowid 1:a not_in_hw 
  match 00800000/00ff0000 at 0
filter parent 1: protocol all pref 1 u32 chain 0 fh 800::804 order 2052 key ht 800 bkt 0 flowid 1:a not_in_hw 
  match 00800000/00ff0000 at 0
        action order 1:  police 0x1 rate 4Gbit burst 14500b mtu 2Kb action reclassify overhead 0b 
        ref 1 bind 1 

filter parent 1: protocol all pref 2 u32 chain 0 
filter parent 1: protocol all pref 2 u32 chain 0 fh 801: ht divisor 1 
filter parent 1: protocol all pref 2 u32 chain 0 fh 801::800 order 2048 key ht 801 bkt 0 flowid 1:14 not_in_hw 
  match 00a00000/00ff0000 at 0
filter parent 1: protocol all pref 2 u32 chain 0 fh 801::801 order 2049 key ht 801 bkt 0 flowid 1:14 not_in_hw 
  match 00b80000/00ff0000 at 0
filter parent 1: protocol all pref 2 u32 chain 0 fh 801::802 order 2050 key ht 801 bkt 0 flowid 1:14 not_in_hw 
  match 00b80000/00ff0000 at 0
        action order 1:  police 0x2 rate 3Gbit burst 15000b mtu 2Kb action reclassify overhead 0b 
        ref 1 bind 1
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_qos.py 
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... 
Selected QoS policy "qos-policy-eth0" does not exist!

ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok
test_12_shaper_with_red_queue (__main__.TestQoS.test_12_shaper_with_red_queue) ... ok
test_13_shaper_delete_only_rule (__main__.TestQoS.test_13_shaper_delete_only_rule) ... ok
test_14_traffic_match_group (__main__.TestQoS.test_14_traffic_match_group) ... ok
test_14_wrong_traffic_match_group (__main__.TestQoS.test_14_wrong_traffic_match_group) ... 
Can not use both IPv6 and IPv4 in one match (one)!


WARNING: Match group "unexpected" does not exist!

ok

----------------------------------------------------------------------
Ran 15 tests in 56.881s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
