### PR TITLE
T6455: (Draft) Add Support for zerotier

### DIFF
--- a/interface-definitions/interfaces_zerotier.xml.in
+++ b/interface-definitions/interfaces_zerotier.xml.in
@@ -1,0 +1,589 @@
+<?xml version="1.0" ?>
+<interfaceDefinition>
+  <node name="interfaces">
+    <children>
+      <tagNode name="zerotier" owner="${vyos_conf_scripts_dir}/zerotier.py">
+        <properties>
+          <help>ZeroTier Interface</help>
+          <priority>451</priority>
+          <constraint>
+            <regex>zt[0-9]+</regex>
+          </constraint>
+          <constraintErrorMessage>ZeroTier interface must be named ztN</constraintErrorMessage>
+          <valueHelp>
+            <format>ztN</format>
+            <description>Zerotier interface name</description>
+          </valueHelp>
+        </properties>
+        <children>
+          <leafNode name="allow-mgmt-from">
+            <properties>
+              <help>Allow management from specified subnets</help>
+              <constraint>
+                  <validator name="ipv4-prefix"/>
+              </constraint>
+              <constraintErrorMessage>Value must be valid IPv4 network</constraintErrorMessage>
+              <valueHelp>
+                  <format>ipv4net</format>
+                  <description>IPv4 Network</description>
+              </valueHelp>
+              <multi/>
+            </properties>
+          </leafNode>
+          <leafNode name="allow-tcp-fallback">
+            <properties>
+              <help>Allow falling back to TCP Relay if UDP fails</help>
+              <valueless/>
+            </properties>
+          </leafNode>
+          <leafNode name="api-key">
+            <properties>
+              <help>ZT API key - DO NOT share</help>
+              <valueHelp>
+                  <format>API key</format>
+                  <description>IP address</description>
+              </valueHelp>
+            </properties>
+          </leafNode>
+          <leafNode name="bind">
+            <properties>
+              <help>Bind ZeroTier to specified IP</help>
+              <constraint>
+                  <validator name="ipv4-address"/>
+              </constraint>
+              <constraintErrorMessage>Can only bind to valid IP Address</constraintErrorMessage>
+              <valueHelp>
+                  <format>ipv4</format>
+                  <description>IP address</description>
+              </valueHelp>
+              <multi/>
+            </properties>
+          </leafNode>
+          <leafNode name="bonding-policy">
+            <properties>
+              <help>Bonding policy to be applied</help>
+              <completionHelp>
+                <list>active-backup broadcast balance-rr balance-xor balance-aware</list>
+              </completionHelp>
+              <valueHelp>
+                  <format>active-backup</format>
+                  <description>Use only one primary link at a time and failover to another designated link</description>
+              </valueHelp>
+              <valueHelp>
+                  <format>broadcast</format>
+                  <description>Duplicate traffic across all available links at all times</description>
+              </valueHelp>
+              <valueHelp>
+                  <format>balance-rr</format>
+                  <description>Stripe packets across multiple links (not for use with TCP.)</description>
+              </valueHelp>
+              <valueHelp>
+                  <format>balance-xor</format>
+                  <description>Hash flows to specific links</description>
+              </valueHelp>
+              <valueHelp>
+                  <format>balance-aware</format>
+                  <description>Auto-balance flows across links</description>
+              </valueHelp>
+              <valueHelp>
+                  <format>&lt;User Defined&gt;</format>
+                  <description>User Defined policy</description>
+              </valueHelp>
+            </properties>
+          </leafNode>
+          <tagNode name="custom-policy">
+            <properties>
+              <help>User created ZeroTier bonding policy</help>
+              <valueHelp>
+                  <format>Policy Name</format>
+                  <description>ZeroTier bonding policy Name</description>
+              </valueHelp>
+            </properties>
+            <children>
+              <leafNode name="base-policy">
+                <properties>
+                  <help>Base bonding policy</help>
+                  <completionHelp>
+                    <list>active-backup broadcast balance-rr balance-xor balance-aware</list>
+                  </completionHelp>
+                  <constraint>
+                    <regex>(active-backup|broadcast|balance-rr|balance-xor|balance-aware)</regex>
+                  </constraint>
+                  <constraintErrorMessage>Value must be a pre-defined policy (e.g. active-backup)</constraintErrorMessage>
+                  <valueHelp>
+                      <format>active-backup</format>
+                      <description>Use only one primary link at a time and failover to another designated link</description>
+                  </valueHelp>
+                  <valueHelp>
+                      <format>broadcast</format>
+                      <description>Duplicate traffic across all available links at all times</description>
+                  </valueHelp>
+                  <valueHelp>
+                      <format>balance-rr</format>
+                      <description>Stripe packets across multiple links (not for use with TCP.)</description>
+                  </valueHelp>
+                  <valueHelp>
+                      <format>balance-xor</format>
+                      <description>Hash flows to specific links</description>
+                  </valueHelp>
+                  <valueHelp>
+                      <format>balance-aware</format>
+                      <description>Auto-balance flows across links</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
+              <leafNode name="down-delay">
+                <properties>
+                  <help>Time for path to become unavailable</help>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-65535"/>
+                  </constraint>
+                  <constraintErrorMessage>Value must be between 0-65535</constraintErrorMessage>
+                  <valueHelp>
+                      <format>u32:0-65535</format>
+                      <description>Time in ms</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
+              <leafNode name="failover-interval">
+                <properties>
+                  <help>How quickly failover occurs</help>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-65535"/>
+                  </constraint>
+                  <constraintErrorMessage>Value must be between 0-65535</constraintErrorMessage>
+                  <valueHelp>
+                      <format>u32:0-65535</format>
+                      <description>Time in ms</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
+              <node name="link-quality">
+                <properties>
+                  <help>Criteria for link failover</help>
+                </properties>
+                <children>
+                  <leafNode name="latency-weight">
+                    <properties>
+                      <help>Importance of latency vs variance</help>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-10"/>
+                      </constraint>
+                      <constraintErrorMessage>Value must be between 0-10</constraintErrorMessage>
+                      <valueHelp>
+                        <format>u32:0-10</format>
+                        <description>Latency and variance weight must equal 10</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="max-latency">
+                    <properties>
+                      <help>Max latency before failing over</help>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-10000"/>
+                      </constraint>
+                      <constraintErrorMessage>Value must be between 0-10000</constraintErrorMessage>
+                      <valueHelp>
+                        <format>u32:0-10000</format>
+                        <description>Maximum latency in milliseconds</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="max-variance">
+                    <properties>
+                      <help>Max variance before failing over</help>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-10000"/>
+                      </constraint>
+                      <constraintErrorMessage>Value must be between 0-10000</constraintErrorMessage>
+                      <valueHelp>
+                        <format>u32:0-10000</format>
+                        <description>Maximum variance in milliseconds</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="variance-weight">
+                    <properties>
+                      <help>Importance of variance vs latency</help>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-10"/>
+                      </constraint>
+                      <constraintErrorMessage>Value must be between 0-10</constraintErrorMessage>
+                      <valueHelp>
+                        <format>u32:0-10</format>
+                        <description>Latency and variance weight must equal 10</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+              <leafNode name="link-select-method">
+                <properties>
+                  <help>Determine when links are failed over</help>
+                  <constraint>
+                    <regex>(always|better|failure|optimize)</regex>
+                  </constraint>
+                  <constraintErrorMessage>Value must be always, better, failure, or optimize</constraintErrorMessage>
+                  <valueHelp>
+                      <format>always</format>
+                      <description>Primary link recovers if available</description>
+                  </valueHelp>
+                  <valueHelp>
+                      <format>better</format>
+                      <description>Primary link recovers if it is best</description>
+                  </valueHelp>
+                  <valueHelp>
+                      <format>failure</format>
+                      <description>Primary link recovers if active link fails</description>
+                  </valueHelp>
+                  <valueHelp>
+                      <format>optimize</format>
+                      <description>Primary like can change if better link exists</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
+              <tagNode name="links">
+                <properties>
+                  <help>Link specific bonding configuration</help>
+                  <valueHelp>
+                      <format>Interface Name</format>
+                      <description>Interface to apply bonding configuration</description>
+                  </valueHelp>
+                </properties>
+                <children>
+                  <leafNode name="capacity">
+                    <properties>
+                      <help>Weigh the amount of traffic sent across this link</help>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-1000000"/>
+                      </constraint>
+                      <constraintErrorMessage>Value must be between 0-1000000</constraintErrorMessage>
+                      <valueHelp>
+                        <format>Relational bandwidth</format>
+                        <description>Arbitrary bandwidth value</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="failover-to">
+                    <properties>
+                      <help>Determine which link should be used next</help>
+                      <valueHelp>
+                        <format>Interface Name</format>
+                        <description>Interface to failover to</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="ip-pref">
+                    <properties>
+                      <help>IP version preference for paths on a link</help>
+                      <constraint>
+                        <regex>(0|4|6|46|64)</regex>
+                      </constraint>
+                      <constraintErrorMessage>Value must be between 0-1000000</constraintErrorMessage>
+                      <valueHelp>
+                        <format>0</format>
+                        <description>No version preference</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>4</format>
+                        <description>Use only IPv4</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>6</format>
+                        <description>Use only IPv6</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>46</format>
+                        <description>Prefer IPv4 over IPv6</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>64</format>
+                        <description>Prefer IPv6 over IPv4</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="mode">
+                    <properties>
+                      <help>Determine when a link should be used</help>
+                      <constraint>
+                        <regex>(primary|spare)</regex>
+                      </constraint>
+                      <constraintErrorMessage>Value must be either primary or spare</constraintErrorMessage>
+                      <valueHelp>
+                        <format>primary</format>
+                        <description>Interface will be used by default</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>spare</format>
+                        <description>Interface will only be used when other links fail</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                </children>
+              </tagNode>
+              <leafNode name="up-delay">
+                <properties>
+                  <help>Time for path to become available</help>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-65535"/>
+                  </constraint>
+                  <constraintErrorMessage>Value must be between 0-65535</constraintErrorMessage>
+                  <valueHelp>
+                      <format>u32:0-65535</format>
+                      <description>Time in ms</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
+            </children>
+          </tagNode>
+          #include <include/generic-description.xml.i>
+          <leafNode name="force-tcp-relay">
+            <properties>
+              <help>Disables UDP communication and forces TCP</help>
+              <valueless/>
+            </properties>
+          </leafNode>
+          <leafNode name="interface-blacklist">
+            <properties>
+              <help>Prevent binding of ZeroTier service to interfaces</help>
+              <valueHelp>
+                  <format>Interface Blacklist</format>
+                  <description>Interface prefix (e.g. eth,br,wg,vxlan,etc...)</description>
+              </valueHelp>
+              <multi/>
+            </properties>
+          </leafNode>
+          <leafNode name="low-bandwidth-mode">
+            <properties>
+              <help>Enable low-bandwidth-mode (limits control traffic)</help>
+              <valueless/>
+            </properties>
+          </leafNode>
+          <leafNode name="multipath-mode">
+            <properties>
+              <help>Multipath load-balancing mode</help>
+              <constraint>
+                  <regex>(0|1|2)</regex>
+              </constraint>
+              <constraintErrorMessage>Value must be 0, 1, or 2</constraintErrorMessage>
+              <valueHelp>
+                  <format>0</format>
+                  <description>Disable multipath</description>
+              </valueHelp>
+              <valueHelp>
+                  <format>1</format>
+                  <description>Multipah random mode</description>
+              </valueHelp>
+              <valueHelp>
+                  <format>2</format>
+                  <description>Multipath proportional mode</description>
+              </valueHelp>
+            </properties>
+          </leafNode>
+          <tagNode name="network-config">
+            <properties>
+              <help>Network specific ZeroTier config</help>
+              <constraint>
+                  <validator name="ipv4-prefix"/>
+              </constraint>
+              <constraintErrorMessage>Value must be valid IPv4 network</constraintErrorMessage>
+              <valueHelp>
+                  <format>ipv4net</format>
+                  <description>IPv4 Network</description>
+              </valueHelp>
+            </properties>
+            <children>
+              <leafNode name="blacklist">
+                <properties>
+                  <help>Prevent ZeroTier service from binding to specified subnet</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="mtu">
+                <properties>
+                  <help>Set ZeroTier MTU for specified IPv4 Network</help>
+                  <constraint>
+                    <validator name="numeric" argument="--range 1000-9000"/>
+                  </constraint>
+                  <constraintErrorMessage>MTU must be between 1000 and 9000</constraintErrorMessage>
+                  <valueHelp>
+                    <format>u32:1000-9000</format>
+                    <description>Maximum Transmission Unit in byte</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
+            </children>
+          </tagNode>
+          <leafNode name="network-id">
+            <properties>
+              <help>ZeroTier Network ID to join (required)</help>
+              <constraint>
+                  <regex>^[A-Fa-f0-9]{16}$</regex>
+              </constraint>
+              <constraintErrorMessage>Network ID must be a 16-digit hexadecimal value</constraintErrorMessage>
+              <valueHelp>
+                  <format>16-digit hex</format>
+                  <description>Zerotier network-id</description>
+              </valueHelp>
+            </properties>
+          </leafNode>
+          <tagNode name="peer-config">
+            <properties>
+              <help>10-digit hex</help>
+              <constraint>
+                  <regex>^[A-Fa-f0-9]{10}$</regex>
+              </constraint>
+              <constraintErrorMessage>Peer address must be 10-digit hexadecimal value</constraintErrorMessage>
+              <valueHelp>
+                  <format>Peer Node ID</format>
+                  <description>Peer specific ZeroTier config</description>
+              </valueHelp>
+            </properties>
+            <children>
+              <leafNode name="blacklist">
+                <properties>
+                  <help>Blacklist path for specific peer</help>
+                  <constraint>
+                    <validator name="ipv4-prefix"/>
+                  </constraint>
+                  <constraintErrorMessage>Value must be valid IPv4 network</constraintErrorMessage>
+                  <valueHelp>
+                    <format>ipv4net</format>
+                    <description>IPv4 Network</description>
+                  </valueHelp>
+                  <multi/>
+                </properties>
+              </leafNode>
+              <leafNode name="try">
+                <properties>
+                  <help>Static peer config for reachablity</help>
+                  <constraint>
+                    <validator name="ipv4-port"/>
+                  </constraint>
+                  <constraintErrorMessage>Value must be in the format: IPv4/Port</constraintErrorMessage>
+                  <valueHelp>
+                    <format>&lt;x.x.x.x/p&gt;</format>
+                    <description>IP/Port of peer (e.g. 10.0.0.1/9993)</description>
+                  </valueHelp>
+                  <multi/>
+                </properties>
+              </leafNode>
+            </children>
+          </tagNode>
+          <tagNode name="peer-specific-bonds">
+            <properties>
+              <help>Apply bonding policies per peer</help>
+              <constraint>
+                <regex>^[A-Fa-f0-9]{10}$</regex>
+              </constraint>
+              <constraintErrorMessage>Peer address must be 10-digit hexadecimal value</constraintErrorMessage>
+              <valueHelp>
+                <format>10-digit hex</format>
+                <description>ZeroTier peer ID</description>
+              </valueHelp>
+            </properties>
+            <children>
+              <leafNode name="bond-name">
+                <properties>
+                  <help>Policy to be applied to specified peer</help>
+                  <valueHelp>
+                      <format>active-backup</format>
+                      <description>Use only one primary link at a time and failover to another designated link</description>
+                  </valueHelp>
+                  <valueHelp>
+                      <format>broadcast</format>
+                      <description>Duplicate traffic across all available links at all times</description>
+                  </valueHelp>
+                  <valueHelp>
+                      <format>balance-rr</format>
+                      <description>Stripe packets across multiple links (not for use with TCP.)</description>
+                  </valueHelp>
+                  <valueHelp>
+                      <format>balance-xor</format>
+                      <description>Hash flows to specific links</description>
+                  </valueHelp>
+                  <valueHelp>
+                      <format>balance-aware</format>
+                      <description>Auto-balance flows across links</description>
+                  </valueHelp>
+                  <valueHelp>
+                      <format>&lt;User Defined&gt;</format>
+                      <description>User Defined policy</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
+            </children>
+          </tagNode>
+          <leafNode name="primary-port">
+            <properties>
+              <help>Primary port for ZeroTier service (required)</help>
+              <constraint>
+                  <validator name="numeric" argument="--range 1-65535"/>
+              </constraint>
+              <constraintErrorMessage>Port number must between 1-65535</constraintErrorMessage>
+              <valueHelp>
+                  <format>u32:1-65535</format>
+                  <description>Zerotier primary port</description>
+              </valueHelp>
+            </properties>
+          </leafNode>
+          <leafNode name="secondary-port">
+            <properties>
+              <help>Secondary port for ZeroTier service</help>
+              <constraint>
+                  <validator name="numeric" argument="--range 1-65535"/>
+              </constraint>
+              <constraintErrorMessage>Port number must between 1-65535</constraintErrorMessage>
+              <valueHelp>
+                  <format>u32:1-65535</format>
+                  <description>Zerotier secondary port</description>
+              </valueHelp>
+            </properties>
+          </leafNode>
+          <leafNode name="tcp-relay">
+            <properties>
+              <help>Define the IP/Port of a TCP Relay</help>
+              <constraint>
+                  <validator name="ipv4-port"/>
+              </constraint>
+              <constraintErrorMessage>Value must be in the format: IPv4/Port</constraintErrorMessage>
+              <valueHelp>
+                  <format>x.x.x.x/p</format>
+                  <description>IP/Port of TCP Relay (e.g. 10.0.0.1/443)</description>
+              </valueHelp>
+            </properties>
+          </leafNode>
+          <leafNode name="tertiary-port">
+            <properties>
+              <help>Tertiary port for ZeroTier service</help>
+              <constraint>
+                  <validator name="numeric" argument="--range 1-65535"/>
+              </constraint>
+              <constraintErrorMessage>Port number must between 1-65535</constraintErrorMessage>
+              <valueHelp>
+                  <format>u32:1-65535</format>
+                  <description>Zerotier tertiary port</description>
+              </valueHelp>
+            </properties>
+          </leafNode>
+          <leafNode name="version">
+            <properties>
+              <help>Version of ZeroTier to use (required)</help>
+              <completionHelp>
+                <list>latest 1.14.0 1.12.2 1.12.1</list>
+              </completionHelp>
+              <constraint>
+                  <regex>(latest|1.14.0|1.12.2|1.12.1)</regex>
+              </constraint>
+              <constraintErrorMessage>Only listed versions are supported</constraintErrorMessage>
+              <valueHelp>
+                  <format>txt</format>
+                  <description>ZeroTier version</description>
+              </valueHelp>
+            </properties>
+          </leafNode>
+        </children>
+      </tagNode>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/op-mode-definitions/zerotier.xml.in
+++ b/op-mode-definitions/zerotier.xml.in
@@ -1,0 +1,231 @@
+<?xml version="1.0" ?>
+<interfaceDefinition>
+  <node name="show">
+    <children>
+      <node name="interfaces">
+        <children>
+          <tagNode name="zerotier">
+            <properties>
+              <help>Show ZeroTier information for given interface</help>
+              <completionHelp>
+                <path>interfaces zerotier</path>
+              </completionHelp>
+            </properties>
+            <command>sudo ${vyos_op_scripts_dir}/zerotier.py show_interfaces --interface $4</command>
+            <children>
+              <tagNode name="bonding">
+                <properties>
+                  <help>Show ZeroTier bonding for given peer</help>
+                  <completionHelp>
+                    <list>&lt;hhhhhhhhhh&gt;</list>
+                  </completionHelp>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/zerotier.py show_command --interface $4 --command "bond $6 show"</command>
+              </tagNode>
+              <node name="bonding">
+                <properties>
+                  <help>Show ZeroTier bonding</help>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/zerotier.py show_command --interface $4 --command "bond list"</command>
+              </node>
+              <node name="metrics">
+                <properties>
+                  <help>Show ZeroTier metrics</help>
+                </properties>
+                <children>
+                  <leafNode name="accepted-packets">
+                    <properties>
+                      <help>Show ZeroTier metrics for accepted packets</help>
+                    </properties>
+                    <command>sudo ${vyos_op_scripts_dir}/zerotier.py show_metrics --interface $4 --metric acceptedpackets</command>
+                  </leafNode>
+                  <leafNode name="errors">
+                    <properties>
+                      <help>Show ZeroTier metrics for control-plane errors</help>
+                    </properties>
+                    <command>sudo ${vyos_op_scripts_dir}/zerotier.py show_metrics --interface $4 --metric errors</command>
+                  </leafNode>
+                  <leafNode name="latency">
+                    <properties>
+                      <help>Show ZeroTier metrics for latency buckets</help>
+                    </properties>
+                    <command>sudo ${vyos_op_scripts_dir}/zerotier.py show_metrics --interface $4 --metric latency</command>
+                  </leafNode>
+                  <leafNode name="packet-types">
+                    <properties>
+                      <help>Show ZeroTier metrics for packet types</help>
+                    </properties>
+                    <command>sudo ${vyos_op_scripts_dir}/zerotier.py show_metrics --interface $4 --metric packettype</command>
+                  </leafNode>
+                  <leafNode name="peer-packets">
+                    <properties>
+                      <help>Show ZeroTier metrics for packets to/from peers</help>
+                    </properties>
+                    <command>sudo ${vyos_op_scripts_dir}/zerotier.py show_metrics --interface $4 --metric peerpackets</command>
+                  </leafNode>
+                  <leafNode name="peer-packet-errors">
+                    <properties>
+                      <help>Show ZeroTier metrics for errors from peers</help>
+                    </properties>
+                    <command>sudo ${vyos_op_scripts_dir}/zerotier.py show_metrics --interface $4 --metric peerpacketerrors</command>
+                  </leafNode>
+                  <leafNode name="protocols">
+                    <properties>
+                      <help>Show ZeroTier metrics for protocols</help>
+                    </properties>
+                    <command>sudo ${vyos_op_scripts_dir}/zerotier.py show_metrics --interface $4 --metric protocols</command>
+                  </leafNode>
+                </children>
+              </node>
+              <leafNode name="network">
+                <properties>
+                  <help>Show ZeroTier network</help>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/zerotier.py show_command --interface $4 --command listnetworks</command>
+              </leafNode>
+              <leafNode name="peers">
+                <properties>
+                  <help>Show ZeroTier peers</help>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/zerotier.py show_command --interface $4 --command peers</command>
+              </leafNode>
+              <leafNode name="peers-all">
+                <properties>
+                  <help>Show peer detail for all peers</help>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/zerotier.py show_peers_all --interface $4</command>
+              </leafNode>
+              <leafNode name="peers-detail">
+                <properties>
+                  <help>Show peer detail for connected peers</help>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/zerotier.py show_peers_detail --interface $4</command>
+              </leafNode>
+            </children>
+          </tagNode>
+          <node name="zerotier">
+            <properties>
+              <help>Show ZeroTier information</help>
+            </properties>
+            <command>sudo ${vyos_op_scripts_dir}/zerotier.py show_interfaces</command>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+  <node name="restart">
+    <children>
+      <tagNode name="zerotier">
+        <properties>
+          <help>Restart ZeroTier interface</help>
+          <completionHelp>
+            <path>interfaces zerotier</path>
+          </completionHelp>
+        </properties>
+        <command>sudo systemctl restart vyos-zerotier@$3.service</command>
+      </tagNode>
+    </children>
+  </node>
+  <node name="zerotier">
+    <properties>
+      <help>ZeroTier operational commands</help>
+    </properties>
+    <children>
+      <tagNode name="interface">
+        <properties>
+          <help>ZeroTier operation commands for given interface</help>
+          <completionHelp>
+            <path>interfaces zerotier</path>
+          </completionHelp>
+        </properties>
+        <children>
+          <node name="allow-default">
+            <properties>
+              <help>Enable/Disable ZeroTier's ability to receive public IP from controller</help>
+            </properties>
+            <children>
+              <leafNode name="disable">
+                <properties>
+                  <help>Disable receiving default route from ZeroTier controller</help>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/zerotier.py set_allowed --interface $3 --allowed allowDefault --state 0</command>
+              </leafNode>
+              <leafNode name="enable">
+                <properties>
+                  <help>Enable receiving default route from ZeroTier controller</help>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/zerotier.py set_allowed --interface $3 --allowed allowDefault --state 1</command>
+              </leafNode>
+            </children>
+          </node>
+          <node name="allow-global">
+            <properties>
+              <help>Enable/Disable ZeroTier's ability to receive public IP from controller</help>
+            </properties>
+            <children>
+              <leafNode name="disable">
+                <properties>
+                  <help>Disable public IP on ZeroTier interface</help>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/zerotier.py set_allowed --interface $3 --allowed allowGlobal --state 0</command>
+              </leafNode>
+              <leafNode name="enable">
+                <properties>
+                  <help>Enable public IP on ZeroTier interface</help>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/zerotier.py set_allowed --interface $3 --allowed allowGlobal --state 1</command>
+              </leafNode>
+            </children>
+          </node>
+          <node name="allow-managed">
+            <properties>
+              <help>Enable/Disable ZeroTier's ability to receive IP from controller</help>
+            </properties>
+            <children>
+              <leafNode name="disable">
+                <properties>
+                  <help>Disable managed IP on ZeroTier interface</help>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/zerotier.py set_allowed --interface $3 --allowed allowManaged --state 0</command>
+              </leafNode>
+              <leafNode name="enable">
+                <properties>
+                  <help>Enable managed IP on ZeroTier interface</help>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/zerotier.py set_allowed --interface $3 --allowed allowManaged --state 1</command>
+              </leafNode>
+            </children>
+          </node>
+          <tagNode name="bonding-failover">
+            <properties>
+              <help>Failover bonding for active-backup peer</help>
+              <completionHelp>
+                <list>&lt;hhhhhhhhhh&gt;</list>
+              </completionHelp>
+            </properties>
+            <command>sudo podman exec vyos_created_$3 zerotier-cli bond $5 rotate</command>
+          </tagNode>
+          <tagNode name="orbit">
+            <properties>
+              <help>Orbit a private-root server (Moon)</help>
+              <completionHelp>
+                <list>&lt;hhhhhhhhhh&gt;</list>
+              </completionHelp>
+            </properties>
+            <command>sudo podman exec vyos_created_$3 zerotier-cli orbit $5</command>
+          </tagNode>
+        </children>
+      </tagNode>
+      <tagNode name="restore">
+        <properties>
+          <help>Restore the config directory of previously deleted interface</help>
+          <completionHelp>
+            <list>&lt;filename&gt;</list>
+            <script>${vyos_completion_dir}/list_files.sh /config/vyos-zerotier/backup</script>
+          </completionHelp>
+        </properties>
+        <command>sudo ${vyos_op_scripts_dir}/zerotier.py reset_node --file $3</command>
+      </tagNode>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/python/vyos/ifconfig/__init__.py
+++ b/python/vyos/ifconfig/__init__.py
@@ -39,3 +39,4 @@ from vyos.ifconfig.macsec import MACsecIf
 from vyos.ifconfig.veth import VethIf
 from vyos.ifconfig.wwan import WWANIf
 from vyos.ifconfig.sstpc import SSTPCIf
