### PR TITLE
vyos_net_name: T5603: rework the helper not to use biosdevname

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -54,7 +54,6 @@ Depends:
   at,
   rsync,
   vyatta-bash,
-  vyatta-biosdevname,
   vyatta-cfg,
   vyos-http-api-tools,
   vyos-utils,

--- a/src/helpers/vyos_net_name
+++ b/src/helpers/vyos_net_name
@@ -20,6 +20,7 @@ import time
 import logging
 import logging.handlers
 import tempfile
+
 from pathlib import Path
 from sys import argv
 
@@ -30,17 +31,16 @@ from vyos.utils.boot import boot_configuration_complete
 from vyos.utils.locking import Lock
 from vyos.migrate import ConfigMigrate
 
+
 # Define variables
 vyos_udev_dir = directories['vyos_udev_dir']
 config_path = '/opt/vyatta/etc/config/config.boot'
-
 
 def is_available(intfs: dict, intf_name: str) -> bool:
     """Check if interface name is already assigned"""
     if intf_name in list(intfs.values()):
         return False
     return True
-
 
 def find_available(intfs: dict, prefix: str) -> str:
     """Find lowest indexed iterface name that is not assigned"""
@@ -55,7 +55,6 @@ def find_available(intfs: dict, prefix: str) -> str:
 
     return f'{prefix}{len(index_list)}'
 
-
 def mod_ifname(ifname: str) -> str:
     """Check interface with names eX and return ifname on the next format eth{ifindex} - 2"""
     if re.match('^e[0-9]+$', ifname):
@@ -67,33 +66,6 @@ def mod_ifname(ifname: str) -> str:
                 return 'eth' + str(intf[1])
 
     return ifname
