### PR TITLE
macsec: T5447: fix error message syntax - there is no tx and rx key, only key

### DIFF
--- a/python/vyos/ifconfig/macsec.py
+++ b/python/vyos/ifconfig/macsec.py
@@ -66,7 +66,7 @@ class MACsecIf(Interface):
                 cmd = 'ip macsec add {ifname} rx port 1 address'.format(**self.config)
                 cmd += f' {peer_config["mac"]}'
                 self._cmd(cmd)
-                # Add the rx-key to the address
+                # Add the encryption key to the address
                 cmd += f' sa 0 pn 1 on key 01 {peer_config["key"]}'
                 self._cmd(cmd)
 

--- a/smoketest/scripts/cli/test_interfaces_macsec.py
+++ b/smoketest/scripts/cli/test_interfaces_macsec.py
@@ -225,11 +225,11 @@ class MACsecInterfaceTest(BasicInterfaceTest.TestCase):
             self.cli_commit()
         self.cli_delete(self._base_path + [interface, 'security', 'mka'])
 
-        # check validate() - tx-key required
+        # check validate() - key required
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
 
-        # check validate() - tx-key length must match cipher
+        # check validate() - key length must match cipher
         self.cli_set(self._base_path + [interface, 'security', 'static', 'key', tx_key_2])
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
@@ -239,7 +239,7 @@ class MACsecInterfaceTest(BasicInterfaceTest.TestCase):
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
 
-        # check validate() - enabled peer must have both rx-key and MAC defined
+        # check validate() - enabled peer must have both key and MAC defined
         self.cli_set(self._base_path + [interface, 'security', 'static', 'peer', 'TESTPEER'])
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
@@ -252,7 +252,7 @@ class MACsecInterfaceTest(BasicInterfaceTest.TestCase):
             self.cli_commit()
         self.cli_set(self._base_path + [interface, 'security', 'static', 'peer', 'TESTPEER', 'mac', peer_mac])
 
-        # check validate() - peer rx-key length must match cipher
+        # check validate() - peer key length must match cipher
         self.cli_set(self._base_path + [interface, 'security', 'cipher', cipher2])
         self.cli_set(self._base_path + [interface, 'security', 'static', 'key', tx_key_2])
         with self.assertRaises(ConfigSessionError):

--- a/src/conf_mode/interfaces_macsec.py
+++ b/src/conf_mode/interfaces_macsec.py
@@ -103,9 +103,9 @@ def verify(macsec):
 
         # Logic to check static configuration
         if dict_search('security.static', macsec) != None:
-            # tx-key must be defined
+            # key must be defined
             if dict_search('security.static.key', macsec) == None:
-                raise ConfigError('Static MACsec tx-key must be defined.')
+                raise ConfigError('Static MACsec key must be defined.')
 
             tx_len = len(dict_search('security.static.key', macsec))
 
@@ -119,12 +119,12 @@ def verify(macsec):
             if 'peer' not in macsec['security']['static']:
                 raise ConfigError('Must have at least one peer defined for static MACsec')
 
-            # For every enabled peer, make sure a MAC and rx-key is defined
+            # For every enabled peer, make sure a MAC and key is defined
             for peer, peer_config in macsec['security']['static']['peer'].items():
                 if 'disable' not in peer_config and ('mac' not in peer_config or 'key' not in peer_config):
-                    raise ConfigError('Every enabled MACsec static peer must have a MAC address and rx-key defined.')
+                    raise ConfigError('Every enabled MACsec static peer must have a MAC address and key defined!')
 
-                # check rx-key length against cipher suite
+                # check key length against cipher suite
                 rx_len = len(peer_config['key'])
 
                 if dict_search('security.cipher', macsec) == 'gcm-aes-128' and rx_len != GCM_AES_128_LEN:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Remove the TX and RX portion from the key error message as the CLI only offers `key`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T5447

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/2156

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```console
cpo@LR2.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_macsec.py
test_add_multiple_ip_addresses (__main__.MACsecInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.MACsecInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.MACsecInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.MACsecInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.MACsecInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.MACsecInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.MACsecInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.MACsecInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.MACsecInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_interface_description (__main__.MACsecInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.MACsecInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.MACsecInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.MACsecInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.MACsecInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.MACsecInterfaceTest.test_ipv6_link_local_address) ... ok
test_macsec_encryption (__main__.MACsecInterfaceTest.test_macsec_encryption) ... ok
test_macsec_gcm_aes_128 (__main__.MACsecInterfaceTest.test_macsec_gcm_aes_128) ... ok
test_macsec_gcm_aes_256 (__main__.MACsecInterfaceTest.test_macsec_gcm_aes_256) ... ok
test_macsec_source_interface (__main__.MACsecInterfaceTest.test_macsec_source_interface) ... ok
test_macsec_static_keys (__main__.MACsecInterfaceTest.test_macsec_static_keys) ... ok
test_mtu_1200_no_ipv6_interface (__main__.MACsecInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.MACsecInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.MACsecInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.MACsecInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.MACsecInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.MACsecInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.MACsecInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.MACsecInterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'

----------------------------------------------------------------------
Ran 28 tests in 154.662s

OK (skipped=7)

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
