### PR TITLE
smoketest: T6555: openvpn: NameError: name 'elf' is not defined

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_openvpn.py
+++ b/smoketest/scripts/cli/test_interfaces_openvpn.py
@@ -656,8 +656,6 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-
-
         config_file = f'/run/openvpn/{vtun_if}.conf'
         config = read_file(config_file)
         self.assertIn(f'dev {vtun_if}', config)
@@ -667,9 +665,7 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'data-ciphers AES-192-CBC', config)
         self.assertIn(f'mode server', config)
         self.assertIn(f'server-bridge {gw_subnet} {mask_subnet} {start_subnet} {stop_subnet}', config)
-        elf.assertIn(f'keepalive 5 25', config)
-
-
+        self.assertIn(f'keepalive 5 25', config)
 
         # TLS options
         self.assertIn(f'ca /run/openvpn/{vtun_if}_ca.pem', config)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Bugfix

```
DEBUG - ======================================================================
DEBUG - ERROR: test_openvpn_server_server_bridge (__main__.TestInterfacesOpenVPN.test_openvpn_server_server_bridge)
DEBUG - ----------------------------------------------------------------------
DEBUG - Traceback (most recent call last):
DEBUG -   File "/usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py", line 670, in test_openvpn_server_server_bridge
DEBUG -     elf.assertIn(f'keepalive 5 25', config)
DEBUG -     ^^^
DEBUG - NameError: name 'elf' is not defined
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/3920
* https://github.com/vyos/vyos-1x/pull/3942

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
OpenVPN smoketests


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py
test_openvpn_client_interfaces (__main__.TestInterfacesOpenVPN.test_openvpn_client_interfaces) ... ok
test_openvpn_client_verify (__main__.TestInterfacesOpenVPN.test_openvpn_client_verify) ... ok
test_openvpn_options (__main__.TestInterfacesOpenVPN.test_openvpn_options) ... ok
test_openvpn_server_server_bridge (__main__.TestInterfacesOpenVPN.test_openvpn_server_server_bridge) ... ok
test_openvpn_server_subnet_topology (__main__.TestInterfacesOpenVPN.test_openvpn_server_subnet_topology) ... ok
test_openvpn_server_verify (__main__.TestInterfacesOpenVPN.test_openvpn_server_verify) ... ok
test_openvpn_site2site_interfaces_tun (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_interfaces_tun) ... ok
test_openvpn_site2site_verify (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_verify) ... ok

----------------------------------------------------------------------
Ran 8 tests in 73.656s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
