### PR TITLE
configverify: T6642: verify_interface_exists requires config_dict arg

### DIFF
--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -344,6 +344,9 @@ class Config(object):
 
             conf_dict['pki'] = pki_dict
 
+        interfaces_root = root_dict.get('interfaces', {})
+        setattr(conf_dict, 'interfaces_root', interfaces_root)
+
         # save optional args for a call to get_config_defaults
         setattr(conf_dict, '_dict_kwargs', kwargs)
 

--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -237,7 +237,7 @@ def verify_bridge_delete(config):
         raise ConfigError(f'Interface "{interface}" cannot be deleted as it '
                           f'is a member of bridge "{bridge_name}"!')
 
-def verify_interface_exists(ifname, state_required=False, warning_only=False):
+def verify_interface_exists(config, ifname, state_required=False, warning_only=False):
     """
     Common helper function used by interface implementations to perform
     recurring validation if an interface actually exists. We first probe
@@ -245,14 +245,12 @@ def verify_interface_exists(ifname, state_required=False, warning_only=False):
     it exists at the OS level.
     """
     from vyos.base import Warning
-    from vyos.configquery import ConfigTreeQuery
     from vyos.utils.dict import dict_search_recursive
     from vyos.utils.network import interface_exists
 
     if not state_required:
         # Check if interface is present in CLI config
-        config = ConfigTreeQuery()
-        tmp = config.get_config_dict(['interfaces'], get_first_key=True)
+        tmp = getattr(config, 'interfaces_root', {})
         if bool(list(dict_search_recursive(tmp, ifname))):
             return True
 

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -402,7 +402,7 @@ def verify(firewall):
                 raise ConfigError(f'Flowtable "{flowtable}" requires at least one interface')
 
             for ifname in flowtable_conf['interface']:
-                verify_interface_exists(ifname)
+                verify_interface_exists(firewall, ifname)
 
             if dict_search_args(flowtable_conf, 'offload') == 'hardware':
                 interfaces = flowtable_conf['interface']

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -310,7 +310,7 @@ def verify_bond_member(ethernet):
     :type ethernet: dict
     """
     ifname = ethernet['ifname']
-    verify_interface_exists(ifname)
+    verify_interface_exists(ethernet, ifname)
     verify_eapol(ethernet)
     verify_mirror_redirect(ethernet)
     ethtool = Ethtool(ifname)
@@ -327,7 +327,7 @@ def verify_ethernet(ethernet):
     :type ethernet: dict
     """
     ifname = ethernet['ifname']
-    verify_interface_exists(ifname)
+    verify_interface_exists(ethernet, ifname)
     verify_mtu(ethernet)
     verify_mtu_ipv6(ethernet)
     verify_dhcpv6(ethernet)

--- a/src/conf_mode/interfaces_wwan.py
+++ b/src/conf_mode/interfaces_wwan.py
@@ -95,7 +95,7 @@ def verify(wwan):
     if not 'apn' in wwan:
         raise ConfigError(f'No APN configured for "{ifname}"!')
 
-    verify_interface_exists(ifname)
+    verify_interface_exists(wwan, ifname)
     verify_authentication(wwan)
     verify_vrf(wwan)
     verify_mirror_redirect(wwan)

--- a/src/conf_mode/policy_local-route.py
+++ b/src/conf_mode/policy_local-route.py
@@ -223,7 +223,7 @@ def verify(pbr):
 
                 if 'inbound_interface' in pbr_route['rule'][rule]:
                     interface = pbr_route['rule'][rule]['inbound_interface']
-                    verify_interface_exists(interface)
+                    verify_interface_exists(pbr, interface)
 
     return None
 

--- a/src/conf_mode/protocols_igmp-proxy.py
+++ b/src/conf_mode/protocols_igmp-proxy.py
@@ -65,7 +65,7 @@ def verify(igmp_proxy):
 
     upstream = 0
     for interface, config in igmp_proxy['interface'].items():
-        verify_interface_exists(interface)
+        verify_interface_exists(igmp_proxy, interface)
         if dict_search('role', config) == 'upstream':
             upstream += 1
 

--- a/src/conf_mode/protocols_isis.py
+++ b/src/conf_mode/protocols_isis.py
@@ -102,7 +102,7 @@ def verify(isis):
         raise ConfigError('Interface used for routing updates is mandatory!')
 
     for interface in isis['interface']:
-        verify_interface_exists(interface)
+        verify_interface_exists(isis, interface)
         # Interface MTU must be >= configured lsp-mtu
         mtu = Interface(interface).get_mtu()
         area_mtu = isis['lsp_mtu']

--- a/src/conf_mode/protocols_mpls.py
+++ b/src/conf_mode/protocols_mpls.py
@@ -49,7 +49,7 @@ def verify(mpls):
 
     if 'interface' in mpls:
         for interface in mpls['interface']:
-            verify_interface_exists(interface)
+            verify_interface_exists(mpls, interface)
 
     # Checks to see if LDP is properly configured
     if 'ldp' in mpls:

