### PR TITLE
T6599: ipsec: support disabling rekey of CHILD_SA, converge and fix defaults

### DIFF
--- a/data/templates/ipsec/swanctl/peer.j2
+++ b/data/templates/ipsec/swanctl/peer.j2
@@ -63,6 +63,11 @@
                 life_packets = {{ vti_esp.life_packets }}
 {%     endif %}
                 life_time = {{ vti_esp.lifetime }}s
+{%     if vti_esp.disable_rekey is vyos_defined %}
+                rekey_bytes = 0
+                rekey_packets = 0
+                rekey_time = 0s
+{%     endif %}
                 local_ts = 0.0.0.0/0,::/0
                 remote_ts = 0.0.0.0/0,::/0
                 updown = "/etc/ipsec.d/vti-up-down {{ peer_conf.vti.bind }}"
@@ -108,6 +113,11 @@
                 life_packets = {{ tunnel_esp.life_packets }}
 {%         endif %}
                 life_time = {{ tunnel_esp.lifetime }}s
+{%         if tunnel_esp.disable_rekey is vyos_defined %}
+                rekey_bytes = 0
+                rekey_packets = 0
+                rekey_time = 0s
+{%         endif %}
 {%         if tunnel_esp.mode is not defined or tunnel_esp.mode == 'tunnel' %}
 {%             if tunnel_conf.local.prefix is vyos_defined %}
 {%                 set local_prefix = tunnel_conf.local.prefix if 'any' not in tunnel_conf.local.prefix else ['0.0.0.0/0', '::/0'] %}

--- a/data/templates/ipsec/swanctl/remote_access.j2
+++ b/data/templates/ipsec/swanctl/remote_access.j2
@@ -8,6 +8,10 @@
         proposals = {{ ike_group[rw_conf.ike_group] | get_esp_ike_cipher | join(',') }}
         version = {{ ike.key_exchange[4:] if ike.key_exchange is vyos_defined else "0" }}
         send_certreq = no
+{% if ike.dead_peer_detection is vyos_defined %}
+        dpd_timeout = {{ ike.dead_peer_detection.timeout }}
+        dpd_delay = {{ ike.dead_peer_detection.interval }}
+{% endif %}
         rekey_time = {{ ike.lifetime }}s
         keyingtries = 0
 {% if rw_conf.unique is vyos_defined %}
