### PR TITLE
pbr: T6430: Allow forwarding into VRFs by name as well as route table IDs

### DIFF
--- a/interface-definitions/include/policy/route-common.xml.i
+++ b/interface-definitions/include/policy/route-common.xml.i
@@ -128,6 +128,24 @@
         </completionHelp>
       </properties>
     </leafNode>
+    <leafNode name="vrf">
+      <properties>
+        <help>VRF to forward packet with</help>
+        <valueHelp>
+          <format>txt</format>
+          <description>VRF instance name</description>
+        </valueHelp>
+        <valueHelp>
+          <format>default</format>
+          <description>Forward into default global VRF</description>
+        </valueHelp>
+        <completionHelp>
+          <list>default</list>
+          <path>vrf name</path>
+        </completionHelp>
+        #include <include/constraint/vrf.xml.i>
+      </properties>
+    </leafNode>
     <leafNode name="tcp-mss">
       <properties>
         <help>TCP Maximum Segment Size</help>

--- a/python/vyos/defaults.py
+++ b/python/vyos/defaults.py
@@ -50,3 +50,13 @@ commit_lock = os.path.join(directories['vyos_configdir'], '.lock')
 component_version_json = os.path.join(directories['data'], 'component-versions.json')
 
 config_default = os.path.join(directories['data'], 'config.boot.default')
+
+rt_symbolic_names = {
+  # Standard routing tables for Linux & reserved IDs for VyOS
+  'default': 253, # Confusingly, a final fallthru, not the default. 
+  'main': 254,    # The actual global table used by iproute2 unless told otherwise. 
+  'local': 255,   # Special kernel loopback table.
+}
+
+rt_global_vrf = rt_symbolic_names['main']
+rt_global_table = rt_symbolic_names['main']

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -30,7 +30,7 @@ from vyos.utils.dict import dict_search_args
 from vyos.utils.dict import dict_search_recursive
 from vyos.utils.process import cmd
 from vyos.utils.process import run
-from vyos.utils.network import get_vrf_table_id
+from vyos.utils.network import get_vrf_tableid
 from vyos.defaults import rt_global_table
 from vyos.defaults import rt_global_vrf
 
@@ -482,8 +482,8 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
             if vrf_name == 'default':
                 table = rt_global_vrf
             else:
-                # NOTE: VRF->table ID lookup depends on the VRF iface already existing. 
-                table = get_vrf_table_id(vrf_name)
+                # NOTE: VRF->table ID lookup depends on the VRF iface already existing.
+                table = get_vrf_tableid(vrf_name)
         if 'table' in rule_conf['set']:
             set_table = True
             table = rule_conf['set']['table']

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -74,6 +74,9 @@ def get_vrf_members(vrf: str) -> list:
         pass
     return interfaces
 
+def get_vrf_table_id(vrf: str):
+    return get_interface_config(vrf)['linkinfo']['info_data']['table']
+
 def get_interface_vrf(interface):
     """ Returns VRF of given interface """
     from vyos.utils.dict import dict_search

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -74,9 +74,6 @@ def get_vrf_members(vrf: str) -> list:
         pass
     return interfaces
 
-def get_vrf_table_id(vrf: str):
-    return get_interface_config(vrf)['linkinfo']['info_data']['table']
-
 def get_interface_vrf(interface):
     """ Returns VRF of given interface """
     from vyos.utils.dict import dict_search

--- a/src/conf_mode/policy_route.py
+++ b/src/conf_mode/policy_route.py
@@ -25,7 +25,7 @@ from vyos.template import render
 from vyos.utils.dict import dict_search_args
 from vyos.utils.process import cmd
 from vyos.utils.process import run
-from vyos.utils.network import get_vrf_table_id
+from vyos.utils.network import get_vrf_tableid
 from vyos.defaults import rt_global_table
 from vyos.defaults import rt_global_vrf
 from vyos import ConfigError
@@ -165,14 +165,14 @@ def apply_table_marks(policy):
                             if set_vrf == 'default':
                                 vrf_table_id = rt_global_vrf
                             else:
-                                vrf_table_id = get_vrf_table_id(set_vrf)
+                                vrf_table_id = get_vrf_tableid(set_vrf)
                         elif set_table:
                             if set_table == 'main':
                                 vrf_table_id = rt_global_table
                             else:
                                 vrf_table_id = set_table
                         if vrf_table_id is not None:
-                            vrf_table_id = int(vrf_table_id) 
+                            vrf_table_id = int(vrf_table_id)
                             if vrf_table_id in tables:
                                 continue
                             tables.append(vrf_table_id)

--- a/src/conf_mode/policy_route.py
+++ b/src/conf_mode/policy_route.py
@@ -25,6 +25,9 @@ from vyos.template import render
 from vyos.utils.dict import dict_search_args
 from vyos.utils.process import cmd
 from vyos.utils.process import run
+from vyos.utils.network import get_vrf_table_id
+from vyos.defaults import rt_global_table
+from vyos.defaults import rt_global_vrf
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -82,6 +85,9 @@ def verify_rule(policy, name, rule_conf, ipv6, rule_id):
             tcp_flags = dict_search_args(rule_conf, 'tcp', 'flags')
             if not tcp_flags or 'syn' not in tcp_flags:
                 raise ConfigError(f'{name} rule {rule_id}: TCP SYN flag must be set to modify TCP-MSS')
+
+        if 'vrf' in rule_conf['set'] and 'table' in rule_conf['set']:
+            raise ConfigError(f'{name} rule {rule_id}: Cannot set both forwarding route table and VRF')
 
     tcp_flags = dict_search_args(rule_conf, 'tcp', 'flags')
     if tcp_flags:
