### PR TITLE
T6294: Service dns forwarding add the ability to configure ZonetoCache

### DIFF
--- a/data/templates/dns-forwarding/recursor.conf.lua.j2
+++ b/data/templates/dns-forwarding/recursor.conf.lua.j2
@@ -6,3 +6,31 @@ dofile("/usr/share/pdns-recursor/lua-config/rootkeys.lua")
 
 -- Load lua from vyos-hostsd --
 dofile("{{ config_dir }}/recursor.vyos-hostsd.conf.lua")
+
+-- ZoneToCache --
+{% if zone_cache is vyos_defined %}
+{%     set option_mapping = {
+    'refresh': 'refreshPeriod',
+    'retry_interval': 'retryOnErrorPeriod',
+    'max_zone_size': 'maxReceivedMBytes'
+} %}
+{%     for name, conf in zone_cache.items() %}
+{%         set source = conf.source.items() | first %}
+{%         set settings = [] %}
+{%         for key, val in conf.options.items() %}
+{%             set mapped_key = option_mapping.get(key, key) %}
+{%             if key == 'refresh' %}
+{%                 set val = val['interval'] %}
+{%             endif %}
+{%             if key in ['dnssec', 'zonemd'] %}
+{%                 set _ = settings.append(mapped_key ~ ' = "' ~ val ~ '"') %}
+{%             else %}
+{%                 set _ = settings.append(mapped_key ~ ' = ' ~ val) %}
+{%             endif %}
+{%         endfor %}
+
+zoneToCache("{{ name }}", "{{ source[0] }}", "{{ source[1] }}", { {{ settings | join(', ') }} })
+
+{%     endfor %}
+
+{% endif %}

--- a/interface-definitions/service_dns_forwarding.xml.in
+++ b/interface-definitions/service_dns_forwarding.xml.in
@@ -793,6 +793,179 @@
                   </leafNode>
                 </children>
               </node>
+              <tagNode name="zone-cache">
+                <properties>
+                  <help>Load a zone into the recursor cache</help>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>Domain name</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="fqdn"/>
+                  </constraint>
+                </properties>
+                <children>
+                  <node name="source">
+                    <properties>
+                      <help>Zone source</help>
+                    </properties>
+                    <children>
+                      <leafNode name="axfr">
+                        <properties>
+                          <help>DNS server address</help>
+                          <valueHelp>
+                            <format>ipv4</format>
+                            <description>IPv4 address</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>ipv6</format>
+                            <description>IPv6 address</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="ip-address"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="url">
+                        <properties>
+                          <help>Source URL</help>
+                          <valueHelp>
+                            <format>url</format>
+                            <description>Zone file URL</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="url" argument="--scheme http --scheme https"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </node>
+                  <node name="options">
+                    <properties>
+                      <help>Zone caching options</help>
+                    </properties>
+                    <children>
+                      <leafNode name="timeout">
+                        <properties>
+                          <help>Zone retrieval timeout</help>
+                          <valueHelp>
+                            <format>u32:1-3600</format>
+                            <description>Request timeout in seconds</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-3600"/>
+                          </constraint>
+                        </properties>
+                        <defaultValue>20</defaultValue>
+                      </leafNode>
+                      <node name="refresh">
+                        <properties>
+                          <help>Zone caching options</help>
+                        </properties>
+                        <children>
+                          <leafNode name="on-reload">
+                            <properties>
+                              <help>Retrieval zone only at startup and on reload</help>
+                              <valueless/>
+                            </properties>
+                          </leafNode>
+                          <leafNode name="interval">
+                            <properties>
+                              <help>Periodic zone retrieval interval</help>
+                              <valueHelp>
+                                <format>u32:0-31536000</format>
+                                <description>Retrieval interval in seconds</description>
+                              </valueHelp>
+                              <constraint>
+                                <validator name="numeric" argument="--range 0-31536000"/>
+                              </constraint>
+                            </properties>
+                            <defaultValue>86400</defaultValue>
+                          </leafNode>
+                        </children>
+                      </node>
+                      <leafNode name="retry-interval">
+                        <properties>
+                          <help>Retry interval after zone retrieval errors</help>
+                          <valueHelp>
+                            <format>u32:1-86400</format>
+                            <description>Retry period in seconds</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-86400"/>
+                          </constraint>
+                        </properties>
+                        <defaultValue>60</defaultValue>
+                      </leafNode>
+                      <leafNode name="max-zone-size">
+                        <properties>
+                          <help>Maximum zone size in megabytes</help>
+                          <valueHelp>
+                            <format>u32:0</format>
+                            <description>No restriction</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>u32:1-1024</format>
+                            <description>Size in megabytes</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 0-1024"/>
+                          </constraint>
+                        </properties>
+                        <defaultValue>0</defaultValue>
+                      </leafNode>
+                      <leafNode name="zonemd">
+                        <properties>
+                          <help>Message Digest for DNS Zones (RFC 8976)</help>
+                          <completionHelp>
+                            <list>ignore validate require</list>
+                          </completionHelp>
+                          <valueHelp>
+                            <format>ignore</format>
+                            <description>Ignore ZONEMD records</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>validate</format>
+                            <description>Validate ZONEMD if present</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>require</format>
+                            <description>Require valid ZONEMD record to be present</description>
+                          </valueHelp>
+                          <constraint>
+                            <regex>(ignore|validate|require)</regex>
+                          </constraint>
+                        </properties>
+                        <defaultValue>validate</defaultValue>
+                      </leafNode>
+                      <leafNode name="dnssec">
+                        <properties>
+                          <help>DNSSEC mode</help>
+                          <completionHelp>
+                            <list>ignore validate require</list>
+                          </completionHelp>
+                          <valueHelp>
+                            <format>ignore</format>
+                            <description>Do not do DNSSEC validation</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>validate</format>
+                            <description>Reject zones with incorrect signatures but accept unsigned zones</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>require</format>
+                            <description>Require DNSSEC validation</description>
+                          </valueHelp>
+                          <constraint>
+                            <regex>(ignore|validate|require)</regex>
+                          </constraint>
+                        </properties>
+                        <defaultValue>validate</defaultValue>
+                      </leafNode>
+                    </children>
+                  </node>
+                </children>
+              </tagNode>
             </children>
           </node>
         </children>

