### PR TITLE
wireless: T6425: Fixing VHT beamforming for 802.11ac

### DIFF
--- a/data/templates/wifi/hostapd.conf.j2
+++ b/data/templates/wifi/hostapd.conf.j2
@@ -383,23 +383,25 @@ vht_oper_chwidth={{ capabilities.vht.channel_set_width }}
 {%     for short_gi in capabilities.vht.short_gi if capabilities.vht.short_gi is vyos_defined %}
 {%         set output.value = output.value ~ '[SHORT-GI-' ~ short_gi | upper ~ ']'  %}
 {%     endfor %}
-{%     for beamform in capabilities.vht.beamform if capabilities.vht.beamform is vyos_defined %}
-{%         set output.value = output.value ~ '[SU-BEAMFORMER]' if beamform is vyos_defined('single-user-beamformer') else '' %}
-{%         set output.value = output.value ~ '[SU-BEAMFORMEE]' if beamform is vyos_defined('single-user-beamformee') else '' %}
-{%         set output.value = output.value ~ '[MU-BEAMFORMER]' if beamform is vyos_defined('multi-user-beamformer')  else '' %}
-{%         set output.value = output.value ~ '[MU-BEAMFORMEE]' if beamform is vyos_defined('multi-user-beamformee')  else '' %}
-{%     endfor %}
-{%     if capabilities.vht.antenna_count is vyos_defined and capabilities.vht.antenna_count | int > 1  %}
-{%         if capabilities.vht.beamform is vyos_defined %}
-{%             if capabilities.vht.beamform == 'single-user-beamformer' %}
+{%     if capabilities.vht.beamform is vyos_defined %}
+{%         for bf in capabilities.vht.beamform %}
+{%             set output.value = output.value ~ '[SU-BEAMFORMER]' if bf is vyos_defined('single-user-beamformer') else output.value %}
+{%             set output.value = output.value ~ '[SU-BEAMFORMEE]' if bf is vyos_defined('single-user-beamformee') else output.value %}
+{%             set output.value = output.value ~ '[MU-BEAMFORMER]' if bf is vyos_defined('multi-user-beamformer') else output.value %}
+{%             set output.value = output.value ~ '[MU-BEAMFORMEE]' if bf is vyos_defined('multi-user-beamformee') else output.value %}
+{%         endfor %}
+{%         if capabilities.vht.antenna_count is vyos_defined and capabilities.vht.antenna_count | int > 1  %}
+{%             if 'single-user-beamformer' in capabilities.vht.beamform %}
 {%                 if capabilities.vht.antenna_count is vyos_defined and capabilities.vht.antenna_count | int > 1 and capabilities.vht.antenna_count | int < 6  %}
-{%                     set output.value = output.value ~ '[BF-ANTENNA-' ~ capabilities.vht.antenna_count | int -1 ~ ']' %}
-{%                     set output.value = output.value ~ '[SOUNDING-DIMENSION-' ~ capabilities.vht.antenna_count | int -1 ~ ']' %}
+{%                     set dimension = capabilities.vht.antenna_count | int - 1 %}
+{%                     set output.value = output.value ~ '[BF-ANTENNA-' ~ dimension ~ ']' %}
+{%                     set output.value = output.value ~ '[SOUNDING-DIMENSION-' ~ dimension ~ ']' %}
 {%                 endif %}
-{%             endif %}
-{%             if capabilities.vht.antenna_count is vyos_defined and capabilities.vht.antenna_count | int > 1 and capabilities.vht.antenna_count | int < 5  %}
-{%                 set output.value = output.value ~ '[BF-ANTENNA-' ~ capabilities.vht.antenna_count ~ ']' %}
-{%                 set output.value = output.value ~ '[SOUNDING-DIMENSION-' ~ capabilities.vht.antenna_count ~ ']' %}
+{%             else %}
+{%                 if capabilities.vht.antenna_count is vyos_defined and capabilities.vht.antenna_count | int > 1 and capabilities.vht.antenna_count | int < 5  %}
+{%                     set output.value = output.value ~ '[BF-ANTENNA-' ~ capabilities.vht.antenna_count ~ ']' %}
+{%                     set output.value = output.value ~ '[SOUNDING-DIMENSION-' ~ capabilities.vht.antenna_count ~ ']' %}
+{%                 endif %}
 {%             endif %}
 {%         endif %}
 {%     endif %}

