### PR TITLE
migration: T6007: add missing check for None in utility function

### DIFF
--- a/python/vyos/component_version.py
+++ b/python/vyos/component_version.py
@@ -129,6 +129,7 @@ def component_from_string(string: str) -> dict:
     return {k: int(v) for k, v in re.findall(r'([\w,-]+)@(\d+)', string)}
 
 def version_info_from_file(config_file) -> VersionInfo:
+    """Return config file component and release version info."""
     version_info = VersionInfo()
     try:
         with open(config_file) as f:
@@ -166,9 +167,7 @@ def version_info_from_file(config_file) -> VersionInfo:
     return version_info
 
 def version_info_from_system() -> VersionInfo:
-    """
-    Return system component versions.
-    """
+    """Return system component and release version info."""
     d = component_version()
     sort_d = dict(sorted(d.items(), key=lambda x: x[0]))
     version_info = VersionInfo(
@@ -180,20 +179,18 @@ def version_info_from_system() -> VersionInfo:
     return version_info
 
 def version_info_copy(v: VersionInfo) -> VersionInfo:
-    """
-    Make a copy of dataclass.
-    """
+    """Make a copy of dataclass."""
     return replace(v)
 
 def version_info_prune_component(x: VersionInfo, y: VersionInfo) -> VersionInfo:
-    """
-    In place pruning of component keys of x not in y.
-    """
+    """In place pruning of component keys of x not in y."""
+    if x.component is None or y.component is None:
+        return
     x.component = { k: v for k,v in x.component.items() if k in y.component }
 
 def add_system_version(config_str: str = None, out_file: str = None):
-    """
-    Wrap config string with system version and write to out_file.
+    """Wrap config string with system version and write to out_file.
+
     For convenience, calling with no argument will write system version
     string to stdout, for use in bash scripts.
     """


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Fix bug in migration utility function in case of config file with empty component string.

Note that the revisions to the migration system have not yet been backported to Circinus, in case of needed fixes, such as this one. Not for mergify yet.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
