### PR TITLE
OPENVPN: T6555: add server-bridge options in mode server

### DIFF
--- a/data/templates/openvpn/server.conf.j2
+++ b/data/templates/openvpn/server.conf.j2
@@ -90,8 +90,8 @@ server-ipv6 {{ subnet }}
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
-{%         if server.server_bridge is vyos_defined and server.server_bridge.disable is not vyos_defined %}
-server-bridge {{ server.server_bridge.gateway }} {{ server.server_bridge.subnet_mask }} {{ server.server_bridge.start }} {{ server.server_bridge.stop if server.server_bridge.stop is vyos_defined }}
+{%         if server.bridge is vyos_defined and server.bridge.disable is not vyos_defined %}
+server-bridge {{ server.bridge.gateway }} {{ server.bridge.subnet_mask }} {{ server.bridge.start }} {{ server.bridge.stop if server.bridge.stop is vyos_defined }}
 {%         endif %}
 {%         if server.client_ip_pool is vyos_defined and server.client_ip_pool.disable is not vyos_defined %}
 ifconfig-pool {{ server.client_ip_pool.start }} {{ server.client_ip_pool.stop }} {{ server.client_ip_pool.subnet_mask if server.client_ip_pool.subnet_mask is vyos_defined }}

--- a/data/templates/openvpn/server.conf.j2
+++ b/data/templates/openvpn/server.conf.j2
@@ -90,7 +90,9 @@ server-ipv6 {{ subnet }}
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
-
+{%         if server.server_bridge is vyos_defined and server.server_bridge.disable is not vyos_defined %}
+server-bridge {{ server.server_bridge.gateway }} {{ server.server_bridge.subnet_mask }} {{ server.server_bridge.start }} {{ server.server_bridge.stop if server.server_bridge.stop is vyos_defined }}
+{%         endif %}
 {%         if server.client_ip_pool is vyos_defined and server.client_ip_pool.disable is not vyos_defined %}
 ifconfig-pool {{ server.client_ip_pool.start }} {{ server.client_ip_pool.stop }} {{ server.client_ip_pool.subnet_mask if server.client_ip_pool.subnet_mask is vyos_defined }}
 {%         endif %}

--- a/interface-definitions/interfaces_openvpn.xml.in
+++ b/interface-definitions/interfaces_openvpn.xml.in
@@ -445,6 +445,62 @@
                   </leafNode>
                 </children>
               </tagNode>
+              <node name="server-bridge">
+                <properties>
+                  <help>Used with TAP device (layer 2)</help>
+                </properties>
+                <children>
+                  #include <include/generic-disable-node.xml.i>
+                  <leafNode name="start">
+                    <properties>
+                      <help>First IP address in the pool</help>
+                      <constraint>
+                        <validator name="ipv4-address"/>
+                      </constraint>
+                      <valueHelp>
+                        <format>ipv4</format>
+                        <description>IPv4 address</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="stop">
+                    <properties>
+                      <help>Last IP address in the pool</help>
+                      <constraint>
+                        <validator name="ipv4-address"/>
+                      </constraint>
+                      <valueHelp>
+                        <format>ipv4</format>
+                        <description>IPv4 address</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="subnet-mask">
+                    <properties>
+                      <help>Subnet mask pushed to dynamic clients.</help>
+                      <constraint>
+                        <validator name="ipv4-address"/>
+                      </constraint>
+                      <valueHelp>
+                        <format>ipv4</format>
+                        <description>IPv4 subnet mask</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="gateway">
+                    <properties>
+                      <help>Gateway IP address</help>
+                      <constraint>
+                        <validator name="ipv4-address"/>
+                      </constraint>
+                      <valueHelp>
+                        <format>ipv4</format>
+                        <description>IPv4 address</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
               <node name="client-ip-pool">
                 <properties>
                   <help>Pool of client IPv4 addresses</help>

--- a/interface-definitions/interfaces_openvpn.xml.in
+++ b/interface-definitions/interfaces_openvpn.xml.in
@@ -445,7 +445,7 @@
                   </leafNode>
                 </children>
               </tagNode>
-              <node name="server-bridge">
+              <node name="bridge">
                 <properties>
                   <help>Used with TAP device (layer 2)</help>
                 </properties>

--- a/smoketest/scripts/cli/test_interfaces_openvpn.py
+++ b/smoketest/scripts/cli/test_interfaces_openvpn.py
@@ -628,7 +628,7 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
 
 
     def test_openvpn_server_server_bridge(self):
