### PR TITLE
T5657: Add VRF support for zabbix-agent

### DIFF
--- a/data/templates/zabbix-agent/10-override.conf.j2
+++ b/data/templates/zabbix-agent/10-override.conf.j2
@@ -1,3 +1,4 @@
+{% set zabbix_command = 'ip vrf exec ' ~ vrf ~ ' ' if vrf is vyos_defined else '' %}
 [Unit]
 After=
 After=vyos-router.service
@@ -5,9 +6,11 @@ ConditionPathExists=
 ConditionPathExists=/run/zabbix/zabbix-agent2.conf
 
 [Service]
+User=
+User=root
 EnvironmentFile=
 ExecStart=
-ExecStart=/usr/sbin/zabbix_agent2 --config /run/zabbix/zabbix-agent2.conf --foreground
+ExecStart={{ zabbix_command }}/usr/sbin/zabbix_agent2 --config /run/zabbix/zabbix-agent2.conf --foreground
 WorkingDirectory=
 WorkingDirectory=/run/zabbix
 Restart=always

--- a/interface-definitions/service_monitoring_zabbix-agent.xml.in
+++ b/interface-definitions/service_monitoring_zabbix-agent.xml.in
@@ -185,6 +185,7 @@
                 </properties>
                 <defaultValue>3</defaultValue>
               </leafNode>
+              #include <include/interface/vrf.xml.i>
             </children>
           </node>
         </children>


### PR DESCRIPTION
To start the service under VRF requires starting under User=root otherwise it had issues with cgroups

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T5657

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
zabbix-agent
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service monitoring zabbix-agent host-name 'r4'
set service monitoring zabbix-agent server '192.168.122.1'
set service monitoring zabbix-agent vrf 'mgmt'
```
Check the service:
```
vyos@r4# sudo systemctl status zabbix-agent2
● zabbix-agent2.service - Zabbix Agent 2
     Loaded: loaded (/lib/systemd/system/zabbix-agent2.service; disabled; preset: enabled)
    Drop-In: /run/systemd/system/zabbix-agent2.service.d
             └─10-override.conf
     Active: active (running) since Wed 2024-07-31 18:01:38 EEST; 23min ago
       Docs: man:zabbix_agent2
   Main PID: 11452 (zabbix_agent2)
      Tasks: 9 (limit: 18718)
     Memory: 15.9M
        CPU: 191ms
     CGroup: /system.slice/zabbix-agent2.service
             └─vrf
               └─mgmt
                 └─11452 /usr/sbin/zabbix_agent2 --config /run/zabbix/zabbix-agent2.conf --foreground

```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_monitoring_zabbix-agent.py
test_01_zabbix_agent (__main__.TestZabbixAgent.test_01_zabbix_agent) ... ok

----------------------------------------------------------------------
Ran 1 test in 13.460s

OK
vyos@r4:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
