### PR TITLE
interface: T6592: remove interface from conntrack ct_iface_map on deletion

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_l2tpv3.py
+++ b/smoketest/scripts/cli/test_interfaces_l2tpv3.py
@@ -20,7 +20,7 @@ import unittest
 
 from base_interfaces_test import BasicInterfaceTest
 from vyos.utils.process import cmd
-
+from vyos.utils.kernel import unload_kmod
 class L2TPv3InterfaceTest(BasicInterfaceTest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -62,7 +62,6 @@ if __name__ == '__main__':
     # reloaded on demand - not needed but test more and more features
     for module in ['l2tp_ip6', 'l2tp_ip', 'l2tp_eth', 'l2tp_eth',
                    'l2tp_netlink', 'l2tp_core']:
-        if os.path.exists(f'/sys/module/{module}'):
-            cmd(f'sudo rmmod {module}')
+        unload_kmod(module)
 
     unittest.main(verbosity=2)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

We always have had stale interface entries in the ct_iface_map of nftables/ conntrack for any interface that once belonged to a VRF.

This commit will always clean the nftables interface map when the interface is deleted from the system.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6592

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/3834

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vyos.interfaces

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR2.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_l2tpv3.py
test_add_multiple_ip_addresses (__main__.L2TPv3InterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.L2TPv3InterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.L2TPv3InterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.L2TPv3InterfaceTest.test_dhcp_client_options) ... skipped 'not supported'
test_dhcp_disable_interface (__main__.L2TPv3InterfaceTest.test_dhcp_disable_interface) ... skipped 'not supported'
test_dhcp_vrf (__main__.L2TPv3InterfaceTest.test_dhcp_vrf) ... skipped 'not supported'
test_dhcpv6_client_options (__main__.L2TPv3InterfaceTest.test_dhcpv6_client_options) ... skipped 'not supported'
test_dhcpv6_vrf (__main__.L2TPv3InterfaceTest.test_dhcpv6_vrf) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.L2TPv3InterfaceTest.test_dhcpv6pd_auto_sla_id) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.L2TPv3InterfaceTest.test_dhcpv6pd_manual_sla_id) ... skipped 'not supported'
test_interface_description (__main__.L2TPv3InterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.L2TPv3InterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.L2TPv3InterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.L2TPv3InterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.L2TPv3InterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.L2TPv3InterfaceTest.test_ipv6_link_local_address) ... ok
test_move_interface_between_vrf_instances (__main__.L2TPv3InterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.L2TPv3InterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.L2TPv3InterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.L2TPv3InterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.L2TPv3InterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.L2TPv3InterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.L2TPv3InterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.L2TPv3InterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.L2TPv3InterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'

----------------------------------------------------------------------
Ran 25 tests in 42.808s

OK (skipped=14)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
