### PR TITLE
pppoe-server: T6685: Add options to accept any and blank service names

### DIFF
--- a/data/templates/accel-ppp/pppoe.config.j2
+++ b/data/templates/accel-ppp/pppoe.config.j2
@@ -70,6 +70,12 @@ vlan-mon={{ iface }},{{ iface_config.vlan | join(',') }}
 {% if service_name %}
 service-name={{ service_name | join(',') }}
 {% endif %}
+{% if accept_any_service is vyos_defined %}
+accept-any-service=1
+{% endif %}
+{% if accept_blank_service is vyos_defined %}
+accept-blank-service=1
+{% endif %}
 {% if pado_delay %}
 {%     set delay_without_sessions = pado_delay.delays_without_sessions[0] | default('0') %}
 {%     set pado_delay_param = namespace(value=delay_without_sessions) %}

--- a/interface-definitions/service_pppoe-server.xml.in
+++ b/interface-definitions/service_pppoe-server.xml.in
@@ -77,6 +77,18 @@
               <multi/>
             </properties>
           </leafNode>
+          <leafNode name="accept-any-service">
+            <properties>
+              <help>Accept any service name in PPPoE Active Discovery Request (PADR)</help>
+              <valueless/>
+            </properties>
+          </leafNode>
+          <leafNode name="accept-blank-service">
+            <properties>
+              <help>Accept blank service name in PADR</help>
+              <valueless/>
+            </properties>
+          </leafNode>
           <tagNode name="pado-delay">
             <properties>
               <help>PADO delays</help>

--- a/smoketest/scripts/cli/test_service_pppoe-server.py
+++ b/smoketest/scripts/cli/test_service_pppoe-server.py
@@ -195,6 +195,22 @@ class TestServicePPPoEServer(BasicAccelPPPTest.TestCase):
         config = read_file(self._config_file)
         self.assertIn('any-login=1', config)
 
+    def test_pppoe_server_accept_service(self):
+        services = ['user1-service', 'user2-service']
+        self.basic_config()
+
+        for service in services:
+            self.set(['service-name', service])
+        self.set(['accept-any-service'])
+        self.set(['accept-blank-service'])
+        self.cli_commit()
+
+        # Validate configuration values
+        config = read_file(self._config_file)
+        self.assertIn(f'service-name={",".join(services)}', config)
+        self.assertIn('accept-any-service=1', config)
+        self.assertIn('accept-blank-service=1', config)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added options:
```
accept-any-service
accept-blank-service
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6685
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set service pppoe-server authentication local-users username user1 password 'user1'
set service pppoe-server authentication mode 'local'
set service pppoe-server client-ip-pool first range '100.64.0.1-100.64.0.100'
set service pppoe-server default-pool 'first'
set service pppoe-server gateway-address '100.64.0.1'
set service pppoe-server interface eth1

set service pppoe-server accept-blank-service
set service pppoe-server accept-any-service

commit

vyos@vyos# cat /run/accel-pppd/pppoe.conf | grep -service
accept-any-service=1
accept-blank-service=1
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# sudo nano /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py
[edit]
vyos@vyos# python3 /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py
test_accel_ipv4_pool (__main__.TestServicePPPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServicePPPoEServer.test_accel_ipv6_pool) ... ok
test_accel_limits (__main__.TestServicePPPoEServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestServicePPPoEServer.test_accel_local_authentication) ... ok
test_accel_log_level (__main__.TestServicePPPoEServer.test_accel_log_level) ... ok
test_accel_name_servers (__main__.TestServicePPPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServicePPPoEServer.test_accel_next_pool) ... ok
test_accel_ppp_options (__main__.TestServicePPPoEServer.test_accel_ppp_options) ... ok
test_pppoe_server_shaper (__main__.TestServicePPPoEServer.test_pppoe_server_shaper) ... ok
test_pppoe_server_vlan (__main__.TestServicePPPoEServer.test_pppoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 19 tests in 139.655s

OK
[edit]
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
