### PR TITLE
T6723: firewall: extend op-mode commands

### DIFF
--- a/op-mode-definitions/firewall.xml.in
+++ b/op-mode-definitions/firewall.xml.in
@@ -98,6 +98,138 @@
                   </node>
                 </children>
               </node>
+              <node name="input">
+                <properties>
+                  <help>Show bridge input firewall ruleset</help>
+                </properties>
+                <children>
+                  <node name="filter">
+                    <properties>
+                      <help>Show bridge input filter firewall ruleset</help>
+                    </properties>
+                    <children>
+                      <leafNode name="detail">
+                        <properties>
+                          <help>Show list view of bridge input filter firewall rules</help>
+                          <completionHelp>
+                            <path>firewall bridge input filter detail</path>
+                          </completionHelp>
+                        </properties>
+                        <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5 --detail $6</command>
+                      </leafNode>
+                      <tagNode name="rule">
+                        <properties>
+                          <help>Show summary of bridge input filter firewall rules</help>
+                          <completionHelp>
+                            <path>firewall bridge input filter rule</path>
+                          </completionHelp>
+                        </properties>
+                        <children>
+                          <leafNode name="detail">
+                            <properties>
+                              <help>Show list view of specific bridge input filter firewall rule</help>
+                              <completionHelp>
+                                <path>firewall bridge input filter detail</path>
+                              </completionHelp>
+                            </properties>
+                            <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5 --rule $7 --detail $8</command>
+                          </leafNode>
+                        </children>
+                        <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5 --rule $7</command>
+                      </tagNode>
+                    </children>
+                    <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5</command>
+                  </node>
+                </children>
+              </node>
+              <node name="output">
+                <properties>
+                  <help>Show bridge output firewall ruleset</help>
+                </properties>
+                <children>
+                  <node name="filter">
+                    <properties>
+                      <help>Show bridge output filter firewall ruleset</help>
+                    </properties>
+                    <children>
+                      <leafNode name="detail">
+                        <properties>
+                          <help>Show list view of bridge output filter firewall rules</help>
+                          <completionHelp>
+                            <path>firewall bridge output filter detail</path>
+                          </completionHelp>
+                        </properties>
+                        <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5 --detail $6</command>
+                      </leafNode>
+                      <tagNode name="rule">
+                        <properties>
+                          <help>Show summary of bridge output filter firewall rules</help>
+                          <completionHelp>
+                            <path>firewall bridge output filter rule</path>
+                          </completionHelp>
+                        </properties>
+                        <children>
+                          <leafNode name="detail">
+                            <properties>
+                              <help>Show list view of specific bridge output filter firewall rule</help>
+                              <completionHelp>
+                                <path>firewall bridge output filter detail</path>
+                              </completionHelp>
+                            </properties>
+                            <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5 --rule $7 --detail $8</command>
+                          </leafNode>
+                        </children>
+                        <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5 --rule $7</command>
+                      </tagNode>
+                    </children>
+                    <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5</command>
+                  </node>
+                </children>
+              </node>
+              <node name="prerouting">
+                <properties>
+                  <help>Show bridge prerouting firewall ruleset</help>
+                </properties>
+                <children>
+                  <node name="filter">
+                    <properties>
+                      <help>Show bridge prerouting filter firewall ruleset</help>
+                    </properties>
+                    <children>
+                      <leafNode name="detail">
+                        <properties>
+                          <help>Show list view of bridge prerouting filter firewall rules</help>
+                          <completionHelp>
+                            <path>firewall bridge prerouting filter detail</path>
+                          </completionHelp>
+                        </properties>
+                        <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5 --detail $6</command>
+                      </leafNode>
+                      <tagNode name="rule">
+                        <properties>
+                          <help>Show summary of bridge prerouting filter firewall rules</help>
+                          <completionHelp>
+                            <path>firewall bridge prerouting filter rule</path>
+                          </completionHelp>
+                        </properties>
+                        <children>
+                          <leafNode name="detail">
+                            <properties>
+                              <help>Show list view of specific bridge prerouting filter firewall rule</help>
+                              <completionHelp>
+                                <path>firewall bridge prerouting filter detail</path>
+                              </completionHelp>
+                            </properties>
+                            <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5 --rule $7 --detail $8</command>
+                          </leafNode>
+                        </children>
+                        <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5 --rule $7</command>
+                      </tagNode>
+                    </children>
+                    <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5</command>
+                  </node>
+                </children>
+              </node>
               <tagNode name="name">
                 <properties>
                   <help>Show bridge custom firewall chains</help>
@@ -278,6 +410,50 @@
                   </node>
                 </children>
               </node>
