### PR TITLE
T6536: nat: add migration script that replaces wildcard charater

### DIFF
--- a/src/migration-scripts/firewall/7-to-8
+++ b/src/migration-scripts/firewall/7-to-8
@@ -71,5 +71,11 @@ def migrate(config: ConfigTree) -> None:
         config.set_tag(['firewall', 'zone'])
 
         for zone in config.list_nodes(zone_base + ['zone']):
+            if 'interface' in config.list_nodes(zone_base + ['zone', zone]):
+                for iface in config.return_values(zone_base + ['zone', zone, 'interface']):
+                    if '+' in iface:
+                        config.delete_value(zone_base + ['zone', zone, 'interface'], value=iface)
+                        iface = iface.replace('+', '*')
+                        config.set(zone_base + ['zone', zone, 'interface'], value=iface, replace=False)
             config.copy(zone_base + ['zone', zone], ['firewall', 'zone', zone])
         config.delete(zone_base)

--- a/src/migration-scripts/nat/6-to-7
+++ b/src/migration-scripts/nat/6-to-7
@@ -47,6 +47,8 @@ def migrate(config: ConfigTree) -> None:
                         tmp = config.return_value(base + [iface, 'interface-name'])
                         if tmp != 'any':
                             config.delete(base + [iface, 'interface-name'])
+                            if '+' in tmp:
+                                tmp = tmp.replace('+', '*')
                             config.set(base + [iface, 'name'], value=tmp)
                         else:
                             config.delete(base + [iface])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Change wildcard character from + to *
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6536

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
nat
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Config valid an running on 1.3:
```
vyos@vyos:~$ show version | grep Version
Version:          VyOS 1.3.7
vyos@upgrade-test:~$ show config comm | grep "nat\|zone"
set nat destination rule 10 destination port '9101'
set nat destination rule 10 inbound-interface 'eth2'
set nat destination rule 10 protocol 'tcp'
set nat destination rule 10 translation address '198.51.100.2'
set nat destination rule 200 inbound-interface 'pppoe2.+'
set nat destination rule 200 protocol 'gre'
set nat destination rule 200 translation address '203.0.113.66'
set nat source rule 10 outbound-interface 'eth0'
set nat source rule 10 translation address 'masquerade'
set nat source rule 200 outbound-interface 'l2tp+'
set nat source rule 200 protocol 'udp'
set nat source rule 200 translation port '8899'
set zone-policy zone LAN interface 'eth2'
set zone-policy zone LAN interface 'bond+'
set zone-policy zone LOCAL local-zone
set zone-policy zone WAN interface 'eth1'
vyos@upgrade-test:~$ 

### And from iptables:
-A VZONE_LAN -i bond+ -j RETURN
-A VZONE_LAN -i eth2 -j RETURN
-A VZONE_LAN -j DROP
-A VZONE_WAN -i eth1 -j RETURN
-A VZONE_WAN -j DROP
# and nat:
-A PREROUTING -j VYATTA_PRE_DNAT_HOOK
-A PREROUTING -i eth2 -p tcp -m tcp --dport 9101 -m comment --comment DST-NAT-10 -j DNAT --to-destination 198.51.100.2
-A PREROUTING -i pppoe2.+ -p gre -m comment --comment DST-NAT-200 -j DNAT --to-destination 203.0.113.66
-A POSTROUTING -j VYATTA_PRE_SNAT_HOOK
-A POSTROUTING -o eth0 -m comment --comment SRC-NAT-10 -j MASQUERADE
-A POSTROUTING -o l2tp+ -p udp -m comment --comment SRC-NAT-200 -j SNAT --to-source :8899

```
And after upgrade:
```
[   45.733753] vyos-router[1058]: Starting VyOS router: migrate system configure.
[   46.221513] vyos-config[1064]: Configuration success

Welcome to VyOS - upgrade-test ttyS0

upgrade-test login: vyos                                                          
Password: 
Welcome to VyOS!

   ┌── ┐
   . VyOS 1.5-rolling-202407031340
   └ ──┘  current

 * Documentation:  https://docs.vyos.io/en/latest
 * Project news:   https://blog.vyos.io
 * Bug reports:    https://vyos.dev

You can change this banner using "set system login banner post-login" command.

VyOS is a free software distribution that includes multiple components,
you can check individual component licenses under /usr/share/doc/*/copyright
vyos@upgrade-test:~$ show config comm | grep "nat\|zone"
set firewall zone LAN default-action 'drop'
set firewall zone LAN interface 'eth2'
set firewall zone LAN interface 'bond*'
set firewall zone LOCAL default-action 'drop'
set firewall zone LOCAL local-zone
set firewall zone WAN default-action 'drop'
set firewall zone WAN interface 'eth1'
set nat destination rule 10 destination port '9101'
set nat destination rule 10 inbound-interface name 'eth2'
set nat destination rule 10 protocol 'tcp'
set nat destination rule 10 translation address '198.51.100.2'
set nat destination rule 200 inbound-interface name 'pppoe2.*'
set nat destination rule 200 protocol 'gre'
set nat destination rule 200 translation address '203.0.113.66'
set nat source rule 10 outbound-interface name 'eth0'
set nat source rule 10 translation address 'masquerade'
set nat source rule 200 outbound-interface name 'l2tp*'
set nat source rule 200 protocol 'udp'
set nat source rule 200 translation port '8899'
vyos@upgrade-test:~$ 
vyos@upgrade-test:~$ sudo nft list table ip vyos_nat | grep "ROUTING\|ifname"
	chain PREROUTING {
		iifname "eth2" tcp dport 9101 counter packets 0 bytes 0 dnat to 198.51.100.2 comment "DST-NAT-10"
		iifname "pppoe2.*" meta l4proto gre counter packets 0 bytes 0 dnat to 203.0.113.66 comment "DST-NAT-200"
	chain POSTROUTING {
		oifname "eth0" counter packets 0 bytes 0 masquerade comment "SRC-NAT-10"
		oifname "l2tp*" meta l4proto udp counter packets 0 bytes 0 snat to :8899 comment "SRC-NAT-200"
vyos@upgrade-test:~$ 
vyos@upgrade-test:~$ sudo nft list table ip vyos_filter | grep "ifname\|ZONE"
	chain VYOS_ZONE_FORWARD {
		oifname { "bond*", "eth2" } counter packets 0 bytes 0 jump VZONE_LAN
		oifname "eth1" counter packets 0 bytes 0 jump VZONE_WAN
	chain VYOS_ZONE_LOCAL {
		counter packets 897 bytes 168268 jump VZONE_LOCAL_IN
	chain VYOS_ZONE_OUTPUT {
		counter packets 144 bytes 10656 jump VZONE_LOCAL_OUT
	chain VZONE_LAN {
		iifname { "bond*", "eth2" } counter packets 0 bytes 0 return
	chain VZONE_LOCAL_IN {
		iifname "lo" counter packets 144 bytes 10656 return
	chain VZONE_LOCAL_OUT {
		oifname "lo" counter packets 144 bytes 10656 return
	chain VZONE_WAN {
		iifname "eth1" counter packets 0 bytes 0 return
vyos@upgrade-test:~$ 

```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
