### PR TITLE
op-mode: T5514: Allow safe reboots to config defaults when config.boot is deleted

### DIFF
--- a/python/vyos/config_mgmt.py
+++ b/python/vyos/config_mgmt.py
@@ -81,9 +81,11 @@ def save_config(target, json_out=None):
     if rc != 0:
         logger.critical(f'save config failed: {out}')
 
-def unsaved_commits() -> bool:
+def unsaved_commits(allow_missing_config=False) -> bool:
     if get_full_version_data()['boot_via'] == 'livecd':
         return False
+    if allow_missing_config and not os.path.exists(config_file):
+        return True
     tmp_save = '/tmp/config.running'
     save_config(tmp_save)
     ret = not cmp(tmp_save, config_file, shallow=False)

--- a/src/op_mode/powerctrl.py
+++ b/src/op_mode/powerctrl.py
@@ -110,7 +110,7 @@ def check_unsaved_config():
     from vyos.config_mgmt import unsaved_commits
     from vyos.utils.boot import boot_configuration_success
 
-    if unsaved_commits() and boot_configuration_success():
+    if unsaved_commits(allow_missing_config=True) and boot_configuration_success():
         print("Warning: there are unsaved configuration changes!")
         print("Run 'save' command if you do not want to lose those changes after reboot/shutdown.")
     else:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

* Added flag to vyos.config_mgmt.unsaved_commits() that will tolerate missing config.boot for specific circumstances
* Shutdown/reboot uses this flag; config will regenerate from defaults after a reboot

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T5514

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* op-mode

## Proposed changes
<!--- Describe your changes in detail -->
I considered regenerating config.boot from defaults on the spot; that will rarely work well. There may also be situations where unsaved_commits() is expected to fail. 

This fix is for a specific situation:
* User has deleted /config/config.boot
* User wants to reboot back to a default config, cleanly
* User has not deleted anything else on the system - this is not a full factory reset or intended to be such
* User will be safely warned that there is unsaved configuration via the normal prompts
   * Breaking out at this point and issuing a save works fine
* Following a reboot, the default config.boot regenerates cleanly

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@TEST-VYOS-LEFT:~$ rm /config/config.boot
vyos@TEST-VYOS-LEFT:~$ reboot
Warning: there are unsaved configuration changes!
Run 'save' command if you do not want to lose those changes after reboot/shutdown.
Are you sure you want to reboot this system? [y/N] y

[...1 reboot & re-IP later...]

vyos@vyos:~$ 
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
No smoketests exist for opmode, but tried to double check over config functions:

```
vyos@TEST-VYOS-LEFT:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_configd_inspect.py 
test_config_modification (__main__.TestConfigdInclude.test_config_modification) ... ok
test_file_instance (__main__.TestConfigdInclude.test_file_instance) ... ok
test_function_instance (__main__.TestConfigdInclude.test_function_instance) ... ok
test_signatures (__main__.TestConfigdInclude.test_signatures) ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.569s

OK
vyos@TEST-VYOS-LEFT:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_configd_init.py 
test_configd_init (__main__.TestConfigdInit.test_configd_init) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.123s

OK
vyos@TEST-VYOS-LEFT:~$ python3 /usr/libexec/vyos/tests/smoke/system/test_config_mount.py 
test_config_dir (__main__.TestConfigDir.test_config_dir) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.000s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
