### PR TITLE
T6679: add group option for nat66

### DIFF
--- a/data/templates/firewall/nftables-nat66.j2
+++ b/data/templates/firewall/nftables-nat66.j2
@@ -1,8 +1,11 @@
 #!/usr/sbin/nft -f
 
+{% import 'firewall/nftables-defines.j2' as group_tmpl %}
+
 {% if first_install is not vyos_defined %}
 delete table ip6 vyos_nat
 {% endif %}
+{% if deleted is not vyos_defined %}
 table ip6 vyos_nat {
     #
     # Destination NAT66 rules build up here
@@ -10,11 +13,11 @@ table ip6 vyos_nat {
     chain PREROUTING {
         type nat hook prerouting priority -100; policy accept;
         counter jump VYOS_DNPT_HOOK
-{% if destination.rule is vyos_defined %}
-{%     for rule, config in destination.rule.items() if config.disable is not vyos_defined %}
-        {{ config | nat_rule(rule, 'destination', ipv6=True) }}
-{%     endfor %}
-{% endif %}
+{%     if destination.rule is vyos_defined %}
+{%         for rule, config in destination.rule.items() if config.disable is not vyos_defined %}
+         {{ config | nat_rule(rule, 'destination', ipv6=True) }}
+{%         endfor %}
+{%     endif %}
     }
 
     #
@@ -23,11 +26,11 @@ table ip6 vyos_nat {
     chain POSTROUTING {
         type nat hook postrouting priority 100; policy accept;
         counter jump VYOS_SNPT_HOOK
-{% if source.rule is vyos_defined %}
-{%     for rule, config in source.rule.items() if config.disable is not vyos_defined %}
+{%     if source.rule is vyos_defined %}
+{%         for rule, config in source.rule.items() if config.disable is not vyos_defined %}
         {{ config | nat_rule(rule, 'source', ipv6=True) }}
-{%     endfor %}
-{% endif %}
+{%         endfor %}
+{%     endif %}
     }
 
     chain VYOS_DNPT_HOOK {
@@ -37,4 +40,7 @@ table ip6 vyos_nat {
     chain VYOS_SNPT_HOOK {
         return
     }
+
+{{ group_tmpl.groups(firewall_group, True, True) }}
 }
+{% endif %}

--- a/interface-definitions/nat66.xml.in
+++ b/interface-definitions/nat66.xml.in
@@ -179,6 +179,7 @@
                     </properties>
                   </leafNode>
                   #include <include/nat-port.xml.i>
+                  #include <include/firewall/source-destination-group-ipv6.xml.i>
                 </children>
               </node>
               <node name="source">

--- a/python/vyos/nat.py
+++ b/python/vyos/nat.py
@@ -199,7 +199,10 @@ def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
                 if group_name[0] == '!':
                     operator = '!='
                     group_name = group_name[1:]
-                output.append(f'{ip_prefix} {prefix}addr {operator} @A_{group_name}')
+                if ipv6:
+                    output.append(f'{ip_prefix} {prefix}addr {operator} @A6_{group_name}')
+                else:
+                    output.append(f'{ip_prefix} {prefix}addr {operator} @A_{group_name}')
             # Generate firewall group domain-group
             elif 'domain_group' in group and not (ignore_type_addr and target == nat_type):
                 group_name = group['domain_group']
@@ -214,7 +217,10 @@ def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
                 if group_name[0] == '!':
                     operator = '!='
                     group_name = group_name[1:]
-                output.append(f'{ip_prefix} {prefix}addr {operator} @N_{group_name}')
+                if ipv6:
+                    output.append(f'{ip_prefix} {prefix}addr {operator} @N6_{group_name}')
+                else:
+                    output.append(f'{ip_prefix} {prefix}addr {operator} @N_{group_name}')
             if 'mac_group' in group:
                 group_name = group['mac_group']
                 operator = ''


### PR DESCRIPTION
## Change Summary
Add group option for nat66 similar to nat44

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6679

## Related PR(s)

## Component(s) name
nat

## Proposed changes
Extend nat66 with destination group

## How to test
```
set firewall group ipv6-address-group smoketest_addr address fc00::1
set firewall group ipv6-network-group smoketest_net network fc00::/64

set nat66 destination rule 1 destination group address-group smoketest_addr
set nat66 destination rule 1 translation address fc01::/64

set nat66 destination rule 2 destination group network-group smoketest_net
set nat66 destination rule 2 translation address fc01::/64
```

## Smoketest result
```
$ /usr/libexec/vyos/tests/smoke/cli/test_nat66.py
test_destination_nat66 (__main__.TestNAT66.test_destination_nat66) ... ok
test_destination_nat66_network_group (__main__.TestNAT66.test_destination_nat66_network_group) ... ok
test_destination_nat66_prefix (__main__.TestNAT66.test_destination_nat66_prefix) ... ok
test_destination_nat66_protocol (__main__.TestNAT66.test_destination_nat66_protocol) ... ok
test_destination_nat66_without_translation_address (__main__.TestNAT66.test_destination_nat66_without_translation_address) ... ok
test_nat66_no_rules (__main__.TestNAT66.test_nat66_no_rules) ... ok
test_source_nat66 (__main__.TestNAT66.test_source_nat66) ... ok
test_source_nat66_address (__main__.TestNAT66.test_source_nat66_address) ... ok
test_source_nat66_protocol (__main__.TestNAT66.test_source_nat66_protocol) ... ok
test_source_nat66_required_translation_prefix (__main__.TestNAT66.test_source_nat66_required_translation_prefix) ...
Source NAT66 configuration error in rule 5: translation address not
specified


Source NAT66 configuration error in rule 5: translation address not
specified

ok

----------------------------------------------------------------------
Ran 10 tests in 84.567s

OK
```

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
