### PR TITLE
conntrack: T6396: correction to helper message for ipv4/ipv6 custom timeout rule

### DIFF
--- a/interface-definitions/system_conntrack.xml.in
+++ b/interface-definitions/system_conntrack.xml.in
@@ -406,7 +406,7 @@
                           <constraint>
                             <validator name="numeric" argument="--range 1-999999"/>
                           </constraint>
-                          <constraintErrorMessage>Ignore rule number must be between 1 and 999999</constraintErrorMessage>
+                          <constraintErrorMessage>Timeout rule number must be between 1 and 999999</constraintErrorMessage>
                         </properties>
                         <children>
                           #include <include/generic-description.xml.i>
@@ -421,7 +421,7 @@
                           </node>
                           <leafNode name="inbound-interface">
                             <properties>
-                              <help>Interface to ignore connections tracking on</help>
+                              <help>Interface to apply custom connection timers on</help>
                               <completionHelp>
                                 <list>any</list>
                                 <script>${vyos_completion_dir}/list_interfaces</script>
@@ -464,7 +464,7 @@
                           <constraint>
                             <validator name="numeric" argument="--range 1-999999"/>
                           </constraint>
-                          <constraintErrorMessage>Ignore rule number must be between 1 and 999999</constraintErrorMessage>
+                          <constraintErrorMessage>Timeout rule number must be between 1 and 999999</constraintErrorMessage>
                         </properties>
                         <children>
                           #include <include/generic-description.xml.i>
@@ -479,7 +479,7 @@
                           </node>
                           <leafNode name="inbound-interface">
                             <properties>
-                              <help>Interface to ignore connections tracking on</help>
+                              <help>Interface to apply custom connection timers on</help>
                               <completionHelp>
                                 <list>any</list>
                                 <script>${vyos_completion_dir}/list_interfaces</script>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The completion helper description for the inbound-interface is incorrect when specifying a custom conntrack timeout rule for both ipv4 and ipv6 timeout rules. This PR is to amend this.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6396

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
tim@ferrari# set system conntrack timeout custom ipv4 rule 10 
Possible completions:
   description          Description
 > destination          Destination parameters
   inbound-interface    Interface to ignore connections tracking on
 > protocol             Customize protocol specific timers, one protocol configuration
                        per rule
 > source               Source parameters
```

Replaces "Interface to ignore connections tracking on" with "Interface to ignore connections tracking on"
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
