### PR TITLE
T6701: Added ability to disable the container DNS plugin 

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -519,6 +519,12 @@
               <multi/>
             </properties>
           </leafNode>
+          <leafNode name="no-name-server">
+            <properties>
+              <help>Disable Domain Name System (DNS) plugin for this network</help>
+              <valueless/>
+            </properties>
+          </leafNode>
           #include <include/interface/vrf.xml.i>
         </children>
       </tagNode>

--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -208,6 +208,22 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
             self.assertEqual(c['NetworkSettings']['Networks'][net_name]['Gateway']          , str(ip_interface(prefix4).ip + 1))
             self.assertEqual(c['NetworkSettings']['Networks'][net_name]['IPAddress']        , str(ip_interface(prefix4).ip + ii))
 
+    def test_no_name_server(self):
+        prefix = '192.0.2.0/24'
+        base_name = 'ipv4'
+        net_name = 'NET01'
+
+        self.cli_set(base_path + ['network', net_name, 'prefix', prefix])
+        self.cli_set(base_path + ['network', net_name, 'no-name-server'])
+
+        name = f'{base_name}-2'
+        self.cli_set(base_path + ['name', name, 'image', cont_image])
+        self.cli_set(base_path + ['name', name, 'network', net_name, 'address', str(ip_interface(prefix).ip + 2)])
+        self.cli_commit()
+
+        n = cmd_to_json(f'sudo podman network inspect {net_name}')
+        self.assertEqual(n['dns_enabled'], False)
+
     def test_uid_gid(self):
         cont_name = 'uid-test'
         gid = '100'

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -421,6 +421,10 @@ def generate(container):
                     'driver': 'host-local'
                 }
             }
+
+            if 'no_name_server' in network_config:
+                tmp['dns_enabled'] = False
+
             for prefix in network_config['prefix']:
                 net = {'subnet': prefix, 'gateway': inc_ip(prefix, 1)}
                 tmp['subnets'].append(net)


### PR DESCRIPTION
Add ability to set the container network with a disable-dns setting to disable the DNS plugin that is on be default.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
This changes allows one to configure a container network without using the built-in DNS plugin.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

https://vyos.dev/T6701

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
podman

## Proposed changes
<!--- Describe your changes in detail -->
Adds ability to set disable-dns on a container network 

`set container network PODNET disable-dns`
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics

-->

```
set container network PODNET prefix '10.10.10.0/24'
set container network PODNET disable-dns
commit

run show ip port | grep 10\.10\.10\.1 | grep 53

```

You should have no DNS port 53 shown on the ports used for the container network.

_**Without** the "disable-dns" setting, you will see a UDP port 53 owned by the "aardvark-dns" process_

`udp        0      0 10.10.10.1:53            0.0.0.0:*                           25950/aardvark-dns  
`

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
