### PR TITLE
T6594: Add missed pppd_compat module

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.j2
+++ b/data/templates/accel-ppp/ipoe.config.j2
@@ -16,6 +16,9 @@ net-snmp
 {% if limits is vyos_defined %}
 connlimit
 {% endif %}
+{% if extended_scripts is vyos_defined %}
+pppd_compat
+{% endif %}
 
 [core]
 thread-count={{ thread_count }}

--- a/data/templates/accel-ppp/l2tp.config.j2
+++ b/data/templates/accel-ppp/l2tp.config.j2
@@ -16,6 +16,9 @@ net-snmp
 {% if limits is vyos_defined %}
 connlimit
 {% endif %}
+{% if extended_scripts is vyos_defined %}
+pppd_compat
+{% endif %}
 
 [core]
 thread-count={{ thread_count }}

--- a/data/templates/accel-ppp/pptp.config.j2
+++ b/data/templates/accel-ppp/pptp.config.j2
@@ -16,6 +16,9 @@ net-snmp
 {% if limits is vyos_defined %}
 connlimit
 {% endif %}
+{% if extended_scripts is vyos_defined %}
+pppd_compat
+{% endif %}
 
 [core]
 thread-count={{ thread_count }}

--- a/data/templates/accel-ppp/sstp.config.j2
+++ b/data/templates/accel-ppp/sstp.config.j2
@@ -16,6 +16,9 @@ net-snmp
 {% if limits is vyos_defined %}
 connlimit
 {% endif %}
+{% if extended_scripts is vyos_defined %}
+pppd_compat
+{% endif %}
 
 [core]
 thread-count={{ thread_count }}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add missed `pppd_compat` module, used for accel-ppp daemons to call external scripts
We have extended scripts in CLI, but they do not call because the module is not loaded.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6594

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
IPoE, SSTP, PPTP, L2TP-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service ipoe-server authentication mode 'noauth'
set service ipoe-server client-ip-pool ONE range '100.64.0.1-100.64.0.10'
set service ipoe-server client-ipv6-pool POOL-v6 delegate 2001:db8:8003::/48 delegation-prefix '56'
set service ipoe-server client-ipv6-pool POOL-v6 prefix 2001:db8::/64
set service ipoe-server default-ipv6-pool 'POOL-v6'
set service ipoe-server default-pool 'ONE'
set service ipoe-server extended-scripts on-up '/config/scripts/accel-pppd/on-up-flush.sh'
set service ipoe-server gateway-address '100.64.0.14/28'
set service ipoe-server interface eth1 network 'shared'
set service ipoe-server name-server '192.168.122.14'

```
Before the fix, after a subscriber connection (ipoe) the script `on-ip-flush.sh` is not  executed 

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
