### PR TITLE
T6525: Add default dir for ext-scripts without absolute path

### DIFF
--- a/smoketest/scripts/cli/test_service_snmp.py
+++ b/smoketest/scripts/cli/test_service_snmp.py
@@ -246,5 +246,19 @@ class TestSNMPService(VyOSUnitTestSHIM.TestCase):
         for excluded in snmpv3_view_oid_exclude:
             self.assertIn(f'view {snmpv3_view} excluded .{excluded}', tmp)
 
+    def test_snmp_script_extensions(self):
+        extensions = {
+            'default': 'snmp_smoketest_extension_script.sh',
+            'external': '/run/external_snmp_smoketest_extension_script.sh'
+        }
+
+        for key, val in extensions.items():
+            self.cli_set(base_path + ['script-extensions', 'extension-name', key, 'script', val])
+        self.cli_commit()
+
+        self.assertEqual(get_config_value('extend default'), f'/config/user-data/{extensions["default"]}')
+        self.assertEqual(get_config_value('extend external'), extensions["external"])
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/service_snmp.py
+++ b/src/conf_mode/service_snmp.py
@@ -41,6 +41,7 @@ config_file_client  = r'/etc/snmp/snmp.conf'
 config_file_daemon  = r'/etc/snmp/snmpd.conf'
 config_file_access  = r'/usr/share/snmp/snmpd.conf'
 config_file_user    = r'/var/lib/snmp/snmpd.conf'
+default_script_dir  = r'/config/user-data/'
 systemd_override    = r'/run/systemd/system/snmpd.service.d/override.conf'
 systemd_service     = 'snmpd.service'
 
@@ -85,7 +86,19 @@ def get_config(config=None):
             tmp = {'::1': {'port': '161'}}
             snmp['listen_address'] = dict_merge(tmp, snmp['listen_address'])
 
+    if 'script_extensions' in snmp and 'extension_name' in snmp['script_extensions']:
+        for key, val in snmp['script_extensions']['extension_name'].items():
+            if 'script' not in val:
+                continue
+            script_path = val['script']
+            # if script has not absolute path, use pre configured path
+            if not os.path.isabs(script_path):
+                script_path = os.path.join(default_script_dir, script_path)
+
+            snmp['script_extensions']['extension_name'][key]['script'] = script_path
+
     return snmp
+
 
 def verify(snmp):
     if 'deleted' in snmp:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6525

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
touch /config/user-data/test.sh
set service snmp script-extensions extension-name tst script test.sh 
commit
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_service_snmp.py 
test_snmp_basic (__main__.TestSNMPService.test_snmp_basic) ... ok
test_snmp_script_extensions (__main__.TestSNMPService.test_snmp_script_extensions) ... ok
test_snmpv3_md5 (__main__.TestSNMPService.test_snmpv3_md5) ... 
service_snmp: ConfigError('Group membership required for user "vyos"!')


service_snmp: ConfigError('Must configure "view" for group "default_group"!')

ok
test_snmpv3_sha (__main__.TestSNMPService.test_snmpv3_sha) ... 
service_snmp: ConfigError('Must configure "view" for group "default"!')

ok
test_snmpv3_view_exclude (__main__.TestSNMPService.test_snmpv3_view_exclude) ... ok

----------------------------------------------------------------------
Ran 5 tests in 24.846s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
