### PR TITLE
op-mode: ipsec: T6407: fix profile generation

### DIFF
--- a/data/templates/ipsec/ios_profile.j2
+++ b/data/templates/ipsec/ios_profile.j2
@@ -83,12 +83,15 @@
                 </dict>
             </dict>
         </dict>
+{% if certs is vyos_defined %}
         <!-- This payload is optional but it provides an easy way to install the CA certificate together with the configuration -->
+{%     for cert in certs %}
+        <!-- Payload for: {{ cert.ca_cn }} -->
         <dict>
             <key>PayloadIdentifier</key>
-            <string>org.example.ca</string>
+            <string>org.{{ cert.ca_cn | lower | replace(' ', '.') | replace('_', '.') }}</string>
             <key>PayloadUUID</key>
-            <string>{{ '' | get_uuid }}</string>
+            <string>{{ cert.ca_cn | generate_uuid4 }}</string>
             <key>PayloadType</key>
             <string>com.apple.security.root</string>
             <key>PayloadVersion</key>
@@ -96,9 +99,11 @@
             <!-- This is the Base64 (PEM) encoded CA certificate -->
             <key>PayloadContent</key>
             <data>
-            {{ ca_cert }}
+            {{ cert.ca_cert }}
             </data>
         </dict>
+{%     endfor %}
+{% endif %}
     </array>
 </dict>
 </plist>

--- a/src/op_mode/ikev2_profile_generator.py
+++ b/src/op_mode/ikev2_profile_generator.py
@@ -144,15 +144,22 @@ tmp = reversed(tmp)
 data['rfqdn'] = '.'.join(tmp)
 
 pki = conf.get_config_dict(pki_base, get_first_key=True)
-ca_name = data['authentication']['x509']['ca_certificate']
 cert_name = data['authentication']['x509']['certificate']
 
-ca_cert = load_certificate(pki['ca'][ca_name]['certificate'])
-cert = load_certificate(pki['certificate'][cert_name]['certificate'])
+data['certs'] = []
 
-data['ca_cn'] = ca_cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
-data['cert_cn'] = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
-data['ca_cert'] = conf.value(pki_base + ['ca', ca_name, 'certificate'])
+for ca_name in data['authentication']['x509']['ca_certificate']:
+    tmp = {}
+    ca_cert = load_certificate(pki['ca'][ca_name]['certificate'])
+    cert = load_certificate(pki['certificate'][cert_name]['certificate'])
+
+
+    tmp['ca_cn'] = ca_cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+    tmp['cert_cn'] = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+    tmp['ca_cert'] = conf.value(pki_base + ['ca', ca_name, 'certificate'])
+
+    data['certs'].append(tmp)
+
 
 esp_proposals = conf.get_config_dict(ipsec_base + ['esp-group', data['esp_group'], 'proposal'],
                                      key_mangling=('-', '_'), get_first_key=True)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Commit 952b1656f51 ("ipsec: T5606: T5871: Use multi node for CA certificates") added support for multiple CA certificates which broke the OP mode command to generate the IPSec profiles as it did not expect a list and was rather working on a string.

Now multiple CAs can be rendered into the Apple IOS profile.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6407

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/3202

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Reference multiple CAs in the profile

```
set vpn ipsec remote-access connection rw authentication x509 ca-certificate 'CAcert_Class_3_Root'
set vpn ipsec remote-access connection rw authentication x509 ca-certificate 'CAcert_Signing_Authority'
```

The resulting Apple IOS connection profile will then show up those embedded CAs during installation

![image](https://github.com/vyos/vyos-1x/assets/25299219/2c2afe3c-d0a5-449a-81ea-e46444392044)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
