### PR TITLE
T4576: Accel-ppp logging level configuration

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.j2
+++ b/data/templates/accel-ppp/ipoe.config.j2
@@ -29,7 +29,9 @@ max-starting={{ max_concurrent_sessions }}
 [log]
 syslog=accel-ipoe,daemon
 copy=1
-level=5
+{% if log.level is vyos_defined %}
+level={{ log.level }}
+{% endif %}
 
 [ipoe]
 verbose=1

--- a/data/templates/accel-ppp/l2tp.config.j2
+++ b/data/templates/accel-ppp/l2tp.config.j2
@@ -28,7 +28,9 @@ max-starting={{ max_concurrent_sessions }}
 [log]
 syslog=accel-l2tp,daemon
 copy=1
-level=5
+{% if log.level is vyos_defined %}
+level={{ log.level }}
+{% endif %}
 
 [client-ip-range]
 0.0.0.0/0

--- a/data/templates/accel-ppp/pppoe.config.j2
+++ b/data/templates/accel-ppp/pppoe.config.j2
@@ -27,7 +27,9 @@ thread-count={{ thread_count }}
 [log]
 syslog=accel-pppoe,daemon
 copy=1
-level=5
+{% if log.level is vyos_defined %}
+level={{ log.level }}
+{% endif %}
 
 {% if authentication.mode is vyos_defined("noauth") %}
 [auth]

--- a/data/templates/accel-ppp/pptp.config.j2
+++ b/data/templates/accel-ppp/pptp.config.j2
@@ -28,7 +28,9 @@ max-starting={{ max_concurrent_sessions }}
 [log]
 syslog=accel-pptp,daemon
 copy=1
-level=5
+{% if log.level is vyos_defined %}
+level={{ log.level }}
+{% endif %}
 
 [client-ip-range]
 0.0.0.0/0

--- a/data/templates/accel-ppp/sstp.config.j2
+++ b/data/templates/accel-ppp/sstp.config.j2
@@ -29,7 +29,9 @@ max-starting={{ max_concurrent_sessions }}
 [log]
 syslog=accel-sstp,daemon
 copy=1
-level=5
+{% if log.level is vyos_defined %}
+level={{ log.level }}
+{% endif %}
 
 [client-ip-range]
 0.0.0.0/0

--- a/interface-definitions/include/accel-ppp/log.xml.i
+++ b/interface-definitions/include/accel-ppp/log.xml.i
@@ -1,0 +1,42 @@
+<!-- include start from accel-ppp/log.xml.i -->
+<node name="log">
+  <properties>
+    <help>Server logging </help>
+  </properties>
+  <children>
+    <leafNode name="level">
+      <properties>
+        <help>Specifies log level</help>
+        <valueHelp>
+          <format>0</format>
+          <description>Turn off logging</description>
+        </valueHelp>
+        <valueHelp>
+          <format>1</format>
+          <description>Log only error messages</description>
+        </valueHelp>
+        <valueHelp>
+          <format>2</format>
+          <description>Log error and warning messages</description>
+        </valueHelp>
+        <valueHelp>
+          <format>3</format>
+          <description>Log error, warning and minimum information messages</description>
+        </valueHelp>
+        <valueHelp>
+          <format>4</format>
+          <description>Log error, warning and full information messages</description>
+        </valueHelp>
+        <valueHelp>
+          <format>5</format>
+          <description>Log all messages including debug messages</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 0-5"/>
+        </constraint>
+      </properties>
+      <defaultValue>3</defaultValue>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/service_ipoe-server.xml.in
+++ b/interface-definitions/service_ipoe-server.xml.in
@@ -189,6 +189,7 @@
           #include <include/accel-ppp/snmp.xml.i>
           #include <include/generic-description.xml.i>
           #include <include/name-server-ipv4-ipv6.xml.i>
+          #include <include/accel-ppp/log.xml.i>
         </children>
       </node>
     </children>

--- a/interface-definitions/service_pppoe-server.xml.in
+++ b/interface-definitions/service_pppoe-server.xml.in
@@ -153,6 +153,7 @@
           #include <include/accel-ppp/wins-server.xml.i>
           #include <include/generic-description.xml.i>
           #include <include/name-server-ipv4-ipv6.xml.i>
+          #include <include/accel-ppp/log.xml.i>
         </children>
       </node>
     </children>

