### PR TITLE
isis: T6429: fix isis metric-style configuration missing

### DIFF
--- a/data/templates/frr/isisd.frr.j2
+++ b/data/templates/frr/isisd.frr.j2
@@ -76,6 +76,9 @@ advertise-passive-only
 {% if set_overload_bit is vyos_defined %}
  set-overload-bit
 {% endif %}
+{% if metric_style is vyos_defined %}
+ metric-style {{ metric_style }}
+{% endif %}
 {% if domain_password.md5 is vyos_defined %}
  domain-password md5 {{ domain_password.plaintext_password }}
 {% elif domain_password.plaintext_password is vyos_defined %}

--- a/smoketest/scripts/cli/test_protocols_isis.py
+++ b/smoketest/scripts/cli/test_protocols_isis.py
@@ -60,6 +60,7 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
         prefix_list = 'EXPORT-ISIS'
         route_map = 'EXPORT-ISIS'
         rule = '10'
+        metric_style = 'transition'
 
         self.cli_set(['policy', 'prefix-list', prefix_list, 'rule', rule, 'action', 'permit'])
         self.cli_set(['policy', 'prefix-list', prefix_list, 'rule', rule, 'prefix', '203.0.113.0/24'])
@@ -80,6 +81,7 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
             self.cli_commit()
 
         self.cli_set(base_path + ['redistribute', 'ipv4', 'connected', 'level-2', 'route-map', route_map])
+        self.cli_set(base_path + ['metric-style', metric_style])
         self.cli_set(base_path + ['log-adjacency-changes'])
 
         # Commit all changes
@@ -88,6 +90,7 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
         # Verify all changes
         tmp = self.getFRRconfig(f'router isis {domain}', daemon='isisd')
         self.assertIn(f' net {net}', tmp)
+        self.assertIn(f' metric-style {metric_style}', tmp)
         self.assertIn(f' log-adjacency-changes', tmp)
         self.assertIn(f' redistribute ipv4 connected level-2 route-map {route_map}', tmp)
 
@@ -401,7 +404,6 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
 
         # Set a basic IS-IS config
         self.cli_set(base_path + ['net', net])
-
         self.cli_set(base_path + ['interface', interface])
         for topology in topologies:
             self.cli_set(base_path + ['topology', topology])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

The ISIS configuration doesn't apply metric-style because the part in the template is missing .

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6429

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
isis
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
VyOS configuration : 
```
vyos@isis-01:~$ show configuration commands | match isis
set protocols isis dynamic-hostname
set protocols isis interface dum0
set protocols isis interface eth1 network point-to-point
set protocols isis level 'level-2'
set protocols isis metric-style 'narrow'
set protocols isis net '49.0001.0bad.cafe.0001.00'
set system host-name 'isis-01'
```
FRR: 

```
router isis VyOS
 is-type level-2-only
 net 49.0001.0bad.cafe.0001.00
 metric-style narrow
exit
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
$$ usr/libexec/vyos/tests/smoke/cli/test_protocols_isis.py
-vbash: usr/libexec/vyos/tests/smoke/cli/test_protocols_isis.py: No such file or directory
vyos@isis-01:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_isis.py
test_isis_01_redistribute (__main__.TestProtocolsISIS.test_isis_01_redistribute) ...
Network entity is mandatory!


Redistribute level-1 or level-2 should be specified in "protocols isis
redistribute ipv4 connected"!

ok
test_isis_02_vrfs (__main__.TestProtocolsISIS.test_isis_02_vrfs) ... ok
test_isis_04_default_information (__main__.TestProtocolsISIS.test_isis_04_default_information) ... ok
test_isis_05_password (__main__.TestProtocolsISIS.test_isis_05_password) ...
Can use either md5 or plaintext-password for area-password!


Can use either md5 or plaintext-password for domain-password!

ok
test_isis_06_spf_delay_bfd (__main__.TestProtocolsISIS.test_isis_06_spf_delay_bfd) ...
All types of spf-delay must be configured. Missing: short-delay, time-
to-learn, long-delay, init-delay


All types of spf-delay must be configured. Missing: short-delay, time-
to-learn, long-delay


All types of spf-delay must be configured. Missing: short-delay, time-
to-learn


All types of spf-delay must be configured. Missing: time-to-learn

ok
test_isis_07_segment_routing_configuration (__main__.TestProtocolsISIS.test_isis_07_segment_routing_configuration) ... ok
test_isis_08_ldp_sync (__main__.TestProtocolsISIS.test_isis_08_ldp_sync) ... ok
test_isis_09_lfa (__main__.TestProtocolsISIS.test_isis_09_lfa) ... ok
test_isis_10_topology (__main__.TestProtocolsISIS.test_isis_10_topology) ... ok

----------------------------------------------------------------------
Ran 9 tests in 72.574s

``` 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
