### PR TITLE
op-mode: T6407: "generate pki" missed to mangle in ACME certificates when required

### DIFF
--- a/op-mode-definitions/generate-ipsec-profile.xml.in
+++ b/op-mode-definitions/generate-ipsec-profile.xml.in
@@ -28,7 +28,7 @@
                         <script>${vyos_completion_dir}/list_local_ips.sh --both</script>
                       </completionHelp>
                     </properties>
-                    <command>${vyos_op_scripts_dir}/ikev2_profile_generator.py --os ios --connection "$5" --remote "$7"</command>
+                    <command>sudo ${vyos_op_scripts_dir}/ikev2_profile_generator.py --os ios --connection "$5" --remote "$7"</command>
                     <children>
                       <tagNode name="name">
                         <properties>
@@ -37,7 +37,7 @@
                             <list>&lt;name&gt;</list>
                           </completionHelp>
                         </properties>
-                        <command>${vyos_op_scripts_dir}/ikev2_profile_generator.py --os ios --connection "$5" --remote "$7" --name "$9"</command>
+                        <command>sudo ${vyos_op_scripts_dir}/ikev2_profile_generator.py --os ios --connection "$5" --remote "$7" --name "$9"</command>
                         <children>
                           <tagNode name="profile">
                             <properties>
@@ -46,7 +46,7 @@
                                 <list>&lt;name&gt;</list>
                               </completionHelp>
                             </properties>
-                            <command>${vyos_op_scripts_dir}/ikev2_profile_generator.py --os ios --connection "$5" --remote "$7" --name "$9" --profile "${11}"</command>
+                            <command>sudo ${vyos_op_scripts_dir}/ikev2_profile_generator.py --os ios --connection "$5" --remote "$7" --name "$9" --profile "${11}"</command>
                           </tagNode>
                         </children>
                       </tagNode>
@@ -57,7 +57,7 @@
                             <list>&lt;name&gt;</list>
                           </completionHelp>
                         </properties>
-                        <command>${vyos_op_scripts_dir}/ikev2_profile_generator.py --os ios --connection "$5" --remote "$7" --profile "$9"</command>
+                        <command>sudo ${vyos_op_scripts_dir}/ikev2_profile_generator.py --os ios --connection "$5" --remote "$7" --profile "$9"</command>
                         <children>
                           <tagNode name="name">
                             <properties>
@@ -66,7 +66,7 @@
                                 <list>&lt;name&gt;</list>
                               </completionHelp>
                             </properties>
-                            <command>${vyos_op_scripts_dir}/ikev2_profile_generator.py --os ios --connection "$5" --remote "$7" --profile "$9" --name "${11}"</command>
+                            <command>sudo ${vyos_op_scripts_dir}/ikev2_profile_generator.py --os ios --connection "$5" --remote "$7" --profile "$9" --name "${11}"</command>
                           </tagNode>
                         </children>
                       </tagNode>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

If the requested certificate to generate an Apple IOS profile was based on an ACME certificate, we also need to mangle in the ACME certs content to retrieve the certificates issuer name.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6407

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Op-Mode PKI profile generation

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
cpo@AC2.wue4# run generate ipsec profile windows-remote-access support remote ipsec.somedomain

==== <snip> ====
Remove-VpnConnection -Name "VyOS IKEv2 VPN" -Force -PassThru

Add-VpnConnection -Name "VyOS IKEv2 VPN" -ServerAddress "ipsec.somedomain" -TunnelType "Ikev2"
Set-VpnConnectionIPsecConfiguration -ConnectionName "VyOS IKEv2 VPN" -AuthenticationTransformConstants GCMAES128 -CipherTransformConstants GCMAES128 -EncryptionMethod GCMAES128 -IntegrityCheckMethod SHA256 -PfsGroup None -DHGroup "Group14" -PassThru -Force
==== </snip> ====
```

```
cpo@AC2.wue4# run generate ipsec profile ios  support remote ipsec.somedomain

