### PR TITLE
T6456: Convert "monitor traffic" to modern op-mode wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,12 +61,13 @@ op_mode_definitions: $(op_xml_obj)
 	rm -f $(OP_TMPL_DIR)/clear/node.def
 	rm -f $(OP_TMPL_DIR)/delete/node.def
 
-	# XXX: ping, traceroute and mtr must be able to recursivly call themselves as the
+	# XXX: tcpdump, ping, traceroute and mtr must be able to recursivly call themselves as the
 	# options are provided from the scripts themselves
 	ln -s ../node.tag $(OP_TMPL_DIR)/ping/node.tag/node.tag/
 	ln -s ../node.tag $(OP_TMPL_DIR)/traceroute/node.tag/node.tag/
 	ln -s ../node.tag $(OP_TMPL_DIR)/mtr/node.tag/node.tag/
 	ln -s ../node.tag $(OP_TMPL_DIR)/monitor/traceroute/node.tag/node.tag/
+	ln -s ../node.tag $(OP_TMPL_DIR)/monitor/traffic/interface/node.tag/node.tag/
 
 	# XXX: test if there are empty node.def files - this is not allowed as these
 	# could mask help strings or mandatory priority statements

--- a/op-mode-definitions/traffic-dump.xml.in
+++ b/op-mode-definitions/traffic-dump.xml.in
@@ -8,7 +8,7 @@
         </properties>
         <children>
           <tagNode name="interface">
-            <command>sudo tcpdump -i $4</command>
+            <command>${vyos_op_scripts_dir}/tcpdump.py $4</command>
             <properties>
               <help>Monitor traffic dump from an interface</help>
               <completionHelp>
@@ -16,54 +16,15 @@
               </completionHelp>
             </properties>
             <children>
-              <node name="verbose">
-                <command>sudo tcpdump -vvv -ne -i $4</command>
+              <leafNode name="node.tag">
                 <properties>
-                  <help>Provide more detailed packets for each monitored traffic</help>
+                  <help>Traffic capture options</help>
+                  <completionHelp>
+                    <script>${vyos_op_scripts_dir}/tcpdump.py --get-options-nested "${COMP_WORDS[@]}"</script>
+                  </completionHelp>
                 </properties>
-                <children>
-                  <tagNode name="filter">
-                    <command>sudo tcpdump -vvv -ne -i $4 "${@:6}"</command>
-                    <properties>
-                      <help>Monitor traffic matching filter conditions</help>
-                    </properties>
-                  </tagNode>
-                  <tagNode name="save">
-                    <command>sudo tcpdump -vvv -ne -i $4 -w $6</command>
-                    <properties>
-                      <help>Save traffic dump from an interface to a file</help>
-                    </properties>
-                    <children>
-                      <tagNode name="filter">
-                        <command>sudo tcpdump -vvv -ne -i $4 -w $6 "${@:8}"</command>
-                        <properties>
-                          <help>Save a dump of traffic matching filter conditions to a file</help>
-                        </properties>
-                      </tagNode>
-                    </children>
-                  </tagNode>
-                </children>
-              </node>
-              <tagNode name="filter">
-                <command>sudo tcpdump -n -i $4 "${@:6}"</command>
-                <properties>
-                  <help>Monitor traffic matching filter conditions</help>
-                </properties>
-              </tagNode>
-              <tagNode name="save">
-                <command>sudo tcpdump -n -i $4 -w $6</command>
-                <properties>
-                  <help>Save traffic dump from an interface to a file</help>
-                </properties>
-                <children>
-                  <tagNode name="filter">
-                    <command>sudo tcpdump -n -i $4 -w $6 "${@:8}"</command>
-                    <properties>
-                      <help>Save a dump of traffic matching filter conditions to a file</help>
-                    </properties>
-                  </tagNode>
-                </children>
-              </tagNode>
+                <command>${vyos_op_scripts_dir}/tcpdump.py "${@:4}"</command>
+              </leafNode>
             </children>
           </tagNode>
         </children>

