### PR TITLE
vxlan: T6401: Avoid calling get_vxlan_vni_filter() unless we need it

### DIFF
--- a/python/vyos/ifconfig/vxlan.py
+++ b/python/vyos/ifconfig/vxlan.py
@@ -138,10 +138,13 @@ class VXLANIf(Interface):
             raise ValueError('Value out of range')
 
         if 'vlan_to_vni_removed' in self.config:
-            cur_vni_filter = get_vxlan_vni_filter(self.ifname)
+            cur_vni_filter = None
+            if dict_search('parameters.vni_filter', self.config) != None:
+                cur_vni_filter = get_vxlan_vni_filter(self.ifname)
+
             for vlan, vlan_config in self.config['vlan_to_vni_removed'].items():
                 # If VNI filtering is enabled, remove matching VNI filter
-                if dict_search('parameters.vni_filter', self.config) != None:
+                if cur_vni_filter != None:
                     vni = vlan_config['vni']
                     if vni in cur_vni_filter:
                         self._cmd(f'bridge vni delete dev {self.ifname} vni {vni}')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
`bridge vni show dev vxlanX` will exit with an error if no VNI filters are installed, but the getter is used even when we haven't installed any.

This fix avoids fetching a list of VNI filters unless we know we've created some.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6401

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* vxlan

## Proposed changes
<!--- Describe your changes in detail -->
I've got 2 fix attempts for this, the first one had get_vxlan_vni_filter() check the return code from bridge and return an empty list on error. This is the second, which simply avoids calling get_vxlan_vni_filter() if vni-filter is not enabled. 

There only appears to be one caller into get_vxlan_vni_filter(), most accessors in vyos.utils don't bother wrapping errors, so I've switched to this solution. 

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@TEST-VYOS-RIGHT# compare
[interfaces]
+ bridge br0 {
+     enable-vlan
+     member {
+         interface vxlan0 {
+         }
+     }
+ }
+ dummy dum0 {
+     address "1.1.1.1/32"
+ }
+ vxlan vxlan0 {
+     parameters {
+         external
+     }
+     source-address "1.1.1.1"
+     vlan-to-vni 10 {
+         vni "10"
+     }
+ }

[edit]
vyos@TEST-VYOS-RIGHT# commit
[edit]
vyos@TEST-VYOS-RIGHT# bridge vni show dev vxlan0
dev               vni                group/remote
RTNETLINK answers: Invalid argument
Dump ternminated
[edit]
vyos@TEST-VYOS-RIGHT# delete interfaces vxlan vxlan0 vlan-to-vni 
[edit]
vyos@TEST-VYOS-RIGHT# commit
[edit]
vyos@TEST-VYOS-RIGHT# rollback-soft 1
Rollback diff has been applied.
Use "compare" to review the changes or "commit" to apply them.
[edit]
vyos@TEST-VYOS-RIGHT# compare
[interfaces vxlan vxlan0]
+ vlan-to-vni 10 {
+     vni "10"
+ }

[edit]
vyos@TEST-VYOS-RIGHT# set interfaces vxlan vxlan0 parameters vni-filter 
[edit]
vyos@TEST-VYOS-RIGHT# commit
[edit]
vyos@TEST-VYOS-RIGHT# bridge vni show dev vxlan0
dev               vni                group/remote
vxlan0            10                 
[edit]
vyos@TEST-VYOS-RIGHT# delete interfaces vxlan vxlan0 vlan-to-vni 
[edit]
vyos@TEST-VYOS-RIGHT# commit
[edit]
vyos@TEST-VYOS-RIGHT# bridge vni show dev vxlan0
dev               vni                group/remote
[edit]
vyos@TEST-VYOS-RIGHT#
```

`bridge` does seem to react differently depending on what is configured. 

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_vxlan.py 
test_add_multiple_ip_addresses (__main__.VXLANInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.VXLANInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.VXLANInterfaceTest.test_dhcp_client_options) ... skipped 'not supported'
test_dhcp_disable_interface (__main__.VXLANInterfaceTest.test_dhcp_disable_interface) ... skipped 'not supported'
test_dhcp_vrf (__main__.VXLANInterfaceTest.test_dhcp_vrf) ... skipped 'not supported'
test_dhcpv6_client_options (__main__.VXLANInterfaceTest.test_dhcpv6_client_options) ... skipped 'not supported'
test_dhcpv6_vrf (__main__.VXLANInterfaceTest.test_dhcpv6_vrf) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.VXLANInterfaceTest.test_dhcpv6pd_auto_sla_id) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.VXLANInterfaceTest.test_dhcpv6pd_manual_sla_id) ... skipped 'not supported'
test_interface_description (__main__.VXLANInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.VXLANInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.VXLANInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.VXLANInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.VXLANInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.VXLANInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.VXLANInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.VXLANInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.VXLANInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.VXLANInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.VXLANInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.VXLANInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.VXLANInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.VXLANInterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'
test_vxlan_external (__main__.VXLANInterfaceTest.test_vxlan_external) ... ok
test_vxlan_neighbor_suppress (__main__.VXLANInterfaceTest.test_vxlan_neighbor_suppress) ... ok
test_vxlan_parameters (__main__.VXLANInterfaceTest.test_vxlan_parameters) ... ok
test_vxlan_vlan_vni_mapping (__main__.VXLANInterfaceTest.test_vxlan_vlan_vni_mapping) ... ok
test_vxlan_vni_filter (__main__.VXLANInterfaceTest.test_vxlan_vni_filter) ... ok
test_vxlan_vni_filter_add_remove (__main__.VXLANInterfaceTest.test_vxlan_vni_filter_add_remove) ... ok

----------------------------------------------------------------------
Ran 29 tests in 158.646s

OK (skipped=14)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
