### PR TITLE
T3493: dhcpv6-server does not have prefix range validation

### DIFF
--- a/interface-definitions/service_dhcpv6-server.xml.in
+++ b/interface-definitions/service_dhcpv6-server.xml.in
@@ -229,7 +229,8 @@
                             <description>IPv6 address used in prefix delegation</description>
                           </valueHelp>
                           <constraint>
-                            <validator name="ipv6-address"/>
+                            <!-- IPv6 address used MUST end with :: -->
+                            <regex>([a-fA-F0-9]{1,4}:)+:</regex>
                           </constraint>
                         </properties>
                         <children>
@@ -254,7 +255,8 @@
                                 <description>IPv6 address used in prefix delegation</description>
                               </valueHelp>
                               <constraint>
-                                <validator name="ipv6-address"/>
+                                <!-- IPv6 address used MUST end with :: -->
+                                <regex>([a-fA-F0-9]{1,4}:)+:</regex>
                               </constraint>
                             </properties>
                           </leafNode>

--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2023 VyOS maintainers and contributors
+# Copyright (C) 2021-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -47,6 +47,8 @@ class VyOSUnitTestSHIM:
         def setUpClass(cls):
             cls._session = ConfigSession(os.getpid())
             cls._session.save_config(save_config)
+            if os.path.exists('/tmp/vyos.smoketest.debug'):
+                cls.debug = True
             pass
 
         @classmethod

--- a/smoketest/scripts/cli/test_service_dhcpv6-server.py
+++ b/smoketest/scripts/cli/test_service_dhcpv6-server.py
@@ -18,6 +18,7 @@ import unittest
 
 from base_vyostest_shim import VyOSUnitTestSHIM
 
+from vyos.configsession import ConfigSessionError
 from vyos.template import inc_ip
 from vyos.utils.process import process_named_running
 from vyos.utils.file import read_file
@@ -143,8 +144,13 @@ class TestServiceDHCPv6Server(VyOSUnitTestSHIM.TestCase):
         pool = base_path + ['shared-network-name', shared_net_name, 'subnet', subnet]
 
         self.cli_set(pool + ['address-range', 'start', range_start, 'stop', range_stop])
-        self.cli_set(pool + ['prefix-delegation', 'start', delegate_start, 'stop', delegate_stop])
         self.cli_set(pool + ['prefix-delegation', 'start', delegate_start, 'prefix-length', delegate_len])
+
+        self.cli_set(pool + ['prefix-delegation', 'start', delegate_start, 'stop', delegate_start])
+        # Prefix delegation stop address must be greater then start address
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(pool + ['prefix-delegation', 'start', delegate_start, 'stop', delegate_stop])
 
         # commit changes
         self.cli_commit()

--- a/src/conf_mode/service_dhcpv6-server.py
+++ b/src/conf_mode/service_dhcpv6-server.py
@@ -105,22 +105,29 @@ def verify(dhcpv6):
                 if 'prefix' in subnet_config:
                     for prefix in subnet_config['prefix']:
                         if ip_network(prefix) not in ip_network(subnet):
-                            raise ConfigError(f'address-range prefix "{prefix}" is not in subnet "{subnet}""')
+                            raise ConfigError(f'address-range prefix "{prefix}" is not in subnet "{subnet}"!')
 
             # Prefix delegation sanity checks
             if 'prefix_delegation' in subnet_config:
                 if 'start' not in subnet_config['prefix_delegation']:
-                    raise ConfigError('prefix-delegation start address not defined!')
+                        raise ConfigError(f'Start address of delegated IPv6 prefix range "{prefix}" '\
+                                          f'must be configured!')
 
                 for prefix, prefix_config in subnet_config['prefix_delegation']['start'].items():
                     if 'stop' not in prefix_config:
-                        raise ConfigError(f'Stop address of delegated IPv6 '\
-                                          f'prefix range "{prefix}" '\
-                                          f'must be configured')
+                        raise ConfigError(f'Stop address of delegated IPv6 prefix range "{prefix}" '\
+                                          f'must be configured!')
+
+                    start_addr = prefix
+                    stop_addr = prefix_config['stop']
+
+                    if ip_address(stop_addr) <= ip_address(start_addr):
+                        raise ConfigError(f'Stop address of delegated IPv6 prefix range "{prefix}" '\
+                                          f'must be greater than start address!')
 
                     if 'prefix_length' not in prefix_config:
                         raise ConfigError(f'Length of delegated IPv6 prefix '\
-                                          f'must be configured')
+                                          f'must be configured!')
 
             # Static mappings don't require anything (but check if IP is in subnet if it's set)
             if 'static_mapping' in subnet_config:

--- a/src/conf_mode/service_dhcpv6-server.py
+++ b/src/conf_mode/service_dhcpv6-server.py
@@ -113,28 +113,10 @@ def verify(dhcpv6):
                     raise ConfigError('prefix-delegation start address not defined!')
 
                 for prefix, prefix_config in subnet_config['prefix_delegation']['start'].items():
-                    prefix_start_addr = prefix
-
-                    # Prefix start address must be inside network
-                    if not ip_address(prefix_start_addr) in ip_network(subnet):
-                        raise ConfigError(f'Prefix delegation start address '\
-                                          f'"{prefix_start_addr}" is not in '\
-                                          f'subnet "{subnet}"')
-
                     if 'stop' not in prefix_config:
                         raise ConfigError(f'Stop address of delegated IPv6 '\
                                           f'prefix range "{prefix}" '\
                                           f'must be configured')
-
-                    if 'stop' in prefix_config:
-                       prefix_stop_addr = prefix_config['stop']
-
-                       # Prefix stop address must be inside network
-                       if not (ip_address(prefix_stop_addr) in
-                              ip_network(subnet)):
-                           raise ConfigError(f'Prefix delegation stop '\
-                                             f'address "{prefix_stop_addr}" '\
-                                             f'is not in subnet "{subnet}"')
 
                     if 'prefix_length' not in prefix_config:
                         raise ConfigError(f'Length of delegated IPv6 prefix '\

--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -388,6 +388,7 @@ start ()
         touch /tmp/vyos.ifconfig.debug
         touch /tmp/vyos.frr.debug
         touch /tmp/vyos.container.debug
+        touch /tmp/vyos.smoketest.debug
     fi
 
     log_action_begin_msg "Mounting VyOS Config"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

ISC DHCP server expects a string: `prefix6 2001:db8:290:: 2001:db8:29f:: /64;` where the IPv6 prefix/range must be :: terminaated with a delegated prefix length at the end.

This commit changes the validator that the IPv6 address defined on the CLI must always end with `::`. In addition a `verify()` step is added to check that the stop address is greater than start address.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T3493

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/3499

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcpv6-server

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR2.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_dhcpv6-server.py
test_global_nameserver (__main__.TestServiceDHCPv6Server.test_global_nameserver) ... ok
test_prefix_delegation (__main__.TestServiceDHCPv6Server.test_prefix_delegation) ... ok
test_single_pool (__main__.TestServiceDHCPv6Server.test_single_pool) ... ok

----------------------------------------------------------------------
Ran 3 tests in 15.454s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