-        # Create OpenVPN server interface using server-bridge.
+        # Create OpenVPN server interface using bridge.
         # Validate configuration afterwards.
         br_if = 'br0'
         vtun_if = 'vtun5010'
@@ -644,10 +644,10 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
         self.cli_set(path + ['encryption', 'data-ciphers', 'aes192'])
         self.cli_set(path + ['hash', auth_hash])
         self.cli_set(path + ['mode', 'server'])
-        self.cli_set(path + ['server', 'server-bridge', 'gateway', gw_subnet])
-        self.cli_set(path + ['server', 'server-bridge', 'start', start_subnet])
-        self.cli_set(path + ['server', 'server-bridge', 'stop', stop_subnet])
-        self.cli_set(path + ['server', 'server-bridge', 'subnet-mask', mask_subnet])
+        self.cli_set(path + ['server', 'bridge', 'gateway', gw_subnet])
+        self.cli_set(path + ['server', 'bridge', 'start', start_subnet])
+        self.cli_set(path + ['server', 'bridge', 'stop', stop_subnet])
+        self.cli_set(path + ['server', 'bridge', 'subnet-mask', mask_subnet])
         self.cli_set(path + ['keep-alive', 'failure-count', '5'])
         self.cli_set(path + ['keep-alive', 'interval', '5'])
         self.cli_set(path + ['tls', 'ca-certificate', 'ovpn_test'])

--- a/smoketest/scripts/cli/test_interfaces_openvpn.py
+++ b/smoketest/scripts/cli/test_interfaces_openvpn.py
@@ -627,5 +627,60 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
             self.assertNotIn(interface, interfaces())
 
 
