### PR TITLE
configd: T6640: enforce in_session returns False under configd

### DIFF
--- a/python/vyos/configsource.py
+++ b/python/vyos/configsource.py
@@ -204,6 +204,8 @@ class ConfigSourceSession(ConfigSource):
         Returns:
             True if called from a configuration session, False otherwise.
         """
+        if os.getenv('VYOS_CONFIGD', ''):
+            return False
         try:
             self._run(self._make_command('inSession', ''))
             return True

--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -267,6 +267,8 @@ if __name__ == '__main__':
     cfg_group = grp.getgrnam(CFG_GROUP)
     os.setgid(cfg_group.gr_gid)
 
+    os.environ['VYOS_CONFIGD'] = 't'
+
     def sig_handler(signum, frame):
         shutdown()
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Injecting the environment variables needed for avoiding the use of my_set under configd (T6633) causes in_session to return True; we should enforce legacy checks to be consistent with the separation of concerns between the config session and conf_mode script execution.

For this (T6489/T6633) and other extensions as we move towards dropping CStore, in_session should return False if running under configd.

The complex of interactions is described in T6639.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe):
        Enforce distinction between configd and config session to allow extensions/alternatives to CStore.

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6633
* https://vyos.dev/T6639

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