--- a/smoketest/scripts/cli/test_interfaces_wireless.py
+++ b/smoketest/scripts/cli/test_interfaces_wireless.py
@@ -159,6 +159,146 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         # Check for running process
         self.assertTrue(process_named_running('hostapd'))
 
+    def test_wireless_hostapd_vht_mu_beamformer_config(self):
+        # Multi-User-Beamformer
+        interface = 'wlan1'
+        ssid = 'vht_mu-beamformer'
+        antennas = '3'
+
+        self.cli_set(self._base_path + [interface, 'ssid', ssid])
+        self.cli_set(self._base_path + [interface, 'country-code', 'se'])
+        self.cli_set(self._base_path + [interface, 'type', 'access-point'])
+        self.cli_set(self._base_path + [interface, 'channel', '36'])
+
+        ht_opt = {
+            # VyOS CLI option           hostapd - ht_capab setting
+            'channel-set-width ht20'  : '[HT20]',
+            'channel-set-width ht40-' : '[HT40-]',
+            'channel-set-width ht40+' : '[HT40+]',
+            'dsss-cck-40'             : '[DSSS_CCK-40]',
+            'short-gi 20'             : '[SHORT-GI-20]',
+            'short-gi 40'             : '[SHORT-GI-40]',
+            'max-amsdu 7935'          : '[MAX-AMSDU-7935]',
+        }
+        for key in ht_opt:
+            self.cli_set(self._base_path + [interface, 'capabilities', 'ht'] + key.split())
+
+        vht_opt = {
+            # VyOS CLI option           hostapd - ht_capab setting
+            'max-mpdu 11454'          : '[MAX-MPDU-11454]',
+            'max-mpdu-exp 2'          : '[MAX-A-MPDU-LEN-EXP-2]',
+            'stbc tx'                 : '[TX-STBC-2BY1]',
+            'stbc rx 12'              : '[RX-STBC-12]',
+            'ldpc'                    : '[RXLDPC]',
+            'tx-powersave'            : '[VHT-TXOP-PS]',
+            'vht-cf'                  : '[HTC-VHT]',
+            'antenna-pattern-fixed'   : '[RX-ANTENNA-PATTERN][TX-ANTENNA-PATTERN]',
+            'link-adaptation both'    : '[VHT-LINK-ADAPT3]',
+            'short-gi 80'             : '[SHORT-GI-80]',
+            'short-gi 160'            : '[SHORT-GI-160]',
+            'beamform multi-user-beamformer' : '[MU-BEAMFORMER][BF-ANTENNA-3][SOUNDING-DIMENSION-3]',
+        }
+
+        self.cli_set(self._base_path + [interface, 'capabilities', 'vht', 'channel-set-width', '1'])
+        self.cli_set(self._base_path + [interface, 'capabilities', 'vht', 'center-channel-freq', 'freq-1', '42'])
+        self.cli_set(self._base_path + [interface, 'capabilities', 'vht', 'antenna-count', antennas])
+        for key in vht_opt:
+            self.cli_set(self._base_path + [interface, 'capabilities', 'vht'] + key.split())
+
+        self.cli_commit()
+
+        #
+        # Validate Config
+        #
+        tmp = get_config_value(interface, 'interface')
+        self.assertEqual(interface, tmp)
+
+        # ssid
+        tmp = get_config_value(interface, 'ssid')
+        self.assertEqual(ssid, tmp)
+
+        # channel
+        tmp = get_config_value(interface, 'channel')
+        self.assertEqual('36', tmp)
+
+        tmp = get_config_value(interface, 'ht_capab')
+        for key, value in ht_opt.items():
+            self.assertIn(value, tmp)
+
+        tmp = get_config_value(interface, 'vht_capab')
+        for key, value in vht_opt.items():
+            self.assertIn(value, tmp)
+
+    def test_wireless_hostapd_vht_su_beamformer_config(self):
+        # Single-User-Beamformer
+        interface = 'wlan1'
+        ssid = 'vht_su-beamformer'
+        antennas = '3'
+
+        self.cli_set(self._base_path + [interface, 'ssid', ssid])
+        self.cli_set(self._base_path + [interface, 'country-code', 'se'])
+        self.cli_set(self._base_path + [interface, 'type', 'access-point'])
+        self.cli_set(self._base_path + [interface, 'channel', '36'])
+
+        ht_opt = {
+            # VyOS CLI option           hostapd - ht_capab setting
+            'channel-set-width ht20'  : '[HT20]',
+            'channel-set-width ht40-' : '[HT40-]',
+            'channel-set-width ht40+' : '[HT40+]',
+            'dsss-cck-40'             : '[DSSS_CCK-40]',
+            'short-gi 20'             : '[SHORT-GI-20]',
+            'short-gi 40'             : '[SHORT-GI-40]',
+            'max-amsdu 7935'          : '[MAX-AMSDU-7935]',
+        }
+        for key in ht_opt:
+            self.cli_set(self._base_path + [interface, 'capabilities', 'ht'] + key.split())
+
+        vht_opt = {
+            # VyOS CLI option           hostapd - ht_capab setting
+            'max-mpdu 11454'          : '[MAX-MPDU-11454]',
+            'max-mpdu-exp 2'          : '[MAX-A-MPDU-LEN-EXP-2]',
+            'stbc tx'                 : '[TX-STBC-2BY1]',
+            'stbc rx 12'              : '[RX-STBC-12]',
+            'ldpc'                    : '[RXLDPC]',
+            'tx-powersave'            : '[VHT-TXOP-PS]',
+            'vht-cf'                  : '[HTC-VHT]',
+            'antenna-pattern-fixed'   : '[RX-ANTENNA-PATTERN][TX-ANTENNA-PATTERN]',
+            'link-adaptation both'    : '[VHT-LINK-ADAPT3]',
+            'short-gi 80'             : '[SHORT-GI-80]',
+            'short-gi 160'            : '[SHORT-GI-160]',
+            'beamform single-user-beamformer' : '[SU-BEAMFORMER][BF-ANTENNA-2][SOUNDING-DIMENSION-2]',
+        }
+
+        self.cli_set(self._base_path + [interface, 'capabilities', 'vht', 'channel-set-width', '1'])
+        self.cli_set(self._base_path + [interface, 'capabilities', 'vht', 'center-channel-freq', 'freq-1', '42'])
+        self.cli_set(self._base_path + [interface, 'capabilities', 'vht', 'antenna-count', antennas])
+        for key in vht_opt:
+            self.cli_set(self._base_path + [interface, 'capabilities', 'vht'] + key.split())
+
+        self.cli_commit()
+
+        #
+        # Validate Config
+        #
+        tmp = get_config_value(interface, 'interface')
+        self.assertEqual(interface, tmp)
+
+        # ssid
+        tmp = get_config_value(interface, 'ssid')
+        self.assertEqual(ssid, tmp)
+
+        # channel
+        tmp = get_config_value(interface, 'channel')
+        self.assertEqual('36', tmp)
+
+        tmp = get_config_value(interface, 'ht_capab')
+        for key, value in ht_opt.items():
+            self.assertIn(value, tmp)
+
+        tmp = get_config_value(interface, 'vht_capab')
+        for key, value in vht_opt.items():
+            self.assertIn(value, tmp)
+
     def test_wireless_hostapd_wpa_config(self):
         # Only set the hostapd (access-point) options
         interface = 'wlan0'

