### PR TITLE
configdep: T6559: fix regression in dependent script error under configd

### DIFF
--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -140,6 +140,7 @@ class Config(object):
 
         self._level = []
         self._dict_cache = {}
+        self.dependency_list = []
         (self._running_config,
          self._session_config) = self._config_source.get_configtree_tuple()
 

--- a/python/vyos/configdep.py
+++ b/python/vyos/configdep.py
@@ -33,7 +33,7 @@ if typing.TYPE_CHECKING:
 dependency_dir = os.path.join(directories['data'],
                               'config-mode-dependencies')
 
-dependent_func: dict[str, list[typing.Callable]] = {}
+dependency_list: list[typing.Callable] = []
 
 DEBUG = False
 
@@ -122,26 +122,24 @@ def def_closure(target: str, config: 'Config',
 
 def set_dependents(case: str, config: 'Config',
                    tagnode: typing.Optional[str] = None):
-    global dependent_func
+    global dependency_list
+
+    dependency_list = config.dependency_list
 
     d = get_dependency_dict(config)
     k = caller_name()
-
-    if hasattr(config, 'dependent_func'):
-        dependent_func = getattr(config, 'dependent_func')
-
-    l = dependent_func.setdefault(k, [])
+    l = dependency_list
 
     for target in d[k][case]:
         func = def_closure(target, config, tagnode)
         append_uniq(l, func)
 
-    debug_print(f'set_dependents: caller {k}, dependents {names_of(l)}')
+    debug_print(f'set_dependents: caller {k}, current dependents {names_of(l)}')
 
 def call_dependents():
     k = caller_name()
-    l = dependent_func.get(k, [])
-    debug_print(f'call_dependents: caller {k}, dependents {names_of(l)}')
+    l = dependency_list
+    debug_print(f'call_dependents: caller {k}, remaining dependents {names_of(l)}')
     while l:
         f = l.pop(0)
         debug_print(f'calling: {f.__name__}')

--- a/python/vyos/configdep.py
+++ b/python/vyos/configdep.py
@@ -33,10 +33,9 @@ if typing.TYPE_CHECKING:
 dependency_dir = os.path.join(directories['data'],
                               'config-mode-dependencies')
 
-local_dependent_func: dict[str, list[typing.Callable]] = {}
+dependent_func: dict[str, list[typing.Callable]] = {}
 
 DEBUG = False
-FORCE_LOCAL = False
 
 def debug_print(s: str):
     if DEBUG:
@@ -50,7 +49,8 @@ def canon_name_of_path(path: str) -> str:
     return canon_name(script)
 
 def caller_name() -> str:
-    return stack()[2].filename
+    filename = stack()[2].filename
+    return canon_name_of_path(filename)
 
 def name_of(f: typing.Callable) -> str:
     return f.__name__
@@ -107,46 +107,49 @@ def run_config_mode_script(script: str, config: 'Config'):
         mod.generate(c)
         mod.apply(c)
     except (VyOSError, ConfigError) as e:
-        raise ConfigError(repr(e))
+        raise ConfigError(str(e)) from e
 
 def def_closure(target: str, config: 'Config',
                 tagnode: typing.Optional[str] = None) -> typing.Callable:
     script = target + '.py'
     def func_impl():
-        if tagnode:
+        if tagnode is not None:
             os.environ['VYOS_TAGNODE_VALUE'] = tagnode
         run_config_mode_script(script, config)
+    tag_ext = f'_{tagnode}' if tagnode is not None else ''
+    func_impl.__name__ = f'{target}{tag_ext}'
     return func_impl
 
 def set_dependents(case: str, config: 'Config',
                    tagnode: typing.Optional[str] = None):
+    global dependent_func
+
     d = get_dependency_dict(config)
-    k = canon_name_of_path(caller_name())
-    tag_ext = f'_{tagnode}' if tagnode is not None else ''
-    if hasattr(config, 'dependent_func') and not FORCE_LOCAL:
+    k = caller_name()
+
+    if hasattr(config, 'dependent_func'):
         dependent_func = getattr(config, 'dependent_func')
-        l = dependent_func.setdefault('vyos_configd', [])
-    else:
-        dependent_func = local_dependent_func
-        l = dependent_func.setdefault(k, [])
+
+    l = dependent_func.setdefault(k, [])
+
     for target in d[k][case]:
         func = def_closure(target, config, tagnode)
-        func.__name__ = f'{target}{tag_ext}'
         append_uniq(l, func)
+
     debug_print(f'set_dependents: caller {k}, dependents {names_of(l)}')
 
-def call_dependents(dependent_func: dict = None):
-    k = canon_name_of_path(caller_name())
-    if dependent_func is None or FORCE_LOCAL:
-        dependent_func = local_dependent_func
-        l = dependent_func.get(k, [])
-    else:
-        l = dependent_func.get('vyos_configd', [])
+def call_dependents():
+    k = caller_name()
+    l = dependent_func.get(k, [])
     debug_print(f'call_dependents: caller {k}, dependents {names_of(l)}')
     while l:
         f = l.pop(0)
         debug_print(f'calling: {f.__name__}')
-        f()
+        try:
+            f()
+        except ConfigError as e:
+            s = f'dependent {f.__name__}: {str(e)}'
+            raise ConfigError(s) from e
 
 def called_as_dependent() -> bool:
     st = stack()[1:]

--- a/smoketest/scripts/cli/test_config_dependency.py
+++ b/smoketest/scripts/cli/test_config_dependency.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright 2024 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+
+from base_vyostest_shim import VyOSUnitTestSHIM
+
+from vyos.configsession import ConfigSessionError
+
+
+class TestConfigDep(VyOSUnitTestSHIM.TestCase):
+    def test_configdep_error(self):
+        address_group = 'AG'
+        address = '192.168.137.5'
+        nat_base = ['nat', 'source', 'rule', '10']
+        interface = 'eth1'
+
+        self.cli_set(['firewall', 'group', 'address-group', address_group,
+                      'address', address])
+        self.cli_set(nat_base + ['outbound-interface', 'name', interface])
+        self.cli_set(nat_base + ['source', 'group', 'address-group', address_group])
+        self.cli_set(nat_base + ['translation', 'address', 'masquerade'])
+        self.cli_commit()
+
+        self.cli_delete(['firewall'])
+        # check error in call to dependent script (nat)
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        # clean up remaining
+        self.cli_delete(['nat'])
+        self.cli_commit()
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -220,6 +220,7 @@ def process_node_data(config, data, last: bool = False) -> int:
 
     script_name = None
     args = []
+    config.dependency_list.clear()
 
     res = re.match(r'^(VYOS_TAGNODE_VALUE=[^/]+)?.*\/([^/]+).py(.*)', data)
     if res.group(1):

--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -30,7 +30,6 @@ from vyos.defaults import directories
 from vyos.utils.boot import boot_configuration_complete
 from vyos.configsource import ConfigSourceString
 from vyos.configsource import ConfigSourceError
-from vyos.configdep import call_dependents
 from vyos.config import Config
 from vyos import ConfigError
 
@@ -134,7 +133,8 @@ def explicit_print(path, mode, msg):
     except OSError:
         logger.critical("error explicit_print")
 
-def run_script(script, config, args) -> int:
+def run_script(script_name, config, args) -> int:
+    script = conf_mode_scripts[script_name]
     script.argv = args
     config.set_level([])
     try:
@@ -143,8 +143,9 @@ def run_script(script, config, args) -> int:
         script.generate(c)
         script.apply(c)
     except ConfigError as e:
-        logger.critical(e)
-        explicit_print(session_out, session_mode, str(e))
+        s = f'{script_name}: {repr(e)}'
+        logger.error(s)
+        explicit_print(session_out, session_mode, s)
         return R_ERROR_COMMIT
     except Exception as e:
         logger.critical(e)
@@ -234,17 +235,10 @@ def process_node_data(config, data, last: bool = False) -> int:
     args.insert(0, f'{script_name}.py')
 
     if script_name not in include_set:
-        # call dependents now if last element of prio queue is run
-        # independent of configd
-        if last:
-            call_dependents(dependent_func=config.dependent_func)
         return R_PASS
 
     with stdout_redirected(session_out, session_mode):
-        result = run_script(conf_mode_scripts[script_name], config, args)
-
-    if last and result == R_SUCCESS:
-        call_dependents(dependent_func=config.dependent_func)
+        result = run_script(script_name, config, args)
 
     return result
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

A regression in the redundant dependency removal when running under configd (T5660) can cause a crash of the config daemon leaving the commit session uncompleted. This occurs when the last element of the priority queue succeeds, but a resulting dependency fails. Taras pointed this out in the case of a particularly crafted config file, but a simple reproducer is as follows:

```
set firewall group address-group AG address '192.168.137.5'
set nat source rule 10 source group address-group 'AG'
set nat source rule 10 translation address 'masquerade'
set nat source rule 10 outbound-interface name 'eth1'
commit
delete firewall
commit
```

The reproducer is added as a smoketest to check graceful exit and reporting of error.
The PR drops the asynchronous calling of dependent scripts, as a fix there would still lack the ability to map the error to the originating element of the priority queue. Secondly, it simplifies the management of the dependency list when running with or without configd.

Configtest and smoketests pass in current (note that smoketests now default to running with configd in current); configtest and configd smoketests pass in sagitta, and sagitta 'make test' (no configd) shows only the errors recently seen in CI. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_config_dependency.py 
test_configdep_error (__main__.TestConfigDep.test_configdep_error) ... 
firewall: ConfigError('dependent nat: Invalid address-group "AG" on nat rule')

ok

----------------------------------------------------------------------
Ran 1 test in 5.997s
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
