### PR TITLE
syslog: T6719: fix the behavior of "syslog global preserve-fqdn"

### DIFF
--- a/data/templates/rsyslog/rsyslog.conf.j2
+++ b/data/templates/rsyslog/rsyslog.conf.j2
@@ -10,6 +10,10 @@ $MarkMessagePeriod {{ global.marker.interval }}
 $PreserveFQDN on
 {% endif %}
 
+{% if global.local_host_name is vyos_defined %}
+$LocalHostName {{ global.local_host_name }}
+{% endif %}
+
 # We always log to /var/log/messages
 $outchannel global,/var/log/messages,262144,/usr/sbin/logrotate {{ logrotate }}
 {% if global.facility is vyos_defined %}

--- a/src/conf_mode/system_syslog.py
+++ b/src/conf_mode/system_syslog.py
@@ -53,6 +53,17 @@ def get_config(config=None):
     if syslog.from_defaults(['global']):
         del syslog['global']
 
+    if (
+        'global' in syslog
+        and 'preserve_fqdn' in syslog['global']
+        and conf.exists(['system', 'host-name'])
+        and conf.exists(['system', 'domain-name'])
+    ):
+        hostname = conf.return_value(['system', 'host-name'])
+        domain = conf.return_value(['system', 'domain-name'])
+        fqdn = f'{hostname}.{domain}'
+        syslog['global']['local_host_name'] = fqdn
+
     return syslog
 
 def verify(syslog):


### PR DESCRIPTION
## Change Summary
Add config option to set local host name for syslog

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T6719

## Related PR(s)

## Component(s) name
system

## How to test
```
set system domain-name example.local
set system syslog global preserve-fqdn
```
Adds the rsyslog config entry
```
$LocalHostName vyos.example.local
```

## Smoketest result
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_syslog.py
test_syslog_basic (__main__.TestRSYSLOGService.test_syslog_basic) ... ok
test_syslog_global (__main__.TestRSYSLOGService.test_syslog_global) ... ok

----------------------------------------------------------------------
Ran 2 tests in 21.041s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