--- a/python/vyos/utils/convert.py
+++ b/python/vyos/utils/convert.py
@@ -12,41 +12,72 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+import re
+
+# Define the number of seconds in each time unit
+time_units = {
+    'y': 60 * 60 * 24 * 365.25,  # year
+    'w': 60 * 60 * 24 * 7,       # week
+    'd': 60 * 60 * 24,           # day
+    'h': 60 * 60,                # hour
+    'm': 60,                     # minute
+    's': 1                       # second
+}
+
+
+def human_to_seconds(time_str):
+    """ Converts a human-readable interval such as 1w4d18h35m59s
+    to number of seconds
+    """
+
+    time_patterns = {
+        'y': r'(\d+)\s*y',
+        'w': r'(\d+)\s*w',
+        'd': r'(\d+)\s*d',
+        'h': r'(\d+)\s*h',
+        'm': r'(\d+)\s*m',
+        's': r'(\d+)\s*s'
+    }
+
+    total_seconds = 0
+
+    for unit, pattern in time_patterns.items():
+        match = re.search(pattern, time_str)
+        if match:
+            value = int(match.group(1))
+            total_seconds += value * time_units[unit]
+
+    return int(total_seconds)
+
 
 def seconds_to_human(s, separator=""):
     """ Converts number of seconds passed to a human-readable
     interval such as 1w4d18h35m59s
     """
     s = int(s)
-
-    year = 60 * 60 * 24 * 365.25
-    week = 60 * 60 * 24 * 7
-    day = 60 * 60 * 24
-    hour = 60 * 60
-
     result = []
 
-    years = s // year
+    years = s // time_units['y']
     if years > 0:
         result.append(f'{int(years)}y')
-        s = int(s % year)
+        s = int(s % time_units['y'])
 
-    weeks = s // week
+    weeks = s // time_units['w']
     if weeks > 0:
         result.append(f'{weeks}w')
-        s = s % week
+        s = s % time_units['w']
 