--- a/src/op_mode/tcpdump.py
+++ b/src/op_mode/tcpdump.py
@@ -1,0 +1,165 @@
+#! /usr/bin/env python3
+
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+
+from vyos.utils.process import call
+
+options = {
+    'dump': {
+        'cmd': '{command} -A',
+        'type': 'noarg',
+        'help': 'Print each packet (minus its link level header) in ASCII.'
+    },
+    'hexdump': {
+        'cmd': '{command} -X',
+        'type': 'noarg',
+        'help': 'Print each packet (minus its link level header) in both hex and ASCII.'
+    },
+    'filter': {
+        'cmd': '{command} \'{value}\'',
+        'type': '<pcap-filter>',
+        'help': 'Match traffic for capture and display with a pcap-filter expression.'
+    },
+    'numeric': {
+        'cmd': '{command} -nn',
+        'type': 'noarg',
+        'help': 'Do not attempt to resolve addresses, protocols or services to names.'
+    },
+    'save': {
+        'cmd': '{command} -w {value}',
+        'type': '<file>',
+        'help': 'Write captured raw packets to <file> rather than parsing or printing them out.'
+    },
+    'verbose': {
+        'cmd': '{command} -vvv -ne',
+        'type': 'noarg',
+        'help': 'Parse packets with increased detail output, including link-level headers and extended decoding protocol sanity checks.'
+    },
+}
+
+tcpdump = 'sudo /usr/bin/tcpdump'
+
+class List(list):
+    def first(self):
+        return self.pop(0) if self else ''
+
+    def last(self):
+        return self.pop() if self else ''
+
+    def prepend(self, value):
+        self.insert(0, value)
+
+
+def completion_failure(option: str) -> None:
+    """
+    Shows failure message after TAB when option is wrong
+    :param option: failure option
+    :type str:
+    """
+    sys.stderr.write('\n\n Invalid option: {}\n\n'.format(option))
+    sys.stdout.write('<nocomps>')
+    sys.exit(1)
+
+
+def expansion_failure(option, completions):
+    reason = 'Ambiguous' if completions else 'Invalid'
+    sys.stderr.write(
+        '\n\n  {} command: {} [{}]\n\n'.format(reason, ' '.join(sys.argv),
+                                               option))
+    if completions:
+        sys.stderr.write('  Possible completions:\n   ')
+        sys.stderr.write('\n   '.join(completions))
+        sys.stderr.write('\n')
+    sys.stdout.write('<nocomps>')
+    sys.exit(1)
+
+
+def complete(prefix):
+    return [o for o in options if o.startswith(prefix)]
+
+
+def convert(command, args):
+    while args:
+        shortname = args.first()
+        longnames = complete(shortname)
+        if len(longnames) != 1:
+            expansion_failure(shortname, longnames)
+        longname = longnames[0]
+        if options[longname]['type'] == 'noarg':
+            command = options[longname]['cmd'].format(
+                command=command, value='')
+        elif not args:
+            sys.exit(f'monitor traffic: missing argument for {longname} option')
+        else:
+            command = options[longname]['cmd'].format(
+                command=command, value=args.first())
+    return command
+
+
+if __name__ == '__main__':
+    args = List(sys.argv[1:])
+    ifname = args.first()
+
+    # Slightly simplified & tweaked version of the code from mtr.py - it may be 
+    # worthwhile to combine and centralise this in a common module. 
+    if ifname == '--get-options-nested':
+        args.first()  # pop monitor
+        args.first()  # pop traffic
+        args.first()  # pop interface
+        args.first()  # pop <ifname>
+        usedoptionslist = []
+        while args:
+            option = args.first()  # pop option
+            matched = complete(option)  # get option parameters
+            usedoptionslist.append(option)  # list of used options
+            # Select options
+            if not args:
+                # remove from Possible completions used options
+                for o in usedoptionslist:
+                    if o in matched:
+                        matched.remove(o)
+                if not matched:
+                    sys.stdout.write('<nocomps>')
+                else:
+                    sys.stdout.write(' '.join(matched))
+                sys.exit(0)
+
+            if len(matched) > 1:
+                sys.stdout.write(' '.join(matched))
+                sys.exit(0)
+            # If option doesn't have value
+            if matched:
+                if options[matched[0]]['type'] == 'noarg':
+                    continue
+            else:
+                # Unexpected option
+                completion_failure(option)
+
+            value = args.first()  # pop option's value
+            if not args:
+                matched = complete(option)
+                helplines = options[matched[0]]['type']
+                # Run helpfunction to get list of possible values
+                if 'helpfunction' in options[matched[0]]:
+                    result = options[matched[0]]['helpfunction']()
+                    if result:
+                        helplines = '\n' + ' '.join(result)
+                sys.stdout.write(helplines)
+                sys.exit(0)
+
+    command = convert(tcpdump, args)
+    call(f'{command} -i {ifname}')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The old "monitor traffic" definition had misaligned arguments under the verbose node and manually offered the same parameter keyword in multiple positions to emulate flexible parameters.

I've wrapped tcpdump for op-mode Python and replicated the "varargs" style from mtr.py/mtr.xml.in to present a few more parameters in a more flexible manner.

Changes to the Makefile were required for recursive varargs lookup.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6456

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* op_mode

## Proposed changes
<!--- Describe your changes in detail -->
The old "monitor traffic" op-mode definition called tcpdump directly, arguments passed through under the uppermost "verbose" node were off by one, so tcpdump would not work properly with verbose + any other following param.  

I've adapted the mtr.xml.in/mtr.py op_mode varargs style for monitor traffic, allowing flexible parameter ordering and adding a few more flags (such as hexdump) without an exponential increase in XML complexity. 

The previous options available are still intact and will work the same way as before - verbose, save and filter, but they may also be used flexibly in any order. The current documentation for "monitor traffic" is still applicable. 

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Running through many variations of each flag, for example:
```
$ monitor traffic interface eth0.12 numeric hexdump filter 'port ! 22' 
COMMAND: "sudo /usr/bin/tcpdump -nn -X 'port ! 22' -i eth0.12"
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eth0.12, link-type EN10MB (Ethernet), snapshot length 262144 bytes
01:35:23.644834 STP 802.1d, Config, Flags [none], bridge-id 8000.26:5e:b2:81:0d:28.8001, length 35
        0x0000:  0000 0000 0080 0026 5eb2 810d 2800 0000  .......&^...(...
        0x0010:  0080 0026 5eb2 810d 2880 0100 0014 0002  ...&^...(.......
        0x0020:  000f 0000 0000 00                        .......
```
(Example shows some debug output I added while working on it: this is removed in the final PR)

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
No smoketests appear to apply to individual op_mode changes. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
