### PR TITLE
T6431: op-mode command "monitor traceroute" missing recursive symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ op_mode_definitions: $(op_xml_obj)
 	ln -s ../node.tag $(OP_TMPL_DIR)/ping/node.tag/node.tag/
 	ln -s ../node.tag $(OP_TMPL_DIR)/traceroute/node.tag/node.tag/
 	ln -s ../node.tag $(OP_TMPL_DIR)/mtr/node.tag/node.tag/
+	ln -s ../node.tag $(OP_TMPL_DIR)/monitor/traceroute/node.tag/node.tag/
 
 	# XXX: test if there are empty node.def files - this is not allowed as these
 	# could mask help strings or mandatory priority statements

--- a/op-mode-definitions/mtr.xml.in
+++ b/op-mode-definitions/mtr.xml.in
@@ -13,7 +13,7 @@
         <children>
           <leafNode name="node.tag">
             <properties>
-              <help>mtr options</help>
+              <help>Traceroute options</help>
               <completionHelp>
                 <script>${vyos_op_scripts_dir}/mtr.py --get-options-nested "${COMP_WORDS[@]}"</script>
               </completionHelp>
@@ -35,7 +35,7 @@
     <children>
       <leafNode name="node.tag">
         <properties>
-          <help>Traceroute options</help>
+          <help>mtr options</help>
           <completionHelp>
             <script>${vyos_op_scripts_dir}/mtr.py --get-options "${COMP_WORDS[@]}"</script>
           </completionHelp>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
There's 4 opmode commands with flexible leafNode parameters, sort of "varargs", using some symlink hackery to work. ping, traceroute and mtr were correctly symlinked in the Makefile, monitor traceroute was not. 

The completion help texts were also switched between mtr and monitor traceroute, they're in the same XML def. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6431

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* monitor 

## Proposed changes
<!--- Describe your changes in detail -->
Added the missing symlink and swapped around the help text. 

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Before the patch:
```
vyos@TEST-VYOS-LEFT:~$ monitor traceroute 8.8.8.8 vrf 
Possible completions:
  <Enter>               Execute the current command
```
After the patch:
``` 
vyos@TEST-VYOS-LEFT:~$ monitor traceroute 8.8.8.8 vrf 
Possible completions:
  <Enter>               Execute the current command
  MGT                   Traceroute options

      
vyos@TEST-VYOS-LEFT:~$ monitor traceroute 8.8.8.8 vrf MGT 
Possible completions:
  <Enter>               Execute the current command
  address               Traceroute options
  aslookup
  bitpattern
  first-ttl
[...etc...]
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
There doesn't appear to be a smoketest for tiny op-mode schema changes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
