### PR TITLE
smoketest: T6425: fix wireless smoketest CLI from invalid backport

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_wireless.py
+++ b/smoketest/scripts/cli/test_interfaces_wireless.py
@@ -34,7 +34,6 @@ def get_config_value(interface, key):
     tmp = re.findall(f'{key}=+(.*)', tmp)
     return tmp[0]
 
-wifi_cc_path = ['system', 'wireless', 'country-code']
 country = 'se'
 class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
     @classmethod
@@ -42,19 +41,23 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         cls._base_path = ['interfaces', 'wireless']
         cls._options = {
             'wlan0':  ['physical-device phy0',
+                       f'country-code {country}',
                        'ssid VyOS-WIFI-0',
                        'type station',
                        'address 192.0.2.1/30'],
             'wlan1':  ['physical-device phy0',
+                       f'country-code {country}',
                        'ssid VyOS-WIFI-1',
                        'type access-point',
                        'address 192.0.2.5/30',
                        'channel 0'],
             'wlan10': ['physical-device phy1',
+                       f'country-code {country}',
                        'ssid VyOS-WIFI-2',
                        'type station',
                        'address 192.0.2.9/30'],
             'wlan11': ['physical-device phy1',
+                       f'country-code {country}',
                        'ssid VyOS-WIFI-3',
                        'type access-point',
                        'address 192.0.2.13/30',
@@ -67,9 +70,6 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         # T5245 - currently testcases are disabled
         cls._test_ipv6 = False
         cls._test_vlan = False
-
-        cls.cli_set(cls, wifi_cc_path + [country])
-
 
     def test_wireless_add_single_ip_address(self):
         # derived method to check if member interfaces are enslaved properly
@@ -91,6 +91,7 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         ssid = 'ssid'
 
         self.cli_set(self._base_path + [interface, 'ssid', ssid])
+        self.cli_set(self._base_path + [interface, 'country-code', country])
         self.cli_set(self._base_path + [interface, 'type', 'access-point'])
 
         # auto-powersave is special
@@ -169,6 +170,7 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         antennas = '3'
 
         self.cli_set(self._base_path + [interface, 'ssid', ssid])
+        self.cli_set(self._base_path + [interface, 'country-code', country])
         self.cli_set(self._base_path + [interface, 'type', 'access-point'])
         self.cli_set(self._base_path + [interface, 'channel', '36'])
 
@@ -238,6 +240,7 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         antennas = '3'
 
         self.cli_set(self._base_path + [interface, 'ssid', ssid])
+        self.cli_set(self._base_path + [interface, 'country-code', country])
         self.cli_set(self._base_path + [interface, 'type', 'access-point'])
         self.cli_set(self._base_path + [interface, 'channel', '36'])
 
@@ -311,6 +314,7 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         center_channel_freq_1 = '15'
 
         self.cli_set(self._base_path + [interface, 'ssid', ssid])
+        self.cli_set(self._base_path + [interface, 'country-code', country])
         self.cli_set(self._base_path + [interface, 'type', 'access-point'])
         self.cli_set(self._base_path + [interface, 'channel', channel])
         self.cli_set(self._base_path + [interface, 'mode', 'ax'])
@@ -394,13 +398,12 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
 
         # SSID and country-code are already configured in self.setUpClass()
         # Therefore, we must delete those here to check if commit will fail without it.
-        self.cli_delete(wifi_cc_path)
         self.cli_delete(self._base_path + [interface, 'ssid'])
 
         # Country-Code must be set
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
-        self.cli_set(wifi_cc_path + [country])
+        self.cli_set(self._base_path + [interface, 'country-code', country])
 
         # SSID must be set
         with self.assertRaises(ConfigSessionError):
@@ -457,6 +460,7 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         self.cli_set(bridge_path + ['member', 'interface', interface])
 
         self.cli_set(self._base_path + [interface, 'ssid', ssid])
+        self.cli_set(self._base_path + [interface, 'country-code', country])
         self.cli_set(self._base_path + [interface, 'type', 'access-point'])
         self.cli_set(self._base_path + [interface, 'channel', '1'])
 
@@ -495,6 +499,7 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         deny_mac = ['00:00:00:00:de:01', '00:00:00:00:de:02', '00:00:00:00:de:03', '00:00:00:00:de:04']
 
         self.cli_set(self._base_path + [interface, 'ssid', ssid])
+        self.cli_set(self._base_path + [interface, 'country-code', country])
         self.cli_set(self._base_path + [interface, 'type', 'access-point'])
         self.cli_set(self._base_path + [interface, 'security', 'station-address', 'mode', 'accept'])
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

New CLI syntax got backported via commit f19a531e3 ("wireless: T6425: Fixing VHT beamforming for 802.11ac").

Revert back to the stable CLI syntax in the 1.4 (sagitta) release.

 This PR only affects the test code, not the real CLI production code!!

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6425

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/3847

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
Smoketest

## Proposed changes
<!--- Describe your changes in detail -->

Revert CLI used in smoketests


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR2.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireless.py
test_add_multiple_ip_addresses (__main__.WirelessInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.WirelessInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.WirelessInterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.WirelessInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.WirelessInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.WirelessInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.WirelessInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.WirelessInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_interface_description (__main__.WirelessInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.WirelessInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.WirelessInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.WirelessInterfaceTest.test_interface_ipv6_options) ... skipped 'not supported'
test_interface_mtu (__main__.WirelessInterfaceTest.test_interface_mtu) ... skipped 'not supported'
test_ipv6_link_local_address (__main__.WirelessInterfaceTest.test_ipv6_link_local_address) ... skipped 'not supported'
test_move_interface_between_vrf_instances (__main__.WirelessInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.WirelessInterfaceTest.test_mtu_1200_no_ipv6_interface) ... skipped 'not supported'
test_span_mirror (__main__.WirelessInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.WirelessInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.WirelessInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.WirelessInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.WirelessInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.WirelessInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.WirelessInterfaceTest.test_vif_s_protocol_change) ... ok
test_wireless_access_point_bridge (__main__.WirelessInterfaceTest.test_wireless_access_point_bridge) ... ok
test_wireless_add_single_ip_address (__main__.WirelessInterfaceTest.test_wireless_add_single_ip_address) ... ok
test_wireless_hostapd_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_config) ... ok
test_wireless_hostapd_he_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_he_config) ... ok
test_wireless_hostapd_vht_mu_beamformer_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_vht_mu_beamformer_config) ... ok
test_wireless_hostapd_vht_su_beamformer_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_vht_su_beamformer_config) ... ok
test_wireless_hostapd_wpa_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_wpa_config) ... ok
test_wireless_security_station_address (__main__.WirelessInterfaceTest.test_wireless_security_station_address) ... ok

----------------------------------------------------------------------
Ran 33 tests in 185.415s

OK (skipped=9)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
