### PR TITLE
T6496: Added support for WPA-Enterprise client-mode

### DIFF
--- a/data/templates/wifi/wpa_supplicant.conf.j2
+++ b/data/templates/wifi/wpa_supplicant.conf.j2
@@ -89,7 +89,7 @@ network={
     key_mgmt=NONE
 {%     endif %}
 {% endif %}
-{% if security.bssid is vyos_defined %}
-    bssid={{ security.bssid }}
+{% if bssid is vyos_defined %}
+    bssid={{ bssid }}
 {% endif %}
 }

--- a/data/templates/wifi/wpa_supplicant.conf.j2
+++ b/data/templates/wifi/wpa_supplicant.conf.j2
@@ -61,6 +61,8 @@ network={
     # If not set, this defaults to: WPA-PSK WPA-EAP
 {%     if security.wpa.mode is vyos_defined('wpa3') %}
     key_mgmt=SAE
+{%     elif security.wpa.username is vyos_defined %}
+    key_mgmt=WPA-EAP WPA-EAP-SHA256
 {%     else %}
     key_mgmt=WPA-PSK WPA-PSK-SHA256
 {%     endif %}
@@ -76,8 +78,18 @@ network={
     # from ASCII passphrase. This process uses lot of CPU and wpa_supplicant
     # startup and reconfiguration time can be optimized by generating the PSK only
     # only when the passphrase or SSID has actually changed.
+{%     if security.wpa.username is vyos_defined %}
+    identity="{{ security.wpa.username }}"
+    password="{{ security.wpa.passphrase }}"
+    phase2="auth=MSCHAPV2"
+    eap=PEAP
+{%     elif security.wpa.username is not vyos_defined %}
     psk="{{ security.wpa.passphrase }}"
-{% else %}
+{%     else %}
     key_mgmt=NONE
+{%     endif %}
+{% endif %}
+{% if security.bssid is vyos_defined %}
+    bssid={{ security.bssid }}
 {% endif %}
 }

--- a/interface-definitions/interfaces_wireless.xml.in
+++ b/interface-definitions/interfaces_wireless.xml.in
@@ -917,7 +917,7 @@
                         <description>Passphrase of at least 8 but not more than 63 printable characters for WPA-Personal and any passphrase for WPA-Enterprise</description>
                       </valueHelp>
                       <constraint>
-                        <regex>.*</regex>
+                        <regex>[[:ascii:]]{1,256}</regex>
                       </constraint>
                       <constraintErrorMessage>Invalid WPA pass phrase, must be 8 to 63 printable characters!</constraintErrorMessage>
                     </properties>

--- a/interface-definitions/interfaces_wireless.xml.in
+++ b/interface-definitions/interfaces_wireless.xml.in
@@ -723,6 +723,15 @@
               <help>Wireless security settings</help>
             </properties>
             <children>
+              <leafNode name="bssid">
+                <properties>
+                  <help>Basic Service Set Identifier (BSSID)</help>
+                  <constraint>
+                    <regex>([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}</regex>
+                  </constraint>
+                  <constraintErrorMessage>Invalid BSSID</constraintErrorMessage>
+                </properties>
+              </leafNode>
               <node name="station-address">
                 <properties>
                   <help>Station MAC address based authentication</help>
@@ -899,15 +908,16 @@
                     </properties>
                     <defaultValue>wpa+wpa2</defaultValue>
                   </leafNode>
+                  #include <include/generic-username.xml.i>
                   <leafNode name="passphrase">
                     <properties>
-                      <help>WPA personal shared pass phrase. If you are using special characters in the WPA passphrase then single quotes are required.</help>
+                      <help>WPA passphrase. If you are using special characters in the WPA passphrase then single quotes are required.</help>
                       <valueHelp>
                         <format>txt</format>
-                        <description>Passphrase of at least 8 but not more than 63 printable characters</description>
+                        <description>Passphrase of at least 8 but not more than 63 printable characters for WPA-Personal and any passphrase for WPA-Enterprise</description>
                       </valueHelp>
                       <constraint>
-                        <regex>.{8,63}</regex>
+                        <regex>.*</regex>
                       </constraint>
                       <constraintErrorMessage>Invalid WPA pass phrase, must be 8 to 63 printable characters!</constraintErrorMessage>
                     </properties>

--- a/interface-definitions/interfaces_wireless.xml.in
+++ b/interface-definitions/interfaces_wireless.xml.in
@@ -723,15 +723,6 @@
               <help>Wireless security settings</help>
             </properties>
             <children>
-              <leafNode name="bssid">
-                <properties>
-                  <help>Basic Service Set Identifier (BSSID)</help>
-                  <constraint>
-                    <regex>([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}</regex>
-                  </constraint>
-                  <constraintErrorMessage>Invalid BSSID</constraintErrorMessage>
-                </properties>
-              </leafNode>
               <node name="station-address">
                 <properties>
                   <help>Station MAC address based authentication</help>
@@ -948,6 +939,19 @@
                 <regex>.{1,32}</regex>
               </constraint>
               <constraintErrorMessage>Invalid SSID</constraintErrorMessage>
+            </properties>
+          </leafNode>
+          <leafNode name="bssid">
+            <properties>
+              <help>Basic Service Set Identifier (BSSID) - currently station mode only</help>
+              <valueHelp>
+                <format>macaddr</format>
+                <description>BSSID (MAC) address</description>
+              </valueHelp>
+              <constraint>
+                <validator name="mac-address"/>
+              </constraint>
+              <constraintErrorMessage>Invalid BSSID</constraintErrorMessage>
             </properties>
           </leafNode>
           <leafNode name="type">

--- a/src/conf_mode/interfaces_wireless.py
+++ b/src/conf_mode/interfaces_wireless.py
@@ -184,11 +184,18 @@ def verify(wifi):
             if not any(i in ['passphrase', 'radius'] for i in wpa):
                 raise ConfigError('Misssing WPA key or RADIUS server')
 
+            if 'username' in wpa:
+                if 'passphrase' not in wpa:
+                    raise ConfigError('WPA-Enterprise configured - missing passphrase!')
+            elif 'passphrase' in wpa:
+                # check if passphrase meets the regex .{8,63}
+                if len(wpa['passphrase']) < 8 or len(wpa['passphrase']) > 63:
+                    raise ConfigError('WPA passphrase must be between 8 and 63 characters long')
             if 'radius' in wpa:
                 if 'server' in wpa['radius']:
                     for server in wpa['radius']['server']:
                         if 'key' not in wpa['radius']['server'][server]:
-                            raise ConfigError(f'Misssing RADIUS shared secret key for server: {server}')
+                            raise ConfigError(f'Missing RADIUS shared secret key for server: {server}')
 
     if 'capabilities' in wifi:
         capabilities = wifi['capabilities']


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added support for WPA-Enterprise client-mode
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6496

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireless

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Configuration:
```
vyos@vyos# edit interfaces wireless wlan0
set security wpa enterprise_username 'somedomain\someuser'
set security wpa enterprise_passphrase 'somepassphrase'
vyos@vyos#
```
`show interface wireless` output:
```
vyos@vyos:~$ show interfaces wireless
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
wlan0            -                                 A/D  SWC-24
wlan1            10.1.0.1/24                       A/D  Test AP (2.4Ghz)
wlan2            10.6.32.101/20                     u/u  SWC-5
vyos@vyos:~$
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation -->  it doesn't seem like the docs for wireless security document everything so I'm going to take that approach.
- [ ] I have updated the documentation accordingly 
