### PR TITLE
pbr: T6430: Local IP rules targeting VRFs by name as well as route table IDs

### DIFF
--- a/interface-definitions/include/firewall/set-packet-modifications-table-and-vrf.xml.i
+++ b/interface-definitions/include/firewall/set-packet-modifications-table-and-vrf.xml.i
@@ -25,24 +25,7 @@
         </completionHelp>
       </properties>
     </leafNode>
-    <leafNode name="vrf">
-      <properties>
-        <help>VRF to forward packet with</help>
-        <valueHelp>
-          <format>txt</format>
-          <description>VRF instance name</description>
-        </valueHelp>
-        <valueHelp>
-          <format>default</format>
-          <description>Forward into default global VRF</description>
-        </valueHelp>
-        <completionHelp>
-          <list>default</list>
-          <path>vrf name</path>
-        </completionHelp>
-        #include <include/constraint/vrf.xml.i>
-      </properties>
-    </leafNode>
+    #include <include/firewall/vrf.xml.i>
   </children>
 </node>
 <!-- include end -->

--- a/interface-definitions/include/firewall/vrf.xml.i
+++ b/interface-definitions/include/firewall/vrf.xml.i
@@ -1,0 +1,20 @@
+<!-- include start from firewall/vrf.xml.i -->
+<leafNode name="vrf">
+  <properties>
+    <help>VRF to forward packet with</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>VRF instance name</description>
+    </valueHelp>
+    <valueHelp>
+      <format>default</format>
+      <description>Forward into default global VRF</description>
+    </valueHelp>
+    <completionHelp>
+      <list>default</list>
+      <path>vrf name</path>
+    </completionHelp>
+    #include <include/constraint/vrf.xml.i>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/policy_local-route.xml.in
+++ b/interface-definitions/policy_local-route.xml.in
@@ -39,24 +39,7 @@
                       </completionHelp>
                     </properties>
                   </leafNode>
-                  <leafNode name="vrf">
-                    <properties>
-                      <help>VRF to forward packet with</help>
-                      <valueHelp>
-                        <format>txt</format>
-                        <description>VRF instance name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>default</format>
-                        <description>Forward into default global VRF</description>
-                      </valueHelp>
-                      <completionHelp>
-                        <list>default</list>
-                        <path>vrf name</path>
-                      </completionHelp>
-                      #include <include/constraint/vrf.xml.i>
-                    </properties>
-                  </leafNode>                  
+                  #include <include/firewall/vrf.xml.i>
                 </children>
               </node>
               <leafNode name="fwmark">
@@ -131,24 +114,7 @@
                       </completionHelp>
                     </properties>
                   </leafNode>
-                  <leafNode name="vrf">
-                    <properties>
-                      <help>VRF to forward packet with</help>
-                      <valueHelp>
-                        <format>txt</format>
-                        <description>VRF instance name</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>default</format>
-                        <description>Forward into default global VRF</description>
-                      </valueHelp>
-                      <completionHelp>
-                        <list>default</list>
-                        <path>vrf name</path>
-                      </completionHelp>
-                      #include <include/constraint/vrf.xml.i>
-                    </properties>
-                  </leafNode>                  
+                  #include <include/firewall/vrf.xml.i>
                 </children>
               </node>
               <leafNode name="fwmark">

--- a/interface-definitions/policy_local-route.xml.in
+++ b/interface-definitions/policy_local-route.xml.in
@@ -39,6 +39,24 @@
                       </completionHelp>
                     </properties>
                   </leafNode>
+                  <leafNode name="vrf">
+                    <properties>
+                      <help>VRF to forward packet with</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>VRF instance name</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>default</format>
+                        <description>Forward into default global VRF</description>
+                      </valueHelp>
+                      <completionHelp>
+                        <list>default</list>
+                        <path>vrf name</path>
+                      </completionHelp>
+                      #include <include/constraint/vrf.xml.i>
+                    </properties>
+                  </leafNode>                  
                 </children>
               </node>
               <leafNode name="fwmark">
@@ -113,6 +131,24 @@
                       </completionHelp>
                     </properties>
                   </leafNode>
+                  <leafNode name="vrf">
+                    <properties>
+                      <help>VRF to forward packet with</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>VRF instance name</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>default</format>
+                        <description>Forward into default global VRF</description>
+                      </valueHelp>
+                      <completionHelp>
+                        <list>default</list>
+                        <path>vrf name</path>
+                      </completionHelp>
+                      #include <include/constraint/vrf.xml.i>
+                    </properties>
+                  </leafNode>                  
                 </children>
               </node>
               <leafNode name="fwmark">