-    days = s // day
+    days = s // time_units['d']
     if days > 0:
         result.append(f'{days}d')
-        s = s % day
+        s = s % time_units['d']
 
-    hours = s // hour
+    hours = s // time_units['h']
     if hours > 0:
         result.append(f'{hours}h')
-        s = s % hour
+        s = s % time_units['h']
 
-    minutes = s // 60
+    minutes = s // time_units['m']
     if minutes > 0:
         result.append(f'{minutes}m')
         s = s % 60
@@ -56,6 +87,7 @@ def seconds_to_human(s, separator=""):
         result.append(f'{seconds}s')
 
     return separator.join(result)
+
 
 def bytes_to_human(bytes, initial_exponent=0, precision=2,
                    int_below_exponent=0):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6294

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
conf
set service dns forwarding allow-from '127.0.0.0/24'
set service dns forwarding listen-address '127.0.0.1'
set service dns forwarding zone-to-cache test source url 'https://www.internic.net/domain/root.zone'
commit
```
```
vyos@vyos# sudo rec_control dump-cache cache.tmp
dumped 15052 records
```
```
sudo journalctl | grep DNS
...
Jul 29 09:46:40 vyos systemd[1]: Started pdns-recursor.service - PowerDNS Recursor.
Jul 29 09:46:40 vyos pdns-recursor[9685]: msg="Getting zone by URL" subsystem="ztc" level="0" tid="2" ts="1722246400.869" zone="test"
Jul 29 09:46:55 vyos pdns-recursor[9685]: msg="ZONEMD digest validation" subsystem="ztc" level="0" tid="2" ts="1722246415.065" validationDone="0" validationSuccess="0" zone="test"
Jul 29 09:46:55 vyos pdns-recursor[9685]: msg="Loaded zone into cache" subsystem="ztc" level="0" tid="2" ts="1722246415.092" refresh="86400" zone="test"
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_service_dns_forwarding.py
test_basic_forwarding (__main__.TestServicePowerDNS.test_basic_forwarding) ... 
service_dns_forwarding: ConfigError('DNS forwarding requires a listen-address')


service_dns_forwarding: ConfigError('DNS forwarding requires a listen-address')

ok
test_dns64 (__main__.TestServicePowerDNS.test_dns64) ... 
service_dns_forwarding: ConfigError('DNS 6to4 prefix must be of length /96')

ok
test_dnssec (__main__.TestServicePowerDNS.test_dnssec) ... ok
test_domain_forwarding (__main__.TestServicePowerDNS.test_domain_forwarding) ... ok
test_ecs_add_for (__main__.TestServicePowerDNS.test_ecs_add_for) ... ok
test_ecs_ipv4_bits (__main__.TestServicePowerDNS.test_ecs_ipv4_bits) ... ok
test_edns_subnet_allow_list (__main__.TestServicePowerDNS.test_edns_subnet_allow_list) ... ok
test_exclude_throttle_adress (__main__.TestServicePowerDNS.test_exclude_throttle_adress) ... ok
test_external_nameserver (__main__.TestServicePowerDNS.test_external_nameserver) ... ok
test_listening_port (__main__.TestServicePowerDNS.test_listening_port) ... ok
test_multiple_ns_records (__main__.TestServicePowerDNS.test_multiple_ns_records) ... ok
test_no_rfc1918_forwarding (__main__.TestServicePowerDNS.test_no_rfc1918_forwarding) ... ok
test_serve_stale_extension (__main__.TestServicePowerDNS.test_serve_stale_extension) ... ok
test_zone_to_cache_axfr (__main__.TestServicePowerDNS.test_zone_to_cache_axfr) ... ok
test_zone_to_cache_options (__main__.TestServicePowerDNS.test_zone_to_cache_options) ... ok
test_zone_to_cache_url (__main__.TestServicePowerDNS.test_zone_to_cache_url) ... ok
test_zone_to_cache_wrong_source (__main__.TestServicePowerDNS.test_zone_to_cache_wrong_source) ... 
service_dns_forwarding: ConfigError('Invalid configuration for zone "smoketest": Please select one source\ntype "url" or "axfr".')

ok

----------------------------------------------------------------------
Ran 17 tests in 68.981s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
