### PR TITLE
op mode: T6498: move uptime helpers to vyos.utils.system

### DIFF
--- a/python/vyos/utils/system.py
+++ b/python/vyos/utils/system.py
@@ -1,4 +1,4 @@
-# Copyright 2023 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2023-2024 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -98,3 +98,33 @@ def load_as_module(name: str, path: str):
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+def get_uptime_seconds():
+    """ Returns system uptime in seconds """
+    from re import search
+    from vyos.utils.file import read_file
+
+    data = read_file("/proc/uptime")
+    seconds = search(r"([0-9\.]+)\s", data).group(1)
+    res  = int(float(seconds))
+
+    return res
+
+def get_load_averages():
+    """ Returns load averages for 1, 5, and 15 minutes as a dict """
+    from re import search
+    from vyos.utils.file import read_file
+    from vyos.utils.cpu import get_core_count
+
+    data = read_file("/proc/loadavg")
+    matches = search(r"\s*(?P<one>[0-9\.]+)\s+(?P<five>[0-9\.]+)\s+(?P<fifteen>[0-9\.]+)\s*", data)
+
+    core_count = get_core_count()
+
+    res = {}
+    res[1]  = float(matches["one"]) / core_count
+    res[5]  = float(matches["five"]) / core_count
+    res[15] = float(matches["fifteen"]) / core_count
+
+    return res
+

--- a/src/op_mode/uptime.py
+++ b/src/op_mode/uptime.py
@@ -18,39 +18,14 @@ import sys
 
 import vyos.opmode
 
-def _get_uptime_seconds():
-  from re import search
-  from vyos.utils.file import read_file
-
-  data = read_file("/proc/uptime")
-  seconds = search("([0-9\.]+)\s", data).group(1)
-
-  return int(float(seconds))
-
-def _get_load_averages():
-    from re import search
-    from vyos.utils.cpu import get_core_count
-    from vyos.utils.process import cmd
-
-    data = cmd("uptime")
-    matches = search(r"load average:\s*(?P<one>[0-9\.]+)\s*,\s*(?P<five>[0-9\.]+)\s*,\s*(?P<fifteen>[0-9\.]+)\s*", data)
-
-    core_count = get_core_count()
-
-    res = {}
-    res[1]  = float(matches["one"]) / core_count
-    res[5]  = float(matches["five"]) / core_count
-    res[15] = float(matches["fifteen"]) / core_count
-
-    return res
-
 def _get_raw_data():
+    from vyos.utils.system import get_uptime_seconds, get_load_averages
     from vyos.utils.convert import seconds_to_human
 
     res = {}
-    res["uptime_seconds"] = _get_uptime_seconds()
-    res["uptime"] = seconds_to_human(_get_uptime_seconds(), separator=' ')
-    res["load_average"] = _get_load_averages()
+    uptime_seconds = get_uptime_seconds()
+    res["uptime"] = seconds_to_human(uptime_seconds, separator=' ')
+    res["load_average"] = get_load_averages()
 
     return res
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Move the functions for getting system uptime and load averages from `uptime.py` to `vyos.utils.system`, mainly to be able to call them from the new tech-support script, but that's not all.

There's also a "while we are at it" change that makes the performance of those functions better.

1. `get_uptime_seconds()` no longer reads the uptime file twice.
2. `get_load_averages()` now reads `/proc/loadavg` directly instead of spawning `uptime` as a subprocess.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Op mode.

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

`run show system uptime` should work as before.

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
