### PR TITLE
T6716: don't automatically set ethernet offload

### DIFF
--- a/src/activation-scripts/20-ethernet_offload.py
+++ b/src/activation-scripts/20-ethernet_offload.py
@@ -17,9 +17,12 @@
 #        CLI. See https://vyos.dev/T3619#102254 for all the details.
 # T3787: Remove deprecated UDP fragmentation offloading option
 # T6006: add to activation-scripts: migration-scripts/interfaces/20-to-21
+# T6716: Honor the configured offload settings and don't automatically add
+#        them to the config if the kernel has them set (unless its a live boot)
 
 from vyos.ethtool import Ethtool
 from vyos.configtree import ConfigTree
+from vyos.system.image import is_live_boot
 
 def activate(config: ConfigTree):
     base = ['interfaces', 'ethernet']
@@ -36,7 +39,7 @@ def activate(config: ConfigTree):
         enabled, fixed = eth.get_generic_receive_offload()
         if configured and fixed:
             config.delete(base + [ifname, 'offload', 'gro'])
-        elif enabled and not fixed:
+        elif is_live_boot() and enabled and not fixed:
             config.set(base + [ifname, 'offload', 'gro'])
 
         # If GSO is enabled by the Kernel - we reflect this on the CLI. If GSO is
@@ -45,7 +48,7 @@ def activate(config: ConfigTree):
         enabled, fixed = eth.get_generic_segmentation_offload()
         if configured and fixed:
             config.delete(base + [ifname, 'offload', 'gso'])
-        elif enabled and not fixed:
+        elif is_live_boot() and enabled and not fixed:
             config.set(base + [ifname, 'offload', 'gso'])
 
         # If LRO is enabled by the Kernel - we reflect this on the CLI. If LRO is
@@ -54,7 +57,7 @@ def activate(config: ConfigTree):
         enabled, fixed = eth.get_large_receive_offload()
         if configured and fixed:
             config.delete(base + [ifname, 'offload', 'lro'])
-        elif enabled and not fixed:
+        elif is_live_boot() and enabled and not fixed:
             config.set(base + [ifname, 'offload', 'lro'])
 
         # If SG is enabled by the Kernel - we reflect this on the CLI. If SG is
@@ -63,7 +66,7 @@ def activate(config: ConfigTree):
         enabled, fixed = eth.get_scatter_gather()
         if configured and fixed:
             config.delete(base + [ifname, 'offload', 'sg'])
-        elif enabled and not fixed:
+        elif is_live_boot() and enabled and not fixed:
             config.set(base + [ifname, 'offload', 'sg'])
 
         # If TSO is enabled by the Kernel - we reflect this on the CLI. If TSO is
@@ -72,7 +75,7 @@ def activate(config: ConfigTree):
         enabled, fixed = eth.get_tcp_segmentation_offload()
         if configured and fixed:
             config.delete(base + [ifname, 'offload', 'tso'])
-        elif enabled and not fixed:
+        elif is_live_boot() and enabled and not fixed:
             config.set(base + [ifname, 'offload', 'tso'])
 
         # Remove deprecated UDP fragmentation offloading option


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Remove the lines of code that checked if the kernel had offloading enabled and was then forcing the config to set it to "on." The behavior now mirrors the config and offloading will only be enabled if the config is explicitly set to enabled.

Note: the code is still present to disable the offloading, in the config, if the kernel doesn't support it.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
 https://vyos.dev/T6716

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
Ethernet activation script (20-ethernet_offload.py)

## Proposed changes
<!--- Describe your changes in detail -->
Delete lines of code that set the ethernet offload setting based on the Kernel offload setting.
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

On a system where the kernel enables offloading at boot and/or the offload is currently set in the config:

```
configure
delete interfaces ethernet eth0 offload 
commit
load
show interfaces ethernet eth0 offload 
```
No offloading settings should be shown. On VyOS 1.5, without this PR, the offload settings will automatically be restored.
 
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
