### PR TITLE
opmode: T6694: move wake-on-lan to "execute wake-on-lan"

### DIFF
--- a/op-mode-definitions/wake-on-lan.xml.in
+++ b/op-mode-definitions/wake-on-lan.xml.in
@@ -1,26 +1,30 @@
 <?xml version="1.0"?>
 <interfaceDefinition>
-  <node name="wake-on-lan">
-    <properties>
-      <help>Send Wake-On-LAN (WOL) Magic Packet</help>
-    </properties>
+  <node name="execute">
     <children>
-      <tagNode name="interface">
+      <node name="wake-on-lan">
         <properties>
-          <help>Interface where the station is connected</help>
-          <completionHelp>
-            <script>${vyos_completion_dir}/list_interfaces</script>
-          </completionHelp>
+          <help>Send Wake-On-LAN (WOL) Magic Packet</help>
         </properties>
         <children>
-          <tagNode name="host">
+          <tagNode name="interface">
             <properties>
-              <help>Station (MAC) address to wake up</help>
+              <help>Interface where the station is connected</help>
+              <completionHelp>
+                <script>${vyos_completion_dir}/list_interfaces</script>
+              </completionHelp>
             </properties>
-            <command>sudo /usr/sbin/etherwake -i "$3" "$5"</command>
-          </tagNode>
+            <children>
+              <tagNode name="host">
+                <properties>
+                  <help>Station (MAC) address to wake up</help>
+                </properties>
+                <command>sudo /usr/sbin/etherwake -i "$3" "$5"</command>
+              </tagNode>
+            </children>
+            </tagNode>
         </children>
-        </tagNode>
+      </node>
     </children>
   </node>
 </interfaceDefinition>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): command renaming.

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Op mode.

## Proposed changes
<!--- Describe your changes in detail -->

Rename `wake-on-lan` to `execute wake-on-lan`.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

`execute wake-on-lan` should work, although I have no idea if it ever worked. ;)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
