### PR TITLE
smoketest: T6600: ospf: enable MPLS LDP on dummy interfaces

### DIFF
--- a/smoketest/scripts/cli/test_protocols_ospf.py
+++ b/smoketest/scripts/cli/test_protocols_ospf.py
@@ -16,7 +16,6 @@
 
 import unittest
 
-from time import sleep
 from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.configsession import ConfigSessionError
@@ -27,6 +26,7 @@ PROCESS_NAME = 'ospfd'
 base_path = ['protocols', 'ospf']
 
 route_map = 'foo-bar-baz10'
+dummy_if = 'dum3562'
 
 class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
     @classmethod
@@ -38,6 +38,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
 
         cls.cli_set(cls, ['policy', 'route-map', route_map, 'rule', '10', 'action', 'permit'])
         cls.cli_set(cls, ['policy', 'route-map', route_map, 'rule', '20', 'action', 'permit'])
+        cls.cli_set(cls, ['interfaces', 'dummy', dummy_if])
 
         # ensure we can also run this test on a live system - so lets clean
         # out the current configuration :)
@@ -46,6 +47,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.cli_delete(cls, ['policy', 'route-map', route_map])
+        cls.cli_delete(cls, ['interfaces', 'dummy', dummy_if])
         super(TestProtocolsOSPF, cls).tearDownClass()
 
     def tearDown(self):
@@ -441,14 +443,13 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         global_block_high = "399"
         local_block_low = "400"
         local_block_high = "499"
-        interface = 'lo'
         maximum_stack_size = '5'
         prefix_one = '192.168.0.1/32'
         prefix_two = '192.168.0.2/32'
         prefix_one_value = '1'
         prefix_two_value = '2'
 
-        self.cli_set(base_path + ['interface', interface])
+        self.cli_set(base_path + ['interface', dummy_if])
         self.cli_set(base_path + ['segment-routing', 'maximum-label-depth', maximum_stack_size])
         self.cli_set(base_path + ['segment-routing', 'global-block', 'low-label-value', global_block_low])
         self.cli_set(base_path + ['segment-routing', 'global-block', 'high-label-value', global_block_high])
@@ -472,16 +473,13 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
 
     def test_ospf_15_ldp_sync(self):
         holddown = "500"
-        interface = 'lo'
         interfaces = Section.interfaces('ethernet')
 
-        self.cli_set(base_path + ['interface', interface])
+        self.cli_set(base_path + ['interface', dummy_if])
         self.cli_set(base_path + ['ldp-sync', 'holddown', holddown])
 
         # Commit main OSPF changes
         self.cli_commit()
-
-        sleep(10)
 
         # Verify main OSPF changes
         frrconfig = self.getFRRconfig('router ospf', daemon=PROCESS_NAME)
@@ -514,7 +512,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
             config = self.getFRRconfig(f'interface {interface}', daemon=PROCESS_NAME)
             self.assertIn(f'interface {interface}', config)
             self.assertIn(f' ip ospf dead-interval 40', config)
-            self.assertIn(f' no ip ospf mpls ldp-sync', config)
+            self.assertNotIn(f' ip ospf mpls ldp-sync', config)
 
     def test_ospf_16_graceful_restart(self):
         period = '300'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6600

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/704

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
OSPF smoketests

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```console
cpo@LR2.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_ospf.py
test_ospf_01_defaults (__main__.TestProtocolsOSPF.test_ospf_01_defaults) ... ok
test_ospf_02_simple (__main__.TestProtocolsOSPF.test_ospf_02_simple) ... ok
test_ospf_03_access_list (__main__.TestProtocolsOSPF.test_ospf_03_access_list) ... ok
test_ospf_04_default_originate (__main__.TestProtocolsOSPF.test_ospf_04_default_originate) ... ok
test_ospf_05_options (__main__.TestProtocolsOSPF.test_ospf_05_options) ... ok
test_ospf_06_neighbor (__main__.TestProtocolsOSPF.test_ospf_06_neighbor) ... ok
test_ospf_07_redistribute (__main__.TestProtocolsOSPF.test_ospf_07_redistribute) ... ok
test_ospf_08_virtual_link (__main__.TestProtocolsOSPF.test_ospf_08_virtual_link) ... ok
test_ospf_09_interface_configuration (__main__.TestProtocolsOSPF.test_ospf_09_interface_configuration) ... ok
test_ospf_11_interface_area (__main__.TestProtocolsOSPF.test_ospf_11_interface_area) ... ok
test_ospf_12_vrfs (__main__.TestProtocolsOSPF.test_ospf_12_vrfs) ... ok
test_ospf_13_export_list (__main__.TestProtocolsOSPF.test_ospf_13_export_list) ... ok
test_ospf_14_segment_routing_configuration (__main__.TestProtocolsOSPF.test_ospf_14_segment_routing_configuration) ... ok
test_ospf_15_ldp_sync (__main__.TestProtocolsOSPF.test_ospf_15_ldp_sync) ... ok
test_ospf_16_graceful_restart (__main__.TestProtocolsOSPF.test_ospf_16_graceful_restart) ... ok
test_ospf_17_duplicate_area_network (__main__.TestProtocolsOSPF.test_ospf_17_duplicate_area_network) ... ok

----------------------------------------------------------------------
Ran 16 tests in 65.369s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