--- a/smoketest/scripts/cli/test_interfaces_wireless.py
+++ b/smoketest/scripts/cli/test_interfaces_wireless.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020-2023 VyOS maintainers and contributors
+# Copyright (C) 2020-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -166,7 +166,6 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         antennas = '3'
 
         self.cli_set(self._base_path + [interface, 'ssid', ssid])
-        self.cli_set(self._base_path + [interface, 'country-code', 'se'])
         self.cli_set(self._base_path + [interface, 'type', 'access-point'])
         self.cli_set(self._base_path + [interface, 'channel', '36'])
 
@@ -236,7 +235,6 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         antennas = '3'
 
         self.cli_set(self._base_path + [interface, 'ssid', ssid])
-        self.cli_set(self._base_path + [interface, 'country-code', 'se'])
         self.cli_set(self._base_path + [interface, 'type', 'access-point'])
         self.cli_set(self._base_path + [interface, 'channel', '36'])
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
* VHT beamforming support was broken which was fixed. 
* Smoketests were added to detect new bugs on VHT beamforming.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6425
 
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireless

## Proposed changes
<!--- Describe your changes in detail -->
This bugfix addresses errors in the `data/templates/wifi/hostapd.conf.j2` template file which prevented correct generation of `/run/hostapd/wlanX.conf` when VHT beamforming was configured. There was also no smoketest yet to detect such an error. Two tests have been added to this PR to check for correct generation of `/run/hostapd/wlanX.conf` when VHT beamforming is configured.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