+from vyos.ifconfig.zerotier import ZeroTierIf

--- a/python/vyos/ifconfig/zerotier.py
+++ b/python/vyos/ifconfig/zerotier.py
@@ -1,0 +1,28 @@
+# # Copyright 2020-2024 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+from vyos.ifconfig.interface import Interface
+
+@Interface.register
+class ZeroTierIf(Interface):
+    iftype = 'zerotier'
+    definition = {
+        **Interface.definition,
+        **{
+            'section': 'zerotier',
+            'prefixes': ['zt', ],
+            'bridgeable': True,
+        },
+    }

--- a/src/completion/list_files.sh
+++ b/src/completion/list_files.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Check if a directory argument is provided
+if [ -z "$1" ]; then
+  exit 1
+fi
+
+# Assign the first argument to DIR variable
+DIR=$1
+
+# Check if the provided argument is a directory
+if [ ! -d "$DIR" ]; then
+  exit 1
+fi
+
+# List only the files in the directory
+find "$DIR" -maxdepth 1 -type f -exec basename {} \;

--- a/src/conf_mode/zerotier.py
+++ b/src/conf_mode/zerotier.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This script will generate ZeroTier interfaces from containers, as well
+# as generate the local.conf file for advanced ZeroTier configurations.
+
+import datetime
+import json
+import os
+import re
+import shutil
+import sys
+import textwrap
+
+from collections import Counter
+
+from vyos.utils.process import cmd, rc_cmd
+from vyos.config import Config
+from vyos import ConfigError
+
+def generate_local_conf(data):
+    # Base local.conf
+    local_conf_dict = {
+            "physical": {},
+            "virtual": {},
+            "settings": {}
+        }
+
+    ############################################################
+    #################### Physical Dict Path ####################
+    ############################################################
+    if data.get('network_config'):
+        for network in data.get('network_config').keys():
+            local_conf_dict['physical'][network] = {}
+            mtu = data.get('network_config').get(network).get('mtu')
+
+            if mtu:
+                local_conf_dict['physical'][network]['mtu'] = int(mtu)
+
+            if data.get('mtu'):
+                local_conf_dict['physical'][network]['mtu'] = data.get('network_config').get("mtu")
+
+            if isinstance(data.get('network_config').get(network).get('blacklist'), dict):
+                local_conf_dict['physical'][network]['blacklist'] = True
+
+    ############################################################
+    #################### Virtual Dict Path #####################
+    ############################################################
+    if data.get('peer_config'):
+        for peer in data.get('peer_config').keys():
+            local_conf_dict['virtual'][peer] = {}
+
+            if data.get('peer_config').get(peer).get('blacklist'):
+                local_conf_dict['virtual'][peer]['blacklist'] = data.get('peer_config').get(peer).get('blacklist')
+            if data.get('peer_config').get(peer).get('try'):
+                local_conf_dict['virtual'][peer]['try'] = data.get('peer_config').get(peer).get('try')
+
+    ############################################################
+    #################### Settings Dict Path ####################
+    ############################################################
+    if isinstance(data.get('low_bandwidth_mode'), dict):
+        local_conf_dict['settings']['lowBandwidthMode'] = True
+    if isinstance(data.get('allow_tcp_fallback'), dict):
+        local_conf_dict['settings']['allowTcpFallbackRelay'] = True
+    if isinstance(data.get('force_tcp_relay'), dict):
+        local_conf_dict['settings']['forceTcpRelay'] = True
+    if data.get('primary_port'):
+        local_conf_dict['settings']['primaryPort'] = int(data.get("primary_port", 9993))
+    if data.get('secondary_port'):
+        local_conf_dict['settings']['secondaryPort'] = int(data.get("secondary_port"))
+    if data.get('tertiary_port'):
+        local_conf_dict['settings']['tertiaryPort'] = int(data.get("tertiary_port"))
+    if data.get('bind'):
+        local_conf_dict['settings']['bind'] = data.get("bind")
+    if data.get('allow_mgmt_from'):
+        local_conf_dict['settings']['allowManagementFrom'] = data.get("allow_mgmt_from")
+    if data.get('interface_blacklist'):
+        local_conf_dict['settings']['interfacePrefixBlacklist'] = data.get("interface_blacklist")
+    if data.get('multipath_mode'):
+        local_conf_dict['settings']['multipathMode'] = int(data.get("multipath_mode"))
+    if data.get('tcp_relay'):
+        local_conf_dict['settings']['tcpFallbackRelay'] = data.get("tcp_relay")
+
+    ############################################################
+    #################### Multipath Dict Path ###################
+    ############################################################
+    if data.get('custom_policy'):
+        local_conf_dict['settings']['policies'] = {}
+        for policy in data.get('custom_policy').keys():
+            local_conf_dict['settings']['policies'][policy] = {}
+
+            if data.get('custom_policy').get(policy).get('link_select_method'):
+                local_conf_dict['settings']['policies'][policy]['linkSelectMethod'] = data.get('custom_policy').get(policy).get("link_select_method")
+
+            if data.get('custom_policy').get(policy).get('down_delay'):
+                local_conf_dict['settings']['policies'][policy]['downDelay'] = int(data.get('custom_policy').get(policy).get("down_delay"))
+
+            if data.get('custom_policy').get(policy).get('up_delay'):
+                local_conf_dict['settings']['policies'][policy]['upDelay'] = int(data.get('custom_policy').get(policy).get("up_delay"))
+
+            if data.get('custom_policy').get(policy).get('failover_interval'):
+                local_conf_dict['settings']['policies'][policy]['failoverInterval'] = int(data.get('custom_policy').get(policy).get("failover_interval"))
+
+            if data.get('custom_policy').get(policy).get('base_policy'):
+                local_conf_dict['settings']['policies'][policy]['basePolicy'] = data.get('custom_policy').get(policy).get("base_policy")
+
+            if data.get('custom_policy').get(policy).get('link_quality'):
+                local_conf_dict['settings']['policies'][policy]['linkQuality'] = {}
+
+                if data.get('custom_policy').get(policy).get('link_quality').get('max_latency'):
+                    local_conf_dict['settings']['policies'][policy]['linkQuality']['lat_max'] = float(data.get('custom_policy').get(policy).get('link_quality').get('max_latency'))
+
+                if data.get('custom_policy').get(policy).get('link_quality').get('max_variance'):
+                    local_conf_dict['settings']['policies'][policy]['linkQuality']['pdv_max'] = float(data.get('custom_policy').get(policy).get('link_quality').get('max_variance'))
+
+                if data.get('custom_policy').get(policy).get('link_quality').get('latency_weight'):
+                    local_conf_dict['settings']['policies'][policy]['linkQuality']['lat_weight'] = float(data.get('custom_policy').get(policy).get('link_quality').get('latency_weight'))/10
+
+                if data.get('custom_policy').get(policy).get('link_quality').get('variance_weight'):
+                    local_conf_dict['settings']['policies'][policy]['linkQuality']['pdv_weight'] = float(data.get('custom_policy').get(policy).get('link_quality').get('variance_weight'))/10
+
+            if data.get('custom_policy').get(policy).get('links'):
+                local_conf_dict['settings']['policies'][policy]['links'] = {}
+                for link in data.get('custom_policy').get(policy).get('links'):
+                    local_conf_dict['settings']['policies'][policy]['links'][link] = {}
+
+                    if data.get('custom_policy').get(policy).get('links').get(link).get('mode'):
+                        local_conf_dict['settings']['policies'][policy]['links'][link]['mode'] = data.get('custom_policy').get(policy).get('links').get(link).get("mode")
+
+                    if data.get('custom_policy').get(policy).get('links').get(link).get('ip_pref'):
+                        local_conf_dict['settings']['policies'][policy]['links'][link]['ip_pref'] = int(data.get('custom_policy').get(policy).get('links').get(link).get("ip_pref"))
+
+                    if data.get('custom_policy').get(policy).get('links').get(link).get('failover_to'):
+                        local_conf_dict['settings']['policies'][policy]['links'][link]['failover_to'] = data.get('custom_policy').get(policy).get('links').get(link).get("failover_to")
+
+                    if data.get('custom_policy').get(policy).get('links').get(link).get('capacity'):
+                        local_conf_dict['settings']['policies'][policy]['links'][link]['capacity'] = int(data.get('custom_policy').get(policy).get('links').get(link).get("capacity"))
+
+    if data.get('peer_specific_bonds'):
+        local_conf_dict['settings']['peerSpecificBonds'] = {}
+        for peer in data.get('peer_specific_bonds').keys():
+            local_conf_dict['settings']['peerSpecificBonds'][peer] = {}
+            local_conf_dict['settings']['peerSpecificBonds'][peer] = data.get("peer_specific_bonds").get(peer).get('bond_name')
+
+    if data.get('bonding_policy'):
+        local_conf_dict['settings']['defaultBondingPolicy'] = data.get("bonding_policy")
+
+    return local_conf_dict
+
+def get_config(config=None):
+    if config:
+        conf = config
+    else:
+        conf = Config()
+
+    base = ['interfaces','zerotier']
+
+    config_data = conf.get_config_dict(base, key_mangling=('-', '_'),
+                                     no_tag_node_value_mangle=True,
+                                     get_first_key=True,
+                                     with_recursive_defaults=True)
+
+    return config_data
+
+def verify(config):
+    primaryPortList = []
+
+    for i in config:
+        verify_data = config[i]
+        priPort = config.get(i).get("primary_port")
+
+        if not config.get(i).get('version'):
+            raise ConfigError("Version must be configured")
+        image_name = f"zerotier/zerotier:{config.get(i).get('version')}"
+
+        # Primary Port must be configured
+        if not priPort:
+            raise ConfigError("Primary Port must be configured")
+
+        # Network ID must be configured
+        if not config.get(i).get('network_id'):
+            raise ConfigError("Network ID must be configured")
+
+        # Check if container images is present
+        if not cmd(f"sudo podman images -q {image_name}"):
+            print(re.sub(r'(?<!\n)\n(?!\n)', ' ', textwrap.dedent(f"""\
+                {image_name} container not present. Ensure that you follow all necessary licensing requirements
+                for using ZeroTier.
+
+                Image installation can be performed using the following op command (Requires Internet Access):
+                                  """)) + "\n")
+            raise ConfigError(f"add container image {image_name}")
+
+        # latency weight and delay variance weight must equal 10
+        if verify_data.get('custom_policy'):
+            for policy in verify_data.get('custom_policy').keys():
+                if verify_data.get('custom_policy').get(policy).get('link_quality'):
+                    lat_weight = float(verify_data.get('custom_policy').get(policy).get('link_quality').get('latency_weight'))/10
+                    pdv_weight = float(verify_data.get('custom_policy').get(policy).get('link_quality').get('variance_weight'))/10
+
+                    if lat_weight or pdv_weight:
+                        if lat_weight and pdv_weight:
+                            if lat_weight+pdv_weight != 1:
+                                raise ConfigError("latency-weight and variance-weight must equal 10")
+                        else:
+                            raise ConfigError("latency-weight and variance-weight must be configured together")
+
+        primaryPortList.append(priPort)
+
+    # Unique ports must be used per interface
+    dupCheck = [item for item, count in Counter(primaryPortList).items() if count > 1]
+    if dupCheck:
+        raise ConfigError(f"Primary Port {', '.join(dupCheck)} configured on more than one interface")
+
+def generate(config):
+    global podmanDict
+    podmanDict = {}
+
+    # Build Quadlet configuration
+    for i in config:
+        podman_quadlet = textwrap.dedent(f"""
+            [Unit]
+            Description=Podman container vyos_created_{i}
+            Wants=network-online.target
+            After=network-online.target
+
+            [Service]
+            Type=simple
+            User=root
+            Group=root
+            ExecStartPre=-/usr/bin/podman rm -f vyos_created_{i}
+            ExecStart=/usr/bin/podman run --name vyos_created_{i} \\
+                --device=/dev/net/tun \\
+                --net=host \\
+                --cap-add=NET_ADMIN \\
+                --cap-add=SYS_ADMIN \\
+                --restart=always \\
+                --no-healthcheck \\
+                -v /config/vyos-zerotier/{i}:/var/lib/zerotier-one \\
+                zerotier/zerotier:{config.get(i).get('version')}
+            ExecStop=/usr/bin/podman stop vyos_created_{i}
+            ExecReload=/usr/bin/podman restart vyos_created_{i}
+            Restart=always
+            RestartSec=5s
+
+            [Install]
+            WantedBy=multi-user.target
+            """)
+
+        # Generate the local.conf file for ZeroTier
+        local_conf = json.dumps(generate_local_conf(config[i]))
+
+        # Generate the configuration dict to use with apply()
+        podmanDict[i] = {
+        "local_conf_content": local_conf,
+        "network_id": config.get(i).get("network_id"),
+        "api_key": config.get(i).get("api_key"),
+        "mtu": config.get(i).get("mtu"),
+        "image_name": f"zerotier/zerotier:{config.get(i).get('version')}",
+        "podman_quadlet": podman_quadlet
+        }
+
+    return podmanDict
+
+def apply(config):
+    path = f"/config/vyos-zerotier/"
+
+    # Check if the directory exists
+    if not os.path.exists(path):
+        os.makedirs(path)
+
+    # Get list of ZeroTier interface config directories
+    directories = [d for d in os.listdir(path) if os.path.isdir(os.path.join(path, d))]
+
+    for i in podmanDict:
+        local_conf_changed, network_id_changed, version_changed = False, False, False
+        networkID = podmanDict.get(i).get('network_id')
+        image_name = podmanDict.get(i).get('image_name')
+        container_data = json.loads(cmd(f"podman container list --format json"))
+        os.makedirs(f"/config/vyos-zerotier/{i}/networks.d", exist_ok=True)
+
+        # Check if version has changed
+        for con in container_data:
+            if i in con.get('Names')[0]:
+                if image_name not in con.get('Image'):
+                    version_changed = True
+
+        # Check if new local.conf is different from existing local.conf
+        try:
+            with open(f"/config/vyos-zerotier/{i}/local.conf", "r") as file:
+                if json.load(file) != json.loads(podmanDict[i]['local_conf_content']):
+                    local_conf_changed = True
+        except:
+            local_conf_changed = True
+
+        # Write new local.conf to
+        if local_conf_changed:
+            with open(f"/config/vyos-zerotier/{i}/local.conf", "w") as file:
+                file.write(podmanDict[i]['local_conf_content'])
+
+        if networkID:
+            # Create <net-id>.local.conf; used to deterime if network should be joined
+            with open(f"/config/vyos-zerotier/{i}/networks.d/{networkID}.conf", "w") as file:
+                file.write("")
+
+            # Create devicemap; used to map zerotier interface to named interface
+            with open(f"/config/vyos-zerotier/{i}/devicemap", "w") as file:
+                file.write(f"{networkID}={i}")
+
+        # Check if network-id has changed; if changed delete old <net-id>.local.conf
+        for filename in os.listdir(f"/config/vyos-zerotier/{i}/networks.d"):
+            file_path = os.path.join(f"/config/vyos-zerotier/{i}/networks.d", filename)
+            if os.path.isfile(file_path):
+                if networkID:
+                    if filename.replace(".conf", "") not in networkID:
+                        os.remove(file_path)
+                        network_id_changed = True
+                else:
+                    os.remove(file_path)
+
+        # Write service Quadlet for container to disk
+        with open(f"/etc/systemd/system/vyos-zerotier@{i}.service", 'w') as file:
+            file.write(podmanDict.get(i).get('podman_quadlet'))
+
+        # Create services for ZeroTier containers
+        cmd("sudo systemctl daemon-reload")
+
+        enabled = rc_cmd(f"sudo systemctl is-enabled vyos-zerotier@{i}.service")[1].strip()
+
+        # If services is not enabled, enable and start it
+        if enabled != "enabled":
+            cmd(f"sudo systemctl enable --now vyos-zerotier@{i}.service")
+            cmd(f"sudo systemctl start vyos-zerotier@{i}.service")
+        else:
+            if local_conf_changed or network_id_changed or version_changed:
+                cmd(f"sudo systemctl restart vyos-zerotier@{i}.service")
+
+    containers = json.loads(cmd("podman ps --format json"))
+
+    # Stop and remove container if interface is deleted
+    for container in containers:
+        if f"{container['Names'][0]}".replace("vyos_created_", "") not in podmanDict.keys():
+            cmd(f"podman container stop {container.get('Names')[0]}")
+            cmd(f"podman container rm {container.get('Names')[0]}")
+
+    # Since elements in the config directory are important to node identities and secrets,
+    # backup config directory so it can be restored if deleted on accident
+    for i in directories:
+        if i not in podmanDict.keys() and i != "backup":
+            timestamp = datetime.datetime.now().strftime("%m-%d-%H%M")
+
+            # Backup the directory for key recovery if necessary
+            shutil.make_archive(f"/config/vyos-zerotier/backup/{i}_{timestamp}.bak", 'zip', i,f"{path}{i}")
+
+            # Remove the directory for the deleted interface
+            shutil.rmtree(f"{path}{i}")
+
+            # Delete to service for the deleted interface
+            cmd(f"sudo systemctl stop vyos-zerotier@{i}.service")
+            cmd(f"sudo systemctl disable vyos-zerotier@{i}.service")
+            os.remove(f"/etc/systemd/system/vyos-zerotier@{i}.service")
+            cmd(f"sudo systemctl daemon-reload")
+
+try:
+    c = get_config()
+    verify(c)
+    generate(c)
+    apply(c)
+except ConfigError as e:
+    print(e)
+    sys.exit(1)

