### PR TITLE
nat: T6345: source NAT port mapping "fully-random" is superfluous in Kernel >=5.0

### DIFF
--- a/interface-definitions/include/nat-translation-options.xml.i
+++ b/interface-definitions/include/nat-translation-options.xml.i
@@ -28,22 +28,18 @@
       <properties>
         <help>Port mapping options</help>
         <completionHelp>
-          <list>random fully-random none</list>
+          <list>random none</list>
         </completionHelp>
         <valueHelp>
           <format>random</format>
           <description>Randomize source port mapping</description>
         </valueHelp>
         <valueHelp>
-          <format>fully-random</format>
-          <description>Full port randomization</description>
-        </valueHelp>
-        <valueHelp>
           <format>none</format>
           <description>Do not apply port randomization</description>
         </valueHelp>
         <constraint>
-          <regex>(random|fully-random|none)</regex>
+          <regex>(random|none)</regex>
         </constraint>
       </properties>
       <defaultValue>none</defaultValue>

--- a/interface-definitions/include/version/nat-version.xml.i
+++ b/interface-definitions/include/version/nat-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/nat-version.xml.i -->
-<syntaxVersion component='nat' version='7'></syntaxVersion>
+<syntaxVersion component='nat' version='8'></syntaxVersion>
 <!-- include end -->

--- a/smoketest/config-tests/nat-basic
+++ b/smoketest/config-tests/nat-basic
@@ -1,0 +1,85 @@
+set interfaces ethernet eth0 offload rps
+set interfaces ethernet eth0 disable
+set interfaces ethernet eth1 offload gro
+set interfaces ethernet eth1 offload gso
+set interfaces ethernet eth1 offload rps
+set interfaces ethernet eth1 offload sg
+set interfaces ethernet eth1 offload tso
+set interfaces ethernet eth2 offload gro
+set interfaces ethernet eth2 offload gso
+set interfaces ethernet eth2 offload rps
+set interfaces ethernet eth2 offload sg
+set interfaces ethernet eth2 offload tso
+set interfaces ethernet eth3 offload gro
+set interfaces ethernet eth3 offload gso
+set interfaces ethernet eth3 offload rps
+set interfaces ethernet eth3 offload sg
+set interfaces ethernet eth3 offload tso
+set interfaces bonding bond10 hash-policy 'layer3+4'
+set interfaces bonding bond10 member interface 'eth2'
+set interfaces bonding bond10 member interface 'eth3'
+set interfaces bonding bond10 mode '802.3ad'
+set interfaces bonding bond10 vif 50 address '192.168.189.1/24'
+set interfaces loopback lo
+set interfaces pppoe pppoe7 authentication password 'vyos'
+set interfaces pppoe pppoe7 authentication username 'vyos'
+set interfaces pppoe pppoe7 dhcpv6-options pd 0 interface bond10.50 address '1'
+set interfaces pppoe pppoe7 dhcpv6-options pd 0 length '56'
+set interfaces pppoe pppoe7 ip adjust-mss '1452'
+set interfaces pppoe pppoe7 ipv6 address autoconf
+set interfaces pppoe pppoe7 ipv6 adjust-mss '1432'
+set interfaces pppoe pppoe7 mtu '1492'
+set interfaces pppoe pppoe7 no-peer-dns
+set interfaces pppoe pppoe7 source-interface 'eth1'
+set service lldp interface eth1 disable
+set service ntp allow-client address '192.168.189.0/24'
+set service ntp server time1.vyos.net
+set service ntp server time2.vyos.net
+set service ntp listen-address '192.168.189.1'
+set service ssh dynamic-protection
+set service dhcp-server shared-network-name LAN subnet 192.168.189.0/24 lease '604800'
+set service dhcp-server shared-network-name LAN subnet 192.168.189.0/24 option default-router '192.168.189.1'
+set service dhcp-server shared-network-name LAN subnet 192.168.189.0/24 option domain-name 'vyos.net'
+set service dhcp-server shared-network-name LAN subnet 192.168.189.0/24 option name-server '1.1.1.1'
+set service dhcp-server shared-network-name LAN subnet 192.168.189.0/24 option name-server '9.9.9.9'
+set service dhcp-server shared-network-name LAN subnet 192.168.189.0/24 range 0 start '192.168.189.20'
+set service dhcp-server shared-network-name LAN subnet 192.168.189.0/24 range 0 stop '192.168.189.254'
+set service dhcp-server shared-network-name LAN subnet 192.168.189.0/24 subnet-id '1'
+set service router-advert interface bond10.50 prefix ::/64 preferred-lifetime '2700'
+set service router-advert interface bond10.50 prefix ::/64 valid-lifetime '5400'
+set system config-management commit-revisions '100'
+set system domain-name 'vyos.net'
+set system host-name 'R1'
+set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'
+set system login user vyos authentication plaintext-password ''
+set system name-server '1.1.1.1'
+set system name-server '9.9.9.9'
+set system console device ttyS0 speed '115200'
+set nat destination rule 1000 destination port '3389'
+set nat destination rule 1000 inbound-interface name 'pppoe7'
+set nat destination rule 1000 protocol 'tcp'
+set nat destination rule 1000 translation address '192.168.189.5'
+set nat destination rule 1000 translation port '3389'
+set nat destination rule 10022 destination port '10022'
+set nat destination rule 10022 inbound-interface name 'pppoe7'
+set nat destination rule 10022 protocol 'tcp'
+set nat destination rule 10022 translation address '192.168.189.2'
+set nat destination rule 10022 translation port '22'
+set nat destination rule 10300 destination port '10300'
+set nat destination rule 10300 inbound-interface name 'pppoe7'
+set nat destination rule 10300 protocol 'udp'
+set nat destination rule 10300 translation address '192.168.189.2'
+set nat destination rule 10300 translation port '10300'
+set nat source rule 10 outbound-interface name 'eth1'
+set nat source rule 10 source address '192.168.189.0/24'
+set nat source rule 10 translation address 'masquerade'
+set nat source rule 10 translation options port-mapping 'random'
+set nat source rule 50 outbound-interface name 'pppoe7'
+set nat source rule 50 protocol 'udp'
+set nat source rule 50 source address '192.168.189.2'
+set nat source rule 50 source port '10300'
+set nat source rule 50 translation address 'masquerade'
+set nat source rule 50 translation port '10300'
+set nat source rule 100 outbound-interface name 'pppoe7'
+set nat source rule 100 source address '192.168.189.0/24'
+set nat source rule 100 translation address 'masquerade'

