### PR TITLE
configd: T6504: send sudo_user on session init and set env variable

### DIFF
--- a/python/vyos/utils/auth.py
+++ b/python/vyos/utils/auth.py
@@ -42,6 +42,10 @@ def split_ssh_public_key(key_string, defaultname=""):
 def get_current_user() -> str:
     import os
     current_user = 'nobody'
+    # During CLI "owner" script execution we use SUDO_USER
     if 'SUDO_USER' in os.environ:
         current_user = os.environ['SUDO_USER']
+    # During op-mode or config-mode interactive CLI we use USER
+    elif 'USER' in os.environ:
+        current_user = os.environ['USER']
     return current_user

--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -74,6 +74,11 @@ class VyOSUnitTestSHIM:
                 print('del ' + ' '.join(config))
             self._session.delete(config)
 
+        def cli_discard(self):
+            if self.debug:
+                print('DISCARD')
+            self._session.discard()
+
         def cli_commit(self):
             self._session.commit()
             # during a commit there is a process opening commit_lock, and run() returns 0

--- a/smoketest/scripts/cli/test_system_login.py
+++ b/smoketest/scripts/cli/test_system_login.py
@@ -24,6 +24,7 @@ from subprocess import Popen, PIPE
 from pwd import getpwall
 
 from vyos.configsession import ConfigSessionError
+from vyos.utils.auth import get_current_user
 from vyos.utils.process import cmd
 from vyos.utils.file import read_file
 from vyos.template import inc_ip
@@ -333,6 +334,15 @@ class TestSystemLogin(VyOSUnitTestSHIM.TestCase):
 
             self.assertIn(f'secret={tacacs_secret}', nss_tacacs_conf)
             self.assertIn(f'server={server}', nss_tacacs_conf)
+
+    def test_delete_current_user(self):
+        current_user = get_current_user()
+
+        # We are not allowed to delete the current user
+        self.cli_delete(base_path + ['user', current_user])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -179,8 +179,13 @@ def initialization(socket):
     pid_string = socket.recv().decode("utf-8", "ignore")
     resp = "pid"
     socket.send(resp.encode())
+    sudo_user_string = socket.recv().decode("utf-8", "ignore")
+    resp = "sudo_user"
+    socket.send(resp.encode())
 
     logger.debug(f"config session pid is {pid_string}")
+    logger.debug(f"config session sudo_user is {sudo_user_string}")
+
     try:
         session_out = os.readlink(f"/proc/{pid_string}/fd/1")
         session_mode = 'w'
@@ -191,6 +196,8 @@ def initialization(socket):
     if not session_out or not boot_configuration_complete():
         session_out = script_stdout_log
         session_mode = 'a'
+
+    os.environ['SUDO_USER'] = sudo_user_string
 
     try:
         configsource = ConfigSourceString(running_config_text=active_string,
@@ -265,9 +272,6 @@ if __name__ == '__main__':
 
     cfg_group = grp.getgrnam(CFG_GROUP)
     os.setgid(cfg_group.gr_gid)
-
-    os.environ['SUDO_USER'] = 'vyos'
-    os.environ['SUDO_GID'] = str(cfg_group.gr_gid)
 
     def sig_handler(signum, frame):
         shutdown()

--- a/src/shim/vyshim.c
+++ b/src/shim/vyshim.c
@@ -178,6 +178,13 @@ int initialization(void* Requester)
     strsep(&pid_val, "_");
     debug_print("config session pid: %s\n", pid_val);
 
+    char *sudo_user = getenv("SUDO_USER");
+    if (!sudo_user) {
+        char nobody[] = "nobody";
+        sudo_user = nobody;
+    }
+    debug_print("sudo_user is %s\n", sudo_user);
+
     debug_print("Sending init announcement\n");
     char *init_announce = mkjson(MKJSON_OBJ, 1,
                                  MKJSON_STRING, "type", "init");
@@ -240,6 +247,10 @@ int initialization(void* Requester)
     zmq_recv(Requester, buffer, 16, 0);
     debug_print("Received pid receipt\n");
 
+    debug_print("Sending config session sudo_user\n");
+    zmq_send(Requester, sudo_user, strlen(sudo_user), 0);
+    zmq_recv(Requester, buffer, 16, 0);
+    debug_print("Received sudo_user receipt\n");
 
     return 0;
 }


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The environment variable SUDO_USER is checked by system_login.py so as to prevent deleting the current user. Provide from config session and set within configd environment.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6504

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/3652

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
