### PR TITLE
T6045: Recreate show lldp detail views & improve remote port selection

### DIFF
--- a/op-mode-definitions/lldp.xml.in
+++ b/op-mode-definitions/lldp.xml.in
@@ -13,6 +13,12 @@
             </properties>
             <command>${vyos_op_scripts_dir}/lldp.py show_neighbors</command>
             <children>
+              <node name="detail">
+                <properties>
+                  <help>Show extended detail for LLDP neighbors</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/lldp.py show_neighbors --detail</command>
+              </node>
               <tagNode name="interface">
                 <properties>
                   <help>Show LLDP for specified interface</help>
@@ -21,6 +27,17 @@
                   </completionHelp>
                 </properties>
                 <command>${vyos_op_scripts_dir}/lldp.py show_neighbors --interface $5</command>
+                <children>
+                  <node name="detail">
+                    <properties>
+                      <help>Show detailed LLDP for specified interface</help>
+                      <completionHelp>
+                        <script>${vyos_completion_dir}/list_interfaces</script>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/lldp.py show_neighbors --interface $5 --detail</command>
+                  </node>
+                </children>
               </tagNode>
             </children>
           </node>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
If the remote device has explicitly sent the interface name as the portID, we should use that first as the interface name, before working through the previous priority order.

I've brought back LLDP detail views by directly calling lldpcli. This can be extended to render a template from op_mode/lldp.py, but lldpcli isn't bad at rendering readable info. Raw mode (including detailed raw) is still accessible for programmatic access.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6045
* https://vyos.dev/T6067

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* op_mode

## Proposed changes
<!--- Describe your changes in detail -->
Different NOSes and full blown OSes return interface information differently, making a proper universal selection on the "Remote Port" field difficult. It's a similar situation in net-snmp between ifName, ifAlias and ifDescr. However, we do get a type attribute for the PortID returned in LLDP (ref: https://github.com/lldpd/lldpd/blob/master/src/lib/atoms/port.c#L41), so if the remote explicitly says it's the interface name (eg, Cisco & HPE do), that's the interface name. 

It will likely need some tweaking and testing, as I'm sure there are still vendors misusing the attribute, but it's a bit closer in the most common use cases from large vendors. 

I started re-implementing a detail view in `op_mode/lldp.py` using some Cisco output samples as a template and calling in with `--detail` set for those tag branches from the XML. However - it's a decent bit of effort, source JSON is very flexible in structure depending on the devices found, we already have an competent renderer in lldpcli. 

I can revisit this one to complete the re-rendering in lldp.py if that's the preferred way of doing things, but this should be a working implementation as-is. 

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@TEST-VYOS-LEFT:~$ show lldp neighbors interface eth1 detail
-------------------------------------------------------------------------------
LLDP neighbors:
-------------------------------------------------------------------------------
Interface:    eth1, via: LLDP, RID: 1, Time: 0 day, 03:02:43
  Chassis:     
    ChassisID:    mac bc:24:11:73:39:f8
    SysName:      TEST-VYOS-RIGHT
    SysDescr:     VyOS 1.5-rolling-202406020021
    MgmtIP:       9.9.9.10
    MgmtIface:    3
    MgmtIP:       fe80::200:ff:fe00:0
    MgmtIface:    1
    Capability:   Bridge, off
    Capability:   Router, on
    Capability:   Wlan, off
    Capability:   Station, off
  Port:        
    PortID:       mac bc:24:11:f3:ab:a8
    PortDescr:    eth1
    TTL:          120
  LLDP-MED:    
    Device Type:  Network Connectivity Device
    Capability:   Capabilities, yes
    Capability:   Policy, yes
    Capability:   Location, yes
    Capability:   MDI/PSE, yes
    Capability:   MDI/PD, yes
    Capability:   Inventory, yes
    Inventory:   
      Hardware Revision: pc-i440fx-8.1
      Software Revision: 6.6.32-amd64-vyos
      Firmware Revision: rel-1.16.2-0-gea1b7a073390-prebu
      Manufacturer: QEMU
      Model:        Standard PC (i440FX + PIIX, 1996
-------------------------------------------------------------------------------
```
and
```
vyos@TEST-VYOS-LEFT:~$ show lldp neighbors details 
-------------------------------------------------------------------------------
LLDP neighbors:
-------------------------------------------------------------------------------
Interface:    eth1, via: LLDP, RID: 1, Time: 0 day, 03:02:49
  Chassis:     
    ChassisID:    mac bc:24:11:73:39:f8
    SysName:      TEST-VYOS-RIGHT
    SysDescr:     VyOS 1.5-rolling-202406020021
    MgmtIP:       9.9.9.10
    MgmtIface:    3
    MgmtIP:       fe80::200:ff:fe00:0
    MgmtIface:    1
    Capability:   Bridge, off
    Capability:   Router, on
    Capability:   Wlan, off
    Capability:   Station, off
  Port:        
    PortID:       mac bc:24:11:f3:ab:a8
    PortDescr:    eth1
    TTL:          120
  LLDP-MED:    
    Device Type:  Network Connectivity Device
    Capability:   Capabilities, yes
    Capability:   Policy, yes
    Capability:   Location, yes
    Capability:   MDI/PSE, yes
    Capability:   MDI/PD, yes
    Capability:   Inventory, yes
    Inventory:   
      Hardware Revision: pc-i440fx-8.1
      Software Revision: 6.6.32-amd64-vyos
      Firmware Revision: rel-1.16.2-0-gea1b7a073390-prebu
      Manufacturer: QEMU
      Model:        Standard PC (i440FX + PIIX, 1996
-------------------------------------------------------------------------------
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
There doesn't appear to be a smoketest for op-mode schema changes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
