### PR TITLE
configd: T6633: inject missing env vars for configfs utility

### DIFF
--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -182,6 +182,12 @@ def initialization(socket):
     sudo_user_string = socket.recv().decode("utf-8", "ignore")
     resp = "sudo_user"
     socket.send(resp.encode())
+    temp_config_dir_string = socket.recv().decode("utf-8", "ignore")
+    resp = "temp_config_dir"
+    socket.send(resp.encode())
+    changes_only_dir_string = socket.recv().decode("utf-8", "ignore")
+    resp = "changes_only_dir"
+    socket.send(resp.encode())
 
     logger.debug(f"config session pid is {pid_string}")
     logger.debug(f"config session sudo_user is {sudo_user_string}")
@@ -198,6 +204,10 @@ def initialization(socket):
         session_mode = 'a'
 
     os.environ['SUDO_USER'] = sudo_user_string
+    if temp_config_dir_string:
+        os.environ['VYATTA_TEMP_CONFIG_DIR'] = temp_config_dir_string
+    if changes_only_dir_string:
+        os.environ['VYATTA_CHANGES_ONLY_DIR'] = changes_only_dir_string
 
     try:
         configsource = ConfigSourceString(running_config_text=active_string,

--- a/src/shim/vyshim.c
+++ b/src/shim/vyshim.c
@@ -185,6 +185,20 @@ int initialization(void* Requester)
     }
     debug_print("sudo_user is %s\n", sudo_user);
 
+    char *temp_config_dir = getenv("VYATTA_TEMP_CONFIG_DIR");
+    if (!temp_config_dir) {
+        char none[] = "";
+        temp_config_dir = none;
+    }
+    debug_print("temp_config_dir is %s\n", temp_config_dir);
+
+    char *changes_only_dir = getenv("VYATTA_CHANGES_ONLY_DIR");
+    if (!changes_only_dir) {
+        char none[] = "";
+        changes_only_dir = none;
+    }
+    debug_print("changes_only_dir is %s\n", changes_only_dir);
+
     debug_print("Sending init announcement\n");
     char *init_announce = mkjson(MKJSON_OBJ, 1,
                                  MKJSON_STRING, "type", "init");
@@ -251,6 +265,16 @@ int initialization(void* Requester)
     zmq_send(Requester, sudo_user, strlen(sudo_user), 0);
     zmq_recv(Requester, buffer, 16, 0);
     debug_print("Received sudo_user receipt\n");
+
+    debug_print("Sending config session temp_config_dir\n");
+    zmq_send(Requester, temp_config_dir, strlen(temp_config_dir), 0);
+    zmq_recv(Requester, buffer, 16, 0);
+    debug_print("Received temp_config_dir receipt\n");
+
+    debug_print("Sending config session changes_only_dir\n");
+    zmq_send(Requester, changes_only_dir, strlen(changes_only_dir), 0);
+    zmq_recv(Requester, buffer, 16, 0);
+    debug_print("Received changes_only_dir receipt\n");
 
     return 0;
 }


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The configfs utility introduced in [T6489](https://vyos.dev/T6489) requires two environment variables to successfully run under configd; provide from config session. Without those available, the script was executed within the CLI context, as a result of [T6608](https://vyos.dev/T6608), defeating the purpose of introduction of configfs.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6489
* https://vyos.dev/T6608

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests confirm success: in this case, one needs to confirm that the script was, in fact, run under configd, and not through the 'pass-through' execution of the shim. The return codes of configd confirm this, as seen in the output of `journalctl -u vyos-configd`

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
