### PR TITLE
ntp: 3956: For correct display of ntp commands sudo permissions are required. 

### DIFF
--- a/src/op_mode/ntp.py
+++ b/src/op_mode/ntp.py
@@ -30,7 +30,7 @@ def _get_raw_data(command: str) -> dict:
     # more parameters, make sure to include them all below.
     # See to chronyc(1) for definition of key variables
     match command:
-        case "chronyc -c activity":
+        case "sudo chronyc -c activity":
             keys: list = [
             'sources_online',
             'sources_offline',
@@ -39,7 +39,7 @@ def _get_raw_data(command: str) -> dict:
             'sources_with_unknown_address'
             ]
 
-        case "chronyc -c sources":
+        case "sudo chronyc -c sources":
             keys: list = [
             'm',
             's',
@@ -53,7 +53,7 @@ def _get_raw_data(command: str) -> dict:
             'last_sample_est_error'
             ]
 
-        case "chronyc -c sourcestats":
+        case "sudo chronyc -c sourcestats":
             keys: list = [
             'name_ip_address',
             'np',
@@ -65,7 +65,7 @@ def _get_raw_data(command: str) -> dict:
             'std_dev'
             ]
 
-        case "chronyc -c tracking":
+        case "sudo chronyc -c tracking":
             keys: list = [
             'ref_id',
             'ref_id_name',
@@ -112,7 +112,7 @@ def _is_configured():
 
 def show_activity(raw: bool):
     _is_configured()
-    command = f'chronyc'
+    command = f'sudo chronyc'
 
     if raw:
        command += f" -c activity"
@@ -123,7 +123,7 @@ def show_activity(raw: bool):
 
 def show_sources(raw: bool):
     _is_configured()
-    command = f'chronyc'
+    command = f'sudo chronyc'
 
     if raw:
        command += f" -c sources"
@@ -134,7 +134,7 @@ def show_sources(raw: bool):
 
 def show_tracking(raw: bool):
     _is_configured()
-    command = f'chronyc'
+    command = f'sudo chronyc'
 
     if raw:
        command += f" -c tracking"
@@ -145,7 +145,7 @@ def show_tracking(raw: bool):
 
 def show_sourcestats(raw: bool):
     _is_configured()
-    command = f'chronyc'
+    command = f'sudo chronyc'
 
     if raw:
        command += f" -c sourcestats"


### PR DESCRIPTION
For correct display of ntp commands sudo permissions are required. 


example:
```bash
king@n-gate:~$ show ntp system 
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/ntp.py", line 159, in <module>
    res = vyos.opmode.run(sys.modules[__name__])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/opmode.py", line 263, in run
    res = func(**args)
          ^^^^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/ntp.py", line 144, in show_tracking
    return cmd(command)
           ^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/utils/process.py", line 155, in cmd
    raise OSError(code, feedback)
PermissionError: [Errno 1] failed to run command: chronyc tracking
returned: 506 Cannot talk to daemon
exit code: 1
king@n-gate:~$ sudo vim /usr/libexec/vyos/op_mode/ntp.py
king@n-gate:~$ show ntp system 
Reference ID    : 12C12900 (ec2-0-0-0-0.eu-central-1.compute.amazonaws.com)
Stratum         : 4
Ref time (UTC)  : Wed Aug 07 19:47:08 2024
System time     : 0.000003570 seconds fast of NTP time
Last offset     : -0.010062192 seconds
RMS offset      : 0.007169825 seconds
Frequency       : 99.099 ppm slow
Residual freq   : -0.003 ppm
Skew            : 1.515 ppm
Root delay      : 0.038659975 seconds
Root dispersion : 0.037690397 seconds
Update interval : 65.1 seconds
Leap status     : Normal

```