### PR TITLE
T6671: defer config dependency if scheduled in priority queue

### DIFF
--- a/python/vyos/utils/dict.py
+++ b/python/vyos/utils/dict.py
@@ -267,6 +267,7 @@ def dict_to_paths_values(conf: dict) -> dict:
         dict_of_options[path] = dict_search(path,conf)
 
     return dict_of_options
+
 def dict_to_key_paths(d: dict) -> list:
     """ Generator to return list of key paths from dict of list[str]|str
     """

--- a/python/vyos/xml_ref/__init__.py
+++ b/python/vyos/xml_ref/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2024 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -54,8 +54,8 @@ def is_valueless(path: list) -> bool:
 def is_leaf(path: list) -> bool:
     return load_reference().is_leaf(path)
 
-def owner(path: list) -> str:
-    return load_reference().owner(path)
+def owner(path: list, with_tag=False) -> str:
+    return load_reference().owner(path, with_tag=with_tag)
 
 def priority(path: list) -> str:
     return load_reference().priority(path)

--- a/python/vyos/xml_ref/definition.py
+++ b/python/vyos/xml_ref/definition.py
@@ -1,4 +1,4 @@
-# Copyright 2023 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2024 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -139,28 +139,38 @@ class Xml:
         ref_path = path.copy()
         d = self.ref
         data = ''
+        tag = ''
         while ref_path and d:
+            tag_val = ''
             d = d.get(ref_path[0], {})
             ref_path.pop(0)
             if self._is_tag_node(d) and ref_path:
+                tag_val = ref_path[0]
                 ref_path.pop(0)
             if self._is_leaf_node(d) and ref_path:
                 ref_path.pop(0)
             res = self._get_ref_node_data(d, name)
             if res is not None:
                 data = res
+                tag = tag_val
 
-        return data
+        return data, tag
 
-    def owner(self, path: list) -> str:
+    def owner(self, path: list, with_tag=False) -> str:
         from pathlib import Path
-        data = self._least_upper_data(path, 'owner')
+        data, tag = self._least_upper_data(path, 'owner')
+        tag_ext = f'_{tag}' if tag else ''
         if data:
-            data = Path(data.split()[0]).name
+            if with_tag:
+                data = Path(data.split()[0]).stem
+                data = f'{data}{tag_ext}'
+            else:
+                data = Path(data.split()[0]).name
         return data
 
     def priority(self, path: list) -> str:
-        return self._least_upper_data(path, 'priority')
+        data, _ = self._least_upper_data(path, 'priority')
+        return data
 
     @staticmethod
     def _dict_get(d: dict, path: list) -> dict:

--- a/smoketest/scripts/cli/test_config_dependency.py
+++ b/smoketest/scripts/cli/test_config_dependency.py
@@ -16,13 +16,39 @@
 
 
 import unittest
+from time import sleep
+
+from vyos.utils.process import is_systemd_service_running
+from vyos.utils.process import cmd
+from vyos.configsession import ConfigSessionError
 
 from base_vyostest_shim import VyOSUnitTestSHIM
 
-from vyos.configsession import ConfigSessionError
-
 
 class TestConfigDep(VyOSUnitTestSHIM.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # smoketests are run without configd in 1.4; with configd in 1.5
+        # the tests below check behavior under configd:
+        # test_configdep_error checks for regression under configd (T6559)
+        # test_configdep_prio_queue checks resolution under configd (T6671)
+        cls.running_state = is_systemd_service_running('vyos-configd.service')
+
+        if not cls.running_state:
+            cmd('sudo systemctl start vyos-configd.service')
+            # allow time for init
+            sleep(1)
+
+        super(TestConfigDep, cls).setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestConfigDep, cls).tearDownClass()
+
+        # return to running_state
+        if not cls.running_state:
+            cmd('sudo systemctl stop vyos-configd.service')
+
     def test_configdep_error(self):
         address_group = 'AG'
         address = '192.168.137.5'
@@ -43,6 +69,61 @@ class TestConfigDep(VyOSUnitTestSHIM.TestCase):
 
         # clean up remaining
         self.cli_delete(['nat'])
