### PR TITLE
T6589: Return a dict when querying information about a single interface

### DIFF
--- a/src/op_mode/interfaces.py
+++ b/src/op_mode/interfaces.py
@@ -445,12 +445,24 @@ def _format_show_counters(data: list):
     print (output)
     return output
 
+
+def _show_raw(data: list, intf_name: str):
+    if intf_name is not None and len(data) <= 1:
+        try:
+            return data[0]
+        except IndexError:
+            raise vyos.opmode.UnconfiguredObject(
+                f"Interface {intf_name} does not exist")
+    else:
+        return data
+
+
 def show(raw: bool, intf_name: typing.Optional[str],
                     intf_type: typing.Optional[str],
                     vif: bool, vrrp: bool):
     data = _get_raw_data(intf_name, intf_type, vif, vrrp)
     if raw:
-        return data
+        return _show_raw(data, intf_name)
     return _format_show_data(data)
 
 def show_summary(raw: bool, intf_name: typing.Optional[str],
@@ -458,10 +470,7 @@ def show_summary(raw: bool, intf_name: typing.Optional[str],
                             vif: bool, vrrp: bool):
     data = _get_summary_data(intf_name, intf_type, vif, vrrp)
     if raw:
-        if intf_name is not None and len(data) <= 1:
-            return data[0] if data else {}
-        else:
-            return data
+        return _show_raw(data, intf_name)
     return _format_show_summary(data)
 
 def show_summary_extended(raw: bool, intf_name: typing.Optional[str],
@@ -469,7 +478,7 @@ def show_summary_extended(raw: bool, intf_name: typing.Optional[str],
                             vif: bool, vrrp: bool):
     data = _get_summary_data(intf_name, intf_type, vif, vrrp)
     if raw:
-        return data
+        return _show_raw(data, intf_name)
     return _format_show_summary_extended(data)
 
 def show_counters(raw: bool, intf_name: typing.Optional[str],
@@ -477,7 +486,7 @@ def show_counters(raw: bool, intf_name: typing.Optional[str],
                              vif: bool, vrrp: bool):
     data = _get_counter_data(intf_name, intf_type, vif, vrrp)
     if raw:
-        return data
+        return _show_raw(data, intf_name)
     return _format_show_counters(data)
 
 def clear_counters(intf_name: typing.Optional[str],

--- a/src/op_mode/interfaces.py
+++ b/src/op_mode/interfaces.py
@@ -458,7 +458,10 @@ def show_summary(raw: bool, intf_name: typing.Optional[str],
                             vif: bool, vrrp: bool):
     data = _get_summary_data(intf_name, intf_type, vif, vrrp)
     if raw:
-        return data
+        if intf_name is not None and len(data) <= 1:
+            return data[0] if data else {}
+        else:
+            return data
     return _format_show_summary(data)
 
 def show_summary_extended(raw: bool, intf_name: typing.Optional[str],


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6589
* https://vyos.dev/T6587

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos:~$ sudo /usr/libexec/vyos/op_mode/interfaces.py show_summary --raw --intf-name eth0
{
    "ifname": "eth0",
    "oper_state": "up",
    "admin_state": "up",
    "addr": [
        "192.168.122.166/24"
    ],
    "description": "OUT",
    "mtu": 1500,
    "mac": "0c:89:0a:2e:00:00",
    "vrf": null
}
vyos@vyos:~$ sudo /usr/libexec/vyos/op_mode/interfaces.py show_summary --raw
[
    {
        "ifname": "eth0",
        "oper_state": "up",
        "admin_state": "up",
        "addr": [
            "192.168.122.166/24"
        ],
        "description": "OUT",
        "mtu": 1500,
        "mac": "0c:89:0a:2e:00:00",
        "vrf": null
    },
    {
        "ifname": "eth1",
        "oper_state": "up",
        "admin_state": "up",
        "addr": [
            "10.0.0.1/24"
        ],
        "description": "INSIDE",
        "mtu": 1500,
        "mac": "0c:89:0a:2e:00:01",
        "vrf": null
    },
    {
        "ifname": "eth2",
        "oper_state": "down",
        "admin_state": "up",
        "addr": [],
        "description": "",
        "mtu": 1500,
        "mac": "0c:89:0a:2e:00:02",
        "vrf": null
    },
    {
        "ifname": "eth3",
        "oper_state": "down",
        "admin_state": "up",
        "addr": [],
        "description": "",
        "mtu": 1500,
        "mac": "0c:89:0a:2e:00:03",
        "vrf": null
    },
    {
        "ifname": "lo",
        "oper_state": "unknown",
        "admin_state": "up",
        "addr": [
            "127.0.0.1/8",
            "::1/128"
        ],
        "description": "",
        "mtu": 65536,
        "mac": "00:00:00:00:00:00",
        "vrf": null
    }
]
vyos@vyos# sudo /usr/libexec/vyos/op_mode/interfaces.py show_summary --raw --intf-name eth11
Interface eth11 does not exist
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
