### PR TITLE
interfaces: T6519: harden config migration if ethernet interface is missing

### DIFF
--- a/python/vyos/ethtool.py
+++ b/python/vyos/ethtool.py
@@ -16,6 +16,7 @@
 import re
 
 from json import loads
+from vyos.utils.network import interface_exists
 from vyos.utils.process import popen
 
 # These drivers do not support using ethtool to change the speed, duplex, or
@@ -64,6 +65,9 @@ class Ethtool:
 
     def __init__(self, ifname):
         # Get driver used for interface
+        if not interface_exists(ifname):
+            raise ValueError(f'Interface "{ifname}" does not exist!')
+
         out, _ = popen(f'ethtool --driver {ifname}')
         driver = re.search(r'driver:\s(\w+)', out)
         if driver:

--- a/src/migration-scripts/interfaces/20-to-21
+++ b/src/migration-scripts/interfaces/20-to-21
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 VyOS maintainers and contributors
+# Copyright (C) 2021-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -22,6 +22,7 @@ from sys import argv
 
 from vyos.ethtool import Ethtool
 from vyos.configtree import ConfigTree
+from vyos.utils.network import interface_exists
 
 if len(argv) < 2:
     print("Must specify file name!")
@@ -38,6 +39,10 @@ if not config.exists(base):
     exit(0)
 
 for ifname in config.list_nodes(base):
+    # Bail out early if interface vanished from system
+    if not interface_exists(ifname):
+        continue
+
     eth = Ethtool(ifname)
 
     # If GRO is enabled by the Kernel - we reflect this on the CLI. If GRO is


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

During a corner case where the configuration is migrated to a different system with fewer ethernet interfaces, migration will fail during an image upgrade.

`vyos.ethtool.Ethtool()` is instantiated with an invalid interface leading to an exception that kills the migrator

This fixes the following error:


```console
vyos@vyos# load /usr/libexec/vyos/tests/config/bgp-evpn-l3vpn-pe-router
Loading configuration from '/usr/libexec/vyos/tests/config/bgp-evpn-l3vpn-pe-router'

Migration script error: /opt/vyatta/etc/config-migrate/migrate/interfaces/20-to-21: [Errno 1] failed to run command: ['/opt/vyatta/etc/con
fig-migrate/migrate/interfaces/20-to-21', '/tmp/tmprr8xf78f']
- op: set path: ['interfaces', 'ethernet', 'eth0', 'offload', 'gro'] value: None replace: True
- op: set path: ['interfaces', 'ethernet', 'eth0', 'offload', 'gso'] value: None replace: True
- op: set path: ['interfaces', 'ethernet', 'eth0', 'offload', 'sg'] value: None replace: True
- op: set path: ['interfaces', 'ethernet', 'eth0', 'offload', 'tso'] value: None replace: True
- op: set path: ['interfaces', 'ethernet', 'eth1', 'offload', 'gro'] value: None replace: True
- op: set path: ['interfaces', 'ethernet', 'eth1', 'offload', 'gso'] value: None replace: True
- op: set path: ['interfaces', 'ethernet', 'eth1', 'offload', 'sg'] value: None replace: True
- op: set path: ['interfaces', 'ethernet', 'eth1', 'offload', 'tso'] value: None replace: True
- op: set path: ['interfaces', 'ethernet', 'eth2', 'offload', 'gro'] value: None replace: True
- op: set path: ['interfaces', 'ethernet', 'eth2', 'offload', 'gso'] value: None replace: True
- op: set path: ['interfaces', 'ethernet', 'eth2', 'offload', 'sg'] value: None replace: True
- op: set path: ['interfaces', 'ethernet', 'eth2', 'offload', 'tso'] value: None replace: True

exit code: 1.
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6519

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
