### PR TITLE
T5931: Add option to append route-target when adding additional imports

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -412,18 +412,18 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
   route-target vpn both {{ afi_config.route_target.vpn.both }}
 {%         else %}
 {%             if afi_config.route_target.vpn.export is vyos_defined %}
-  {%             if afi_config.route_target.vpn.export is iterable and not afi_config.route_target.vpn.export is string %}
+{%                 if afi_config.route_target.vpn.export is iterable and not afi_config.route_target.vpn.export is string %}
   route-target vpn export {{ afi_config.route_target.vpn.export | join(' ') }}
-  {%             else %}
+{%                 else %}
   route-target vpn export {{ afi_config.route_target.vpn.export }}
-  {%             endif %}
+{%                 endif %}
 {%             endif %}
 {%             if afi_config.route_target.vpn.import is vyos_defined %}
-  {%             if afi_config.route_target.vpn.import is iterable and not afi_config.route_target.vpn.import is string %}
+{%                 if afi_config.route_target.vpn.import is iterable and not afi_config.route_target.vpn.import is string %}
   route-target vpn import {{ afi_config.route_target.vpn.import | join(' ') }}
-  {%             else %}
+{%                 else %}
   route-target vpn import {{ afi_config.route_target.vpn.import }}
-  {%             endif %}
+{%                 endif %}
 {%             endif %}
 {%         endif %}
 {%         if afi_config.route_target.both is vyos_defined %}

--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -412,10 +412,18 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
   route-target vpn both {{ afi_config.route_target.vpn.both }}
 {%         else %}
 {%             if afi_config.route_target.vpn.export is vyos_defined %}
+  {%             if afi_config.route_target.vpn.export is iterable and not afi_config.route_target.vpn.export is string %}
+  route-target vpn export {{ afi_config.route_target.vpn.export | join(' ') }}
+  {%             else %}
   route-target vpn export {{ afi_config.route_target.vpn.export }}
+  {%             endif %}
 {%             endif %}
 {%             if afi_config.route_target.vpn.import is vyos_defined %}
+  {%             if afi_config.route_target.vpn.import is iterable and not afi_config.route_target.vpn.import is string %}
+  route-target vpn import {{ afi_config.route_target.vpn.import | join(' ') }}
+  {%             else %}
   route-target vpn import {{ afi_config.route_target.vpn.import }}
+  {%             endif %}
 {%             endif %}
 {%         endif %}
 {%         if afi_config.route_target.both is vyos_defined %}

--- a/interface-definitions/include/bgp/afi-route-target-vpn.xml.i
+++ b/interface-definitions/include/bgp/afi-route-target-vpn.xml.i
@@ -31,6 +31,7 @@
             <constraint>
               <validator name="bgp-rd-rt" argument="--route-target-multi"/>
             </constraint>
+            <multi/>
           </properties>
         </leafNode>
         <leafNode name="export">
@@ -43,6 +44,7 @@
             <constraint>
               <validator name="bgp-rd-rt" argument="--route-target-multi"/>
             </constraint>
+            <multi/>
           </properties>
         </leafNode>
       </children>


### PR DESCRIPTION
This PR adds the ability to have multiple import/export lines of route-target configs within the VPN address-family.
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T5931
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
frr, bdgd
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Prior to the change, you could only configure a single import or export line. This required you to place the route-targets in a space separated string:
```
set vrf name Admins protocols bgp address-family ipv4-unicast route-target vpn import '1:1 1:2'
```
After the change, you can have those on a single line. This logic more falls in line with industry standards when configuring route-targets:
```
set vrf name Admins protocols bgp address-family ipv4-unicast route-target vpn import '1:1'
set vrf name Admins protocols bgp address-family ipv4-unicast route-target vpn import '1:2'
```
Verification can be performed within FRR:
```
router bgp 65000 vrf Admins
 address-family ipv4 unicast
  rt vpn import 1:1 1:2
 exit-address-family
```
Configurations that contain space separated values can still exist alongside the additional config:
```
set vrf name Admins protocols bgp address-family ipv4-unicast route-target vpn import '1:1'
set vrf name Admins protocols bgp address-family ipv4-unicast route-target vpn import '1:2'
set vrf name Admins protocols bgp address-family ipv4-unicast route-target vpn import '1:3 1:4'

router bgp 65000 vrf Admins
 address-family ipv4 unicast
  rt vpn import 1:1 1:2 1:3 1:4
 exit-address-family
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
