### PR TITLE
T6561: Add vrf aware for show ntp

### DIFF
--- a/op-mode-definitions/ntp.xml.in
+++ b/op-mode-definitions/ntp.xml.in
@@ -6,25 +6,25 @@
         <properties>
           <help>Show peer status of NTP daemon</help>
         </properties>
-        <command>${vyos_op_scripts_dir}/ntp.py show_sourcestats</command>
+        <command>sudo ${vyos_op_scripts_dir}/ntp.py show_sourcestats</command>
         <children>
           <node name="activity">
             <properties>
               <help>Report the number of servers and peers that are online and offline</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/ntp.py show_activity</command>
+            <command>sudo ${vyos_op_scripts_dir}/ntp.py show_activity</command>
           </node>
           <node name="sources">
             <properties>
               <help>Show information about the current time sources being accessed</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/ntp.py show_sources</command>
+            <command>sudo ${vyos_op_scripts_dir}/ntp.py show_sources</command>
           </node>
           <node name="system">
             <properties>
               <help>Show parameters about the system clock performance</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/ntp.py show_tracking</command>
+            <command>sudo ${vyos_op_scripts_dir}/ntp.py show_tracking</command>
           </node>
         </children>
       </node>

--- a/src/op_mode/ntp.py
+++ b/src/op_mode/ntp.py
@@ -110,49 +110,62 @@ def _is_configured():
     if not config.exists("service ntp"):
         raise vyos.opmode.UnconfiguredSubsystem("NTP service is not enabled.")
 
+def _extend_command_vrf():
+    config = ConfigTreeQuery()
+    if config.exists('service ntp vrf'):
+        vrf = config.value('service ntp vrf')
+        return f'ip vrf exec {vrf} '
+    return ''
+
+
 def show_activity(raw: bool):
     _is_configured()
     command = f'chronyc'
 
     if raw:
-       command += f" -c activity"
-       return _get_raw_data(command)
+        command += f" -c activity"
+        return _get_raw_data(command)
     else:
-       command += f" activity"
-       return cmd(command)
+        command = _extend_command_vrf() + command
+        command += f" activity"
+        return cmd(command)
 
 def show_sources(raw: bool):
     _is_configured()
     command = f'chronyc'
 
     if raw:
-       command += f" -c sources"
-       return _get_raw_data(command)
+        command += f" -c sources"
+        return _get_raw_data(command)
     else:
-       command += f" sources -v"
-       return cmd(command)
+        command = _extend_command_vrf() + command
+        command += f" sources -v"
+        return cmd(command)
 
 def show_tracking(raw: bool):
     _is_configured()
     command = f'chronyc'
 
     if raw:
-       command += f" -c tracking"
-       return _get_raw_data(command)
+        command += f" -c tracking"
+        return _get_raw_data(command)
     else:
-       command += f" tracking"
-       return cmd(command)
+        command = _extend_command_vrf() + command
+        command += f" tracking"
+        return cmd(command)
 
 def show_sourcestats(raw: bool):
     _is_configured()
     command = f'chronyc'
 
     if raw:
-       command += f" -c sourcestats"
-       return _get_raw_data(command)
+        command += f" -c sourcestats"
+        return _get_raw_data(command)
     else:
-       command += f" sourcestats -v"
-       return cmd(command)
+        command = _extend_command_vrf() + command
+        command += f" sourcestats -v"
+        return cmd(command)
+
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add vrf aware for `show ntp`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6561

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces ethernet eth0 address '192.168.122.14/24'
set interfaces ethernet eth0 vrf 'MGMT'
set service ntp allow-client address '127.0.0.0/8'
set service ntp allow-client address '169.254.0.0/16'
set service ntp allow-client address '10.0.0.0/8'
set service ntp allow-client address '172.16.0.0/12'
set service ntp allow-client address '192.168.0.0/16'
set service ntp allow-client address '::1/128'
set service ntp allow-client address 'fe80::/10'
set service ntp allow-client address 'fc00::/7'
set service ntp server time1.vyos.net
set service ntp server time2.vyos.net
set service ntp server time3.vyos.net
set service ntp vrf 'MGMT'
set service ssh vrf 'MGMT'
set service ssh vrf 'default'
set vrf bind-to-all
set vrf name MGMT protocols static route 0.0.0.0/0 next-hop 192.168.122.1
set vrf name MGMT table '123'

