### PR TITLE
T6460: fix DHCPv6 duid formatting

### DIFF
--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -47,7 +47,8 @@ def _utc_to_local(utc_dt):
     return datetime.fromtimestamp((datetime.fromtimestamp(utc_dt) - datetime(1970, 1, 1)).total_seconds())
 
 
-def _format_hex_string(in_str):
+def _format_hex_string(in_bytes):
+    in_str = bytes(in_bytes).hex()
     out_str = ""
     # if input is divisible by 2, add : every 2 chars
     if len(in_str) > 0 and len(in_str) % 2 == 0:


### PR DESCRIPTION
## Change Summary
duid is an array of bytes of the iaid (https://github.com/MartijnBraam/python-isc-dhcp-leases).

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6460

## Component(s) name
dhcp

## Proposed changes
convert byte array to string before formatting

## How to test
Add a dhcpv6 lease to /config/dhcpv6.leases
```
ia-na "\334\005\2750\000\004\004\360.\224\341h\033#\243\261d\344'\275b6" {
  cltt 5 2024/06/07 14:22:18;
  iaaddr fd00::1:0:0:ffff:b1d9 {
    binding state active;
    preferred-life 7200;
    max-life 7500;
    ends 5 2024/06/07 16:27:18;
  }
}
```
Then try to list it with `show dhcpv6 server leases `

## Smoketest result

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
