### PR TITLE
T6313: Add "NAT" to "generate" command for rule resequence

### DIFF
--- a/op-mode-definitions/generate_nat64_rule-resequence.xml.in
+++ b/op-mode-definitions/generate_nat64_rule-resequence.xml.in
@@ -2,9 +2,9 @@
 <interfaceDefinition>
   <node name="generate">
     <children>
-      <node name="firewall">
+      <node name="nat64">
         <properties>
-          <help>Firewall</help>
+          <help>Network Address Translation (NAT64)</help>
         </properties>
         <children>
           #include <include/rule-resequence.xml.i>

--- a/op-mode-definitions/generate_nat66_rule-resequence.xml.in
+++ b/op-mode-definitions/generate_nat66_rule-resequence.xml.in
@@ -2,9 +2,9 @@
 <interfaceDefinition>
   <node name="generate">
     <children>
-      <node name="firewall">
+      <node name="nat66">
         <properties>
-          <help>Firewall</help>
+          <help>Network Prefix Translation (NAT66/NPTv6)</help>
         </properties>
         <children>
           #include <include/rule-resequence.xml.i>

--- a/op-mode-definitions/generate_nat_rule-resequence.xml.in
+++ b/op-mode-definitions/generate_nat_rule-resequence.xml.in
@@ -2,9 +2,9 @@
 <interfaceDefinition>
   <node name="generate">
     <children>
-      <node name="firewall">
+      <node name="nat">
         <properties>
-          <help>Firewall</help>
+          <help>Network Address Translation (NAT)</help>
         </properties>
         <children>
           #include <include/rule-resequence.xml.i>

--- a/op-mode-definitions/include/rule-resequence.xml.i
+++ b/op-mode-definitions/include/rule-resequence.xml.i
@@ -1,0 +1,30 @@
+<!-- included start from show-nht.xml.i -->
+<node name="rule-resequence">
+  <properties>
+    <help>Resequence rules</help>
+  </properties>
+  <command>${vyos_op_scripts_dir}/generate_service_rule-resequence.py --service $2</command>
+  <children>
+    <tagNode name="start">
+      <properties>
+        <help>Set the first sequence number</help>
+        <completionHelp>
+          <list>1-1000</list>
+        </completionHelp>
+      </properties>
+      <command>${vyos_op_scripts_dir}/generate_service_rule-resequence.py --service $2 --start $5</command>
+      <children>
+        <tagNode name="step">
+          <properties>
+            <help>Step between rules</help>
+            <completionHelp>
+              <list>1-1000</list>
+            </completionHelp>
+          </properties>
+          <command>${vyos_op_scripts_dir}/generate_service_rule-resequence.py --service $2 --start $5 --step $7</command>
+        </tagNode>
+      </children>
+    </tagNode>
+  </children>
+</node>
+<!-- included end -->


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6313

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
generate firewall rule-resequence
generate firewall rule-resequence start 200
generate firewall rule-resequence start 200 step 100

generate nat rule-resequence
generate nat rule-resequence start 200
generate nat rule-resequence start 200 step 100

generate nat64 rule-resequence
generate nat64 rule-resequence start 200
generate nat64 rule-resequence start 200 step 100

generate nat66 rule-resequence
generate nat66 rule-resequence start 200
generate nat66 rule-resequence start 200 step 100
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