--- a/smoketest/configs/nat-basic
+++ b/smoketest/configs/nat-basic
@@ -1,0 +1,256 @@
+interfaces {
+    bonding bond10 {
+        hash-policy "layer3+4"
+        member {
+            interface "eth2"
+            interface "eth3"
+        }
+        mode "802.3ad"
+        vif 50 {
+            address "192.168.189.1/24"
+        }
+    }
+    ethernet eth0 {
+        disable
+        offload {
+            gro
+            gso
+            rps
+            sg
+            tso
+        }
+    }
+    ethernet eth1 {
+        offload {
+            gro
+            gso
+            rps
+            sg
+            tso
+        }
+    }
+    ethernet eth2 {
+        offload {
+            gro
+            gso
+            rps
+            sg
+            tso
+        }
+    }
+    ethernet eth3 {
+        offload {
+            gro
+            gso
+            rps
+            sg
+            tso
+        }
+    }
+    loopback lo {
+    }
+    pppoe pppoe7 {
+        authentication {
+            password "vyos"
+            username "vyos"
+        }
+        dhcpv6-options {
+            pd 0 {
+                interface bond10.50 {
+                    address "1"
+                }
+                length "56"
+            }
+        }
+        ip {
+            adjust-mss "1452"
+        }
+        ipv6 {
+            address {
+                autoconf
+            }
+            adjust-mss "1432"
+        }
+        mtu "1492"
+        no-peer-dns
+        source-interface "eth1"
+    }
+}
+nat {
+    destination {
+        rule 1000 {
+            destination {
+                port "3389"
+            }
+            inbound-interface {
+                name "pppoe7"
+            }
+            protocol "tcp"
+            translation {
+                address "192.168.189.5"
+                port "3389"
+            }
+        }
+        rule 10022 {
+            destination {
+                port "10022"
+            }
+            inbound-interface {
+                name "pppoe7"
+            }
+            protocol "tcp"
+            translation {
+                address "192.168.189.2"
+                port "22"
+            }
+        }
+        rule 10300 {
+            destination {
+                port "10300"
+            }
+            inbound-interface {
+                name "pppoe7"
+            }
+            protocol "udp"
+            translation {
+                address "192.168.189.2"
+                port "10300"
+            }
+        }
+    }
+    source {
+        rule 10 {
+            outbound-interface {
+                name "eth1"
+            }
+            source {
+                address "192.168.189.0/24"
+            }
+            translation {
+                address "masquerade"
+                options {
+                    port-mapping fully-random
+                }
+            }
+        }
+        rule 50 {
+            outbound-interface {
+                name "pppoe7"
+            }
+            protocol "udp"
+            source {
+                address "192.168.189.2"
+                port "10300"
+            }
+            translation {
+                address "masquerade"
+                port "10300"
+            }
+        }
+        rule 100 {
+            outbound-interface {
+                name "pppoe7"
+            }
+            source {
+                address "192.168.189.0/24"
+            }
+            translation {
+                address "masquerade"
+            }
+        }
+    }
+}
+service {
+    dhcp-server {
+        shared-network-name LAN {
+            subnet 192.168.189.0/24 {
+                default-router "192.168.189.1"
+                domain-name "vyos.net"
+                lease "604800"
+                name-server "1.1.1.1"
+                name-server "9.9.9.9"
+                range 0 {
+                    start "192.168.189.20"
+                    stop "192.168.189.254"
+                }
+            }
+        }
+    }
+    lldp {
+        interface all {
+        }
+        interface eth1 {
+            disable
+        }
+    }
+    ntp {
+        allow-client {
+            address "192.168.189.0/24"
+        }
+        listen-address "192.168.189.1"
+        server time1.vyos.net {
+        }
+        server time2.vyos.net {
+        }
+    }
+    router-advert {
+        interface bond10.50 {
+            prefix ::/64 {
+                preferred-lifetime "2700"
+                valid-lifetime "5400"
+            }
+        }
+    }
+    ssh {
+        disable-host-validation
+        dynamic-protection {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    conntrack {
+        modules {
+            ftp
+            h323
+            nfs
+            pptp
+            sip
+            sqlnet
+            tftp
+        }
+    }
+    console {
+        device ttyS0 {
+            speed "115200"
+        }
+    }
+    domain-name "vyos.net"
+    host-name "R1"
+    login {
+        user vyos {
+            authentication {
+                encrypted-password $6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/
+                plaintext-password ""
+            }
+        }
+    }
+    name-server "1.1.1.1"
+    name-server "9.9.9.9"
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}
+
+// Warning: Do not remove the following line.
+// vyos-config-version: "bgp@5:broadcast-relay@1:cluster@2:config-management@1:conntrack@5:conntrack-sync@2:container@2:dhcp-relay@2:dhcp-server@8:dhcpv6-server@1:dns-dynamic@4:dns-forwarding@4:firewall@15:flow-accounting@1:https@6:ids@1:interfaces@32:ipoe-server@3:ipsec@13:isis@3:l2tp@9:lldp@2:mdns@1:monitoring@1:nat@7:nat66@3:ntp@3:openconnect@3:ospf@2:pim@1:policy@8:pppoe-server@10:pptp@5:qos@2:quagga@11:rip@1:rpki@2:salt@1:snmp@3:ssh@2:sstp@6:system@27:vrf@3:vrrp@4:vyos-accel-ppp@2:wanloadbalance@3:webproxy@2"
+// Release version: 1.4.0-epa3

--- a/src/migration-scripts/nat/7-to-8
+++ b/src/migration-scripts/nat/7-to-8
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# T6345: random - In kernel 5.0 and newer this is the same as fully-random.
+#        In earlier kernels the port mapping will be randomized using a seeded
+#        MD5 hash mix using source and destination address and destination port.
+#        drop fully-random from CLI
+
+from sys import argv,exit
+from vyos.configtree import ConfigTree
+
+if len(argv) < 2:
+    print("Must specify file name!")
+    exit(1)
+
+file_name = argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+
+if not config.exists(['nat']):
+    # Nothing to do
+    exit(0)
+
+for direction in ['source', 'destination']:
+    # If a node doesn't exist, we obviously have nothing to do.
+    if not config.exists(['nat', direction]):
+        continue
+
+    # However, we also need to handle the case when a 'source' or 'destination' sub-node does exist,
+    # but there are no rules under it.
+    if not config.list_nodes(['nat', direction]):
+        continue
+
+    for rule in config.list_nodes(['nat', direction, 'rule']):
+        port_mapping = ['nat', direction, 'rule', rule, 'translation', 'options', 'port-mapping']
+        if config.exists(port_mapping):
+            tmp = config.return_value(port_mapping)
+            if tmp == 'fully-random':
+                config.set(port_mapping, value='random')
+
+try:
+    with open(file_name, 'w') as f:
+        f.write(config.to_string())
+except OSError as e:
+    print(f'Failed to save the modified config: {e}')
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

`random` - In kernel 5.0 and newer this is the same as `fully-random`. In earlier kernels the port mapping will be randomized using a seeded MD5 hash mix using source and destination address and destination port.

https://git.netfilter.org/nftables/commit/?id=fbe27464dee4588d906492749251454

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6345

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
NAT

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_nat.py
test_dnat (__main__.TestNAT.test_dnat) ... ok
test_dnat_negated_addresses (__main__.TestNAT.test_dnat_negated_addresses) ... ok
test_dnat_redirect (__main__.TestNAT.test_dnat_redirect) ... ok
test_dnat_without_translation_address (__main__.TestNAT.test_dnat_without_translation_address) ... ok
test_nat_balance (__main__.TestNAT.test_nat_balance) ... ok
test_nat_no_rules (__main__.TestNAT.test_nat_no_rules) ... ok
test_snat (__main__.TestNAT.test_snat) ... ok
test_snat_groups (__main__.TestNAT.test_snat_groups) ... ok
test_snat_net_port_map (__main__.TestNAT.test_snat_net_port_map) ... ok
test_snat_required_translation_address (__main__.TestNAT.test_snat_required_translation_address) ... ok
test_static_nat (__main__.TestNAT.test_static_nat) ... ok

----------------------------------------------------------------------
Ran 11 tests in 54.925s

OK
```

`make testc` reports

![image](https://github.com/vyos/vyos-1x/assets/25299219/77c7a1e9-c940-45e8-b74a-b14d046961f0)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
