### PR TITLE
suricata: T6624: Make it possible for suricata address groups to reference each other

### DIFF
--- a/src/conf_mode/service_suricata.py
+++ b/src/conf_mode/service_suricata.py
@@ -59,7 +59,7 @@ def topological_sort(source):
         temporary_marks.add(n)
 
         for m in v.get('group', []):
-            m = m.lstrip('!')
+            m = m.lstrip('!').replace('-', '_')
             if m not in source:
                 raise ConfigError(f'Undefined referenced group "{m}"')
             visit(m, source[m])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6624
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
service suricata
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set service suricata interface 'eth1'
set service suricata port-group port-group port '5080'
set service suricata address-group home-net address '19.168.1.0/24'
set service suricata address-group home-net address '2001:8e0:3a60:b2c1::/64'
set service suricata address-group home-net address 'fd1a:dcb9:501c:1201::/64'
set service suricata address-group external-net group '!home-net'
commit
```
before the fix there was an error
```
vyos@vyos# commit

Invalid address-group: Undefined referenced group "home-net"

[[service suricata]] failed
Commit failed
[edit]
```
now it's working
```
vyos@vyos# commit
[ service suricata ]

WARNING: To fetch the latest rules, use "update suricata"; To
periodically fetch the latest rules, use the task scheduler!


[edit]
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
