### PR TITLE
T6486: T6379: Rewrite generate openvpn client-config

### DIFF
--- a/src/op_mode/generate_ovpn_client_file.py
+++ b/src/op_mode/generate_ovpn_client_file.py
@@ -19,42 +19,53 @@ import argparse
 from jinja2 import Template
 from textwrap import fill
 
-from vyos.configquery import ConfigTreeQuery
+from vyos.config import Config
 from vyos.ifconfig import Section
 
 client_config = """
 
 client
 nobind
-remote {{ remote_host }} {{ port }}
+remote {{ local_host if local_host else 'x.x.x.x' }} {{ port }}
 remote-cert-tls server
-proto {{ 'tcp-client' if protocol == 'tcp-active' else 'udp' }}
-dev {{ device }}
-dev-type {{ device }}
+proto {{ 'tcp-client' if protocol == 'tcp-passive' else 'udp' }}
+dev {{ device_type }}
+dev-type {{ device_type }}
 persist-key
 persist-tun
 verb 3
 
 # Encryption options
+{# Define the encryption map #}
+{% set encryption_map = {
+    'des': 'DES-CBC',
+    '3des': 'DES-EDE3-CBC',
+    'bf128': 'BF-CBC',
+    'bf256': 'BF-CBC',
+    'aes128gcm': 'AES-128-GCM',
+    'aes128': 'AES-128-CBC',
+    'aes192gcm': 'AES-192-GCM',
+    'aes192': 'AES-192-CBC',
+    'aes256gcm': 'AES-256-GCM',
+    'aes256': 'AES-256-CBC'
+} %}
+
 {% if encryption is defined and encryption is not none %}
-{%   if encryption.cipher is defined and encryption.cipher is not none %}
-cipher {{ encryption.cipher }}
-{%     if encryption.cipher == 'bf128' %}
-keysize 128
-{%     elif encryption.cipher == 'bf256' %}
-keysize 256
+{%     if encryption.ncp_ciphers is defined and encryption.ncp_ciphers is not none %}
+cipher {% for algo in encryption.ncp_ciphers %}
+{{ encryption_map[algo] if algo in encryption_map.keys() else algo }}{% if not loop.last %}:{% endif %}
+{%      endfor %}
+
+data-ciphers {% for algo in encryption.ncp_ciphers %}
+{{ encryption_map[algo] if algo in encryption_map.keys() else algo }}{% if not loop.last %}:{% endif %}
+{%      endfor %}
 {%     endif %}
-{%   endif %}
-{%   if encryption.ncp_ciphers is defined and encryption.ncp_ciphers is not none %}
-data-ciphers {{ encryption.ncp_ciphers }}
-{%   endif %}
 {% endif %}
 
 {% if hash is defined and hash is not none %}
 auth {{ hash }}
 {% endif %}
-keysize 256
-comp-lzo {{ '' if use_lzo_compression is defined else 'no' }}
+{{ 'comp-lzo' if use_lzo_compression is defined else '' }}
 
 <ca>
 -----BEGIN CERTIFICATE-----
@@ -79,7 +90,7 @@ comp-lzo {{ '' if use_lzo_compression is defined else 'no' }}
 
 """
 
-config = ConfigTreeQuery()
+config = Config()
 base = ['interfaces', 'openvpn']
 
 if not config.exists(base):
@@ -89,10 +100,22 @@ if not config.exists(base):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("-i", "--interface", type=str, help='OpenVPN interface the client is connecting to', required=True)
-    parser.add_argument("-a", "--ca", type=str, help='OpenVPN CA cerificate', required=True)
-    parser.add_argument("-c", "--cert", type=str, help='OpenVPN client cerificate', required=True)
-    parser.add_argument("-k", "--key", type=str, help='OpenVPN client cerificate key', action="store")
+    parser.add_argument(
+        "-i",
+        "--interface",
+        type=str,
+        help='OpenVPN interface the client is connecting to',
+        required=True,
+    )
+    parser.add_argument(
+        "-a", "--ca", type=str, help='OpenVPN CA cerificate', required=True
+    )
+    parser.add_argument(
+        "-c", "--cert", type=str, help='OpenVPN client cerificate', required=True
+    )
+    parser.add_argument(
+        "-k", "--key", type=str, help='OpenVPN client cerificate key', action="store"
+    )
     args = parser.parse_args()
 
     interface = args.interface
