### PR TITLE
op-mode: T6586: add a distinct exception for unconfigured objects (as opposed to entire subsystems)

### DIFF
--- a/python/vyos/opmode.py
+++ b/python/vyos/opmode.py
@@ -31,7 +31,15 @@ class Error(Exception):
 
 class UnconfiguredSubsystem(Error):
     """ Requested operation is valid, but cannot be completed
-        because corresponding subsystem is not configured and running.
+        because corresponding subsystem is not configured
+        and thus is not running.
+    """
+    pass
+
+class UnconfiguredObject(UnconfiguredSubsystem):
+    """ Requested operation is valid but cannot be completed
+        because its parameter refers to an object that does not exist
+        in the system configuration.
     """
     pass
 

--- a/src/op_mode/bridge.py
+++ b/src/op_mode/bridge.py
@@ -70,7 +70,7 @@ def _get_raw_data_fdb(bridge):
     # From iproute2 fdb.c, fdb_show() will only exit(-1) in case of
     # non-existent bridge device; raise error.
     if code == 255:
-        raise vyos.opmode.UnconfiguredSubsystem(f"no such bridge device {bridge}")
+        raise vyos.opmode.UnconfiguredObject(f"bridge {bridge} does not exist in the system")
     data_dict = json.loads(json_data)
     return data_dict
 

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -332,7 +332,7 @@ def _verify_client(func):
 
         # Check if config does not exist
         if not config.exists(f'interfaces {interface_path} address dhcp{v}'):
-            raise vyos.opmode.UnconfiguredSubsystem(unconf_message)
+            raise vyos.opmode.UnconfiguredObject(unconf_message)
         return func(*args, **kwargs)
     return _wrapper
 

--- a/src/op_mode/ssh.py
+++ b/src/op_mode/ssh.py
@@ -65,7 +65,7 @@ def show_fingerprints(raw: bool, ascii: bool):
 def show_dynamic_protection(raw: bool):
     config = ConfigTreeQuery()
     if not config.exists(['service', 'ssh', 'dynamic-protection']):
-        raise vyos.opmode.UnconfiguredSubsystem("SSH server dynamic-protection is not enabled.")
+        raise vyos.opmode.UnconfiguredObject("SSH server dynamic-protection is not enabled.")
 
     attackers = []
     try:

--- a/src/op_mode/zone.py
+++ b/src/op_mode/zone.py
@@ -104,7 +104,7 @@ def _convert_config(zones_config: dict, zone: str = None) -> list:
         if zones_config:
             output = [_convert_one_zone_data(zone, zones_config)]
         else:
-            raise vyos.opmode.DataUnavailable(f'Zone {zone} not found')
+            raise vyos.opmode.UnconfiguredObject(f'Zone {zone} not found')
     else:
         if zones_config:
             output = _convert_zones_data(zones_config)

--- a/src/services/api/graphql/session/errors/op_mode_errors.py
+++ b/src/services/api/graphql/session/errors/op_mode_errors.py
@@ -1,5 +1,6 @@
 op_mode_err_msg = {
     "UnconfiguredSubsystem": "subsystem is not configured or not running",
+    "UnconfiguredObject": "object does not exist in the system configuration",
     "DataUnavailable": "data currently unavailable",
     "PermissionDenied": "client does not have permission",
     "InsufficientResources": "insufficient system resources",
@@ -9,6 +10,7 @@ op_mode_err_msg = {
 
 op_mode_err_code = {
     "UnconfiguredSubsystem": 2000,
+    "UnconfiguredObject": 2003,
     "DataUnavailable": 2001,
     "InsufficientResources": 2002,
     "PermissionDenied": 1003,


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Using `UnconfiguredSubsystem` when it's just one entity that isn't configured is overreaching, we likely want something more specific for those cases so that API clients can decide how to present the error to the user.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Op mode.

## Proposed changes
<!--- Describe your changes in detail -->

The new `UnconfiguredObject` exception is a subclass of `UnconfiguredSubsystems` so clients can choose whether to differentiate them or not.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
