### PR TITLE
T6630: ntp: support hardware timestamp offload and other mechanisms to improve accuracy

### DIFF
--- a/data/templates/chrony/chrony.conf.j2
+++ b/data/templates/chrony/chrony.conf.j2
@@ -67,15 +67,14 @@ binddevice {{ interface }}
 {%     endif %}
 {% endif %}
 
-{% if offload.timestamp.interface is vyos_defined %}
+{% if ptp.timestamp.interface is vyos_defined %}
 # Enable hardware timestamping on the specified interfaces
-{%     for interface, config in offload.timestamp.interface.items() %}
-hwtimestamp {{ interface }} {{- ' rxfilter ' ~ config.receive_filter if config.receive_filter is vyos_defined }}
+{%     for iface, iface_config in ptp.timestamp.interface.items() %}
+{%         if iface == "all" %}
+{%             set iface = "*" %}
+{%         endif %}
+hwtimestamp {{ iface }} {{- ' rxfilter ' ~ iface_config.receive_filter if iface_config.receive_filter is vyos_defined }}
 {%     endfor %}
-{% endif %}
-{% if offload.timestamp.default_enable is vyos_defined %}
-# Enable hardware timestamping on all supported interfaces not otherwise configured
-hwtimestamp *
 {% endif %}
 
 {% if ptp.port is vyos_defined %}

--- a/data/templates/chrony/chrony.conf.j2
+++ b/data/templates/chrony/chrony.conf.j2
@@ -66,3 +66,14 @@ bindaddress {{ address }}
 binddevice {{ interface }}
 {%     endif %}
 {% endif %}
+
+{% if offload.timestamp.interface is vyos_defined %}
+# Enable hardware timestamping on the specified interfaces
+{%     for interface, config in offload.timestamp.interface.items() %}
+hwtimestamp {{ interface }} {{- ' rxfilter ' ~ config.receive_filter if config.receive_filter is vyos_defined }}
+{%     endfor %}
+{% endif %}
+{% if offload.timestamp.default_enable is vyos_defined %}
+# Enable hardware timestamping on all supported interfaces not otherwise configured
+hwtimestamp *
+{% endif %}

--- a/data/templates/chrony/chrony.conf.j2
+++ b/data/templates/chrony/chrony.conf.j2
@@ -42,7 +42,7 @@ user {{ user }}
 {%         if config.pool is vyos_defined %}
 {%             set association = 'pool' %}
 {%         endif %}
-{{ association }} {{ server | replace('_', '-') }} iburst {{- ' nts' if config.nts is vyos_defined }} {{- ' noselect' if config.noselect is vyos_defined }} {{- ' prefer' if config.prefer is vyos_defined }} {{- ' xleave' if config.interleave is vyos_defined }}
+{{ association }} {{ server | replace('_', '-') }} iburst {{- ' nts' if config.nts is vyos_defined }} {{- ' noselect' if config.noselect is vyos_defined }} {{- ' prefer' if config.prefer is vyos_defined }} {{- ' xleave' if config.interleave is vyos_defined }} {{- ' port 319' if config.ptp_transport is vyos_defined }}
 {%     endfor %}
 {% endif %}
 