--- a/interface-definitions/vpn_l2tp.xml.in
+++ b/interface-definitions/vpn_l2tp.xml.in
@@ -140,6 +140,7 @@
               #include <include/accel-ppp/wins-server.xml.i>
               #include <include/generic-description.xml.i>
               #include <include/name-server-ipv4-ipv6.xml.i>
+              #include <include/accel-ppp/log.xml.i>
             </children>
           </node>
         </children>

--- a/interface-definitions/vpn_pptp.xml.in
+++ b/interface-definitions/vpn_pptp.xml.in
@@ -56,6 +56,7 @@
               #include <include/accel-ppp/wins-server.xml.i>
               #include <include/generic-description.xml.i>
               #include <include/name-server-ipv4-ipv6.xml.i>
+              #include <include/accel-ppp/log.xml.i>
             </children>
           </node>
         </children>

--- a/interface-definitions/vpn_sstp.xml.in
+++ b/interface-definitions/vpn_sstp.xml.in
@@ -62,6 +62,7 @@
               <constraintErrorMessage>Host-name must be alphanumeric and can contain hyphens</constraintErrorMessage>
             </properties>
           </leafNode>
+          #include <include/accel-ppp/log.xml.i>
         </children>
       </node>
     </children>

--- a/smoketest/scripts/cli/base_accel_ppp_test.py
+++ b/smoketest/scripts/cli/base_accel_ppp_test.py
@@ -628,3 +628,21 @@ delegate={delegate_2_prefix},{delegate_mask},name={pool_name}"""
             self.assertEqual(conf['connlimit']['limit'], limits)
             self.assertEqual(conf['connlimit']['burst'], burst)
             self.assertEqual(conf['connlimit']['timeout'], timeout)
+
+        def test_accel_log_level(self):
+            self.basic_config()
+            self.cli_commit()
+
+            # check default value
+            conf = ConfigParser(allow_no_value=True)
+            conf.read(self._config_file)
+            self.assertEqual(conf['log']['level'], '3')
+
+            for log_level in range(0, 5):
+                self.set(['log', 'level', str(log_level)])
+                self.cli_commit()
+                # Validate configuration values
+                conf = ConfigParser(allow_no_value=True)
+                conf.read(self._config_file)
+
+                self.assertEqual(conf['log']['level'], str(log_level))


### PR DESCRIPTION
add ability to change logging level config for:
* VPN L2TP
* VPN PPTP
* VPN SSTP
* IPoE Server
* PPPoE Serve

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T4576

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configure service e.g. VPN L2TP:
```
set vpn ipsec interface 'eth0'
set vpn l2tp remote-access authentication local-users username test password 'test'
set vpn l2tp remote-access authentication mode 'local'
set vpn l2tp remote-access client-ip-pool L2TP-POOL range '192.168.255.2-192.168.255.254'
set vpn l2tp remote-access default-pool 'L2TP-POOL'
set vpn l2tp remote-access gateway-address '192.168.255.1'
set vpn l2tp remote-access ipsec-settings authentication mode 'pre-shared-secret'
set vpn l2tp remote-access ipsec-settings authentication pre-shared-secret 'test'
set vpn l2tp remote-access outside-address '192.168.122.166'
```
and connect to service:
```
vyos@vyos:~$ show l2tp-server sessions
 ifname | username |      ip       | ip6 | ip6-dp |  calling-sid  | rate-limit | state  |  uptime  | rx-bytes | tx-bytes 
--------+----------+---------------+-----+--------+---------------+------------+--------+----------+----------+----------
 l2tp0  | test     | 192.168.255.2 |     |        | 192.168.122.1 |            | active | 00:00:29 | 52 B     | 208 B
```
log level = 5
```
vyos@vyos:~$ journalctl --unit accel-ppp@l2tp.service
May 23 12:06:14 vyos systemd[1]: Stopping accel-ppp@l2tp.service - Accel-PPP - >
May 23 12:06:14 vyos accel-l2tp[2883]: terminate, sig = 15
May 23 12:06:15 vyos systemd[1]: accel-ppp@l2tp.service: Deactivated successful>
May 23 12:06:15 vyos systemd[1]: Stopped accel-ppp@l2tp.service - Accel-PPP - H>
May 23 12:06:15 vyos systemd[1]: Starting accel-ppp@l2tp.service - Accel-PPP - >
May 23 12:06:15 vyos systemd[1]: Started accel-ppp@l2tp.service - Accel-PPP - H>
May 23 12:06:15 vyos accel-l2tp[3925]: l2tp: iprange module disabled, improper >
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp: recv [L2TP tid=0 sid=0 Ns=0 Nr=0 <>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp: handling SCCRQ from 192.168.122.1
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp: new tunnel 48754-6741 created foll>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp session 48754-6741, 54439-63018: se>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp session 48754-6741, 54439-63018: ha>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: l2tp tunnel 48754-6741 (192.168.122.1:17>
May 23 12:06:45 vyos accel-l2tp[3925]: :: starting data channel for l2tp(192.16>
May 23 12:06:45 vyos accel-l2tp[3925]: :: lcp_layer_init
May 23 12:06:45 vyos accel-l2tp[3925]: :: auth_layer_init
May 23 12:06:45 vyos accel-l2tp[3925]: :: ccp_layer_init
May 23 12:06:45 vyos accel-l2tp[3925]: :: ipcp_layer_init
May 23 12:06:45 vyos accel-l2tp[3925]: :: ipv6cp_layer_init
May 23 12:06:45 vyos accel-l2tp[3925]: :: ppp establishing
May 23 12:06:45 vyos accel-l2tp[3925]: :: lcp_layer_start
May 23 12:06:45 vyos accel-l2tp[3925]: :: send [LCP ConfReq id=61 <auth PAP> <m>
May 23 12:06:45 vyos accel-l2tp[3925]: :: recv [LCP ConfReq id=1 <mru 1400> < 2>
May 23 12:06:45 vyos accel-l2tp[3925]: :: send [LCP ConfRej id=1 < 2 6 0 0 0 0 >
May 23 12:06:45 vyos accel-l2tp[3925]: :: recv [LCP ConfReq id=2 <mru 1400> <ma>
May 23 12:06:45 vyos accel-l2tp[3925]: :: send [LCP ConfAck id=2]
May 23 12:06:48 vyos accel-l2tp[3925]: :: fsm timeout 9
```
log level 0:
```
vyos@vyos# set vpn l2tp remote-access log level 0
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# journalctl --unit accel-ppp@l2tp.service
May 23 12:10:10 vyos systemd[1]: Stopping accel-ppp@l2tp.service - Accel-PPP - >
May 23 12:10:10 vyos accel-l2tp[3925]: terminate, sig = 15
May 23 12:10:11 vyos systemd[1]: accel-ppp@l2tp.service: Deactivated successful>
May 23 12:10:11 vyos systemd[1]: Stopped accel-ppp@l2tp.service - Accel-PPP - H>
May 23 12:10:11 vyos systemd[1]: Starting accel-ppp@l2tp.service - Accel-PPP - >
May 23 12:10:11 vyos systemd[1]: accel-ppp@l2tp.service: Can't open PID file /r>
May 23 12:10:11 vyos systemd[1]: Started accel-ppp@l2tp.service - Accel-PPP - H>
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_vpn_l2tp.py 
test_accel_ipv4_pool (__main__.TestVPNL2TPServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestVPNL2TPServer.test_accel_ipv6_pool) ... 
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_limits (__main__.TestVPNL2TPServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestVPNL2TPServer.test_accel_local_authentication) ... 
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_log_level (__main__.TestVPNL2TPServer.test_accel_log_level) ... ok
test_accel_name_servers (__main__.TestVPNL2TPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNL2TPServer.test_accel_next_pool) ... 
WARNING: 'default-pool' is not defined

ok
test_accel_ppp_options (__main__.TestVPNL2TPServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestVPNL2TPServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestVPNL2TPServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestVPNL2TPServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestVPNL2TPServer.test_accel_wins_server) ... ok
test_l2tp_radius_server (__main__.TestVPNL2TPServer.test_l2tp_radius_server) ... ok
test_l2tp_server_authentication_protocols (__main__.TestVPNL2TPServer.test_l2tp_server_authentication_protocols) ... ok
test_vpn_l2tp_dependence_ipsec_swanctl (__main__.TestVPNL2TPServer.test_vpn_l2tp_dependence_ipsec_swanctl) ... 
WARNING: 'default-pool' is not defined

ok

----------------------------------------------------------------------
Ran 15 tests in 81.208s

OK
```

```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_vpn_pptp.py 
test_accel_ipv4_pool (__main__.TestVPNPPTPServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestVPNPPTPServer.test_accel_ipv6_pool) ... 
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_limits (__main__.TestVPNPPTPServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestVPNPPTPServer.test_accel_local_authentication) ... 
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_log_level (__main__.TestVPNPPTPServer.test_accel_log_level) ... ok
test_accel_name_servers (__main__.TestVPNPPTPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNPPTPServer.test_accel_next_pool) ... 
WARNING: 'default-pool' is not defined

ok
test_accel_ppp_options (__main__.TestVPNPPTPServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestVPNPPTPServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestVPNPPTPServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestVPNPPTPServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestVPNPPTPServer.test_accel_wins_server) ... ok

----------------------------------------------------------------------
Ran 12 tests in 62.968s

OK
```

```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_vpn_sstp.py 
test_accel_ipv4_pool (__main__.TestVPNSSTPServer.test_accel_ipv4_pool) ... PKI: Updating config: vpn sstp ssl certificate sstp
PKI: Updating config: vpn sstp ssl ca_certificate sstp
ok
test_accel_ipv6_pool (__main__.TestVPNSSTPServer.test_accel_ipv6_pool) ... 
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_limits (__main__.TestVPNSSTPServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestVPNSSTPServer.test_accel_local_authentication) ... 
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_log_level (__main__.TestVPNSSTPServer.test_accel_log_level) ... ok
test_accel_name_servers (__main__.TestVPNSSTPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNSSTPServer.test_accel_next_pool) ... 
WARNING: 'default-pool' is not defined

ok
test_accel_ppp_options (__main__.TestVPNSSTPServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestVPNSSTPServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestVPNSSTPServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestVPNSSTPServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestVPNSSTPServer.test_accel_wins_server) ... ok
test_sstp_host_name (__main__.TestVPNSSTPServer.test_sstp_host_name) ... ok

----------------------------------------------------------------------
Ran 13 tests in 60.533s

OK
```

```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py 
test_accel_ipv4_pool (__main__.TestServicePPPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServicePPPoEServer.test_accel_ipv6_pool) ... 
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_limits (__main__.TestServicePPPoEServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestServicePPPoEServer.test_accel_local_authentication) ... 
User "test" has rate-limit configured for only one direction but both
upload and download must be given!

ok
test_accel_log_level (__main__.TestServicePPPoEServer.test_accel_log_level) ... ok
test_accel_name_servers (__main__.TestServicePPPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServicePPPoEServer.test_accel_next_pool) ... 
WARNING: 'default-pool' is not defined

ok
test_accel_ppp_options (__main__.TestServicePPPoEServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestServicePPPoEServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestServicePPPoEServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestServicePPPoEServer.test_accel_wins_server) ... ok
test_pppoe_limits (__main__.TestServicePPPoEServer.test_pppoe_limits) ... ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer.test_pppoe_server_authentication_protocols) ... ok
test_pppoe_server_pado_delay (__main__.TestServicePPPoEServer.test_pppoe_server_pado_delay) ... ok
test_pppoe_server_shaper (__main__.TestServicePPPoEServer.test_pppoe_server_shaper) ... ok
test_pppoe_server_vlan (__main__.TestServicePPPoEServer.test_pppoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 17 tests in 80.276s

OK
```

```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_service_ipoe-server.py 
test_accel_ipv4_pool (__main__.TestServiceIPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServiceIPoEServer.test_accel_ipv6_pool) ... 
WARNING: IPv4 Server requires gateway-address to be configured!


WARNING: 'default-ipv6-pool' is not defined

ok
test_accel_limits (__main__.TestServiceIPoEServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestServiceIPoEServer.test_accel_local_authentication) ... 
No IPoE interface configured

ok
test_accel_log_level (__main__.TestServiceIPoEServer.test_accel_log_level) ... ok
test_accel_name_servers (__main__.TestServiceIPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServiceIPoEServer.test_accel_next_pool) ... 
WARNING: 'default-pool' is not defined

ok
test_accel_ppp_options (__main__.TestServiceIPoEServer.test_accel_ppp_options) ... skipped 'PPP is not a part of IPoE'
test_accel_radius_authentication (__main__.TestServiceIPoEServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestServiceIPoEServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestServiceIPoEServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestServiceIPoEServer.test_accel_wins_server) ... skipped 'WINS server is not used in IPoE'

----------------------------------------------------------------------
Ran 12 tests in 45.621s

OK (skipped=2)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
