### PR TITLE
T6693: wireless: Enable WiFi-6 (802.11ax) for 2.4GHz AccessPoints

### DIFF
--- a/data/templates/wifi/hostapd.conf.j2
+++ b/data/templates/wifi/hostapd.conf.j2
@@ -46,7 +46,14 @@ hw_mode=a
 ieee80211h=1
 ieee80211ac=1
 {%     elif mode is vyos_defined('ax') %}
+{#{%         if capabilities.ht is vyos_defined and capabilities.vht not vyos_defined %}#}
+{%         if capabilities.he.channel_set_width is vyos_defined('81') or capabilities.he.channel_set_width is vyos_defined('83') or capabilities.he.channel_set_width is vyos_defined('84') %}
+{#         This is almost certainly a 2.4GHz network #}
+hw_mode=g
+{%         else %}
+{#         This is likely a 5GHz or 6GHz network #}
 hw_mode=a
+{%         endif %}
 ieee80211h=1
 ieee80211ax=1
 {%     else %}
@@ -202,7 +209,7 @@ require_he=1
 {% else %}
 ieee80211n={{ '1' if 'n' in mode or 'ac' in mode or 'ax' in mode else '0' }}
 {% endif %}
-{# HE (802.11ax 6GHz) #}
+{# HE (802.11ax) #}
 {% if capabilities.he is vyos_defined and mode in 'ax' %}
 {# For now, hard-code power levels for indoor-only AP #}
 he_6ghz_reg_pwr_type=0
@@ -219,6 +226,9 @@ op_class={{ capabilities.he.channel_set_width }}
 {%     endif %}
 {%     if capabilities.he.bss_color is vyos_defined %}
 he_bss_color={{ capabilities.he.bss_color }}
+{%     endif %}
+{%     if capabilities.he.coding_scheme is vyos_defined %}
+he_basic_mcs_nss_set={{ capabilities.he.coding_scheme }}
 {%     endif %}
 he_6ghz_rx_ant_pat={{ '1' if capabilities.he.antenna_pattern_fixed is vyos_defined else '0' }}
 he_su_beamformer={{ '1' if capabilities.he.beamform.single_user_beamformer is vyos_defined else '0' }}

--- a/interface-definitions/interfaces_wireless.xml.in
+++ b/interface-definitions/interfaces_wireless.xml.in
@@ -248,26 +248,26 @@
                         <properties>
                           <help>VHT operating channel center frequency - center freq 1 (for use with 80, 80+80 and 160 modes)</help>
                           <valueHelp>
-                            <format>u32:34-173</format>
+                            <format>u32:34-177</format>
                             <description>5Ghz (802.11 a/h/j/n/ac) center channel index (use 42 for primary 80MHz channel 36)</description>
                           </valueHelp>
                           <constraint>
-                            <validator name="numeric" argument="--range 34-173"/>
+                            <validator name="numeric" argument="--range 34-177"/>
                           </constraint>
-                          <constraintErrorMessage>Channel center value must be between 34 and 173</constraintErrorMessage>
+                          <constraintErrorMessage>Channel center value must be between 34 and 177</constraintErrorMessage>
                         </properties>
                       </leafNode>
                       <leafNode name="freq-2">
                         <properties>
                           <help>VHT operating channel center frequency - center freq 2 (for use with the 80+80 mode)</help>
                           <valueHelp>
-                            <format>u32:34-173</format>
+                            <format>u32:34-177</format>
                             <description>5Ghz (802.11 ac) center channel index (use 58 for secondary 80MHz channel 52)</description>
                           </valueHelp>
                           <constraint>
-                            <validator name="numeric" argument="--range 34-173"/>
+                            <validator name="numeric" argument="--range 34-177"/>
                           </constraint>
-                          <constraintErrorMessage>Channel center value must be between 34 and 173</constraintErrorMessage>
+                          <constraintErrorMessage>Channel center value must be between 34 and 177</constraintErrorMessage>
                         </properties>
                       </leafNode>
                     </children>
@@ -436,30 +436,42 @@
                           https://w1.fi/cgit/hostap/tree/src/common/ieee802_11_common.c?id=195cc3d919503fb0d699d9a56a58a72602b25f51#n1525
                           802.11ax (WiFi-6e - HE) can use up to 160MHz bandwidth channels
                         -->
-                        <list>131 132 133 134 135</list>
+                        <list>81 83 84 131 132 133 134 135</list>
                       </completionHelp>
                       <valueHelp>
+                        <format>81</format>
+                        <description>2.4GHz, 20 MHz channel width</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>83</format>
+                        <description>2.4GHz, 40 MHz channel width, secondary 20MHz channel above primary channel</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>84</format>
+                        <description>2.4GHz, 40 MHz channel width, secondary 20MHz channel below primary channel</description>
+                      </valueHelp>
+                      <valueHelp>
                         <format>131</format>
-                        <description>20 MHz channel width</description>
+                        <description>6GHz, 20 MHz channel width</description>
                       </valueHelp>
                       <valueHelp>
                         <format>132</format>
-                        <description>40 MHz channel width</description>
+                        <description>6GHz, 40 MHz channel width</description>
                       </valueHelp>
                       <valueHelp>
                         <format>133</format>
-                        <description>80 MHz channel width</description>
+                        <description>6GHz, 80 MHz channel width</description>
                       </valueHelp>
                       <valueHelp>
                         <format>134</format>
-                        <description>160 MHz channel width</description>
+                        <description>6GHz, 160 MHz channel width</description>
                       </valueHelp>
                       <valueHelp>
                         <format>135</format>
-                        <description>80+80 MHz channel width</description>
+                        <description>6GHz, 80+80 MHz channel width</description>
                       </valueHelp>
                       <constraint>
-                        <regex>(131|132|133|134|135)</regex>
+                        <regex>(81|83|84|131|132|133|134|135)</regex>
                       </constraint>
                     </properties>
                   </leafNode>
@@ -535,6 +547,30 @@
                       </constraint>
                     </properties>
                   </leafNode>
+                  <leafNode name="coding-scheme">
+                    <properties>
+                      <help>Spacial Stream and Modulation Coding Scheme settings</help>
+                      <valueHelp>
+                        <format>u32:0</format>
+                        <description>HE-MCS 0-7</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>u32:1</format>
+                        <description>HE-MCS 0-9</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>u32:2</format>
+                        <description>HE-MCS 0-11</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>u32:3</format>
+                        <description>HE-MCS is not supported</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-3"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
                 </children>
               </node>
               <leafNode name="require-he">
@@ -554,10 +590,10 @@
               </valueHelp>
               <valueHelp>
                 <format>u32:1-14</format>
-                <description>2.4Ghz (802.11 b/g/n) Channel</description>
+                <description>2.4Ghz (802.11 b/g/n/ax) Channel</description>
               </valueHelp>
               <valueHelp>
-                <format>u32:34-173</format>
+                <format>u32:34-177</format>
                 <description>5Ghz (802.11 a/h/j/n/ac) Channel</description>
               </valueHelp>
               <valueHelp>
@@ -565,7 +601,7 @@
                 <description>6Ghz (802.11 ax) Channel</description>
               </valueHelp>
               <constraint>
-                <validator name="numeric" argument="--range 0-0 --range 1-14 --range 34-173 --range 1-233"/>
+                <validator name="numeric" argument="--range 0-0 --range 1-14 --range 34-177 --range 1-233"/>
               </constraint>
             </properties>
             <defaultValue>0</defaultValue>

--- a/smoketest/scripts/cli/test_interfaces_wireless.py
+++ b/smoketest/scripts/cli/test_interfaces_wireless.py
@@ -300,7 +300,89 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         for key, value in vht_opt.items():
             self.assertIn(value, tmp)
 
-    def test_wireless_hostapd_he_config(self):
+    def test_wireless_hostapd_he_2ghz_config(self):
+        # Only set the hostapd (access-point) options - HE mode for 802.11ax at 2.4GHz
+        interface = self._interfaces[1] # wlan1
+        ssid = 'ssid'
+        channel = '1'
+        sae_pw = 'VyOSVyOSVyOS'
+        bss_color = '13'
+        channel_set_width = '81'
+
+        self.cli_set(self._base_path + [interface, 'ssid', ssid])
+        self.cli_set(self._base_path + [interface, 'type', 'access-point'])
+        self.cli_set(self._base_path + [interface, 'channel', channel])
+        self.cli_set(self._base_path + [interface, 'mode', 'ax'])
+        self.cli_set(self._base_path + [interface, 'security', 'wpa', 'mode', 'wpa2'])
+        self.cli_set(self._base_path + [interface, 'security', 'wpa', 'passphrase', sae_pw])
+        self.cli_set(self._base_path + [interface, 'security', 'wpa', 'cipher', 'CCMP'])
+        self.cli_set(self._base_path + [interface, 'security', 'wpa', 'cipher', 'GCMP'])
+        self.cli_set(self._base_path + [interface, 'capabilities', 'ht', '40mhz-incapable'])
+        self.cli_set(self._base_path + [interface, 'capabilities', 'ht', 'channel-set-width', 'ht20'])
+        self.cli_set(self._base_path + [interface, 'capabilities', 'ht', 'channel-set-width', 'ht40+'])
+        self.cli_set(self._base_path + [interface, 'capabilities', 'ht', 'channel-set-width', 'ht40-'])
+        self.cli_set(self._base_path + [interface, 'capabilities', 'ht', 'short-gi', '20'])
+        self.cli_set(self._base_path + [interface, 'capabilities', 'ht', 'short-gi', '40'])
+        self.cli_set(self._base_path + [interface, 'capabilities', 'he', 'bss-color', bss_color])
+        self.cli_set(self._base_path + [interface, 'capabilities', 'he', 'channel-set-width', channel_set_width])
+        self.cli_set(self._base_path + [interface, 'capabilities', 'he', 'beamform', 'multi-user-beamformer'])
+        self.cli_set(self._base_path + [interface, 'capabilities', 'he', 'beamform', 'single-user-beamformer'])
+        self.cli_set(self._base_path + [interface, 'capabilities', 'he', 'beamform', 'single-user-beamformee'])
+
+        self.cli_commit()
+
+        #
+        # Validate Config
+        #
+        tmp = get_config_value(interface, 'interface')
+        self.assertEqual(interface, tmp)
+
+        # ssid
+        tmp = get_config_value(interface, 'ssid')
+        self.assertEqual(ssid, tmp)
+
+        # mode of operation resulting from [interface, 'mode', 'ax']
+        tmp = get_config_value(interface, 'hw_mode')
+        self.assertEqual('g', tmp)
+        tmp = get_config_value(interface, 'ieee80211h')
+        self.assertEqual('1', tmp)
+        tmp = get_config_value(interface, 'ieee80211ax')
+        self.assertEqual('1', tmp)
+
+        # channel and channel width
+        tmp = get_config_value(interface, 'channel')
+        self.assertEqual(channel, tmp)
+        tmp = get_config_value(interface, 'op_class')
+        self.assertEqual(channel_set_width, tmp)
+
+        # BSS coloring
+        tmp = get_config_value(interface, 'he_bss_color')
+        self.assertEqual(bss_color, tmp)
+
+        # sae_password
+        tmp = get_config_value(interface, 'wpa_passphrase')
+        self.assertEqual(sae_pw, tmp)
+
+        # WPA3 and dependencies
+        tmp = get_config_value(interface, 'wpa')
+        self.assertEqual('2', tmp)
+        tmp = get_config_value(interface, 'rsn_pairwise')
+        self.assertEqual('CCMP GCMP', tmp)
+        tmp = get_config_value(interface, 'wpa_key_mgmt')
+        self.assertEqual('WPA-PSK WPA-PSK-SHA256', tmp)
+
+        # beamforming
+        tmp = get_config_value(interface, 'he_mu_beamformer')
+        self.assertEqual('1', tmp)
+        tmp = get_config_value(interface, 'he_su_beamformee')
+        self.assertEqual('1', tmp)
+        tmp = get_config_value(interface, 'he_mu_beamformer')
+        self.assertEqual('1', tmp)
+
+        # Check for running process
+        self.assertTrue(process_named_running('hostapd'))
+
+    def test_wireless_hostapd_he_6ghz_config(self):
         # Only set the hostapd (access-point) options - HE mode for 802.11ax at 6GHz
         interface = self._interfaces[1] # wlan1
         ssid = 'ssid'
@@ -323,6 +405,7 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         self.cli_set(self._base_path + [interface, 'capabilities', 'he', 'bss-color', bss_color])
         self.cli_set(self._base_path + [interface, 'capabilities', 'he', 'channel-set-width', channel_set_width])
         self.cli_set(self._base_path + [interface, 'capabilities', 'he', 'center-channel-freq', 'freq-1', center_channel_freq_1])
+        self.cli_set(self._base_path + [interface, 'capabilities', 'he', 'antenna-pattern-fixed'])
         self.cli_set(self._base_path + [interface, 'capabilities', 'he', 'beamform', 'multi-user-beamformer'])
         self.cli_set(self._base_path + [interface, 'capabilities', 'he', 'beamform', 'single-user-beamformer'])
 
@@ -369,6 +452,10 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         self.assertEqual('CCMP GCMP', tmp)
         tmp = get_config_value(interface, 'wpa_key_mgmt')
         self.assertEqual('SAE', tmp)
+
+        # antenna pattern
+        tmp = get_config_value(interface, 'he_6ghz_rx_ant_pat')
+        self.assertEqual('1', tmp)
 
         # beamforming
         tmp = get_config_value(interface, 'he_mu_beamformer')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add support for WiFi-6 (802.11ax) on 2.4GHz.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6693

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireless

## Proposed changes
<!--- Describe your changes in detail -->
Users in areas which are clogged with 2.4GHz AccessPoints usually experience very low throughput on their WiFi networks. Throughput may be as low as only a low single-digit number in megabytes per second on networks based on 802.11n.

Tests showed that by implementing 802.11ax for 2.4GHz can significantly increase throughput in such areas, reaching up to 5 times the speed as 802.11n would be capable of.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
* on VyOS, configure this:
  ```
  set system wireless country-code de
  set interfaces wireless wlan0 capabilities he antenna-pattern-fixed
  set interfaces wireless wlan0 capabilities he beamform multi-user-beamformer
  set interfaces wireless wlan0 capabilities he beamform single-user-beamformee
  set interfaces wireless wlan0 capabilities he beamform single-user-beamformer
  set interfaces wireless wlan0 capabilities he bss-color 13
  set interfaces wireless wlan0 capabilities he channel-set-width 81
  set interfaces wireless wlan0 capabilities ht 40mhz-incapable
  set interfaces wireless wlan0 capabilities ht channel-set-width ht20
  set interfaces wireless wlan0 capabilities ht channel-set-width ht40+
  set interfaces wireless wlan0 capabilities ht channel-set-width ht40-
  set interfaces wireless wlan0 capabilities ht short-gi 20
  set interfaces wireless wlan0 capabilities ht short-gi 40
  set interfaces wireless wlan0 channel 11
  set interfaces wireless wlan0 description "802.11ax 2.4GHz"
  set interfaces wireless wlan0 mode ax
  set interfaces wireless wlan0 security wpa cipher CCMP
  set interfaces wireless wlan0 security wpa cipher CCMP-256
  set interfaces wireless wlan0 security wpa cipher GCMP-256
  set interfaces wireless wlan0 security wpa cipher GCMP
  set interfaces wireless wlan0 security wpa mode wpa2
  set interfaces wireless wlan0 security wpa passphrase super-dooper-secure-passphrase
  set interfaces wireless wlan0 ssid test.ax
  set interfaces wireless wlan0 type access-point
  commit
  ```
* Connection to this new SSID `test.ax` should succeed
* After connecting, on the connecting machine, issue these commands and check for presence of these lines:
  ```
  user@host $ sudo wpa_cli status
  Selected interface 'wlp1s0'
  [...]
  freq=2462
  ssid=test.ax
  id=0
  mode=station
  wifi_generation=6
  [...]
  ```


## Smoketest result
<!-- Provide the output of the smoketest -->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireless.py
test_add_multiple_ip_addresses (__main__.WirelessInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.WirelessInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.WirelessInterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.WirelessInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.WirelessInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.WirelessInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.WirelessInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.WirelessInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_interface_description (__main__.WirelessInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.WirelessInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.WirelessInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.WirelessInterfaceTest.test_interface_ipv6_options) ... skipped 'not supported'
test_interface_mtu (__main__.WirelessInterfaceTest.test_interface_mtu) ... skipped 'not supported'
test_ipv6_link_local_address (__main__.WirelessInterfaceTest.test_ipv6_link_local_address) ... skipped 'not supported'
test_move_interface_between_vrf_instances (__main__.WirelessInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.WirelessInterfaceTest.test_mtu_1200_no_ipv6_interface) ... skipped 'not supported'
test_span_mirror (__main__.WirelessInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.WirelessInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.WirelessInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.WirelessInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.WirelessInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.WirelessInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.WirelessInterfaceTest.test_vif_s_protocol_change) ... ok
test_wireless_access_point_bridge (__main__.WirelessInterfaceTest.test_wireless_access_point_bridge) ... ok
test_wireless_add_single_ip_address (__main__.WirelessInterfaceTest.test_wireless_add_single_ip_address) ... ok
test_wireless_hostapd_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_config) ... ok
test_wireless_hostapd_he_2ghz_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_he_2ghz_config) ... ok
test_wireless_hostapd_he_6ghz_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_he_6ghz_config) ... ok
test_wireless_hostapd_vht_mu_beamformer_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_vht_mu_beamformer_config) ... ok
test_wireless_hostapd_vht_su_beamformer_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_vht_su_beamformer_config) ... ok
test_wireless_hostapd_wpa_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_wpa_config) ... ok
test_wireless_security_station_address (__main__.WirelessInterfaceTest.test_wireless_security_station_address) ... ok

----------------------------------------------------------------------
Ran 34 tests in 252.187s

OK (skipped=9)
vyos@vyos:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
