### PR TITLE
firewall: T4694: Adding rt ipsec exists/missing match to firewall configs

### DIFF
--- a/interface-definitions/include/firewall/common-rule-inet.xml.i
+++ b/interface-definitions/include/firewall/common-rule-inet.xml.i
@@ -7,7 +7,6 @@
 #include <include/generic-disable-node.xml.i>
 #include <include/firewall/dscp.xml.i>
 #include <include/firewall/fragment.xml.i>
-#include <include/firewall/match-ipsec.xml.i>
 #include <include/firewall/limit.xml.i>
 #include <include/firewall/log.xml.i>
 #include <include/firewall/log-options.xml.i>

--- a/interface-definitions/include/firewall/common-rule-ipv4-raw.xml.i
+++ b/interface-definitions/include/firewall/common-rule-ipv4-raw.xml.i
@@ -9,7 +9,6 @@
 #include <include/firewall/limit.xml.i>
 #include <include/firewall/log.xml.i>
 #include <include/firewall/log-options.xml.i>
-#include <include/firewall/match-ipsec.xml.i>
 #include <include/firewall/protocol.xml.i>
 #include <include/firewall/nft-queue.xml.i>
 #include <include/firewall/recent.xml.i>

--- a/interface-definitions/include/firewall/common-rule-ipv6-raw.xml.i
+++ b/interface-definitions/include/firewall/common-rule-ipv6-raw.xml.i
@@ -9,7 +9,6 @@
 #include <include/firewall/limit.xml.i>
 #include <include/firewall/log.xml.i>
 #include <include/firewall/log-options.xml.i>
-#include <include/firewall/match-ipsec.xml.i>
 #include <include/firewall/protocol.xml.i>
 #include <include/firewall/nft-queue.xml.i>
 #include <include/firewall/recent.xml.i>

--- a/interface-definitions/include/firewall/ipv4-hook-input.xml.i
+++ b/interface-definitions/include/firewall/ipv4-hook-input.xml.i
@@ -27,7 +27,7 @@
           <children>
             #include <include/firewall/common-rule-ipv4.xml.i>
             #include <include/firewall/inbound-interface.xml.i>
-            #include <include/firewall/match-ipsec.xml.i>
+            #include <include/firewall/match-ipsec-in.xml.i>
           </children>
         </tagNode>
       </children>

--- a/interface-definitions/include/firewall/ipv4-hook-output.xml.i
+++ b/interface-definitions/include/firewall/ipv4-hook-output.xml.i
@@ -26,6 +26,7 @@
           </properties>
           <children>
             #include <include/firewall/common-rule-ipv4.xml.i>
+            #include <include/firewall/match-ipsec-out.xml.i>
             #include <include/firewall/outbound-interface.xml.i>
           </children>
         </tagNode>
@@ -53,6 +54,7 @@
           </properties>
           <children>
             #include <include/firewall/common-rule-ipv4-raw.xml.i>
+            #include <include/firewall/match-ipsec-out.xml.i>
             #include <include/firewall/outbound-interface.xml.i>
           </children>
         </tagNode>

--- a/interface-definitions/include/firewall/ipv4-hook-prerouting.xml.i
+++ b/interface-definitions/include/firewall/ipv4-hook-prerouting.xml.i
@@ -33,6 +33,7 @@
           </properties>
           <children>
             #include <include/firewall/common-rule-ipv4-raw.xml.i>
+            #include <include/firewall/match-ipsec-in.xml.i>
             #include <include/firewall/inbound-interface.xml.i>
             <leafNode name="jump-target">
               <properties>

--- a/interface-definitions/include/firewall/ipv6-hook-input.xml.i
+++ b/interface-definitions/include/firewall/ipv6-hook-input.xml.i
@@ -27,7 +27,7 @@
           <children>
             #include <include/firewall/common-rule-ipv6.xml.i>
             #include <include/firewall/inbound-interface.xml.i>
