### PR TITLE
configd: T6608: report uncaught config script exceptions as commit error

### DIFF
--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -24,6 +24,7 @@ import json
 import typing
 import logging
 import signal
+import traceback
 import importlib.util
 import io
 from contextlib import redirect_stdout
@@ -136,9 +137,10 @@ def run_script(script_name, config, args) -> tuple[int, str]:
     except ConfigError as e:
         logger.error(e)
         return R_ERROR_COMMIT, str(e)
-    except Exception as e:
-        logger.critical(e)
-        return R_ERROR_DAEMON, str(e)
+    except Exception:
+        tb = traceback.format_exc()
+        logger.error(tb)
+        return R_ERROR_COMMIT, tb
 
     return R_SUCCESS, ''
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Exceptions uncaught by config scripts should be caught by configd and returned as commit error. The previous behavior of configd was to catch and report as a daemon error to the shim, allowing for the possibility of a pass-through execution (as with any other daemon originating error). The introduction of config dependencies, however, requires the return of a commit error.

The error output returns the traceback, consistent with the output running without configd; simple test case below for comparison:

with configd:

```
vyos@vyos# commit
[ simple some-tag-node some0 ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 134, in run_script
    script.verify(c)
  File "/usr/libexec/vyos//conf_mode/simple.py", line 50, in verify
    raise OSError('This is an uncaught exception')
OSError: This is an uncaught exception

[[simple some-tag-node some0]] failed
Commit failed
```

without configd:

```
vyos@vyos# set simple some-tag-node some0
[edit]
vyos@vyos# commit
[ simple some-tag-node some0 ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/simple.py", line 64, in <module>
    verify(c)
  File "/usr/libexec/vyos/conf_mode/simple.py", line 50, in verify
    raise OSError('This is an uncaught exception')
OSError: This is an uncaught exception

[[simple some-tag-node some0]] failed
Commit failed
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
