### PR TITLE
vyos.configtree: T6620: allow list_nodes() to work on non-existent paths

### DIFF
--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -1,5 +1,5 @@
 # configtree -- a standalone VyOS config file manipulation library (Python bindings)
-# Copyright (C) 2018-2022 VyOS maintainers and contributors
+# Copyright (C) 2018-2024 VyOS maintainers and contributors
 #
 # This library is free software; you can redistribute it and/or modify it under the terms of
 # the GNU Lesser General Public License as published by the Free Software Foundation;
@@ -290,7 +290,7 @@ class ConfigTree(object):
         else:
             return True
 
-    def list_nodes(self, path):
+    def list_nodes(self, path, path_must_exist=True):
         check_path(path)
         path_str = " ".join(map(str, path)).encode()
 
@@ -298,7 +298,10 @@ class ConfigTree(object):
         res = json.loads(res_json)
 
         if res is None:
-            raise ConfigTreeError("Path [{}] doesn't exist".format(path_str))
+            if path_must_exist:
+                raise ConfigTreeError("Path [{}] doesn't exist".format(path_str))
+            else:
+                return []
         else:
             return res
 

--- a/src/migration-scripts/openvpn/1-to-2
+++ b/src/migration-scripts/openvpn/1-to-2
@@ -20,12 +20,8 @@
 from vyos.configtree import ConfigTree
 
 def migrate(config: ConfigTree) -> None:
-    if not config.exists(['interfaces', 'openvpn']):
-        # Nothing to do
-        return
-
-    ovpn_intfs = config.list_nodes(['interfaces', 'openvpn'])
-    for	i in ovpn_intfs:
+    ovpn_intfs = config.list_nodes(['interfaces', 'openvpn'], path_must_exist=False)
+    for i in ovpn_intfs:
         # Remove 'encryption cipher' and add this value to 'encryption ncp-ciphers'
         # for server and client mode.
         # Site-to-site mode still can use --cipher option

--- a/src/migration-scripts/openvpn/2-to-3
+++ b/src/migration-scripts/openvpn/2-to-3
@@ -20,12 +20,8 @@
 from vyos.configtree import ConfigTree
 
 def migrate(config: ConfigTree) -> None:
-    if not config.exists(['interfaces', 'openvpn']):
-        # Nothing to do
-        return
-
-    ovpn_intfs = config.list_nodes(['interfaces', 'openvpn'])
-    for	i in ovpn_intfs:
+    ovpn_intfs = config.list_nodes(['interfaces', 'openvpn'], path_must_exist=False)
+    for i in ovpn_intfs:
         mode = config.return_value(['interfaces', 'openvpn', i, 'mode'])
         if mode != 'server':
             # If it's a client or a site-to-site OpenVPN interface,

--- a/src/migration-scripts/openvpn/3-to-4
+++ b/src/migration-scripts/openvpn/3-to-4
@@ -18,11 +18,7 @@
 from vyos.configtree import ConfigTree
 
 def migrate(config: ConfigTree) -> None:
-    if not config.exists(['interfaces', 'openvpn']):
-        # Nothing to do
-        return
-
-    ovpn_intfs = config.list_nodes(['interfaces', 'openvpn'])
+    ovpn_intfs = config.list_nodes(['interfaces', 'openvpn'], path_must_exist=False)
     for i in ovpn_intfs:
         #Rename 'encryption ncp-ciphers' with 'encryption data-ciphers'
         ncp_cipher_path = ['interfaces', 'openvpn', i, 'encryption', 'ncp-ciphers']


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add an optional argument `path_must_exist=True` to `list_nodes()` to make it easier to write migration scripts and the like.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): internal API extension

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
>>> import vyos.configtree
>>> c = vyos.configtree.ConfigTree("foo {}")
>>> c.list_nodes(["foo", "bar"], path_must_exist=False)
[]
>>> c.list_nodes(["foo", "bar"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/vyos/configtree.py", line 302, in list_nodes
    raise ConfigTreeError("Path [{}] doesn't exist".format(path_str))
vyos.configtree.ConfigTreeError: Path [b'foo bar'] doesn't exist
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