--- a/src/helpers/strip-private.py
+++ b/src/helpers/strip-private.py
@@ -35,6 +35,8 @@ parser.add_argument('--domain', action='store_true', help='strip off domain name
 parser.add_argument('--asn', action='store_true', help='strip off BGP ASNs')
 parser.add_argument('--snmp', action='store_true', help='strip off SNMP location information')
 parser.add_argument('--lldp', action='store_true', help='strip off LLDP location information')
+parser.add_argument('--zt_node', action='store_true', help='strip off SNMP location information')
+parser.add_argument('--zt_network', action='store_true', help='strip off LLDP location information')
 
 address_preserval = parser.add_mutually_exclusive_group()
 address_preserval.add_argument('--address', action='store_true', help='strip off all IPv4 and IPv6 addresses')
@@ -95,7 +97,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     # Strict mode is the default and the absence of loose mode implies presence of strict mode.
     if not args.loose:
-        args.mac = args.domain = args.hostname = args.username = args.dhcp = args.asn = args.snmp = args.lldp = True
+        args.mac = args.domain = args.hostname = args.username = args.dhcp = args.asn = args.snmp = args.lldp = args.zt_node = args.zt_network = True
         if not args.public_address and not args.keep_address:
             args.address = True
     elif not args.address and not args.public_address:
@@ -123,6 +125,8 @@ if __name__ == "__main__":
         (True, re.compile(r'md5-key \S+'), 'md5-key xxxxxx'),
         # Strip WireGuard private-key
         (True, re.compile(r'private-key \S+'), 'private-key xxxxxx'),
+        # Strip ZeroTier api-key
+        (True, re.compile(r'api-key \S+'), 'api-key xxxxxx'),
 
         # Strip MAC addresses
         (args.mac, re.compile(r'([0-9a-fA-F]{2}\:){5}([0-9a-fA-F]{2}((\:{0,1})){3})'), r'xx:xx:xx:xx:xx:\2'),
@@ -149,5 +153,10 @@ if __name__ == "__main__":
 
         # Strip SNMP location
         (args.snmp, re.compile(r'(location) \S+'), r'\1 xxxxxx'),
+
+        # Strip ZeroTier information
+        (args.zt_node, re.compile(r'([A-Fa-f0-9]{16})'), r'xxxxxxxxxxxxxxxx'.strip()),
+        (args.zt_network, re.compile(r'([A-Fa-f0-9]{10})'), r'xxxxxxxxxx'.strip()),
     ]
