### PR TITLE
T6411: CGNAT fix sequences for external address ranges

### DIFF
--- a/src/conf_mode/nat_cgnat.py
+++ b/src/conf_mode/nat_cgnat.py
@@ -252,7 +252,11 @@ def generate(config):
         ext_pool_name: str = rule_config['translation']['pool']
         int_pool_name: str = rule_config['source']['pool']
 
-        external_ranges: list = [range for range in config['pool']['external'][ext_pool_name]['range']]
+        # Sort the external ranges by sequence
+        external_ranges: list = sorted(
+            config['pool']['external'][ext_pool_name]['range'],
+            key=lambda r: int(config['pool']['external'][ext_pool_name]['range'][r].get('seq', 999999))
+        )
         internal_ranges: list = [range for range in config['pool']['internal'][int_pool_name]['range']]
         external_list_hosts_count = []
         external_list_hosts = []


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix the bug where address external allocation was not rely on sequences of the external IP addresses (if set)
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6411

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
cgnat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Initial configuration:
```
set nat cgnat pool external ext-01 external-port-range '1024-65535'
set nat cgnat pool external ext-01 per-user-limit port '10000'
set nat cgnat pool external ext-01 range 192.168.122.121/32
set nat cgnat pool external ext-01 range 198.51.100.23/32 seq '3'
set nat cgnat pool external ext-01 range 203.0.113.102/32 seq '10'
set nat cgnat pool internal int-01 range '100.64.0.0/28'
set nat cgnat rule 10 source pool 'int-01'
set nat cgnat rule 10 translation pool 'ext-01'
```

Before the fix external address allocation not rely on the `seq`
```
vyos@r4# run show nat cgnat allocation 
Internal IP    External IP      Port range
-------------  ---------------  ------------
100.64.0.0     192.168.122.121  1024-11023
100.64.0.1     192.168.122.121  11024-21023
100.64.0.2     192.168.122.121  21024-31023
100.64.0.3     192.168.122.121  31024-41023
100.64.0.4     192.168.122.121  41024-51023
100.64.0.5     192.168.122.121  51024-61023
100.64.0.6     198.51.100.23    1024-11023
100.64.0.7     198.51.100.23    11024-21023
100.64.0.8     198.51.100.23    21024-31023
100.64.0.9     198.51.100.23    31024-41023
100.64.0.10    198.51.100.23    41024-51023
100.64.0.11    198.51.100.23    51024-61023
100.64.0.12    203.0.113.102    1024-11023
100.64.0.13    203.0.113.102    11024-21023
100.64.0.14    203.0.113.102    21024-31023
100.64.0.15    203.0.113.102    31024-41023
[edit]
vyos@r4#
```
After the fix, we see correctly external address allocations correctly based on sequences
```
vyos@r4# run show nat cgnat allocation 
Internal IP    External IP      Port range
-------------  ---------------  ------------
100.64.0.0     198.51.100.23    1024-11023
100.64.0.1     198.51.100.23    11024-21023
100.64.0.2     198.51.100.23    21024-31023
100.64.0.3     198.51.100.23    31024-41023
100.64.0.4     198.51.100.23    41024-51023
100.64.0.5     198.51.100.23    51024-61023
100.64.0.6     203.0.113.102    1024-11023
100.64.0.7     203.0.113.102    11024-21023
100.64.0.8     203.0.113.102    21024-31023
100.64.0.9     203.0.113.102    31024-41023
100.64.0.10    203.0.113.102    41024-51023
100.64.0.11    203.0.113.102    51024-61023
100.64.0.12    192.168.122.121  1024-11023
100.64.0.13    192.168.122.121  11024-21023
100.64.0.14    192.168.122.121  21024-31023
100.64.0.15    192.168.122.121  31024-41023
[edit]
vyos@r4# 

```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_cgnat.py
test_cgnat (__main__.TestCGNAT.test_cgnat) ... ok
test_cgnat_sequence (__main__.TestCGNAT.test_cgnat_sequence) ... ok

----------------------------------------------------------------------
Ran 2 tests in 26.153s

OK
vyos@r4:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
