### PR TITLE
system: op-mode: T3334: allow delayed getty restart when configuring serial ports

### DIFF
--- a/op-mode-definitions/restart-serial.xml.in
+++ b/op-mode-definitions/restart-serial.xml.in
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="restart">
+    <children>
+      <node name="serial">
+        <properties>
+          <help>Restart services on serial ports</help>
+        </properties>
+        <children>
+          <node name="console">
+            <properties>
+              <help>Restart serial console service for login TTYs</help>
+            </properties>
+            <command>sudo ${vyos_op_scripts_dir}/serial.py restart_console</command>
+            <children>
+              <tagNode name="device">
+                <properties>
+                  <help>Restart specific TTY device</help>
+                  <completionHelp>
+                    <script>${vyos_completion_dir}/list_login_ttys.py</script>
+                  </completionHelp>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/serial.py restart_console --device-name "$5"</command>
+              </tagNode>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/python/vyos/utils/serial.py
+++ b/python/vyos/utils/serial.py
@@ -1,0 +1,117 @@
+# Copyright 2024 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+import os, re, json
+from typing import List
+
+from vyos.base import Warning
+from vyos.utils.io import ask_yes_no
+from vyos.utils.process import cmd
+
+GLOB_GETTY_UNITS = 'serial-getty@*.service'
+RE_GETTY_DEVICES = re.compile(r'.+@(.+).service$')
+
+SD_UNIT_PATH = '/run/systemd/system'
+UTMP_PATH = '/run/utmp'
+
+def get_serial_units(include_devices=[]):
+    # Since we cannot depend on the current config for decommissioned ports,
+    # we just grab everything that systemd knows about.
+    tmp = cmd(f'systemctl list-units {GLOB_GETTY_UNITS} --all --output json --no-pager')
+    getty_units = json.loads(tmp)
+    for sdunit in getty_units:
+        m = RE_GETTY_DEVICES.search(sdunit['unit'])
+        if m is None:
+            Warning(f'Serial console unit name "{sdunit["unit"]}" is malformed and cannot be checked for activity!')
+            continue
+
+        getty_device = m.group(1)
+        if include_devices and getty_device not in include_devices:
+            continue
+
+        sdunit['device'] = getty_device
+
+    return getty_units
+
+def get_authenticated_ports(units):
+    connected = []
+    ports = [ x['device'] for x in units if 'device' in x ]
+    #
+    # utmpdump just gives us an easily parseable dump of currently logged-in sessions, for eg:
+    # $ utmpdump /run/utmp
+    # Utmp dump of /run/utmp
+    # [2] [00000] [~~  ] [reboot  ] [~           ] [6.6.31-amd64-vyos   ] [0.0.0.0        ] [2024-06-18T13:56:53,958484+00:00]
+    # [1] [00051] [~~  ] [runlevel] [~           ] [6.6.31-amd64-vyos   ] [0.0.0.0        ] [2024-06-18T13:57:01,790808+00:00]
+    # [6] [03178] [tty1] [LOGIN   ] [tty1        ] [                    ] [0.0.0.0        ] [2024-06-18T13:57:31,015392+00:00]
+    # [7] [37151] [ts/0] [vyos    ] [pts/0       ] [10.9.8.7            ] [10.9.8.7       ] [2024-07-04T13:42:08,760892+00:00]
+    # [8] [24812] [ts/1] [        ] [pts/1       ] [10.9.8.7            ] [10.9.8.7       ] [2024-06-20T18:10:07,309365+00:00]
+    #
+    # We can safely skip blank or LOGIN sessions with valid device names.
+    #
+    for line in cmd(f'utmpdump {UTMP_PATH}').splitlines():
+        row = line.split('] [')
+        user_name = row[3].strip()
+        user_term = row[4].strip()
+        if user_name and user_name != 'LOGIN' and user_term in ports:
+            connected.append(user_term)
+
+    return connected
+
+def restart_login_consoles(prompt_user=False, quiet=True, devices: List[str]=[]):
+    # restart_login_consoles() is called from both conf- and op-mode scripts, including
+    # the warning messages and user prompts common to both.
+    #
+    # The default case, called with no arguments, is a simple serial-getty restart &
+    # cleanup wrapper with no output or prompts that can be used from anywhere.
+    #
+    # quiet and prompt_user args have been split from an original "no_prompt", in
+    # order to support the completely silent default use case. "no_prompt" would
+    # only suppress the user interactive prompt.
+    #
+    # quiet intentionally does not suppress a vyos.base.Warning() for malformed
+    # device names in _get_serial_units().
+    #
+    cmd('systemctl daemon-reload')
+
+    units = get_serial_units(devices)
+    connected = get_authenticated_ports(units)
+
+    if connected:
+        if not quiet:
+            print('There are user sessions connected via serial console that will be terminated\n' \
+                  'when serial console settings are changed.\n') # extra newline is deliberate. 
+            if not prompt_user:
+                # This flag is used by conf_mode/system_console.py to reset things, if there's
+                # a problem, the user should issue a manual restart for serial-getty. 
+                print('Please ensure all settings are committed and saved before issuing a\n' \
+                      '"restart serial console" command to apply new configuration.')
+        if not prompt_user:
+            return False
+        if not ask_yes_no('Any uncommitted changes from these sessions will be lost and in-progress actions\n' \
+                          'may be left in an inconsistent state. Continue?'):
+            return False
+
+    for unit in units:
+        if 'device' not in unit:
+            continue # malformed or filtered.
+        unit_name = unit['unit']
+        unit_device = unit['device']
+        if os.path.exists(os.path.join(SD_UNIT_PATH, unit_name)):
+            cmd(f'systemctl restart {unit_name}')
+        else:
+            # Deleted stubs don't need to be restarted, just shut them down.
+            cmd(f'systemctl stop {unit_name}')
+
+    return True

