### PR TITLE
T6672: Fix system option ssh-client source-interface

### DIFF
--- a/smoketest/scripts/cli/test_system_option.py
+++ b/smoketest/scripts/cli/test_system_option.py
@@ -80,5 +80,20 @@ class TestSystemOption(VyOSUnitTestSHIM.TestCase):
         self.assertEqual(sysctl_read('net.ipv4.neigh.default.gc_thresh2'), gc_thresh2)
         self.assertEqual(sysctl_read('net.ipv4.neigh.default.gc_thresh3'), gc_thresh3)
 
+    def test_ssh_client_options(self):
+        loopback = 'lo'
+        ssh_client_opt_file = '/etc/ssh/ssh_config.d/91-vyos-ssh-client-options.conf'
+
+        self.cli_set(['system', 'option', 'ssh-client', 'source-interface', loopback])
+        self.cli_commit()
+
+        tmp = read_file(ssh_client_opt_file)
+        self.assertEqual(tmp, f'BindInterface {loopback}')
+
+        self.cli_delete(['system', 'option'])
+        self.cli_commit()
+        self.assertFalse(os.path.exists(ssh_client_opt_file))
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=True)

--- a/src/conf_mode/system_option.py
+++ b/src/conf_mode/system_option.py
@@ -85,6 +85,8 @@ def verify(options):
                 raise ConfigError('No interface with address "{address}" configured!')
 
         if 'source_interface' in config:
+            # verify_source_interface reuires key 'ifname'
+            config['ifname'] = config['source_interface']
             verify_source_interface(config)
             if 'source_address' in config:
                 address = config['source_address']


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix for system option ssh-client source-interface
For the `verify_source_interface` the key `ifname` is required

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6672

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Before the fix
```
vyos@r14# set system option ssh-client source-interface lo 
[edit]
vyos@r14# commit
[ system option ]
VyOS had an issue completing a command.

Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/system_option.py", line 190, in <module>
    verify(c)
  File "/usr/libexec/vyos/conf_mode/system_option.py", line 88, in verify
    verify_source_interface(config)
  File "/usr/lib/python3/dist-packages/vyos/configverify.py", line 276, in verify_source_interface
    ifname = config['ifname']
             ~~~~~~^^^^^^^^^^
KeyError: 'ifname'

[[system option]] failed
Commit failed
[edit]
vyos@r14# 

```
After the fix:
```
vyos@r14# set system option ssh-client source-interface lo 
[edit]
vyos@r14# commit
[edit]
vyos@r14# cat /etc/ssh/ssh_config.d/91-vyos-ssh-client-options.conf 
BindInterface lo
[edit]
vyos@r14# 

```
## Smoketest result
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_option.py
test_ctrl_alt_delete (__main__.TestSystemOption.test_ctrl_alt_delete) ... ok
test_performance (__main__.TestSystemOption.test_performance) ... ok
test_reboot_on_panic (__main__.TestSystemOption.test_reboot_on_panic) ... ok
test_ssh_client_options (__main__.TestSystemOption.test_ssh_client_options) ... ok

----------------------------------------------------------------------
Ran 4 tests in 24.152s

OK
vyos@r14:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
