### PR TITLE
openvpn: T5487:  Remove deprecated option --cipher for server and client mode

### DIFF
--- a/interface-definitions/include/version/openvpn-version.xml.i
+++ b/interface-definitions/include/version/openvpn-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/openvpn-version.xml.i -->
-<syntaxVersion component='openvpn' version='1'></syntaxVersion>
+<syntaxVersion component='openvpn' version='2'></syntaxVersion>
 <!-- include end -->

--- a/smoketest/scripts/cli/test_interfaces_openvpn.py
+++ b/smoketest/scripts/cli/test_interfaces_openvpn.py
@@ -164,6 +164,12 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
             self.cli_commit()
         self.cli_delete(path + ['shared-secret-key', 'ovpn_test'])
 
+        # check validate() - cannot specify "encryption cipher" in  client mode
+        self.cli_set(path + ['encryption', 'cipher', 'aes192gcm'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(path + ['encryption', 'cipher'])
+
         self.cli_set(path + ['tls', 'ca-certificate', 'ovpn_test'])
         self.cli_set(path + ['tls', 'certificate', 'ovpn_test'])
 
@@ -191,7 +197,7 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
             auth_hash = 'sha1'
 
             self.cli_set(path + ['device-type', 'tun'])
-            self.cli_set(path + ['encryption', 'cipher', 'aes256'])
+            self.cli_set(path + ['encryption', 'ncp-ciphers', 'aes256'])
             self.cli_set(path + ['hash', auth_hash])
             self.cli_set(path + ['mode', 'client'])
             self.cli_set(path + ['persistent-tunnel'])
@@ -221,7 +227,7 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f'remote {remote_host}', config)
             self.assertIn(f'persist-tun', config)
             self.assertIn(f'auth {auth_hash}', config)
-            self.assertIn(f'cipher AES-256-CBC', config)
+            self.assertIn(f'data-ciphers AES-256-CBC', config)
 
             # TLS options
             self.assertIn(f'ca /run/openvpn/{interface}_ca.pem', config)
@@ -328,6 +334,12 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
             self.cli_commit()
         self.cli_delete(path + ['tls', 'dh-params'])
 
+        # check validate() - cannot specify "encryption cipher" in server mode
+        self.cli_set(path + ['encryption', 'cipher', 'aes256'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(path + ['encryption', 'cipher'])
+
         # Now test the other path with tls role passive
         self.cli_set(path + ['tls', 'role', 'passive'])
         # check validate() - cannot specify "tcp-active" when "tls role" is "passive"
@@ -359,7 +371,7 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
             port = str(2000 + ii)
 
             self.cli_set(path + ['device-type', 'tun'])
-            self.cli_set(path + ['encryption', 'cipher', 'aes192'])
+            self.cli_set(path + ['encryption', 'ncp-ciphers', 'aes192'])
             self.cli_set(path + ['hash', auth_hash])
             self.cli_set(path + ['mode', 'server'])
             self.cli_set(path + ['local-port', port])
@@ -404,7 +416,7 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f'persist-key', config)
             self.assertIn(f'proto udp', config) # default protocol
             self.assertIn(f'auth {auth_hash}', config)
-            self.assertIn(f'cipher AES-192-CBC', config)
+            self.assertIn(f'data-ciphers AES-192-CBC', config)
             self.assertIn(f'topology subnet', config)
             self.assertIn(f'lport {port}', config)
             self.assertIn(f'push "redirect-gateway def1"', config)

--- a/src/conf_mode/interfaces_openvpn.py
+++ b/src/conf_mode/interfaces_openvpn.py
@@ -515,6 +515,10 @@ def verify(openvpn):
                 print('Warning: using dh-params and EC keys simultaneously will ' \
                       'lead to DH ciphers being used instead of ECDH')
 
+        if dict_search('encryption.cipher', openvpn):
+            raise ConfigError('"encryption cipher" option is deprecated for TLS mode. '
+                              'Use "encryption ncp-ciphers" instead')
+
     if dict_search('encryption.cipher', openvpn) == 'none':
         print('Warning: "encryption none" was specified!')
         print('No encryption will be performed and data is transmitted in ' \

--- a/src/migration-scripts/openvpn/1-to-2
+++ b/src/migration-scripts/openvpn/1-to-2
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Removes --cipher option (deprecated) from OpenVPN configs
+# and moves it to --data-ciphers for server and client modes
+
+import sys
+
+from vyos.configtree import ConfigTree
+
+if len(sys.argv) < 2:
+    print("Must specify file name!")
+    sys.exit(1)
+
+file_name = sys.argv[1]
+
+with open(file_name, 'r') as f:
+    config_file = f.read()
+
+config = ConfigTree(config_file)
+
+if not config.exists(['interfaces', 'openvpn']):
+    # Nothing to do
+    sys.exit(0)
+else:
+    ovpn_intfs = config.list_nodes(['interfaces', 'openvpn'])
+    for	i in ovpn_intfs:
+        # Remove 'encryption cipher' and add this value to 'encryption ncp-ciphers'
+        # for server and client mode.
+        # Site-to-site mode still can use --cipher option
+        cipher_path = ['interfaces', 'openvpn', i, 'encryption', 'cipher']
+        ncp_cipher_path = ['interfaces', 'openvpn', i, 'encryption', 'ncp-ciphers']
+        if config.exists(cipher_path):
+            if config.exists(['interfaces', 'openvpn', i, 'shared-secret-key']):
+                continue
+            cipher = config.return_value(cipher_path)
+            config.delete(cipher_path)
+            if cipher == 'none':
+                if not config.exists(ncp_cipher_path):
+                    config.delete(['interfaces', 'openvpn', i, 'encryption'])
+                continue
+
+            ncp_ciphers = []
+            if config.exists(ncp_cipher_path):
+                ncp_ciphers = config.return_values(ncp_cipher_path)
+                config.delete(ncp_cipher_path)
+
+            # need to add the deleted cipher at the first place in the list
+            if cipher in ncp_ciphers:
+                ncp_ciphers.remove(cipher)
+            ncp_ciphers.insert(0, cipher)
+
+            for c in ncp_ciphers:
+                config.set(ncp_cipher_path, value=c, replace=False)
+
+    try:
+        with open(file_name, 'w') as f:
+            f.write(config.to_string())
+    except OSError as e:
+        print("Failed to save the modified config: {}".format(e))
+        sys.exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Option ```cipher``` is deprecated for server and client mode. 
To specify the cipher to use on the data channel just need to configure ```ncp-ciphers```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): remove deprecated option

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T5487
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
interfaces openvpn
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configure --cipher should not be allowed for server and client mode:
```
vyos@vyos# set interfaces openvpn vtun2 encryption cipher aes256
[edit]
vyos@vyos# commit
[ interfaces openvpn vtun2 ]
"encryption cipher" option is deprecated for TLS mode. Use "encryption
ncp-ciphers" instead

[[interfaces openvpn vtun2]] failed
Commit failed
[edit]
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# python3 /usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py
test_openvpn_client_interfaces (__main__.TestInterfacesOpenVPN.test_openvpn_client_interfaces) ... ok
test_openvpn_client_verify (__main__.TestInterfacesOpenVPN.test_openvpn_client_verify) ... ok
test_openvpn_options (__main__.TestInterfacesOpenVPN.test_openvpn_options) ... ok
test_openvpn_server_subnet_topology (__main__.TestInterfacesOpenVPN.test_openvpn_server_subnet_topology) ... ok
test_openvpn_server_verify (__main__.TestInterfacesOpenVPN.test_openvpn_server_verify) ... ok
test_openvpn_site2site_interfaces_tun (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_interfaces_tun) ... ok
test_openvpn_site2site_verify (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_verify) ... ok

----------------------------------------------------------------------
Ran 7 tests in 106.594s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
