### PR TITLE
T6659: suricata: use unique cluster_id per interface

### DIFF
--- a/data/templates/ids/suricata.j2
+++ b/data/templates/ids/suricata.j2
@@ -79,7 +79,7 @@ af-packet:
 {% for interface in suricata.interface %}
   - interface: {{ interface }}
     # Default clusterid. AF_PACKET will load balance packets based on flow.
-    cluster-id: 99
+    cluster-id: {{ 100 - loop.index }}
     # Default AF_PACKET cluster type. AF_PACKET can load balance per flow or per hash.
     # This is only supported for Linux kernel > 3.1
     # possible value are:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

If I assign suricata to monitor more than one interface, the suricata process consumes 100% CPU for about 30 seconds at startup, then crashes and repeats.

This appears to be because we use the same "cluster-id: 99" for every interface under the "af-packet" section of the YAML config. I am relatively new to configuring this daemon, but from a quick perusal of documentation and reference materials I could find, a unique cluster_id is expected for every interface (these can simply be incrementing or decrementing numbers—it's not clear what the acceptable range is or whether it is possible to conflict with other applications).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
https://vyos.dev/T6659

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
suricata

## Proposed changes
<!--- Describe your changes in detail -->

This changes 

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

You'll need a basic Suricata config with at least two interfaces configured:
```
set service suricata address-group aim-servers group 'external-net'
set service suricata address-group dc-servers group 'home-net'
set service suricata address-group dnp3-client group 'home-net'
set service suricata address-group dnp3-server group 'home-net'
set service suricata address-group dns-servers group 'home-net'
set service suricata address-group enip-client group 'home-net'
set service suricata address-group enip-server group 'home-net'
set service suricata address-group external-net group '!home-net'
set service suricata address-group home-net address '10.0.0.0/8'
set service suricata address-group http-servers group 'home-net'
set service suricata address-group modbus-client group 'home-net'
set service suricata address-group modbus-server group 'home-net'
set service suricata address-group smtp-servers group 'home-net'
set service suricata address-group sql-servers group 'home-net'
set service suricata address-group telnet-servers group 'home-net'
set service suricata interface 'eth1'
set service suricata interface 'eth2'
set service suricata log eve type 'alert'
set service suricata log eve type 'anomaly'
set service suricata port-group dnp3-ports port '20000'
set service suricata port-group file-data-ports group 'http-ports'
set service suricata port-group file-data-ports port '110'
set service suricata port-group file-data-ports port '143'
set service suricata port-group ftp-ports port '21'
set service suricata port-group geneve-ports port '6081'
set service suricata port-group http-ports port '80'
set service suricata port-group modbus-port port '502'
set service suricata port-group oracle-ports port '1521'
set service suricata port-group shellcode-ports group '!http-ports'
set service suricata port-group ssh-ports port '22'
set service suricata port-group teredo-ports port '3544'
set service suricata port-group vxlan-ports port '4789'
```

(unfortunately with the required default dictionaries the config is pretty large)

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
There are currently no smoketests for Suricata.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
