### PR TITLE
ipoe_server: T6649: Accel-ppp separate vlan-mon from listen interfaces

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.j2
+++ b/data/templates/accel-ppp/ipoe.config.j2
@@ -56,7 +56,7 @@ verbose=1
 {%         set relay = ',' ~ 'relay=' ~ iface_config.external_dhcp.dhcp_relay  if iface_config.external_dhcp.dhcp_relay is vyos_defined else '' %}
 {%         set giaddr = ',' ~ 'giaddr=' ~ iface_config.external_dhcp.giaddr if iface_config.external_dhcp.giaddr is vyos_defined else '' %}
 {{ tmp }},{{ shared }}mode={{ iface_config.mode | upper }},ifcfg=1,{{ range }}start=dhcpv4,ipv6=1{{ relay }}{{ giaddr }}
-{%         if iface_config.vlan is vyos_defined %}
+{%         if iface_config.vlan_mon is vyos_defined %}
 vlan-mon={{ iface }},{{ iface_config.vlan | join(',') }}
 {%         endif %}
 {%     endfor %}

--- a/data/templates/accel-ppp/pppoe.config.j2
+++ b/data/templates/accel-ppp/pppoe.config.j2
@@ -61,7 +61,9 @@ interface={{ iface }}
 {%             for vlan in iface_config.vlan %}
 interface=re:^{{ iface }}\.{{ vlan | range_to_regex }}$
 {%             endfor %}
+{%             if iface_config.vlan_mon is vyos_defined %}
 vlan-mon={{ iface }},{{ iface_config.vlan | join(',') }}
+{%             endif %}
 {%         endif %}
 {%     endfor %}
 {% endif %}

--- a/interface-definitions/include/accel-ppp/vlan-mon.xml.i
+++ b/interface-definitions/include/accel-ppp/vlan-mon.xml.i
@@ -1,0 +1,8 @@
+<!-- include start from accel-ppp/vlan-mon.xml.i -->
+<leafNode name="vlan-mon">
+  <properties>
+    <help>Automatically create VLAN interfaces</help>
+    <valueless/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/version/ipoe-server-version.xml.i
+++ b/interface-definitions/include/version/ipoe-server-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/ipoe-server-version.xml.i -->
-<syntaxVersion component='ipoe-server' version='3'></syntaxVersion>
+<syntaxVersion component='ipoe-server' version='4'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/include/version/pppoe-server-version.xml.i
+++ b/interface-definitions/include/version/pppoe-server-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/pppoe-server-version.xml.i -->
-<syntaxVersion component='pppoe-server' version='10'></syntaxVersion>
+<syntaxVersion component='pppoe-server' version='11'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/service_ipoe-server.xml.in
+++ b/interface-definitions/service_ipoe-server.xml.in
@@ -175,6 +175,7 @@
                 </children>
               </node>
               #include <include/accel-ppp/vlan.xml.i>
+              #include <include/accel-ppp/vlan-mon.xml.i>
             </children>
           </tagNode>
           #include <include/accel-ppp/client-ip-pool.xml.i>

--- a/interface-definitions/service_pppoe-server.xml.in
+++ b/interface-definitions/service_pppoe-server.xml.in
@@ -64,6 +64,7 @@
             </properties>
             <children>
               #include <include/accel-ppp/vlan.xml.i>
+              #include <include/accel-ppp/vlan-mon.xml.i>
             </children>
           </tagNode>
           <leafNode name="service-name">

--- a/smoketest/scripts/cli/test_service_pppoe-server.py
+++ b/smoketest/scripts/cli/test_service_pppoe-server.py
@@ -21,6 +21,7 @@ from base_accel_ppp_test import BasicAccelPPPTest
 from configparser import ConfigParser
 from vyos.utils.file import read_file
 from vyos.template import range_to_regex
+from vyos.configsession import ConfigSessionError
 
 local_if = ['interfaces', 'dummy', 'dum667']
 ac_name = 'ACN'
@@ -132,6 +133,12 @@ class TestServicePPPoEServer(BasicAccelPPPTest.TestCase):
 
         # Test configuration of local authentication for PPPoE server
         self.basic_config()
+
+        self.set(['interface', interface, 'vlan-mon'])
+
+        # cannot use option "vlan-mon" if no "vlan" set
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
 
         for vlan in vlans:
             self.set(['interface', interface, 'vlan', vlan])

--- a/src/conf_mode/service_ipoe-server.py
+++ b/src/conf_mode/service_ipoe-server.py
@@ -70,6 +70,8 @@ def verify(ipoe):
         if 'client_subnet' in iface_config and 'vlan' in iface_config:
             raise ConfigError('Option "client-subnet" and "vlan" are mutually exclusive, '
                               'use "client-ip-pool" instead!')
+        if 'vlan_mon' in iface_config and not 'vlan' in iface_config:
+            raise ConfigError('Option "vlan-mon" requires "vlan" to be set!')
 
     verify_accel_ppp_authentication(ipoe, local_users=False)
     verify_accel_ppp_ip_pool(ipoe)

--- a/src/conf_mode/service_pppoe-server.py
+++ b/src/conf_mode/service_pppoe-server.py
@@ -121,8 +121,11 @@ def verify(pppoe):
         raise ConfigError('At least one listen interface must be defined!')
 
     # Check is interface exists in the system