--- a/src/conf_mode/protocols_ospf.py
+++ b/src/conf_mode/protocols_ospf.py
@@ -144,7 +144,7 @@ def verify(ospf):
 
     if 'interface' in ospf:
         for interface, interface_config in ospf['interface'].items():
-            verify_interface_exists(interface)
+            verify_interface_exists(ospf, interface)
             # One can not use dead-interval and hello-multiplier at the same
             # time. FRR will only activate the last option set via CLI.
             if {'hello_multiplier', 'dead_interval'} <= set(interface_config):

--- a/src/conf_mode/protocols_ospfv3.py
+++ b/src/conf_mode/protocols_ospfv3.py
@@ -127,7 +127,7 @@ def verify(ospfv3):
 
     if 'interface' in ospfv3:
         for interface, interface_config in ospfv3['interface'].items():
-            verify_interface_exists(interface)
+            verify_interface_exists(ospfv3, interface)
             if 'ifmtu' in interface_config:
                 mtu = Interface(interface).get_mtu()
                 if int(interface_config['ifmtu']) > int(mtu):

--- a/src/conf_mode/protocols_pim.py
+++ b/src/conf_mode/protocols_pim.py
@@ -97,7 +97,7 @@ def verify(pim):
         raise ConfigError('PIM require defined interfaces!')
 
     for interface, interface_config in pim['interface'].items():
-        verify_interface_exists(interface)
+        verify_interface_exists(pim, interface)
 
         # Check join group in reserved net
         if 'igmp' in interface_config and 'join' in interface_config['igmp']:

--- a/src/conf_mode/protocols_pim6.py
+++ b/src/conf_mode/protocols_pim6.py
@@ -63,7 +63,7 @@ def verify(pim6):
         return
 
     for interface, interface_config in pim6.get('interface', {}).items():
-        verify_interface_exists(interface)
+        verify_interface_exists(pim6, interface)
         if 'mld' in interface_config:
             mld = interface_config['mld']
             for group in mld.get('join', {}).keys():

--- a/src/conf_mode/qos.py
+++ b/src/conf_mode/qos.py
@@ -303,7 +303,7 @@ def apply(qos):
         return None
 
     for interface, interface_config in qos['interface'].items():
-        if not verify_interface_exists(interface, state_required=True, warning_only=True):
+        if not verify_interface_exists(qos, interface, state_required=True, warning_only=True):
             # When shaper is bound to a dialup (e.g. PPPoE) interface it is
             # possible that it is yet not availbale when to QoS code runs.
             # Skip the configuration and inform the user via warning_only=True

--- a/src/conf_mode/service_broadcast-relay.py
+++ b/src/conf_mode/service_broadcast-relay.py
@@ -59,7 +59,7 @@ def verify(relay):
             raise ConfigError('At least two interfaces are required for UDP broadcast relay "{instance}"')
 
         for interface in config.get('interface', []):
-            verify_interface_exists(interface)
+            verify_interface_exists(relay, interface)
             if not is_afi_configured(interface, AF_INET):
                 raise ConfigError(f'Interface "{interface}" has no IPv4 address configured!')
 

--- a/src/conf_mode/service_conntrack-sync.py
+++ b/src/conf_mode/service_conntrack-sync.py
@@ -67,7 +67,7 @@ def verify(conntrack):
 
     has_peer = False
     for interface, interface_config in conntrack['interface'].items():
-        verify_interface_exists(interface)
+        verify_interface_exists(conntrack, interface)
         # Interface must not only exist, it must also carry an IP address
         if len(get_ipv4(interface)) < 1:
             raise ConfigError(f'Interface {interface} requires an IP address!')

--- a/src/conf_mode/service_dns_dynamic.py
+++ b/src/conf_mode/service_dns_dynamic.py
@@ -104,7 +104,7 @@ def verify(dyndns):
                     Warning(f'Interface "{config["address"]["interface"]}" does not exist yet and '
                             f'cannot be used for Dynamic DNS service "{service}" until it is up!')
             else:
-                verify_interface_exists(config['address']['interface'])
+                verify_interface_exists(dyndns, config['address']['interface'])
 
         if 'web' in config['address']:
             # If 'skip' is specified, 'url' is required as well

--- a/src/conf_mode/service_ipoe-server.py
+++ b/src/conf_mode/service_ipoe-server.py
@@ -66,7 +66,7 @@ def verify(ipoe):
         raise ConfigError('No IPoE interface configured')
 
     for interface, iface_config in ipoe['interface'].items():
-        verify_interface_exists(interface, warning_only=True)
+        verify_interface_exists(ipoe, interface, warning_only=True)
         if 'client_subnet' in iface_config and 'vlan' in iface_config:
             raise ConfigError('Option "client-subnet" and "vlan" are mutually exclusive, '
                               'use "client-ip-pool" instead!')

--- a/src/conf_mode/service_mdns_repeater.py
+++ b/src/conf_mode/service_mdns_repeater.py
@@ -65,7 +65,7 @@ def verify(mdns):
     # For mdns-repeater to work it is essential that the interfaces has
     # an IPv4 address assigned
     for interface in mdns['interface']:
