### PR TITLE
vrf: T6602: verify supplied VRF name on all interface types

### DIFF
--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -303,6 +303,24 @@ class BasicInterfaceTest:
             self.cli_delete(['vrf', 'name', vrf1_name])
             self.cli_delete(['vrf', 'name', vrf2_name])
 
+        def test_add_to_invalid_vrf(self):
+            if not self._test_vrf:
+                self.skipTest('not supported')
+
+            # move interface into first VRF
+            for interface in self._interfaces:
+                for option in self._options.get(interface, []):
+                    self.cli_set(self._base_path + [interface] + option.split())
+                self.cli_set(self._base_path + [interface, 'vrf', 'invalid'])
+
+            # check validate() - can not use a non-existing VRF
+            with self.assertRaises(ConfigSessionError):
+                self.cli_commit()
+
+            for interface in self._interfaces:
+                self.cli_delete(self._base_path + [interface, 'vrf', 'invalid'])
+                self.cli_set(self._base_path + [interface, 'description', 'test_add_to_invalid_vrf'])
+
         def test_span_mirror(self):
             if not self._mirror_interfaces:
                 self.skipTest('not supported')

--- a/src/conf_mode/interfaces_geneve.py
+++ b/src/conf_mode/interfaces_geneve.py
@@ -24,6 +24,7 @@ from vyos.configverify import verify_mtu_ipv6
 from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_mirror_redirect
 from vyos.configverify import verify_bond_bridge_member
+from vyos.configverify import verify_vrf
 from vyos.ifconfig import GeneveIf
 from vyos.utils.network import interface_exists
 from vyos import ConfigError
@@ -59,6 +60,7 @@ def verify(geneve):
 
     verify_mtu_ipv6(geneve)
     verify_address(geneve)
+    verify_vrf(geneve)
     verify_bond_bridge_member(geneve)
     verify_mirror_redirect(geneve)
 

--- a/src/conf_mode/interfaces_l2tpv3.py
+++ b/src/conf_mode/interfaces_l2tpv3.py
@@ -24,6 +24,7 @@ from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_mtu_ipv6
 from vyos.configverify import verify_mirror_redirect
 from vyos.configverify import verify_bond_bridge_member
+from vyos.configverify import verify_vrf
 from vyos.ifconfig import L2TPv3If
 from vyos.utils.kernel import check_kmod
 from vyos.utils.network import is_addr_assigned
@@ -76,6 +77,7 @@ def verify(l2tpv3):
 
     verify_mtu_ipv6(l2tpv3)
     verify_address(l2tpv3)
+    verify_vrf(l2tpv3)
     verify_bond_bridge_member(l2tpv3)
     verify_mirror_redirect(l2tpv3)
     return None

--- a/src/conf_mode/interfaces_vti.py
+++ b/src/conf_mode/interfaces_vti.py
@@ -19,6 +19,7 @@ from sys import exit
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
 from vyos.configverify import verify_mirror_redirect
+from vyos.configverify import verify_vrf
 from vyos.ifconfig import VTIIf
 from vyos import ConfigError
 from vyos import airbag
@@ -38,6 +39,7 @@ def get_config(config=None):
     return vti
 
 def verify(vti):
+    verify_vrf(vti)
     verify_mirror_redirect(vti)
     return None
 

--- a/src/conf_mode/interfaces_vxlan.py
+++ b/src/conf_mode/interfaces_vxlan.py
@@ -28,6 +28,7 @@ from vyos.configverify import verify_mtu_ipv6
 from vyos.configverify import verify_mirror_redirect
 from vyos.configverify import verify_source_interface
 from vyos.configverify import verify_bond_bridge_member
+from vyos.configverify import verify_vrf
 from vyos.ifconfig import Interface
 from vyos.ifconfig import VXLANIf
 from vyos.template import is_ipv6
@@ -216,6 +217,7 @@ def verify(vxlan):
 
     verify_mtu_ipv6(vxlan)
     verify_address(vxlan)
+    verify_vrf(vxlan)
     verify_bond_bridge_member(vxlan)
     verify_mirror_redirect(vxlan)
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Only some (e.g. ethernet or wireguard) interfaces validate if the supplied VRF actually exists. If this is not validated, one can pass an invalid VRF to the system which generates an OSError exception.

To reproduce

```
set interfaces vxlan vxlan1 vni 1000
set interfaces vxlan vxlan1 remote 1.2.3.4
set interfaces vxlan vxlan1 vrf smoketest
```

results in

`OSError: [Errno 255] failed to run command: ip link set dev vxlan1 master smoketest_mgmt`

This commit adds the missing `verify_vrf()` call to the missing interface types and an appropriate smoketest for all interfaces supporting VRF assignment.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6602

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR2.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_l2tpv3.py
test_add_multiple_ip_addresses (__main__.L2TPv3InterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.L2TPv3InterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.L2TPv3InterfaceTest.test_add_to_invalid_vrf) ... ok <- NEW TESTCASE
test_dhcp_client_options (__main__.L2TPv3InterfaceTest.test_dhcp_client_options) ... skipped 'not supported'
test_dhcp_disable_interface (__main__.L2TPv3InterfaceTest.test_dhcp_disable_interface) ... skipped 'not supported'
test_dhcp_vrf (__main__.L2TPv3InterfaceTest.test_dhcp_vrf) ... skipped 'not supported'
test_dhcpv6_client_options (__main__.L2TPv3InterfaceTest.test_dhcpv6_client_options) ... skipped 'not supported'
test_dhcpv6_vrf (__main__.L2TPv3InterfaceTest.test_dhcpv6_vrf) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.L2TPv3InterfaceTest.test_dhcpv6pd_auto_sla_id) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.L2TPv3InterfaceTest.test_dhcpv6pd_manual_sla_id) ... skipped 'not supported'
test_interface_description (__main__.L2TPv3InterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.L2TPv3InterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.L2TPv3InterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.L2TPv3InterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.L2TPv3InterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.L2TPv3InterfaceTest.test_ipv6_link_local_address) ... ok
test_move_interface_between_vrf_instances (__main__.L2TPv3InterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.L2TPv3InterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.L2TPv3InterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.L2TPv3InterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.L2TPv3InterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.L2TPv3InterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.L2TPv3InterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.L2TPv3InterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.L2TPv3InterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'

----------------------------------------------------------------------
Ran 25 tests in 42.808s

OK (skipped=14)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
