### PR TITLE
T6183: interfaces openvpn: suppport specifying IP protocol version

### DIFF
--- a/data/templates/openvpn/server.conf.j2
+++ b/data/templates/openvpn/server.conf.j2
@@ -11,11 +11,11 @@ dev-type {{ device_type }}
 dev {{ ifname }}
 persist-key
 {% if protocol is vyos_defined('tcp-active') %}
-proto tcp-client
+proto tcp{{ protocol_modifier }}-client
 {% elif protocol is vyos_defined('tcp-passive') %}
-proto tcp-server
+proto tcp{{ protocol_modifier }}-server
 {% else %}
-proto udp
+proto udp{{ protocol_modifier }}
 {% endif %}
 {% if local_host is vyos_defined %}
 local {{ local_host }}
@@ -63,6 +63,9 @@ nobind
 #
 # OpenVPN Server mode
 #
+{%     if ip_version is vyos_defined('ipv6') %}
+bind ipv6only
+{%     endif %}
 mode server
 tls-server
 {%     if server is vyos_defined %}
@@ -131,6 +134,9 @@ plugin "{{ plugin_dir }}/openvpn-otp.so" "otp_secrets=/config/auth/openvpn/{{ if
 #
 # OpenVPN site-2-site mode
 #
+{%     if ip_version is vyos_defined('ipv6') %}
+bind ipv6only
+{%     endif %}
 ping {{ keep_alive.interval }}
 ping-restart {{ keep_alive.failure_count }}
 

--- a/interface-definitions/interfaces_openvpn.xml.in
+++ b/interface-definitions/interfaces_openvpn.xml.in
@@ -318,6 +318,34 @@
             </properties>
             <defaultValue>udp</defaultValue>
           </leafNode>
+          <leafNode name="ip-version">
+            <properties>
+              <help>Force OpenVPN to use a specific IP protocol version</help>
+              <completionHelp>
+                <list>auto ipv4 ipv6 dual-stack</list>
+              </completionHelp>
+              <valueHelp>
+                <format>auto</format>
+                <description>Select one IP protocol to use based on local or remote host</description>
+              </valueHelp>
+              <valueHelp>
+                <format>_ipv4</format>
+                <description>Accept connections on or initate connections to IPv4 addresses only</description>
+              </valueHelp>
+              <valueHelp>
+                <format>_ipv6</format>
+                <description>Accept connections on or initate connections to IPv6 addresses only</description>
+              </valueHelp>
+              <valueHelp>
+                <format>dual-stack</format>
+                <description>Accept connections on both protocols simultaneously (only supported in server mode)</description>
+              </valueHelp>
+              <constraint>
+                <regex>(auto|ipv4|ipv6|dual-stack)</regex>
+              </constraint>
+            </properties>
+            <defaultValue>auto</defaultValue>
+          </leafNode>
           <leafNode name="remote-address">
             <properties>
               <help>IP address of remote end of tunnel</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Currently, VyOS does not specify the IP protocol version when telling OpenVPN which transport protocol to use. E.g., if you configure a UDP server, it specifies `protocol udp`. OpenVPN also supports specifying the IP protocol version, e.g. `protocol udp4` or `protocol udp6`.  This adds a new `ip-version` option to the OpenVPN interface to allow specifying an explicit IP protocol version.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
https://vyos.dev/T6183

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
interfaces openvpn

## Proposed changes
<!--- Describe your changes in detail -->

In general, for `client` and `site-to-site` mode, specifying an explicit IP protocol version is rarely necessary. OpenVPN will tell the kernel to open a socket to the remote host, and the kernel will figure out what type of socket to open based on the remote host (e.g. does it resolve to an IPv4 address or an IPv6 address). Using `ip-version ipv4` or `ip-version ipv6` lets users mandate a particular protocol, which could be useful if you are using a DNS hostname and want to ignore responses of a certain address family.

For `server` mode,  particularly if you don't specify an explicit `local-host` (letting OpenVPN bind to all interfaces), the kernel tends to choose an IPv4 socket. By setting `ip-version ipv6` or `ip-version ipv6-dual-stack`, you can force the server to listen on IPv6.

The additional `ipv6-dual-stack` option is only supported in `server` mode (I don't believe it makes sense in any other mode), and is to account for the following Linux behavior:

When binding an IPv6 socket to the unspecified address,  Linux will also send IPv4 traffic to the socket, by way of translating the IPv4 source address into an IPv6 address with the format `::ffff:<ipv4 address>`. This assumes the sysctl `net.ipv6.bindv6only` is disable, which it is on VyOS. By specifying `bind ipv6only` in the OpenVPN configuration, this "dual-stack" behavior is turned off by OpenVPN setting the `IPV6_V6ONLY` socket option. I decided to set this by default when `ip-version ipv6` is used, and offer an additional keyword `ip-version ipv6-dual-stack` for users that explicitly want the dual-stack behavior.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Example dual-stack server configuration:
```
edit interfaces openvpn vtun0
set ip-version 'ipv6-dual-stack'
set local-port '1194'
set mode 'server'
set persistent-tunnel
set protocol 'udp'
set server subnet '10.23.59.0/24'
set server topology 'subnet'
set tls ca-certificate '<ca name>'
set tls certificate '<cert name>'
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
DEBUG - vyos@vyos:~$ /usr/bin/vyos-smoketest
DEBUG - /usr/bin/vyos-smoketest
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py
DEBUG - test_openvpn_client_interfaces (__main__.TestInterfacesOpenVPN.test_openvpn_client_interfaces) ... ok
DEBUG - test_openvpn_client_ip_version (__main__.TestInterfacesOpenVPN.test_openvpn_client_ip_version) ... ok
DEBUG - test_openvpn_client_verify (__main__.TestInterfacesOpenVPN.test_openvpn_client_verify) ... ok
DEBUG - test_openvpn_options (__main__.TestInterfacesOpenVPN.test_openvpn_options) ... ok
DEBUG - test_openvpn_server_ip_version (__main__.TestInterfacesOpenVPN.test_openvpn_server_ip_version) ... ok
DEBUG - test_openvpn_server_server_bridge (__main__.TestInterfacesOpenVPN.test_openvpn_server_server_bridge) ... ok
DEBUG - test_openvpn_server_subnet_topology (__main__.TestInterfacesOpenVPN.test_openvpn_server_subnet_topology) ... ok
DEBUG - test_openvpn_server_verify (__main__.TestInterfacesOpenVPN.test_openvpn_server_verify) ... ok
DEBUG - test_openvpn_site2site_interfaces_tun (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_interfaces_tun) ... ok
DEBUG - test_openvpn_site2site_ip_version (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_ip_version) ... ok
DEBUG - test_openvpn_site2site_verify (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_verify) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 11 tests in 76.658s
DEBUG -
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