-            #include <include/firewall/match-ipsec.xml.i>
+            #include <include/firewall/match-ipsec-in.xml.i>
           </children>
         </tagNode>
       </children>

--- a/interface-definitions/include/firewall/ipv6-hook-output.xml.i
+++ b/interface-definitions/include/firewall/ipv6-hook-output.xml.i
@@ -26,6 +26,7 @@
           </properties>
           <children>
             #include <include/firewall/common-rule-ipv6.xml.i>
+            #include <include/firewall/match-ipsec-out.xml.i>
             #include <include/firewall/outbound-interface.xml.i>
           </children>
         </tagNode>
@@ -53,6 +54,7 @@
           </properties>
           <children>
             #include <include/firewall/common-rule-ipv6-raw.xml.i>
+            #include <include/firewall/match-ipsec-out.xml.i>
             #include <include/firewall/outbound-interface.xml.i>
           </children>
         </tagNode>

--- a/interface-definitions/include/firewall/ipv6-hook-prerouting.xml.i
+++ b/interface-definitions/include/firewall/ipv6-hook-prerouting.xml.i
@@ -33,6 +33,7 @@
           </properties>
           <children>
             #include <include/firewall/common-rule-ipv6-raw.xml.i>
+            #include <include/firewall/match-ipsec-in.xml.i>
             #include <include/firewall/inbound-interface.xml.i>
             <leafNode name="jump-target">
               <properties>

--- a/interface-definitions/include/firewall/match-ipsec-in.xml.i
+++ b/interface-definitions/include/firewall/match-ipsec-in.xml.i
@@ -1,0 +1,21 @@
+<!-- include start from firewall/match-ipsec-in.xml.i -->
+<node name="ipsec">
+  <properties>
+    <help>Inbound IPsec packets</help>
+  </properties>
+  <children>
+    <leafNode name="match-ipsec-in">
+      <properties>
+        <help>Inbound traffic that was IPsec encapsulated</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+    <leafNode name="match-none-in">
+      <properties>
+        <help>Inbound traffic that was not IPsec encapsulated</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/firewall/match-ipsec-out.xml.i
+++ b/interface-definitions/include/firewall/match-ipsec-out.xml.i
@@ -1,0 +1,21 @@
+<!-- include start from firewall/match-ipsec-out.xml.i -->
+<node name="ipsec">
+  <properties>
+    <help>Outbound IPsec packets</help>
+  </properties>
+  <children>
+    <leafNode name="match-ipsec-out">
+      <properties>
+        <help>Outbound traffic to be IPsec encapsulated</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+    <leafNode name="match-none-out">
+      <properties>
+        <help>Outbound traffic that will not be IPsec encapsulated</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/firewall/match-ipsec.xml.i
+++ b/interface-definitions/include/firewall/match-ipsec.xml.i
@@ -1,21 +1,33 @@
 <!-- include start from firewall/match-ipsec.xml.i -->
 <node name="ipsec">
   <properties>
-    <help>Inbound IPsec packets</help>
+    <help>IPsec encapsulated packets</help>
   </properties>
   <children>
-    <leafNode name="match-ipsec">
+    <leafNode name="match-ipsec-in">
       <properties>
-        <help>Inbound IPsec packets</help>
+        <help>Inbound traffic that was IPsec encapsulated</help>
         <valueless/>
       </properties>
     </leafNode>
-    <leafNode name="match-none">
+    <leafNode name="match-none-in">
       <properties>
-        <help>Inbound non-IPsec packets</help>
+        <help>Inbound traffic that was not IPsec encapsulated</help>
         <valueless/>
       </properties>
     </leafNode>
+    <leafNode name="match-ipsec-out">
+      <properties>
+        <help>Outbound traffic to be IPsec encapsulated</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+    <leafNode name="match-none-out">
+      <properties>
+        <help>Outbound traffic that will not be IPsec encapsulated</help>
+        <valueless/>
+      </properties>
+    </leafNode>    
   </children>
 </node>
 <!-- include end -->

