### PR TITLE
firewall: T4694: Adding GRE flags & fields matches to firewall rules

### DIFF
--- a/interface-definitions/include/firewall/common-rule-inet.xml.i
+++ b/interface-definitions/include/firewall/common-rule-inet.xml.i
@@ -19,5 +19,6 @@
 #include <include/firewall/synproxy.xml.i>
 #include <include/firewall/tcp-flags.xml.i>
 #include <include/firewall/tcp-mss.xml.i>
+#include <include/firewall/gre.xml.i>
 #include <include/firewall/time.xml.i>
 <!-- include end -->

--- a/interface-definitions/include/firewall/gre.xml.i
+++ b/interface-definitions/include/firewall/gre.xml.i
@@ -1,0 +1,116 @@
+<!-- include start from firewall/gre.xml.i -->
+<node name="gre">
+  <properties>
+    <help>GRE fields to match</help>
+  </properties>
+  <children>
+    <node name="flags">
+      <properties>
+        <help>GRE flag bits to match</help>
+      </properties>
+      <children>
+        <node name="key">
+          <properties>
+            <help>Header includes optional key field</help>
+          </properties>
+          <children>
+            <leafNode name="unset">
+              <properties>
+                <help>Header does not include optional key field</help>
+                <valueless/>
+              </properties>
+            </leafNode>
+          </children>
+        </node>
+        <node name="checksum">
+          <properties>
+            <help>Header includes optional checksum</help>
+          </properties>
+          <children>
+            <leafNode name="unset">
+              <properties>
+                <help>Header does not include optional checksum</help>
+                <valueless/>
+              </properties>
+            </leafNode>
+          </children>            
+        </node>
+        <node name="sequence">
+          <properties>
+            <help>Header includes a sequence number field</help>
+          </properties>
+          <children>
+            <leafNode name="unset">
+              <properties>
+                <help>Header does not include a sequence number field</help>
+                <valueless/>
+              </properties>
+            </leafNode>
+          </children>
+        </node>
+      </children>
+    </node>
+    <leafNode name="inner-proto">
+      <properties>
+        <help>EtherType of encapsulated packet</help>
+        <completionHelp>
+          <list>ip ip6 arp 802.1q 802.1ad</list>
+        </completionHelp>
+        <valueHelp>
+          <format>u32:0-65535</format>
+          <description>Ethernet protocol number</description>
+        </valueHelp>
+        <valueHelp>
+          <format>u32:0x0-0xffff</format>
+          <description>Ethernet protocol number (hex)</description>
+        </valueHelp>
+        <valueHelp>
+          <format>ip</format>
+          <description>IPv4</description>
+        </valueHelp>
+        <valueHelp>
+          <format>ip6</format>
+          <description>IPv6</description>
+        </valueHelp>
+        <valueHelp>
+          <format>arp</format>
+          <description>Address Resolution Protocol</description>
+        </valueHelp>
+        <valueHelp>
+          <format>802.1q</format>
+          <description>VLAN-tagged frames (IEEE 802.1q)</description>
+        </valueHelp>
+        <valueHelp>
+          <format>802.1ad</format>
+          <description>Provider Bridging (IEEE 802.1ad, Q-in-Q)</description>
+        </valueHelp>
+        <valueHelp>
+          <format>gretap</format>
+          <description>Transparent Ethernet Bridging (L2 Ethernet over GRE, gretap)</description>
+        </valueHelp>
+        <constraint>
+          <regex>(ip|ip6|arp|802.1q|802.1ad|gretap|0x[0-9a-fA-F]{1,4})</regex>
+          <validator name="numeric" argument="--range 0-65535"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    #include <interface/parameters-key.xml.i>
+    <leafNode name="version">
+      <properties>
+        <help>GRE Version</help>
+        <valueHelp>
+          <format>gre</format>
+          <description>Standard GRE</description>
+        </valueHelp>
+        <valueHelp>
+          <format>pptp</format>
+          <description>Point to Point Tunnelling Protocol</description>
+        </valueHelp>
+        <constraint>
+          <regex>(gre|pptp)</regex>
+        </constraint>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow firewall rules to match flags and fields in GRE protocol headers, primarily, the "key" field. 

Adding this will allow firewall rules to distinguish individual GRE sessions and apply appropriate policy, such as blocking sending or forwarding certain tunnels in the clear if IPsec is down. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T4694
* https://vyos.dev/T4667

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/3616

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* firewall

## Proposed changes
<!--- Describe your changes in detail -->
I've covered some concerns I have about my implementation in the forum: https://forum.vyos.io/t/outbound-ipsec-filtering-by-firewall-would-like-some-dev-opinions/14710.

