### PR TITLE
T6538: Add the ability to set GENEVE interfaces to VRF

### DIFF
--- a/interface-definitions/interfaces_geneve.xml.in
+++ b/interface-definitions/interfaces_geneve.xml.in
@@ -52,6 +52,7 @@
           #include <include/interface/mirror.xml.i>
           #include <include/interface/redirect.xml.i>
           #include <include/interface/tunnel-remote.xml.i>
+          #include <include/interface/vrf.xml.i>
           #include <include/vni.xml.i>
         </children>
       </tagNode>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add the ability to set GENEVE interfaces to VRF
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6538

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
geneve
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set vrf bind-to-all
set vrf name first table '123'

set interfaces ethernet eth1 address '100.64.0.1/29'
set interfaces ethernet eth1 vrf 'first'
set interfaces geneve gnv0 address '10.0.0.1/30'
set interfaces geneve gnv0 remote '100.64.0.2'
set interfaces geneve gnv0 vni '10'
set interfaces geneve gnv0 vrf 'first'

set policy local-route rule 10 destination address '100.64.0.2'
set policy local-route rule 10 set table '123'
```
Ping the remote site geneve interface
```
vyos@vyos# run ping 10.0.0.2 vrf first count 2
PING 10.0.0.2 (10.0.0.2) 56(84) bytes of data.
64 bytes from 10.0.0.2: icmp_seq=1 ttl=64 time=3.38 ms
64 bytes from 10.0.0.2: icmp_seq=2 ttl=64 time=0.991 ms

--- 10.0.0.2 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1002ms
rtt min/avg/max/mdev = 0.991/2.185/3.380/1.194 ms
[edit]
vyos@vyos#
```
Check dump on the remote site:
```
vyos@r2:~$ sudo tcpdump -ni gnv0
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on gnv0, link-type EN10MB (Ethernet), capture size 262144 bytes
14:05:30.099307 IP 10.0.0.1 > 10.0.0.2: ICMP echo request, id 39014, seq 1, length 64
14:05:30.099419 IP 10.0.0.2 > 10.0.0.1: ICMP echo reply, id 39014, seq 1, length 64
14:05:31.101400 IP 10.0.0.1 > 10.0.0.2: ICMP echo request, id 39014, seq 2, length 64
14:05:31.101648 IP 10.0.0.2 > 10.0.0.1: ICMP echo reply, id 39014, seq 2, length 64
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
