### PR TITLE
tunnel: T6157: fixing GRE tunnel uniqueness checks

### DIFF
--- a/src/conf_mode/interfaces_tunnel.py
+++ b/src/conf_mode/interfaces_tunnel.py
@@ -145,11 +145,20 @@ def verify(tunnel):
                 # If no IP GRE key is defined we can not have more then one GRE tunnel
                 # bound to any one interface/IP address and the same remote. This will
                 # result in a OS  PermissionError: add tunnel "gre0" failed: File exists
-                if (their_address == our_address or our_source_if == their_source_if) and \
-                    our_remote == their_remote:
-                    raise ConfigError(f'Missing required "ip key" parameter when '\
-                                       'running more then one GRE based tunnel on the '\
-                                       'same source-interface/source-address')
+                if our_remote == their_remote:
+                    if our_address is not None and their_address == our_address: 
+                        # If set to the same values, this is always a fail 
+                        raise ConfigError(f'Missing required "ip key" parameter when '\
+                                           'running more then one GRE based tunnel on the '\
+                                           'same source-address')
+
+                    if their_source_if == our_source_if and their_address == our_address:
+                        # Note that lack of None check on these is deliberate. 
+                        # source-if and source-ip matching while unset (all None) is a fail
+                        # source-ifs set and matching with unset source-ips is a fail
+                        raise ConfigError(f'Missing required "ip key" parameter when '\
+                                           'running more then one GRE based tunnel on the '\
+                                           'same source-interface')
 
     # Keys are not allowed with ipip and sit tunnels
     if tunnel['encapsulation'] in ['ipip', 'sit']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Unset params would mistakenly match when None and trigger a validation error even when used params were unique. 
Updated check to ensure unique source-addresses if not None, and that (source-interfaces, source-addresses) are
unique together appropriately.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6157

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
* tunnel gre/gretap

## Proposed changes
<!--- Describe your changes in detail -->
The original validation check runs into the issue experienced in T6157: under normal circumstances, you would specify either a source-address or a source-interface - not both. It is also a valid config to have matching source-interfaces but different source-addresses. 

With the original check, if the remote address is the same between 2 tunnels, this check will ALWAYS fail validation if either source-address or source-interface pairs match, including the situation where neither are actually set and resolve to None. 

I've updated the code to check:
 * (remote-address, source-address) matching is an always-fail
 * duplicated (remote-addresses, source-interfaces and source-addresses) together (including the None case for source-addresses, effectively meaning the main interface IP) are a fail
 * generate a tweaked message depending on whether the address or interface check failed

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

* I replicated the reported configuration on a 1.5-rolling-202405240020 and confirmed the fault, with the same output
* I additionally adjusted source-interface values and confirmed there was still an issue when set
* Shut down configd and applied my patch to interfaces_tunnel.py
* Test scenarios work as expected:
```
vyos@TEST-VYOS-LEFT# compare
[interfaces]
+ tunnel tun100 {
+     address "192.168.8.100/31"
+     encapsulation "gre"
+     ip {
+         adjust-mss "1436"
+     }
+     remote "100.123.124.124"
+     source-address "100.123.123.123"
+ }
+ tunnel tun102 {
+     address "192.168.8.104/31"
+     encapsulation "gre"
+     ip {
+         adjust-mss "1436"
+     }
+     remote "100.123.124.124"
+     source-address "100.123.123.124"
+ }
vyos@TEST-VYOS-LEFT# commit
[edit]
vyos@TEST-VYOS-LEFT# set interfaces tunnel tun102 source-interface eth0.900
vyos@TEST-VYOS-LEFT# set interfaces tunnel tun100 source-interface eth0.900
vyos@TEST-VYOS-LEFT# commit
[edit]
vyos@TEST-VYOS-LEFT# delete interfaces tunnel tun100 source-address 
vyos@TEST-VYOS-LEFT# commit
[edit]
vyos@TEST-VYOS-LEFT# delete interfaces tunnel tun102 source-address 
vyos@TEST-VYOS-LEFT# commit
[ interfaces tunnel tun102 ]
Missing required "ip key" parameter when running more then one GRE based
tunnel on the same source-interface

[[interfaces tunnel tun102]] failed
Commit failed
[edit]
vyos@TEST-VYOS-LEFT# show interfaces tunnel
 tunnel tun100 {
     address 192.168.8.100/31
     encapsulation gre
     ip {
         adjust-mss 1436
     }
     remote 100.123.124.124
     source-interface eth0.900
 }
 tunnel tun102 {
     address 192.168.8.104/31
     encapsulation gre
     ip {
         adjust-mss 1436
     }
     remote 100.123.124.124
-    source-address 100.123.123.124
     source-interface eth0.900
 }
[edit]
vyos@TEST-VYOS-LEFT# discard

  Changes have been discarded

[edit]
vyos@TEST-VYOS-LEFT# set interfaces tunnel tun100 source-address 100.123.123.124
[edit]
vyos@TEST-VYOS-LEFT# commit
[ interfaces tunnel tun100 ]
Missing required "ip key" parameter when running more then one GRE based
tunnel on the same source-address

[[interfaces tunnel tun100]] failed
Commit failed
[edit]
vyos@TEST-VYOS-LEFT# delete interfaces tunnel tun100 source-interface 
[edit]
vyos@TEST-VYOS-LEFT# commit
[ interfaces tunnel tun100 ]
Missing required "ip key" parameter when running more then one GRE based
tunnel on the same source-address

[[interfaces tunnel tun100]] failed
Commit failed
[edit]
vyos@TEST-VYOS-LEFT# delete interfaces tunnel tun102 source-interface 
[edit]
vyos@TEST-VYOS-LEFT# commit
[ interfaces tunnel tun100 ]
Missing required "ip key" parameter when running more then one GRE based
tunnel on the same source-address

[[interfaces tunnel tun100]] failed
[ interfaces tunnel tun102 ]
Missing required "ip key" parameter when running more then one GRE based
tunnel on the same source-address

[[interfaces tunnel tun102]] failed
Commit failed
[edit]
vyos@TEST-VYOS-LEFT# 
```




## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_tunnel.py
test_add_multiple_ip_addresses (__main__.TunnelInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.TunnelInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.TunnelInterfaceTest.test_dhcp_client_options) ... skipped 'not supported'
test_dhcp_disable_interface (__main__.TunnelInterfaceTest.test_dhcp_disable_interface) ... skipped 'not supported'
test_dhcp_vrf (__main__.TunnelInterfaceTest.test_dhcp_vrf) ... skipped 'not supported'
test_dhcpv6_client_options (__main__.TunnelInterfaceTest.test_dhcpv6_client_options) ... skipped 'not supported'
test_dhcpv6_vrf (__main__.TunnelInterfaceTest.test_dhcpv6_vrf) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.TunnelInterfaceTest.test_dhcpv6pd_auto_sla_id) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.TunnelInterfaceTest.test_dhcpv6pd_manual_sla_id) ... skipped 'not supported'
test_erspan_v1 (__main__.TunnelInterfaceTest.test_erspan_v1) ... ok
test_gretap_parameters_change (__main__.TunnelInterfaceTest.test_gretap_parameters_change) ... ok
test_interface_description (__main__.TunnelInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.TunnelInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.TunnelInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.TunnelInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.TunnelInterfaceTest.test_interface_mtu) ... ok
test_ip6erspan_v2 (__main__.TunnelInterfaceTest.test_ip6erspan_v2) ... ok
test_ipv4_encapsulations (__main__.TunnelInterfaceTest.test_ipv4_encapsulations) ... ok
test_ipv6_encapsulations (__main__.TunnelInterfaceTest.test_ipv6_encapsulations) ... ok
test_ipv6_link_local_address (__main__.TunnelInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.TunnelInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_multiple_gre_tunnel_different_remote (__main__.TunnelInterfaceTest.test_multiple_gre_tunnel_different_remote) ... ok
test_multiple_gre_tunnel_same_remote (__main__.TunnelInterfaceTest.test_multiple_gre_tunnel_same_remote) ... ok
test_span_mirror (__main__.TunnelInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_tunnel_invalid_source_interface (__main__.TunnelInterfaceTest.test_tunnel_invalid_source_interface) ... ok
test_tunnel_parameters_gre (__main__.TunnelInterfaceTest.test_tunnel_parameters_gre) ... ok
test_tunnel_src_any_gre_key (__main__.TunnelInterfaceTest.test_tunnel_src_any_gre_key) ... ok
test_vif_8021q_interfaces (__main__.TunnelInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.TunnelInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.TunnelInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.TunnelInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.TunnelInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.TunnelInterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'

----------------------------------------------------------------------
Ran 33 tests in 356.212s

OK (skipped=14)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
