### PR TITLE
op_mode: T5744: PKI import OpenVPN shared key includess unexpected BEGIN and END

### DIFF
--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -844,7 +844,8 @@ def import_openvpn_secret(name, path):
     key_version = '1'
 
     with open(path) as f:
-        key_lines = f.read().split("\n")
+        key_lines = f.read().strip().split("\n")
+        key_lines = list(filter(lambda line: not line.strip().startswith('#'), key_lines)) # Remove commented lines
         key_data = "".join(key_lines[1:-1]) # Remove wrapper tags and line endings
 
     version_search = re.search(r'BEGIN OpenVPN Static key V(\d+)', key_lines[0]) # Future-proofing (hopefully)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T5744
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
op mode:  import pki openvpn
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos# cat /config/auth/foo.key
#
# 2048 bit OpenVPN static key
#
-----BEGIN OpenVPN Static key V1-----
6bc8ba8bb6234c9adaa755ba94303970
d5f9486d4b2d1b7b2851e49e5b7b648f
82fc9c80bc79cf77a98de8d9afb4add5
a8ae2c14befe9da7d8eebdd138759466
54e9bdc2f4ddf25ec46d15e6230df2d6
d85ebc30f634bb07dddc3ce375cd699d
fefb95029bf0396a9f9873c203aa4ebf
10a96b9e102f455bef67c62479a2f19f
9abc53d4ce3bbf4db4cf354b4885d59d
456a05368f70a0c0a413b5109db8a984
a5d9a33af99e137e9dd55a69413d94b1
9b9c6db3537fb3207ed5b36477e41948
e13f7def87312f3aefcd08573c4ad11c
27bb7ff5d26b752bdeba595ac914d6bb
81b56b9831779c415f43ae4d9c0db361
455e917a5db6c84019edeeb58ef78490
-----END OpenVPN Static key V1-----
[edit]

vyos@vyos# run import pki openvpn shared-secret foo file /config/auth/foo.key
2 value(s) installed. Use "compare" to see the pending changes, and "commit" to apply.
[edit]
vyos@vyos# compare
+ pki {
+     openvpn {
+         shared-secret foo {
+             key "6bc8ba8bb6234c9adaa755ba94303970d5f9486d4b2d1b7b2851e49e5b7b648f82fc9c80bc79cf77a98de8d9afb4add5a8ae2c14befe9da7d8eebdd13875946654e9bdc2f4ddf25ec46d15e6230df2d6d85ebc30f634bb07dddc3ce375cd699dfefb95029bf0396a9f9873c203aa4ebf10a96b9e102f455bef67c62479a2f19f9abc53d4ce3bbf4db4cf354b4885d59d456a05368f70a0c0a413b5109db8a984a5d9a33af99e137e9dd55a69413d94b19b9c6db3537fb3207ed5b36477e41948e13f7def87312f3aefcd08573c4ad11c27bb7ff5d26b752bdeba595ac914d6bb81b56b9831779c415f43ae4d9c0db361455e917a5db6c84019edeeb58ef78490"
+             version "1"
+         }
+     }
+ }

[edit]
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
