### PR TITLE
dns: T6422: allow multiple redundant NS records

### DIFF
--- a/interface-definitions/service_dns_forwarding.xml.in
+++ b/interface-definitions/service_dns_forwarding.xml.in
@@ -311,6 +311,7 @@
                               <constraint>
                                 <regex>[-_a-zA-Z0-9.]{1,63}(?&lt;!\.)</regex>
                               </constraint>
+                              <multi/>
                             </properties>
                           </leafNode>
                           #include <include/dns/time-to-live.xml.i>

--- a/smoketest/scripts/cli/test_service_dns_forwarding.py
+++ b/smoketest/scripts/cli/test_service_dns_forwarding.py
@@ -291,5 +291,15 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         tmp = get_config_value('edns-subnet-allow-list')
         self.assertEqual(tmp, ','.join(options))
 
+    def test_multiple_ns_records(self):
+        test_zone = 'example.com'
+        self.cli_set(base_path + ['authoritative-domain', test_zone, 'records', 'ns', 'test', 'target', f'ns1.{test_zone}'])
+        self.cli_set(base_path + ['authoritative-domain', test_zone, 'records', 'ns', 'test', 'target', f'ns2.{test_zone}'])
+        self.cli_commit()
+        zone_config = read_file(f'{PDNS_REC_RUN_DIR}/zone.{test_zone}.conf')
+        self.assertRegex(zone_config, fr'test\s+\d+\s+NS\s+ns1\.{test_zone}\.')
+        self.assertRegex(zone_config, fr'test\s+\d+\s+NS\s+ns2\.{test_zone}\.')
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/service_dns_forwarding.py
+++ b/src/conf_mode/service_dns_forwarding.py
@@ -115,7 +115,7 @@ def get_config(config=None):
                         })
                     elif rtype == 'ns':
                         if not 'target' in rdata:
-                            dns['authoritative_zone_errors'].append(f'{subnode}.{node}: at leaast one target is required')
+                            dns['authoritative_zone_errors'].append(f'{subnode}.{node}: at least one target is required')
                             continue
 
                         for target in rdata['target']:
@@ -123,7 +123,7 @@ def get_config(config=None):
                                 'name': subnode,
                                 'type': rtype.upper(),
                                 'ttl': rdata['ttl'],
-                                'value': '{}.'.format(target)
+                                'value': f'{target}.'
                             })
 
                     elif rtype == 'mx':

--- a/src/conf_mode/service_dns_forwarding.py
+++ b/src/conf_mode/service_dns_forwarding.py
@@ -102,7 +102,7 @@ def get_config(config=None):
                                 'ttl': rdata['ttl'],
                                 'value': address
                             })
-                    elif rtype in ['cname', 'ptr', 'ns']:
+                    elif rtype in ['cname', 'ptr']:
                         if not 'target' in rdata:
                             dns['authoritative_zone_errors'].append(f'{subnode}.{node}: target is required')
                             continue
@@ -113,6 +113,19 @@ def get_config(config=None):
                             'ttl': rdata['ttl'],
                             'value': '{}.'.format(rdata['target'])
                         })
+                    elif rtype == 'ns':
+                        if not 'target' in rdata:
+                            dns['authoritative_zone_errors'].append(f'{subnode}.{node}: at leaast one target is required')
+                            continue
+
+                        for target in rdata['target']:
+                            zone['records'].append({
+                                'name': subnode,
+                                'type': rtype.upper(),
+                                'ttl': rdata['ttl'],
+                                'value': '{}.'.format(target)
+                            })
+
                     elif rtype == 'mx':
                         if not 'server' in rdata:
                             dns['authoritative_zone_errors'].append(f'{subnode}.{node}: at least one server is required')


### PR DESCRIPTION
## Change Summary
NS is unlike CNAME or PTR, multiple NS records are perfectly valid and is a common use case: multiple redundant DNS servers is a common configuration and should be supported.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Component(s) name
dns

## Proposed changes
Make NS record configuration behave more like A record, where multiple records with the same target are allowed.

## How to test

```
set service dns forwarding authoritative-domain example.com records ns test target 'ns1.example.com'
set service dns forwarding authoritative-domain example.com records ns test target 'ns2.example.com'
commit

dig ns test.example.com

Response:
;; ANSWER SECTION:
test.example.com.	254	IN	NS	ns2.example.com.
test.example.com.	254	IN	NS	ns1.example.com.

```

## Smoketest result
```
$ /usr/libexec/vyos/tests/smoke/cli/test_service_dns_forwarding.py
test_basic_forwarding (__main__.TestServicePowerDNS.test_basic_forwarding) ...
DNS forwarding requires a listen-address


DNS forwarding requires a listen-address

ok
test_dns64 (__main__.TestServicePowerDNS.test_dns64) ...
DNS 6to4 prefix must be of length /96

ok
test_dnssec (__main__.TestServicePowerDNS.test_dnssec) ... ok
test_domain_forwarding (__main__.TestServicePowerDNS.test_domain_forwarding) ... ok
test_ecs_add_for (__main__.TestServicePowerDNS.test_ecs_add_for) ... ok
test_ecs_ipv4_bits (__main__.TestServicePowerDNS.test_ecs_ipv4_bits) ... ok
test_edns_subnet_allow_list (__main__.TestServicePowerDNS.test_edns_subnet_allow_list) ... ok
test_exclude_throttle_adress (__main__.TestServicePowerDNS.test_exclude_throttle_adress) ... ok
test_external_nameserver (__main__.TestServicePowerDNS.test_external_nameserver) ... ok
test_listening_port (__main__.TestServicePowerDNS.test_listening_port) ... ok
test_multiple_ns_records (__main__.TestServicePowerDNS.test_multiple_ns_records) ... ok
test_no_rfc1918_forwarding (__main__.TestServicePowerDNS.test_no_rfc1918_forwarding) ... ok
test_serve_stale_extension (__main__.TestServicePowerDNS.test_serve_stale_extension) ... ok

----------------------------------------------------------------------
Ran 13 tests in 230.559s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
