### PR TITLE
T6681: Add option for SLAAC to support suppress Interval Advertisement in RA Packets

### DIFF
--- a/data/templates/router-advert/radvd.conf.j2
+++ b/data/templates/router-advert/radvd.conf.j2
@@ -19,7 +19,7 @@ interface {{ iface }} {
 {%         if iface_config.reachable_time is vyos_defined %}
     AdvReachableTime {{ iface_config.reachable_time }};
 {%         endif %}
-    AdvIntervalOpt {{ 'off' if iface_config.no_send_advert is vyos_defined else 'on' }};
+    AdvIntervalOpt {{ 'off' if iface_config.no_send_interval is vyos_defined else 'on' }};
     AdvSendAdvert {{ 'off' if iface_config.no_send_advert is vyos_defined else 'on' }};
 {%         if iface_config.default_lifetime is vyos_defined %}
     AdvDefaultLifetime {{ iface_config.default_lifetime }};

--- a/interface-definitions/service_router-advert.xml.in
+++ b/interface-definitions/service_router-advert.xml.in
@@ -390,6 +390,12 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <leafNode name="no-send-interval">
+                <properties>
+                  <help>Do not send Advertisement Interval option in RAs</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
             </children>
           </tagNode>
         </children>

--- a/smoketest/scripts/cli/test_service_router-advert.py
+++ b/smoketest/scripts/cli/test_service_router-advert.py
@@ -224,5 +224,34 @@ class TestServiceRADVD(VyOSUnitTestSHIM.TestCase):
         self.assertIn(tmp, config)
         self.assertIn('AdvValidLifetime 65528;', config) # default
 
+    def test_advsendadvert_advintervalopt(self):
+        ra_src = ['fe80::1', 'fe80::2']
+
+        self.cli_set(base_path + ['prefix', prefix])
+        self.cli_set(base_path + ['no-send-advert'])
+        # commit changes
+        self.cli_commit()
+
+        # Verify generated configuration
+        config = read_file(RADVD_CONF)
+        tmp = get_config_value('AdvSendAdvert')
+        self.assertEqual(tmp, 'off')
+
+        tmp = get_config_value('AdvIntervalOpt')
+        self.assertEqual(tmp, 'on')
+
+        self.cli_set(base_path + ['no-send-interval'])
+        # commit changes
+        self.cli_commit()
+
+        # Verify generated configuration
+        config = read_file(RADVD_CONF)
+        tmp = get_config_value('AdvSendAdvert')
+        self.assertEqual(tmp, 'off')
+
+        tmp = get_config_value('AdvIntervalOpt')
+        self.assertEqual(tmp, 'off')
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6681

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
SLAAC,  RADVD, IPv6
## Proposed changes
<!--- Describe your changes in detail -->

MikroTik's IPv6 SLAAC client has a bug, when it received a RA packet with Interval advertisement field, it can't obtain an address correctly from the router.

The log on MikroTik shows like that:

```
 22:01:50 radvd,debug received Router Advertisement on ether1 from <some mac>
 22:01:50 radvd,debug   prefix: <some prefix> valid: 1800 preferred: 900
 22:01:50 radvd,debug   unsupported option 7

```
So I'm submitted a patch which allows VyOS don't send Interval advertisement in RA packet.

e.g. the command line will be:

```
set service router-advert interface <some int> no-send-interval
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Run the command I described above, and use Wireshark to capture packet from router, and the 'Interval Advertisement' field in RA packet is gone.

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
