### PR TITLE
system_option: T5552: Apply IPv4 and IPv6 options after reapplying sysctls by TuneD

### DIFF
--- a/data/config-mode-dependencies/vyos-1x.json
+++ b/data/config-mode-dependencies/vyos-1x.json
@@ -63,5 +63,9 @@
     },
     "system_wireless": {
         "wireless": ["interfaces_wireless"]
+    },
+    "system_option": {
+        "ip": ["system_ip"],
+        "ipv6": ["system_ipv6"]
     }
 }


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Since TuneD reapplies sysctls from configuration files (particularly [net.ipv6.conf.all.forwarding](https://github.com/vyos/vyos-1x/blob/current/src/etc/sysctl.d/30-vyos-router.conf#L87)) we need to apply sysctl parameters that were manually set  for IPv4 and IPv6 
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T5552
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
system_option
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set system ip disable-forwarding
set system ipv6 disable-forwarding
commit

vyos@vyos# sudo sysctl -a | grep conf.all.forwarding
net.ipv4.conf.all.forwarding = 0
net.ipv6.conf.all.forwarding = 0

set system option performance throughput
commit
```
Before the fix after this commit ipv4 and ipv6 forwarding was enabled. Now it stays as it should be.
```
vyos@vyos# sudo sysctl -a | grep conf.all.forwarding
net.ipv4.conf.all.forwarding = 0
net.ipv6.conf.all.forwarding = 0
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
