### PR TITLE
GitHub: T6494: do not use 0/null value to mark build succeed

### DIFF
--- a/.github/workflows/package-smoketest.yml
+++ b/.github/workflows/package-smoketest.yml
@@ -79,12 +79,13 @@ jobs:
         id: test
         shell: bash
         run: |
-          # always fail first
-          echo "exit_code=1" >> $GITHUB_OUTPUT
+          set -e
           sudo make test
-          exit_code=$?
-          echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
-          exit $exit_code
+          if [[ $? == 0 ]]; then
+            echo "exit_code=success" >> $GITHUB_OUTPUT
+          else
+            echo "exit_code=fail" >> $GITHUB_OUTPUT
+          fi
 
   test_config_load:
     needs: build_iso
@@ -109,12 +110,13 @@ jobs:
         id: test
         shell: bash
         run: |
-          # always fail first
-          echo "exit_code=1" >> $GITHUB_OUTPUT
+          set -e
           sudo make testc
-          exit_code=$?
-          echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
-          exit $exit_code
+          if [[ $? == 0 ]]; then
+            echo "exit_code=success" >> $GITHUB_OUTPUT
+          else
+            echo "exit_code=fail" >> $GITHUB_OUTPUT
+          fi
 
   test_raid1_install:
     needs: build_iso
@@ -139,12 +141,13 @@ jobs:
         id: test
         shell: bash
         run: |
-          # always fail first
-          echo "exit_code=1" >> $GITHUB_OUTPUT
+          set -e
           sudo make testraid
-          exit_code=$?
-          echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
-          exit $exit_code
+          if [[ $? == 0 ]]; then
+            echo "exit_code=success" >> $GITHUB_OUTPUT
+          else
+            echo "exit_code=fail" >> $GITHUB_OUTPUT
+          fi
 
   result:
     needs:
@@ -160,15 +163,15 @@ jobs:
         uses: mshick/add-pr-comment@v2
         with:
           message: |
-            CI integration ${{ needs.test_smoketest_cli.outputs.exit_code == 0 && needs.test_config_load.outputs.exit_code == 0 && needs.test_raid1_install.outputs.exit_code == 0 && '👍 passed!' || '❌ failed!' }}
+            CI integration ${{ needs.test_smoketest_cli.outputs.exit_code == 'success' && needs.test_config_load.outputs.exit_code == 'success' && needs.test_raid1_install.outputs.exit_code == 'success' && '👍 passed!' || '❌ failed!' }}
 
             ### Details
 
             [CI logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
-            * ${{ needs.test_smoketest_cli.outputs.exit_code == '0' && '👍 passed' || '❌ failed' }} CLI Smoketests returned: ${{ needs.test_smoketest_cli.outputs.exit_code }}
-            * ${{ needs.test_config_load.outputs.exit_code == '0' && '👍 passed' || '❌ failed' }} Config tests returned: ${{ needs.test_config_load.outputs.exit_code }}
-            * ${{ needs.test_raid1_install.outputs.exit_code == '0' && '👍 passed' || '❌ failed' }} RAID1 tests returned: ${{ needs.test_raid1_install.outputs.exit_code }}
+            * CLI Smoketests ${{ needs.test_smoketest_cli.outputs.exit_code == 'success' && '👍 passed' || '❌ failed' }}
+            * Config tests ${{ needs.test_config_load.outputs.exit_code == 'success' && '👍 passed' || '❌ failed' }}
+            * RAID1 tests ${{ needs.test_raid1_install.outputs.exit_code == 'success' && '👍 passed' || '❌ failed' }}
 
           message-id: "SMOKETEST_RESULTS"
           allow-repeats: false


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

GitHub performs loose equality comparisons.
If the types do not match, GitHub coerces the type to a number. GitHub casts data types to a number using these conversions:

https://docs.github.com/en/actions/learn-github-actions/expressions

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
GitHub action

## Proposed changes
<!--- Describe your changes in detail -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
