### PR TITLE
smoketest: T6614: initial support for op-mode command testing

### DIFF
--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -15,6 +15,7 @@
 import os
 import unittest
 import paramiko
+import pprint
 
 from time import sleep
 from typing import Type
@@ -87,13 +88,25 @@ class VyOSUnitTestSHIM:
             while run(f'sudo lsof -nP {commit_lock}') == 0:
                 sleep(0.250)
 
+        def op_mode(self, path : list) -> None:
+            """
+            Execute OP-mode command and return stdout
+            """
+            if self.debug:
+                print('commit')
+            path = ' '.join(path)
+            out = cmd(f'/opt/vyatta/bin/vyatta-op-cmd-wrapper {path}')
+            if self.debug:
+                print(f'\n\ncommand "{path}" returned:\n')
+                pprint.pprint(out)
+            return out
+
         def getFRRconfig(self, string=None, end='$', endsection='^!', daemon=''):
             """ Retrieve current "running configuration" from FRR """
             command = f'vtysh -c "show run {daemon} no-header"'
             if string: command += f' | sed -n "/^{string}{end}/,/{endsection}/p"'
             out = cmd(command)
             if self.debug:
-                import pprint
                 print(f'\n\ncommand "{command}" returned:\n')
                 pprint.pprint(out)
             return out

--- a/smoketest/scripts/cli/test_op-mode_show.py
+++ b/smoketest/scripts/cli/test_op-mode_show.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from base_vyostest_shim import VyOSUnitTestSHIM
+
+from vyos.version import get_version
+
+base_path = ['show']
+
+class TestOPModeShow(VyOSUnitTestSHIM.TestCase):
+    def test_op_mode_show_version(self):
+        # Retrieve output of "show version" OP-mode command
+        tmp = self.op_mode(base_path + ['version'])
+        # Validate
+        version = get_version()
+        self.assertIn(f'Version:          VyOS {version}', tmp)
+
+    def test_op_mode_show_vrf(self):
+        # Retrieve output of "show version" OP-mode command
+        tmp = self.op_mode(base_path + ['vrf'])
+        # Validate
+        self.assertIn('VRF is not configured', tmp)
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

We currently lack behind testing OP-mode commands with the smoketest framework.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6614

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Smoketests

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR2.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_op-mode_show.py
test_op_mode_show_version (__main__.TestOPModeShow.test_op_mode_show_version) ... ok
test_op_mode_show_vrf (__main__.TestOPModeShow.test_op_mode_show_vrf) ... ok

----------------------------------------------------------------------
Ran 2 tests in 1.469s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
