### PR TITLE
Fix: Handle Missing Hostname File in DHCP Configuration

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1358,10 +1358,11 @@ class Interface(Control):
                 # read configured system hostname.
                 # maybe change to vyos hostd client ???
                 hostname = 'vyos'
-                with open('/etc/hostname', 'r') as f:
-                    hostname = f.read().rstrip('\n')
-                    tmp = {'dhcp_options' : { 'host_name' : hostname}}
-                    self.config = dict_merge(tmp, self.config)
+                if os.path.isfile('/etc/hostname'):
+                    with open('/etc/hostname', 'r') as f:
+                        hostname = f.read().rstrip('\n')
+                        tmp = {'dhcp_options' : { 'host_name' : hostname}}
+                        self.config = dict_merge(tmp, self.config)
 
             render(systemd_override_file, 'dhcp-client/override.conf.j2', self.config)
             render(dhclient_config_file, 'dhcp-client/ipv4.j2', self.config)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
After the initial installation of VyOS, the hostname file does not exist, which prevents DHCP configuration. I added a check for the existence of this file to resolve this issue
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
Architecture:     x86_64
Boot via:         installed image
System type:      KVM guest

Hardware vendor:  QEMU
Hardware model:   Standard PC (i440FX + PIIX, 1996)
Hardware S/N:     
Hardware UUID:    6d392efb-9581-4438-925a-67f195d695ca

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/interfaces_ethernet.py", line 433, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/interfaces_ethernet.py", line 410, in apply
    e.update(ethernet)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/ethernet.py", line 454, in update
    super().update(config)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 1603, in update
    self.add_addr(addr)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 1194, in add_addr
    self.set_dhcp(True)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 1361, in set_dhcp
    with open('/etc/hostname', 'r') as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/etc/hostname'

noteworthy:
```
After adding the check, the DHCP configuration function no longer reports errors.
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
