### PR TITLE
utils: T6530: add a helper for easily calling iproute2 commands

### DIFF
--- a/python/vyos/utils/process.py
+++ b/python/vyos/utils/process.py
@@ -245,3 +245,18 @@ def is_systemd_service_running(service):
     Copied from: https://unix.stackexchange.com/a/435317 """
     tmp = cmd(f'systemctl show --value -p SubState {service}')
     return bool((tmp == 'running'))
+
+def ip_cmd(args, json=True):
+    """ A helper for easily calling iproute2 commands """
+    if json:
+        from json import loads
+        res = cmd(f"ip --json {args}").strip()
+        if res:
+            return loads(res)
+        else:
+            # Many mutation commands like "ip link set"
+            # return an empty string
+            return None
+    else:
+        res = cmd(f"ip {args}")
+        return res


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The helper calls iproute2 and returns a dict produced from its JSON output by default, but also offers an option to get a raw output instead.

```
from vyos.utils.process import ip_cmd

ip_cmd("link list")
# [{'ifindex': 1, 'ifname': 'lo', 'flags': ['LOOPBACK', 'UP', 'LOWER_UP'], 'mtu': 65536, 'qdisc': 'noqueue', 'operstate': 'UNKNOWN', 'linkmode': 'DEFAULT', 'group': 'default', 'txqlen': 1000, 'link_type': 'loopback', 'address': '00:00:00:00:00:00', 'broadcast': '00:00:00:00:00:00'},

ip_cmd("link list", json=False) # returns raw output
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

`vyos.utils`

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
