### PR TITLE
wireless: T4287: use Debian postinst over preinst when using update-alternatives

### DIFF
--- a/debian/vyos-1x.postinst
+++ b/debian/vyos-1x.postinst
@@ -256,3 +256,6 @@ python3 /usr/lib/python3/dist-packages/vyos/xml_ref/update_cache.py
 if [ ! -f /lib/systemd/system/ssh@.service ]; then
     ln /lib/systemd/system/ssh.service /lib/systemd/system/ssh@.service
 fi
+
+# T4287 - as we have a non-signed kernel use the upstream wireless reulatory database
+update-alternatives --set regulatory.db /lib/firmware/regulatory.db-upstream

--- a/debian/vyos-1x.preinst
+++ b/debian/vyos-1x.preinst
@@ -9,6 +9,3 @@ dpkg-divert --package vyos-1x --add --no-rename /etc/netplug/netplugd.conf
 dpkg-divert --package vyos-1x --add --no-rename /etc/netplug/netplug
 dpkg-divert --package vyos-1x --add --no-rename /etc/rsyslog.d/45-frr.conf
 dpkg-divert --package vyos-1x --add --no-rename /lib/udev/rules.d/99-systemd.rules
-
-# T4287 - as we have a non-signed kernel use the upstream wireless reulatory database
-update-alternatives --set regulatory.db /lib/firmware/regulatory.db-upstream


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This fixes an error during ISO assembly:

```
update-alternatives: error: no alternatives for regulatory.db dpkg: error processing archive /tmp/apt-dpkg-install-PJplR3/00-vyos-1x_1.5dev0-1880-gecaa44498_amd64.deb (--unpack):
 new vyos-1x package pre-installation script subprocess returned error exit status 2
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/3777

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
