### PR TITLE
T6555: openvpn: fix inclusion of data-ciphers for server bridge test

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_openvpn.py
+++ b/smoketest/scripts/cli/test_interfaces_openvpn.py
@@ -625,7 +625,7 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
 
         self.cli_set(['interfaces', 'bridge', br_if, 'member', 'interface', vtun_if])
         self.cli_set(path + ['device-type', 'tap'])
-        self.cli_set(path + ['encryption', 'data-ciphers', 'aes192'])
+        self.cli_set(path + ['encryption', 'ncp-ciphers', 'aes192'])
         self.cli_set(path + ['hash', auth_hash])
         self.cli_set(path + ['mode', 'server'])
         self.cli_set(path + ['server', 'bridge', 'gateway', gw_subnet])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Commit dc1da7c ("OPENVPN: T6555: add server-bridge options in mode server") added a new smoketest which used the `data-ciphers` command which is new starting with VyOS 1.5, where VyOS 1.4 expects `ncp-ciphers`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6555

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
[OPENVPN: T6555: add server-bridge options in mode server (backport #3920) #4037](https://github.com/vyos/vyos-1x/pull/4037)

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
`test_interfaces_openvpn.py`:`test_openvpn_server_server_bridge` smoketest

## Proposed changes
<!--- Describe your changes in detail -->
Change the invalid configuration path `data-ciphers` to the valid-for-VyOS 1.4 `ncp-ciphers`.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
conf
set interfaces openvpn vtun5010 encryption data-ciphers aes192
```
Observe the produced error:
```
  Configuration path: interfaces openvpn vtun5010 encryption [data-ciphers] is not valid
  Set failed
```

or execute `/usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py`
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py
DEBUG - test_openvpn_client_interfaces (__main__.TestInterfacesOpenVPN.test_openvpn_client_interfaces) ... ok
DEBUG - test_openvpn_client_verify (__main__.TestInterfacesOpenVPN.test_openvpn_client_verify) ... ok
DEBUG - test_openvpn_options (__main__.TestInterfacesOpenVPN.test_openvpn_options) ... ok
DEBUG - test_openvpn_server_server_bridge (__main__.TestInterfacesOpenVPN.test_openvpn_server_server_bridge) ... ERROR
DEBUG - test_openvpn_server_subnet_topology (__main__.TestInterfacesOpenVPN.test_openvpn_server_subnet_topology) ... ok
DEBUG - test_openvpn_server_verify (__main__.TestInterfacesOpenVPN.test_openvpn_server_verify) ... ok
DEBUG - test_openvpn_site2site_interfaces_tun (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_interfaces_tun) ... ok
DEBUG - test_openvpn_site2site_verify (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_verify) ... ok
DEBUG - 
DEBUG - ======================================================================
DEBUG - ERROR: test_openvpn_server_server_bridge (__main__.TestInterfacesOpenVPN.test_openvpn_server_server_bridge)
DEBUG - ----------------------------------------------------------------------
DEBUG - Traceback (most recent call last):
DEBUG -   File "/usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py", line 628, in test_openvpn_server_server_bridge
DEBUG -     self.cli_set(path + ['encryption', 'data-ciphers', 'aes192'])
DEBUG -   File "/usr/libexec/vyos/tests/smoke/cli/base_vyostest_shim.py", line 71, in cli_set
DEBUG -     self._session.set(config)
DEBUG -   File "/usr/lib/python3/dist-packages/vyos/configsession.py", line 154, in set
DEBUG -     self.__run_command([SET] + path + value)
DEBUG -   File "/usr/lib/python3/dist-packages/vyos/configsession.py", line 143, in __run_command
DEBUG -     raise ConfigSessionError(output)
DEBUG - vyos.configsession.ConfigSessionError: Configuration path: [interfaces openvpn vtun5010 encryption data-ciphers aes192] is not valid
DEBUG - 
DEBUG - Set failed
DEBUG - 
DEBUG - 
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 8 tests in 75.145s

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
After making the necessary change found in this PR:
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py
DEBUG - test_openvpn_client_interfaces (__main__.TestInterfacesOpenVPN.test_openvpn_client_interfaces) ... ok
DEBUG - test_openvpn_client_verify (__main__.TestInterfacesOpenVPN.test_openvpn_client_verify) ... ok
DEBUG - test_openvpn_options (__main__.TestInterfacesOpenVPN.test_openvpn_options) ... ok
DEBUG - test_openvpn_server_server_bridge (__main__.TestInterfacesOpenVPN.test_openvpn_server_server_bridge) ... ok
DEBUG - test_openvpn_server_subnet_topology (__main__.TestInterfacesOpenVPN.test_openvpn_server_subnet_topology) ... ok
DEBUG - test_openvpn_server_verify (__main__.TestInterfacesOpenVPN.test_openvpn_server_verify) ... ok
DEBUG - test_openvpn_site2site_interfaces_tun (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_interfaces_tun) ... ok
DEBUG - test_openvpn_site2site_verify (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_verify) ... ok
DEBUG - 
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 8 tests in 320.848s
DEBUG - 
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