* Only matching flags and fields used by modern RFC2890 "extended GRE" - this is backwards-compatible, but does not match all possible flags. 
* There are no nftables helpers for the GRE key field, which is critical to match individual tunnel sessions (more detail in the forum post)
  * nft expression syntax is not flexible enough for multiple field matches in a single rule and the key offset changes depending on flags.
  * Thus, clumsy compromise in requiring an explicit match on the "checksum" flag if a key is present, so we know where key will be. In most cases, nobody uses the checksum, but assuming it to be off or automatically adding a "not checksum" match unless told otherwise would be confusing
  * The automatic "flags key" check when specifying a key doesn't have similar validation, I added it first and it makes sense. I would still like to find a workaround to the "checksum" offset problem.
  * If we could add 2 rules from 1 config definition, we could match both cases with appropriate offsets, but this would break existing FW generation logic, logging, etc.
* Added a "gre-protocol" validator for the fields we can pass to nft's gre matches.
  * The protocol names are out of synch with other parts of the firewall def, but for eg, I can't call a completion+valueHelp "ipv6" without VyOS deciding to show an IPv6 pattern instead of my help text.
  * I've allowed arbitrary radix numbers for the ethertype, for eg, it's common to use 0x8100 for .1q instead of 33024. nft should accept these as well.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
* Configured VyOS testing pair in a "triangle" (LEFT -> FAKEWWW <- RIGHT) 
* 2 additional VMs behind LEFT and RIGHT for forward chain testing
* Applied numerous combinations of gre/ip6gre matches in logging/nflogging rules across all filter chains
* Created GRE/GRETAP point to point and thru-tunnels between LEFT and RIGHT and the VMs behind them
* Checking dmesg output and tcpdump on FAKEWWW for expected operation in hitting all the right rules