+    def test_openvpn_server_server_bridge(self):
+        # Create OpenVPN server interface using server-bridge.
+        # Validate configuration afterwards.
+        br_if = 'br0'
+        vtun_if = 'vtun5010'
+        auth_hash = 'sha256'
+        path = base_path + [vtun_if]
+        start_subnet = "192.168.0.100"
+        stop_subnet = "192.168.0.200"
+        mask_subnet = "255.255.255.0"
+        gw_subnet = "192.168.0.1"
+
+        self.cli_set(['interfaces', 'bridge', br_if, 'member', 'interface', vtun_if])
+        self.cli_set(path + ['device-type', 'tap'])
+        self.cli_set(path + ['encryption', 'data-ciphers', 'aes192'])
+        self.cli_set(path + ['hash', auth_hash])
+        self.cli_set(path + ['mode', 'server'])
+        self.cli_set(path + ['server', 'server-bridge', 'gateway', gw_subnet])
+        self.cli_set(path + ['server', 'server-bridge', 'start', start_subnet])
+        self.cli_set(path + ['server', 'server-bridge', 'stop', stop_subnet])
+        self.cli_set(path + ['server', 'server-bridge', 'subnet-mask', mask_subnet])
+        self.cli_set(path + ['keep-alive', 'failure-count', '5'])
+        self.cli_set(path + ['keep-alive', 'interval', '5'])
+        self.cli_set(path + ['tls', 'ca-certificate', 'ovpn_test'])
+        self.cli_set(path + ['tls', 'certificate', 'ovpn_test'])
+        self.cli_set(path + ['tls', 'dh-params', 'ovpn_test'])
+
+        self.cli_commit()
+
+
+
+        config_file = f'/run/openvpn/{vtun_if}.conf'
+        config = read_file(config_file)
+        self.assertIn(f'dev {vtun_if}', config)
+        self.assertIn(f'dev-type tap', config)
+        self.assertIn(f'proto udp', config) # default protocol
+        self.assertIn(f'auth {auth_hash}', config)
+        self.assertIn(f'data-ciphers AES-192-CBC', config)
+        self.assertIn(f'mode server', config)
+        self.assertIn(f'server-bridge {gw_subnet} {mask_subnet} {start_subnet} {stop_subnet}', config)
+        elf.assertIn(f'keepalive 5 25', config)
+
+
+
+        # TLS options
+        self.assertIn(f'ca /run/openvpn/{vtun_if}_ca.pem', config)
+        self.assertIn(f'cert /run/openvpn/{vtun_if}_cert.pem', config)
+        self.assertIn(f'key /run/openvpn/{vtun_if}_cert.key', config)
+        self.assertIn(f'dh /run/openvpn/{vtun_if}_dh.pem', config)
+
+        # check that no interface remained after deleting them
+        self.cli_delete((['interfaces', 'bridge', br_if, 'member', 'interface', vtun_if])
+        self.cli_delete(base_path)
+        self.cli_commit()
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/interfaces_openvpn.py
+++ b/src/conf_mode/interfaces_openvpn.py
@@ -378,21 +378,21 @@ def verify(openvpn):
                 if (client_v.get('ip') and len(client_v['ip']) > 1) or (client_v.get('ipv6_ip') and len(client_v['ipv6_ip']) > 1):
                     raise ConfigError(f'Server client "{client_k}": cannot specify more than 1 IPv4 and 1 IPv6 IP')
 
-        if dict_search('server.server_bridge', openvpn):
+        if dict_search('server.bridge', openvpn):
             # check if server-bridge is a tap interfaces
-            if not openvpn['device_type'] == 'tap' and dict_search('server.server_bridge', openvpn):
-               raise ConfigError('Must specify "device-type tap" with server-bridge mode')
-            elif not (dict_search('server.server_bridge.start', openvpn) and dict_search('server.server_bridge.stop', openvpn)):
-                raise ConfigError('Server server-bridge requires both start and stop addresses')
+            if not openvpn['device_type'] == 'tap' and dict_search('server.bridge', openvpn):
+               raise ConfigError('Must specify "device-type tap" with server bridge mode')
+            elif not (dict_search('server.bridge.start', openvpn) and dict_search('server.bridge.stop', openvpn)):
+                raise ConfigError('Server server bridge requires both start and stop addresses')
             else:
-                v4PoolStart = IPv4Address(dict_search('server.server_bridge.start', openvpn))
-                v4PoolStop = IPv4Address(dict_search('server.server_bridge.stop', openvpn))
+                v4PoolStart = IPv4Address(dict_search('server.bridge.start', openvpn))
+                v4PoolStop = IPv4Address(dict_search('server.bridge.stop', openvpn))
                 if v4PoolStart > v4PoolStop:
-                    raise ConfigError(f'Server server-bridge start address {v4PoolStart} is larger than stop address {v4PoolStop}')
+                    raise ConfigError(f'Server server bridge start address {v4PoolStart} is larger than stop address {v4PoolStop}')
 
                 v4PoolSize = int(v4PoolStop) - int(v4PoolStart)
                 if v4PoolSize >= 65536:
-                    raise ConfigError(f'Server server_bridge is too large [{v4PoolStart} -> {v4PoolStop} = {v4PoolSize}], maximum is 65536 addresses.')
+                    raise ConfigError(f'Server bridge is too large [{v4PoolStart} -> {v4PoolStop} = {v4PoolSize}], maximum is 65536 addresses.')
 
         if dict_search('server.client_ip_pool', openvpn):
             if not (dict_search('server.client_ip_pool.start', openvpn) and dict_search('server.client_ip_pool.stop', openvpn)):

--- a/src/conf_mode/interfaces_openvpn.py
+++ b/src/conf_mode/interfaces_openvpn.py
@@ -378,6 +378,22 @@ def verify(openvpn):
                 if (client_v.get('ip') and len(client_v['ip']) > 1) or (client_v.get('ipv6_ip') and len(client_v['ipv6_ip']) > 1):
                     raise ConfigError(f'Server client "{client_k}": cannot specify more than 1 IPv4 and 1 IPv6 IP')
 
+        if dict_search('server.server_bridge', openvpn):
+            # check if server-bridge is a tap interfaces
+            if not openvpn['device_type'] == 'tap' and dict_search('server.server_bridge', openvpn):
+               raise ConfigError('Must specify "device-type tap" with server-bridge mode')
+            elif not (dict_search('server.server_bridge.start', openvpn) and dict_search('server.server_bridge.stop', openvpn)):
+                raise ConfigError('Server server-bridge requires both start and stop addresses')
+            else:
+                v4PoolStart = IPv4Address(dict_search('server.server_bridge.start', openvpn))
+                v4PoolStop = IPv4Address(dict_search('server.server_bridge.stop', openvpn))
+                if v4PoolStart > v4PoolStop:
+                    raise ConfigError(f'Server server-bridge start address {v4PoolStart} is larger than stop address {v4PoolStop}')
+
+                v4PoolSize = int(v4PoolStop) - int(v4PoolStart)
+                if v4PoolSize >= 65536:
+                    raise ConfigError(f'Server server_bridge is too large [{v4PoolStart} -> {v4PoolStop} = {v4PoolSize}], maximum is 65536 addresses.')
+
         if dict_search('server.client_ip_pool', openvpn):
             if not (dict_search('server.client_ip_pool.start', openvpn) and dict_search('server.client_ip_pool.stop', openvpn)):
                 raise ConfigError('Server client-ip-pool requires both start and stop addresses')

--- a/src/conf_mode/interfaces_openvpn.py
+++ b/src/conf_mode/interfaces_openvpn.py
@@ -379,16 +379,16 @@ def verify(openvpn):
                     raise ConfigError(f'Server client "{client_k}": cannot specify more than 1 IPv4 and 1 IPv6 IP')
 
         if dict_search('server.bridge', openvpn):
-            # check if server-bridge is a tap interfaces
+            # check if server bridge is a tap interfaces
             if not openvpn['device_type'] == 'tap' and dict_search('server.bridge', openvpn):
                raise ConfigError('Must specify "device-type tap" with server bridge mode')
             elif not (dict_search('server.bridge.start', openvpn) and dict_search('server.bridge.stop', openvpn)):
-                raise ConfigError('Server server bridge requires both start and stop addresses')
+                raise ConfigError('Server bridge requires both start and stop addresses')
             else:
                 v4PoolStart = IPv4Address(dict_search('server.bridge.start', openvpn))
                 v4PoolStop = IPv4Address(dict_search('server.bridge.stop', openvpn))
                 if v4PoolStart > v4PoolStop:
-                    raise ConfigError(f'Server server bridge start address {v4PoolStart} is larger than stop address {v4PoolStop}')
+                    raise ConfigError(f'Server bridge start address {v4PoolStart} is larger than stop address {v4PoolStop}')
 
                 v4PoolSize = int(v4PoolStop) - int(v4PoolStart)
                 if v4PoolSize >= 65536:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

based in official documentation , OpenVPN add a new mode how to created bridge interface ( TAP- to Layer2 frames). this requirement involved in change new feature request .

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6555
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openvpn
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Vyos server - configuration: 

```
set interfaces bridge br10 member interface eth2.304
set interfaces bridge br10 member interface vtun10

set interfaces ethernet eth1 address '172.16.100.1/24'
set interfaces openvpn vtun10 device-type 'tap'
set interfaces openvpn vtun10 local-host '172.16.100.1'
set interfaces openvpn vtun10 local-port '1194'
set interfaces openvpn vtun10 mode 'server'
set interfaces openvpn vtun10 openvpn-option 'cipher none'
set interfaces openvpn vtun10 openvpn-option 'comp-lzo no'
set interfaces openvpn vtun10 server bridge gateway '10.10.0.1'
set interfaces openvpn vtun10 server bridge start '10.10.0.100'
set interfaces openvpn vtun10 server bridge stop '10.10.0.200'
set interfaces openvpn vtun10 server bridge subnet-mask '255.255.255.0'
set interfaces openvpn vtun10 tls ca-certificate 'openvpn_vtun10_1'
set interfaces openvpn vtun10 tls certificate 'openvpn_vtun10'
set interfaces openvpn vtun10 tls dh-params 'openvpn_vtun10' 
```
check openvpn tunnel : 
```
vyos@openvpn-server:~$ show openvpn server

OpenVPN status on vtun10

Client CN    Remote Host         Tunnel IP            Local Host         TX bytes    RX bytes    Connected Since
-----------  ------------------  -------------------  -----------------  ----------  ----------  -------------------
client2      172.16.100.2:42680  26:76:bf:4c:8d:df@0  172.16.100.1:1194  17.9 KB     17.5 KB     2024-07-31 18:13:26

traffic over br : 
 vyos@openvpn-server:~$ sudo tcpdump -nvi br10
tcpdump: listening on br10, link-type EN10MB (Ethernet), snapshot length 262144 bytes
18:14:49.944817 IP (tos 0x0, ttl 64, id 39778, offset 0, flags [DF], proto ICMP (1), length 84)
    10.10.0.100 > 10.10.0.200: ICMP echo request, id 38281, seq 1, length 64
18:14:49.945180 IP (tos 0x0, ttl 64, id 27786, offset 0, flags [none], proto ICMP (1), length 84)
    10.10.0.200 > 10.10.0.100: ICMP echo reply, id 38281, seq 1, length 64
18:14:50.946734 IP (tos 0x0, ttl 64, id 40319, offset 0, flags [DF], proto ICMP (1), length 84)
    10.10.0.100 > 10.10.0.200: ICMP echo request, id 38281, seq 2, length 64

````

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py

```
test_openvpn_server_server_bridge (__main__.TestInterfacesOpenVPN.test_openvpn_server_server_bridge) ... Warning: using dh-params and EC keys simultaneously will lead to DH ciphers being used instead of ECDH
ok
......
ok

----------------------------------------------------------------------
Ran 8 tests in 53.703s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
