### PR TITLE
smoketest: T6539: remove explicit test for non existing global log entry

### DIFF
--- a/smoketest/scripts/cli/test_load-balancing_reverse-proxy.py
+++ b/smoketest/scripts/cli/test_load-balancing_reverse-proxy.py
@@ -465,8 +465,6 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
 
         # Ensure default logging configuration is present
         config = read_file(HAPROXY_CONF)
-        self.assertIn('log /dev/log local0', config)
-        self.assertIn('log /dev/log local1 notice', config)
 
         # Test global-parameters logging options
         self.cli_set(base_path + ['global-parameters', 'logging', 'facility', 'local1', 'level', 'err'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Commit dd5908eac ("T6539: add logging options to load-balancer reverse-proxy") added CLI commands to add custom log entries for frontend and backend servers as well as a global log directive.

Remove explicit test code for no longer always present "global log" directive.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6539

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/3753

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR2.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_load-balancing_reverse-proxy.py
test_01_lb_reverse_proxy_domain (__main__.TestLoadBalancingReverseProxy.test_01_lb_reverse_proxy_domain) ... ok
test_02_lb_reverse_proxy_cert_not_exists (__main__.TestLoadBalancingReverseProxy.test_02_lb_reverse_proxy_cert_not_exists) ... ok
test_03_lb_reverse_proxy_ca_not_exists (__main__.TestLoadBalancingReverseProxy.test_03_lb_reverse_proxy_ca_not_exists) ... ok
test_04_lb_reverse_proxy_backend_ssl_no_verify (__main__.TestLoadBalancingReverseProxy.test_04_lb_reverse_proxy_backend_ssl_no_verify) ... ok
test_05_lb_reverse_proxy_backend_http_check (__main__.TestLoadBalancingReverseProxy.test_05_lb_reverse_proxy_backend_http_check) ... ok
test_06_lb_reverse_proxy_tcp_mode (__main__.TestLoadBalancingReverseProxy.test_06_lb_reverse_proxy_tcp_mode) ... ok
test_07_lb_reverse_proxy_http_response_headers (__main__.TestLoadBalancingReverseProxy.test_07_lb_reverse_proxy_http_response_headers) ... ok
test_08_lb_reverse_proxy_tcp_health_checks (__main__.TestLoadBalancingReverseProxy.test_08_lb_reverse_proxy_tcp_health_checks) ... ok
test_09_lb_reverse_proxy_logging (__main__.TestLoadBalancingReverseProxy.test_09_lb_reverse_proxy_logging) ... ok

----------------------------------------------------------------------
Ran 9 tests in 62.535s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
