### PR TITLE
vyos_net_name: T6544: Updated the `vyos_net_name` script (backport from `current`)

### DIFF
--- a/python/vyos/utils/__init__.py
+++ b/python/vyos/utils/__init__.py
@@ -25,6 +25,7 @@ from vyos.utils import file
 from vyos.utils import io
 from vyos.utils import kernel
 from vyos.utils import list
+from vyos.utils import locking
 from vyos.utils import misc
 from vyos.utils import network
 from vyos.utils import permission

--- a/python/vyos/utils/locking.py
+++ b/python/vyos/utils/locking.py
@@ -1,0 +1,115 @@
+# Copyright 2024 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+import fcntl
+import re
+import time
+from pathlib import Path
+
+
+class LockTimeoutError(Exception):
+    """Custom exception raised when lock acquisition times out."""
+
+    pass
+
+
+class InvalidLockNameError(Exception):
+    """Custom exception raised when the lock name is invalid."""
+
+    pass
+
+
+class Lock:
+    """Lock class to acquire and release a lock file"""
+
+    def __init__(self, lock_name: str) -> None:
+        """Lock class constructor
+
+        Args:
+            lock_name (str): Name of the lock file
+
+        Raises:
+            InvalidLockNameError: If the lock name is invalid
+        """
+        # Validate lock name
+        if not re.match(r'^[a-zA-Z0-9_\-]+$', lock_name):
+            raise InvalidLockNameError(f'Invalid lock name: {lock_name}')
+
+        self.__lock_dir = Path('/run/vyos/lock')
+        self.__lock_dir.mkdir(parents=True, exist_ok=True)
+
+        self.__lock_file_path: Path = self.__lock_dir / f'{lock_name}.lock'
+        self.__lock_file = None
+
+        self._is_locked = False
+
+    def __del__(self) -> None:
+        """Ensure the lock file is removed when the object is deleted"""
+        self.release()
+
+    @property
+    def is_locked(self) -> bool:
+        """Check if the lock is acquired
+
+        Returns:
+            bool: True if the lock is acquired, False otherwise
+        """
+        return self._is_locked
+
+    def __unlink_lockfile(self) -> None:
+        """Remove the lock file if it is not currently locked."""
+        try:
+            with self.__lock_file_path.open('w') as f:
+                fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                self.__lock_file_path.unlink(missing_ok=True)
+        except IOError:
+            # If we cannot acquire the lock, it means another process has it, so we do nothing.
+            pass
+
+    def acquire(self, timeout: int = 0) -> None:
+        """Acquire a lock file
+
+        Args:
+            timeout (int, optional): A time to wait for lock. Defaults to 0.
+
+        Raises:
+            LockTimeoutError: If lock could not be acquired within timeout
+        """
+        start_time: float = time.time()
+        while True:
+            try:
+                self.__lock_file = self.__lock_file_path.open('w')
+                fcntl.flock(self.__lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                self._is_locked = True
+                return
+            except IOError:
+                if timeout > 0 and (time.time() - start_time) >= timeout:
+                    if self.__lock_file:
+                        self.__lock_file.close()
+                    raise LockTimeoutError(
+                        f'Could not acquire lock within {timeout} seconds'
+                    )
+                time.sleep(0.1)
+
+    def release(self) -> None:
+        """Release a lock file"""
+        if self.__lock_file and self._is_locked:
+            try:
+                fcntl.flock(self.__lock_file, fcntl.LOCK_UN)
+                self._is_locked = False
+            finally:
+                self.__lock_file.close()
+                self.__lock_file = None
+                self.__unlink_lockfile()

--- a/src/helpers/vyos_net_name
+++ b/src/helpers/vyos_net_name
@@ -18,42 +18,35 @@ import os
 import re
 import time
 import logging
+import logging.handlers
 import tempfile
-import threading
+from pathlib import Path
 from sys import argv
 
 from vyos.configtree import ConfigTree
 from vyos.defaults import directories
 from vyos.utils.process import cmd
 from vyos.utils.boot import boot_configuration_complete
+from vyos.utils.locking import Lock
 from vyos.migrator import VirtualMigrator
 
+# Define variables
 vyos_udev_dir = directories['vyos_udev_dir']
-vyos_log_dir = '/run/udev/log'
-vyos_log_file = os.path.join(vyos_log_dir, 'vyos-net-name')
-
 config_path = '/opt/vyatta/etc/config/config.boot'
 
-lock = threading.Lock()
-
-try:
-    os.mkdir(vyos_log_dir)
-except FileExistsError:
-    pass
-
-logging.basicConfig(filename=vyos_log_file, level=logging.DEBUG)
 
 def is_available(intfs: dict, intf_name: str) -> bool:
-    """ Check if interface name is already assigned
-    """
+    """Check if interface name is already assigned"""
     if intf_name in list(intfs.values()):
         return False
     return True
 
+
 def find_available(intfs: dict, prefix: str) -> str:
-    """ Find lowest indexed iterface name that is not assigned
-    """
-    index_list = [int(x.replace(prefix, '')) for x in list(intfs.values()) if prefix in x]
+    """Find lowest indexed iterface name that is not assigned"""
+    index_list = [
+        int(x.replace(prefix, '')) for x in list(intfs.values()) if prefix in x
+    ]
     index_list.sort()
     # find 'holes' in list, if any
     missing = sorted(set(range(index_list[0], index_list[-1])) - set(index_list))
@@ -62,21 +55,22 @@ def find_available(intfs: dict, prefix: str) -> str:
 
     return f'{prefix}{len(index_list)}'
 
+
 def mod_ifname(ifname: str) -> str:
-    """ Check interface with names eX and return ifname on the next format eth{ifindex} - 2
-    """
-    if re.match("^e[0-9]+$", ifname):
-        intf = ifname.split("e")
+    """Check interface with names eX and return ifname on the next format eth{ifindex} - 2"""
+    if re.match('^e[0-9]+$', ifname):
+        intf = ifname.split('e')
         if intf[1]:
             if int(intf[1]) >= 2:
-                return "eth" + str(int(intf[1]) - 2)
+                return 'eth' + str(int(intf[1]) - 2)
             else:
-               return "eth" + str(intf[1])
+                return 'eth' + str(intf[1])
 
     return ifname
 
+
 def get_biosdevname(ifname: str) -> str:
-    """ Use legacy vyatta-biosdevname to query for name
+    """Use legacy vyatta-biosdevname to query for name
 
     This is carried over for compatability only, and will likely be dropped
     going forward.
@@ -95,10 +89,11 @@ def get_biosdevname(ifname: str) -> str:
     try:
         biosname = cmd(f'/sbin/biosdevname --policy all_ethN -i {ifname}')
     except Exception as e:
-        logging.error(f'biosdevname error: {e}')
+        logger.error(f'biosdevname error: {e}')
         biosname = ''
 
     return intf if biosname == '' else biosname
+
 
 def leave_rescan_hint(intf_name: str, hwid: str):
     """Write interface information reported by udev
@@ -112,18 +107,18 @@ def leave_rescan_hint(intf_name: str, hwid: str):
     except FileExistsError:
         pass
     except Exception as e:
-        logging.critical(f"Error creating rescan hint directory: {e}")
+        logger.critical(f'Error creating rescan hint directory: {e}')
         exit(1)
 
     try:
         with open(os.path.join(vyos_udev_dir, intf_name), 'w') as f:
             f.write(hwid)
     except OSError as e:
-        logging.critical(f"OSError {e}")
+        logger.critical(f'OSError {e}')
+
 
 def get_configfile_interfaces() -> dict:
-    """Read existing interfaces from config file
-    """
+    """Read existing interfaces from config file"""
     interfaces: dict = {}
 
     if not os.path.isfile(config_path):
@@ -134,14 +129,14 @@ def get_configfile_interfaces() -> dict:
         with open(config_path) as f:
             config_file = f.read()
     except OSError as e:
-        logging.critical(f"OSError {e}")
+        logger.critical(f'OSError {e}')
         exit(1)
 
     try:
         config = ConfigTree(config_file)
     except Exception:
         try:
-            logging.debug(f"updating component version string syntax")
+            logger.debug('updating component version string syntax')
             # this will update the component version string syntax,
             # required for updates 1.2 --> 1.3/1.4
             with tempfile.NamedTemporaryFile() as fp:
@@ -155,7 +150,8 @@ def get_configfile_interfaces() -> dict:
             config = ConfigTree(config_file)
 
         except Exception as e:
-            logging.critical(f"ConfigTree error: {e}")
+            logger.critical(f'ConfigTree error: {e}')
+            exit(1)
 
     base = ['interfaces', 'ethernet']
     if config.exists(base):
@@ -163,11 +159,13 @@ def get_configfile_interfaces() -> dict:
         for intf in eth_intfs:
             path = base + [intf, 'hw-id']
             if not config.exists(path):
-                logging.warning(f"no 'hw-id' entry for {intf}")
+                logger.warning(f"no 'hw-id' entry for {intf}")
                 continue
             hwid = config.return_value(path)
             if hwid in list(interfaces):
-                logging.warning(f"multiple entries for {hwid}: {interfaces[hwid]}, {intf}")
+                logger.warning(
+                    f'multiple entries for {hwid}: {interfaces[hwid]}, {intf}'
+                )
                 continue
             interfaces[hwid] = intf
 
@@ -177,21 +175,23 @@ def get_configfile_interfaces() -> dict:
         for intf in wlan_intfs:
             path = base + [intf, 'hw-id']
             if not config.exists(path):
-                logging.warning(f"no 'hw-id' entry for {intf}")
+                logger.warning(f"no 'hw-id' entry for {intf}")
                 continue
             hwid = config.return_value(path)
             if hwid in list(interfaces):
-                logging.warning(f"multiple entries for {hwid}: {interfaces[hwid]}, {intf}")
+                logger.warning(
+                    f'multiple entries for {hwid}: {interfaces[hwid]}, {intf}'
+                )
                 continue
             interfaces[hwid] = intf
 
-    logging.debug(f"config file entries: {interfaces}")
+    logger.debug(f'config file entries: {interfaces}')
 
     return interfaces
 
+
 def add_assigned_interfaces(intfs: dict):
-    """Add interfaces found by previous invocation of udev rule
-    """
+    """Add interfaces found by previous invocation of udev rule"""
     if not os.path.isdir(vyos_udev_dir):
         return
 
@@ -201,55 +201,74 @@ def add_assigned_interfaces(intfs: dict):
             with open(path) as f:
                 hwid = f.read().rstrip()
         except OSError as e:
-            logging.error(f"OSError {e}")
+            logger.error(f'OSError {e}')
             continue
         intfs[hwid] = intf
 
+
 def on_boot_event(intf_name: str, hwid: str, predefined: str = '') -> str:
-    """Called on boot by vyos-router: 'coldplug' in vyatta_net_name
-    """
-    logging.info(f"lookup {intf_name}, {hwid}")
+    """Called on boot by vyos-router: 'coldplug' in vyatta_net_name"""
+    logger.info(f'lookup {intf_name}, {hwid}')
     interfaces = get_configfile_interfaces()
-    logging.debug(f"config file interfaces are {interfaces}")
+    logger.debug(f'config file interfaces are {interfaces}')
 
     if hwid in list(interfaces):
-        logging.info(f"use mapping from config file: '{hwid}' -> '{interfaces[hwid]}'")
+        logger.info(f"use mapping from config file: '{hwid}' -> '{interfaces[hwid]}'")
         return interfaces[hwid]
 
     add_assigned_interfaces(interfaces)
-    logging.debug(f"adding assigned interfaces: {interfaces}")
+    logger.debug(f'adding assigned interfaces: {interfaces}')
 
     if predefined:
         newname = predefined
-        logging.info(f"predefined interface name for '{intf_name}' is '{newname}'")
+        logger.info(f"predefined interface name for '{intf_name}' is '{newname}'")
     else:
         newname = get_biosdevname(intf_name)
-        logging.info(f"biosdevname returned '{newname}' for '{intf_name}'")
+        logger.info(f"biosdevname returned '{newname}' for '{intf_name}'")
 
     if not is_available(interfaces, newname):
         prefix = re.sub(r'\d+$', '', newname)
         newname = find_available(interfaces, prefix)
 
-    logging.info(f"new name for '{intf_name}' is '{newname}'")
+    logger.info(f"new name for '{intf_name}' is '{newname}'")
 
     leave_rescan_hint(newname, hwid)
 
     return newname
 
+
 def hotplug_event():
     # Not yet implemented, since interface-rescan will only be run on boot.
     pass
 
-if len(argv) > 3:
-    predef_name = argv[3]
-else:
-    predef_name = ''
 
-lock.acquire()
-if not boot_configuration_complete():
-    res = on_boot_event(argv[1], argv[2], predefined=predef_name)
-    logging.debug(f"on boot, returned name is {res}")
-    print(res)
-else:
-    logging.debug("boot configuration complete")
-lock.release()
+if __name__ == '__main__':
+    # Set up logging to syslog
+    syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
+    formatter = logging.Formatter(f'{Path(__file__).name}: %(message)s')
+    syslog_handler.setFormatter(formatter)
+
+    logger = logging.getLogger()
+    logger.addHandler(syslog_handler)
+    logger.setLevel(logging.DEBUG)
+
+    logger.debug(f'Started with arguments: {argv}')
+
+    if len(argv) > 3:
+        predef_name = argv[3]
+    else:
+        predef_name = ''
+
+    lock = Lock('vyos_net_name')
+    # Wait 60 seconds for other running scripts to finish
+    lock.acquire(60)
+
+    if not boot_configuration_complete():
+        res = on_boot_event(argv[1], argv[2], predefined=predef_name)
+        logger.debug(f'on boot, returned name is {res}')
+        print(res)
+    else:
+        logger.debug('boot configuration complete')
+
+    lock.release()
+    logger.debug('Finished')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Updated the `vyos_net_name` script

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6544

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
udev, vyos_net_name

## Proposed changes
<!--- Describe your changes in detail -->
Improvements in the `vyos_net_name`:

- Used a new locking system, to be sure that multiple running scripts will not try to perform operations at the same time.
- Replace logging from a file to syslog. This is common with all the rest logs, and additionally gives a better view of actions done during a boot.
- Small bug fix in `get_configfile_interfaces()`: exit with an error in case a config file cannot be parsed. This resolves potentially an unbound `config` object.
- Minor formatting fixes to follow our requirements.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Boot with a config like this on a device where `eth0` and `eth1` interfaces defined in it are connected via PCIe, and there are at least two extra onboard NICs :
```
interfaces {
    ethernet eth0 {
        hw-id "xx:xx:xx:xx:xx:xx"
    }
    ethernet eth1 {
        hw-id "xx:xx:xx:xx:xx:xx"
    }
    loopback lo {
    }
}
```

The easiest way to see a difference is to check logs - without a new locking system they are out of order:

```
INFO:root:lookup e3, <REDACTED>
INFO:root:lookup e2, <REDACTED>
INFO:root:lookup e5, <REDACTED>
INFO:root:lookup e4, <REDACTED>
DEBUG:root:config file entries: {'<REDACTED>: 'eth0', ' <REDACTED>': 'eth1'}
DEBUG:root:config file entries: {'<REDACTED>': 'eth0', ' <REDACTED>': 'eth1'}
DEBUG:root:config file entries: {'<REDACTED>': 'eth0', ' <REDACTED>': 'eth1'}
DEBUG:root:config file interfaces are {'<REDACTED>': 'eth0', ' <REDACTED>': 'eth1'}
DEBUG:root:config file interfaces are {'<REDACTED>': 'eth0', ' <REDACTED>': 'eth1'}
DEBUG:root:config file interfaces are {'<REDACTED>': 'eth0', ' <REDACTED>': 'eth1'}
INFO:root:use mapping from config file: '<REDACTED>' -> 'eth1'
DEBUG:root:adding assigned interfaces: {'<REDACTED>': 'eth0', '<REDACTED>': 'eth1'}
DEBUG:root:adding assigned interfaces: {'<REDACTED>': 'eth0', '<REDACTED>': 'eth1'}
DEBUG:root:on boot, returned name is eth1
DEBUG:root:config file entries: {'<REDACTED>': 'eth0', '<REDACTED>': 'eth1'}
DEBUG:root:config file interfaces are {'<REDACTED>': 'eth0', '<REDACTED>': 'eth1'}
INFO:root:use mapping from config file: '<REDACTED>' -> 'eth0'
DEBUG:root:on boot, returned name is eth0
INFO:root:biosdevname returned 'eth1' for 'e3'
INFO:root:new name for 'e3' is 'eth2'
DEBUG:root:on boot, returned name is eth2
INFO:root:biosdevname returned 'eth0' for 'e2'
INFO:root:new name for 'e2' is 'eth2'
DEBUG:root:on boot, returned name is eth2
```

With an updated file, everything is in order:

```
Jul 03 20:15:17 c3-small-x86-01 vyos_net_name[1123]: Started with arguments: ['/lib/udev/vyos_net_name', 'e3', '<REDACTED>']
Jul 03 20:15:17 c3-small-x86-01 vyos_net_name[1133]: Started with arguments: ['/lib/udev/vyos_net_name', 'e4', '<REDACTED>']
Jul 03 20:15:17 c3-small-x86-01 vyos_net_name[1132]: Started with arguments: ['/lib/udev/vyos_net_name', 'e5', '<REDACTED>']
Jul 03 20:15:17 c3-small-x86-01 vyos_net_name[1133]: lookup e4, <REDACTED>
Jul 03 20:15:17 c3-small-x86-01 vyos_net_name[1122]: Started with arguments: ['/lib/udev/vyos_net_name', 'e2', '<REDACTED>']
Jul 03 20:15:18 c3-small-x86-01 vyos_net_name[1133]: config file entries: {'<REDACTED>': 'eth0', '<REDACTED>': 'eth1'}
Jul 03 20:15:18 c3-small-x86-01 vyos_net_name[1133]: config file interfaces are {'<REDACTED>': 'eth0', '<REDACTED>': 'eth1'}
Jul 03 20:15:18 c3-small-x86-01 vyos_net_name[1133]: use mapping from config file: '<REDACTED>' -> 'eth0'
Jul 03 20:15:18 c3-small-x86-01 vyos_net_name[1133]: on boot, returned name is eth0
Jul 03 20:15:18 c3-small-x86-01 vyos_net_name[1133]: Finished
Jul 03 20:15:18 c3-small-x86-01 vyos_net_name[1132]: lookup e5, <REDACTED>
Jul 03 20:15:18 c3-small-x86-01 vyos_net_name[1132]: config file entries: {'<REDACTED>': 'eth0', '<REDACTED>': 'eth1'}
Jul 03 20:15:18 c3-small-x86-01 vyos_net_name[1132]: config file interfaces are {'<REDACTED>': 'eth0', '<REDACTED>': 'eth1'}
Jul 03 20:15:18 c3-small-x86-01 vyos_net_name[1132]: use mapping from config file: '<REDACTED>' -> 'eth1'
Jul 03 20:15:18 c3-small-x86-01 vyos_net_name[1132]: on boot, returned name is eth1
Jul 03 20:15:18 c3-small-x86-01 vyos_net_name[1132]: Finished
Jul 03 20:15:18 c3-small-x86-01 vyos_net_name[1122]: lookup e2, <REDACTED>
Jul 03 20:15:18 c3-small-x86-01 vyos_net_name[1122]: config file entries: {'<REDACTED>': 'eth0', '<REDACTED>': 'eth1'}
Jul 03 20:15:18 c3-small-x86-01 vyos_net_name[1122]: config file interfaces are {'<REDACTED>': 'eth0', '<REDACTED>': 'eth1'}
Jul 03 20:15:18 c3-small-x86-01 vyos_net_name[1122]: adding assigned interfaces: {'<REDACTED>': 'eth0', '<REDACTED>': 'eth1'}
Jul 03 20:15:19 c3-small-x86-01 vyos_net_name[1122]: biosdevname returned 'eth0' for 'e2'
Jul 03 20:15:19 c3-small-x86-01 vyos_net_name[1122]: new name for 'e2' is 'eth2'
Jul 03 20:15:19 c3-small-x86-01 vyos_net_name[1122]: on boot, returned name is eth2
Jul 03 20:15:19 c3-small-x86-01 vyos_net_name[1122]: Finished
Jul 03 20:15:19 c3-small-x86-01 vyos_net_name[1123]: lookup e3, <REDACTED>
Jul 03 20:15:19 c3-small-x86-01 vyos_net_name[1123]: config file entries: {'<REDACTED>': 'eth0', '<REDACTED>': 'eth1'}
Jul 03 20:15:19 c3-small-x86-01 vyos_net_name[1123]: config file interfaces are {'<REDACTED>': 'eth0', '<REDACTED>': 'eth1'}
Jul 03 20:15:19 c3-small-x86-01 vyos_net_name[1123]: adding assigned interfaces: {'<REDACTED>': 'eth0', '<REDACTED>': 'eth1', '<REDACTED>': 'eth2'}
Jul 03 20:15:20 c3-small-x86-01 vyos_net_name[1123]: biosdevname returned 'eth1' for 'e3'
Jul 03 20:15:20 c3-small-x86-01 vyos_net_name[1123]: new name for 'e3' is 'eth3'
Jul 03 20:15:20 c3-small-x86-01 vyos_net_name[1123]: on boot, returned name is eth3
Jul 03 20:15:20 c3-small-x86-01 vyos_net_name[1123]: Finished
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
