### PR TITLE
op-mode: T6424: ipsec: honor certificate CN and CA chain during profile generation

### DIFF
--- a/data/templates/ipsec/ios_profile.j2
+++ b/data/templates/ipsec/ios_profile.j2
@@ -48,10 +48,10 @@
                 <!-- Optional, if it matches the CN of the root CA certificate (not the full subject DN) a certificate request will be sent
                      NOTE: If this is not configured make sure to configure leftsendcert=always on the server, otherwise it won't send its certificate -->
                 <key>ServerCertificateIssuerCommonName</key>
-                <string>{{ ca_cn }}</string>
+                <string>{{ ca_common_name }}</string>
                 <!-- Optional, the CN or one of the subjectAltNames of the server certificate to verify it, if not set RemoteIdentifier will be used -->
                 <key>ServerCertificateCommonName</key>
-                <string>{{ cert_cn }}</string>
+                <string>{{ cert_common_name }}</string>
                 <!-- The server is authenticated using a certificate -->
                 <key>AuthenticationMethod</key>
                 <string>Certificate</string>
@@ -83,24 +83,22 @@
                 </dict>
             </dict>
         </dict>
-{% if certs is vyos_defined %}
+{% if ca_certificates is vyos_defined %}
         <!-- This payload is optional but it provides an easy way to install the CA certificate together with the configuration -->
-{%     for cert in certs %}
-        <!-- Payload for: {{ cert.ca_cn }} -->
+{%     for ca in ca_certificates %}
+        <!-- Payload for: {{ ca.ca_name }} -->
         <dict>
             <key>PayloadIdentifier</key>
-            <string>org.{{ cert.ca_cn | lower | replace(' ', '.') | replace('_', '.') }}</string>
+            <string>org.{{ ca.ca_name | lower | replace(' ', '.') | replace('_', '.') }}</string>
             <key>PayloadUUID</key>
-            <string>{{ cert.ca_cn | generate_uuid4 }}</string>
+            <string>{{ ca.ca_name | get_uuid }}</string>
             <key>PayloadType</key>
             <string>com.apple.security.root</string>
             <key>PayloadVersion</key>
             <integer>1</integer>
             <!-- This is the Base64 (PEM) encoded CA certificate -->
             <key>PayloadContent</key>
-            <data>
-            {{ cert.ca_cert }}
-            </data>
+            <data>{{ ca.ca_chain }}</data>
         </dict>
 {%     endfor %}
 {% endif %}

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -525,10 +525,17 @@ def get_esp_ike_cipher(group_config, ike_group=None):
     return ciphers
 
 @register_filter('get_uuid')
-def get_uuid(interface):
+def get_uuid(seed):
     """ Get interface IP addresses"""
-    from uuid import uuid1
-    return uuid1()
+    if seed:
+        from hashlib import md5
+        from uuid import UUID
+        tmp = md5()
+        tmp.update(seed.encode('utf-8'))
+        return str(UUID(tmp.hexdigest()))
+    else:
+        from uuid import uuid1
+        return uuid1()
 
 openvpn_translate = {
     'des': 'des-cbc',

--- a/src/op_mode/ikev2_profile_generator.py
+++ b/src/op_mode/ikev2_profile_generator.py
@@ -168,6 +168,10 @@ for ca_name in data['authentication']['x509']['ca_certificate']:
         }
         data['ca_certificates'].append(tmp)
 
+# Remove duplicate list entries for CA certificates, as they are added by their common name
+# https://stackoverflow.com/a/9427216
+data['ca_certificates'] = [dict(t) for t in {tuple(d.items()) for d in data['ca_certificates']}]
+
 esp_proposals = conf.get_config_dict(ipsec_base + ['esp-group', data['esp_group'], 'proposal'],
                                      key_mangling=('-', '_'), get_first_key=True)
 ike_proposal = conf.get_config_dict(ipsec_base + ['ike-group', data['ike_group'], 'proposal'],


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

In e6fe6e50a5c ("op-mode: ipsec: T6407: fix profile generation") we fixed support for multiple CAs when dealing with the generation of Apple IOS profiles.

This commit extends support to properly include the common name of the server certificate issuer and all it's paren't CAs. A list of parent CAs is automatically generated from the "PKI" subsystem content and embedded into the resulting profile.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6424

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/3552

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

A resulting profile would look like this:

```xml
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <!-- Set the name to whatever you like, it is used in the profile list on the device -->
    <key>PayloadDisplayName</key>
    <string>VyOS IKEv2 Profile</string>
    <!-- This is a reverse-DNS style unique identifier used to detect duplicate profiles -->
    <key>PayloadIdentifier</key>
    <string>wue3.LR1</string>
    <!-- A globally unique identifier, use uuidgen on Linux/Mac OS X to generate it -->
    <key>PayloadUUID</key>
    <string>f735996a-265d-11ef-9e65-f2422b8b73f7</string>
    <key>PayloadType</key>
    <string>Configuration</string>
    <key>PayloadVersion</key>
    <integer>1</integer>
    <key>PayloadContent</key>
    <array>
        <!-- It is possible to add multiple VPN payloads with different identifiers/UUIDs and names -->
        <dict>
            <dict>
                <key>ServerCertificateIssuerCommonName</key>
                <string>CAcert Class 3 Root</string>
                <key>ServerCertificateCommonName</key>
                <string>ipsec.vyos.net</string>
                 ...
            </dict>
        </dict>
        <!-- This payload is optional but it provides an easy way to install the CA certificate together with the configuration -->
        <!-- Payload for: CAcert Class 3 Root -->
        <dict>
            <key>PayloadIdentifier</key>
            <string>org.cacert.class.3.root</string>
            <key>PayloadUUID</key>
            <string>158483b0-8df8-8146-e725-42d6ee51ba69</string>
            <key>PayloadType</key>
            <string>com.apple.security.root</string>
            <key>PayloadVersion</key>
            <integer>1</integer>
            <!-- This is the Base64 (PEM) encoded CA certificate -->
            <key>PayloadContent</key>
            <data>MIIGPTCCB,,,</data>
        </dict>
        <!-- Payload for: CA Cert Signing Authority -->
        <dict>
            <key>PayloadIdentifier</key>
            <string>org.ca.cert.signing.authority</string>
            <key>PayloadUUID</key>
            <string>ead21fee-8172-7060-e9b7-921b7c270556</string>
            <key>PayloadType</key>
            <string>com.apple.security.root</string>
            <key>PayloadVersion</key>
            <integer>1</integer>
            <!-- This is the Base64 (PEM) encoded CA certificate -->
            <key>PayloadContent</key>
            <data>MIIG7jCC...</data>
        </dict>
    </array>
</dict>
</plist>

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