```
Before the fix:
```
$ show ntp
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/ntp.py", line 159, in <module>
    res = vyos.opmode.run(sys.modules[__name__])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/opmode.py", line 263, in run
    res = func(**args)
          ^^^^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/ntp.py", line 155, in show_sourcestats
    return cmd(command)
           ^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/utils/process.py", line 155, in cmd
    raise OSError(code, feedback)
PermissionError: [Errno 1] failed to run command: chronyc sourcestats -v
returned: 506 Cannot talk to daemon
exit code: 1
```
After the fix:
```
vyos@r14:~$ show ntp 
.- Number of sample points in measurement set.
                            /    .- Number of residual runs with same sign.
                           |    /    .- Length of measurement set (time).
                           |   |    /      .- Est. clock freq error (ppm).
                           |   |   |      /           .- Est. error in freq.
                           |   |   |     |           /         .- Est. offset.
                           |   |   |     |          |          |   On the -.
                           |   |   |     |          |          |   samples. \
                           |   |   |     |          |          |             |
Name/IP Address            NP  NR  Span  Frequency  Freq Skew  Offset  Std Dev
==============================================================================
ec2-34-206-168-146.compu>  31  15   70m     +0.225      0.056  +1275us   112us
ec2-18-193-41-138.eu-cen>  31  13   70m     -0.305      0.070   -942us   119us
ec2-122-248-201-177.ap-s>   6   3   52m     -2.587      0.901   +332us   252us
vyos@r14:~$ 
vyos@r14:~$ 

vyos@r14:~$ show ntp activity 
200 OK
3 sources online
0 sources offline
0 sources doing burst (return to online)
0 sources doing burst (return to offline)
0 sources with unknown address
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ show ntp sources 
.-- Source mode  '^' = server, '=' = peer, '#' = local clock.
 / .- Source state '*' = current best, '+' = combined, '-' = not combined,
| /             'x' = may be in error, '~' = too variable, '?' = unusable.
||                                                 .- xxxx [ yyyy ] +/- zzzz
||      Reachability register (octal) -.           |  xxxx = adjusted offset,
||      Log2(Polling interval) --.      |          |  yyyy = measured offset,
||                                \     |          |  zzzz = estimated error.
||                                 |    |           \
MS Name/IP address         Stratum Poll Reach LastRx Last sample               
===============================================================================
^+ ec2-34-206-168-146.compu>     3  10   377   310  +1101us[+1101us] +/-  130ms
^* ec2-18-193-41-138.eu-cen>     3  10   377   323   -814us[ -880us] +/-   86ms
^- ec2-122-248-201-177.ap-s>     2   8   337   822  +1095us[+1032us] +/-  174ms
vyos@r14:~$ 
vyos@r14:~$ 

vyos@r14:~$ show ntp system 
Reference ID    : 12C1298A (ec2-18-193-41-138.eu-central-1.compute.amazonaws.com)
Stratum         : 4
Ref time (UTC)  : Thu Aug 22 13:10:15 2024
System time     : 0.000009878 seconds fast of NTP time
Last offset     : -0.000066325 seconds
RMS offset      : 0.000187446 seconds
Frequency       : 19.087 ppm slow
Residual freq   : -0.001 ppm
Skew            : 0.053 ppm
Root delay      : 0.045273069 seconds
Root dispersion : 0.052451510 seconds
Update interval : 516.6 seconds
Leap status     : Normal
vyos@r14:~$ 
vyos@r14:~$ 
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
