### PR TITLE
op-mode: T6503: "restart ssh" command not working

### DIFF
--- a/op-mode-definitions/restart-ssh.xml.in
+++ b/op-mode-definitions/restart-ssh.xml.in
@@ -6,7 +6,7 @@
         <properties>
           <help>Restart SSH service</help>
         </properties>
-        <command>if cli-shell-api existsActive service ssh; then sudo systemctl restart ssh.service; else echo "Service SSH not configured"; fi</command>
+        <command>if cli-shell-api existsActive service ssh; then sudo systemctl restart "ssh@*.service"; else echo "Service SSH not configured"; fi</command>
       </node>
     </children>
   </node>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Commit e5af1f090 ("ssh: T6192: allow binding to multiple VRF instances") switched the systemd unit file from `ssh.service` to `ssh@*.service`, this change was not reflected in the "restart ssh" op-mode command.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6503

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
op-mode ssh

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

See PID increasing

```
cpo@LR2.wue3:~$ ps faux | grep /usr/sbin/sshd
cpo         6381  0.0  0.2   6468  2048 pts/0    S+   22:53   0:00          \_ grep /usr/sbin/sshd
root        6375  0.0  0.9  15564  9344 ?        Ss   22:48   0:00 sshd: /usr/sbin/sshd -f /run/sshd/sshd_config [listener] 0 of 10-100 startups
cpo@LR2.wue3:~$ restart ssh
cpo@LR2.wue3:~$ ps faux | grep /usr/sbin/sshd
cpo         6431  0.0  0.2   6468  2048 pts/0    S+   22:53   0:00          \_ grep /usr/sbin/sshd
root        6429  0.0  0.9  15568  9472 ?        Ss   22:53   0:00 sshd: /usr/sbin/sshd -f /run/sshd/sshd_config [listener] 0 of 10-100 startups
cpo@LR2.wue3:~$ restart ssh
cpo@LR2.wue3:~$ ps faux | grep /usr/sbin/sshd
cpo         6457  0.0  0.2   6468  2176 pts/0    S+   22:53   0:00          \_ grep /usr/sbin/sshd
root        6454  0.0  0.9  15564  9472 ?        Ss   22:53   0:00 sshd: /usr/sbin/sshd -f /run/sshd/sshd_config [listener] 0 of 10-100 startups
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