--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -147,6 +147,18 @@ class VyOSUnitTestSHIM:
                         break
                 self.assertTrue(not matched if inverse else matched, msg=search)
 
+        # Verify ip rule output
+        def verify_rules(self, rules_search, inverse=False, addr_family='inet'):
+            rule_output = cmd(f'ip -family {addr_family} rule show')
+
+            for search in rules_search:
+                matched = False
+                for line in rule_output.split("\n"):
+                    if all(item in line for item in search):
+                        matched = True
+                        break
+                self.assertTrue(not matched if inverse else matched, msg=search)
+
 # standard construction; typing suggestion: https://stackoverflow.com/a/70292317
 def ignore_warning(warning: Type[Warning]):
     import warnings

--- a/smoketest/scripts/cli/test_policy_local-route.py
+++ b/smoketest/scripts/cli/test_policy_local-route.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from base_vyostest_shim import VyOSUnitTestSHIM
+
+interface = 'eth0'
+mark = '100'
+table_id = '101'
+extra_table_id = '102'
+vrf_name = 'LPBRVRF'
+vrf_rt_id = '202'
+
+class TestPolicyLocalRoute(VyOSUnitTestSHIM.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestPolicyLocalRoute, cls).setUpClass()
+        # Clear out current configuration to allow running this test on a live system
+        cls.cli_delete(cls, ['policy', 'local-route'])
+        cls.cli_delete(cls, ['policy', 'local-route6'])
+
+        cls.cli_set(cls, ['vrf', 'name', vrf_name, 'table', vrf_rt_id])
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.cli_delete(cls, ['vrf', 'name', vrf_name])
+
+        super(TestPolicyLocalRoute, cls).tearDownClass()
+
+    def tearDown(self):
+        self.cli_delete(['policy', 'local-route'])
+        self.cli_delete(['policy', 'local-route6'])
+        self.cli_commit()
+
+        ip_rule_search = [
+            [f'lookup {table_id}']
+        ]
+
+        self.verify_rules(ip_rule_search, inverse=True)
+        self.verify_rules(ip_rule_search, inverse=True, addr_family='inet6')
+
+    def test_local_pbr_matching_criteria(self):
+        self.cli_set(['policy', 'local-route', 'rule', '4', 'inbound-interface', interface])
+        self.cli_set(['policy', 'local-route', 'rule', '4', 'protocol', 'udp'])
+        self.cli_set(['policy', 'local-route', 'rule', '4', 'fwmark', mark])
+        self.cli_set(['policy', 'local-route', 'rule', '4', 'destination', 'address', '198.51.100.0/24'])
+        self.cli_set(['policy', 'local-route', 'rule', '4', 'destination', 'port', '111'])
+        self.cli_set(['policy', 'local-route', 'rule', '4', 'source', 'address', '198.51.100.1'])
+        self.cli_set(['policy', 'local-route', 'rule', '4', 'source', 'port', '443'])
+        self.cli_set(['policy', 'local-route', 'rule', '4', 'set', 'table', table_id])
+
+        self.cli_set(['policy', 'local-route6', 'rule', '6', 'inbound-interface', interface])
+        self.cli_set(['policy', 'local-route6', 'rule', '6', 'protocol', 'tcp'])
+        self.cli_set(['policy', 'local-route6', 'rule', '6', 'fwmark', mark])
+        self.cli_set(['policy', 'local-route6', 'rule', '6', 'destination', 'address', '2001:db8::/64'])
+        self.cli_set(['policy', 'local-route6', 'rule', '6', 'destination', 'port', '123'])
+        self.cli_set(['policy', 'local-route6', 'rule', '6', 'source', 'address', '2001:db8::1'])
+        self.cli_set(['policy', 'local-route6', 'rule', '6', 'source', 'port', '80'])
+        self.cli_set(['policy', 'local-route6', 'rule', '6', 'set', 'table', table_id])
+
+        self.cli_commit()
+
+        rule_lookup = f'lookup {table_id}'
+        rule_fwmark = 'fwmark ' + hex(int(mark))
+        rule_interface = f'iif {interface}'
+
+        ip4_rule_search = [
+            ['from 198.51.100.1', 'to 198.51.100.0/24', rule_fwmark, rule_interface, 'ipproto udp', 'sport 443', 'dport 111', rule_lookup]
+        ]
+
+        self.verify_rules(ip4_rule_search)
+
+        ip6_rule_search = [
+            ['from 2001:db8::1', 'to 2001:db8::/64', rule_fwmark, rule_interface, 'ipproto tcp', 'sport 80', 'dport 123', rule_lookup]
+        ]
+
+        self.verify_rules(ip6_rule_search, addr_family='inet6')
+
+    def test_local_pbr_rule_removal(self):
+        self.cli_set(['policy', 'local-route', 'rule', '1', 'destination', 'address', '198.51.100.1'])
+        self.cli_set(['policy', 'local-route', 'rule', '1', 'set', 'table', table_id])
+
+        self.cli_set(['policy', 'local-route', 'rule', '2', 'destination', 'address', '198.51.100.2'])
+        self.cli_set(['policy', 'local-route', 'rule', '2', 'set', 'table', table_id])
+
+        self.cli_set(['policy', 'local-route', 'rule', '3', 'destination', 'address', '198.51.100.3'])
+        self.cli_set(['policy', 'local-route', 'rule', '3', 'set', 'table', table_id])
+
+        self.cli_commit()
+
+        rule_lookup = f'lookup {table_id}'
+
+        ip_rule_search = [
+            ['to 198.51.100.1', rule_lookup],
+            ['to 198.51.100.2', rule_lookup],
+            ['to 198.51.100.3', rule_lookup],
+        ]
+
+        self.verify_rules(ip_rule_search)
+
+        self.cli_delete(['policy', 'local-route', 'rule', '2'])
+        self.cli_commit()
+
+        ip_rule_missing = [
+            ['to 198.51.100.2', rule_lookup],
+        ]
+
+        self.verify_rules(ip_rule_missing, inverse=True)
+
+    def test_local_pbr_rule_changes(self):
+        self.cli_set(['policy', 'local-route', 'rule', '1', 'destination', 'address', '198.51.100.0/24'])
+        self.cli_set(['policy', 'local-route', 'rule', '1', 'set', 'table', table_id])
+
+        self.cli_commit()
+
+        self.cli_set(['policy', 'local-route', 'rule', '1', 'set', 'table', extra_table_id])
+        self.cli_commit()
+
+        ip_rule_search_extra = [
+            ['to 198.51.100.0/24', f'lookup {extra_table_id}']
+        ]
+
+        self.verify_rules(ip_rule_search_extra)
+
+        ip_rule_search_orig = [
+            ['to 198.51.100.0/24', f'lookup {table_id}']
+        ]
+
+        self.verify_rules(ip_rule_search_orig, inverse=True)
+
+        self.cli_delete(['policy', 'local-route', 'rule', '1', 'set', 'table'])
+        self.cli_set(['policy', 'local-route', 'rule', '1', 'set', 'vrf', vrf_name])
+
+        self.cli_commit()
+
+        ip_rule_search_vrf = [
+            ['to 198.51.100.0/24', f'lookup {vrf_name}']
+        ]
+
+        self.verify_rules(ip_rule_search_extra, inverse=True)
+        self.verify_rules(ip_rule_search_vrf)
+
+    def test_local_pbr_target_vrf(self):
+        self.cli_set(['policy', 'local-route', 'rule', '1', 'destination', 'address', '198.51.100.0/24'])
+        self.cli_set(['policy', 'local-route', 'rule', '1', 'set', 'vrf', vrf_name])
+
+        self.cli_commit()
+
+        ip_rule_search = [
+            ['to 198.51.100.0/24', f'lookup {vrf_name}']
+        ]
+
+        self.verify_rules(ip_rule_search)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/smoketest/scripts/cli/test_policy_route.py
+++ b/smoketest/scripts/cli/test_policy_route.py
@@ -18,8 +18,6 @@ import unittest
 
 from base_vyostest_shim import VyOSUnitTestSHIM
 
