### PR TITLE
T6406: Container CPU limits

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -192,7 +192,7 @@
               </leafNode>
             </children>
           </tagNode>
-          <leafNode name="cpus">
+          <leafNode name="cpu-quota">
             <properties>
               <help>This limits the number of CPU resources the container can use</help>
               <valueHelp>

--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -192,6 +192,24 @@
               </leafNode>
             </children>
           </tagNode>
+          <leafNode name="cpus">
+            <properties>
+              <help>This limits the number of CPU resources the container can use</help>
+              <valueHelp>
+                <format>u32:0</format>
+                <description>Unlimited</description>
+              </valueHelp>
+              <valueHelp>
+                <format>txt</format>
+                <description>Amount of CPU time the container can use in amount of cores (up to three decimals)</description>
+              </valueHelp>
+              <constraint>
+                <regex>(0|[1-9]\d*)(\.\d{1,3})?</regex>
+              </constraint>
+              <constraintErrorMessage>Container CPU limit must be a (decimal) number in range 0 to number of threads</constraintErrorMessage>
+            </properties>
+            <defaultValue>0</defaultValue>
+          </leafNode>
           <leafNode name="memory">
             <properties>
               <help>Memory (RAM) available to this container</help>

--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -96,7 +96,7 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
 
         self.cli_set(base_path + ['name', cont_name, 'allow-host-networks'])
         self.cli_set(base_path + ['name', cont_name, 'image', cont_image])
-        self.cli_set(base_path + ['name', cont_name, 'cpus', '1.25'])
+        self.cli_set(base_path + ['name', cont_name, 'cpu-quota', '1.25'])
 
         self.cli_commit()
 

--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -91,6 +91,22 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         # Check for running process
         self.assertEqual(process_named_running(PROCESS_NAME), pid)
 
+    def test_cpu_limit(self):
+        cont_name = 'c2'
+
+        self.cli_set(base_path + ['name', cont_name, 'allow-host-networks'])
+        self.cli_set(base_path + ['name', cont_name, 'image', cont_image])
+        self.cli_set(base_path + ['name', cont_name, 'cpus', '1.25'])
+
+        self.cli_commit()
+
+        pid = 0
+        with open(PROCESS_PIDFILE.format(cont_name), 'r') as f:
+            pid = int(f.read())
+
+        # Check for running process
+        self.assertEqual(process_named_running(PROCESS_NAME), pid)
+
     def test_ipv4_network(self):
         prefix = '192.0.2.0/24'
         base_name = 'ipv4'

--- a/smoketest/scripts/system/test_kernel_options.py
+++ b/smoketest/scripts/system/test_kernel_options.py
@@ -120,5 +120,13 @@ class TestKernelModules(unittest.TestCase):
             tmp = re.findall(f'{option}=(y|m)', self._config_data)
             self.assertTrue(tmp)
 
+    def test_container_cpu(self):
+        options_to_check = [
+            'CONFIG_CGROUP_SCHED', 'CONFIG_CPUSETS', 'CONFIG_CGROUP_CPUACCT', 'CONFIG_CFS_BANDWIDTH'
+            ]
+        for option in options_to_check:
+            tmp = re.findall(f'{option}=(y|m)', self._config_data)
+            self.assertTrue(tmp)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -128,9 +128,9 @@ def verify(container):
                         f'locally. Please use "add container image {image}" to add it '\
                         f'to the system! Container "{name}" will not be started!')
 
-            if 'cpus' in container_config:
-                cores = os.cpu_count()
-                if Decimal(container_config['cpus']) > cores:
+            if 'cpu_quota' in container_config:
+                cores = vyos.cpu.get_core_count()
+                if Decimal(container_config['cpu_quota']) > cores:
                     raise ConfigError(f'Cannot set limit to more cores than available "{name}"!')
 
             if 'network' in container_config:
@@ -263,7 +263,7 @@ def verify(container):
 
 def generate_run_arguments(name, container_config):
     image = container_config['image']
-    cpus = container_config['cpus']
+    cpu_quota = container_config['cpu_quota']
     memory = container_config['memory']
     shared_memory = container_config['shared_memory']
     restart = container_config['restart']
@@ -340,7 +340,7 @@ def generate_run_arguments(name, container_config):
     if 'allow_host_pid' in container_config:
       host_pid = '--pid host'
 
-    container_base_cmd = f'--detach --interactive --tty --replace {capabilities} --cpus {cpus} ' \
+    container_base_cmd = f'--detach --interactive --tty --replace {capabilities} --cpus {cpu_quota} ' \
                          f'--memory {memory}m --shm-size {shared_memory}m --memory-swap 0 --restart {restart} ' \
                          f'--name {name} {hostname} {device} {port} {volume} {env_opt} {label} {uid} {host_pid}'
 


### PR DESCRIPTION
## Change Summary
Add container config option for cpu limits

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6406

## Related PR(s)
* vyos/vyos-build#645
* vyos/vyos-documentation#1462

## Component(s) name
container

## Proposed changes
Add option to enable cpu limits per container similar to memory l imits

## How to test
```
set container name c1 image hello-world
set container name c1 allow-host-networks
set container name c1 cpus 1.5
```

## Smoketest result
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_container.py
test_basic (__main__.TestContainer.test_basic) ... ok
test_cpu_limit (__main__.TestContainer.test_cpu_limit) ... ok
test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... 
IP address "192.0.2.1" can not be used for a container, reserved for the
container engine!

ok
test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... 
IP address "192.0.2.1" can not be used for a container, reserved for the
container engine!

ok
test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... 
IP address "2001:db8::1" can not be used for a container, reserved for
the container engine!

ok
test_uid_gid (__main__.TestContainer.test_uid_gid) ... 
Cannot set "gid" without "uid" for container

ok

----------------------------------------------------------------------
Ran 6 tests in 165.714s

OK
```

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/system/test_kernel_options.py
test_bond_interface (__main__.TestKernelModules.test_bond_interface) ... ok
test_bridge_interface (__main__.TestKernelModules.test_bridge_interface) ... ok
test_container_cgroup_support (__main__.TestKernelModules.test_container_cgroup_support) ... ok
test_container_cpu (__main__.TestKernelModules.test_container_cpu) ... ok
test_dropmon_enabled (__main__.TestKernelModules.test_dropmon_enabled) ... ok
test_ip_routing_support (__main__.TestKernelModules.test_ip_routing_support) ... ok
test_qemu_support (__main__.TestKernelModules.test_qemu_support) ... ok
test_synproxy_enabled (__main__.TestKernelModules.test_synproxy_enabled) ... ok
test_vfio (__main__.TestKernelModules.test_vfio) ... ok
test_vmware_support (__main__.TestKernelModules.test_vmware_support) ... ok

----------------------------------------------------------------------
Ran 10 tests in 0.068s
```

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
