### PR TITLE
T6534: fix incorrect imports in vyos-config-encrypt.py

### DIFF
--- a/src/helpers/vyos-config-encrypt.py
+++ b/src/helpers/vyos-config-encrypt.py
@@ -26,9 +26,8 @@ from tempfile import TemporaryDirectory
 from vyos.tpm import clear_tpm_key
 from vyos.tpm import read_tpm_key
 from vyos.tpm import write_tpm_key
-from vyos.util import ask_input
-from vyos.util import ask_yes_no
-from vyos.util import cmd
+from vyos.utils.io import ask_input, ask_yes_no
+from vyos.utils.process import cmd
 
 persistpath_cmd = '/opt/vyatta/sbin/vyos-persistpath'
 mount_paths = ['/config', '/opt/vyatta/etc/config']


### PR DESCRIPTION
## Change Summary

When executing command encryption enable, the command fails with:
```
Traceback (most recent call last):
  File "/usr/libexec/vyos/vyos-config-encrypt.py", line 29, in <module>
    from vyos.util import ask_input
ModuleNotFoundError: No module named 'vyos.util'
```

This is due to incorrect python imports (`from vyos.util import ask_input` instead of `from vyos.utils.io import ask_input`). This PR fixes this.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
[https://vyos.dev/T6534](https://vyos.dev/T6534)

## Related PR(s)
none

## Component(s) name
encryption

## Proposed changes
Fix incorrect python imports.

## How to test
Execute `encryption enable`.

## Smoketest result
There is no smoketest for this. I've build qemu-live image, here's the cmd output:
```
vyos@vyos:~$ encryption enable
WARNING: VyOS will boot into a default config when encrypted without a TPM
You will need to manually login with default credentials and use "encryption load"
to mount the encrypted volume and use "load /config/config.boot"
```

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
