### PR TITLE
wireless: T4287: use upstream regulatory database due to kernel signing

### DIFF
--- a/debian/vyos-1x.preinst
+++ b/debian/vyos-1x.preinst
@@ -9,3 +9,6 @@ dpkg-divert --package vyos-1x --add --no-rename /etc/netplug/netplugd.conf
 dpkg-divert --package vyos-1x --add --no-rename /etc/netplug/netplug
 dpkg-divert --package vyos-1x --add --no-rename /etc/rsyslog.d/45-frr.conf
 dpkg-divert --package vyos-1x --add --no-rename /lib/udev/rules.d/99-systemd.rules
+
+# T4287 - as we have a non-signed kernel use the upstream wireless reulatory database
+update-alternatives --set regulatory.db /lib/firmware/regulatory.db-upstream


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Most likely b/c of our non signed Kernel binary we do not trust the Debian signed wireless regulatory database. Fallback to the upstream database instead.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T4287

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireless

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

### Before

```
$ sudo modprobe mac80211_hwsim
$ sudo dmesg | grep cfg802
[300193.910158] cfg80211: Loading compiled-in X.509 certificates for regulatory database
[300193.963289] cfg80211: loaded regulatory.db is malformed or signature is missing/invalid
```

### After
```
$ sudo modprobe mac80211_hwsim
$ sudo dmesg | grep cfg802
[  214.146753] cfg80211: Loading compiled-in X.509 certificates for regulatory database
[  214.150882] Loaded X.509 cert 'sforshee: 00b28ddf47aef9cea7'
[  214.151035] Loaded X.509 cert 'wens: 61c038651aabdcf94bd0ac7ff06c7248db18c600'
[  214.593082] mac80211_hwsim: initializing netlink
[  214.593560] ieee80211 phy0: Selected rate control algorithm 'minstrel_ht'
[  214.594285] ieee80211 phy1: Selected rate control algorithm 'minstrel_ht'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
