### PR TITLE
op-mode: T6580: read active nodes directly from the config tree without calling cli-shell-api

### DIFF
--- a/scripts/build-command-op-templates
+++ b/scripts/build-command-op-templates
@@ -3,7 +3,7 @@
 #    build-command-template: converts new style command definitions in XML
 #      to the old style (bunch of dirs and node.def's) command templates
 #
-#    Copyright (C) 2017 VyOS maintainers <maintainers@vyos.net>
+#    Copyright (C) 2017-2024 VyOS maintainers <maintainers@vyos.net>
 #
 #    This library is free software; you can redistribute it and/or
 #    modify it under the terms of the GNU Lesser General Public
@@ -20,6 +20,7 @@
 #    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
 #    USA
 
+import re
 import sys
 import os
 import argparse
@@ -108,7 +109,8 @@ def get_properties(p):
             for i in lists:
                 comp_exprs.append("echo \"{0}\"".format(i.text))
             for i in paths:
-                comp_exprs.append("/bin/cli-shell-api listActiveNodes {0} | sed -e \"s/'//g\" && echo".format(i.text))
+                path = re.sub(r'\s+', '/', i.text)
+                comp_exprs.append("ls /opt/vyatta/config/active/{0} 2>/dev/null".format(path))
             for i in scripts:
                 comp_exprs.append("{0}".format(i.text))
             if comptype is not None:


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

For op mode completion purposes, we only need to care about nodes in the active config, so none of the complexities of config sessions apply. In the current implementation that uses a directory tree for the config tree, that's equivalent to `ls`.

The task is made easier by the fact that op mode template interpreter doesn't care about exit codes, so even if `ls` exits with a non-zero code on non-existent dirs, that has no negative effects, we can just supress its error output with `ls 2>/dev/null`. And node names cannot contain whitespace, so we can always use them in UNIX path strings without escaping. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): performance optimization.

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Op mode.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Every command that uses a node path in completion, like `run show interfaces`, should work as before.

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
