### PR TITLE
T6219: Add support for container sysctl parameter

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -71,6 +71,26 @@
               <multi/>
             </properties>
           </leafNode>
+          <tagNode name="kernel-parameter">
+            <properties>
+              <help>Add custom kernel parameters (sysctl)</help>
+              <constraint>
+                <regex>[._a-z*]+</regex>
+              </constraint>
+              <constraintErrorMessage>Kernel parameter name must be alphanumeric and can contain periods, asterisks and underscores</constraintErrorMessage>
+            </properties>
+            <children>
+              <leafNode name="value">
+                <properties>
+                  <help>Set kernel parameter option value</help>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>Set kernel parameter option value</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
+            </children>
+          </tagNode>
           #include <include/generic-description.xml.i>
           <tagNode name="device">
             <properties>

--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -71,26 +71,35 @@
               <multi/>
             </properties>
           </leafNode>
-          <tagNode name="kernel-parameter">
+          <node name="sysctl">
             <properties>
-              <help>Add custom kernel parameters (sysctl)</help>
-              <constraint>
-                <regex>[._a-z*]+</regex>
-              </constraint>
-              <constraintErrorMessage>Kernel parameter name must be alphanumeric and can contain periods, asterisks and underscores</constraintErrorMessage>
+              <help>Configure namespaced kernel parameters of the container</help>
             </properties>
             <children>
-              <leafNode name="value">
+              <tagNode name="parameter">
                 <properties>
-                  <help>Set kernel parameter option value</help>
+                  <help>Sysctl key name</help>
+                  <completionHelp>
+                    <script>${vyos_completion_dir}/list_container_sysctl_parameters.sh</script>
+                  </completionHelp>
                   <valueHelp>
                     <format>txt</format>
-                    <description>Set kernel parameter option value</description>
+                    <description>Sysctl key name</description>
                   </valueHelp>
+                  <constraint>
+                    <validator name="sysctl"/>
+                  </constraint>
                 </properties>
-              </leafNode>
+                <children>
+                  <leafNode name="value">
+                    <properties>
+                      <help>Sysctl configuration value</help>
+                    </properties>
+                  </leafNode>
+                </children>
+              </tagNode>
             </children>
-          </tagNode>
+          </node>
           #include <include/generic-description.xml.i>
           <tagNode name="device">
             <properties>

--- a/smoketest/config-tests/container-simple
+++ b/smoketest/config-tests/container-simple
@@ -11,4 +11,4 @@ set container name c02 allow-host-networks
 set container name c02 allow-host-pid
 set container name c02 capability 'sys-time'
 set container name c02 image 'busybox:stable'
-set container name c02 kernel-parameter 'net.ipv4.conf.all.forwarding' value '1'
+set container name c02 sysctl parameter kernel.msgmax value '8192'

--- a/smoketest/config-tests/container-simple
+++ b/smoketest/config-tests/container-simple
@@ -11,3 +11,4 @@ set container name c02 allow-host-networks
 set container name c02 allow-host-pid
 set container name c02 capability 'sys-time'
 set container name c02 image 'busybox:stable'
+set container name c02 kernel-parameter 'net.ipv4.conf.all.forwarding' value '1'

--- a/smoketest/configs/container-simple
+++ b/smoketest/configs/container-simple
@@ -10,6 +10,9 @@ container {
         allow-host-pid
         cap-add sys-time
         image busybox:stable
+        kernel-parameter "net.ipv4.ip_forward" {
+            value "1"
+        }
     }
 }
 interfaces {

--- a/smoketest/configs/container-simple
+++ b/smoketest/configs/container-simple
@@ -10,8 +10,10 @@ container {
         allow-host-pid
         cap-add sys-time
         image busybox:stable
-        kernel-parameter "net.ipv4.ip_forward" {
-            value "1"
+        sysctl {
+            parameter kernel.msgmax {
+                value "8192"
+            }
         }
     }
 }

--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -80,6 +80,7 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
 
         self.cli_set(base_path + ['name', cont_name, 'image', cont_image])
         self.cli_set(base_path + ['name', cont_name, 'allow-host-networks'])
+        self.cli_set(base_path + ['name', cont_name, 'sysctl', 'parameter', 'kernel.msgmax', 'value', '4096'])
 
         # commit changes
         self.cli_commit()
@@ -90,6 +91,10 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
 
         # Check for running process
         self.assertEqual(process_named_running(PROCESS_NAME), pid)
+
+        # verify
+        tmp = cmd(f'sudo podman exec -it {cont_name} sysctl kernel.msgmax')
+        self.assertEqual(tmp, 'kernel.msgmax = 4096')
 
     def test_cpu_limit(self):
         cont_name = 'c2'

--- a/src/completion/list_container_sysctl_parameters.sh
+++ b/src/completion/list_container_sysctl_parameters.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+declare -a vals
+eval "vals=($(/sbin/sysctl -N -a|grep -E '^(fs.mqueue|net)\.|^(kernel.msgmax|kernel.msgmnb|kernel.msgmni|kernel.sem|kernel.shmall|kernel.shmmax|kernel.shmmni|kernel.shm_rmid_forced)$'))"
+echo ${vals[@]}
+exit 0


### PR DESCRIPTION
I can't append to #3288, so I took the liberty to build upon it.
Aligned configuration with system sysctl and added completion with allowed sysctl values for container

## Change Summary
Allow setting sysctl settings for containers

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6219

## Related PR(s)
#3288

## Component(s) name
container

## Proposed changes
Adds support for configuring a container with the sysctl option:
```
container {
    name c1 {
        allow-host-networks
        image "busybox:stable"
        sysctl {
            parameter kernel.msgmax {
                value "8192"
            }
        }
    }
}
```

## How to test
```
set container name c1 image busybox:stable
set container name c1 allow-host-networks
set container name c1 sysctl parameter kernel.msgmax value 8192
```

## Smoketest result
```
test_basic (__main__.TestContainer.test_basic) ... ok
test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... 
IP address "192.0.2.1" can not be used for a container, reserved for the
container engine!

ok
test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... 
IP address "192.0.2.1" can not be used for a container, reserved for the
container engine!

ok
test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... 
IP address "2001:db8::1" can not be used for a container, reserved for
the container engine!

ok
test_uid_gid (__main__.TestContainer.test_uid_gid) ... 
Cannot set "gid" without "uid" for container

ok

----------------------------------------------------------------------
Ran 5 tests in 146.650s
```

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
