### PR TITLE
reverse-proxy: T6454: Set default value of http for haproxy mode

### DIFF
--- a/data/templates/load-balancing/haproxy.cfg.j2
+++ b/data/templates/load-balancing/haproxy.cfg.j2
@@ -67,25 +67,23 @@ frontend {{ front }}
 {%         if front_config.redirect_http_to_https is vyos_defined %}
     http-request redirect scheme https unless { ssl_fc }
 {%         endif %}
-{%         if front_config.mode is vyos_defined %}
     mode {{ front_config.mode }}
-{%             if front_config.tcp_request.inspect_delay is vyos_defined %}
+{%         if front_config.tcp_request.inspect_delay is vyos_defined %}
     tcp-request inspect-delay {{ front_config.tcp_request.inspect_delay }}
-{%             endif %}
-{# add tcp-request related directive if ssl is configed #}
-{%             if front_config.mode is vyos_defined('tcp') and front_config.rule is vyos_defined %}
-{%                 for rule, rule_config in front_config.rule.items() %}
-{%                     if rule_config.ssl is vyos_defined %}
+{%         endif %}
+{# add tcp-request related directive if ssl is configured #}
+{%         if front_config.mode == 'tcp' and front_config.rule is vyos_defined %}
+{%             for rule, rule_config in front_config.rule.items() %}
+{%                 if rule_config.ssl is vyos_defined %}
     tcp-request content accept if { req_ssl_hello_type 1 }
-{%                         break %}
-{%                     endif %}
-{%                 endfor %}
-{%             endif %}
-{%             if front_config.http_response_headers is vyos_defined %}
-{%                 for header, header_config in front_config.http_response_headers.items() %}
+{%                     break %}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%         if front_config.http_response_headers is vyos_defined %}
+{%             for header, header_config in front_config.http_response_headers.items() %}
     http-response set-header {{ header }} '{{ header_config['value'] }}'
-{%                 endfor %}
-{%             endif %}
+{%             endfor %}
 {%         endif %}
 {%         if front_config.rule is vyos_defined %}
 {%             for rule, rule_config in front_config.rule.items() %}
@@ -162,19 +160,17 @@ backend {{ back }}
 {%             set balance_translate = {'least-connection': 'leastconn', 'round-robin': 'roundrobin', 'source-address': 'source'} %}
     balance {{ balance_translate[back_config.balance] }}
 {%         endif %}
-{# If mode is not TCP skip Forwarded #}
-{%         if back_config.mode is not vyos_defined('tcp') %}
+{# If mode is HTTP add X-Forwarded headers #}
+{%         if back_config.mode == 'http' %}
     option forwardfor
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
 {%         endif %}
-{%         if back_config.mode is vyos_defined %}
     mode {{ back_config.mode }}
-{%             if back_config.http_response_headers is vyos_defined %}
-{%                 for header, header_config in back_config.http_response_headers.items() %}
+{%         if back_config.http_response_headers is vyos_defined %}
+{%             for header, header_config in back_config.http_response_headers.items() %}
     http-response set-header {{ header }} '{{ header_config['value'] }}'
-{%                 endfor %}
-{%             endif %}
+{%             endfor %}
 {%         endif %}
 {%         if back_config.rule is vyos_defined %}
 {%             for rule, rule_config in back_config.rule.items() %}

--- a/interface-definitions/include/haproxy/mode.xml.i
+++ b/interface-definitions/include/haproxy/mode.xml.i
@@ -18,5 +18,6 @@
       <regex>(http|tcp)</regex>
     </constraint>
   </properties>
+  <defaultValue>http</defaultValue>
 </leafNode>
 <!-- include end -->

--- a/src/conf_mode/load-balancing_reverse-proxy.py
+++ b/src/conf_mode/load-balancing_reverse-proxy.py
@@ -85,7 +85,7 @@ def verify(lb):
                 raise ConfigError(f'"expect status" and "expect string" can not be configured together!')
 
         if 'health_check' in back_config:
-            if 'mode' not in back_config or back_config['mode'] != 'tcp':
+            if back_config['mode'] != 'tcp':
                 raise ConfigError(f'backend "{back}" can only be configured with {back_config["health_check"]} ' +
                                   f'health-check whilst in TCP mode!')
             if 'http_check' in back_config:
@@ -108,7 +108,7 @@ def verify(lb):
     # Check if http-response-headers are configured in any frontend/backend where mode != http
     for group in ['service', 'backend']:
         for config_name, config in lb[group].items():
-            if 'http_response_headers' in config and ('mode' not in config or config['mode'] != 'http'):
+            if 'http_response_headers' in config and config['mode'] != 'http':
                 raise ConfigError(f'{group} {config_name} must be set to http mode to use http_response_headers!')
 
     for front, front_config in lb['service'].items():


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Set a default value of **http** for reverse-proxy service/backend mode.
HAProxy defaults to using http mode if unset - adding a default value in VyOS will avoid ambiguity without any logic change.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Improvement on existing functionality

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
[https://vyos.dev/T6454](https://vyos.dev/T6454)

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
- load-balancing -> reverse-proxy

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Whilst in configuration mode, check VyOS is displaying a default value for mode
```
[edit]
vyos@vyos# set load-balancing reverse-proxy service fe-01 ?
Possible completions:
+  backend              Backend member
   description          Description
+> http-response-headers
						Headers to include in HTTP response
+  listen-address       Local IP addresses to listen on
   mode                 Proxy mode (default: http)
   port                 Port number used by connection
   redirect-http-to-https
						Redirect HTTP to HTTPS
+> rule                 Proxy rule number
 > ssl                  SSL Certificate, SSL Key and CA
 > tcp-request          TCP request directive
 
 [edit]
vyos@vyos# set load-balancing reverse-proxy backend bk-01 ?
Possible completions:
   balance              Load-balancing algorithm (default: round-robin)
   description          Description
   health-check         Non HTTP health check options
 > http-check           HTTP check configuration
+> http-response-headers
                        Headers to include in HTTP response
   mode                 Proxy mode (default: http)
+> rule                 Proxy rule number
+> server               Backend server name
 > ssl                  SSL Certificate, SSL Key and CA
 > timeout              Timeout options
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_load-balancing_reverse-proxy.py
test_01_lb_reverse_proxy_domain (__main__.TestLoadBalancingReverseProxy.test_01_lb_reverse_proxy_domain) ... ok
test_02_lb_reverse_proxy_cert_not_exists (__main__.TestLoadBalancingReverseProxy.test_02_lb_reverse_proxy_cert_not_exists) ...
PKI does not contain any certificates!


Certificate "cert" not found in configuration!

ok
test_03_lb_reverse_proxy_ca_not_exists (__main__.TestLoadBalancingReverseProxy.test_03_lb_reverse_proxy_ca_not_exists) ...
PKI does not contain any CA certificates!


CA Certificate "ca-test" not found in configuration!

ok
test_04_lb_reverse_proxy_backend_ssl_no_verify (__main__.TestLoadBalancingReverseProxy.test_04_lb_reverse_proxy_backend_ssl_no_verify) ...
backend bk-01 cannot have both ssl options no-verify and ca-certificate
set!

ok
test_05_lb_reverse_proxy_backend_http_check (__main__.TestLoadBalancingReverseProxy.test_05_lb_reverse_proxy_backend_http_check) ...
backend "bk-01" can only be configured with ldap health-check whilst in
TCP mode!

ok
test_06_lb_reverse_proxy_tcp_mode (__main__.TestLoadBalancingReverseProxy.test_06_lb_reverse_proxy_tcp_mode) ... ok
test_07_lb_reverse_proxy_http_response_headers (__main__.TestLoadBalancingReverseProxy.test_07_lb_reverse_proxy_http_response_headers) ...
service https_front must be set to http mode to use
http_response_headers!

ok
test_08_lb_reverse_proxy_tcp_health_checks (__main__.TestLoadBalancingReverseProxy.test_08_lb_reverse_proxy_tcp_health_checks) ... ok

----------------------------------------------------------------------
Ran 8 tests in 37.224s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
