### PR TITLE
T5786: Add set/show system image to /image endpoint

### DIFF
--- a/python/vyos/configsession.py
+++ b/python/vyos/configsession.py
@@ -34,6 +34,8 @@ INSTALL_IMAGE = ['/usr/libexec/vyos/op_mode/image_installer.py',
                  '--action', 'add', '--no-prompt', '--image-path']
 REMOVE_IMAGE = ['/usr/libexec/vyos/op_mode/image_manager.py',
                 '--action', 'delete', '--no-prompt', '--image-name']
+SET_DEFAULT_IMAGE = ['/usr/libexec/vyos/op_mode/image_manager.py',
+                '--action', 'set', '--no-prompt', '--image-name']
 GENERATE = ['/opt/vyatta/bin/vyatta-op-cmd-wrapper', 'generate']
 SHOW = ['/opt/vyatta/bin/vyatta-op-cmd-wrapper', 'show']
 RESET = ['/opt/vyatta/bin/vyatta-op-cmd-wrapper', 'reset']
@@ -233,6 +235,10 @@ class ConfigSession(object):
 
     def remove_image(self, name):
         out = self.__run_command(REMOVE_IMAGE + [name])
+        return out
+
+    def set_default_image(self, name):
+        out = self.__run_command(SET_DEFAULT_IMAGE + [name])
         return out
 
     def generate(self, path):

--- a/smoketest/scripts/cli/test_service_https.py
+++ b/smoketest/scripts/cli/test_service_https.py
@@ -412,6 +412,47 @@ class TestHTTPSService(VyOSUnitTestSHIM.TestCase):
         self.assertEqual(r.status_code, 200)
 
     @ignore_warning(InsecureRequestWarning)
+    def test_api_image(self):
+        address = '127.0.0.1'
+        key = 'VyOS-key'
+        url = f'https://{address}/image'
+        headers = {}
+
+        self.cli_set(base_path + ['api', 'keys', 'id', 'key-01', 'key', key])
+        self.cli_commit()
+
+        payload = {
+            'data': '{"op": "add"}',
+            'key': f'{key}',
+        }
+        r = request('POST', url, verify=False, headers=headers, data=payload)
+        self.assertEqual(r.status_code, 400)
+        self.assertIn('Missing required field "url"', r.json().get('error'))
+
+        payload = {
+            'data': '{"op": "delete"}',
+            'key': f'{key}',
+        }
+        r = request('POST', url, verify=False, headers=headers, data=payload)
+        self.assertEqual(r.status_code, 400)
+        self.assertIn('Missing required field "name"', r.json().get('error'))
+
+        payload = {
+            'data': '{"op": "set_default"}',
+            'key': f'{key}',
+        }
+        r = request('POST', url, verify=False, headers=headers, data=payload)
+        self.assertEqual(r.status_code, 400)
+        self.assertIn('Missing required field "name"', r.json().get('error'))
+
+        payload = {
+            'data': '{"op": "show"}',
+            'key': f'{key}',
+        }
+        r = request('POST', url, verify=False, headers=headers, data=payload)
+        self.assertEqual(r.status_code, 200)
+
+    @ignore_warning(InsecureRequestWarning)
     def test_api_config_file_load_http(self):
         # Test load config from HTTP URL
         address = '127.0.0.1'

--- a/src/services/vyos-http-api-server
+++ b/src/services/vyos-http-api-server
@@ -23,16 +23,17 @@ import logging
 import signal
 import traceback
 import threading
+from enum import Enum
 
 from time import sleep
-from typing import List, Union, Callable, Dict
+from typing import List, Union, Callable, Dict, Self
 
 from fastapi import FastAPI, Depends, Request, Response, HTTPException
 from fastapi import BackgroundTasks
 from fastapi.responses import HTMLResponse
 from fastapi.exceptions import RequestValidationError
 from fastapi.routing import APIRoute
-from pydantic import BaseModel, StrictStr, validator
+from pydantic import BaseModel, StrictStr, validator, model_validator
 from starlette.middleware.cors import CORSMiddleware
 from starlette.datastructures import FormData
 from starlette.formparsers import FormParser, MultiPartParser
@@ -177,16 +178,35 @@ class ConfigFileModel(ApiModel):
             }
         }
 
+
+class ImageOp(str, Enum):
+    add = "add"
+    delete = "delete"
+    show = "show"
+    set_default = "set_default"
+
+
 class ImageModel(ApiModel):
-    op: StrictStr
+    op: ImageOp
     url: StrictStr = None
     name: StrictStr = None
+
+    @model_validator(mode='after')
+    def check_data(self) -> Self:
+        if self.op == 'add':
+            if not self.url:
+                raise ValueError("Missing required field \"url\"")
+        elif self.op in ['delete', 'set_default']:
+            if not self.name:
+                raise ValueError("Missing required field \"name\"")
+
+        return self
 
     class Config:
         schema_extra = {
             "example": {
                 "key": "id_key",
-                "op": "add | delete",
+                "op": "add | delete | show | set_default",
                 "url": "imagelocation",
                 "name": "imagename",
             }
@@ -668,19 +688,13 @@ def image_op(data: ImageModel):
 
     try:
         if op == 'add':
-            if data.url:
-                url = data.url
-            else:
-                return error(400, "Missing required field \"url\"")
-            res = session.install_image(url)
+            res = session.install_image(data.url)
         elif op == 'delete':
-            if data.name:
-                name = data.name
-            else:
-                return error(400, "Missing required field \"name\"")
-            res = session.remove_image(name)
-        else:
-            return error(400, f"'{op}' is not a valid operation")
+            res = session.remove_image(data.name)
+        elif op == 'show':
+            res = session.show(["system", "image"])
+        elif op == 'set_default':
+            res = session.set_default_image(data.name)
     except ConfigSessionError as e:
         return error(400, str(e))
     except Exception as e:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T5786

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
curl --location 'https://vyos_url/image' \
--header 'Content-Type: application/json' \
--data '{
    "key": "api_key",
    "op": "show"
}'
```

```
curl --location 'https://vyos_url/image' \
--header 'Content-Type: application/json' \
--data '{
    "key": "api_key",
    "op": "set_default",
    "name": "1.5-rolling-20240527002"
}'
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_service_https.py 
test_api_add_delete (__main__.TestHTTPSService.test_api_add_delete) ... ok
test_api_auth (__main__.TestHTTPSService.test_api_auth) ... ok
test_api_config_file (__main__.TestHTTPSService.test_api_config_file) ... ok
test_api_config_file_load_http (__main__.TestHTTPSService.test_api_config_file_load_http) ... ok
test_api_configure (__main__.TestHTTPSService.test_api_configure) ... ok
test_api_generate (__main__.TestHTTPSService.test_api_generate) ... ok
test_api_image (__main__.TestHTTPSService.test_api_image) ... ok
test_api_incomplete_key (__main__.TestHTTPSService.test_api_incomplete_key) ... ok
test_api_missing_keys (__main__.TestHTTPSService.test_api_missing_keys) ... ok
test_api_reset (__main__.TestHTTPSService.test_api_reset) ... ok
test_api_show (__main__.TestHTTPSService.test_api_show) ... ok
test_certificate (__main__.TestHTTPSService.test_certificate) ... ok

----------------------------------------------------------------------
Ran 12 tests in 98.410s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
