### PR TITLE
op-mode: T6514: rework the "show system storage" code to handle live CD systems correctly

### DIFF
--- a/python/vyos/utils/disk.py
+++ b/python/vyos/utils/disk.py
@@ -1,4 +1,4 @@
-# Copyright 2023 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2023-2024 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -21,3 +21,52 @@ def device_from_id(id):
     for device in path.iterdir():
         if device.name.endswith(id):
             return device.readlink().stem
+
+def get_storage_stats(directory, human_units=True):
+    """ Return basic storage stats for given directory """
+    from re import sub as re_sub
+    from vyos.utils.process import cmd
+    from vyos.utils.convert import human_to_bytes
+
+    # XXX: using `df -h` and converting human units to bytes
+    # may seem pointless, but there's a reason.
+    # df uses different header field names with `-h` and without it ("Size" vs "1K-blocks")
+    # and outputs values in 1K blocks without `-h`,
+    # so some amount of conversion is needed anyway.
+    # Using `df -h` by default seems simpler.
+    #
+    # This is what the output looks like, as of Debian Buster/Bullseye:
+    # $ df -h -t ext4 --output=source,size,used,avail,pcent
+    # Filesystem      Size  Used Avail Use%
+    # /dev/sda1        16G  7.6G  7.3G  51%
+
+    out = cmd(f"df -h --output=source,size,used,avail,pcent {directory}")
+    lines = out.splitlines()
+    lists = [l.split() for l in lines]
+    res = {lists[0][i]: lists[1][i] for i in range(len(lists[0]))}
+
+    convert = (lambda x: x) if human_units else human_to_bytes
+
+    stats = {}
+
+    stats["filesystem"] = res["Filesystem"]
+    stats["size"] = convert(res["Size"])
+    stats["used"] = convert(res["Used"])
+    stats["avail"] = convert(res["Avail"])
+    stats["use_percentage"] = re_sub(r'%', '', res["Use%"])
+
+    return stats
+
+def get_persistent_storage_stats(human_units=True):
+    from os.path import exists as path_exists
+
+    persistence_dir = "/usr/lib/live/mount/persistence"
+    if path_exists(persistence_dir):
+        stats = get_storage_stats(persistence_dir, human_units=human_units)
+    else:
+        # If the persistence path doesn't exist,
+        # the system is running from a live CD
+        # and the concept of persistence storage stats is not applicable
+        stats = None
+
+    return stats


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

* Fix an unhandled exception when running `storage.py show --raw` on live CD systems.
* Make formatted and raw outputs use the same data.
* Put storage helpers in `vyos.utils.disk` to allow reuse in other scripts.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

On an installed system:

```
vyos@vyos:~$ show system storage 
Filesystem: /dev/sda3
Size:       20G
Used:       665M (4%)
Available:  18G (96%)

vyos@vyos:~$ sudo /usr/libexec/vyos/op_mode/storage.py show --raw
{
    "filesystem": "/dev/sda3",
    "size": 21474836480,
    "used": 698351616,
    "avail": 19327352832,
    "use_percentage": "4"
}

```

On a live CD it will give "Storage statistics are not available"

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