+
     strip_lines(stripping_rules)

--- a/src/op_mode/zerotier.py
+++ b/src/op_mode/zerotier.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2016-2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This script is will output various information related to ZeroTier
+
+import json
+import os
+import re
+import requests
+import sys
+import typing
+import zipfile
+
+from tabulate import tabulate
+
+import vyos.opmode
+from vyos.utils.process import cmd
+from vyos.configquery import ConfigTreeQuery
+
+conf = ConfigTreeQuery()
+
+def show_interfaces(raw: bool, interface: typing.Optional[str]):
+    # Get list of interfaces
+    zt_int_dict = conf.get_config_dict(['interfaces', 'zerotier'], key_mangling=('-', '_'),
+                            get_first_key=True)
+
+    if interface:
+        # Check if interface that was specified exists
+        if interface not in zt_int_dict.keys():
+            raise vyos.opmode.Error(f'ZeroTier interface not configured')
+        if_list = [interface]
+    else:
+        if_list = zt_int_dict.keys()
+
+    if not if_list:
+        raise vyos.opmode.Error(f'No ZeroTier interfaces configured')
+
+    output_list = []
+    raw_dict = {}
+    for interface in if_list:
+        zt_dict = zt_int_dict.get(interface)
+        raw_dict[interface] = {}
+
+        if zt_dict:
+            interface_name = interface
+
+            # Get Network ID
+            network_id = zt_dict.get('network_id')
+
+            description = zt_dict.get('description')
+
+            # Get Node ID and Version
+            cli_dict = json.loads(cmd(f"podman exec vyos_created_{interface_name} zerotier-cli info -j"))
+            node_id = cli_dict.get('address')
+            version = cli_dict.get('version')
+
+            # Get IP address(es) on interface
+            tmp = json.loads(cmd(f"ip -j addr show dev {interface_name}"))[0].get('addr_info')
+
+            ip_list = []
+            for address in tmp:
+                ip_list.append(f"{address.get('local')}/{address.get('prefixlen')}")
+
+            # Generate list for tabulate output
+            output_list.append([interface_name,
+                                node_id,
+                                '\n'.join(ip_list),
+                                network_id,
+                                version,
+                                description]
+                               )
+
+            # Generate dict for raw output
+            raw_dict[interface]['node_id'] = node_id
+            raw_dict[interface]['ip_address'] = ip_list
+            raw_dict[interface]['network_id'] = network_id
+            raw_dict[interface]['version'] = version
+            raw_dict[interface]['description'] = description
+
+    if raw:
+        return {'zerotier': raw_dict}
+    else:
+        # Tabulate print information
+        headers = ["Interface", "Node ID", "IP Address", "Network", "Version", "Description"]
+        print(tabulate(output_list, headers))
+
+def zt_api(url, api_token, api_type):
+    # Create the headers for API calls
+    if api_type == "service":
+        headers = {
+            "X-ZT1-Auth": api_token
+        }
+    elif api_type == "central":
+        headers = {
+            'Authorization': f'token {api_token}'
+        }
+
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()  # Raises HTTPError for bad responses (4xx and 5xx)
+        return response
+    except requests.exceptions.HTTPError as http_err:
+        raise vyos.opmode.Error(f'HTTP error occurred: {http_err}')
+    except Exception as err:
+        raise vyos.opmode.Error(f'Other error occurred: {err}')
+
+def show_peers_detail(raw: bool, interface: typing.Optional[str]):
+    localNodeList = []
+    controllerNodeList = []
+    controllerNetworkList = []
+
+    headers = ['Name', 'NodeID', 'Description', 'ZeroTier IP', 'Public IP', 'Network', 'Version']
+    peer_dict = conf.get_config_dict(['interfaces', 'zerotier', interface], key_mangling=('-', '_'),
+                            get_first_key=True)
+
+    primary_port = peer_dict.get('primary_port')
+
+    # peers-all and peers-detail does API calls to ZeroTier Central and requires API key to be configured
+    api_token = peer_dict.get('api_key')
+    if not api_token:
+        raise vyos.opmode.Error("This command requires a ZeroTier Central API key to be configured")
+
+    # peers-detail does a local API call to get local peers and requires an authtoken
+    try:
+        with open(f'/config/vyos-zerotier/{interface}/authtoken.secret', 'r') as file:
+            authtoken = file.read()
+    except FileNotFoundError:
+        raise vyos.opmode.Error(f'authtoken.secret not found! This should have been created when creating an interface. Does {interface} exist')
+
+    # Get local list of nodes
+    network_data = zt_api(f'http://127.0.0.1:{primary_port}/peer', authtoken, 'service').json()
+    for peers in network_data:
+        localNodeList.append(peers['address'])
+
+    # Get list of all networks in a ZeroTier controller
+    network_data = zt_api('https://api.zerotier.com/api/v1/network', api_token, 'central').json()
+    for networks in network_data:
+        controllerNetworkList.append(networks['id'])
+
+    raw_dict = {}
+    for controllerNode in controllerNetworkList:
+        raw_dict[controllerNode] = []
+        network_data = zt_api(f'https://api.zerotier.com/api/v1/network/{controllerNode}/member', api_token, 'central').json()
+        for i in network_data:
+            if i['nodeId'] in localNodeList:
+                controllerNodeList.append([i['name'], i['nodeId'], i['description'], '\n'.join(i['config']['ipAssignments']), i['physicalAddress'], i['networkId'], i['clientVersion']])
+                raw_dict[controllerNode].append(i)
+
+    if raw:
+        return {'zerotier': raw_dict}
+    else:
+        sorted_list = sorted(controllerNodeList, key=lambda x: x[0].lower())
+        print(tabulate(sorted_list, headers))
+
+def show_peers_all(raw: bool, interface: typing.Optional[str]):
+    controllerNodeList = []
+    controllerNetworkList = []
+
+    headers = ['Name', 'NodeID', 'Description', 'ZeroTier IP', 'Network', 'Version']
+    peer_dict = conf.get_config_dict(['interfaces', 'zerotier', interface], key_mangling=('-', '_'),
+                            get_first_key=True)
+
+    # peers-all and peers-detail does API calls to ZeroTier Central and requires API key to be configured
+    api_token = peer_dict.get('api_key')
+    if not api_token:
+        raise vyos.opmode.Error("This command requires a ZeroTier Central API key to be configured")
+
+    # Get list of all networks in a ZeroTier controller
+    network_data = zt_api('https://api.zerotier.com/api/v1/network', api_token, 'central').json()
+    for networks in network_data:
+        controllerNetworkList.append(networks['id'])
+
+    raw_dict = {}
+    for controllerNode in controllerNetworkList:
+        network_data = zt_api(f'https://api.zerotier.com/api/v1/network/{controllerNode}/member', api_token, 'central').json()
+        for i in network_data:
+            controllerNodeList.append([i['name'], i['nodeId'], i['description'], '\n'.join(i['config']['ipAssignments']), i['networkId'], i['clientVersion']])
+        raw_dict[controllerNode] = network_data
+
+    if raw:
+        return {'zerotier': raw_dict}
+    else:
+        sorted_list = sorted(controllerNodeList, key=lambda x: x[0].lower())
+        print(tabulate(sorted_list, headers))
+
+def show_metrics(raw: bool, metric: typing.Optional[str], interface: typing.Optional[str]):
+    def format_counts(value_list):
+        aggregated_counts = {}
+
+        for direction, value_type, count in value_list:
+            count = int(count)
+
+            if value_type not in aggregated_counts:
+                aggregated_counts[value_type] = {'rx': 0, 'tx': 0}
+
+            aggregated_counts[value_type][direction] += count
+        sorted_list = sorted([[tmp, counts['rx'], counts['tx']] for tmp, counts in aggregated_counts.items()], key=lambda x: x[0])
+
+        return sorted_list
+
+    def output_parse(pattern, line):
+        match = re.search(pattern, line)
+
+        if match:
+            # Join the matched groups into a single comma-separated string
+            result = ','.join(match.groups())
+            return result
+
+    primary_port = conf.get_config_dict(['interfaces', 'zerotier', interface], key_mangling=('-', '_'),
+                            get_first_key=True).get('primary_port')
+
+    accepted_packets_list, errors_list, latency_list, peer_packet_list, packet_type_list, protocol_list, peer_error_list = [], [], [], [], [], [], []
+
+    try:
+        with open(f'/config/vyos-zerotier/{interface}/metricstoken.secret', 'r') as file:
+            authtoken = file.read()
+    except FileNotFoundError:
+        raise vyos.opmode.Error(f'metricstoken.secret not found! This should have been created when when creating an interface. Does {interface} exist?')
+
+    network_data = zt_api(f'http://127.0.0.1:{primary_port}/metrics', authtoken, 'service')
+
+    for i in network_data.text.split('\n'):
+        # Skip comments
+        if i.startswith('# '):
+            continue
+
+        if 'packettype' == metric:
+            if 'packet_type=' in i:
+                pattern = r'zt_packet\{direction="(tx|rx)",packet_type="([^"]+)"\}\s(\d+)'
+                packet_type_list.append(output_parse(pattern, i).split(','))
+        elif 'errors' == metric:
+            if 'error_type=' in i:
+                pattern = r'zt_packet_error\{direction="(tx|rx)",error_type="([^"]+)"\}\s(\d+)'
+                errors_list.append(output_parse(pattern, i).split(','))
+        elif 'acceptedpackets' == metric:
+            if 'zt_network_packets{' in i:
+                pattern = r'zt_network_packets\{accepted="(yes|no)",direction="(tx|rx)",network_id="([^"]+)"\}\s(\d+)'
+                accepted_packets_list.append(output_parse(pattern, i).split(','))
+        elif 'protocols' == metric:
+            if 'protocol="' in i:
+                pattern = r'zt_data\{direction="(tx|rx)",protocol="([^"]+)"\}\s(\d+)'
+                protocol_list.append(output_parse(pattern, i).split(','))
+        elif 'peerpackets' == metric:
+            if 'zt_peer_packets{' in i:
+                pattern = r'zt_peer_packets\{direction="(tx|rx)",node_id="([^"]+)"\}\s(\d+)'
+                peer_packet_list.append(output_parse(pattern, i).split(','))
+        elif 'peerpacketerrors' == metric:
+            if 'zt_peer_packet_errors{' in i:
+                pattern = r'node_id="([^"]+)"\} (\d+)'
+                peer_error_list.append(output_parse(pattern, i).split(','))
+        elif 'latency' == metric:
+            if 'zt_peer_latency_bucket{' in i:
+                latency_list.append(i.replace('zt_peer_latency_bucket{','').replace('"', '').replace('node_id=', '').replace('} ', ',').split(','))
+
+    if 'peerpackets' == metric:
+        sorted_list = format_counts(peer_packet_list)
+        headers = ["Peer", "RX Count", "TX Count"]
+    elif 'protocols' == metric:
+        sorted_list = format_counts(protocol_list)
+        headers = ["Protocol", "RX Count", "TX Count"]
+    elif 'packettype' == metric:
+        sorted_list = format_counts(packet_type_list)
+        headers = ["Packet Type", "RX Count", "TX Count"]
+    elif 'errors' == metric:
+        sorted_list = format_counts(errors_list)
+        headers = ["Error Type", "RX Count", "TX Count"]
+    elif 'acceptedpackets' == metric:
+        sorted_list = sorted(accepted_packets_list, key=lambda x: (x[2], x[0]))
+        headers = ["Allowed", "Direction", "NetworkID", "Count"]
+    elif 'peerpacketerrors' == metric:
+        sorted_list = sorted(peer_error_list, key=lambda x: (x[1], x[0]))
+        headers = ["Peer Node ID", "Error Count"]
+    elif 'latency' == metric:
+        node_data = {}
+
+        for node_id, le_value, count in latency_list:
+            if node_id not in node_data:
+                node_data[node_id] = {}
+            node_data[node_id][le_value] = int(count)
+
+        headers = ["NodeID", "le=1", "le=3", "le=6", "le=10", "le=30", "le=60", "le=100", "le=300", "le=600", "le=1000", "le=+Inf"]
+
+        table_data = []
+
+        for node_id, counts in sorted(node_data.items()):
+            row = [node_id] + [counts.get(le, 0) for le in headers[1:]]
+            table_data.append(row)
+
+        sorted_list = sorted(table_data, key=lambda x: (x[2], x[0]))
+
+    print(tabulate(sorted_list, headers))
+
+def show_command(raw: bool, command: typing.Optional[str], interface: typing.Optional[str]):
+    # Validate commands
+    def is_10_digit_hex(value):
+        pattern = re.compile(r'^[0-9a-fA-F]{10}$')
+        return bool(pattern.match(value))
+
+    # Valdiate that provide Node-ID is a 10-digit hexadecimal value
+    if 'bond' in command and 'show' in command:
+        tmp = is_10_digit_hex(command.split()[1])
+        if not tmp:
+            raise vyos.opmode.Error(f"'{command.split()[1]}' must be a 10-digit hex value")
+
+    if 'listnetworks' == command or 'peers' == command or ('bond' in command and 'list' in command):
+        error_msg = f"Command could not be executed. Is {interface} up?"
+
+    try:
+        if raw:
+            return {'zerotier': json.loads(cmd(f"podman exec vyos_created_{interface} zerotier-cli {command} -j"))}
+        else:
+            print(cmd(f"podman exec vyos_created_{interface} zerotier-cli {command}"))
+    except:
+        raise vyos.opmode.DataUnavailable(error_msg)
+
+def set_allowed(raw: bool, allowed: typing.Optional[str], interface: typing.Optional[str], state: typing.Optional[str]):
+    allow_dict = conf.get_config_dict(['interfaces', 'zerotier', interface], key_mangling=('-', '_'),
+                            get_first_key=True)
+
+    network_id = allow_dict.get('network_id')
+
+    if not network_id:
+        raise vyos.opmode.DataUnavailable(f"Command could not be executed. Is {interface} up?")
+
+    cmd(f"podman exec vyos_created_{interface} zerotier-cli set {network_id} {allowed}={state}")
+
+def reset_node(raw: bool, file: typing.Optional[str]):
+    # Since elements in the config directory are important to node identities and secrets,
+    # a backup is created when deleting a node. This can be used to recover the config
+    interface_name = file.split('_')[0]
+    directory = f"/config/vyos-zerotier/{interface_name}"
+
+    # Check if the directory exists
+    if os.path.exists(directory) and os.path.isdir(directory):
+        raise vyos.opmode.Error(f"A directory for {interface_name} already exists, unable to restore")
+    else:
+        try:
+            with zipfile.ZipFile(f"/config/vyos-zerotier/backup/{file}", 'r') as zip_ref:
+                zip_ref.extractall("/")
+        except Exception as e:
+            print(f"An error occurred: {e}")
+            raise vyos.opmode.Error(f"Unable to restore backup {file}")
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except (ValueError, vyos.opmode.Error) as e:
+        print(e)
+        sys.exit(1)

