### PR TITLE
T6442: CGNAT add log for address allocation

### DIFF
--- a/interface-definitions/nat_cgnat.xml.in
+++ b/interface-definitions/nat_cgnat.xml.in
@@ -8,6 +8,12 @@
           <priority>221</priority>
         </properties>
         <children>
+          <leafNode name="log-allocation">
+            <properties>
+              <help>Log IP address and port allocation</help>
+              <valueless/>
+            </properties>
+          </leafNode>
           <node name="pool">
             <properties>
               <help>External and internal pool parameters</help>

--- a/src/conf_mode/nat_cgnat.py
+++ b/src/conf_mode/nat_cgnat.py
@@ -16,9 +16,11 @@
 
 import ipaddress
 import jmespath
+import logging
 import os
 
 from sys import exit
+from logging.handlers import SysLogHandler
 
 from vyos.config import Config
 from vyos.template import render
@@ -31,6 +33,18 @@ airbag.enable()
 
 
 nftables_cgnat_config = '/run/nftables-cgnat.nft'
+
+# Logging
+logger = logging.getLogger('cgnat')
+logger.setLevel(logging.DEBUG)
+
+syslog_handler = SysLogHandler(address="/dev/log")
+syslog_handler.setLevel(logging.INFO)
+
+formatter = logging.Formatter('%(name)s: %(message)s')
+syslog_handler.setFormatter(formatter)
+
+logger.addHandler(syslog_handler)
 
 
 class IPOperations:
@@ -314,6 +328,22 @@ def apply(config):
             os.unlink(nftables_cgnat_config)
         return None
     cmd(f'nft --file {nftables_cgnat_config}')
+
+    # Logging allocations
+    if 'log_allocation' in config:
+        allocations = config['proto_map_elements']
+        allocations = allocations.split(',')
+        for allocation in allocations:
+            try:
+                # Split based on the delimiters used in the nft data format
+                internal_host, rest = allocation.split(' : ')
+                external_host, port_range = rest.split(' . ')
+                # Log the parsed data
+                logger.info(
+                    f"Internal host: {internal_host.lstrip()}, external host: {external_host}, Port range: {port_range}")
+            except ValueError as e:
+                # Log error message
+                logger.error(f"Error processing line '{allocation}': {e}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add the configuration command to log the current CGNAT allocation.
```
set nat cgnat log-allocation
```
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6442

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
cgnat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set nat cgnat log-allocation
set nat cgnat pool external ext-01 external-port-range '1024-65535'
set nat cgnat pool external ext-01 per-user-limit port '2000'
set nat cgnat pool external ext-01 range 192.168.122.222/32
set nat cgnat pool internal int-01 range '100.64.0.0/28'
set nat cgnat rule 10 source pool 'int-01'
set nat cgnat rule 10 translation pool 'ext-01'
```
Check logs:
```
Jun 10 14:10:02 r4 sudo[9057]:     vyos : TTY=pts/0 ; PWD=/home/vyos ; USER=root ; COMMAND=/usr/bin/sh -c ' /usr/libexec/vyos/conf_mode/nat_cgnat.py'
Jun 10 14:10:02 r4 sudo[9057]: pam_unix(sudo:session): session opened for user root(uid=0) by vyos(uid=1003)
Jun 10 14:10:03 r4 cgnat[9059]: Internal host: 100.64.0.0, external host: 192.168.122.222, Port range: 1024-3023
Jun 10 14:10:03 r4 cgnat[9059]: Internal host: 100.64.0.1, external host: 192.168.122.222, Port range: 3024-5023
Jun 10 14:10:03 r4 cgnat[9059]: Internal host: 100.64.0.2, external host: 192.168.122.222, Port range: 5024-7023
Jun 10 14:10:03 r4 cgnat[9059]: Internal host: 100.64.0.3, external host: 192.168.122.222, Port range: 7024-9023
Jun 10 14:10:03 r4 cgnat[9059]: Internal host: 100.64.0.4, external host: 192.168.122.222, Port range: 9024-11023
Jun 10 14:10:03 r4 cgnat[9059]: Internal host: 100.64.0.5, external host: 192.168.122.222, Port range: 11024-13023
Jun 10 14:10:03 r4 cgnat[9059]: Internal host: 100.64.0.6, external host: 192.168.122.222, Port range: 13024-15023
Jun 10 14:10:03 r4 cgnat[9059]: Internal host: 100.64.0.7, external host: 192.168.122.222, Port range: 15024-17023
Jun 10 14:10:03 r4 cgnat[9059]: Internal host: 100.64.0.8, external host: 192.168.122.222, Port range: 17024-19023
Jun 10 14:10:03 r4 cgnat[9059]: Internal host: 100.64.0.9, external host: 192.168.122.222, Port range: 19024-21023
Jun 10 14:10:03 r4 cgnat[9059]: Internal host: 100.64.0.10, external host: 192.168.122.222, Port range: 21024-23023
Jun 10 14:10:03 r4 cgnat[9059]: Internal host: 100.64.0.11, external host: 192.168.122.222, Port range: 23024-25023
Jun 10 14:10:03 r4 cgnat[9059]: Internal host: 100.64.0.12, external host: 192.168.122.222, Port range: 25024-27023
Jun 10 14:10:03 r4 cgnat[9059]: Internal host: 100.64.0.13, external host: 192.168.122.222, Port range: 27024-29023
Jun 10 14:10:03 r4 cgnat[9059]: Internal host: 100.64.0.14, external host: 192.168.122.222, Port range: 29024-31023
Jun 10 14:10:03 r4 cgnat[9059]: Internal host: 100.64.0.15, external host: 192.168.122.222, Port range: 31024-33023
Jun 10 14:10:03 r4 sudo[9057]: pam_unix(sudo:session): session closed for user root

```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_cgnat.py
test_cgnat (__main__.TestCGNAT.test_cgnat) ... 


ok
test_cgnat_sequence (__main__.TestCGNAT.test_cgnat_sequence) ... ok

----------------------------------------------------------------------
Ran 2 tests in 28.574s

OK
vyos@r4:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
