### PR TITLE
op_mode: T6181: A feature for checking ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ op_mode_definitions: $(op_xml_obj)
 	ln -s ../node.tag $(OP_TMPL_DIR)/mtr/node.tag/node.tag/
 	ln -s ../node.tag $(OP_TMPL_DIR)/monitor/traceroute/node.tag/node.tag/
 	ln -s ../node.tag $(OP_TMPL_DIR)/monitor/traffic/interface/node.tag/node.tag/
+	ln -s ../node.tag $(OP_TMPL_DIR)/execute/port-scan/host/node.tag/node.tag/
 
 	# XXX: test if there are empty node.def files - this is not allowed as these
 	# could mask help strings or mandatory priority statements

--- a/op-mode-definitions/execute-port-scan.xml.in
+++ b/op-mode-definitions/execute-port-scan.xml.in
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="execute">
+    <children>
+      <node name="port-scan">
+        <properties>
+          <help>Scan network for open ports</help>
+        </properties>
+        <children>
+          <tagNode name="host">
+            <properties>
+              <help>IP address or domain name of the host to scan (scan all ports 1-65535)</help>
+              <completionHelp>
+                <list>&lt;hostname&gt; &lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
+              </completionHelp>
+            </properties>
+            <command>nmap -p- -T4 --max-retries=1 --host-timeout=30s "$4"</command>
+            <children>
+              <leafNode name="node.tag">
+                <properties>
+                  <help>Port scan options</help>
+                  <completionHelp>
+                    <script>${vyos_op_scripts_dir}/execute_port-scan.py --get-options-nested "${COMP_WORDS[@]}"</script>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/execute_port-scan.py "${@:4}"</command>
+              </leafNode>
+            </children>
+          </tagNode>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/src/op_mode/execute_port-scan.py
+++ b/src/op_mode/execute_port-scan.py
@@ -1,0 +1,155 @@
+#! /usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+
+from vyos.utils.process import call
+
+
+options = {
+    'port': {
+        'cmd': '{command} -p {value}',
+        'type': '<1-65535> <list>',
+        'help': 'Scan specified ports.'
+    },
+    'tcp': {
+        'cmd': '{command} -sT',
+        'type': 'noarg',
+        'help': 'Use TCP scan.'
+    },
+    'udp': {
+        'cmd': '{command} -sU',
+        'type': 'noarg',
+        'help': 'Use UDP scan.'
+    },
+    'skip-ping': {
+        'cmd': '{command} -Pn',
+        'type': 'noarg',
+        'help': 'Skip the Nmap discovery stage altogether.'
+    },
+    'ipv6': {
+        'cmd': '{command} -6',
+        'type': 'noarg',
+        'help': 'Enable IPv6 scanning.'
+    },
+}
+
+nmap = 'sudo /usr/bin/nmap'
+
+
+class List(list):
+    def first(self):
+        return self.pop(0) if self else ''
+
+    def last(self):
+        return self.pop() if self else ''
+
+    def prepend(self, value):
+        self.insert(0, value)
+
+
+def completion_failure(option: str) -> None:
+    """
+    Shows failure message after TAB when option is wrong
+    :param option: failure option
+    :type str:
+    """
+    sys.stderr.write('\n\n Invalid option: {}\n\n'.format(option))
+    sys.stdout.write('<nocomps>')
+    sys.exit(1)
+
+
+def expansion_failure(option, completions):
+    reason = 'Ambiguous' if completions else 'Invalid'
+    sys.stderr.write(
+        '\n\n  {} command: {} [{}]\n\n'.format(reason, ' '.join(sys.argv),
+                                               option))
+    if completions:
+        sys.stderr.write('  Possible completions:\n   ')
+        sys.stderr.write('\n   '.join(completions))
+        sys.stderr.write('\n')
+    sys.stdout.write('<nocomps>')
+    sys.exit(1)
+
+
+def complete(prefix):
+    return [o for o in options if o.startswith(prefix)]
+
+
+def convert(command, args):
+    while args:
+        shortname = args.first()
+        longnames = complete(shortname)
+        if len(longnames) != 1:
+            expansion_failure(shortname, longnames)
+        longname = longnames[0]
+        if options[longname]['type'] == 'noarg':
+            command = options[longname]['cmd'].format(
+                command=command, value='')
+        elif not args:
+            sys.exit(f'port-scan: missing argument for {longname} option')
+        else:
+            command = options[longname]['cmd'].format(
+                command=command, value=args.first())
+    return command
+
+
+if __name__ == '__main__':
+    args = List(sys.argv[1:])
+    host = args.first()
+
+    if host == '--get-options-nested':
+        args.first()  # pop execute
+        args.first()  # pop port-scan
+        args.first()  # pop host
+        args.first()  # pop <host>
+        usedoptionslist = []
+        while args:
+            option = args.first()  # pop option
+            matched = complete(option)  # get option parameters
+            usedoptionslist.append(option)  # list of used options
+            # Select options
+            if not args:
+                # remove from Possible completions used options
+                for o in usedoptionslist:
+                    if o in matched:
+                        matched.remove(o)
+                if not matched:
+                    sys.stdout.write('<nocomps>')
+                else:
+                    sys.stdout.write(' '.join(matched))
+                sys.exit(0)
+
+            if len(matched) > 1:
+                sys.stdout.write(' '.join(matched))
+                sys.exit(0)
+            # If option doesn't have value
+            if matched:
+                if options[matched[0]]['type'] == 'noarg':
+                    continue
+            else:
+                # Unexpected option
+                completion_failure(option)
+
+            value = args.first()  # pop option's value
+            if not args:
+                matched = complete(option)
+                helplines = options[matched[0]]['type']
+                sys.stdout.write(helplines)
+                sys.exit(0)
+
+    command = convert(nmap, args)
+    call(f'{command} -T4 {host}')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added op mode command to scan specific host for open ports
```
execute port-scan host <target> [ <Options> ]
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6181
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
op_mode: ```execute port-scan ```
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
op mode command:
```
vyos@vyos:~$ execute port-scan host 192.0.2.2
Starting Nmap 7.93 ( https://nmap.org ) at 2024-09-05 08:18 UTC
Nmap scan report for 192.0.2.2
Host is up (0.0018s latency).
Not shown: 65533 closed tcp ports (conn-refused)
PORT    STATE SERVICE
22/tcp  open  ssh
443/tcp open  https

Nmap done: 1 IP address (1 host up) scanned in 17.84 seconds
```
With options:
```
vyos@vyos:~$ execute port-scan host 192.0.2.2
Possible completions:
  <Enter>               Execute the current command
  ipv6                  Port scan options
  port
  skip-ping
  tcp
  udp

vyos@vyos:~$ execute port-scan host 192.0.2.2 skip-ping tcp port 22,100-105,440-450
Starting Nmap 7.93 ( https://nmap.org ) at 2024-09-05 08:20 UTC
Nmap scan report for 192.0.2.2
Host is up (0.0010s latency).

PORT    STATE  SERVICE
22/tcp  open   ssh
100/tcp closed newacct
101/tcp closed hostname
102/tcp closed iso-tsap
103/tcp closed gppitnp
104/tcp closed acr-nema
105/tcp closed csnet-ns
440/tcp closed sgcp
441/tcp closed decvms-sysmgt
442/tcp closed cvc_hostd
443/tcp open   https
444/tcp closed snpp
445/tcp closed microsoft-ds
446/tcp closed ddm-rdb
447/tcp closed ddm-dfm
448/tcp closed ddm-ssl
449/tcp closed as-servermap
450/tcp closed tserver

Nmap done: 1 IP address (1 host up) scanned in 13.04 seconds
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