--- a/interface-definitions/include/version/firewall-version.xml.i
+++ b/interface-definitions/include/version/firewall-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/firewall-version.xml.i -->
-<syntaxVersion component='firewall' version='16'></syntaxVersion>
+<syntaxVersion component='firewall' version='17'></syntaxVersion>
 <!-- include end -->

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -366,10 +366,14 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
         output.append(f'ip{def_suffix} dscp != {{{negated_dscp_str}}}')
 
     if 'ipsec' in rule_conf:
-        if 'match_ipsec' in rule_conf['ipsec']:
+        if 'match_ipsec_in' in rule_conf['ipsec']:
             output.append('meta ipsec == 1')
-        if 'match_none' in rule_conf['ipsec']:
+        if 'match_none_in' in rule_conf['ipsec']:
             output.append('meta ipsec == 0')
+        if 'match_ipsec_out' in rule_conf['ipsec']:
+            output.append('rt ipsec exists')
+        if 'match_none_out' in rule_conf['ipsec']:
+            output.append('rt ipsec missing')
 
     if 'fragment' in rule_conf:
         # Checking for fragmentation after priority -400 is not possible,

--- a/src/migration-scripts/firewall/16-to-17
+++ b/src/migration-scripts/firewall/16-to-17
@@ -1,0 +1,60 @@
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#
+# T4694: Adding rt ipsec exists/missing match to firewall configs.
+# This involves a syntax change for IPsec matches, reflecting that different 
+# nftables expressions are required depending on whether we're matching a 
+# decrypted packet or a packet that will be encrypted - it's directional. 
+# The old rules only matched decrypted packets, those matches are now *-in:
+    # from: set firewall <family> <chainspec> rule <rule#> ipsec match-ipsec|match-none
+    #   to: set firewall <family> <chainspec> rule <rule#> ipsec match-ipsec-in|match-none-in
+#
+# The <chainspec> positions this match allowed were:
+# name (any custom chains), forward filter, input filter, prerouting raw.
+# There are positions where it was possible to set, but it would never commit 
+# (nftables rejects 'meta ipsec' in output hooks), they are not considered here.
+#
+
+import sys
+
+from vyos.configtree import ConfigTree
+
+firewall_base = ['firewall']
+
+def migrate_chain(config: ConfigTree, path: list[str]) -> None:
+    for rule_num in config.list_nodes(path + ['rule']):
+        tmp_path = path + ['rule', rule_num, 'ipsec']
+        if config.exists(tmp_path + ['match-ipsec']):
+            config.delete(tmp_path + ['match-ipsec'])
+            config.set(tmp_path + ['match-ipsec-in'])
+        elif config.exists(tmp_path + ['match-none']):
+            config.delete(tmp_path + ['match-none'])
+            config.set(tmp_path + ['match-none-in'])
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(firewall_base):
+        # Nothing to do
+        return
+
+    for family in ['ipv4', 'ipv6']:
+        tmp_path = firewall_base + [family, 'name']
+        if config.exists(tmp_path):
+            for custom_fwname in config.list_nodes(tmp_path):
+                migrate_chain(config, tmp_path + [custom_fwname])
+
+        for base_hook in [['forward', 'filter'], ['input', 'filter'], ['prerouting', 'raw']]:
+            tmp_path = firewall_base + [family] + base_hook
+            if config.exists(tmp_path):
+                migrate_chain(config, tmp_path)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Current firewall syntax only permits inbound matching of IPsec, using "meta ipsec", which indicates a packet was decrypted from IPsec encap.

This extends firewall capability to also be able to match outbound traffic using "rt ipsec", which indicates a packet will be encrypted into an IPsec encap. 

"meta ipsec" is not valid (nft will refuse to load config) inside output hooks so additional care has been taken to ensure it doesn't end up in output or any inappropriate jump targets from an output chain. 

