### PR TITLE
T6636: firewall: fix firewall template in order print logs for default-action

### DIFF
--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -135,7 +135,7 @@ table ip vyos_filter {
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}
-        {{ conf | nft_default_rule(name_text, 'ipv4') }}
+        {{ conf | nft_default_rule('NAM-' + name_text, 'ipv4') }}
     }
 {%         endfor %}
 {%     endif %}
@@ -287,7 +287,7 @@ table ip6 vyos_filter {
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}
-        {{ conf | nft_default_rule(name_text, 'ipv6') }}
+        {{ conf | nft_default_rule('NAM-' + name_text, 'ipv6') }}
     }
 {%         endfor %}
 {%     endif %}
@@ -416,7 +416,7 @@ table bridge vyos_filter {
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}
-        {{ conf | nft_default_rule(name_text, 'bri') }}
+        {{ conf | nft_default_rule('NAM-' + name_text, 'bri') }}
     }
 {%         endfor %}
 {%     endif %}

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -280,7 +280,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['chain NAME_smoketest'],
             ['saddr 172.16.20.10', 'daddr 172.16.10.10', 'log prefix "[ipv4-NAM-smoketest-1-A]" log level debug', 'ip ttl 15', 'accept'],
             ['tcp flags syn / syn,ack', 'tcp dport 8888', 'log prefix "[ipv4-NAM-smoketest-2-R]" log level err', 'ip ttl > 102', 'reject'],
-            ['log prefix "[ipv4-smoketest-default-D]"','smoketest default-action', 'drop']
+            ['log prefix "[ipv4-NAM-smoketest-default-D]"','smoketest default-action', 'drop']
         ]
 
         self.verify_nftables(nftables_search, 'ip vyos_filter')
@@ -341,7 +341,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             [f'chain NAME_{name}'],
             ['ip length { 64, 512, 1024 }', 'ip dscp { 0x11, 0x34 }', f'log prefix "[ipv4-NAM-{name}-6-A]" log group 66 snaplen 6666 queue-threshold 32000', 'accept'],
             ['ip length 1-30000', 'ip length != 60000-65535', 'ip dscp 0x03-0x0b', 'ip dscp != 0x15-0x19', 'accept'],
-            [f'log prefix "[ipv4-{name}-default-D]"', 'drop']
+            [f'log prefix "[ipv4-NAM-{name}-default-D]"', 'drop']
         ]
 
         self.verify_nftables(nftables_search, 'ip vyos_filter')
@@ -511,7 +511,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['PRE-raw default-action accept', 'accept'],
             [f'chain NAME6_{name}'],
             ['saddr 2002::1-2002::10', 'daddr 2002::1:1', 'log prefix "[ipv6-NAM-v6-smoketest-1-A]" log level crit', 'accept'],
-            [f'"{name} default-action drop"', f'log prefix "[ipv6-{name}-default-D]"', 'drop'],
+            [f'"NAM-{name} default-action drop"', f'log prefix "[ipv6-NAM-{name}-default-D]"', 'drop'],
             ['jump VYOS_STATE_POLICY6'],
             ['chain VYOS_STATE_POLICY6'],
             ['ct state established', 'accept'],
@@ -522,9 +522,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.verify_nftables(nftables_search, 'ip6 vyos_filter')
 
     def test_ipv6_advanced(self):
-        name = 'v6-smoketest-adv'
-        name2 = 'v6-smoketest-adv2'
-        interface = 'eth0'
+        name = 'v6-smoke-adv'
 
         self.cli_set(['firewall', 'ipv6', 'name', name, 'default-action', 'drop'])
         self.cli_set(['firewall', 'ipv6', 'name', name, 'default-log'])
@@ -559,7 +557,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['ip6 saddr 2001:db8::/64', 'meta mark != 0x000019ff-0x00001e56', f'jump NAME6_{name}'],
             [f'chain NAME6_{name}'],
             ['ip6 length { 65, 513, 1025 }', 'ip6 dscp { af21, 0x35 }', 'accept'],