Starting firewall config (note ethtype 0x6558 is gretap):
```
firewall {
    ipv4 {
        forward {
            filter {
                rule 100 {
                    action jump
                    jump-target TEST-LOG-UNKEYED
                }
                rule 110 {
                    action jump
                    jump-target TEST-LOG-KEYED
                }
                rule 120 {
                    action jump
                    jump-target TEST-LOG-CSUMMED
                }
                rule 130 {
                    action jump
                    jump-target TEST-LOG-ETHTYPE
                }
            }
        }
        input {
            filter {
                rule 100 {
                    action jump
                    jump-target TEST-LOG-UNKEYED
                }
                rule 110 {
                    action jump
                    jump-target TEST-LOG-KEYED
                }
                rule 120 {
                    action jump
                    jump-target TEST-LOG-CSUMMED
                }
                rule 130 {
                    action jump
                    jump-target TEST-LOG-ETHTYPE
                }
            }
        }
        name TEST-LOG-CSUMMED {
            default-action return
            rule 10 {
                action continue
                gre {
                    flags {
                        checksum
                    }
                }
                log
                protocol gre
            }
        }
        name TEST-LOG-ETHTYPE {
            default-action return
            rule 10 {
                action continue
                gre {
                    inner-proto ip
                }
                log
                protocol gre
            }
            rule 20 {
                action continue
                gre {
                    inner-proto 0x6558
                }
                log
                protocol gre
            }
        }
        name TEST-LOG-KEYED {
            default-action return
            rule 10 {
                action continue
                gre {
                    flags {
                        key
                        not {
                            checksum
                        }
                    }
                    key 1234
                }
                log
                protocol gre
            }
            rule 20 {
                action continue
                gre {
                    flags {
                        key
                        not {
                            checksum
                        }
                    }
                    key 4321
                }
                log
                protocol gre
            }
            rule 30 {
                action continue
                gre {
                    flags {
                        key
                        not {
                            checksum
                        }
                    }
                }
                log
                protocol gre
            }
        }
        name TEST-LOG-UNKEYED {
            default-action return
            rule 10 {
                action continue
                gre {
                    flags {
                        not {
                            key
                        }
                    }
                }
                log
                protocol gre
            }
        }
        output {
            filter {
                rule 100 {
                    action jump
                    jump-target TEST-LOG-UNKEYED
                }
                rule 110 {
                    action jump
                    jump-target TEST-LOG-KEYED
                }
                rule 120 {
                    action jump
                    jump-target TEST-LOG-CSUMMED
                }
                rule 130 {
                    action jump
                    jump-target TEST-LOG-ETHTYPE
                }
            }
        }
        prerouting {
            raw {
                rule 100 {
                    action jump
                    jump-target TEST-LOG-UNKEYED
                }
                rule 110 {
                    action jump
                    jump-target TEST-LOG-KEYED
                }
                rule 120 {
                    action jump
                    jump-target TEST-LOG-CSUMMED
                }
                rule 130 {
                    action jump
                    jump-target TEST-LOG-ETHTYPE
                }
            }
        }
    }
    ipv6 {
        forward {
            filter {
                rule 100 {
                    action jump
                    jump-target TEST6-LOG-UNKEYED
                }
                rule 110 {
                    action jump
                    jump-target TEST6-LOG-KEYED
                }
                rule 120 {
                    action jump
                    jump-target TEST6-LOG-CSUMMED
                }
                rule 130 {
                    action jump
                    jump-target TEST6-LOG-ETHTYPE
                }
            }
        }
        input {
            filter {
                rule 100 {
                    action jump
                    jump-target TEST6-LOG-UNKEYED
                }
                rule 110 {
                    action jump
                    jump-target TEST6-LOG-KEYED
                }
                rule 120 {
                    action jump
                    jump-target TEST6-LOG-CSUMMED
                }
                rule 130 {
                    action jump
                    jump-target TEST6-LOG-ETHTYPE
                }
            }
        }
        name TEST6-LOG-CSUMMED {
            default-action return
            rule 10 {
                action continue
                gre {
                    flags {
                        checksum
                    }
                }
                log
                protocol gre
            }
        }
        name TEST6-LOG-ETHTYPE {
            default-action return
            rule 10 {
                action continue
                gre {
                    inner-proto ip
                }
                log
                protocol gre
            }
            rule 20 {
                action continue
                gre {
                    inner-proto 0x6558
                }
                log
                protocol gre
            }
        }
        name TEST6-LOG-KEYED {
            default-action return
            rule 10 {
                action continue
                gre {
                    flags {
                        key
                        not {
                            checksum
                        }
                    }
                    key 1234
                }
                log
                protocol gre
            }
            rule 20 {
                action continue
                gre {
                    flags {
                        key
                        not {
                            checksum
                        }
                    }
                    key 4321
                }
                log
                protocol gre
            }
            rule 30 {
                action continue
                gre {
                    flags {
                        key
                        not {
                            checksum
                        }
                    }
                }
                log
                protocol gre
            }
        }
        name TEST6-LOG-UNKEYED {
            default-action return
            rule 10 {
                action continue
                gre {
                    flags {
                        not {
                            key
                        }
                    }
                }
                log
                protocol gre
            }
        }
        output {
            filter {
                rule 100 {
                    action jump
                    jump-target TEST6-LOG-UNKEYED
                }
                rule 110 {
                    action jump
                    jump-target TEST6-LOG-KEYED
                }
                rule 120 {
                    action jump
                    jump-target TEST6-LOG-CSUMMED
                }
                rule 130 {
                    action jump
                    jump-target TEST6-LOG-ETHTYPE
                }
            }
        }
        prerouting {
            raw {
                rule 100 {
                    action jump
                    jump-target TEST6-LOG-UNKEYED
                }
                rule 110 {
                    action jump
                    jump-target TEST6-LOG-KEYED
                }
                rule 120 {
                    action jump
                    jump-target TEST6-LOG-CSUMMED
                }
                rule 130 {
                    action jump
                    jump-target TEST6-LOG-ETHTYPE
                }
            }
        }
    }
}
```

This was a starting point, specific rules were fed directly into top level chains for testing outside of custom named chains and more yes/no logging firewall pairs were added to cover as many combinations of attributes & flags as possible. 

The validators were also given exercise to make sure invalid flag/attribute combos weren't possible. 

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Note, the groups failure below is also encountered in a clean rolling image:
```
# python3 /usr/libexec/vyos/tests/smoke/cli/test_firewall.py 
test_bridge_basic_rules (__main__.TestFirewall.test_bridge_basic_rules) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
test_geoip (__main__.TestFirewall.test_geoip) ... ok
test_groups (__main__.TestFirewall.test_groups) ... FAIL
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_dynamic_groups (__main__.TestFirewall.test_ipv4_dynamic_groups) ... ok
test_ipv4_global_state (__main__.TestFirewall.test_ipv4_global_state) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_dynamic_groups (__main__.TestFirewall.test_ipv6_dynamic_groups) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_timeout_sysctl (__main__.TestFirewall.test_timeout_sysctl) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... ok

======================================================================
FAIL: test_groups (__main__.TestFirewall.test_groups)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/libexec/vyos/tests/smoke/cli/test_firewall.py", line 152, in test_groups
    self.verify_nftables(nftables_search, 'ip vyos_filter')
  File "/usr/libexec/vyos/tests/smoke/cli/base_vyostest_shim.py", line 122, in verify_nftables
    self.assertTrue(not matched if inverse else matched, msg=search)
AssertionError: False is not true : ['elements = { 192.0.2.5, 192.0.2.8,']

----------------------------------------------------------------------
Ran 21 tests in 184.628s

FAILED (failures=1)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