@@ -44,8 +48,18 @@
         children {
             ikev2-vpn  {
                 esp_proposals = {{ esp | get_esp_ike_cipher(ike) | join(',') }}
-                rekey_time = {{ esp.lifetime }}s
-                rand_time = 540s
+{% if esp.life_bytes is vyos_defined %}
+                life_bytes = {{ esp.life_bytes }}
+{% endif %}
+{% if esp.life_packets is vyos_defined %}
+                life_packets = {{ esp.life_packets }}
+{% endif %}
+                life_time = {{ esp.lifetime }}s
+{% if esp.disable_rekey is vyos_defined %}
+                rekey_bytes = 0
+                rekey_packets = 0
+                rekey_time = 0s
+{% endif %}
                 dpd_action = clear
                 inactivity = {{ rw_conf.timeout }}
 {% if rw_conf.replay_window is vyos_defined %}

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -99,6 +99,12 @@
                   </constraint>
                 </properties>
               </leafNode>
+              <leafNode name="disable-rekey">
+                <properties>
+                  <help>Do not locally initiate a re-key of the SA, remote peer must re-key before expiration</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
               <leafNode name="mode">
                 <properties>
                   <help>ESP mode</help>

--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -252,6 +252,15 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         for line in swanctl_conf_lines:
             self.assertIn(line, swanctl_conf)
 
+        # if dpd is not specified it should not be enabled (see T6599)
+        swanctl_unexpected_lines = [
+            f'dpd_timeout'
+            f'dpd_delay'
+        ]
+
+        for unexpected_line in swanctl_unexpected_lines:
+            self.assertNotIn(unexpected_line, swanctl_conf)
+
         swanctl_secrets_lines = [
             f'id-{regex_uuid4} = "{local_id}"',
             f'id-{regex_uuid4} = "{remote_id}"',

--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -639,8 +639,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             f'auth = eap-mschapv2',
             f'eap_id = %any',
             f'esp_proposals = aes256-sha512,aes256-sha384,aes256-sha256,aes256-sha1,aes128gcm128-sha256',
-            f'rekey_time = {eap_lifetime}s',
-            f'rand_time = 540s',
+            f'life_time = {eap_lifetime}s',
             f'dpd_action = clear',
             f'replay_window = 32',
             f'inactivity = 28800',
@@ -761,8 +760,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             f'auth = eap-tls',
             f'eap_id = %any',
             f'esp_proposals = aes256-sha512,aes256-sha384,aes256-sha256,aes256-sha1,aes128gcm128-sha256',
-            f'rekey_time = {eap_lifetime}s',
-            f'rand_time = 540s',
+            f'life_time = {eap_lifetime}s',
             f'dpd_action = clear',
             f'inactivity = 28800',
             f'local_ts = 0.0.0.0/0,::/0',
@@ -876,8 +874,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             f'certs = peer1.pem',
             f'cacerts = MyVyOS-CA.pem,MyVyOS-IntCA.pem',
             f'esp_proposals = aes256-sha512,aes256-sha384,aes256-sha256,aes256-sha1,aes128gcm128-sha256',
-            f'rekey_time = {eap_lifetime}s',
-            f'rand_time = 540s',
+            f'life_time = {eap_lifetime}s',
             f'dpd_action = clear',
             f'inactivity = 28800',
             f'local_ts = 0.0.0.0/0,::/0',
@@ -965,6 +962,118 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'{interface}.{vif}', dhcp_interfaces) # Ensure dhcp interface was added for dhclient hook
 
         self.cli_delete(ethernet_path + [interface, 'vif', vif, 'address'])
+
+        self.tearDownPKI()
+
+    def test_remote_access_no_rekey(self):
+        # In some RA secnarios, disabling server-initiated rekey of IKE and CHILD SA is desired
+        self.setupPKI()
+
+        ike_group = 'IKE-RW'
+        esp_group = 'ESP-RW'
+
+        conn_name = 'vyos-rw'
+        local_address = '192.0.2.1'
+        ip_pool_name = 'ra-rw-ipv4'
+        ike_lifetime = '7200'
+        eap_lifetime = '3600'
+        local_id = 'ipsec.vyos.net'
+
+        name_servers = ['172.16.254.100', '172.16.254.101']
+        prefix = '172.16.250.0/28'
+
+        # IKE
+        self.cli_set(base_path + ['ike-group', ike_group, 'key-exchange', 'ikev2'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'lifetime', '0'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '1',  'dh-group', '14'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '1',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '1',  'hash', 'sha512'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '2',  'dh-group', '14'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '2',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '2',  'hash', 'sha256'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '3',  'dh-group', '2'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '3',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '3',  'hash', 'sha256'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '10', 'dh-group', '14'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '10', 'encryption', 'aes128gcm128'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '10', 'hash', 'sha256'])
+
+        # ESP
+        self.cli_set(base_path + ['esp-group', esp_group, 'lifetime', eap_lifetime])
+        self.cli_set(base_path + ['esp-group', esp_group, 'pfs', 'disable'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'disable-rekey'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '1',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '1',  'hash', 'sha512'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '2',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '2',  'hash', 'sha384'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '3',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '3',  'hash', 'sha256'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '4',  'encryption', 'aes256'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '4',  'hash', 'sha1'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '10', 'encryption', 'aes128gcm128'])
+        self.cli_set(base_path + ['esp-group', esp_group, 'proposal', '10', 'hash', 'sha256'])
+
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'local-id', local_id])
+        # Use client-mode x509 instead of default EAP-MSCHAPv2
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'client-mode', 'x509'])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'server-mode', 'x509'])
+
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'x509', 'certificate', peer_name])
+        # verify() - CA cert required for x509 auth
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'x509', 'ca-certificate', ca_name])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'authentication', 'x509', 'ca-certificate', int_ca_name])
+
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'esp-group', esp_group])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'ike-group', ike_group])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'local-address', local_address])
+        self.cli_set(base_path + ['remote-access', 'connection', conn_name, 'pool', ip_pool_name])
+
+        for ns in name_servers:
+            self.cli_set(base_path + ['remote-access', 'pool', ip_pool_name, 'name-server', ns])
+        self.cli_set(base_path + ['remote-access', 'pool', ip_pool_name, 'prefix', prefix])
+
+        self.cli_commit()
+
+        # verify applied configuration
+        swanctl_conf = read_file(swanctl_file)
+        swanctl_lines = [
+            f'{conn_name}',
+            f'remote_addrs = %any',
+            f'local_addrs = {local_address}',
+            f'proposals = aes256-sha512-modp2048,aes256-sha256-modp2048,aes256-sha256-modp1024,aes128gcm128-sha256-modp2048',
+            f'version = 2',
+            f'send_certreq = no',
+            f'rekey_time = 0s',
+            f'keyingtries = 0',
+            f'pools = {ip_pool_name}',
+            f'id = "{local_id}"',
+            f'auth = pubkey',
+            f'certs = peer1.pem',
+            f'cacerts = MyVyOS-CA.pem,MyVyOS-IntCA.pem',
+            f'esp_proposals = aes256-sha512,aes256-sha384,aes256-sha256,aes256-sha1,aes128gcm128-sha256',
+            f'life_time = {eap_lifetime}s',
+            f'rekey_time = 0s',
+            f'dpd_action = clear',
+            f'inactivity = 28800',
+            f'local_ts = 0.0.0.0/0,::/0',
+        ]
+        for line in swanctl_lines:
+            self.assertIn(line, swanctl_conf)
+
+        swanctl_pool_lines = [
+            f'{ip_pool_name}',
+            f'addrs = {prefix}',
+            f'dns = {",".join(name_servers)}',
+        ]
+        for line in swanctl_pool_lines:
+            self.assertIn(line, swanctl_conf)
+
+        # Check Root CA, Intermediate CA and Peer cert/key pair is present
+        self.assertTrue(os.path.exists(os.path.join(CA_PATH, f'{ca_name}.pem')))
+        self.assertTrue(os.path.exists(os.path.join(CA_PATH, f'{int_ca_name}.pem')))
+        self.assertTrue(os.path.exists(os.path.join(CERT_PATH, f'{peer_name}.pem')))
 
         self.tearDownPKI()
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This extends the functionality of disabling IKE_SA rekeying introduced in T5139 to support disabling CHILD_SA rekeying as well. Disabling re-keying could be useful particularly for road warrior configurations, where it is often better to let clients drive the rekeying behavior so that clients can plan ahead sleep intervals, maximize battery life, etc.

