### PR TITLE
reverse-proxy: T6434: Support additional healthcheck options

### DIFF
--- a/data/templates/load-balancing/haproxy.cfg.j2
+++ b/data/templates/load-balancing/haproxy.cfg.j2
@@ -131,6 +131,13 @@ frontend {{ front }}
 {% if backend is vyos_defined %}
 {%     for back, back_config in backend.items() %}
 backend {{ back }}
+{%         if back_config.health_check is vyos_defined %}
+{%             if back_config.health_check == 'smtp' %}
+    option smtpchk
+{%             else  %}
+    option {{ back_config.health_check }}-check
+{%             endif %}
+{%         endif %}
 {%         if back_config.http_check is vyos_defined %}
     option httpchk
 {%         endif %}

--- a/interface-definitions/load-balancing_reverse-proxy.xml.in
+++ b/interface-definitions/load-balancing_reverse-proxy.xml.in
@@ -151,6 +151,37 @@
                   </node>
                 </children>
               </node>
+              <leafNode name="health-check">
+                <properties>
+                  <help>Non HTTP health check options</help>
+                  <completionHelp>
+                    <list>ldap mysql pgsql redis smtp</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>ldap</format>
+                    <description>LDAP protocol check</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>mysql</format>
+                    <description>MySQL protocol check</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>pgsql</format>
+                    <description>PostgreSQL protocol check</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>redis</format>
+                    <description>Redis protocol check</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>smtp</format>
+                    <description>SMTP protocol check</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(ldap|mysql|redis|pgsql|smtp)</regex>
+                  </constraint>
+                </properties>
+              </leafNode>
               #include <include/haproxy/rule-backend.xml.i>
               <tagNode name="server">
                 <properties>

--- a/src/conf_mode/load-balancing_reverse-proxy.py
+++ b/src/conf_mode/load-balancing_reverse-proxy.py
@@ -79,12 +79,21 @@ def verify(lb):
             raise ConfigError(f'"TCP" port "{tmp_port}" is used by another service')
 
     for back, back_config in lb['backend'].items():
-        if 'http-check' in back_config:
-            http_check = back_config['http-check']
+        if 'http_check' in back_config:
+            http_check = back_config['http_check']
             if 'expect' in http_check and 'status' in http_check['expect'] and 'string' in http_check['expect']:
                 raise ConfigError(f'"expect status" and "expect string" can not be configured together!')
+
+        if 'health_check' in back_config:
+            if 'mode' not in back_config or back_config['mode'] != 'tcp':
+                raise ConfigError(f'backend "{back}" can only be configured with {back_config["health_check"]} ' +
+                                  f'health-check whilst in TCP mode!')
+            if 'http_check' in back_config:
+                raise ConfigError(f'backend "{back}" cannot be configured with both http-check and health-check!')
+
         if 'server' not in back_config:
             raise ConfigError(f'"{back} server" must be configured!')
+
         for bk_server, bk_server_conf in back_config['server'].items():
             if 'address' not in bk_server_conf or 'port' not in bk_server_conf:
                 raise ConfigError(f'"backend {back} server {bk_server} address and port" must be configured!')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add support for health checking additional protocols other than HTTP in reverse-proxy backends.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
[https://vyos.dev/T6434](https://vyos.dev/T6434)

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
load-balancing -> reverse-proxy
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

1. Create a reverse-proxy configuration using the new options:
```
set load-balancing reverse-proxy backend bk-01 mode 'tcp'
set load-balancing reverse-proxy backend bk-01 server srv-01 address '192.0.2.11'
set load-balancing reverse-proxy backend bk-01 server srv-01 port '389'
set load-balancing reverse-proxy backend bk-01 server srv-01 check
set load-balancing reverse-proxy backend bk-01 health-check 'ldap'

set load-balancing reverse-proxy service fe-01 backend 'bk-01'
set load-balancing reverse-proxy service fe-01 mode 'tcp'
set load-balancing reverse-proxy service fe-01 port '389'
```

2. Check the HAProxy backend server configuration is showing the correct options:
```
vyos@vyos:~$ cat /var/run/haproxy/haproxy.cfg | grep '# Backend' -A 5
# Backend
backend bk-01
	option ldap-check
	balance roundrobin
	mode tcp
	server srv-01 192.0.2.11:389 check
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_load-balancing_reverse-proxy.py
test_01_lb_reverse_proxy_domain (__main__.TestLoadBalancingReverseProxy.test_01_lb_reverse_proxy_domain) ... ok
test_02_lb_reverse_proxy_cert_not_exists (__main__.TestLoadBalancingReverseProxy.test_02_lb_reverse_proxy_cert_not_exists) ...
PKI does not contain any certificates!


Certificate "cert" not found in configuration!

ok
test_03_lb_reverse_proxy_ca_not_exists (__main__.TestLoadBalancingReverseProxy.test_03_lb_reverse_proxy_ca_not_exists) ...
PKI does not contain any CA certificates!


CA Certificate "ca-test" not found in configuration!

ok
test_04_lb_reverse_proxy_backend_ssl_no_verify (__main__.TestLoadBalancingReverseProxy.test_04_lb_reverse_proxy_backend_ssl_no_verify) ...
backend bk-01 cannot have both ssl options no-verify and ca-certificate
set!

ok
test_05_lb_reverse_proxy_backend_http_check (__main__.TestLoadBalancingReverseProxy.test_05_lb_reverse_proxy_backend_http_check) ...
backend "bk-01" can only be configured with ldap health-check whilst in
TCP mode!

ok
test_06_lb_reverse_proxy_tcp_mode (__main__.TestLoadBalancingReverseProxy.test_06_lb_reverse_proxy_tcp_mode) ... ok
test_07_lb_reverse_proxy_http_response_headers (__main__.TestLoadBalancingReverseProxy.test_07_lb_reverse_proxy_http_response_headers) ...
service https_front must be set to http mode to use
http_response_headers!

ok
test_08_lb_reverse_proxy_tcp_health_checks (__main__.TestLoadBalancingReverseProxy.test_08_lb_reverse_proxy_tcp_health_checks) ... ok

----------------------------------------------------------------------
Ran 8 tests in 37.243s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly