### PR TITLE
ISIS: T6332: Fix isis not working only ipv6

### DIFF
--- a/data/templates/frr/isisd.frr.j2
+++ b/data/templates/frr/isisd.frr.j2
@@ -178,7 +178,7 @@ advertise-passive-only
 {%             for priority, priority_limit_options in fast_reroute.lfa.local.priority_limit.items() %}
 {%                 for level in priority_limit_options %}
  fast-reroute priority-limit {{ priority }} {{ level | replace('_', '-') }}
-{%                 endfor %}                   
+{%                 endfor %}
 {%             endfor %}
 {%         endif %}
 {%         if fast_reroute.lfa.local.tiebreaker is vyos_defined %}
@@ -232,6 +232,9 @@ fast-reroute remote-lfa prefix-list {{ prefix_list }}
 {%             endif %}
 {%         endfor %}
 {%     endfor %}
+{% endif %}
+{% if topology is vyos_defined %}
+topology {{ topology }}
 {% endif %}
 {% if level is vyos_defined('level-2') %}
  is-type level-2-only

--- a/interface-definitions/include/isis/protocol-common-config.xml.i
+++ b/interface-definitions/include/isis/protocol-common-config.xml.i
@@ -165,6 +165,41 @@
   </properties>
 </leafNode>
 #include <include/isis/ldp-sync-protocol.xml.i>
+<leafNode name="topology">
+  <properties>
+    <help>Configure IS-IS topologies</help>
+    <completionHelp>
+      <list>ipv4-multicast ipv4-mgmt ipv6-unicast ipv6-multicast ipv6-mgmt ipv6-dstsrc</list>
+    </completionHelp>
+    <valueHelp>
+      <format>ipv4-multicast</format>
+      <description>Use IPv4 multicast topology</description>
+    </valueHelp>
+    <valueHelp>
+      <format>ipv4-mgmt</format>
+      <description>Use IPv4 management topology</description>
+    </valueHelp>
+    <valueHelp>
+      <format>ipv6-unicast</format>
+      <description>Use IPv6 unicast topology</description>
+    </valueHelp>
+    <valueHelp>
+      <format>ipv6-multicast</format>
+      <description>Use IPv6 multicast topology</description>
+    </valueHelp>
+    <valueHelp>
+      <format>ipv6-mgmt</format>
+      <description>Use IPv6 management topology</description>
+    </valueHelp>
+    <valueHelp>
+      <format>ipv6-dstsrc</format>
+      <description>Use IPv6 dst-src topology</description>
+    </valueHelp>
+    <constraint>
+      <regex>(ipv4-multicast|ipv4-mgmt|ipv6-unicast|ipv6-multicast|ipv6-mgmt|ipv6-dstsrc)</regex>
+    </constraint>
+  </properties>
+</leafNode>
 <node name="fast-reroute">
   <properties>
     <help>IS-IS fast reroute configuration</help>

--- a/smoketest/scripts/cli/test_protocols_isis.py
+++ b/smoketest/scripts/cli/test_protocols_isis.py
@@ -395,5 +395,20 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(['policy', 'prefix-list', prefix_list])
         self.cli_commit()
 
+    def test_isis_10_topology(self):
+        topologies = ['ipv4-multicast', 'ipv4-mgmt', 'ipv6-unicast', 'ipv6-multicast', 'ipv6-mgmt']
+        interface = 'lo'
+
+        # Set a basic IS-IS config
+        self.cli_set(base_path + ['net', net])
+
+        self.cli_set(base_path + ['interface', interface])
+        for topology in topologies:
+            self.cli_set(base_path + ['topology', topology])
+            self.cli_commit()
+            tmp = self.getFRRconfig(f'router isis {domain}', daemon='isisd')
+            self.assertIn(f' net {net}', tmp)
+            self.assertIn(f' topology {topology}', tmp)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->
ISIS is not working on a IPv6 only environment , needs to be enable the topology when is not ipv4 unicast
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/TXXXX-->

https://vyos.dev/T6332

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
isis
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
#vyos without topology ipv6 , don't see the routes 

set interfaces dummy dum0 address '2001:db8:1:1::1/64'

set interfaces ethernet eth1 address '2001:db8:3::1/64'
set interfaces ethernet eth1 mtu '1500'
set protocols isis dynamic-hostname
set protocols isis interface dum0
set protocols isis interface eth1 network point-to-point
set protocols isis level 'level-2'
set protocols isis net '49.0001.0bad.cafe.0001.0

# vyos new command: 

set protocols isis topology 'ipv6-unicast'

```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
ok
test_isis_06_spf_delay_bfd (__main__.TestProtocolsISIS.test_isis_06_spf_delay_bfd) ...
All types of spf-delay must be configured. Missing: short-delay, long-
delay, init-delay, time-to-learn


All types of spf-delay must be configured. Missing: short-delay, long-
delay, time-to-learn


All types of spf-delay must be configured. Missing: short-delay, time-
to-learn


All types of spf-delay must be configured. Missing: time-to-learn

ok
test_isis_07_segment_routing_configuration (__main__.TestProtocolsISIS.test_isis_07_segment_routing_configuration) ... ok
test_isis_08_ldp_sync (__main__.TestProtocolsISIS.test_isis_08_ldp_sync) ... ok
test_isis_09_lfa (__main__.TestProtocolsISIS.test_isis_09_lfa) ... ok
test_isis_10_topology (__main__.TestProtocolsISIS.test_isis_10_topology) ... ok

----------------------------------------------------------------------
Ran 9 tests in 68.197s

OK
````
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