==== <snip> ====
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <!-- Set the name to whatever you like, it is used in the profile list on the device -->
    <key>PayloadDisplayName</key>
    <string>VyOS IKEv2 Profile</string>
    <!-- This is a reverse-DNS style unique identifier used to detect duplicate profiles -->
    <key>PayloadIdentifier</key>
    <string>wue4.AC2</string>
    <!-- A globally unique identifier, use uuidgen on Linux/Mac OS X to generate it -->
    <key>PayloadUUID</key>
    <string>3f5370b4-2a41-11ef-9e00-00505698355e</string>
    <key>PayloadType</key>
    <string>Configuration</string>
    <key>PayloadVersion</key>
    <integer>1</integer>
    <key>PayloadContent</key>
    <array>
        <!-- It is possible to add multiple VPN payloads with different identifiers/UUIDs and names -->
        <dict>
            <!-- This is an extension of the identifier given above -->
            <key>PayloadIdentifier</key>
            <string>wue4.AC2.conf1</string>
            <!-- A globally unique identifier for this payload -->
            <key>PayloadUUID</key>
            <string>3f5370b5-2a41-11ef-9e00-00505698355e</string>
            <key>PayloadType</key>
            <string>com.apple.vpn.managed</string>
            <key>PayloadVersion</key>
            <integer>1</integer>
            <!-- This is the name of the VPN connection as seen in the VPN application later -->
            <key>UserDefinedName</key>
            <string>VyOS IKEv2 VPN</string>
            <key>VPNType</key>
            <string>IKEv2</string>
            <key>IKEv2</key>
            <dict>
                <!-- Hostname or IP address of the VPN server -->
                <key>RemoteAddress</key>
                <string>ipsec.somedomain</string>
                <!-- Remote identity, can be a FQDN, a userFQDN, an IP or (theoretically) a certificate's subject DN. Can't be empty.
                     IMPORTANT: DNs are currently not handled correctly, they are always sent as identities of type FQDN -->
                <key>RemoteIdentifier</key>
                <string>vpn.somedomain.com</string>
                <!-- Local IKE identity, same restrictions as above. If it is empty the client's IP address will be used -->
                <key>LocalIdentifier</key>
                <string></string>
                <!-- Optional, if it matches the CN of the root CA certificate (not the full subject DN) a certificate request will be sent
                     NOTE: If this is not configured make sure to configure leftsendcert=always on the server, otherwise it won't send its certificate -->
                <key>ServerCertificateIssuerCommonName</key>
                <string>R10</string>
                <!-- Optional, the CN or one of the subjectAltNames of the server certificate to verify it, if not set RemoteIdentifier will be used -->
                <key>ServerCertificateCommonName</key>
                <string>eth0.ac2.wue4.mybll.net</string>
                <!-- The server is authenticated using a certificate -->
                <key>AuthenticationMethod</key>
                <string>Certificate</string>
                <!-- The client uses EAP to authenticate -->
                <key>ExtendedAuthEnabled</key>
                <integer>1</integer>
                <!-- The next two dictionaries are optional (as are the keys in them), but it is recommended to specify them as the default is to use 3DES.
                     IMPORTANT: Because only one proposal is sent (even if nothing is configured here) it must match the server configuration -->
                <key>IKESecurityAssociationParameters</key>
                <dict>
                    <!-- @see https://developer.apple.com/documentation/networkextension/nevpnikev2encryptionalgorithm -->
                    <key>EncryptionAlgorithm</key>
                    <string>AES-128-GCM</string>
                    <!-- @see https://developer.apple.com/documentation/networkextension/nevpnikev2integrityalgorithm -->
                    <key>IntegrityAlgorithm</key>
                    <string>SHA2-256</string>
                    <!-- @see https://developer.apple.com/documentation/networkextension/nevpnikev2diffiehellmangroup -->
                    <key>DiffieHellmanGroup</key>
                    <integer>14</integer>
                </dict>
                <key>ChildSecurityAssociationParameters</key>
                <dict>
                    <key>EncryptionAlgorithm</key>
                    <string>AES-128-GCM</string>
                    <key>IntegrityAlgorithm</key>
                    <string>SHA2-256</string>
                    <key>DiffieHellmanGroup</key>
                    <integer>14</integer>
                </dict>
            </dict>
        </dict>
        <!-- This payload is optional but it provides an easy way to install the CA certificate together with the configuration -->
        <!-- Payload for: ISRG Root X1 -->
        <dict>
            <key>PayloadIdentifier</key>
            <string>org.isrg.root.x1</string>
            <key>PayloadUUID</key>
            <string>e6f9d895-6f20-7819-07a8-24979130186c</string>
            <key>PayloadType</key>
            <string>com.apple.security.root</string>
            <key>PayloadVersion</key>
            <integer>1</integer>
            <!-- This is the Base64 (PEM) encoded CA certificate -->
            <key>PayloadContent</key>
            <data>MIIFazCCA1OgA...</data>
        </dict>
        <!-- Payload for: R10 -->
        <dict>
            <key>PayloadIdentifier</key>
            <string>org.r10</string>
            <key>PayloadUUID</key>
            <string>33df7d55-41bc-0941-336b-1513815da7a5</string>
            <key>PayloadType</key>
            <string>com.apple.security.root</string>
            <key>PayloadVersion</key>
            <integer>1</integer>
            <!-- This is the Base64 (PEM) encoded CA certificate -->
            <key>PayloadContent</key>
            <data>MIIFBTCCAu2gAwIBAgIQ...</data>
        </dict>
    </array>
</dict>
</plist>
==== </snip> ====

Save the XML from above to a new file named "vyos.mobileconfig" and E-Mail it to your phone.
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
