### PR TITLE
T6693: wireless: add missing country-code for 2.4GHz 802.11ax smoketest

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_wireless.py
+++ b/smoketest/scripts/cli/test_interfaces_wireless.py
@@ -313,6 +313,7 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         channel_set_width = '81'
 
         self.cli_set(self._base_path + [interface, 'ssid', ssid])
+        self.cli_set(self._base_path + [interface, 'country-code', country])
         self.cli_set(self._base_path + [interface, 'type', 'access-point'])
         self.cli_set(self._base_path + [interface, 'channel', channel])
         self.cli_set(self._base_path + [interface, 'mode', 'ax'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Sagitta fails the `test_wireless_hostapd_he_2ghz_config` smoketest due to a missing command to set the country code.
Added the missing step.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6693

## Related PR(s)

* https://github.com/vyos/vyos-1x/pull/4044

## Component(s) name
`test_interfaces_wireless.py`:`test_wireless_hostapd_he_2ghz_config` smoketest
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->
Add the `set interfaces wireless wlan1 country-code se` command with the proper variables as found in the equivalent 6GHz routine (`test_wireless_hostapd_he_6ghz_config`).

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
-->
Manually:
```
conf
set interfaces wireless wlan1 ssid ssid
set interfaces wireless wlan1 type access-point
commit
```
Observe the produced error:
```
Wireless country-code is mandatory

[[interfaces wireless wlan1]] failed
Commit failed
```

or execute `/usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireless.py`:
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireless.py
...
<<stripped>>
...
DEBUG - test_wireless_hostapd_he_2ghz_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_he_2ghz_config) ... ERROR
...
<<stripped>>
...
DEBUG - ----------------------------------------------------------------------
DEBUG - Traceback (most recent call last):
DEBUG -   File "/usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireless.py", line 335, in test_wireless_hostapd_he_2ghz_config
DEBUG -     self.cli_commit()
DEBUG -   File "/usr/libexec/vyos/tests/smoke/cli/base_vyostest_shim.py", line 81, in cli_commit
DEBUG -     self._session.commit()
DEBUG -   File "/usr/lib/python3/dist-packages/vyos/configsession.py", line 206, in commit
DEBUG -     out = self.__run_command([COMMIT])
DEBUG -           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
DEBUG -   File "/usr/lib/python3/dist-packages/vyos/configsession.py", line 143, in __run_command
DEBUG -     raise ConfigSessionError(output)
DEBUG - vyos.configsession.ConfigSessionError: [[interfaces wireless wlan1]] failed
DEBUG - Commit failed
DEBUG - 
DEBUG - 
DEBUG - ----------------------------------------------------------------------
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
After making the necessary change found in this PR:
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireless.py
DEBUG - test_add_multiple_ip_addresses (__main__.WirelessInterfaceTest.test_add_multiple_ip_addresses) ... ok
DEBUG - test_add_single_ip_address (__main__.WirelessInterfaceTest.test_add_single_ip_address) ... ok
DEBUG - test_add_to_invalid_vrf (__main__.WirelessInterfaceTest.test_add_to_invalid_vrf) ... ok
DEBUG - test_dhcp_client_options (__main__.WirelessInterfaceTest.test_dhcp_client_options) ... ok
DEBUG - test_dhcp_disable_interface (__main__.WirelessInterfaceTest.test_dhcp_disable_interface) ... ok
DEBUG - test_dhcp_vrf (__main__.WirelessInterfaceTest.test_dhcp_vrf) ... ok
DEBUG - test_dhcpv6_client_options (__main__.WirelessInterfaceTest.test_dhcpv6_client_options) ... ok
DEBUG - test_dhcpv6_vrf (__main__.WirelessInterfaceTest.test_dhcpv6_vrf) ... ok
DEBUG - test_dhcpv6pd_auto_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
DEBUG - test_dhcpv6pd_manual_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
DEBUG - test_interface_description (__main__.WirelessInterfaceTest.test_interface_description) ... ok
DEBUG - test_interface_disable (__main__.WirelessInterfaceTest.test_interface_disable) ... ok
DEBUG - test_interface_ip_options (__main__.WirelessInterfaceTest.test_interface_ip_options) ... ok
DEBUG - test_interface_ipv6_options (__main__.WirelessInterfaceTest.test_interface_ipv6_options) ... skipped 'not supported'
DEBUG - test_interface_mtu (__main__.WirelessInterfaceTest.test_interface_mtu) ... skipped 'not supported'
DEBUG - test_ipv6_link_local_address (__main__.WirelessInterfaceTest.test_ipv6_link_local_address) ... skipped 'not supported'
DEBUG - test_move_interface_between_vrf_instances (__main__.WirelessInterfaceTest.test_move_interface_between_vrf_instances) ... ok
DEBUG - test_mtu_1200_no_ipv6_interface (__main__.WirelessInterfaceTest.test_mtu_1200_no_ipv6_interface) ... skipped 'not supported'
DEBUG - test_span_mirror (__main__.WirelessInterfaceTest.test_span_mirror) ... skipped 'not supported'
DEBUG - test_vif_8021q_interfaces (__main__.WirelessInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
DEBUG - test_vif_8021q_lower_up_down (__main__.WirelessInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
DEBUG - test_vif_8021q_mtu_limits (__main__.WirelessInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
DEBUG - test_vif_8021q_qos_change (__main__.WirelessInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
DEBUG - test_vif_s_8021ad_vlan_interfaces (__main__.WirelessInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
DEBUG - test_vif_s_protocol_change (__main__.WirelessInterfaceTest.test_vif_s_protocol_change) ... ok
DEBUG - test_wireless_access_point_bridge (__main__.WirelessInterfaceTest.test_wireless_access_point_bridge) ... ok
DEBUG - test_wireless_add_single_ip_address (__main__.WirelessInterfaceTest.test_wireless_add_single_ip_address) ... ok
DEBUG - test_wireless_hostapd_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_config) ... ok
DEBUG - test_wireless_hostapd_he_2ghz_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_he_2ghz_config) ... ok
DEBUG - test_wireless_hostapd_he_6ghz_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_he_6ghz_config) ... ok
DEBUG - test_wireless_hostapd_vht_mu_beamformer_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_vht_mu_beamformer_config) ... ok
DEBUG - test_wireless_hostapd_vht_su_beamformer_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_vht_su_beamformer_config) ... ok
DEBUG - test_wireless_hostapd_wpa_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_wpa_config) ... ok
DEBUG - test_wireless_security_station_address (__main__.WirelessInterfaceTest.test_wireless_security_station_address) ... ok
DEBUG - 
DEBUG - 
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 34 tests in 214.871s
DEBUG - 
DEBUG - OK (skipped=9)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
