### PR TITLE
T5657: start zabbix-agent under user zabbix for VRF

### DIFF
--- a/data/templates/zabbix-agent/10-override.conf.j2
+++ b/data/templates/zabbix-agent/10-override.conf.j2
@@ -8,9 +8,9 @@ ConditionPathExists=/run/zabbix/zabbix-agent2.conf
 [Service]
 User=
 User=root
-EnvironmentFile=
 ExecStart=
-ExecStart={{ zabbix_command }}/usr/sbin/zabbix_agent2 --config /run/zabbix/zabbix-agent2.conf --foreground
+ExecStart={{ zabbix_command }}sudo -E -n -u zabbix /usr/sbin/zabbix_agent2 --config /run/zabbix/zabbix-agent2.conf --foreground
+EnvironmentFile=
 WorkingDirectory=
 WorkingDirectory=/run/zabbix
 Restart=always

--- a/src/conf_mode/service_monitoring_zabbix-agent.py
+++ b/src/conf_mode/service_monitoring_zabbix-agent.py
@@ -18,15 +18,19 @@ import os
 
 from vyos.config import Config
 from vyos.template import render
+from vyos.utils.permission import chown
 from vyos.utils.process import call
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
 
 
+user = 'zabbix'
+group = user
 service_name = 'zabbix-agent2'
 service_conf = f'/run/zabbix/{service_name}.conf'
 systemd_override = r'/run/systemd/system/zabbix-agent2.service.d/10-override.conf'
+log_file = '/var/log/zabbix/zabbix_agent2.log'
 
 
 def get_config(config=None):
@@ -75,6 +79,8 @@ def generate(config):
     # Write configuration file
     render(service_conf, 'zabbix-agent/zabbix-agent.conf.j2', config)
     render(systemd_override, 'zabbix-agent/10-override.conf.j2', config)
+
+    chown(log_file, user, group)
 
     return None
 


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add user zabbix to sudoers.d and allow to start zabbix-agent2 service under VRF
Remove the user root from the systemd unit override, as we want to start the service from the user `zabbix`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Start zabbix-agent under user `zabbix`

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T5657

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
zabbix-agent
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set service monitoring zabbix-agent host-name 'r4'
set service monitoring zabbix-agent server '192.0.2.5'
set service monitoring zabbix-agent vrf 'mgmt'

```
check status
```
vyos@r4# sudo systemctl status zabbix-agent2
● zabbix-agent2.service - Zabbix Agent 2
     Loaded: loaded (/lib/systemd/system/zabbix-agent2.service; disabled; preset: enabled)
    Drop-In: /run/systemd/system/zabbix-agent2.service.d
             └─10-override.conf
     Active: active (running) since Tue 2024-08-13 11:32:40 EEST; 7min ago
       Docs: man:zabbix_agent2
   Main PID: 9587 (sudo)
      Tasks: 8 (limit: 18718)
     Memory: 16.5M
        CPU: 78ms
     CGroup: /system.slice/zabbix-agent2.service
             ├─9587 sudo ip vrf exec mgmt /usr/sbin/zabbix_agent2 --config /run/zabbix/zabbix-agent2.conf --foreground
             └─vrf
               └─mgmt
                 └─9588 /usr/sbin/zabbix_agent2 --config /run/zabbix/zabbix-agent2.conf --foreground

Aug 13 11:32:40 r4 systemd[1]: Started zabbix-agent2.service - Zabbix Agent 2.
Aug 13 11:32:40 r4 sudo[9587]:   zabbix : PWD=/run/zabbix ; USER=root ; COMMAND=/bin/ip vrf exec mgmt /usr/sbin/zabbix_agent2 --config /run/zabbix/zabbix-agent2.conf --for>
Aug 13 11:32:40 r4 sudo[9587]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=101)
Aug 13 11:32:40 r4 sudo[9588]: Starting Zabbix Agent 2 (6.0.14)
Aug 13 11:32:40 r4 sudo[9588]: Zabbix Agent2 hostname: [r4]
Aug 13 11:32:40 r4 sudo[9588]: Press Ctrl+C to exit.
[edit]
vyos@r4# 

```

## Smoketest result
```
vyos@r4:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_monitoring_zabbix-agent.py
test_01_zabbix_agent (__main__.TestZabbixAgent.test_01_zabbix_agent) ... ok

----------------------------------------------------------------------
Ran 1 test in 13.926s

OK
vyos@r4:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