1. Configure a WiFi interface `wlanX` using the config below.
2. Commit your changes. 
  - When using `mac80211_hwsim`, prepare to see an error because simulated WiFi NICs do not support VHT beamforming.
4. Check `/run/hostapd/wlanX.conf`
  - Verify this line: `vht_capab=[MAX-MPDU-11454][MAX-A-MPDU-LEN-EXP-3][MU-BEAMFORMER][SU-BEAMFORMEE][SU-BEAMFORMER][BF-ANTENNA-2][SOUNDING-DIMENSION-2]`. 
  - Alternatively use the smoketest `/usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireless.py`.

`show interfaces wireless wlanX`:
```
 address 10.255.5.254/24
 capabilities {
     ht {
         channel-set-width ht20
         channel-set-width ht40+
         channel-set-width ht40-
         dsss-cck-40
         short-gi 20
         short-gi 40
     }
     vht {
         antenna-count 3
         beamform multi-user-beamformer
         beamform single-user-beamformee
         beamform single-user-beamformer
         center-channel-freq {
             freq-1 42
         }
         channel-set-width 1
         max-mpdu 11454
         max-mpdu-exp 3
     }
 }
 channel 36
 country-code de
 description "5GHz 802.11ac"
 mode ac
 security {
     wpa {
         mode wpa2
         passphrase secretpassphrase123
     }
 }
 ssid 80211ac-5GHz
 type access-point
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireless.py
test_add_multiple_ip_addresses (__main__.WirelessInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.WirelessInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.WirelessInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.WirelessInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.WirelessInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.WirelessInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.WirelessInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_interface_description (__main__.WirelessInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.WirelessInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.WirelessInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.WirelessInterfaceTest.test_interface_ipv6_options) ... skipped 'not supported'
test_interface_mtu (__main__.WirelessInterfaceTest.test_interface_mtu) ... skipped 'not supported'
test_ipv6_link_local_address (__main__.WirelessInterfaceTest.test_ipv6_link_local_address) ... skipped 'not supported'
test_mtu_1200_no_ipv6_interface (__main__.WirelessInterfaceTest.test_mtu_1200_no_ipv6_interface) ... skipped 'not supported'
test_span_mirror (__main__.WirelessInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.WirelessInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.WirelessInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.WirelessInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.WirelessInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.WirelessInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.WirelessInterfaceTest.test_vif_s_protocol_change) ... ok
test_wireless_access_point_bridge (__main__.WirelessInterfaceTest.test_wireless_access_point_bridge) ... ok
test_wireless_add_single_ip_address (__main__.WirelessInterfaceTest.test_wireless_add_single_ip_address) ... ok
test_wireless_hostapd_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_config) ... ok
test_wireless_hostapd_vht_mu_beamformer_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_vht_mu_beamformer_config) ... ok
test_wireless_hostapd_vht_su_beamformer_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_vht_su_beamformer_config) ... ok
test_wireless_hostapd_wpa_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_wpa_config) ... ok
test_wireless_security_station_address (__main__.WirelessInterfaceTest.test_wireless_security_station_address) ... FAIL

======================================================================
FAIL: test_wireless_security_station_address (__main__.WirelessInterfaceTest.test_wireless_security_station_address)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireless.py", line 434, in test_wireless_security_station_address
    self.assertTrue(process_named_running('hostapd'))
AssertionError: None is not true

----------------------------------------------------------------------
Ran 30 tests in 184.864s

FAILED (failures=1, skipped=9)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