+              <node name="prerouting">
+                <properties>
+                  <help>Show IPv6 prerouting firewall ruleset</help>
+                </properties>
+                <children>
+                  <node name="raw">
+                    <properties>
+                      <help>Show IPv6 prerouting raw firewall ruleset</help>
+                    </properties>
+                    <children>
+                      <leafNode name="detail">
+                        <properties>
+                          <help>Show list view of IPv6 prerouting raw firewall ruleset</help>
+                          <completionHelp>
+                            <path>firewall ipv6 prerouting raw detail</path>
+                          </completionHelp>
+                        </properties>
+                        <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5 --detail $6</command>
+                      </leafNode>
+                      <tagNode name="rule">
+                        <properties>
+                          <help>Show summary of IPv6 prerouting raw firewall rules</help>
+                          <completionHelp>
+                            <path>firewall ipv6 prerouting raw rule</path>
+                          </completionHelp>
+                        </properties>
+                        <children>
+                          <leafNode name="detail">
+                            <properties>
+                              <help>Show list view of IPv6 prerouting raw firewall rules</help>
+                              <completionHelp>
+                                <path>firewall ipv6 prerouting raw rule detail</path>
+                              </completionHelp>
+                            </properties>
+                            <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5 --rule $7 --detail $8</command>
+                          </leafNode>
+                        </children>
+                        <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5 --rule $7</command>
+                      </tagNode>
+                    </children>
+                    <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5</command>
+                  </node>
+                </children>
+              </node>
               <tagNode name="name">
                 <properties>
                   <help>Show IPv6 custom firewall chains</help>
@@ -446,6 +622,50 @@
                               <help>Show list view of IPv4 output filter firewall rules</help>
                               <completionHelp>
                                 <path>firewall ipv4 input output rule detail</path>
+                              </completionHelp>
+                            </properties>
+                            <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5 --rule $7 --detail $8</command>
+                          </leafNode>
+                        </children>
+                        <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5 --rule $7</command>
+                      </tagNode>
+                    </children>
+                    <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5</command>
+                  </node>
+                </children>
+              </node>
+              <node name="prerouting">
+                <properties>
+                  <help>Show IPv4 prerouting firewall ruleset</help>
+                </properties>
+                <children>
+                  <node name="raw">
+                    <properties>
+                      <help>Show IPv4 prerouting raw firewall ruleset</help>
+                    </properties>
+                    <children>
+                      <leafNode name="detail">
+                        <properties>
+                          <help>Show list view of IPv4 prerouting raw firewall ruleset</help>
+                          <completionHelp>
+                            <path>firewall ipv4 prerouting raw detail</path>
+                          </completionHelp>
+                        </properties>
+                        <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5 --detail $6</command>
+                      </leafNode>
+                      <tagNode name="rule">
+                        <properties>
+                          <help>Show summary of IPv4 prerouting raw firewall rules</help>
+                          <completionHelp>
+                            <path>firewall ipv4 prerouting raw rule</path>
+                          </completionHelp>
+                        </properties>
+                        <children>
+                          <leafNode name="detail">
+                            <properties>
+                              <help>Show list view of IPv4 prerouting raw firewall rules</help>
+                              <completionHelp>
+                                <path>firewall ipv4 prerouting raw rule detail</path>
                               </completionHelp>
                             </properties>
                             <command>sudo ${vyos_op_scripts_dir}/firewall.py --action show --family $3 --hook $4 --priority $5 --rule $7 --detail $8</command>

--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -172,6 +172,81 @@
                       </node>
                     </children>
                   </node>