+        self.cli_commit()
+
+    def test_configdep_prio_queue(self):
+        # confirm that that a dependency (in this case, conntrack ->
+        # conntrack-sync) is not immediately called if the target is
+        # scheduled in the priority queue, indicating that it may require an
+        # intermediate activitation (bond0)
+        bonding_base = ['interfaces', 'bonding']
+        bond_interface = 'bond0'
+        bond_address = '192.0.2.1/24'
+        vrrp_group_base = ['high-availability', 'vrrp', 'group']
+        vrrp_sync_group_base = ['high-availability', 'vrrp', 'sync-group']
+        vrrp_group = 'ETH2'
+        vrrp_sync_group = 'GROUP'
+        conntrack_sync_base = ['service', 'conntrack-sync']
+        conntrack_peer = '192.0.2.77'
+
+        # simple set to trigger in-session conntrack -> conntrack-sync
+        # dependency; note that this is triggered on boot in 1.4 due to
+        # default 'system conntrack modules'
+        self.cli_set(['system', 'conntrack', 'table-size', '524288'])
+
+        self.cli_set(['interfaces', 'ethernet', 'eth2', 'address',
+                      '198.51.100.2/24'])
+
+        self.cli_set(bonding_base + [bond_interface, 'address',
+                                     bond_address])
+        self.cli_set(bonding_base + [bond_interface, 'member', 'interface',
+                                     'eth3'])
+
+        self.cli_set(vrrp_group_base + [vrrp_group, 'address',
+                                        '198.51.100.200/24'])
+        self.cli_set(vrrp_group_base + [vrrp_group, 'hello-source-address',
+                                        '198.51.100.2'])
+        self.cli_set(vrrp_group_base + [vrrp_group, 'interface', 'eth2'])
+        self.cli_set(vrrp_group_base + [vrrp_group, 'priority', '200'])
+        self.cli_set(vrrp_group_base + [vrrp_group, 'vrid', '22'])
+        self.cli_set(vrrp_sync_group_base + [vrrp_sync_group, 'member',
+                                             vrrp_group])
+
+        self.cli_set(conntrack_sync_base + ['failover-mechanism', 'vrrp',
+                                            'sync-group', vrrp_sync_group])
+
+        self.cli_set(conntrack_sync_base + ['interface', bond_interface,
+                                            'peer', conntrack_peer])
+
+        self.cli_commit()
+
+        # clean up
+        self.cli_delete(bonding_base)
+        self.cli_delete(vrrp_group_base)
+        self.cli_delete(vrrp_sync_group_base)
+        self.cli_delete(conntrack_sync_base)
+        self.cli_delete(['interfaces', 'ethernet', 'eth2', 'address'])
+        self.cli_delete(['system', 'conntrack', 'table-size'])
         self.cli_commit()
 
 if __name__ == '__main__':

--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -30,6 +30,7 @@ from vyos.defaults import directories
 from vyos.utils.boot import boot_configuration_complete
 from vyos.configsource import ConfigSourceString
 from vyos.configsource import ConfigSourceError
+from vyos.configdiff import get_commit_scripts
 from vyos.config import Config
 from vyos import ConfigError
 
@@ -220,6 +221,12 @@ def initialization(socket):
     dependent_func: dict[str, list[typing.Callable]] = {}
     setattr(config, 'dependent_func', dependent_func)
 
+    commit_scripts = get_commit_scripts(config)
+    logger.debug(f'commit_scripts: {commit_scripts}')
+
+    scripts_called = []
+    setattr(config, 'scripts_called', scripts_called)
+
     return config
 
 def process_node_data(config, data, last: bool = False) -> int:
@@ -228,6 +235,7 @@ def process_node_data(config, data, last: bool = False) -> int:
         return R_ERROR_DAEMON
 
     script_name = None
+    os.environ['VYOS_TAGNODE_VALUE'] = ''
     args = []
     config.dependency_list.clear()
 
@@ -243,6 +251,12 @@ def process_node_data(config, data, last: bool = False) -> int:
     if res.group(3):
         args = res.group(3).split()
     args.insert(0, f'{script_name}.py')
+
+    tag_value = os.getenv('VYOS_TAGNODE_VALUE', '')
+    tag_ext = f'_{tag_value}' if tag_value else ''
+    script_record = f'{script_name}{tag_ext}'
+    scripts_called = getattr(config, 'scripts_called', [])
+    scripts_called.append(script_record)
 
     if script_name not in include_set:
         return R_PASS
@@ -302,11 +316,12 @@ if __name__ == '__main__':
             socket.send(resp.encode())
             config = initialization(socket)
         elif message["type"] == "node":
-            if message["last"]:
-                logger.debug(f'final element of priority queue')
             res = process_node_data(config, message["data"], message["last"])
             response = res.to_bytes(1, byteorder=sys.byteorder)
             logger.debug(f"Sending response {res}")
             socket.send(response)
+            if message["last"] and config:
+                scripts_called = getattr(config, 'scripts_called', [])
+                logger.debug(f'scripts_called: {scripts_called}')
         else:
             logger.critical(f"Unexpected message: {message}")


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

If a config dependency is scheduled to run later in the priority queue, defer instead of running immediately from the source script of the dependency. This avoids running a script too early, if it will require the result of an intermediate script in the priority order. For example:

```
            dep
conntrack  ---->  conntrack-sync
   prio \            / prio
      interfaces_bonding

```

This becomes evident in 1.4 on boot with a suitable configuration, given the presence of the default conntrack modules entries (resolved in 1.5 for new installs; T3275). However, it indicates a general issue, which has a simple resolution in this PR.

Note that this is not apparent in 1.4.0, as there was a earlier pruning mechanism in place for config dependency scripts; that had to be dropped given other issues (T6559; also due to conntrack modules, which provides a useful canary given its low priority) and replaced by a smarter approach in this PR.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketest added in PR.

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