--- a/src/validators/ipv4-port
+++ b/src/validators/ipv4-port
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+#
+# This script validates that a '/' separated IP/Port contains a valid IP and
+# Port
+
+from sys import argv
+import ipaddress
+
+def validate_ip_port(ip_port):
+    try:
+        ip, port = ip_port.split('/')
+        ipaddress.ip_address(ip)
+
+        port = int(port)
+        if not (1 <= port <= 65535):
+            exit(1)
+        exit(0)
+    except Exception as e:
+        exit(1)
+
+if __name__ == '__main__':
+    if len(argv)>1:
+        validate_ip_port(argv[1])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This is a draft PR for adding ZeroTier support to VyOS
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6455

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
zerotier

## Proposed changes
<!--- Describe your changes in detail -->
This feature request is for adding support for ZeroTier. Adding ZeroTier would provide bolt-on SD-WAN support for VyOS.

### Implementation plan.
Each configured ZeroTier interface will be run in a new ZeroTier process as a container. This is done for a number of reasons.

1. Resource Utilization
    - Unless using ZeroTier, there will be no running processes or services to use system resources. A number of NOS are moving to this approach.
2. Software Updates/Patching
    - Running in a container allows for easy updating of the software without needing to fully update VyOS. This is important if an upstream fix for a vulnerability is patched.