@@ -114,33 +137,25 @@ if __name__ == '__main__':
     if not config.exists(['pki', 'certificate', cert, 'private', 'key']):
         exit(f'OpenVPN certificate key "{key}" does not exist!')
 
-    ca = config.value(['pki', 'ca', ca, 'certificate'])
+    config = config.get_config_dict(
+        base + [interface],
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        with_recursive_defaults=True,
+        with_pki=True,
+    )
+
+    ca = config['pki']['ca'][ca]['certificate']
     ca = fill(ca, width=64)
-    cert = config.value(['pki', 'certificate', cert, 'certificate'])
+    cert = config['pki']['certificate'][cert]['certificate']
     cert = fill(cert, width=64)
-    key = config.value(['pki', 'certificate', key, 'private', 'key'])
+    key = config['pki']['certificate'][key]['private']['key']
     key = fill(key, width=64)
-    remote_host = config.value(base + [interface, 'local-host'])
 
-    ovpn_conf = config.get_config_dict(base + [interface], key_mangling=('-', '_'), get_first_key=True)
+    config['ca'] = ca
+    config['cert'] = cert
+    config['key'] = key
+    config['port'] = '1194' if 'local_port' not in config else config['local_port']
 
-    port = '1194' if 'local_port' not in ovpn_conf else ovpn_conf['local_port']
-    proto = 'udp' if 'protocol' not in ovpn_conf else ovpn_conf['protocol']
-    device = 'tun' if 'device_type' not in ovpn_conf else ovpn_conf['device_type']
-
-    config = {
-        'interface'   : interface,
-        'ca'          : ca,
-        'cert'        : cert,
-        'key'         : key,
-        'device'      : device,
-        'port'        : port,
-        'proto'       : proto,
-        'remote_host' : remote_host,
-        'address'     : [],
-    }
-
-# Clear out terminal first
-print('\x1b[2J\x1b[H')
-client = Template(client_config, trim_blocks=True).render(config)
-print(client)
+    client = Template(client_config, trim_blocks=True).render(config)
+    print(client)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This command helps to generate users `.ovpn` files Rewrite `generate openvpn client-config` to use Config() It needs to get the default values as `ConfigTreeQuery` is not supporting default values.

Fixed "ignores configured protocol type" if TCP is used 
Fixed lzo, was used even if lzo was not configured
Fixed encryption does not parse the dict

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6486
* https://vyos.dev/T6379

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openvpn
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure Openvpn in TCP mode, 
```
set interfaces openvpn vtun20 encryption ncp-ciphers 'aes256'
set interfaces openvpn vtun20 hash 'sha512'
set interfaces openvpn vtun20 local-host '203.0.113.1'
set interfaces openvpn vtun20 mode 'server'
set interfaces openvpn vtun20 protocol 'tcp-passive'
set interfaces openvpn vtun20 server subnet '10.0.22.0/24'
set interfaces openvpn vtun20 tls ca-certificate 'openvpn-ca'
set interfaces openvpn vtun20 tls certificate 'openvpn-cert'
set interfaces openvpn vtun20 tls dh-params 'dh'
```
Before the fix the proto is UDP, but expected TCP
Generated OpenVPN client config file
```
client
nobind
remote None 1194
remote-cert-tls server
proto udp
dev tun
dev-type tun
persist-key
persist-tun
verb 3
comp-lzo no
```

After the fix the protocol is correct, encyption with correct maps, lzo not exists:
```
vyos@vyos# run generate openvpn client-config interface vtun20 ca openvpn-ca certificate openvpn-client

client
nobind
remote 203.0.113.1 1194
remote-cert-tls server
proto tcp-client
dev tun
dev-type tun
persist-key
persist-tun
verb 3

# Encryption options

cipher AES-256-CBC
data-ciphers AES-256-CBC
auth sha512
...
```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
