### PR TITLE
pki: T4026: Only emit private keys when available

### DIFF
--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -426,11 +426,15 @@ def generate_ca_certificate_sign(name, ca_name, install=False, file=False):
         return None
 
     cert = generate_certificate(cert_req, ca_cert, ca_private_key, is_ca=True, is_sub_ca=True)
-    passphrase = ask_passphrase()
+
+    passphrase = None
+    if private_key is not None:
+        passphrase = ask_passphrase()
 
     if not install and not file:
         print(encode_certificate(cert))
-        print(encode_private_key(private_key, passphrase=passphrase))
+        if private_key is not None:
+            print(encode_private_key(private_key, passphrase=passphrase))
         return None
 
     if install:
@@ -438,7 +442,8 @@ def generate_ca_certificate_sign(name, ca_name, install=False, file=False):
 
     if file:
         write_file(f'{name}.pem', encode_certificate(cert))
-        write_file(f'{name}.key', encode_private_key(private_key, passphrase=passphrase))
+        if private_key is not None:
+            write_file(f'{name}.key', encode_private_key(private_key, passphrase=passphrase))
 
 def generate_certificate_sign(name, ca_name, install=False, file=False):
     ca_dict = get_config_ca_certificate(ca_name)
@@ -492,11 +497,15 @@ def generate_certificate_sign(name, ca_name, install=False, file=False):
         return None
 
     cert = generate_certificate(cert_req, ca_cert, ca_private_key, is_ca=False)
-    passphrase = ask_passphrase()
+    
+    passphrase = None
+    if private_key is not None:
+        passphrase = ask_passphrase()
 
     if not install and not file:
         print(encode_certificate(cert))
-        print(encode_private_key(private_key, passphrase=passphrase))
+        if private_key is not None:
+            print(encode_private_key(private_key, passphrase=passphrase))
         return None
 
     if install:
@@ -504,7 +513,8 @@ def generate_certificate_sign(name, ca_name, install=False, file=False):
 
     if file:
         write_file(f'{name}.pem', encode_certificate(cert))
-        write_file(f'{name}.key', encode_private_key(private_key, passphrase=passphrase))
+        if private_key is not None:
+            write_file(f'{name}.key', encode_private_key(private_key, passphrase=passphrase))
 
 def generate_certificate_selfsign(name, install=False, file=False):
     private_key, key_type = generate_private_key()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Adding a simple check before printing out the private key to a file or console output that it exists, where the code path permits a None private_key. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T4026

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* pki

## Proposed changes
<!--- Describe your changes in detail -->
* install_certificate() code path handles private_key=None & key_passphrase=None OK already
* file and console output paths will error trying to encode None as a key
* This is only an issue for a couple of the generate_*_sign() functions, where having a null private key is possible
  * Self-signing and CA creation always generate a private key
  * Certreqs will generate a private key if not already provided
* Do not prompt for a private key passphrase if we aren't giving back a  private key

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
# run generate pki certificate sign test-ca 
Do you already have a certificate request? [y/N] y
Paste certificate request and press enter:
[...snip...]
Enter how many days certificate will be valid: (Default: 365) 
Enter certificate type: (client, server) (Default: server) 
Note: If you plan to use the generated key on this router, do not encrypt the private key.
Do you want to encrypt the private key with a passphrase? [y/N] 
-----BEGIN CERTIFICATE-----
[...snip, but valid...]
-----END CERTIFICATE-----

[edit]
```
Also ran through ca_cert and install combinations successfully. 

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
$ python3 /usr/libexec/vyos/tests/smoke/cli/test_pki.py 
test_certificate_eapol_update (__main__.TestPKI.test_certificate_eapol_update) ... PKI: Updating config: interfaces ethernet eth1 eapol certificate eapol
ok
test_certificate_https_update (__main__.TestPKI.test_certificate_https_update) ... PKI: Updating config: service https certificates certificate smoke-test_foo

WARNING: No certificate specified, using build-in self-signed
certificates. Do not use them in a production environment!

ok
test_certificate_in_use (__main__.TestPKI.test_certificate_in_use) ... 
PKI object "smoketest" still in use by "service https certificates
certificate"


WARNING: No certificate specified, using build-in self-signed
certificates. Do not use them in a production environment!

ok
test_invalid_ca_valid_certificate (__main__.TestPKI.test_invalid_ca_valid_certificate) ... 
Invalid certificate on CA certificate "invalid-ca"

ok
test_valid_pki (__main__.TestPKI.test_valid_pki) ... ok

----------------------------------------------------------------------
Ran 5 tests in 38.449s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