+                  <node name="input">
+                    <properties>
+                      <help>Show Bridge input firewall log</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot -k | grep bri-INP</command>
+                    <children>
+                      <node name="filter">
+                        <properties>
+                          <help>Show Bridge firewall input filter</help>
+                        </properties>
+                        <command>journalctl --no-hostname --boot -k | grep bri-INP-filter</command>
+                        <children>
+                          <tagNode name="rule">
+                            <properties>
+                              <help>Show log for a rule in the specified firewall</help>
+                              <completionHelp>
+                                <path>firewall bridge input filter rule</path>
+                              </completionHelp>
+                            </properties>
+                            <command>journalctl --no-hostname --boot -k | egrep "\[bri-INP-filter-$8-[ADRJC]\]"</command>
+                          </tagNode>
+                        </children>
+                      </node>
+                    </children>
+                  </node>
+                  <node name="output">
+                    <properties>
+                      <help>Show Bridge output firewall log</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot -k | grep bri-OUT</command>
+                    <children>
+                      <node name="filter">
+                        <properties>
+                          <help>Show Bridge firewall output filter</help>
+                        </properties>
+                        <command>journalctl --no-hostname --boot -k | grep bri-OUT-filter</command>
+                        <children>
+                          <tagNode name="rule">
+                            <properties>
+                              <help>Show log for a rule in the specified firewall</help>
+                              <completionHelp>
+                                <path>firewall bridge output filter rule</path>
+                              </completionHelp>
+                            </properties>
+                            <command>journalctl --no-hostname --boot -k | egrep "\[bri-OUT-filter-$8-[ADRJC]\]"</command>
+                          </tagNode>
+                        </children>
+                      </node>
+                    </children>
+                  </node>
+                  <node name="prerouting">
+                    <properties>
+                      <help>Show Bridge prerouting firewall log</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot -k | grep bri-PRE</command>
+                    <children>
+                      <node name="filter">
+                        <properties>
+                          <help>Show Bridge firewall prerouting filter</help>
+                        </properties>
+                        <command>journalctl --no-hostname --boot -k | grep bri-PRE-filter</command>
+                        <children>
+                          <tagNode name="rule">
+                            <properties>
+                              <help>Show log for a rule in the specified firewall</help>
+                              <completionHelp>
+                                <path>firewall bridge prerouting filter rule</path>
+                              </completionHelp>
+                            </properties>
+                            <command>journalctl --no-hostname --boot -k | egrep "\[bri-PRE-filter-$8-[ADRJC]\]"</command>
+                          </tagNode>
+                        </children>
+                      </node>
+                    </children>
+                  </node>
                   <tagNode name="name">
                     <properties>
                       <help>Show custom Bridge firewall log</help>
@@ -295,6 +370,31 @@
                       </node>
                     </children>
                   </node>
+                  <node name="prerouting">
+                    <properties>
+                      <help>Show firewall IPv4 prerouting log</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot -k | grep ipv4-PRE</command>
+                    <children>
+                      <node name="raw">
+                        <properties>
+                          <help>Show firewall IPv4 prerouting raw log</help>
+                        </properties>
+                        <command>journalctl --no-hostname --boot -k | grep ipv4-PRE-raw</command>
+                        <children>
+                          <tagNode name="rule">
+                            <properties>
+                              <help>Show log for a rule in the specified firewall</help>
+                              <completionHelp>
+                                <path>firewall ipv4 prerouting raw rule</path>
+                              </completionHelp>
+                            </properties>
+                            <command>journalctl --no-hostname --boot -k | egrep "\[ipv4-PRE-raw-$8-[ADRJC]\]"</command>
+                          </tagNode>
+                        </children>
+                      </node>
+                    </children>
+                  </node>
                 </children>
               </node>
               <node name="ipv6">
@@ -393,6 +493,31 @@
                               </completionHelp>
                             </properties>
                             <command>journalctl --no-hostname --boot -k | egrep "\[ipv6-OUT-filter-$8-[ADRJC]\]"</command>
