### PR TITLE
T6375: Fix/Update NAT logging

### DIFF
--- a/interface-definitions/nat.xml.in
+++ b/interface-definitions/nat.xml.in
@@ -141,6 +141,7 @@
                 </children>
               </node>
               #include <include/inbound-interface.xml.i>
+              #include <include/firewall/log.xml.i>
               <node name="translation">
                 <properties>
                   <help>Translation address or prefix</help>

--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -464,12 +464,56 @@
             </properties>
             <command>journalctl --no-hostname --boot --unit lldpd.service</command>
           </leafNode>
-          <leafNode name="nat">
+          <node name="nat">
             <properties>
               <help>Show log for Network Address Translation (NAT)</help>
             </properties>
-            <command>egrep -i "kernel:.*\[NAT-[A-Z]{3,}-[0-9]+(-MASQ)?\]" $(find /var/log -maxdepth 1 -type f -name messages\* | sort -t. -k2nr)</command>
-          </leafNode>
+            <children>
+              <node name="destination">
+                <properties>
+                  <help>Show NAT destination log</help>
+                </properties>
+                <command>journalctl --no-hostname --boot -k | egrep "\[DST-NAT-[0-9]+\]"</command>
+                <children>
+                  <tagNode name="rule">
+                    <properties>
+                      <help>Show NAT destination log for specified rule</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot -k | egrep "\[DST-NAT-$6\]"</command>
+                  </tagNode>
+                </children>
+              </node>
+              <node name="source">
+                <properties>
+                  <help>Show NAT source log</help>
+                </properties>
+                <command>journalctl --no-hostname --boot -k | egrep "\[SRC-NAT-[0-9]+(-MASQ)?\]"&quot;"</command>
+                <children>
+                  <tagNode name="rule">
+                    <properties>
+                      <help>Show NAT source log for specified rule</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot -k | egrep "\[SRC-NAT-$6(-MASQ)?\]"</command>
+                  </tagNode>
+                </children>
+              </node>
+              <node name="static">
+                <properties>
+                  <help>Show NAT static log</help>
+                </properties>
+                <command>journalctl --no-hostname --boot -k | egrep "\[STATIC-(SRC|DST)-NAT-[0-9]+\]"</command>
+                <children>
+                  <tagNode name="rule">
+                    <properties>
+                      <help>Show NAT static log for specified rule</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot -k | egrep "\[STATIC-(SRC|DST)-NAT-$6\]"</command>
+                  </tagNode>
+                </children>
+              </node>
+            </children>
+            <command>journalctl --no-hostname --boot -k | egrep "\[(STATIC-)?(DST|SRC)-NAT-[0-9]+(-MASQ)?\]"</command>
+          </node>
           <leafNode name="ndp-proxy">
             <properties>
               <help>Show log for Neighbor Discovery Protocol (NDP) Proxy</help>

--- a/python/vyos/nat.py
+++ b/python/vyos/nat.py
@@ -300,11 +300,11 @@ def parse_nat_static_rule(rule_conf, rule_id, nat_type):
 
     output.append('counter')
 
-    if translation_str:
-        output.append(translation_str)
-
     if 'log' in rule_conf:
         output.append(f'log prefix "[{log_prefix}{log_suffix}]"')
+
+    if translation_str:
+        output.append(translation_str)
 
     output.append(f'comment "{log_prefix}"')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed broken logging for "show log nat"

Added the following commands:
show log nat source
show log nat source rule \<ruleNum>
show log nat destination nat
show log nat destination nat rule \<ruleNum>
show log nat static
show log nat static rule \<ruleNum>

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6257

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat, log

## Proposed changes
<!--- Describe your changes in detail -->
This change will fix the broken `show log nat`, as well as add additional `show log nat` commands with filtering on source/destination/static

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configure NAT and run show commands:
```
vyos@vyos:~$ show log nat
May 21 05:45:40 kernel: [SRC-NAT-15-MASQ]IN= OUT=eth0.101 SRC=10.5.5.5 DST=4.2.2.2 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=38271 DF PROTO=ICMP TYPE=8 CODE=0 ID=30181 SEQ=1
May 21 05:51:39 kernel: [STATIC-SRC-NAT-10]IN= OUT=eth0.101 SRC=10.5.5.5 DST=4.2.2.2 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=11281 DF PROTO=ICMP TYPE=8 CODE=0 ID=32481 SEQ=1
May 21 05:53:17 kernel: [STATIC-DST-NAT-10]IN=eth0.101 OUT= MAC=0c:11:a6:1d:00:00:64:9d:99:d2:08:53:08:00 SRC=192.168.2.21 DST=10.0.101.235 LEN=60 TOS=0x00 PREC=0x00 TTL=127 ID=16028 PROTO=ICMP TYPE=8 CODE=0 ID=208 SEQ=34739
May 21 13:49:51 kernel: [DST-NAT-10]IN=eth0.101 OUT= MAC=0c:11:a6:1d:00:00:64:9d:99:d2:08:53:08:00 SRC=192.168.2.21 DST=10.0.101.235 LEN=52 TOS=0x00 PREC=0x00 TTL=127 ID=19424 DF PROTO=TCP SPT=15495 DPT=22 WINDOW=64240 RES=0x00 SYN URGP=0

vyos@vyos:~$ show log nat source
May 21 05:45:40 kernel: [SRC-NAT-15-MASQ]IN= OUT=eth0.101 SRC=10.5.5.5 DST=4.2.2.2 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=38271 DF PROTO=ICMP TYPE=8 CODE=0 ID=30181 SEQ=1

vyos@vyos:~$ show log nat source rule 15
May 21 05:45:40 kernel: [SRC-NAT-15-MASQ]IN= OUT=eth0.101 SRC=10.5.5.5 DST=4.2.2.2 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=38271 DF PROTO=ICMP TYPE=8 CODE=0 ID=30181 SEQ=1
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
