### PR TITLE
container: T6406: fix NameError: name 'vyos' is not defined

### DIFF
--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -29,6 +29,7 @@ from vyos.configdict import node_changed
 from vyos.configdict import is_node_changed
 from vyos.configverify import verify_vrf
 from vyos.ifconfig import Interface
+from vyos.cpu import get_core_count
 from vyos.utils.file import write_file
 from vyos.utils.process import call
 from vyos.utils.process import cmd
@@ -129,7 +130,7 @@ def verify(container):
                         f'to the system! Container "{name}" will not be started!')
 
             if 'cpu_quota' in container_config:
-                cores = vyos.cpu.get_core_count()
+                cores = get_core_count()
                 if Decimal(container_config['cpu_quota']) > cores:
                     raise ConfigError(f'Cannot set limit to more cores than available "{name}"!')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Commit 74910564f ("T6406: rename cpus to cpu") did not import the function from the Python module. @nvollmar 

```python
Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/container.py", line 490, in <module>
    verify(c)
  File "/usr/libexec/vyos/conf_mode/container.py", line 132, in verify
    cores = vyos.cpu.get_core_count()
            ^^^^
NameError: name 'vyos' is not defined
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6406

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/3530

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
container

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_container.py
test_basic (__main__.TestContainer.test_basic) ... ok
test_cpu_limit (__main__.TestContainer.test_cpu_limit) ... ok
test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... ok
test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... ok
test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... ok
test_uid_gid (__main__.TestContainer.test_uid_gid) ... ok

----------------------------------------------------------------------
Ran 6 tests in 114.165s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
