### PR TITLE
T6605: restore configd error formatting to be consistent with CLI

### DIFF
--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -143,9 +143,8 @@ def run_script(script_name, config, args) -> int:
         script.generate(c)
         script.apply(c)
     except ConfigError as e:
-        s = f'{script_name}: {repr(e)}'
-        logger.error(s)
-        explicit_print(session_out, session_mode, s)
+        logger.error(e)
+        explicit_print(session_out, session_mode, str(e))
         return R_ERROR_COMMIT
     except Exception as e:
         logger.critical(e)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Restore formatting of ConfigError under configd to be consistent with running with no configd support. The formatting was extended in T6559 to report a clearer distinction between configdep script errors and originating script errors, but the change can confuse consistent parsing of errors. Note that this was and remains only a difference in formatting; errors are correctly triggered by configd, both historically and following the fix in T6559.

The only discrepancy in formatting under configd, persistent since its introduction in 1.3, is the lack of the initial path statement, redundant as repeated below the commit error. The example below is the behavior since 1.3, and restored by this PR.

With configd:

```
vyos@vyos# set interfaces vxlan vxlan1 description 'this is strange'
[edit]
vyos@vyos# commit

Group, remote, source-address or source-interface must be configured

[[interfaces vxlan vxlan1]] failed
Commit failed
[edit]
```

Without configd:

```
vyos@vyos# set interfaces vxlan vxlan1 description 'this is strange'
[edit]
vyos@vyos# commit
[ interfaces vxlan vxlan1 ]
Group, remote, source-address or source-interface must be configured

[[interfaces vxlan vxlan1]] failed
Commit failed
[edit]
```

Any other desired formatting changes can be provided under this or a separate task. This PR simply restores the previous formatting consistency.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