--- a/python/vyos/utils/serial.py
+++ b/python/vyos/utils/serial.py
@@ -90,17 +90,18 @@ def restart_login_consoles(prompt_user=False, quiet=True, devices: List[str]=[])
 
     if connected:
         if not quiet:
-            print('There are user sessions connected via serial console that will be terminated\n' \
-                  'when serial console settings are changed.\n') # extra newline is deliberate. 
+            Warning('There are user sessions connected via serial console that '\
+                    'will be terminated when serial console settings are changed!')
             if not prompt_user:
                 # This flag is used by conf_mode/system_console.py to reset things, if there's
-                # a problem, the user should issue a manual restart for serial-getty. 
-                print('Please ensure all settings are committed and saved before issuing a\n' \
-                      '"restart serial console" command to apply new configuration.')
+                # a problem, the user should issue a manual restart for serial-getty.
+                Warning('Please ensure all settings are committed and saved before issuing a ' \
+                      '"restart serial console" command to apply new configuration!')
         if not prompt_user:
             return False
-        if not ask_yes_no('Any uncommitted changes from these sessions will be lost and in-progress actions\n' \
-                          'may be left in an inconsistent state. Continue?'):
+        if not ask_yes_no('Any uncommitted changes from these sessions will be lost\n' \
+                          'and in-progress actions may be left in an inconsistent state.\n'\
+                          '\nContinue?'):
             return False
 
     for unit in units:

--- a/src/completion/list_login_ttys.py
+++ b/src/completion/list_login_ttys.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from vyos.utils.serial import get_serial_units
+
+if __name__ == '__main__':
+    # Autocomplete uses runtime state rather than the config tree, as a manual 
+    # restart/cleanup may be needed for deleted devices. 
+    tty_completions = [ '<text>' ] + [ x['device'] for x in get_serial_units() if 'device' in x ]
+    print(' '.join(tty_completions))
+
+

--- a/src/op_mode/serial.py
+++ b/src/op_mode/serial.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys, typing
+
+import vyos.opmode
+from vyos.utils.serial import restart_login_consoles as _restart_login_consoles
+
+def restart_console(device_name: typing.Optional[str]):
+    # Service control moved to vyos.utils.serial to unify checks and prompts. 
+    # If users are connected, we want to show an informational message and a prompt
+    # to continue, verifying that the user acknowledges possible interruptions. 
+    if device_name:
+        _restart_login_consoles(prompt_user=True, quiet=False, devices=[device_name])
+    else:
+        _restart_login_consoles(prompt_user=True, quiet=False)
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except (ValueError, vyos.opmode.Error) as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Reconfiguration of serial console settings from the serial console is not currently possible - the restart at commit terminates the login shell and does not complete the commit. 

This PR relocates the serial-getty service control portion from the conf-mode handler into an op-mode user command "restart serial-console", wrapping it in additional checks and helpful messages. The conf handler will still call the op command, which will either silently succeed by restarting units (when no active sessions) or provide instructions to complete the process. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T3334

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* op-mode
* system

## Proposed changes
<!--- Describe your changes in detail -->
* Relocated service control to op-mode command "restart serial-console"
* Checking for logged-in serial sessions that may be affected by getty reconfig (extracted and adapted from ticket patch)
* Warning the user when changes are committed and serial sessions are active, otherwise restart services as normal. No prompts issued during commit, all config gen/commit steps still occur except for the service restarts (everything remains consistent)
* To apply committed changes, user will need to run "restart serial-console" to complete the process or reboot the whole router

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
* Starting with no serial ports, configuring new ones, all OK
* Adding more ports with existing commited ports, all OK
* Removing ports, working as expected
* Removing all ports, all OK
* Rebooting with working serial devices, boot-time configuration applies as expected
* Rebooting with missing serial devices (shutdown, remove VM device, power on), boot-time configuration applies as expected (missing device units created, sitting in failed state, does not affect working units)

One sample run through from the serial session itself:
```
vyos@TEST-VYOS-LEFT# set system console device ttyS1
[edit]
vyos@TEST-VYOS-LEFT# commit
There are user sessions connected via serial console that will be terminated
when serial console settings are changed.

Please ensure all settings are committed and saved before issuing a
"restart serial-console" command to apply new configuration.
[edit]
vyos@TEST-VYOS-LEFT# save
[edit]
vyos@TEST-VYOS-LEFT# exit
exit
vyos@TEST-VYOS-LEFT:~$ restart serial-console
There are user sessions connected via serial console that will be terminated
when serial console settings are changed.

Any uncommitted changes from these sessions will be lost and in-progress actions
may be left in an inconsistent state. Continue? [y/N] y

Welcome to VyOS - TEST-VYOS-LEFT ttyS0

TEST-VYOS-LEFT login: vyos
Password:
Welcome to VyOS!
[...banner snipped...]
vyos@TEST-VYOS-LEFT:~$ configure
[edit]
vyos@TEST-VYOS-LEFT# show system console
 device ttyS0 {
 }
 device ttyS1 {
 }
[edit]
vyos@TEST-VYOS-LEFT#
```

Additional run through when nobody is logged into a serial console:
```
vyos@TEST-VYOS-LEFT# delete  system console device ttyS1 
[edit]
vyos@TEST-VYOS-LEFT# commit
[edit]
vyos@TEST-VYOS-LEFT# save
[edit]
```
No interruption or messages, as expected. Service confirmed restarted. 

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
There does not seem to be an appropriate smoketest for this change. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
