### PR TITLE
T6486: use data-ciphers instead of ncp-ciphers in "run generate openvpn client-config"

### DIFF
--- a/src/op_mode/generate_ovpn_client_file.py
+++ b/src/op_mode/generate_ovpn_client_file.py
@@ -51,12 +51,12 @@ verb 3
 } %}
 
 {% if encryption is defined and encryption is not none %}
-{%     if encryption.ncp_ciphers is defined and encryption.ncp_ciphers is not none %}
-cipher {% for algo in encryption.ncp_ciphers %}
+{%     if encryption.data_ciphers is defined and encryption.data_ciphers is not none %}
+cipher {% for algo in encryption.data_ciphers %}
 {{ encryption_map[algo] if algo in encryption_map.keys() else algo }}{% if not loop.last %}:{% endif %}
 {%      endfor %}
 
-data-ciphers {% for algo in encryption.ncp_ciphers %}
+data-ciphers {% for algo in encryption.data_ciphers %}
 {{ encryption_map[algo] if algo in encryption_map.keys() else algo }}{% if not loop.last %}:{% endif %}
 {%      endfor %}
 {%     endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
In the PR https://github.com/vyos/vyos-1x/pull/3823 the `ncp-ciphers` were replaced with `data-ciphers`
fix the template for `generate openvpn client-config`

Backport is not required until #3823 is not backported.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/TT6486

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openvpn
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
VyOS configuration:
```
set interfaces openvpn vtun20 encryption data-ciphers 'aes256'
set interfaces openvpn vtun20 hash 'sha512'
set interfaces openvpn vtun20 local-host '203.0.113.1'
set interfaces openvpn vtun20 mode 'server'
set interfaces openvpn vtun20 openvpn-option 'push keepalive 1 10'
set interfaces openvpn vtun20 protocol 'tcp-passive'
set interfaces openvpn vtun20 server client foo ip '100.64.0.2'
set interfaces openvpn vtun20 server subnet '10.0.22.0/24'
set interfaces openvpn vtun20 server topology 'subnet'
set interfaces openvpn vtun20 tls ca-certificate 'ca'
set interfaces openvpn vtun20 tls certificate 'cert'
set interfaces openvpn vtun20 tls dh-params 'dh'
```
Generate OpenVPN client config
Check `cipher AES-256-CBC`
```
vyos@r4:~$ generate openvpn client-config interface vtun20 ca ca certificate openvpn-client 

client
nobind
remote 203.0.113.1 1194
remote-cert-tls server
proto tcp-client
dev tun
dev-type tun
persist-key
persist-tun
verb 3

# Encryption options
cipher AES-256-CBC
data-ciphers AES-256-CBC
auth sha512

<ca>
xxx
</ca>

<cert>
xxx
</cert>

<key>
xxx
</key>
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
