### PR TITLE
T6617: T6618: vpn ipsec remote-access: fix profile generators

### DIFF
--- a/data/templates/ipsec/ios_profile.j2
+++ b/data/templates/ipsec/ios_profile.j2
@@ -55,9 +55,11 @@
                 <!-- The server is authenticated using a certificate -->
                 <key>AuthenticationMethod</key>
                 <string>Certificate</string>
+{% if authentication.client_mode.startswith("eap") %}
                 <!-- The client uses EAP to authenticate -->
                 <key>ExtendedAuthEnabled</key>
                 <integer>1</integer>
+{% endif %}
                 <!-- The next two dictionaries are optional (as are the keys in them), but it is recommended to specify them as the default is to use 3DES.
                      IMPORTANT: Because only one proposal is sent (even if nothing is configured here) it must match the server configuration -->
                 <key>IKESecurityAssociationParameters</key>
@@ -78,9 +80,14 @@
                     <string>{{ esp_encryption.encryption }}</string>
                     <key>IntegrityAlgorithm</key>
                     <string>{{ esp_encryption.hash }}</string>
+{% if esp_encryption.pfs is vyos_defined %}
                     <key>DiffieHellmanGroup</key>
-                    <integer>{{ ike_encryption.dh_group }}</integer>
+                    <integer>{{ esp_encryption.pfs }}</integer>
+{% endif %}
                 </dict>
+                <!-- Controls whether the client offers Perfect Forward Secrecy (PFS). This should be set to match the server. -->
+                <key>EnablePFS</key>
+                <integer>{{ '1' if esp_encryption.pfs is vyos_defined else '0' }}</integer>
             </dict>
         </dict>
 {% if ca_certificates is vyos_defined %}

--- a/data/templates/ipsec/windows_profile.j2
+++ b/data/templates/ipsec/windows_profile.j2
@@ -1,4 +1,4 @@
 Remove-VpnConnection -Name "{{ vpn_name }}" -Force -PassThru
 
 Add-VpnConnection -Name "{{ vpn_name }}" -ServerAddress "{{ remote }}" -TunnelType "Ikev2"
-Set-VpnConnectionIPsecConfiguration -ConnectionName "{{ vpn_name }}" -AuthenticationTransformConstants {{ ike_encryption.encryption }} -CipherTransformConstants {{ ike_encryption.encryption }} -EncryptionMethod {{ esp_encryption.encryption }} -IntegrityCheckMethod {{ esp_encryption.hash }} -PfsGroup None -DHGroup "Group{{ ike_encryption.dh_group }}" -PassThru -Force
+Set-VpnConnectionIPsecConfiguration -ConnectionName "{{ vpn_name }}" -AuthenticationTransformConstants {{ ike_encryption.encryption }} -CipherTransformConstants {{ ike_encryption.encryption }} -EncryptionMethod {{ esp_encryption.encryption }} -IntegrityCheckMethod {{ esp_encryption.hash }} -PfsGroup {{ esp_encryption.pfs }} -DHGroup {{ ike_encryption.dh_group }} -PassThru -Force


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This fixes several issues with the iOS and Windows remote access VPN profile generators (`generate ipsec profile`) not working correctly in certain scenarios.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
https://vyos.dev/T6617
https://vyos.dev/T6618

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vpn ipsec remote-access

## Proposed changes
<!--- Describe your changes in detail -->

This updates both the iOS and Windows profile generators. 

- For both, support for PFS was added
- Windows now appears to support DH groups 19 and 20 (see https://learn.microsoft.com/en-us/powershell/module/vpnclient/set-vpnconnectionipsecconfiguration?view=windowsserver2022-ps), so those were added
- Better error messaging was added for when generation fails because the connection uses an unsupported algorithm or DH group.
- For iOS, the `ExtendedAuthEnabled` setting is now properly omitted when `authentication client-mode x509` is used.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
within `edit vpn ipsec`:
```
set ike-group ClientVPN-Client key-exchange 'ikev2'
set ike-group ClientVPN-Client lifetime '0'
set ike-group ClientVPN-Client proposal 1 dh-group '19'
set ike-group ClientVPN-Client proposal 1 encryption 'aes256gcm128'
set ike-group ClientVPN-Client proposal 1 hash 'sha256'
set esp-group ClientVPN-Client lifetime '3600'
set esp-group ClientVPN-Client pfs 'enable'
set esp-group ClientVPN-Client proposal 1 encryption 'aes256gcm128'
set esp-group ClientVPN-Client proposal 1 hash 'sha256'
set remote-access connection ClientVPN authentication client-mode 'x509'
set remote-access connection ClientVPN authentication local-id 'router.test.com'
set remote-access connection ClientVPN authentication server-mode 'x509'
set remote-access connection ClientVPN authentication x509 ca-certificate <CA CERT ID>
set remote-access connection ClientVPN authentication x509 certificate <SERVER CERT ID>
set remote-access connection ClientVPN dhcp-interface 'eth0'
set remote-access connection ClientVPN esp-group 'ClientVPN-Client'
set remote-access connection ClientVPN ike-group 'ClientVPN-Client'
set remote-access connection ClientVPN pool 'Client-Pool-v4'
set remote-access pool Client-Pool-v4 prefix 10.10.10.0/24
```

commit and then try:
`generate ipsec profile ios-remote-access ClientVPN remote router.test.com`
`generate ipsec profile windows-remote-access ClientVPN remote router.test.com`

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
