### PR TITLE
T6489: Add support for CLI config scripts that change the underlaying working configuration

### DIFF
--- a/data/configd-include.json
+++ b/data/configd-include.json
@@ -92,6 +92,7 @@
 "system_ip.py",
 "system_ipv6.py",
 "system_lcd.py",
+"system_login.py",
 "system_login_banner.py",
 "system_logs.py",
 "system_option.py",

--- a/python/vyos/configsession.py
+++ b/python/vyos/configsession.py
@@ -1,5 +1,4 @@
-# configsession -- the write API for the VyOS running config
-# Copyright (C) 2019-2023 VyOS maintainers and contributors
+# Copyright (C) 2019-2024 VyOS maintainers and contributors
 #
 # This library is free software; you can redistribute it and/or modify it under the terms of
 # the GNU Lesser General Public License as published by the Free Software Foundation;
@@ -12,11 +11,14 @@
 # You should have received a copy of the GNU Lesser General Public License along with this library;
 # if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
+# configsession -- the write API for the VyOS running config
+
 import os
 import re
 import sys
 import subprocess
 
+from vyos.defaults import directories
 from vyos.utils.process import is_systemd_service_running
 from vyos.utils.dict import dict_to_paths
 
@@ -58,7 +60,7 @@ def inject_vyos_env(env):
     env['VYOS_HEADLESS_CLIENT'] = 'vyos_http_api'
     env['vyatta_bindir']= '/opt/vyatta/bin'
     env['vyatta_cfg_templates'] = '/opt/vyatta/share/vyatta-cfg/templates'
-    env['vyatta_configdir'] = '/opt/vyatta/config'
+    env['vyatta_configdir'] = directories['vyos_configdir']
     env['vyatta_datadir'] = '/opt/vyatta/share'
     env['vyatta_datarootdir'] = '/opt/vyatta/share'
     env['vyatta_libdir'] = '/opt/vyatta/lib'
@@ -70,7 +72,7 @@ def inject_vyos_env(env):
     env['vyos_bin_dir'] = '/usr/bin'
     env['vyos_cfg_templates'] = '/opt/vyatta/share/vyatta-cfg/templates'
     env['vyos_completion_dir'] = '/usr/libexec/vyos/completion'
-    env['vyos_configdir'] = '/opt/vyatta/config'
+    env['vyos_configdir'] = directories['vyos_configdir']
     env['vyos_conf_scripts_dir'] = '/usr/libexec/vyos/conf_mode'
     env['vyos_datadir'] = '/opt/vyatta/share'
     env['vyos_datarootdir']= '/opt/vyatta/share'

--- a/python/vyos/defaults.py
+++ b/python/vyos/defaults.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2018-2024 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -35,6 +35,7 @@ directories = {
   'vyos_udev_dir' : '/run/udev/vyos',
   'isc_dhclient_dir' : '/run/dhclient',
   'dhcp6_client_dir' : '/run/dhcp6c',
+  'vyos_configdir' : '/opt/vyatta/config'
 }
 
 config_status = '/tmp/vyos-config-status'
@@ -44,7 +45,7 @@ cfg_group = 'vyattacfg'
 
 cfg_vintage = 'vyos'
 
-commit_lock = '/opt/vyatta/config/.lock'
+commit_lock = os.path.join(directories['vyos_configdir'], '.lock')
 
 component_version_json = os.path.join(directories['data'], 'component-versions.json')
 

--- a/python/vyos/utils/__init__.py
+++ b/python/vyos/utils/__init__.py
@@ -17,6 +17,7 @@ from vyos.utils import assertion
 from vyos.utils import auth
 from vyos.utils import boot
 from vyos.utils import commit
+from vyos.utils import configfs
 from vyos.utils import convert
 from vyos.utils import cpu
 from vyos.utils import dict

--- a/python/vyos/utils/auth.py
+++ b/python/vyos/utils/auth.py
@@ -1,6 +1,6 @@
 # authutils -- miscelanneous functions for handling passwords and publis keys
 #
-# Copyright (C) 2018 VyOS maintainers and contributors
+# Copyright (C) 2023-2024 VyOS maintainers and contributors
 #
 # This library is free software; you can redistribute it and/or modify it under the terms of
 # the GNU Lesser General Public License as published by the Free Software Foundation;
@@ -11,12 +11,11 @@
 # See the GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License along with this library;
-# if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA 
+# if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 import re
 
 from vyos.utils.process import cmd
-
 
 def make_password_hash(password):
     """ Makes a password hash for /etc/shadow using mkpasswd """
@@ -39,3 +38,10 @@ def split_ssh_public_key(key_string, defaultname=""):
         raise ValueError("Bad key type \'{0}\', must be one of must be one of ssh-rsa, ssh-dss, ecdsa-sha2-nistp<256|384|521> or ssh-ed25519".format(key_type))
 
     return({"type": key_type, "data": key_data, "name": key_name})
+
+def get_current_user() -> str:
+    import os
+    current_user = 'nobody'
+    if 'SUDO_USER' in os.environ:
+        current_user = os.environ['SUDO_USER']
+    return current_user

--- a/python/vyos/utils/configfs.py
+++ b/python/vyos/utils/configfs.py
@@ -1,0 +1,37 @@
+# Copyright 2024 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+def delete_cli_node(cli_path: list):
+    from shutil import rmtree
+    for config_dir in ['VYATTA_TEMP_CONFIG_DIR', 'VYATTA_CHANGES_ONLY_DIR']:
+        tmp = os.path.join(os.environ[config_dir], '/'.join(cli_path))
+        # delete CLI node
+        if os.path.exists(tmp):
+            rmtree(tmp)
+
+def add_cli_node(cli_path: list, value: str=None):
+    from vyos.utils.auth import get_current_user
+    from vyos.utils.file import write_file
+
+    current_user = get_current_user()
+    for config_dir in ['VYATTA_TEMP_CONFIG_DIR', 'VYATTA_CHANGES_ONLY_DIR']:
+        # store new value
+        tmp = os.path.join(os.environ[config_dir], '/'.join(cli_path))
+        write_file(f'{tmp}/node.val', value, user=current_user, group='vyattacfg', mode=0o664)
+        # mark CLI node as modified
+        if config_dir == 'VYATTA_CHANGES_ONLY_DIR':
+            write_file(f'{tmp}/.modified', '', user=current_user, group='vyattacfg', mode=0o664)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

We still have some scripts (python owners) for CLI commands that are incompatible with vyos-configd.

[T6481](https://vyos.dev/T6481) is just another request for such a feature.

Instead of calling my_set and my_delete binary helpers for the store backend we could create a thin Python wrapper who interacts with the unionfs directly - and without the configsession overhead when spawning the cstore code.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6489

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

![image](https://github.com/vyos/vyos-1x/assets/25299219/41d5d877-4a2f-4617-9c89-39ec2d9806b0)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
