### PR TITLE
T6648: dhcpv6-server: align stateless DHCPv6 options with stateful

### DIFF
--- a/interface-definitions/include/dhcp/option-v6.xml.i
+++ b/interface-definitions/include/dhcp/option-v6.xml.i
@@ -78,6 +78,18 @@
         <multi/>
       </properties>
     </leafNode>
+    <leafNode name="info-refresh-time">
+      <properties>
+      <help>Time (in seconds) that stateless clients should wait between refreshing the information they were given</help>
+      <valueHelp>
+        <format>u32:1-4294967295</format>
+        <description>DHCPv6 information refresh time</description>
+      </valueHelp>
+      <constraint>
+        <validator name="numeric" argument="--range 1-4294967295"/>
+      </constraint>
+      </properties>
+    </leafNode>
     <node name="vendor-option">
       <properties>
         <help>Vendor Specific Options</help>

--- a/interface-definitions/include/version/dhcpv6-server-version.xml.i
+++ b/interface-definitions/include/version/dhcpv6-server-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/dhcpv6-server-version.xml.i -->
-<syntaxVersion component='dhcpv6-server' version='5'></syntaxVersion>
+<syntaxVersion component='dhcpv6-server' version='6'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/service_dhcpv6-server.xml.in
+++ b/interface-definitions/service_dhcpv6-server.xml.in
@@ -63,27 +63,7 @@
                   </constraint>
                 </properties>
               </leafNode>
-              <node name="common-options">
-                <properties>
-                  <help>Common options to distribute to all clients, including stateless clients</help>
-                </properties>
-                <children>
-                  <leafNode name="info-refresh-time">
-                    <properties>
-                      <help>Time (in seconds) that stateless clients should wait between refreshing the information they were given</help>
-                      <valueHelp>
-                        <format>u32:1-4294967295</format>
-                        <description>DHCPv6 information refresh time</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 1-4294967295"/>
-                      </constraint>
-                    </properties>
-                  </leafNode>
-                  #include <include/dhcp/domain-search.xml.i>
-                  #include <include/name-server-ipv6.xml.i>
-                </children>
-              </node>
+              #include <include/dhcp/option-v6.xml.i>
               <tagNode name="subnet">
                 <properties>
                   <help>IPv6 DHCP subnet for this shared network</help>

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -922,8 +922,8 @@ def kea6_shared_network_json(shared_networks):
             'subnet6': []
         }
 
-        if 'common_options' in config:
-            network['option-data'] = kea6_parse_options(config['common_options'])
+        if 'option' in config:
+            network['option-data'] = kea6_parse_options(config['option'])
 
         if 'interface' in config:
             network['interface'] = config['interface']

--- a/src/migration-scripts/dhcpv6-server/5-to-6
+++ b/src/migration-scripts/dhcpv6-server/5-to-6
@@ -1,0 +1,31 @@
+# Copyright 2024 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# T6648: Rename "common-options" to "option" at shared-network level
+
+from vyos.configtree import ConfigTree
+
+base = ['service', 'dhcpv6-server', 'shared-network-name']
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(base):
+        # Nothing to do
+        return
+
+    for network in config.list_nodes(base):
+        if not config.exists(base + [network, 'common-options']):
+            continue
+
+        config.rename(base + [network, 'common-options'], 'option')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

As we've expanded the number of DHCPv6 options supported at the `subnet` level, we've left out the ability to set these new options at the `shared-network` level under the `common-options` config key.

Under the old ISC implementation, `common-options` was originally added to support stateless clients (DHCPv6 INFORMATION-REQUEST message). However, with Kea (and seemingly the old ISC implementation), it seems to also be useful as a way to specify options once that should be shared among all (stateful) subnets in the network. Additionally, in Kea, it seems the daemon will try to "infer" a subnet for stateless requests (looking at the `interface` parameter), and return those options.

As such, for all intents and purposes we should support the same set of options at both levels. In addition, I am proposing using the same config syntax and losing the separate `common-options` name.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
https://vyos.dev/T6648

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
service dhcpv6-server

## Proposed changes
<!--- Describe your changes in detail -->

This PR update the DHCPv6 server config to use the same include, `option-v6.xml.in`, at the `shared-network` level that is currently used at the `subnet` level. A migration script is also included to rename existing instances of `common-options` in peoples' configs to `option`.

Old config:
```
     dhcpv6-server {
         shared-network-name LANv6 {
             common-options {
                 domain-search mydomain.com
                 info-refresh-time 86400
                 name-server fdcc:2200:a8ee:2355::1
             }
             subnet fdcc:2200:a8ee:2355::0/64 {
                 interface eth1
                 subnet-id 1
             }
         }
     }
```

New config:
```
     dhcpv6-server {
         shared-network-name LANv6 {
             option {
                 domain-search mydomain.com
                 info-refresh-time 86400
                 name-server fdcc:2200:a8ee:2355::1
             }
             subnet fdcc:2200:a8ee:2355::0/64 {
                 interface eth1
                 subnet-id 1
             }
         }
     }
```

With the new config, you can now add additional options such as `sntp-server` at the `shared-network` level.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

For a refresher on stateless DHCPv6 configuration:

New config:
```
 interfaces {
     // ...
     ethernet eth1 {
         address 10.23.55.1/24
         address fdcc:2200:a8ee:2355::1/64
         description LAN
     }
 }
 service {
     dhcpv6-server {
         shared-network-name LANv6 {
             option {
                 domain-search mydomain.com
                 info-refresh-time 86400
                 name-server fdcc:2200:a8ee:2355::1
                 sntp-server fdcc:2200:a8ee:2355::1
             }
             subnet fdcc:2200:a8ee:2355::0/64 {
                 interface eth1
                 subnet-id 1
             }
         }
     }
     // ... (omitted: dns forwarding config, ntp config) ...
     router-advert {
         interface eth1 {
             name-server fdcc:2200:a8ee:2355::1
             other-config-flag
             prefix ::/64 {
             }
         }
     }
  }
```

Once configured, you should see supported clients obtain their search domains (and possibly an NTP configuration) by sending a DHCPv6 `INFORMATION_REQUEST` packet when they join the network. Keep in mind that Android clients do not support DHCPv6.

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