@@ -152,15 +158,26 @@ def apply_table_marks(policy):
             for name, pol_conf in policy[route].items():
                 if 'rule' in pol_conf:
                     for rule_id, rule_conf in pol_conf['rule'].items():
+                        vrf_table_id = None
                         set_table = dict_search_args(rule_conf, 'set', 'table')
-                        if set_table:
+                        set_vrf = dict_search_args(rule_conf, 'set', 'vrf')
+                        if set_vrf:
+                            if set_vrf == 'default':
+                                vrf_table_id = rt_global_vrf
+                            else:
+                                vrf_table_id = get_vrf_table_id(set_vrf)
+                        elif set_table:
                             if set_table == 'main':
-                                set_table = '254'
-                            if set_table in tables:
+                                vrf_table_id = rt_global_table
+                            else:
+                                vrf_table_id = set_table
+                        if vrf_table_id is not None:
+                            vrf_table_id = int(vrf_table_id) 
+                            if vrf_table_id in tables:
                                 continue
-                            tables.append(set_table)
-                            table_mark = mark_offset - int(set_table)
-                            cmd(f'{cmd_str} rule add pref {set_table} fwmark {table_mark} table {set_table}')
+                            tables.append(vrf_table_id)
+                            table_mark = mark_offset - vrf_table_id
+                            cmd(f'{cmd_str} rule add pref {vrf_table_id} fwmark {table_mark} table {vrf_table_id}')
 
 def cleanup_table_marks():
     for cmd_str in ['ip', 'ip -6']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
My [previous PR](https://github.com/vyos/vyos-1x/pull/3581) for simply extending the table ID range was rejected, so I've prepared another PR closer to my own use case for this - "policy based route leaking" between VRFs. It may or may not line up with Bernhard's intention from the original ticket. 

This PR extends PBR syntax to allow "set vrf" as well as "set table", resolving table ID from an active VRF and then treating it the same as a "set table". 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6430

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
 
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* pbr

## Proposed changes
<!--- Describe your changes in detail -->
* PBR can only target table IDs up to 200 and the previous PR to extend the range was rejected
* PBR with this PR can now also target VRFs directly by name, working around targeting problems for VRF table IDs outside the overlapping 100-200 range
* Validation ensures rules can't target both a table ID and a VRF name (internally they are handled the same)
* Added a simple accessor (get_vrf_table_id) for runtime mapping a VRF name to table ID, based on vyos.ifconfig.interface._set_vrf_ct_zone(). It does not replace that usage, as it deliberately does not handle non-VRF interface lookups (would fail with a KeyError). 
* Added smoketest to validate PBR 'set vrf' syntax

The use cases of this feature are limited and you will need to know *exactly* what you are doing to have it work properly, but for example, when I was experimenting with cross-VRF DNS lookup solutions, this would've been better than manipulating ip rules and nftables manually and externally. 

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Rules apply OK:
```
set name MGT table '666'
set policy route TEST rule 100 destination address '8.8.8.8'
set policy route TEST rule 100 destination port '53'
set policy route TEST rule 100 protocol 'tcp_udp'
set policy route TEST rule 100 set vrf 'MGT'
set policy route TEST2 rule 100 destination address '10.11.12.77'
set policy route TEST2 rule 100 protocol 'tcp_udp'
set policy route TEST2 rule 100 set vrf 'default'
set policy route TEST2 rule 100 source port '53'
```

Looking at the results:
``` 
# sudo ip rule show
220:    from all lookup 220
254:    from all fwmark 0x7fffff01 lookup main
666:    from all fwmark 0x7ffffd65 lookup MGT 
1000:   from all lookup [l3mdev-table]
2000:   from all lookup [l3mdev-table] unreachable
32765:  from all lookup local
32766:  from all lookup main
32767:  from all lookup default
# sudo nft list ruleset
[...]
table ip vyos_mangle {
        chain VYOS_PBR_PREROUTING {
                type filter hook prerouting priority mangle; policy accept;
        }

        chain VYOS_PBR_POSTROUTING {
                type filter hook postrouting priority mangle; policy accept;
        }

        chain VYOS_PBR_UD_TEST {
                meta l4proto { tcp, udp } ip daddr 8.8.8.8 th dport 53 counter packets 0 bytes 0 meta mark set 0x7ffffd65 return comment "ipv4-route-TEST-100"
        }

        chain VYOS_PBR_UD_TEST2 {
                meta l4proto { tcp, udp } ip daddr 10.11.12.77 th sport 53 counter packets 0 bytes 0 meta mark set 0x7fffff01 return comment "ipv4-route-TEST2-100"
        }
}
[...]
```

Attaching the PBRs to interfaces and watching traffic flow with tcpdump works as expected, the same as `set table`. 

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
$ python3 /usr/libexec/vyos/tests/smoke/cli/test_policy_route.py 
test_pbr_group (__main__.TestPolicyRoute.test_pbr_group) ... ok
test_pbr_mark (__main__.TestPolicyRoute.test_pbr_mark) ... ok
test_pbr_mark_connection (__main__.TestPolicyRoute.test_pbr_mark_connection) ... ok
test_pbr_matching_criteria (__main__.TestPolicyRoute.test_pbr_matching_criteria) ... ok
test_pbr_table (__main__.TestPolicyRoute.test_pbr_table) ... ok
test_pbr_vrf (__main__.TestPolicyRoute.test_pbr_vrf) ... ok

----------------------------------------------------------------------
Ran 6 tests in 32.673s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
