### PR TITLE
op-mode: T6471: add optimized get_config_dict

### DIFF
--- a/python/vyos/utils/dict.py
+++ b/python/vyos/utils/dict.py
@@ -307,6 +307,13 @@ def dict_to_paths(d: dict) -> list:
     for r in func(d, []):
         yield r
 
+def embed_dict(p: list[str], d: dict) -> dict:
+    path = p.copy()
+    ret = d
+    while path:
+        ret = {path.pop(): ret}
+    return ret
+
 def check_mutually_exclusive_options(d, keys, required=False):
     """ Checks if a dict has at most one or only one of
     mutually exclusive keys.

--- a/python/vyos/utils/error.py
+++ b/python/vyos/utils/error.py
@@ -1,0 +1,24 @@
+# Copyright 2024 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+from enum import IntEnum
+
+class cli_shell_api_err(IntEnum):
+    """ vyatta-cfg/src/vyos-errors.h """
+    VYOS_SUCCESS = 0
+    VYOS_GENERAL_FAILURE = 1
+    VYOS_INVALID_PATH = 2
+    VYOS_EMPTY_CONFIG = 3
+    VYOS_CONFIG_PARSE_ERROR = 4


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add a faster `get_config_dict` for use by op-mode commands. This function avoids the overhead of reading the full config-dict in `Config` (implicitly used by `ConfigTreeQuery`) --- the overhead is necessary for config-mode, and is moderated by vyos-configd and caching; it is unnecessary and slow in op-mode, which has no daemon (yet).

Note that a low-level Popen is used instead of a vyos.utils.process function, as it was noticed that as well incurred a heavy performance hit: this will be investigated in a separate task.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe):
        Performance improvement available for op-mode scripts.

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Loading a non-trivial config (using vyos-1x/smoketest/configs/bgp-big-as-cloud), test with a Python script, as one would call in a op-mode show command, with interpreter startup and import overhead intact:

```
#!/usr/bin/env python3

import argparse

from vyos.configquery import ConfigTreeQuery
from vyos.configquery import op_mode_config_dict

parser = argparse.ArgumentParser()
parser.add_argument('--path', nargs='*', help='path to subtree')
parser.add_argument('--op-mode', action='store_true', help='use op-mode version')
parser.add_argument('--no-print', action='store_true', help='no output, for timing test')
args = parser.parse_args()

path = args.path

if args.op_mode:
    out = op_mode_config_dict(path)
else:
    out = ConfigTreeQuery().get_config_dict(path)
        
if not args.no_print:
    print(out)

```
Results (representative example over repeated runs):

```
vyos@vyos:~$ time ./config_dict.py --path interfaces ethernet --no-print

real    0m0.373s
user    0m0.156s
sys     0m0.212s
vyos@vyos:~$ time ./config_dict.py --path interfaces ethernet --no-print --op-mode

real    0m0.133s
user    0m0.083s
sys     0m0.050s
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
