### PR TITLE
T3202: Enable wireguard debug messages

### DIFF
--- a/interface-definitions/system_option.xml.in
+++ b/interface-definitions/system_option.xml.in
@@ -49,6 +49,19 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <node name="debug">
+                <properties>
+                  <help>Dynamic debugging for kernel module</help>
+                </properties>
+                <children>
+                  <leafNode name="wireguard">
+                    <properties>
+                      <help>Dynamic debugging for Wireguard module</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
              </children>
            </node>
            <leafNode name="keyboard-layout">

--- a/src/conf_mode/system_option.py
+++ b/src/conf_mode/system_option.py
@@ -39,6 +39,7 @@ curlrc_config = r'/etc/curlrc'
 ssh_config = r'/etc/ssh/ssh_config.d/91-vyos-ssh-client-options.conf'
 systemd_action_file = '/lib/systemd/system/ctrl-alt-del.target'
 usb_autosuspend = r'/etc/udev/rules.d/40-usb-autosuspend.rules'
+kernel_dynamic_debug = r'/sys/kernel/debug/dynamic_debug/control'
 time_format_to_locale = {
     '12-hour': 'en_US.UTF-8',
     '24-hour': 'en_GB.UTF-8'
@@ -160,6 +161,7 @@ def apply(options):
         time_format = time_format_to_locale.get(options['time_format'])
         cmd(f'localectl set-locale LC_TIME={time_format}')
 
+    # Reload UDEV, required for USB auto suspend
     cmd('udevadm control --reload-rules')
 
     # Enable/disable dynamic debugging for kernel modules
@@ -168,9 +170,9 @@ def apply(options):
     for module in modules:
         if module in modules_enabled:
             check_kmod(module)
-            write_file('/sys/kernel/debug/dynamic_debug/control', f'module {module} +p')
+            write_file(kernel_dynamic_debug, f'module {module} +p')
         else:
-            write_file('/sys/kernel/debug/dynamic_debug/control', f'module {module} -p')
+            write_file(kernel_dynamic_debug, f'module {module} -p')
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added ability to enable or disable dynamic debugging for Wireguard on demand
```
set system option kernel debug wireguard
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T3202
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
system option
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set system option kernel debug wireguard
commit

# configure wireguard interface
set interfaces wireguard wg01 address '10.1.0.1/30'
set interfaces wireguard wg01 description 'VPN-to-wg02'
set interfaces wireguard wg01 peer to-wg02 address '192.0.2.1'
set interfaces wireguard wg01 peer to-wg02 allowed-ips '192.168.2.0/24'
set interfaces wireguard wg01 peer to-wg02 port '51820'
set interfaces wireguard wg01 peer to-wg02 public-key 'XMrlPykaxhdAAiSjhtPlvi30NVkvLQliQuKP7AI7CyI='
set interfaces wireguard wg01 per-client-thread
set interfaces wireguard wg01 port '51820'
set interfaces wireguard wg01 private-key 'cNcQKm4KTmtOFyUp+THWKWs50rAh/3il9YAUvSHzInE='
set protocols static route 192.168.2.0/24 interface wg01
commit
```
now dynamic debugging messages can be viewed by running ```journalctl```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
