### PR TITLE
T6703: Adds option to configure AMD pstate driver

### DIFF
--- a/interface-definitions/system_option.xml.in
+++ b/interface-definitions/system_option.xml.in
@@ -57,15 +57,15 @@
                   </completionHelp>
                   <valueHelp>
                     <format>active</format>
-                    <description>This is the low-level firmware control mode based on the profile set and the system governor has no effect</description>
+                    <description>The firmware controls performance states and the system governor has no effect</description>
                   </valueHelp>
                   <valueHelp>
                     <format>passive</format>
-                    <description>The driver allows the system governor to manage CPU frequency while providing available performance states</description>
+                    <description>Allow the system governor to manage performance states</description>
                   </valueHelp>
                   <valueHelp>
                     <format>guided</format>
-                    <description>The driver allows to set desired performance levels and the firmware selects a performance level in this range and fitting to the current workload</description>
+                    <description>The firmware controls performance states guided by the system governor</description>
                   </valueHelp>
                 </properties>
               </leafNode>

--- a/interface-definitions/system_option.xml.in
+++ b/interface-definitions/system_option.xml.in
@@ -49,6 +49,26 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <leafNode name="amd-pstate-driver">
+                <properties>
+                  <help>Enables and configures pstate driver for AMD Ryzen and Epyc CPUs</help>
+                  <completionHelp>
+                    <list>active passive guided</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>active</format>
+                    <description>This is the low-level firmware control mode based on the profile set and the system governor has no effect</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>passive</format>
+                    <description>The driver allows the system governor to manage CPU frequency while providing available performance states</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>guided</format>
+                    <description>The driver allows to set desired performance levels and the firmware selects a performance level in this range and fitting to the current workload</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
               <node name="debug">
                 <properties>
                   <help>Dynamic debugging for kernel module</help>

--- a/src/conf_mode/system_option.py
+++ b/src/conf_mode/system_option.py
@@ -37,6 +37,7 @@ from vyos.configdep import set_dependents
 from vyos.configdep import call_dependents
 from vyos import ConfigError
 from vyos import airbag
+
 airbag.enable()
 
 curlrc_config = r'/etc/curlrc'
@@ -44,10 +45,8 @@ ssh_config = r'/etc/ssh/ssh_config.d/91-vyos-ssh-client-options.conf'
 systemd_action_file = '/lib/systemd/system/ctrl-alt-del.target'
 usb_autosuspend = r'/etc/udev/rules.d/40-usb-autosuspend.rules'
 kernel_dynamic_debug = r'/sys/kernel/debug/dynamic_debug/control'
-time_format_to_locale = {
-    '12-hour': 'en_US.UTF-8',
-    '24-hour': 'en_GB.UTF-8'
-}
+time_format_to_locale = {'12-hour': 'en_US.UTF-8', '24-hour': 'en_GB.UTF-8'}
+
 
 def get_config(config=None):
     if config:
@@ -55,9 +54,9 @@ def get_config(config=None):
     else:
         conf = Config()
     base = ['system', 'option']
-    options = conf.get_config_dict(base, key_mangling=('-', '_'),
-                                   get_first_key=True,
-                                   with_recursive_defaults=True)
+    options = conf.get_config_dict(
+        base, key_mangling=('-', '_'), get_first_key=True, with_recursive_defaults=True
+    )
 
     if 'performance' in options:
         # Update IPv4/IPv6 and sysctl options after tuned applied it's settings
@@ -66,6 +65,7 @@ def get_config(config=None):
 
     return options
 
+
 def verify(options):
     if 'http_client' in options:
         config = options['http_client']
@@ -73,7 +73,9 @@ def verify(options):
             verify_interface_exists(options, config['source_interface'])
 
         if {'source_address', 'source_interface'} <= set(config):
-            raise ConfigError('Can not define both HTTP source-interface and source-address')
+            raise ConfigError(
+                'Can not define both HTTP source-interface and source-address'
+            )
 
         if 'source_address' in config:
             if not is_addr_assigned(config['source_address']):
@@ -94,7 +96,9 @@ def verify(options):
                 address = config['source_address']
                 interface = config['source_interface']
                 if not is_intf_addr_assigned(interface, address):
-                    raise ConfigError(f'Address "{address}" not assigned on interface "{interface}"!')
+                    raise ConfigError(
+                        f'Address "{address}" not assigned on interface "{interface}"!'
+                    )
 
     if 'kernel' in options:
         cpu_vendor = get_cpus()[0]['vendor_id']
@@ -104,6 +108,7 @@ def verify(options):
             )
 
     return None
+
 
 def generate(options):
     render(curlrc_config, 'system/curlrc.j2', options)
@@ -124,6 +129,7 @@ def generate(options):
     grub_util.update_kernel_cmdline_options(' '.join(cmdline_options))
 
     return None
+
 
 def apply(options):
     # System bootup beep
@@ -163,7 +169,7 @@ def apply(options):
     if 'performance' in options:
         cmd('systemctl restart tuned.service')
         # wait until daemon has started before sending configuration
-        while (not is_systemd_service_running('tuned.service')):
+        while not is_systemd_service_running('tuned.service'):
             sleep(0.250)
         cmd('tuned-adm profile network-{performance}'.format(**options))
     else:
@@ -178,9 +184,9 @@ def apply(options):
 
     # Enable/diable root-partition-auto-resize SystemD service
     if 'root_partition_auto_resize' in options:
-      cmd('systemctl enable root-partition-auto-resize.service')
+        cmd('systemctl enable root-partition-auto-resize.service')
     else:
-      cmd('systemctl disable root-partition-auto-resize.service')
+        cmd('systemctl disable root-partition-auto-resize.service')
 
     # Time format 12|24-hour
     if 'time_format' in options:
@@ -199,6 +205,7 @@ def apply(options):
             write_file(kernel_dynamic_debug, f'module {module} +p')
         else:
             write_file(kernel_dynamic_debug, f'module {module} -p')
+
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
## Change Summary
Add system option to configure AMD pstate driver

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6703

## Related PR(s)
vyos/vyos-build#755
vyos/vyos-documentation#1543

## Component(s) name
system

## Proposed changes
Enable system command to set kernel boot args for configuring AMD pstate driver.

## How to test
```
set system option kernel amd-pstate-driver passive
```

## Smoketest result
None

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
