### PR TITLE
nat64: T6627: call check_kmod within standard config function

### DIFF
--- a/src/conf_mode/nat64.py
+++ b/src/conf_mode/nat64.py
@@ -46,7 +46,12 @@ def get_config(config: Config | None = None) -> None:
     base = ["nat64"]
     nat64 = config.get_config_dict(base, key_mangling=("-", "_"), get_first_key=True)
 
-    base_src = base + ["source", "rule"]
+    return nat64
+
+
+def verify(nat64) -> None:
+    check_kmod(["jool"])
+    base_src = ["nat64", "source", "rule"]
 
     # Load in existing instances so we can destroy any unknown
     lines = cmd("jool instance display --csv").splitlines()
@@ -76,12 +81,8 @@ def get_config(config: Config | None = None) -> None:
         ):
             rules[num]["recreate"] = True
 
-    return nat64
-
-
-def verify(nat64) -> None:
     if not nat64:
-        # no need to verify the CLI as nat64 is going to be deactivated
+        # nothing left to do
         return
 
     if dict_search("source.rule", nat64):
@@ -128,6 +129,9 @@ def verify(nat64) -> None:
 
 
 def generate(nat64) -> None:
+    if not nat64:
+        return
+
     os.makedirs(JOOL_CONFIG_DIR, exist_ok=True)
 
     if dict_search("source.rule", nat64):
@@ -184,6 +188,7 @@ def generate(nat64) -> None:
 
 def apply(nat64) -> None:
     if not nat64:
+        unload_kmod(['jool'])
         return
 
     if dict_search("source.rule", nat64):
@@ -211,7 +216,6 @@ def apply(nat64) -> None:
 
 if __name__ == "__main__":
     try:
-        check_kmod(["jool"])
         c = get_config()
         verify(c)
         generate(c)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The config mode script nat64.py calls the modprobe utility `check_kmod` outside of the standard functions, leading to an `OSError` when run under configd. Current behavior of configd will re-run the script within the CLI context, leading to config and smoketest success; as that behavior will be changed in the future to accommodate all scripts running within the configd context (T6608), correct now.

There are several other config scripts that use this pattern, which will be all changed in a separate PR. The nat64.py script deserved special attention as it provides an example of state configuration informing the syntax verification stage, which should be kept in mind as we move to distinguishing syntax verification from system state verification.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/T6608 -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Confirmation provided in task. Success in smoketest and journalctl output, below.

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:/usr/libexec/vyos/tests/smoke/cli$ ./test_nat64.py
test_snat64 (__main__.TestNAT64.test_snat64) ... ok

----------------------------------------------------------------------
Ran 1 test in 3.788s

OK
vyos@vyos:/usr/libexec/vyos/tests/smoke/cli$ journalctl -u vyos-configd --no-pager

...
Aug 01 16:43:35 vyos vyos-configd[4299]: Received message: {"type": "node", "last": true, "data": "/usr/libexec/vyos/conf_mode/nat64.py"}
...
Aug 01 16:43:35 vyos vyos-configd[4299]: Sending response 1
...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
