### PR TITLE
T5949: Add option to disable USB autosuspend

### DIFF
--- a/data/templates/system/40_usb_autosuspend.j2
+++ b/data/templates/system/40_usb_autosuspend.j2
@@ -1,0 +1,5 @@
+{% set autosuspend = "auto" %}
+{% if disable_usb_autosuspend is vyos_defined %}
+{%     set autosuspend = "on" %}
+{% endif %}
+ACTION=="add", SUBSYSTEM=="usb", TEST=="power/control", ATTR{power/control}="{{ autosuspend }}"

--- a/interface-definitions/system_option.xml.in
+++ b/interface-definitions/system_option.xml.in
@@ -183,6 +183,12 @@
             </properties>
             <defaultValue>12-hour</defaultValue>
            </leafNode>
+           <leafNode name="disable-usb-autosuspend">
+            <properties>
+              <help>Disable autosuspend for all USB devices</help>
+              <valueless/>
+            </properties>
+           </leafNode>
         </children>
       </node>
     </children>

--- a/src/conf_mode/system_option.py
+++ b/src/conf_mode/system_option.py
@@ -35,6 +35,7 @@ airbag.enable()
 curlrc_config = r'/etc/curlrc'
 ssh_config = r'/etc/ssh/ssh_config.d/91-vyos-ssh-client-options.conf'
 systemd_action_file = '/lib/systemd/system/ctrl-alt-del.target'
+usb_autosuspend = r'/etc/udev/rules.d/40-usb-autosuspend.rules'
 time_format_to_locale = {
     '12-hour': 'en_US.UTF-8',
     '24-hour': 'en_GB.UTF-8'
@@ -85,6 +86,7 @@ def verify(options):
 def generate(options):
     render(curlrc_config, 'system/curlrc.j2', options)
     render(ssh_config, 'system/ssh_config.j2', options)
+    render(usb_autosuspend, 'system/40_usb_autosuspend.j2', options)
 
     cmdline_options = []
     if 'kernel' in options:
@@ -154,6 +156,9 @@ def apply(options):
     if 'time_format' in options:
         time_format = time_format_to_locale.get(options['time_format'])
         cmd(f'localectl set-locale LC_TIME={time_format}')
+
+    cmd('udevadm control --reload-rules')
+
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T5949

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->
https://docs.kernel.org/driver-api/usb/power-management.html

By default used the option `auto` is the normal state in which the kernel is allowed to autosuspend and autoresume the device.

command `set system option disable-usb-autosuspend` used option `on` to disallow autosuspend

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set system option disable-usb-autosuspend
commit
cat /etc/udev/rules.d/40-usb-autosuspend.rules
```
`ACTION=="add", SUBSYSTEM=="usb", TEST=="power/control", ATTR{power/control}="on"`

```
del system option disable-usb-autosuspend
commit
cat /etc/udev/rules.d/40-usb-autosuspend.rules
```
`ACTION=="add", SUBSYSTEM=="usb", TEST=="power/control", ATTR{power/control}="auto"`


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