Bundled with this change is a fix for a significant behavior change introduced by refactoring of the defaults logic: dead peer detection was incorrectly enabled by default even when the requisite key was not specified in the IKE group.

I also tried to bring further parity between remote-access and site-to-site connections in terms of the options supported as well as defaults.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Behavior change for esp-group `lifetime` property when used with remote-access VPN

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6599

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
`vpn ipsec site-to-site`
`vpn ipsec remote-access`

## Proposed changes
<!--- Describe your changes in detail -->

### New feature: Disable re-key of CHILD_SA

This feature can be enabled by `set vpn ipsec esp-group <name> rekey disable`. When enabled, the local ipsec instance will _not_ initiate rekeying of the child SA.

Disabling rekeying does not prevent the other side from initiating a re-key. Configured lifetime limits still apply and if the other side fails to re-key before a limit is reached, the SA will expire and the connection will be torn down. This feature also disables proactive rekeying when `life-bytes` and `life-packets` limits are approached.

By default, re-keying is enabled so this does not introduce any behavior changes to existing configurations.

### New feature and potentially breaking change: parity of ike/esp-group options between remote-access and site-to-site

Some ike-group and esp-group options had different meanings depending on whether the group was used with a `site-to-site peer` or a `remote-access connection`.

For example, the ESP `lifetime` property is interpreted:
- for site-to-site peers, as a hard lifetime. ipsec will attempt to re-key somewhere between when 80%-90% of the lifetime has elapsed.
- for remote-access connections, as the latest re-key time. the actual hard lifetime is `1.1 * lifetime`. ipsec will try to re-key within some random interval up to a hardcoded 540 seconds before `lifetime`.

This PR proposes changing the remote-access behavior to match that of site-to-site. Additionally, `life_bytes` and `life_packets` on the ESP group and `dead-peer-detection` on the IKE group are ignored for remote-access connections. These settings have been brought over in the name of feature parity with exception to `dead-peer-detection action` (where only `clear` makes sense for remote-access).

### Bugfix: dead-peer-detection enabled by default and no way to disable it

Likely introduced by changes in the defaults logic (e.g https://github.com/vyos/vyos-1x/commit/6c0ac21b9f37d4467c966bf72546c694001512c4), dead peer detection now defaults to ON regardless of whether the `dead-peer-detection` node is present in the IKE group. This differs from VyOS 1.3 and is an undocumented (and presumably unintentional) behavior change. Reverted to 1.3 behavior.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
```
DEBUG - vyos@vyos:~$ /usr/bin/vyos-smoketest
DEBUG - /usr/bin/vyos-smoketest
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
DEBUG - test_dhcp_fail_handling (__main__.TestVPNIPsec.test_dhcp_fail_handling) ... ok
DEBUG - test_dmvpn (__main__.TestVPNIPsec.test_dmvpn) ... ok
DEBUG - test_flex_vpn_vips (__main__.TestVPNIPsec.test_flex_vpn_vips) ... ok
DEBUG - test_remote_access (__main__.TestVPNIPsec.test_remote_access) ... ok
DEBUG - test_remote_access_dhcp_fail_handling (__main__.TestVPNIPsec.test_remote_access_dhcp_fail_handling) ... ok
DEBUG - test_remote_access_eap_tls (__main__.TestVPNIPsec.test_remote_access_eap_tls) ... ok
DEBUG - test_remote_access_no_rekey (__main__.TestVPNIPsec.test_remote_access_no_rekey) ... ok
DEBUG - test_remote_access_pool_range (__main__.TestVPNIPsec.test_remote_access_pool_range) ... ok
DEBUG - test_remote_access_vti (__main__.TestVPNIPsec.test_remote_access_vti) ... ok
DEBUG - test_remote_access_x509 (__main__.TestVPNIPsec.test_remote_access_x509) ... ok
DEBUG - test_site_to_site (__main__.TestVPNIPsec.test_site_to_site) ... ok
DEBUG - test_site_to_site_vti (__main__.TestVPNIPsec.test_site_to_site_vti) ... ok
DEBUG - test_site_to_site_x509 (__main__.TestVPNIPsec.test_site_to_site_x509) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 13 tests in 56.540s
DEBUG - OK
DEBUG - vyos@vyos:~$ echo EXITCODE:$?
DEBUG - echo EXITCODE:$?
DEBUG - EXITCODE:0
 INFO - Smoketest finished successfully!
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
