### PR TITLE
T6711: Fix restart vrrp missed comma between services

### DIFF
--- a/src/op_mode/restart.py
+++ b/src/op_mode/restart.py
@@ -25,11 +25,11 @@ from vyos.utils.commit import commit_in_progress
 config = ConfigTreeQuery()
 
 service_map = {
-    'dhcp' : {
+    'dhcp': {
         'systemd_service': 'kea-dhcp4-server',
         'path': ['service', 'dhcp-server'],
     },
-    'dhcpv6' : {
+    'dhcpv6': {
         'systemd_service': 'kea-dhcp6-server',
         'path': ['service', 'dhcpv6-server'],
     },
@@ -61,24 +61,40 @@ service_map = {
         'systemd_service': 'radvd',
         'path': ['service', 'router-advert'],
     },
-    'snmp' : {
+    'snmp': {
         'systemd_service': 'snmpd',
     },
-    'ssh' : {
+    'ssh': {
         'systemd_service': 'ssh',
     },
-    'suricata' : {
+    'suricata': {
         'systemd_service': 'suricata',
     },
-    'vrrp' : {
+    'vrrp': {
         'systemd_service': 'keepalived',
         'path': ['high-availability', 'vrrp'],
     },
-    'webproxy' : {
+    'webproxy': {
         'systemd_service': 'squid',
     },
 }
-services = typing.Literal['dhcp', 'dhcpv6', 'dns_dynamic', 'dns_forwarding', 'igmp_proxy', 'ipsec', 'mdns_repeater', 'reverse_proxy', 'router_advert', 'snmp', 'ssh', 'suricata' 'vrrp', 'webproxy']
+services = typing.Literal[
+    'dhcp',
+    'dhcpv6',
+    'dns_dynamic',
+    'dns_forwarding',
+    'igmp_proxy',
+    'ipsec',
+    'mdns_repeater',
+    'reverse_proxy',
+    'router_advert',
+    'snmp',
+    'ssh',
+    'suricata',
+    'vrrp',
+    'webproxy',
+]
+
 
 def _verify(func):
     """Decorator checks if DHCP(v6) config exists"""
@@ -102,12 +118,17 @@ def _verify(func):
 
         # Check if config does not exist
         if not config.exists(path):
-            raise vyos.opmode.UnconfiguredSubsystem(f'Service {human_name} is not configured!')
+            raise vyos.opmode.UnconfiguredSubsystem(
+                f'Service {human_name} is not configured!'
+            )
         if config.exists(path + ['disable']):
-            raise vyos.opmode.UnconfiguredSubsystem(f'Service {human_name} is disabled!')
+            raise vyos.opmode.UnconfiguredSubsystem(
+                f'Service {human_name} is disabled!'
+            )
         return func(*args, **kwargs)
 
     return _wrapper
+
 
 @_verify
 def restart_service(raw: bool, name: services, vrf: typing.Optional[str]):
@@ -116,6 +137,7 @@ def restart_service(raw: bool, name: services, vrf: typing.Optional[str]):
         call(f'systemctl restart "{systemd_service}@{vrf}.service"')
     else:
         call(f'systemctl restart "{systemd_service}.service"')
+
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Missing comma in the list between services
` 'ssh', 'suricata' 'vrrp', 'webproxy'`
Fix it
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6711

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
restart
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Before the fix:
```
vyos@r14:~$ restart vrrp 
usage: restart.py restart_service [-h] [--raw] --name
                                  {dhcp,dhcpv6,dns_dynamic,dns_forwarding,igmp_proxy,ipsec,mdns_repeater,reverse_proxy,router_advert,snmp,ssh,suricatavrrp,webproxy} [--vrf VRF]
restart.py restart_service: error: argument --name: invalid choice: 'vrrp' (choose from 'dhcp', 'dhcpv6', 'dns_dynamic', 'dns_forwarding', 'igmp_proxy', 'ipsec', 'mdns_repeater', 'reverse_proxy', 'router_advert', 'snmp', 'ssh', 'suricatavrrp', 'webproxy')
vyos@r14:~$ 
```
After the fix:
```
vyos@r14:~$ restart vrrp 
Service vrrp is not configured!
vyos@r14:~$ 

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
