### PR TITLE
T6477: Add telegraf loki output plugin

### DIFF
--- a/data/templates/telegraf/telegraf.j2
+++ b/data/templates/telegraf/telegraf.j2
@@ -41,6 +41,21 @@
   bucket = "{{ influxdb.bucket }}"
 ### End InfluxDB2 ###
 {% endif %}
+{% if loki is vyos_defined %}
+### Loki ###
+[[outputs.loki]]
+  ## The domain of Loki
+  domain = "{{ loki.url }}:{{ loki.port }}"
+{%     if loki.authentication.username is vyos_defined and loki.authentication.password is vyos_defined  %}
+  ## Basic Authentication
+  username = "{{ loki.authentication.username }}"
+  password = "{{ loki.authentication.password }}"
+{%     endif %}
+{%     if loki.metric_name_label is vyos_defined %}
+metric_name_label = "{{ loki.metric_name_label }}"
+{%     endif %}
+### End Loki ###
+{% endif %}
 {% if prometheus_client is vyos_defined %}
 ### Prometheus ###
 [[outputs.prometheus_client]]

--- a/interface-definitions/service_monitoring_telegraf.xml.in
+++ b/interface-definitions/service_monitoring_telegraf.xml.in
@@ -148,6 +148,39 @@
                   #include <include/url-http-https.xml.i>
                 </children>
               </node>
+              <node name="loki">
+                <properties>
+                  <help>Output plugin Loki</help>
+                </properties>
+                <children>
+                  <node name="authentication">
+                    <properties>
+                      <help>HTTP basic authentication parameters</help>
+                    </properties>
+                    <children>
+                      #include <include/generic-username.xml.i>
+                      #include <include/generic-password.xml.i>
+                    </children>
+                  </node>
+                  <leafNode name="metric-name-label">
+                    <properties>
+                      <help>Metric name label</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Label to use for the metric name</description>
+                      </valueHelp>
+                      <constraint>
+                        #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  #include <include/port-number.xml.i>
+                  <leafNode name="port">
+                    <defaultValue>3100</defaultValue>
+                  </leafNode>
+                  #include <include/url-http-https.xml.i>
+                </children>
+              </node>
               <leafNode name="source">
                 <properties>
                   <help>Source parameters for monitoring</help>

--- a/smoketest/scripts/cli/test_service_monitoring_telegraf.py
+++ b/smoketest/scripts/cli/test_service_monitoring_telegraf.py
@@ -17,6 +17,7 @@
 import unittest
 
 from base_vyostest_shim import VyOSUnitTestSHIM
+from vyos.configsession import ConfigSessionError
 
 from vyos.utils.process import process_named_running
 from vyos.utils.file import read_file
@@ -62,6 +63,34 @@ class TestMonitoringTelegraf(VyOSUnitTestSHIM.TestCase):
 
         for input in inputs:
             self.assertIn(input, config)
+
+    def test_02_loki(self):
+        label = 'r123'
+        loki_url = 'http://localhost'
+        port = '3100'
+        loki_username = 'VyOS'
+        loki_password = 'PassW0Rd_VyOS'
+
+        self.cli_set(base_path + ['loki', 'url', loki_url])
+        self.cli_set(base_path + ['loki', 'port', port])
+        self.cli_set(base_path + ['loki', 'metric-name-label', label])
+
+        self.cli_set(base_path + ['loki', 'authentication', 'username', loki_username])
+        # password not set
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(base_path + ['loki', 'authentication', 'password', loki_password])
+
+        # commit changes
+        self.cli_commit()
+
+        config = read_file(TELEGRAF_CONF)
+        self.assertIn(f'[[outputs.loki]]', config)
+        self.assertIn(f'domain = "{loki_url}:{port}"', config)
+        self.assertIn(f'metric_name_label = "{label}"', config)
+        self.assertIn(f'username = "{loki_username}"', config)
+        self.assertIn(f'password = "{loki_password}"', config)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/service_monitoring_telegraf.py
+++ b/src/conf_mode/service_monitoring_telegraf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2023 VyOS maintainers and contributors
+# Copyright (C) 2021-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -113,6 +113,9 @@ def get_config(config=None):
     if not conf.exists(base + ['azure-data-explorer']):
         del monitoring['azure_data_explorer']
 
+    if not conf.exists(base + ['loki']):
+        del monitoring['loki']
+
     return monitoring
 
 def verify(monitoring):
@@ -158,6 +161,19 @@ def verify(monitoring):
 
         if 'url' not in monitoring['splunk']:
             raise ConfigError(f'Monitoring splunk "url" is mandatory!')
+
+    # Verify Loki
+    if 'loki' in monitoring:
+        if 'url' not in monitoring['loki']:
+            raise ConfigError(f'Monitoring loki "url" is mandatory!')
+        if 'authentication' in monitoring['loki']:
+            if (
+                'username' not in monitoring['loki']['authentication']
+                or 'password' not in monitoring['loki']['authentication']
+            ):
+                raise ConfigError(
+                    f'Authentication "username" and "password" are mandatory!'
+                )
 
     return None
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add Loki plugin to telegraf

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6477

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
telegraf
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
```
set service monitoring telegraf loki url http://localhost
```
Check service:
```
vyos@vyos# sudo systemctl status telegraf
● telegraf.service - The plugin-driven server agent for reporting metrics into InfluxDB
     Loaded: loaded (/lib/systemd/system/telegraf.service; disabled; preset: enabled)
    Drop-In: /run/systemd/system/telegraf.service.d
             └─10-override.conf
     Active: active (running) since Tue 2024-06-25 10:03:48 UTC; 29s ago
       Docs: https://github.com/influxdata/telegraf
   Main PID: 123625 (telegraf)
      Tasks: 9 (limit: 1129)
     Memory: 43.0M
        CPU: 604ms
```
Check config:
```
vyos@vyos# cat /run/telegraf/telegraf.conf | grep -i loki -A 4
### Loki ###
[[outputs.loki]]
  ## The domain of Loki
  domain = "http://localhost:3100"
### End Loki ###
```

## Smoketest result
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_monitoring_telegraf.py
test_01_basic_config (__main__.TestMonitoringTelegraf.test_01_basic_config) ... ok
test_02_loki (__main__.TestMonitoringTelegraf.test_02_loki) ... ok

----------------------------------------------------------------------
Ran 2 tests in 20.102s

OK
vyos@vyos:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