-    for interface in pppoe['interface']:
+    for interface, interface_config in pppoe['interface'].items():
         verify_interface_exists(pppoe, interface, warning_only=True)
+
+        if 'vlan_mon' in interface_config and not 'vlan' in interface_config:
+            raise ConfigError('Option "vlan-mon" requires "vlan" to be set!')
 
     return None
 

--- a/src/migration-scripts/ipoe-server/3-to-4
+++ b/src/migration-scripts/ipoe-server/3-to-4
@@ -1,0 +1,30 @@
+# Copyright 2024 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# Add the "vlan-mon" option to the configuration to prevent it
+# from disappearing from the configuration file
+
+from vyos.configtree import ConfigTree
+
+base = ['service', 'ipoe-server']
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(base):
+        return
+
+    for interface in config.list_nodes(base + ['interface']):
+        base_path = base + ['interface', interface]
+        if config.exists(base_path + ['vlan']):
+            config.set(base_path + ['vlan-mon'])

--- a/src/migration-scripts/pppoe-server/10-to-11
+++ b/src/migration-scripts/pppoe-server/10-to-11
@@ -1,0 +1,30 @@
+# Copyright 2024 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# Add the "vlan-mon" option to the configuration to prevent it
+# from disappearing from the configuration file
+
+from vyos.configtree import ConfigTree
+
+base = ['service', 'pppoe-server']
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(base):
+        return
+
+    for interface in config.list_nodes(base + ['interface']):
+        base_path = base + ['interface', interface]
+        if config.exists(base_path + ['vlan']):
+            config.set(base_path + ['vlan-mon'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6649
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipoe-server, pppoe-server
## Proposed changes
<!--- Describe your changes in detail -->
Added ability to enable ```vlan-mon``` option and not to use it by default
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set service ipoe-server authentication mode 'radius'
set service ipoe-server authentication radius server 192.168.122.14 key 'vyos-secret'
set service ipoe-server client-ip-pool ONE range '100.64.0.1-100.64.0.10'
set service ipoe-server default-pool 'ONE'
set service ipoe-server gateway-address '100.64.0.14/28'
set service ipoe-server name-server '1.1.1.1'
set service ipoe-server name-server '8.8.8.8'
set service ipoe-server interface eth1 vlan '5-20'
set service ipoe-server interface eth1 vlan-mon
commit

vyos@vyos# cat /run/accel-pppd/ipoe.conf | grep vlan-mon
vlan-mon=eth1,5-20

```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Ipoe-server tests:
```
vyos@vyos# python3 /usr/libexec/vyos/tests/smoke/cli/test_service_ipoe-server.py
test_accel_ipv4_pool (__main__.TestServiceIPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServiceIPoEServer.test_accel_ipv6_pool) ... ok
test_accel_limits (__main__.TestServiceIPoEServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestServiceIPoEServer.test_accel_local_authentication) ... ok
test_accel_log_level (__main__.TestServiceIPoEServer.test_accel_log_level) ... ok
test_accel_name_servers (__main__.TestServiceIPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServiceIPoEServer.test_accel_next_pool) ... ok
test_accel_ppp_options (__main__.TestServiceIPoEServer.test_accel_ppp_options) ... skipped 'PPP is not a part of IPoE'
test_accel_radius_authentication (__main__.TestServiceIPoEServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestServiceIPoEServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestServiceIPoEServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestServiceIPoEServer.test_accel_wins_server) ... skipped 'WINS server is not used in IPoE'
test_ipoe_server_vlan (__main__.TestServiceIPoEServer.test_ipoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 13 tests in 61.904s

OK (skipped=2)
[edit]
vyos@vyos#
```
PPPoe-server tests:
```
vyos@vyos# python3 /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py
test_accel_ipv4_pool (__main__.TestServicePPPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServicePPPoEServer.test_accel_ipv6_pool) ... ok
test_accel_limits (__main__.TestServicePPPoEServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestServicePPPoEServer.test_accel_local_authentication) ... ok
test_accel_log_level (__main__.TestServicePPPoEServer.test_accel_log_level) ... ok
test_accel_name_servers (__main__.TestServicePPPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServicePPPoEServer.test_accel_next_pool) ... ok
test_accel_ppp_options (__main__.TestServicePPPoEServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestServicePPPoEServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestServicePPPoEServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestServicePPPoEServer.test_accel_wins_server) ... ok
test_pppoe_limits (__main__.TestServicePPPoEServer.test_pppoe_limits) ... ok
test_pppoe_server_any_login (__main__.TestServicePPPoEServer.test_pppoe_server_any_login) ... ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer.test_pppoe_server_authentication_protocols) ... ok
test_pppoe_server_pado_delay (__main__.TestServicePPPoEServer.test_pppoe_server_pado_delay) ... ok
test_pppoe_server_shaper (__main__.TestServicePPPoEServer.test_pppoe_server_shaper) ... ok
test_pppoe_server_vlan (__main__.TestServicePPPoEServer.test_pppoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 18 tests in 111.528s

OK
[edit]
vyos@vyos#
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
