### PR TITLE
vxlan: T6505: Support VXLAN VLAN-VNI range mapping in CLI

### DIFF
--- a/interface-definitions/interfaces_vxlan.xml.in
+++ b/interface-definitions/interfaces_vxlan.xml.in
@@ -117,15 +117,35 @@
                 <format>u32:0-4094</format>
                 <description>Virtual Local Area Network (VLAN) ID</description>
               </valueHelp>
+              <valueHelp>
+                <format>&lt;start-end&gt;</format>
+                <description>VLAN IDs range (use '-' as delimiter)</description>
+              </valueHelp>
               <constraint>
-                <validator name="numeric" argument="--range 0-4094"/>
+                <validator name="numeric" argument="--allow-range --range 0-4094"/>
               </constraint>
-              <constraintErrorMessage>VLAN ID must be between 0 and 4094</constraintErrorMessage>
+              <constraintErrorMessage>Not a valid VLAN ID or range, VLAN ID must be between 0 and 4094</constraintErrorMessage>
             </properties>
             <children>
-              #include <include/vni.xml.i>
+              <leafNode name="vni">
+                <properties>
+                  <help>Virtual Network Identifier</help>
+                  <valueHelp>
+                    <format>u32:0-16777214</format>
+                    <description>VXLAN virtual network identifier</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>&lt;start-end&gt;</format>
+                    <description>VXLAN virtual network IDs range (use '-' as delimiter)</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--allow-range --range 0-16777214"/>
+                  </constraint>
+                  <constraintErrorMessage>Not a valid VXLAN virtual network ID or range</constraintErrorMessage>
+                </properties>
+              </leafNode>
             </children>
-            </tagNode>
+          </tagNode>
         </children>
       </tagNode>
     </children>

--- a/src/conf_mode/interfaces_vxlan.py
+++ b/src/conf_mode/interfaces_vxlan.py
@@ -178,13 +178,36 @@ def verify(vxlan):
                               'is member of a bridge interface!')
 
         vnis_used = []
+        vlans_used = []
         for vif, vif_config in vxlan['vlan_to_vni'].items():
             if 'vni' not in vif_config:
                 raise ConfigError(f'Must define VNI for VLAN "{vif}"!')
             vni = vif_config['vni']
-            if vni in vnis_used:
-                raise ConfigError(f'VNI "{vni}" is already assigned to a different VLAN!')
-            vnis_used.append(vni)
+
+            err_msg = f'VLAN range "{vif}" does not match VNI range "{vni}"!'
+            vif_range, vni_range = list(map(int, vif.split('-'))), list(map(int, vni.split('-')))
+
+            if len(vif_range) != len(vni_range):
+                raise ConfigError(err_msg)
+
+            if len(vif_range) > 1:
+                if vni_range[0] > vni_range[-1] or vif_range[0] > vif_range[-1]:
+                    raise ConfigError('The upper bound of the range must be greater than the lower bound!')
+                vni_range = range(vni_range[0], vni_range[1] + 1)
+                vif_range = range(vif_range[0], vif_range[1] + 1)
+
+            if len(vif_range) != len(vni_range):
+                raise ConfigError(err_msg)
+
+            for vni_id in vni_range:
+                if vni_id in vnis_used:
+                    raise ConfigError(f'VNI "{vni_id}" is already assigned to a different VLAN!')
+                vnis_used.append(vni_id)
+
+            for vif_id in vif_range:
+                if vif_id in vlans_used:
+                    raise ConfigError(f'VLAN "{vif_id}" is already in use!')
+                vlans_used.append(vif_id)
 
     if dict_search('parameters.neighbor_suppress', vxlan) != None:
         if 'is_bridge_member' not in vxlan:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Now can add vlan-to-vni range mapping
```
set interfaces vxlan vxlan0 vlan-to-vni 31-35 vni 10031-10035
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6505
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set interfaces bridge br0 member interface vxlan0
set interfaces vxlan vxlan0 parameters external
set interfaces vxlan vxlan0 source-address '127.0.0.1'
set interfaces vxlan vxlan0 vlan-to-vni 30 vni '10030'
set interfaces vxlan vxlan0 vlan-to-vni 35-40 vni '10035-10040'
commit

vyos@vyos# bridge --json vlan tunnelshow dev vxlan0
[{"ifname":"vxlan0","tunnels":[{"vlan":30,"tunid":10030},{"vlan":35,"vlanEnd":40,"tunid":10035,"tunidEnd":10040}]}]
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# python3 /usr/libexec/vyos/tests/smoke/cli/test_interfaces_vxlan.py
test_add_multiple_ip_addresses (__main__.VXLANInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.VXLANInterfaceTest.test_add_single_ip_address) ... ok
test_dhcp_client_options (__main__.VXLANInterfaceTest.test_dhcp_client_options) ... skipped 'not supported'
test_dhcp_disable_interface (__main__.VXLANInterfaceTest.test_dhcp_disable_interface) ... skipped 'not supported'
test_dhcp_vrf (__main__.VXLANInterfaceTest.test_dhcp_vrf) ... skipped 'not supported'
test_dhcpv6_client_options (__main__.VXLANInterfaceTest.test_dhcpv6_client_options) ... skipped 'not supported'
test_dhcpv6_vrf (__main__.VXLANInterfaceTest.test_dhcpv6_vrf) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.VXLANInterfaceTest.test_dhcpv6pd_auto_sla_id) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.VXLANInterfaceTest.test_dhcpv6pd_manual_sla_id) ... skipped 'not supported'
test_interface_description (__main__.VXLANInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.VXLANInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.VXLANInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.VXLANInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.VXLANInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.VXLANInterfaceTest.test_ipv6_link_local_address) ... ok
test_mtu_1200_no_ipv6_interface (__main__.VXLANInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.VXLANInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.VXLANInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.VXLANInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.VXLANInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.VXLANInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.VXLANInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.VXLANInterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'
test_vxlan_external (__main__.VXLANInterfaceTest.test_vxlan_external) ... ok
test_vxlan_neighbor_suppress (__main__.VXLANInterfaceTest.test_vxlan_neighbor_suppress) ... ok
test_vxlan_parameters (__main__.VXLANInterfaceTest.test_vxlan_parameters) ... ok
test_vxlan_vlan_vni_mapping (__main__.VXLANInterfaceTest.test_vxlan_vlan_vni_mapping) ... ok
test_vxlan_vni_filter (__main__.VXLANInterfaceTest.test_vxlan_vni_filter) ... ok
test_vxlan_vni_filter_add_remove (__main__.VXLANInterfaceTest.test_vxlan_vni_filter_add_remove) ... ok

----------------------------------------------------------------------
Ran 29 tests in 141.478s

OK (skipped=14)
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
