### PR TITLE
bgp: T6473: missing completion helper for peer-groups inside a VRF

### DIFF
--- a/interface-definitions/include/bgp/peer-group.xml.i
+++ b/interface-definitions/include/bgp/peer-group.xml.i
@@ -3,7 +3,7 @@
   <properties>
     <help>Peer group for this peer</help>
     <completionHelp>
-      <path>protocols bgp peer-group</path>
+      <path>${COMP_WORDS[@]:1:${#COMP_WORDS[@]}-5} peer-group</path>
     </completionHelp>
     <valueHelp>
       <format>txt</format>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Using BGP peer-groups inside a VRF instance will make use if the global VRFs peer-group list during tab-completion and not the peer-groups defined within the BGP instance of the given VRF.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6473

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```console
set vrf name red protocols bgp neighbor 1.2.3.4 peer-group 'PG-VYOS-123'
set vrf name red protocols bgp neighbor 100.64.151.254 peer-group 'PG-VYOS-123'
set vrf name red protocols bgp peer-group PG-VYOS remote-as 'external'
set vrf name red protocols bgp peer-group PG-VYOS-123 address-family ipv4-unicast nexthop-self
set vrf name red protocols bgp peer-group PG-VYOS-123 remote-as 'internal'
set vrf name red protocols bgp system-as '2000'
set vrf name red table '2000'
```

```
vyos@vyos# set vrf name red protocols bgp neighbor 10.10.10.10 peer-group
Possible completions:
   <text>               Peer-group name
   PG-VYOS
   PG-VYOS-123
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