In doing these checks, I've also added an infinite jump-target loop check to the validation pass. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Changes to existing firewall ipsec match syntax

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T4694
* https://vyos.dev/T4667

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/3637

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* firewall

## Proposed changes
<!--- Describe your changes in detail -->
I've covered some concerns I have about my implementation in the forum: https://forum.vyos.io/t/outbound-ipsec-filtering-by-firewall-would-like-some-dev-opinions/14710.

 * Change ipsec match-ipsec/none to match-ipsec-in and match-none-in for fw rules
 * Add ipsec match-ipsec-out and match-none-out
   * *-in means "decrypted" and *-out means "encrypting", the names may benefit from tweaking to make intent clearer
 * Change all the points where the match-ipsec.xml.i include was used before, making sure the new includes (match-ipsec-in/out.xml.i) are used appropriately. There were a handful of spots where match-ipsec.xml.i had snuck back in for output hooked chains already (the common-rule-* includes)
 * Add the -out generators to rendered templates
 * Heavy modification to firewall config validators:
   * I needed to check for ipsec-in matches no matter how deeply nested under an output-hook chain(via jump-target) - this always generates an error.
   * Ended up retrofitting the jump-targets validator from root chains and for named custom chains. It checks for recursive loops and bad IPsec. However, it could be improved - it will not detect a cycle between 2 otherwise un-referenced named chains.
    * Alternatively, perhaps custom chains shouldn't be able to jump or have depth restrictions. The code is already capable of the latter (currently issues a depth warning at 7 jumps deep).

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

* Configured VyOS testing pair in a "triangle" (LEFT -> FAKEWWW <- RIGHT)
* 2 additional VMs behind LEFT and RIGHT for forward/prerouting chain testing
* Applied numerous combinations of GRE & IPsec matches in logging/nflogging rules across all filter chains
* Created several common IPsec & clear use cases for both ptp and forwarded traffic:
  * DMVPN clear
  * DMVPN encrypted
  * IPsec transport, PtP GRE encrypted
  * IPsec tunnel mode
* Checking dmesg output and tcpdump on FAKEWWW for expected operation in hitting all the right rules
* Combined with GRE-match PR for complete testing in a handful of logical and completely stupid scenarios
* Created specific scenarios for blocking DMVPN traffic in the clear when SAs go down, without interfering with other GRE/IPsec traffic, checking coverage on the original ticket issues
* Exercised validators and ensured all possible combinations of new matches to chains result in working nftables rules. 

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Note, the groups failure below is also encountered in a clean rolling image:
```
# python3 /usr/libexec/vyos/tests/smoke/cli/test_firewall.py 
test_bridge_basic_rules (__main__.TestFirewall.test_bridge_basic_rules) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
test_geoip (__main__.TestFirewall.test_geoip) ... ok
test_groups (__main__.TestFirewall.test_groups) ... FAIL
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_dynamic_groups (__main__.TestFirewall.test_ipv4_dynamic_groups) ... ok
test_ipv4_global_state (__main__.TestFirewall.test_ipv4_global_state) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_dynamic_groups (__main__.TestFirewall.test_ipv6_dynamic_groups) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_timeout_sysctl (__main__.TestFirewall.test_timeout_sysctl) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... ok

======================================================================
FAIL: test_groups (__main__.TestFirewall.test_groups)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/libexec/vyos/tests/smoke/cli/test_firewall.py", line 152, in test_groups
    self.verify_nftables(nftables_search, 'ip vyos_filter')
  File "/usr/libexec/vyos/tests/smoke/cli/base_vyostest_shim.py", line 122, in verify_nftables
    self.assertTrue(not matched if inverse else matched, msg=search)
AssertionError: False is not true : ['elements = { 192.0.2.5, 192.0.2.8,']

----------------------------------------------------------------------
Ran 21 tests in 184.628s

FAILED (failures=1)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