3. Compatibility
    - Each interface can run as a different version for compatibility. For instance, if one version is better for remote-access VPNs, and another is better for site-to-site VPNs.
4. Performance
    - Running services in parallel allows for great scaling of throughput using ECMP. The CPU scheduler can give unused cores directly to the process. This can allow for >40Gbps of encrypted throughput on relatively inexpensive hardware.
5. Licensing
    - ZeroTier uses a BSL license. By running the software as a container, it pushes the requirement to acquire the software and adhere to all licensing on the user/operator, rather than the distro/maintainers. ZeroTier would not be bundled with VyOS, VyOS would simply expose configuration elements if the user wants and is allowed to run ZeroTier.
Naming of the containers will be vyos_created_zt<num>. This is to prevent any potential naming conflicts with manual installations of ZeroTier.

### Configuration
The configuration of ZeroTier's local.conf file will be fully supported in configuration syntax, including the creation of custom bonding policies.
```
vyos@vyos# set interfaces zerotier zt3
Possible completions:
+  allow-mgmt-from      Allow management from specified subnets
   allow-tcp-fallback   Allow falling back to TCP Relay if UDP fails
   api-key              ZT API key - DO NOT share
+  bind                 Bind ZeroTier to specified IP
   bonding-policy       Bonding policy to be applied
+> custom-policy        User created ZeroTier bonding policy
   description          Description
   force-tcp-relay      Disables UDP communication and forces TCP
+  interface-blacklist  Prevent binding of ZeroTier service to interfaces
   low-bandwidth-mode   Enable low-bandwidth-mode (limits control traffic)
   multipath-mode       Multipath load-balancing mode
+> network-config       Network specific ZeroTier config
   network-id           ZeroTier Network ID to join (required)
+> peer-config          10-digit hex
+> peer-specific-bonds  Apply bonding policies per peer
   primary-port         Primary port for ZeroTier service (required)
   secondary-port       Secondary port for ZeroTier service
   tcp-relay            Define the IP/Port of a TCP Relay
   tertiary-port        Tertiary port for ZeroTier service
   version              Version of ZeroTier to use (required)
```
### Op Mode
The following op mode commands will be added:
```
show interfaces zerotier 
show interfaces zerotier <interface>

show interfaces zerotier <interface> networks

show interfaces zerotier <interface> peers
show interfaces zerotier <interface> peers-all
show interfaces zerotier <interface> peers-detail

show interfaces zerotier <interface> metrics accepted-packets
show interfaces zerotier <interface> metrics errors
show interfaces zerotier <interface> metrics latency
show interfaces zerotier <interface> metrics packet-types
show interfaces zerotier <interface> metrics peer-packets
show interfaces zerotier <interface> metrics peer-packet-errors
show interfaces zerotier <interface> metrics protocols

show interfaces zerotier <interface> bonding
show interfaces zerotier <interface> bonding <node id>

restart zerotier <zt interface>

zerotier interface <interface> orbit <root id>
zerotier interface <interface> allow-default enable/disable
zerotier interface <interface> allow-managed enable/disable
zerotier interface <interface> allow-global enable/disable
zerotier interface <interface> bonding-failover <node id>
zerotier restore <backup file>
```
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
