### PR TITLE
wireless: T6462: add op-mode command for hostapd and wpa_supplicant logs

### DIFF
--- a/op-mode-definitions/monitor-log.xml.in
+++ b/op-mode-definitions/monitor-log.xml.in
@@ -359,6 +359,47 @@
             </properties>
             <command>journalctl --no-hostname --boot --follow --unit keepalived.service</command>
           </leafNode>
+          <node name="wireless">
+            <properties>
+              <help>Monitor last lines of Wireless interface log</help>
+            </properties>
+            <children>
+              <node name="wpa-supplicant">
+                <properties>
+                  <help>Monitor last lines of WPA supplicant</help>
+                </properties>
+                <command>if cli-shell-api existsActive interfaces wireless; then journalctl --no-hostname --boot --follow --unit "wpa_supplicant@*.service"; else echo "No wireless interface configured!"; fi</command>
+                <children>
+                  <tagNode name="interface">
+                    <properties>
+                      <help>Monitor last lines of specific wireless interface supplicant</help>
+                      <completionHelp>
+                        <path>interfaces wireless</path>
+                      </completionHelp>
+                    </properties>
+                    <command>if [[ $(cli-shell-api returnActiveValue interfaces wireless $6 type) == "station" ]]; then journalctl --no-hostname --boot --follow --unit "wpa_supplicant@$6.service"; else echo "Wireless interface $6 not configured as station!"; fi</command>
+                  </tagNode>
+                </children>
+              </node>
+              <node name="hostapd">
+                <properties>
+                  <help>Monitor last lines of host access point daemon</help>
+                </properties>
+                <command>if cli-shell-api existsActive interfaces wireless; then journalctl --no-hostname --boot --follow --unit "hostapd@*.service"; else echo "No wireless interface configured!"; fi</command>
+                <children>
+                  <tagNode name="interface">
+                    <properties>
+                      <help>Monitor last lines of specific host access point interface</help>
+                      <completionHelp>
+                        <path>interfaces wireless</path>
+                      </completionHelp>
+                    </properties>
+                    <command>if [[ $(cli-shell-api returnActiveValue interfaces wireless $6 type) == "access-point" ]]; then journalctl --no-hostname --boot --follow --unit "hostapd@$6.service"; else echo "Wireless interface $6 not configured as access-point!"; fi</command>
+                  </tagNode>
+                </children>
+              </node>
+            </children>
+          </node>
         </children>
       </node>
     </children>

--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -762,6 +762,47 @@
             </properties>
             <command>journalctl --no-hostname --boot --unit keepalived.service</command>
           </leafNode>
+          <node name="wireless">
+            <properties>
+              <help>Show log for Wireless interface</help>
+            </properties>
+            <children>
+              <node name="wpa-supplicant">
+                <properties>
+                  <help>Show log for WPA supplicant</help>
+                </properties>
+                <command>if cli-shell-api existsActive interfaces wireless; then journalctl --no-hostname --boot --unit "wpa_supplicant@*.service"; else echo "No wireless interface configured!"; fi</command>
+                <children>
+                  <tagNode name="interface">
+                    <properties>
+                      <help>Show log for specific wireless interface supplicant</help>
+                      <completionHelp>
+                        <path>interfaces wireless</path>
+                      </completionHelp>
+                    </properties>
+                    <command>if [[ $(cli-shell-api returnActiveValue interfaces wireless $6 type) == "station" ]]; then journalctl --no-hostname --boot --unit "wpa_supplicant@$6.service"; else echo "Wireless interface $6 not configured as station!"; fi</command>
+                  </tagNode>
+                </children>
+              </node>
+              <node name="hostapd">
+                <properties>
+                  <help>Show log for host access point daemon</help>
+                </properties>
+                <command>if cli-shell-api existsActive interfaces wireless; then journalctl --no-hostname --boot --unit "hostapd@*.service"; else echo "No wireless interface configured!"; fi</command>
+                <children>
+                  <tagNode name="interface">
+                    <properties>
+                      <help>Show log for specific host access point daemon interface</help>
+                      <completionHelp>
+                        <path>interfaces wireless</path>
+                      </completionHelp>
+                    </properties>
+                    <command>if [[ $(cli-shell-api returnActiveValue interfaces wireless $6 type) == "access-point" ]]; then journalctl --no-hostname --boot --unit "hostapd@$6.service"; else echo "Wireless interface $6 not configured as access-point!"; fi</command>
+                  </tagNode>
+                </children>
+              </node>
+            </children>
+          </node>
           <leafNode name="webproxy">
             <properties>
               <help>Show log for Webproxy</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

There is currently no easy CLI-ish way to read the logs from hostapd and wpa_supplicant for wireless connections

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6462

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireless interfaces

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

* `monitor log wireless hostapd [interface <name>]`
* `monitor log wireless wpa-supplicant [interface <name>]`
* `show log wireless hostapd [interface <name>]`
* `show log wireless wpa-supplicant [interface <name>]`

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