-
-
-def get_biosdevname(ifname: str) -> str:
-    """Use legacy vyatta-biosdevname to query for name
-
-    This is carried over for compatability only, and will likely be dropped
-    going forward.
-    XXX: This throws an error, and likely has for a long time, unnoticed
-    since vyatta_net_name redirected stderr to /dev/null.
-    """
-    intf = mod_ifname(ifname)
-
-    if 'eth' not in intf:
-        return intf
-    if os.path.isdir('/proc/xen'):
-        return intf
-
-    time.sleep(1)
-
-    try:
-        biosname = cmd(f'/sbin/biosdevname --policy all_ethN -i {ifname}')
-    except Exception as e:
-        logger.error(f'biosdevname error: {e}')
-        biosname = ''
-
-    return intf if biosname == '' else biosname
-
 
 def leave_rescan_hint(intf_name: str, hwid: str):
     """Write interface information reported by udev
@@ -116,7 +88,6 @@ def leave_rescan_hint(intf_name: str, hwid: str):
     except OSError as e:
         logger.critical(f'OSError {e}')
 
-
 def get_configfile_interfaces() -> dict:
     """Read existing interfaces from config file"""
     interfaces: dict = {}
@@ -136,7 +107,7 @@ def get_configfile_interfaces() -> dict:
         config = ConfigTree(config_file)
     except Exception:
         try:
-            logger.debug('updating component version string syntax')
+            logger.debug('Updating component version string syntax')
             # this will update the component version string syntax,
             # required for updates 1.2 --> 1.3/1.4
             with tempfile.NamedTemporaryFile() as fp:
@@ -161,12 +132,12 @@ def get_configfile_interfaces() -> dict:
         for intf in eth_intfs:
             path = base + [intf, 'hw-id']
             if not config.exists(path):
-                logger.warning(f"no 'hw-id' entry for {intf}")
+                logger.warning(f"No 'hw-id' entry for {intf}")
                 continue
             hwid = config.return_value(path)
             if hwid in list(interfaces):
                 logger.warning(
-                    f'multiple entries for {hwid}: {interfaces[hwid]}, {intf}'
+                    f'Multiple entries for {hwid}: {interfaces[hwid]}, {intf}'
                 )
                 continue
             interfaces[hwid] = intf
@@ -177,20 +148,19 @@ def get_configfile_interfaces() -> dict:
         for intf in wlan_intfs:
             path = base + [intf, 'hw-id']
             if not config.exists(path):
-                logger.warning(f"no 'hw-id' entry for {intf}")
+                logger.warning(f"No 'hw-id' entry for {intf}")
                 continue
             hwid = config.return_value(path)
             if hwid in list(interfaces):
                 logger.warning(
-                    f'multiple entries for {hwid}: {interfaces[hwid]}, {intf}'
+                    f'Multiple entries for {hwid}: {interfaces[hwid]}, {intf}'
                 )
                 continue
             interfaces[hwid] = intf
 
-    logger.debug(f'config file entries: {interfaces}')
+    logger.debug(f'Config file entries: {interfaces}')
 
     return interfaces
-
 
 def add_assigned_interfaces(intfs: dict):
     """Add interfaces found by previous invocation of udev rule"""
@@ -207,37 +177,30 @@ def add_assigned_interfaces(intfs: dict):
             continue
         intfs[hwid] = intf
 
-
-def on_boot_event(intf_name: str, hwid: str, predefined: str = '') -> str:
+def on_boot_event(intf_name: str, hwid: str, newname: str) -> str:
     """Called on boot by vyos-router: 'coldplug' in vyatta_net_name"""
-    logger.info(f'lookup {intf_name}, {hwid}')
+    logger.info(f'Looking up {intf_name}, {hwid}')
     interfaces = get_configfile_interfaces()
-    logger.debug(f'config file interfaces are {interfaces}')
+    logger.debug(f'Config file interfaces are {interfaces}')
 
     if hwid in list(interfaces):
-        logger.info(f"use mapping from config file: '{hwid}' -> '{interfaces[hwid]}'")
+        logger.info(f"Using the mapping from the config file: '{hwid}' -> '{interfaces[hwid]}'")
         return interfaces[hwid]
 
     add_assigned_interfaces(interfaces)
-    logger.debug(f'adding assigned interfaces: {interfaces}')
+    logger.debug(f'Adding assigned interfaces: {interfaces}')
 
-    if predefined:
-        newname = predefined
-        logger.info(f"predefined interface name for '{intf_name}' is '{newname}'")
-    else:
-        newname = get_biosdevname(intf_name)
-        logger.info(f"biosdevname returned '{newname}' for '{intf_name}'")
+    logger.info(f"Predefined interface name for '{intf_name}' is '{newname}'")
 
     if not is_available(interfaces, newname):
         prefix = re.sub(r'\d+$', '', newname)
         newname = find_available(interfaces, prefix)
 
-    logger.info(f"new name for '{intf_name}' is '{newname}'")
+    logger.info(f"The new name for '{intf_name}' is '{newname}'")
 
     leave_rescan_hint(newname, hwid)
 
     return newname
-
 
 def hotplug_event():
     # Not yet implemented, since interface-rescan will only be run on boot.
@@ -257,20 +220,22 @@ if __name__ == '__main__':
     logger.debug(f'Started with arguments: {argv}')
 
     if len(argv) > 3:
+        intf_name = argv[1]
+        hwid = argv[2]
         predef_name = argv[3]
     else:
-        predef_name = ''
+        raise RuntimeError('vyos_net_name helper called without required arguments')
 
     lock = Lock('vyos_net_name')
     # Wait 60 seconds for other running scripts to finish
     lock.acquire(60)
 
     if not boot_configuration_complete():
-        res = on_boot_event(argv[1], argv[2], predefined=predef_name)
-        logger.debug(f'on boot, returned name is {res}')
+        res = on_boot_event(intf_name, hwid, predef_name)
+        logger.debug(f'Processed an on-boot event for {intf_name}, assigned name is {res}')
         print(res)
     else:
-        logger.debug('boot configuration complete')
+        logger.debug(f'Called outside of boot-time configuration, exiting')
 
     lock.release()
     logger.debug('Finished')


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Since it's always supposed to be called with an explicit interface name argument, there is no reason to use that legacy code that was called without the `--allow-vm` argument anyway and thus would never work in VMs.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

`vyos_net_name` udev helper.

## Proposed changes
<!--- Describe your changes in detail -->

I removed the option to call `on_boot_event` without an explicit predefined name and added a `RuntimeError` (which may not be a perfect exception choice...) when the script is called without correct arguments.

Also took a chance to rework debug messages and remove a bunch of extra whitespace.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Interface names after boot should be the same as intended in the config.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
