### PR TITLE
openvpn: T6591: deprecate OpenVPN server net30 topology

### DIFF
--- a/interface-definitions/include/version/openvpn-version.xml.i
+++ b/interface-definitions/include/version/openvpn-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/openvpn-version.xml.i -->
-<syntaxVersion component='openvpn' version='2'></syntaxVersion>
+<syntaxVersion component='openvpn' version='3'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/interfaces_openvpn.xml.in
+++ b/interface-definitions/interfaces_openvpn.xml.in
@@ -589,25 +589,25 @@
                 <properties>
                   <help>Topology for clients</help>
                   <completionHelp>
-                    <list>net30 point-to-point subnet</list>
+                    <list>subnet point-to-point net30</list>
                   </completionHelp>
                   <valueHelp>
-                    <format>net30</format>
-                    <description>net30 topology</description>
+                    <format>subnet</format>
+                    <description>Subnet topology (recommended)</description>
                   </valueHelp>
                   <valueHelp>
                     <format>point-to-point</format>
                     <description>Point-to-point topology</description>
                   </valueHelp>
                   <valueHelp>
-                    <format>subnet</format>
-                    <description>Subnet topology</description>
+                    <format>net30</format>
+                    <description>net30 topology (deprecated)</description>
                   </valueHelp>
                   <constraint>
                     <regex>(subnet|point-to-point|net30)</regex>
                   </constraint>
                 </properties>
-                <defaultValue>net30</defaultValue>
+                <defaultValue>subnet</defaultValue>
               </leafNode>
               <node name="mfa">
                 <properties>

--- a/src/conf_mode/interfaces_openvpn.py
+++ b/src/conf_mode/interfaces_openvpn.py
@@ -432,6 +432,13 @@ def verify(openvpn):
                                 if IPv6Address(client['ipv6_ip'][0]) in v6PoolNet:
                                     print(f'Warning: Client "{client["name"]}" IP {client["ipv6_ip"][0]} is in server IP pool, it is not reserved for this client.')
 
+        if 'topology' in openvpn['server']:
+            if openvpn['server']['topology'] == 'net30':
+                DeprecationWarning('Topology net30 is deprecated '\
+                                   'and will be removed in future VyOS versions. '\
+                                   'Switch to "subnet" or "p2p"'
+                )
+
         # add mfa users to the file the mfa plugin uses
         if dict_search('server.mfa.totp', openvpn):
             user_data = ''

--- a/src/migration-scripts/openvpn/2-to-3
+++ b/src/migration-scripts/openvpn/2-to-3
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Adds an explicit old default for 'server topology'
+# to keep old configs working as before even though the default has changed.
+
+from vyos.configtree import ConfigTree
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(['interfaces', 'openvpn']):
+        # Nothing to do
+        return
+
+    ovpn_intfs = config.list_nodes(['interfaces', 'openvpn'])
+    for	i in ovpn_intfs:
+        mode = config.return_value(['interfaces', 'openvpn', i, 'mode'])
+        if mode != 'server':
+            # If it's a client or a site-to-site OpenVPN interface,
+            # the topology setting is not applicable
+            # and will cause commit errors on load,
+            # so we must not change such interfaces.
+            continue
+        else:
+            # The default OpenVPN server topology was changed from net30 to subnet
+            # because net30 is deprecated and causes problems with Windows clients.
+            # We add 'net30' to old configs if topology is not set there
+            # to ensure that if anyone relies on net30, their configs work as before.
+            topology_path = ['interfaces', 'openvpn', i, 'server', 'topology']
+            if not config.exists(topology_path):
+                config.set(topology_path, value='net30', replace=False)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Set the default topology to `subnet` for new configs, add a deprecation warning, and insert `net30` in old configs explicitly for compatibility.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): default change, deprecation.

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

OpenVPN

## Proposed changes
<!--- Describe your changes in detail -->


The `net30` topology is:

* only there because it was the default in OpenVPN, but even then it was just for compatibility reasons, not because it's good;
* bad for Windows clients, they don't work with it;
* deprecated in OpenVPN and may eventually be removed.

We should set the new default to `subnet` and mark `net30` as deprecated. But some people may rely on the `net30` behavior, so we'll use a migration script to inject the old default into old configs explicitly.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
