### PR TITLE
container: T6702: re-add missing UNIX API socket

### DIFF
--- a/debian/vyos-1x.postinst
+++ b/debian/vyos-1x.postinst
@@ -244,6 +244,9 @@ fi
 # Enable Cloud-init pre-configuration service
 systemctl enable vyos-config-cloud-init.service
 
+# Enable Podman API
+systemctl enable podman.service
+
 # Generate API GraphQL schema
 /usr/libexec/vyos/services/api/graphql/generate/generate_schema.py
 

--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -230,5 +230,23 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         tmp = cmd(f'sudo podman exec -it {cont_name} id -g')
         self.assertEqual(tmp, gid)
 
+    def test_api_socket(self):
+        base_name = 'api-test'
+        container_list = range(1, 5)
+
+        for ii in container_list:
+            name = f'{base_name}-{ii}'
+            self.cli_set(base_path + ['name', name, 'image', cont_image])
+            self.cli_set(base_path + ['name', name, 'allow-host-networks'])
+
+        self.cli_commit()
+
+        # Query API about running containers
+        tmp = cmd("sudo curl --unix-socket /run/podman/podman.sock -H 'content-type: application/json' -sf http://localhost/containers/json")
+        tmp = json.loads(tmp)
+
+        # We expect the same amount of containers from the API that we started above
+        self.assertEqual(len(container_list), len(tmp))
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/systemd/podman.service
+++ b/src/systemd/podman.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Podman API Service
+Requires=podman.socket
+After=podman.socket
+Documentation=man:podman-system-service(1)
+StartLimitIntervalSec=0
+
+[Service]
+Delegate=true
+Type=exec
+KillMode=process
+Environment=LOGGING="--log-level=info"
+ExecStart=/usr/bin/podman $LOGGING system service
+
+[Install]
+WantedBy=default.target

--- a/src/systemd/podman.socket
+++ b/src/systemd/podman.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=Podman API Socket
+Documentation=man:podman-system-service(1)
+
+[Socket]
+ListenStream=%t/podman/podman.sock
+SocketMode=0660
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
## Change Summary

During podman upgrade and a build from the original source the UNIX socket definition for systemd got lost in translation.

This commit re-adds the UNIX socket which is started on boot to interact with Podman.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6702

## How to test

Example:
```bash
curl --unix-socket /run/podman/podman.sock -H 'content-type: application/json' -sf http://localhost/containers/json
```

yields:

```
[{'AdjustCPUShares': False,
  'Command': 'sh',
  'Config': None,
  'Created': 1725638554,
  'Id': '816d8d00fdb069219513352bd741b05d547242166951d7044a73c51091fed6ae',
  'Image': 'docker.io/library/busybox:stable',
  'ImageID': 'sha256:87ff76f62d367950186bde563642e39208c0e2b4afc833b4b3b01b8fef60ae9e',
  'Labels': {'PODMAN_SYSTEMD_UNIT': 'vyos-container-c1.service'},
  'Mounts': [],
  'Name': '',
  'Names': ['/c1'],
  'NetworkSettings': {'Networks': {'host': {'Aliases': None,
                                            'DriverOpts': None,
                                            'EndpointID': '',
                                            'Gateway': '',
                                            'GlobalIPv6Address': '',
                                            'GlobalIPv6PrefixLen': 0,
                                            'IPAMConfig': None,
                                            'IPAddress': '',
                                            'IPPrefixLen': 0,
                                            'IPv6Gateway': '',
                                            'Links': None,
                                            'MacAddress': '',
                                            'NetworkID': 'host'}}},
  'NetworkingConfig': None,
  'Platform': None,
  'Ports': [],
  'State': 'running',
  'Status': 'Up Less than a second'}]
```

## Smoketest result

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_container.py
test_api_socket (__main__.TestContainer.test_api_socket) ... ok
test_basic (__main__.TestContainer.test_basic) ... ok
test_cpu_limit (__main__.TestContainer.test_cpu_limit) ... ok
test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... ok
test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... ok
test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... ok
test_uid_gid (__main__.TestContainer.test_uid_gid) ... ok

----------------------------------------------------------------------
Ran 7 tests in 124.777s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