-from vyos.utils.process import cmd
-
 mark = '100'
 conn_mark = '555'
 conn_mark_set = '111'
@@ -41,7 +39,7 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
 
         cls.cli_set(cls, ['interfaces', 'ethernet', interface, 'address', interface_ip])
         cls.cli_set(cls, ['protocols', 'static', 'table', table_id, 'route', '0.0.0.0/0', 'interface', interface])
-        
+
         cls.cli_set(cls, ['vrf', 'name', vrf, 'table', vrf_table_id])
 
     @classmethod
@@ -72,17 +70,6 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
         ]
 
         self.verify_rules(ip_rule_search, inverse=True)
-
-    def verify_rules(self, rules_search, inverse=False):
-        rule_output = cmd('ip rule show')
-
-        for search in rules_search:
-            matched = False
-            for line in rule_output.split("\n"):
-                if all(item in line for item in search):
-                    matched = True
-                    break
-            self.assertTrue(not matched if inverse else matched, msg=search)
 
     def test_pbr_group(self):
         self.cli_set(['firewall', 'group', 'network-group', 'smoketest_network', 'network', '172.16.99.0/24'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
My [previous PR](https://github.com/vyos/vyos-1x/pull/3581) for simply extending the table ID range was rejected, so I've prepared another PR set closer to my own use case for this - "policy based route leaking" between VRFs. It may or may not line up with Bernhard's intention from the original ticket. 

This PR extends `policy local-route` syntax to allow `set vrf` as well as `set table`. 

The [main PR](https://github.com/vyos/vyos-1x/pull/3740) for firewall-driven forward PBR has already been merged, this one covers local `ip rule` manipulation. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6430

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* pbr

## Proposed changes
<!--- Describe your changes in detail -->
* This is the `policy local-route*` part of T6430, manipulating ip rules, another PR covers firewall-backed `policy route*` for similar functionality
* Local PBR (policy local-route*) can only target table IDs up to 200 and the previous PR to extend the range was rejected
* PBR with this PR can now also target VRFs directly by name, working around targeting problems for VRF table IDs outside the overlapping 100-200 range
* Validation ensures rules can't target both a table ID and a VRF name
*  Unlike the first PR, this one depends on ip rule aliasing for VRF symbolic names rather than looking up and manipulating table IDs from the conf script
* Added a set of smoketests for `policy local-route` functionality
* Relocated TestPolicyRoute.verify_rules() into VyOSUnitTestSHIM.TestCase, extended to allow lookups in other address families (IPv6 in the new tests). verify_rules() is used by original pbr and new lpbr smoketests in this PR.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Rules apply OK:
```
set policy local-route rule 4 inbound-interface eth0
set policy local-route rule 4 protocol udp
set policy local-route rule 4 fwmark 111
set policy local-route rule 4 destination address 198.51.100.0/24
set policy local-route rule 4 destination port 111
set policy local-route rule 4 source address 198.51.100.1
set policy local-route rule 4 source port 443
set policy local-route rule 4 set vrf MGT
set policy local-route6 rule 6 inbound-interface eth0
set policy local-route6 rule 6 protocol udp
set policy local-route6 rule 6 fwmark 111
set policy local-route6 rule 6 destination port 111
set policy local-route6 rule 6 source port 443
set policy local-route6 rule 6 set vrf MGT
set policy local-route6 rule 6 source address 2001:db8::1
set policy local-route6 rule 6 destination address 2001:db8::/64

# commit
[edit]
vyos@TEST-VYOS-LEFT#  ip rule show
4:      from 198.51.100.1 to 198.51.100.0/24 fwmark 0x6f iif eth0 ipproto udp sport 443 dport 111 lookup MGT
220:    from all lookup 220
1000:   from all lookup [l3mdev-table]
2000:   from all lookup [l3mdev-table] unreachable
32765:  from all lookup local
32766:  from all lookup main
32767:  from all lookup default
[edit]
vyos@TEST-VYOS-LEFT#  ip -6 rule show
6:      from 2001:db8::1 to 2001:db8::/64 fwmark 0x6f iif eth0 ipproto udp sport 443 dport 111 lookup MGT
220:    from all lookup 220
1000:   from all lookup [l3mdev-table]
2000:   from all lookup [l3mdev-table] unreachable
32765:  from all lookup local
32766:  from all lookup main
[edit]
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Since I changed the `policy route` smoketests and the parent shim, I ran through both smoketests to double check:
```
$ python3 /usr/libexec/vyos/tests/smoke/cli/test_policy_route.py 
test_pbr_group (__main__.TestPolicyRoute.test_pbr_group) ... ok
test_pbr_mark (__main__.TestPolicyRoute.test_pbr_mark) ... ok
test_pbr_mark_connection (__main__.TestPolicyRoute.test_pbr_mark_connection) ... ok
test_pbr_matching_criteria (__main__.TestPolicyRoute.test_pbr_matching_criteria) ... ok
test_pbr_table (__main__.TestPolicyRoute.test_pbr_table) ... ok
test_pbr_vrf (__main__.TestPolicyRoute.test_pbr_vrf) ... ok

----------------------------------------------------------------------
Ran 6 tests in 44.617s

OK
$ python3 /usr/libexec/vyos/tests/smoke/cli/test_policy_local-route.py 
test_local_pbr_matching_criteria (__main__.TestPolicyLocalRoute.test_local_pbr_matching_criteria) ... ok
test_local_pbr_rule_changes (__main__.TestPolicyLocalRoute.test_local_pbr_rule_changes) ... ok
test_local_pbr_rule_removal (__main__.TestPolicyLocalRoute.test_local_pbr_rule_removal) ... ok
test_local_pbr_target_vrf (__main__.TestPolicyLocalRoute.test_local_pbr_target_vrf) ... ok

----------------------------------------------------------------------
Ran 4 tests in 28.064s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
