### PR TITLE
T6647: firewall. Introduce patch for accepting invalid ARP and DHCP

### DIFF
--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -376,8 +376,14 @@ table bridge vyos_filter {
 
 {%     if bridge.output is vyos_defined %}
 {%         for prior, conf in bridge.output.items() %}
-    chain VYOS_OUTUT_{{ prior }} {
+    chain VYOS_OUTPUT_{{ prior }} {
         type filter hook output priority {{ prior }}; policy accept;
+{%             if global_options.apply_to_bridged_traffic is vyos_defined %}
+{%                 if 'invalid_connections' in global_options.apply_to_bridged_traffic %}
+        ct state invalid udp sport 67 udp dport 68 counter accept
+        ct state invalid ether type arp counter accept
+{%                 endif %}
+{%             endif %}
 {%             if global_options.state_policy is vyos_defined %}
         jump VYOS_STATE_POLICY
 {%             endif %}

--- a/interface-definitions/include/firewall/common-rule-bridge.xml.i
+++ b/interface-definitions/include/firewall/common-rule-bridge.xml.i
@@ -10,6 +10,7 @@
 #include <include/firewall/limit.xml.i>
 #include <include/firewall/log.xml.i>
 #include <include/firewall/log-options.xml.i>
+#include <include/firewall/match-ether-type.xml.i>
 #include <include/firewall/match-ipsec.xml.i>
 #include <include/firewall/match-vlan.xml.i>
 #include <include/firewall/nft-queue.xml.i>

--- a/interface-definitions/include/firewall/global-options.xml.i
+++ b/interface-definitions/include/firewall/global-options.xml.i
@@ -49,6 +49,12 @@
         <help>Apply configured firewall rules to traffic switched by bridges</help>
       </properties>
       <children>
+        <leafNode name="invalid-connections">
+          <properties>
+            <help>Accept ARP and DHCP despite they are marked as invalid connection</help>
+            <valueless/>
+          </properties>
+        </leafNode>
         <leafNode name="ipv4">
           <properties>
             <help>Apply configured IPv4 firewall rules</help>

--- a/interface-definitions/include/firewall/match-ether-type.xml.i
+++ b/interface-definitions/include/firewall/match-ether-type.xml.i
@@ -1,0 +1,30 @@
+<!-- include start from firewall/match-ether-type.xml.i -->
+<leafNode name="ethernet-type">
+  <properties>
+    <help>Ethernet type</help>
+    <completionHelp>
+      <list>802.1q 802.1ad arp ipv4 ipv6</list>
+    </completionHelp>
+    <valueHelp>
+      <format>802.1q</format>
+      <description>Customer VLAN tag type</description>
+    </valueHelp>
+    <valueHelp>
+      <format>802.1ad</format>
+      <description>Service VLAN tag type</description>
+    </valueHelp>
+    <valueHelp>
+      <format>arp</format>
+      <description>Adress Resolution Protocol</description>
+    </valueHelp>
+    <valueHelp>
+      <format>_ipv4</format>
+      <description>Internet Protocol version 4</description>
+    </valueHelp>
+    <valueHelp>
+      <format>_ipv6</format>
+      <description>Internet Protocol version 6</description>
+    </valueHelp>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -151,6 +151,20 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
             proto = '{tcp, udp}'
         output.append(f'meta l4proto {operator} {proto}')
 
+    if 'ethernet_type' in rule_conf:
+        ether_type_mapping = {
+            '802.1q': '8021q',
+            '802.1ad': '8021ad',
+            'ipv6': 'ip6',
+            'ipv4': 'ip',
+            'arp': 'arp'
+        }
+        ether_type = rule_conf['ethernet_type']
+        operator = '!=' if ether_type.startswith('!') else ''
+        ether_type = ether_type.lstrip('!')
+        ether_type = ether_type_mapping.get(ether_type, ether_type)
+        output.append(f'ether type {operator} {ether_type}')
+
     for side in ['destination', 'source']:
         if side in rule_conf:
             prefix = side[0]


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Introduce patch for accepting invalid ARP and DHCP in stateful bridge firewall. This patch is needed because ARP and DHCP are marked as invalid connections.
Also, add ehternet-type matcher in bridge firewall.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6647

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

At first  we tried accepting ARP packets with the new option `ehternet-type`. This was not enough because if global state policies were configured, this rules were evaluated before custom rules, so ARP replies, which are flaged as INVALID still got droped.
So now there's a new global-option for bridge firewall, which accepts invalid connections for the two known scenarios where this connections are marked as invalid:
 * For DHCP: when bridge is configured as a DHCP server
 * For ARP. 

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@bri# run show config comm | grep firewall
set firewall bridge prerouting filter rule 10 action 'accept'
set firewall bridge prerouting filter rule 10 ethernet-type 'arp'
set firewall global-options apply-to-bridged-traffic invalid-connections
set firewall global-options state-policy established action 'accept'
set firewall global-options state-policy invalid action 'drop'
set firewall global-options state-policy related action 'accept'
[edit]
vyos@bri# 
```
And nftables output:
```
vyos@bri# sudo nft -s list table bridge vyos_filter
table bridge vyos_filter {
        chain VYOS_FORWARD_filter {
                type filter hook forward priority filter; policy accept;
                jump VYOS_STATE_POLICY
                counter accept comment "FWD-filter default-action accept"
        }

        chain VYOS_INPUT_filter {
                type filter hook input priority filter; policy accept;
                jump VYOS_STATE_POLICY
                counter accept comment "INP-filter default-action accept"
        }

        chain VYOS_OUTPUT_filter {
                type filter hook output priority filter; policy accept;
                ct state invalid udp sport 67 udp dport 68 counter accept
                ct state invalid ether type arp counter accept
                jump VYOS_STATE_POLICY
                counter accept comment "OUT-filter default-action accept"
        }

        chain VYOS_PREROUTING_filter {
                type filter hook prerouting priority filter; policy accept;
                ether type arp counter accept comment "bri-PRE-filter-10"
                counter accept comment "PRE-filter default-action accept"
        }

        chain VYOS_STATE_POLICY {
                ct state established counter accept
                ct state invalid counter drop
                ct state related counter accept
                return
        }
}
[edit]
vyos@bri# 
```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
test_firewall.py --> OK

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
