### PR TITLE
xml: T6423: enforce priority on nodes having an owner

### DIFF
--- a/interface-definitions/load-balancing_reverse-proxy.xml.in
+++ b/interface-definitions/load-balancing_reverse-proxy.xml.in
@@ -5,6 +5,7 @@
       <node name="reverse-proxy" owner="${vyos_conf_scripts_dir}/load-balancing_reverse-proxy.py">
         <properties>
           <help>Configure reverse-proxy</help>
+          <priority>900</priority>
         </properties>
         <children>
           <tagNode name="service">

--- a/interface-definitions/load-balancing_wan.xml.in
+++ b/interface-definitions/load-balancing_wan.xml.in
@@ -3,12 +3,12 @@
   <node name="load-balancing">
     <properties>
       <help>Configure load-balancing</help>
-      <priority>900</priority>
     </properties>
     <children>
       <node name="wan" owner="${vyos_conf_scripts_dir}/load-balancing_wan.py">
         <properties>
           <help>Configure Wide Area Network (WAN) load-balancing</help>
+          <priority>900</priority>
         </properties>
         <children>
           <leafNode name="disable-source-nat">

--- a/interface-definitions/protocols_static_arp.xml.in
+++ b/interface-definitions/protocols_static_arp.xml.in
@@ -7,6 +7,7 @@
           <node name="arp" owner="${vyos_conf_scripts_dir}/protocols_static_arp.py">
             <properties>
               <help>Static ARP translation</help>
+              <priority>481</priority>
             </properties>
             <children>
               <tagNode name="interface">

--- a/interface-definitions/protocols_static_multicast.xml.in
+++ b/interface-definitions/protocols_static_multicast.xml.in
@@ -7,6 +7,7 @@
           <node name="multicast" owner="${vyos_conf_scripts_dir}/protocols_static_multicast.py">
             <properties>
               <help>Multicast static route</help>
+              <priority>481</priority>
             </properties>
             <children>
               <tagNode name="route">

--- a/interface-definitions/protocols_static_neighbor-proxy.xml.in
+++ b/interface-definitions/protocols_static_neighbor-proxy.xml.in
@@ -7,6 +7,7 @@
           <node name="neighbor-proxy" owner="${vyos_conf_scripts_dir}/protocols_static_neighbor-proxy.py">
             <properties>
               <help>Neighbor proxy parameters</help>
+              <priority>481</priority>
             </properties>
             <children>
               <tagNode name="arp">

--- a/interface-definitions/service_aws_glb.xml.in
+++ b/interface-definitions/service_aws_glb.xml.in
@@ -5,12 +5,12 @@
       <node name="aws">
         <properties>
           <help>Amazon Web Service</help>
-          <priority>1280</priority>
         </properties>
         <children>
           <node name="glb" owner="${vyos_conf_scripts_dir}/service_aws_glb.py">
             <properties>
               <help>Gateway load-balancer tunnel handler</help>
+              <priority>1280</priority>
             </properties>
             <children>
               <node name="script">

--- a/interface-definitions/service_config-sync.xml.in
+++ b/interface-definitions/service_config-sync.xml.in
@@ -5,6 +5,7 @@
       <node name="config-sync" owner="${vyos_conf_scripts_dir}/service_config-sync.py">
         <properties>
           <help>Configuration synchronization</help>
+          <priority>10000</priority>
         </properties>
         <children>
           <node name="secondary">

--- a/interface-definitions/service_console-server.xml.in
+++ b/interface-definitions/service_console-server.xml.in
@@ -5,6 +5,7 @@
       <node name="console-server" owner="${vyos_conf_scripts_dir}/service_console-server.py">
         <properties>
           <help>Serial Console Server</help>
+          <priority>2</priority>
         </properties>
         <children>
           <tagNode name="device">

--- a/interface-definitions/service_event-handler.xml.in
+++ b/interface-definitions/service_event-handler.xml.in
@@ -5,6 +5,7 @@
       <node name="event-handler" owner="${vyos_conf_scripts_dir}/service_event-handler.py">
         <properties>
           <help>Service event handler</help>
+          <priority>2</priority>
         </properties>
         <children>
           <tagNode name="event">

--- a/interface-definitions/service_monitoring_telegraf.xml.in
+++ b/interface-definitions/service_monitoring_telegraf.xml.in
@@ -5,12 +5,12 @@
       <node name="monitoring">
         <properties>
           <help>Monitoring services</help>
-          <priority>1280</priority>
         </properties>
         <children>
           <node name="telegraf" owner="${vyos_conf_scripts_dir}/service_monitoring_telegraf.py">
             <properties>
               <help>Telegraf metric collector</help>
+              <priority>1280</priority>
             </properties>
             <children>
               <node name="influxdb">

--- a/interface-definitions/service_monitoring_zabbix-agent.xml.in
+++ b/interface-definitions/service_monitoring_zabbix-agent.xml.in
@@ -7,6 +7,7 @@
           <node name="zabbix-agent" owner="${vyos_conf_scripts_dir}/service_monitoring_zabbix-agent.py">
             <properties>
               <help>Zabbix-agent settings</help>
+              <priority>1280</priority>
             </properties>
             <children>
               <leafNode name="directory">

--- a/interface-definitions/service_sla.xml.in
+++ b/interface-definitions/service_sla.xml.in
@@ -5,6 +5,7 @@
       <node name="sla" owner="${vyos_conf_scripts_dir}/service_sla.py">
         <properties>
           <help>Service level agreement (SLA)</help>
+          <priority>2</priority>
         </properties>
         <children>
           <node name="owamp-server">

--- a/interface-definitions/system_login_banner.xml.in
+++ b/interface-definitions/system_login_banner.xml.in
@@ -11,6 +11,7 @@
           <node name="banner" owner="${vyos_conf_scripts_dir}/system_login_banner.py">
             <properties>
               <help>System login banners</help>
+              <priority>410</priority>
             </properties>
             <children>
               <leafNode name="post-login">

--- a/interface-definitions/system_proxy.xml.in
+++ b/interface-definitions/system_proxy.xml.in
@@ -5,6 +5,7 @@
       <node name="proxy" owner="${vyos_conf_scripts_dir}/system_proxy.py">
         <properties>
           <help>Sets a proxy for system wide use</help>
+          <priority>100</priority>
         </properties>
         <children>
           <leafNode name="url">

--- a/scripts/build-command-templates
+++ b/scripts/build-command-templates
@@ -287,6 +287,12 @@ def process_node(n, tmpl_dir):
     props = get_properties(props_elem, n.find("defaultValue"))
     if owner:
         props["owner"] = owner
+        # <priority> tag is mandatory if the parent node has an owner
+        if "priority" not in props:
+            raise ValueError(
+                f"<priority> tag should be set for the node <{name}> path '{' '.join(my_tmpl_dir[1:])}'"
+            )
+
     # Type should not be set for non-tag, non-leaf nodes
     # For non-valueless leaf nodes, set the type to txt: to make them have some type,
     # actual value validation is handled by constraints translated to syntax:expression:
@@ -335,4 +341,8 @@ nodes = root.iterfind("*")
 for n in nodes:
     if n.tag == "syntaxVersion":
         continue
-    process_node(n, [output_dir])
+    try:
+        process_node(n, [output_dir])
+    except ValueError as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added checking for priority tag if owner is defined in xml schema
If no priority then error is raised
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Added priority tag

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/6423
* ## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
 
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