-        verify_interface_exists(interface)
+        verify_interface_exists(mdns, interface)
 
         if mdns['ip_version'] in ['ipv4', 'both'] and AF_INET not in ifaddresses(interface):
             raise ConfigError('mDNS repeater requires an IPv4 address to be '

--- a/src/conf_mode/service_ndp-proxy.py
+++ b/src/conf_mode/service_ndp-proxy.py
@@ -50,7 +50,7 @@ def verify(ndpp):
 
     if 'interface' in ndpp:
         for interface, interface_config in ndpp['interface'].items():
-            verify_interface_exists(interface)
+            verify_interface_exists(ndpp, interface)
 
             if 'rule' in interface_config:
                 for rule, rule_config in interface_config['rule'].items():

--- a/src/conf_mode/service_ntp.py
+++ b/src/conf_mode/service_ntp.py
@@ -64,7 +64,7 @@ def verify(ntp):
     if 'interface' in ntp:
         # If ntpd should listen on a given interface, ensure it exists
         interface = ntp['interface']
-        verify_interface_exists(interface)
+        verify_interface_exists(ntp, interface)
 
         # If we run in a VRF, our interface must belong to this VRF, too
         if 'vrf' in ntp:

--- a/src/conf_mode/service_pppoe-server.py
+++ b/src/conf_mode/service_pppoe-server.py
@@ -122,7 +122,7 @@ def verify(pppoe):
 
     # Check is interface exists in the system
     for interface in pppoe['interface']:
-        verify_interface_exists(interface, warning_only=True)
+        verify_interface_exists(pppoe, interface, warning_only=True)
 
     return None
 

--- a/src/conf_mode/service_salt-minion.py
+++ b/src/conf_mode/service_salt-minion.py
@@ -70,7 +70,7 @@ def verify(salt):
         Warning('Do not use sha1 hashing algorithm, upgrade to sha256 or later!')
 
     if 'source_interface' in salt:
-        verify_interface_exists(salt['source_interface'])
+        verify_interface_exists(salt, salt['source_interface'])
 
     return None
 

--- a/src/conf_mode/system_flow-accounting.py
+++ b/src/conf_mode/system_flow-accounting.py
@@ -183,7 +183,7 @@ def verify(flow_config):
 
     # check that all configured interfaces exists in the system
     for interface in flow_config['interface']:
-        verify_interface_exists(interface, warning_only=True)
+        verify_interface_exists(flow_config, interface, warning_only=True)
 
     # check sFlow configuration
     if 'sflow' in flow_config:

--- a/src/conf_mode/system_option.py
+++ b/src/conf_mode/system_option.py
@@ -68,7 +68,7 @@ def verify(options):
     if 'http_client' in options:
         config = options['http_client']
         if 'source_interface' in config:
-            verify_interface_exists(config['source_interface'])
+            verify_interface_exists(options, config['source_interface'])
 
         if {'source_address', 'source_interface'} <= set(config):
             raise ConfigError('Can not define both HTTP source-interface and source-address')

--- a/src/conf_mode/vpn_ipsec.py
+++ b/src/conf_mode/vpn_ipsec.py
@@ -210,9 +210,9 @@ def verify(ipsec):
         for interface in ipsec['interface']:
             # exclude check interface for dynamic interfaces
             if tmp.match(interface):
-                verify_interface_exists(interface, warning_only=True)
+                verify_interface_exists(ipsec, interface, warning_only=True)
             else:
-                verify_interface_exists(interface)
+                verify_interface_exists(ipsec, interface)
 
     if 'l2tp' in ipsec:
         if 'esp_group' in ipsec['l2tp']:
@@ -273,7 +273,7 @@ def verify(ipsec):
                 if 'dhcp_interface' in ra_conf:
                     dhcp_interface = ra_conf['dhcp_interface']
 
-                    verify_interface_exists(dhcp_interface)
+                    verify_interface_exists(ipsec, dhcp_interface)
                     dhcp_base = directories['isc_dhclient_dir']
 
                     if not os.path.exists(f'{dhcp_base}/dhclient_{dhcp_interface}.conf'):
@@ -502,7 +502,7 @@ def verify(ipsec):
             if 'dhcp_interface' in peer_conf:
                 dhcp_interface = peer_conf['dhcp_interface']
 
-                verify_interface_exists(dhcp_interface)
+                verify_interface_exists(ipsec, dhcp_interface)
                 dhcp_base = directories['isc_dhclient_dir']
 
                 if not os.path.exists(f'{dhcp_base}/dhclient_{dhcp_interface}.conf'):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The function `verify_interface_exists` requires access to the ambient `config_dict`, rather than its own instantiation using `ConfigTreeQuery`, in order to get the correct working config representation under configd and at boot. Including the root path 'interfaces' for the syntactical verification test as a config_dict key similar to the case of `with_pki` would interfere with script-specific path searches (e.g. `interfaces_bonding.py`); consequently, the dict of path 'interfaces' is included as an attribute of the class `ConfigDict`.

This construction appears redundant in the case of, say, `interfaces_ethernet.py`, but is of the right generality to cover all cases.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6638

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-1x/pull/3960

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