+                          </tagNode>
+                        </children>
+                      </node>
+                    </children>
+                  </node>
+                  <node name="prerouting">
+                    <properties>
+                      <help>Show firewall IPv6 prerouting log</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot -k | grep ipv6-PRE</command>
+                    <children>
+                      <node name="raw">
+                        <properties>
+                          <help>Show firewall IPv6 prerouting raw log</help>
+                        </properties>
+                        <command>journalctl --no-hostname --boot -k | grep ipv6-PRE-raw</command>
+                        <children>
+                          <tagNode name="rule">
+                            <properties>
+                              <help>Show log for a rule in the specified firewall</help>
+                              <completionHelp>
+                                <path>firewall ipv6 prerouting raw rule</path>
+                              </completionHelp>
+                            </properties>
+                            <command>journalctl --no-hostname --boot -k | egrep "\[ipv6-PRE-raw-$8-[ADRJC]\]"</command>
                           </tagNode>
                         </children>
                       </node>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Extend op-mode commands <show firewall ..> and a <show log firewall ..> in order to match all chains/priorities
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6723

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Ipv4 test:
```
vyos@bridge:~$ show firewall ipv4 prerouting raw
Ruleset Information

---------------------------------
ipv4 Firewall "prerouting raw"

Rule     Action    Protocol      Packets    Bytes  Conditions
-------  --------  ----------  ---------  -------  -------------------------------------------------------
10       accept    icmp                2      168  meta l4proto icmp  prefix "[ipv4-PRE-raw-10-A]"  accept
default  drop      all               913   297958

vyos@bridge:~$ show log firewall ipv4 prerouting raw 
Sep 18 13:52:45 kernel: [ipv4-PRE-raw-10-A]IN=eth0 OUT= MAC=50:00:00:01:00:00:4c:d5:77:c0:19:81:08:00 SRC=192.168.77.14 DST=192.168.77.24 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=39884 DF PROTO=ICMP TYPE=8 CODE=0 ID=2 SEQ=1 
Sep 18 13:52:46 kernel: [ipv4-PRE-raw-10-A]IN=eth0 OUT= MAC=50:00:00:01:00:00:4c:d5:77:c0:19:81:08:00 SRC=192.168.77.14 DST=192.168.77.24 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=40793 DF PROTO=ICMP TYPE=8 CODE=0 ID=2 SEQ=2 
vyos@bridge:~$ show log firewall ipv4 prerouting raw rule 
Possible completions:
  10                    Show log for a rule in the specified firewall

      
vyos@bridge:~$ show log firewall ipv4 prerouting raw rule 20
vyos@bridge:~$ show log firewall ipv4 prerouting raw rule 10
Sep 18 13:52:45 kernel: [ipv4-PRE-raw-10-A]IN=eth0 OUT= MAC=50:00:00:01:00:00:4c:d5:77:c0:19:81:08:00 SRC=192.168.77.14 DST=192.168.77.24 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=39884 DF PROTO=ICMP TYPE=8 CODE=0 ID=
2 SEQ=1 
Sep 18 13:52:46 kernel: [ipv4-PRE-raw-10-A]IN=eth0 OUT= MAC=50:00:00:01:00:00:4c:d5:77:c0:19:81:08:00 SRC=192.168.77.14 DST=192.168.77.24 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=40793 DF PROTO=ICMP TYPE=8 CODE=0 ID=
2 SEQ=2 
vyos@bridge:~$
```
And bridge test:
```
vyos@bridge:~$ show firewall bridge prerouting filter
Ruleset Information

---------------------------------
bridge Firewall "prerouting filter"

Rule     Action    Protocol      Packets    Bytes  Conditions
-------  --------  ----------  ---------  -------  ------------------------------------------------------------------------
10       jump      all                 3      150  iifname @I_br0-ifaces  prefix "[bri-PRE-filter-10-J]"  jump NAME_br0-pre
20       jump      all                 0        0  iifname @I_br1-ifaces  jump NAME_br1-pre
30       jump      all                 0        0  iifname @I_br2-ifaces  jump NAME_br2-pre
default  drop      all                 0        0

vyos@bridge:~$ show log firewall bridge prerouting 
Sep 18 13:53:40 kernel: [bri-PRE-filter-10-J]IN=eth1 OUT= ARP HTYPE=1 PTYPE=0x0800 OPCODE=1 MACSRC=00:50:79:66:68:02 IPSRC=10.0.0.12 MACDST=ff:ff:ff:ff:ff:ff IPDST=10.0.0.11
Sep 18 13:53:41 kernel: [bri-PRE-filter-10-J]IN=eth1 OUT= ARP HTYPE=1 PTYPE=0x0800 OPCODE=1 MACSRC=00:50:79:66:68:02 IPSRC=10.0.0.12 MACDST=ff:ff:ff:ff:ff:ff IPDST=10.0.0.11
Sep 18 13:53:42 kernel: [bri-PRE-filter-10-J]IN=eth1 OUT= ARP HTYPE=1 PTYPE=0x0800 OPCODE=1 MACSRC=00:50:79:66:68:02 IPSRC=10.0.0.12 MACDST=ff:ff:ff:ff:ff:ff IPDST=10.0.0.11
vyos@bridge:~$ show log firewall bridge prerouting filter rule 
Possible completions:
  10                    Show log for a rule in the specified firewall
  20
  30
      
vyos@bridge:~$ show log firewall bridge prerouting filter rule 20
vyos@bridge:~$ show log firewall bridge prerouting filter rule 10
Sep 18 13:53:40 kernel: [bri-PRE-filter-10-J]IN=eth1 OUT= ARP HTYPE=1 PTYPE=0x0800 OPCODE=1 MACSRC=00:50:79:66:68:02 IPSRC=10.0.0.12 MACDST=ff:ff:ff:ff:ff:ff IPDST=10.0.0.11
Sep 18 13:53:41 kernel: [bri-PRE-filter-10-J]IN=eth1 OUT= ARP HTYPE=1 PTYPE=0x0800 OPCODE=1 MACSRC=00:50:79:66:68:02 IPSRC=10.0.0.12 MACDST=ff:ff:ff:ff:ff:ff IPDST=10.0.0.11
Sep 18 13:53:42 kernel: [bri-PRE-filter-10-J]IN=eth1 OUT= ARP HTYPE=1 PTYPE=0x0800 OPCODE=1 MACSRC=00:50:79:66:68:02 IPSRC=10.0.0.12 MACDST=ff:ff:ff:ff:ff:ff IPDST=10.0.0.11
vyos@bridge:~$ 
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
