### PR TITLE
qos: T6638: require interface state existence in verify conditional

### DIFF
--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -237,7 +237,7 @@ def verify_bridge_delete(config):
         raise ConfigError(f'Interface "{interface}" cannot be deleted as it '
                           f'is a member of bridge "{bridge_name}"!')
 
-def verify_interface_exists(ifname, warning_only=False):
+def verify_interface_exists(ifname, state_required=False, warning_only=False):
     """
     Common helper function used by interface implementations to perform
     recurring validation if an interface actually exists. We first probe
@@ -249,11 +249,12 @@ def verify_interface_exists(ifname, warning_only=False):
     from vyos.utils.dict import dict_search_recursive
     from vyos.utils.network import interface_exists
 
-    # Check if interface is present in CLI config
-    config = ConfigTreeQuery()
-    tmp = config.get_config_dict(['interfaces'], get_first_key=True)
-    if bool(list(dict_search_recursive(tmp, ifname))):
-        return True
+    if not state_required:
+        # Check if interface is present in CLI config
+        config = ConfigTreeQuery()
+        tmp = config.get_config_dict(['interfaces'], get_first_key=True)
+        if bool(list(dict_search_recursive(tmp, ifname))):
+            return True
 
     # Interface not found on CLI, try Linux Kernel
     if interface_exists(ifname):

--- a/src/conf_mode/qos.py
+++ b/src/conf_mode/qos.py
@@ -303,7 +303,7 @@ def apply(qos):
         return None
 
     for interface, interface_config in qos['interface'].items():
-        if not verify_interface_exists(interface, warning_only=True):
+        if not verify_interface_exists(interface, state_required=True, warning_only=True):
             # When shaper is bound to a dialup (e.g. PPPoE) interface it is
             # possible that it is yet not availbale when to QoS code runs.
             # Skip the configuration and inform the user via warning_only=True


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add an optional strict requirement of interface state existence to `verify_interface_exists`: this has no effect unless keyword `state_required=True`, as needed in qos.py in case of a late arriving `pppoe` interface.

This restores the intended behavior of the conditional in qos.py:
https://github.com/vyos/vyos-1x/pull/3960/commits/ed63c9d1896a218715e13e1799fc059f4561f75e#diff-c3e850625edc3ba2f44020fcda8640d00631b3c67bac756f258b919667b9d67eR306

The obvious question of how to approach re-applying `qos.TrafficShaper.update` when the interface is available (other than providing a warning to the user) is a separate issue which will need to be addressed in a subtask, if not obvious to those more familiar with the subsystem.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
