### PR TITLE
dhclient: T6667: Added workaround for communication with FRR

### DIFF
--- a/src/etc/dhcp/dhclient-enter-hooks.d/03-vyos-ipwrapper
+++ b/src/etc/dhcp/dhclient-enter-hooks.d/03-vyos-ipwrapper
@@ -72,6 +72,22 @@ function delroute () {
     fi
 }
 
+# try to communicate with vtysh
+function vtysh_conf () {
+    # perform 10 attempts with 1 second delay for retries
+    for i in {1..10} ; do
+        if vtysh  -c "conf t" -c "$1" ; then
+            logmsg info "Command was executed successfully via vtysh: \"$1\""
+            return 0
+        else
+            logmsg info "Failed to send command to vtysh, retrying in 1 second"
+            sleep 1
+        fi
+    done
+    logmsg error "Failed to execute command via vtysh after 10 attempts: \"$1\""
+    return 1
+}
+
 # replace ip command with this wrapper
 function ip () {
     # pass comand to system `ip` if this is not related to routes change
@@ -84,7 +100,7 @@ function ip () {
             delroute ${@:4}
             iptovtysh $@
             logmsg info "Sending command to vtysh"
-            vtysh -c "conf t" -c "$VTYSH_CMD"
+            vtysh_conf "$VTYSH_CMD"
         else
             # add ip route to kernel
             logmsg info "Modifying routes in kernel: \"/usr/sbin/ip $@\""


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added workaround for communication with FRR

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6667

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhclient

## Proposed changes
<!--- Describe your changes in detail -->
To increase the chance for dhclient to configure routes in FRR, added a workaround. Now 10 attempts are performed with 1 second delay and only after this dhclient gives up.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Unfortunately, the issue is hard to catch, using VyOS config scripts only, without explicitly forcing it.
More details about reproducing are in: https://vyos.dev/T6667

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