-            [f'log prefix "[ipv6-{name}-default-D]"', 'drop']
+            [f'log prefix "[ipv6-NAM-{name}-default-D]"', 'drop']
         ]
 
         self.verify_nftables(nftables_search, 'ip6 vyos_filter')
@@ -686,7 +684,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['ct state new', 'ct status dnat', 'accept'],
             ['ct state { established, new }', 'ct status snat', 'accept'],
             ['ct state related', 'ct helper { "ftp", "pptp" }', 'accept'],
-            ['drop', f'comment "{name} default-action drop"']
+            ['drop', f'comment "NAM-{name} default-action drop"']
         ]
 
         self.verify_nftables(nftables_search, 'ip vyos_filter')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Firewall: fix firewall template in order to write logs for default-action in order to match same structure as in rules. This way op-mode command for showing firewall log prints logs for default-actions too

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6636

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@T6646:~$ show config commands | grep firewall
set firewall ipv4 name FOO default-action 'accept'
set firewall ipv4 name FOO default-log
set firewall ipv4 name FOO rule 9 action 'accept'
set firewall ipv4 name FOO rule 9 log
set firewall ipv4 name FOO rule 9 protocol 'icmp'
set firewall ipv4 output filter rule 99 action 'accept'
set firewall ipv4 output filter rule 99 log
set firewall ipv4 output filter rule 99 protocol 'tcp'
set firewall ipv4 output filter rule 150 action 'jump'
set firewall ipv4 output filter rule 150 jump-target 'FOO'
set firewall ipv6 name v6-asd-adv default-log
set firewall ipv6 name v6-asd-adv rule 1 action 'accept'
```
Logs for ipv4:
```
vyos@T6646:~$ show log firewall ipv4 name FOO 
Aug 14 14:50:23 kernel: [ipv4-NAM-FOO-default-A]IN= OUT=eth0 SRC=192.168.77.22 DST=8.8.8.8 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=52996 DF PROTO=UDP SPT=42672 DPT=53 LEN=40 
Aug 14 14:50:23 kernel: [ipv4-NAM-FOO-default-A]IN= OUT=eth0 SRC=192.168.77.22 DST=8.8.8.8 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=52997 DF PROTO=UDP SPT=42672 DPT=53 LEN=40 
Aug 14 14:50:23 kernel: [ipv4-NAM-FOO-9-A]IN= OUT=eth0 SRC=192.168.77.22 DST=142.251.134.36 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=11989 DF PROTO=ICMP TYPE=8 CODE=0 ID=38567 SEQ=1 
Aug 14 14:50:23 kernel: [ipv4-NAM-FOO-default-A]IN= OUT=eth0 SRC=192.168.77.22 DST=8.8.8.8 LEN=73 TOS=0x00 PREC=0x00 TTL=64 ID=33408 DF PROTO=UDP SPT=50066 DPT=53 LEN=53 
Aug 14 14:50:24 kernel: [ipv4-NAM-FOO-9-A]IN= OUT=eth0 SRC=192.168.77.22 DST=142.251.134.36 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=12759 DF PROTO=ICMP TYPE=8 CODE=0 ID=38567 SEQ=2 
Aug 14 14:50:24 kernel: [ipv4-NAM-FOO-default-A]IN= OUT=eth0 SRC=192.168.77.22 DST=8.8.8.8 LEN=73 TOS=0x00 PREC=0x00 TTL=64 ID=49379 DF PROTO=UDP SPT=37078 DPT=53 LEN=53 
```
Ipv6 rules:
```
        chain NAME6_v6-asd-adv {
                counter packets 0 bytes 0 accept comment "ipv6-NAM-v6-asd-adv-1"
                counter packets 0 bytes 0 log prefix "[ipv6-NAM-v6-asd-adv-default-D]" drop comment "NAM-v6-asd-adv default-action drop"
        }
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
test_firewall --> OK

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