@@ -76,4 +76,9 @@ hwtimestamp {{ interface }} {{- ' rxfilter ' ~ config.receive_filter if config.r
 {% if offload.timestamp.default_enable is vyos_defined %}
 # Enable hardware timestamping on all supported interfaces not otherwise configured
 hwtimestamp *
+{% endif %}
+
+{% if ptp_transport is vyos_defined %}
+# Enable sending and receiving NTP over PTP packets (PTP transport)
+ptpport 319
 {% endif %}

--- a/data/templates/chrony/chrony.conf.j2
+++ b/data/templates/chrony/chrony.conf.j2
@@ -42,7 +42,7 @@ user {{ user }}
 {%         if config.pool is vyos_defined %}
 {%             set association = 'pool' %}
 {%         endif %}
-{{ association }} {{ server | replace('_', '-') }} iburst {{- ' nts' if config.nts is vyos_defined }} {{- ' noselect' if config.noselect is vyos_defined }} {{- ' prefer' if config.prefer is vyos_defined }} {{- ' xleave' if config.interleave is vyos_defined }} {{- ' port 319' if config.ptp_transport is vyos_defined }}
+{{ association }} {{ server | replace('_', '-') }} iburst {{- ' nts' if config.nts is vyos_defined }} {{- ' noselect' if config.noselect is vyos_defined }} {{- ' prefer' if config.prefer is vyos_defined }} {{- ' xleave' if config.interleave is vyos_defined }} {{- ' port ' ~ ptp.port if ptp.port is vyos_defined and config.ptp is vyos_defined }}
 {%     endfor %}
 {% endif %}
 
@@ -78,7 +78,7 @@ hwtimestamp {{ interface }} {{- ' rxfilter ' ~ config.receive_filter if config.r
 hwtimestamp *
 {% endif %}
 
-{% if ptp_transport is vyos_defined %}
+{% if ptp.port is vyos_defined %}
 # Enable sending and receiving NTP over PTP packets (PTP transport)
-ptpport 319
+ptpport {{ ptp.port }}
 {% endif %}

--- a/data/templates/chrony/chrony.conf.j2
+++ b/data/templates/chrony/chrony.conf.j2
@@ -42,7 +42,7 @@ user {{ user }}
 {%         if config.pool is vyos_defined %}
 {%             set association = 'pool' %}
 {%         endif %}
-{{ association }} {{ server | replace('_', '-') }} iburst {{ 'nts' if config.nts is vyos_defined }} {{ 'noselect' if config.noselect is vyos_defined }} {{ 'prefer' if config.prefer is vyos_defined }}
+{{ association }} {{ server | replace('_', '-') }} iburst {{- ' nts' if config.nts is vyos_defined }} {{- ' noselect' if config.noselect is vyos_defined }} {{- ' prefer' if config.prefer is vyos_defined }} {{- ' xleave' if config.interleave is vyos_defined }}
 {%     endfor %}
 {% endif %}
 

--- a/interface-definitions/service_ntp.xml.in
+++ b/interface-definitions/service_ntp.xml.in
@@ -77,12 +77,17 @@
               </node>
             </children>
           </node>
-          <leafNode name="ptp-transport">
+          <node name="ptp">
             <properties>
-              <help>Enables the PTP transport for NTP packets</help>
-              <valueless/>
+              <help>Enable Precision Time Protocol (PTP) transport</help>
             </properties>
-          </leafNode>
+            <children>
+              #include <include/port-number.xml.i>
+              <leafNode name="port">
+                <defaultValue>319</defaultValue>
+              </leafNode>
+            </children>
+          </node>
           <leafNode name="leap-second">
             <properties>
               <help>Leap second behavior</help>
@@ -156,9 +161,9 @@
                   <valueless/>
                 </properties>
               </leafNode>
-              <leafNode name="ptp-transport">
+              <leafNode name="ptp">
                 <properties>
-                  <help>Use the PTP transport for the server</help>
+                  <help>Use Precision Time Protocol (PTP) transport for the server</help>
                   <valueless/>
                 </properties>
               </leafNode>

--- a/interface-definitions/service_ntp.xml.in
+++ b/interface-definitions/service_ntp.xml.in
@@ -86,6 +86,12 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <leafNode name="interleave">
+                <properties>
+                  <help>Use the interleaved mode for the server</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
             </children>
           </tagNode>
         </children>

--- a/interface-definitions/service_ntp.xml.in
+++ b/interface-definitions/service_ntp.xml.in
@@ -48,7 +48,7 @@
                         <properties>
                           <help>Selects which inbound packets are timestamped by the NIC</help>
                           <completionHelp>
-                            <list>all ntp none</list>
+                            <list>all ntp ptp none</list>
                           </completionHelp>
                           <valueHelp>
                             <format>all</format>
@@ -59,11 +59,15 @@
                             <description>Only NTP packets are timestamped</description>
                           </valueHelp>
                           <valueHelp>
+                            <format>ptp</format>
+                            <description>Only PTP packets, or NTP packets using the PTP transport, are timestamped</description>
+                          </valueHelp>
+                          <valueHelp>
                             <format>none</format>
                             <description>No received packets are timestamped</description>
                           </valueHelp>
                           <constraint>
-                            <regex>(all|ntp|none)</regex>
+                            <regex>(all|ntp|ptp|none)</regex>
                           </constraint>
                         </properties>
                       </leafNode>
@@ -73,6 +77,12 @@
               </node>
             </children>
           </node>
+          <leafNode name="ptp-transport">
+            <properties>
+              <help>Enables the PTP transport for NTP packets</help>
+              <valueless/>
+            </properties>
+          </leafNode>
           <leafNode name="leap-second">
             <properties>
               <help>Leap second behavior</help>
@@ -143,6 +153,12 @@
               <leafNode name="prefer">
                 <properties>
                   <help>Marks the server as preferred</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="ptp-transport">
+                <properties>
+                  <help>Use the PTP transport for the server</help>
                   <valueless/>
                 </properties>
               </leafNode>

--- a/interface-definitions/service_ntp.xml.in
+++ b/interface-definitions/service_ntp.xml.in
@@ -13,34 +13,38 @@
           #include <include/generic-interface.xml.i>
           #include <include/listen-address.xml.i>
           #include <include/interface/vrf.xml.i>
-          <node name="offload">
+          <node name="ptp">
             <properties>
-              <help>Configurable offload options</help>
+              <help>Enable Precision Time Protocol (PTP) transport</help>
             </properties>
             <children>
+              #include <include/port-number.xml.i>
+              <leafNode name="port">
+                <defaultValue>319</defaultValue>
+              </leafNode>
               <node name="timestamp">
                 <properties>
                   <help>Enable timestamping of packets in the NIC hardware</help>
                 </properties>
                 <children>
-                  <leafNode name="default-enable">
-                    <properties>
-                      <help>Enable timestamping on all supported interfaces</help>
-                      <valueless/>
-                    </properties>
-                  </leafNode>
                   <tagNode name="interface">
                     <properties>
                       <help>Interface to enable timestamping on</help>
                       <completionHelp>
                         <script>${vyos_completion_dir}/list_interfaces</script>
+                        <list>all</list>
                       </completionHelp>
+                      <valueHelp>
+                        <format>all</format>
+                        <description>Select all interfaces</description>
+                      </valueHelp>
                       <valueHelp>
                         <format>txt</format>
                         <description>Interface name</description>
                       </valueHelp>
                       <constraint>
                         #include <include/constraint/interface-name.xml.i>
+                        <regex>all</regex>
                       </constraint>
                     </properties>
                     <children>
@@ -52,7 +56,7 @@
                           </completionHelp>
                           <valueHelp>
                             <format>all</format>
-                            <description>All received packets are timestamped</description>
+                            <description>All packets are timestamped</description>
                           </valueHelp>
                           <valueHelp>
                             <format>ntp</format>
@@ -60,11 +64,11 @@
                           </valueHelp>
                           <valueHelp>
                             <format>ptp</format>
-                            <description>Only PTP packets, or NTP packets using the PTP transport, are timestamped</description>
+                            <description>Only PTP or NTP packets using the PTP transport are timestamped</description>
                           </valueHelp>
                           <valueHelp>
                             <format>none</format>
-                            <description>No received packets are timestamped</description>
+                            <description>No packet is timestamped</description>
                           </valueHelp>
                           <constraint>
                             <regex>(all|ntp|ptp|none)</regex>
@@ -75,17 +79,6 @@
                   </tagNode>
                 </children>
               </node>
-            </children>
-          </node>
-          <node name="ptp">
-            <properties>
-              <help>Enable Precision Time Protocol (PTP) transport</help>
-            </properties>
-            <children>
-              #include <include/port-number.xml.i>
-              <leafNode name="port">
-                <defaultValue>319</defaultValue>
-              </leafNode>
             </children>
           </node>
           <leafNode name="leap-second">

--- a/interface-definitions/service_ntp.xml.in
+++ b/interface-definitions/service_ntp.xml.in
@@ -13,6 +13,66 @@
           #include <include/generic-interface.xml.i>
           #include <include/listen-address.xml.i>
           #include <include/interface/vrf.xml.i>
+          <node name="offload">
+            <properties>
+              <help>Configurable offload options</help>
+            </properties>
+            <children>
+              <node name="timestamp">
+                <properties>
+                  <help>Enable timestamping of packets in the NIC hardware</help>
+                </properties>
+                <children>
+                  <leafNode name="default-enable">
+                    <properties>
+                      <help>Enable timestamping on all supported interfaces</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <tagNode name="interface">
+                    <properties>
+                      <help>Interface to enable timestamping on</help>
+                      <completionHelp>
+                        <script>${vyos_completion_dir}/list_interfaces</script>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Interface name</description>
+                      </valueHelp>
+                      <constraint>
+                        #include <include/constraint/interface-name.xml.i>
+                      </constraint>
+                    </properties>
+                    <children>
+                      <leafNode name="receive-filter">
+                        <properties>
+                          <help>Selects which inbound packets are timestamped by the NIC</help>
+                          <completionHelp>
+                            <list>all ntp none</list>
+                          </completionHelp>
+                          <valueHelp>
+                            <format>all</format>
+                            <description>All received packets are timestamped</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>ntp</format>
+                            <description>Only NTP packets are timestamped</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>none</format>
+                            <description>No received packets are timestamped</description>
+                          </valueHelp>
+                          <constraint>
+                            <regex>(all|ntp|none)</regex>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </tagNode>
+                </children>
+              </node>
+            </children>
+          </node>
           <leafNode name="leap-second">
             <properties>
               <help>Leap second behavior</help>

--- a/smoketest/scripts/cli/test_service_ntp.py
+++ b/smoketest/scripts/cli/test_service_ntp.py
@@ -224,5 +224,39 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
 
         self.assertIn('hwtimestamp *', config)
 
+    def test_ptp_transport(self):
+        # Test offloading of NIC timestamp
+        servers = ['192.0.2.1', '192.0.2.2']
+        options = ['prefer']
+
+        for server in servers:
+            for option in options:
+                self.cli_set(base_path + ['server', server, option])
+            self.cli_set(base_path + ['server', server, 'ptp-transport'])
+
+        # commit changes (expected to fail)
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        # add the required top-level option and commit
+        self.cli_set(base_path + ['ptp-transport'])
+        self.cli_commit()
+
+        # Check generated configuration
+        # this file must be read with higher permissions
+        config = cmd(f'sudo cat {NTP_CONF}')
+        self.assertIn('driftfile /run/chrony/drift', config)
+        self.assertIn('dumpdir /run/chrony', config)
+        self.assertIn('ntsdumpdir /run/chrony', config)
+        self.assertIn('clientloglimit 1048576', config)
+        self.assertIn('rtcsync', config)
+        self.assertIn('makestep 1.0 3', config)
+        self.assertIn('leapsectz right/UTC', config)
+
+        for server in servers:
+            self.assertIn(f'server {server} iburst ' + ' '.join(options) + ' port 319', config)
+
+        self.assertIn('ptpport 319', config)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/smoketest/scripts/cli/test_service_ntp.py
+++ b/smoketest/scripts/cli/test_service_ntp.py
@@ -171,7 +171,6 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
         # name is not a 1:1 mapping from VyOS config
         servers = ['192.0.2.1', '192.0.2.2']
         options = ['prefer']
-        offload_interface = 'eth0'
 
         for server in servers:
             for option in options:
@@ -198,13 +197,13 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
     def test_offload_timestamp_default(self):
         # Test offloading of NIC timestamp
         servers = ['192.0.2.1', '192.0.2.2']
-        options = ['prefer']
+        ptp_port = '8319'
 
         for server in servers:
-            for option in options:
-                self.cli_set(base_path + ['server', server, option])
+            self.cli_set(base_path + ['server', server, 'ptp'])
 
-        self.cli_set(base_path + ['offload', 'timestamp', 'default-enable'])
+        self.cli_set(base_path + ['ptp', 'port', ptp_port])
+        self.cli_set(base_path + ['ptp', 'timestamp', 'interface', 'all'])
 
         # commit changes
         self.cli_commit()
@@ -221,7 +220,7 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
         self.assertIn('leapsectz right/UTC', config)
 
         for server in servers:
-            self.assertIn(f'server {server} iburst ' + ' '.join(options), config)
+            self.assertIn(f'server {server} iburst port {ptp_port}', config)
 
         self.assertIn('hwtimestamp *', config)
 

--- a/src/conf_mode/service_ntp.py
+++ b/src/conf_mode/service_ntp.py
@@ -87,6 +87,15 @@ def verify(ntp):
         if ipv6_addresses > 1:
             raise ConfigError(f'NTP Only admits one ipv6 value for listen-address parameter ')
 
+    if 'server' in ntp:
+        for host, server in ntp['server'].items():
+            if 'ptp_transport' in server:
+                if 'ptp_transport' not in ntp:
+                    raise ConfigError('ptp-transport must be enabled on the service '\
+                                      f'before it can be used with server {host}')
+                else:
+                    break
+
     return None
 
 def generate(ntp):

--- a/src/conf_mode/service_ntp.py
+++ b/src/conf_mode/service_ntp.py
@@ -17,6 +17,7 @@
 import os
 
 from vyos.config import Config
+from vyos.config import config_dict_merge
 from vyos.configdict import is_node_changed
 from vyos.configverify import verify_vrf
 from vyos.configverify import verify_interface_exists
@@ -42,13 +43,21 @@ def get_config(config=None):
     if not conf.exists(base):
         return None
 
-    ntp = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True, with_defaults=True)
+    ntp = conf.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
     ntp['config_file'] = config_file
     ntp['user'] = user_group
 
     tmp = is_node_changed(conf, base + ['vrf'])
     if tmp: ntp.update({'restart_required': {}})
 
+    # We have gathered the dict representation of the CLI, but there are default
+    # options which we need to update into the dictionary retrived.
+    default_values = conf.get_config_defaults(**ntp.kwargs, recursive=True)
+    # Only defined PTP default port, if PTP feature is in use
+    if 'ptp' not in ntp:
+        del default_values['ptp']
+
+    ntp = config_dict_merge(default_values, ntp)
     return ntp
 
 def verify(ntp):
@@ -89,10 +98,10 @@ def verify(ntp):
 
     if 'server' in ntp:
         for host, server in ntp['server'].items():
-            if 'ptp_transport' in server:
-                if 'ptp_transport' not in ntp:
-                    raise ConfigError('ptp-transport must be enabled on the service '\
-                                      f'before it can be used with server {host}')
+            if 'ptp' in server:
+                if 'ptp' not in ntp:
+                    raise ConfigError('PTP must be enabled for the NTP service '\
+                                      f'before it can be used for server "{host}"')
                 else:
                     break
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

This PR exposes features of the `chrony` daemon that underlies the current VyOS NTP service implementation. These features leverage hardware capabilities of the NIC to achieve more accurate time synchronization.

Running NTP on the local network, we can often get system clocks within hundreds of microseconds of each other. With these additional features, we can get within double digit nanosecond accuracy.

Precisely synchronized clocks may be of limited benefit to generalized networking and computing usecases (outside of accurate log timestamps), but can be immensely helpful for some HPC and A/V production usecases. If you value relative accuracy (systems synchronized with each other) over absolute accuracy (network synchronized with a stratum 0 GPS clock, etc.), being able to use VyOS as a hub for precise time synchronization can be convenient over deploying a dedicated linux system for this purpose.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
https://vyos.dev/T6630

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ntp

## Proposed changes

This change exposes several options supported by the `chrony` daemon that can increase the accuracy of the NTP time synchronization.

### Hardware Timestamp Offload

chrony can leverage NIC hardware capabilities to record the exact time packets are received on the interface, as well as when packets were actually transmitted.

My finding is that this is widely supported by a number of Intel NICs, including:
- Intel X553 10Gb SFP+
- Intel I350 gigabit ethernet
- Intel I225-LM 2.5Gbe card

One newer NIC oddly could only timestamp received packets that it detected being of the PTP protocol, but it could still timestamp transmitted packets:
- Intel X710 10Gb SFP+

In general you can just tell chrony to enable timestamping to the fullest extent it is supported on all available NICs:
`set service ntp offload timestamp default-enable`.

If you find the functionality to be buggy on certain interfaces, you can specify specific interfaces to enable:
`set service ntp offload timestamp interface eth0`, `set service ntp offload timestamp interface eth1`, etc.

If the interface supports timestamping only received NTP packets, chrony will use this by default. If you find this buggy on your NIC, you can customize the RX filter: `set service ntp offload timestamp interface eth0 rx-filter all` (timestamp all received packets) or `set service ntp offload timestamp interface eth0 rx-filter none` (turn off RX timestamping).

### Interleaved mode

Interleaved mode is currently an internet draft (https://datatracker.ietf.org/doc/draft-ietf-ntp-interleaved-modes/07/), and is expected to be incorporated into the upcoming NTPv5. It relies on exchanging multiple packets where the second packet contains the true transmit time of the previous packet (which was not known when the packet was constructed in userspace).

Combined with hardware timestamping, NTP servers/clients can exchange extremely accurate timestamps that cut out any variance caused by kernel queuing delays or variable context switching overhead.

### Experimental PTP transport for NTP packets

As mentioned, the Intel X710 series will only timestamp received packets on the PTP port/protocol. To work around this, chrony has a clever (somewhat non-standard, but there is an internet draft here: https://datatracker.ietf.org/doc/draft-ietf-ntp-over-ptp/) mechanism where it wrap a NTP packet inside a PTP protocol message. This is only ever going to be usable in your local LAN with known clients that you can ensure are running a compatible version of chrony.

Whether this should be included at all in VyOS is debatable. Alternatively we could explore implementing a proper `ptp` service (either to consume time from an existing PTP time infrastructure on the network, or supply time from `ntp` to the network over `ptp`).

## How to test

### Hardware Timestamp Offload

Enable timestamp offload for your existing NTP configuration:
```
set service ntp offload timestamp default-enable
```

To confirm hardware timestamping is enabled, run `show log ntp` and look for the following line: `Enabled HW timestamping on <interface>`. This confirms hardware timestamping is enabled in both directions on your NIC. That's it and you should see increased stability and less jitter in your NTP measurements.

If the line you see looks more like the following: `Enabled HW timestamping (TX only) on <Interface>`, this means your NIC does not support being configured to add a hardware timestamp to all received packets. You can use `ethtool -T <interface>` to verify what "Hardware Receive Filter Modes" your interface supports.

### Experimental PTP transport for NTP packets

If your interface supports the various `ptp` rx filter modes but not the `all` mode, you can try the experimental "PTP transport" option if your other clients are VyOS devices or other linux systems running the `chrony` daemon.

On the server:
```
edit service ntp
set ptp-transport
set offload timestamp interface <interface> receive-filter ptp
```

On the client:
```
edit service ntp
set ptp-transport
set offload timestamp interface <interface> receive-filter ptp
set server <server IP> ptp-transport
```

### Interleave mode

If you have VyOS configured as a client to another NTP server that you know is running `chrony` or otherwise supports the NTP interleaved mode, simply add the `interleave` option to your server configuration:

```
edit service ntp
set server <server IP> interleave
```

## Smoketest result

```
DEBUG - vyos@vyos:~$ /usr/bin/vyos-smoketest
DEBUG - /usr/bin/vyos-smoketest
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_service_ntp.py
DEBUG - test_base_options (__main__.TestSystemNTP.test_base_options) ... ok
DEBUG - test_clients (__main__.TestSystemNTP.test_clients) ... ok
DEBUG - test_interface (__main__.TestSystemNTP.test_interface) ... ok
DEBUG - test_interleave_option (__main__.TestSystemNTP.test_interleave_option) ... ok
DEBUG - test_leap_seconds (__main__.TestSystemNTP.test_leap_seconds) ... ok
DEBUG - test_offload_timestamp_default (__main__.TestSystemNTP.test_offload_timestamp_default) ... ok
DEBUG - test_ptp_transport (__main__.TestSystemNTP.test_ptp_transport) ... ok
DEBUG - test_vrf (__main__.TestSystemNTP.test_vrf) ... ok
```

Note that the smoketests do not cover the `rx-filter` option, as this is not supported by the virtual NIC used in QEMU.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
