### PR TITLE
wireless: T6709: fix missing wpa_supplicant configuration

### DIFF
--- a/python/vyos/ifconfig/bond.py
+++ b/python/vyos/ifconfig/bond.py
@@ -504,3 +504,6 @@ class BondIf(Interface):
 
         # call base class first
         super().update(config)
+
+        # enable/disable EAPoL (Extensible Authentication Protocol over Local Area Network)
+        self.set_eapol()

--- a/python/vyos/ifconfig/ethernet.py
+++ b/python/vyos/ifconfig/ethernet.py
@@ -452,3 +452,6 @@ class EthernetIf(Interface):
 
         # call base class last
         super().update(config)
+
+        # enable/disable EAPoL (Extensible Authentication Protocol over Local Area Network)
+        self.set_eapol()

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1813,9 +1813,6 @@ class Interface(Control):
         value = '1' if (tmp != None) else '0'
         self.set_per_client_thread(value)
 
-        # enable/disable EAPoL (Extensible Authentication Protocol over Local Area Network)
-        self.set_eapol()
-
         # Enable/Disable of an interface must always be done at the end of the
         # derived class to make use of the ref-counting set_admin_state()
         # function. We will only enable the interface if 'up' was called as


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Commit 0ee8d5e35 ("ethernet: T6709: move EAPoL support to common framework") added support to also have EAPoL on other interface types then ethernet. This introduced a regression where the wireless interface wpa_supplicant configuration would get deleted.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6709

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4069

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->



## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ TEST_ETH="eth2 eth3" /usr/libexec/vyos/tests/smoke/cli/test_interfaces_ethernet.py
test_add_multiple_ip_addresses (__main__.EthernetInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.EthernetInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.EthernetInterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.EthernetInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.EthernetInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.EthernetInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.EthernetInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.EthernetInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol (__main__.EthernetInterfaceTest.test_eapol) ... ok
test_ethtool_evpn_uplink_tarcking (__main__.EthernetInterfaceTest.test_ethtool_evpn_uplink_tarcking) ... ok
test_ethtool_flow_control (__main__.EthernetInterfaceTest.test_ethtool_flow_control) ... ok
test_ethtool_ring_buffer (__main__.EthernetInterfaceTest.test_ethtool_ring_buffer) ... ok
test_interface_description (__main__.EthernetInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.EthernetInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.EthernetInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.EthernetInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.EthernetInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.EthernetInterfaceTest.test_ipv6_link_local_address) ... ok
test_move_interface_between_vrf_instances (__main__.EthernetInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.EthernetInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_non_existing_interface (__main__.EthernetInterfaceTest.test_non_existing_interface) ... ok
test_offloading_rfs (__main__.EthernetInterfaceTest.test_offloading_rfs) ... ok
test_offloading_rps (__main__.EthernetInterfaceTest.test_offloading_rps) ... ok
test_span_mirror (__main__.EthernetInterfaceTest.test_span_mirror) ... ok
test_speed_duplex_verify (__main__.EthernetInterfaceTest.test_speed_duplex_verify) ... ok
test_vif_8021q_interfaces (__main__.EthernetInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.EthernetInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.EthernetInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.EthernetInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.EthernetInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.EthernetInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 33 tests in 184.811s

OK
```
```
vyos@vyos:~$ TEST_ETH="eth2 eth3" /usr/libexec/vyos/tests/smoke/cli/test_interfaces_bonding.py
test_add_multiple_ip_addresses (__main__.BondingInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.BondingInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.BondingInterfaceTest.test_add_to_invalid_vrf) ... ok
test_bonding_evpn_multihoming (__main__.BondingInterfaceTest.test_bonding_evpn_multihoming) ... ok
test_bonding_hash_policy (__main__.BondingInterfaceTest.test_bonding_hash_policy) ... ok
test_bonding_lacp_rate (__main__.BondingInterfaceTest.test_bonding_lacp_rate) ... ok
test_bonding_mii_monitoring_interval (__main__.BondingInterfaceTest.test_bonding_mii_monitoring_interval) ... ok
test_bonding_min_links (__main__.BondingInterfaceTest.test_bonding_min_links) ... ok
test_bonding_multi_use_member (__main__.BondingInterfaceTest.test_bonding_multi_use_member) ... ok
test_bonding_remove_member (__main__.BondingInterfaceTest.test_bonding_remove_member) ... ok
test_bonding_source_bridge_interface (__main__.BondingInterfaceTest.test_bonding_source_bridge_interface) ... ok
test_bonding_source_interface (__main__.BondingInterfaceTest.test_bonding_source_interface) ... ok
test_bonding_system_mac (__main__.BondingInterfaceTest.test_bonding_system_mac) ... ok
test_bonding_uniq_member_description (__main__.BondingInterfaceTest.test_bonding_uniq_member_description) ... ok
test_dhcp_client_options (__main__.BondingInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.BondingInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.BondingInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.BondingInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.BondingInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.BondingInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.BondingInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol (__main__.BondingInterfaceTest.test_eapol) ... ok
test_interface_description (__main__.BondingInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.BondingInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.BondingInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.BondingInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.BondingInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.BondingInterfaceTest.test_ipv6_link_local_address) ... ok
test_move_interface_between_vrf_instances (__main__.BondingInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.BondingInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.BondingInterfaceTest.test_span_mirror) ... ok
test_vif_8021q_interfaces (__main__.BondingInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.BondingInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.BondingInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.BondingInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.BondingInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.BondingInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 37 tests in 175.470s

OK
```
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireless.py
test_add_multiple_ip_addresses (__main__.WirelessInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.WirelessInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.WirelessInterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.WirelessInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.WirelessInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.WirelessInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.WirelessInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.WirelessInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol (__main__.WirelessInterfaceTest.test_eapol) ... skipped 'not supported'
test_interface_description (__main__.WirelessInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.WirelessInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.WirelessInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.WirelessInterfaceTest.test_interface_ipv6_options) ... skipped 'not supported'
test_interface_mtu (__main__.WirelessInterfaceTest.test_interface_mtu) ... skipped 'not supported'
test_ipv6_link_local_address (__main__.WirelessInterfaceTest.test_ipv6_link_local_address) ... skipped 'not supported'
test_move_interface_between_vrf_instances (__main__.WirelessInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.WirelessInterfaceTest.test_mtu_1200_no_ipv6_interface) ... skipped 'not supported'
test_span_mirror (__main__.WirelessInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.WirelessInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.WirelessInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.WirelessInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.WirelessInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.WirelessInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.WirelessInterfaceTest.test_vif_s_protocol_change) ... ok
test_wireless_access_point_bridge (__main__.WirelessInterfaceTest.test_wireless_access_point_bridge) ... ok
test_wireless_add_single_ip_address (__main__.WirelessInterfaceTest.test_wireless_add_single_ip_address) ... ok
test_wireless_hostapd_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_config) ... ok
test_wireless_hostapd_he_2ghz_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_he_2ghz_config) ... ok
test_wireless_hostapd_he_6ghz_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_he_6ghz_config) ... ok
test_wireless_hostapd_vht_mu_beamformer_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_vht_mu_beamformer_config) ... ok
test_wireless_hostapd_vht_su_beamformer_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_vht_su_beamformer_config) ... ok
test_wireless_hostapd_wpa_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_wpa_config) ... ok
test_wireless_security_station_address (__main__.WirelessInterfaceTest.test_wireless_security_station_address) ... ok

----------------------------------------------------------------------
Ran 35 tests in 189.242s

OK (skipped=10)
```

```
vyos@vyos:~$ TEST_ETH="eth2 eth3" /usr/libexec/vyos/tests/smoke/cli/test_interfaces_macsec.py
test_add_multiple_ip_addresses (__main__.MACsecInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.MACsecInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.MACsecInterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.MACsecInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.MACsecInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.MACsecInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.MACsecInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.MACsecInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.MACsecInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.MACsecInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol (__main__.MACsecInterfaceTest.test_eapol) ... skipped 'not supported'
test_interface_description (__main__.MACsecInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.MACsecInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.MACsecInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.MACsecInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.MACsecInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.MACsecInterfaceTest.test_ipv6_link_local_address) ... ok
test_macsec_encryption (__main__.MACsecInterfaceTest.test_macsec_encryption) ... ok
test_macsec_gcm_aes_128 (__main__.MACsecInterfaceTest.test_macsec_gcm_aes_128) ... ok
test_macsec_gcm_aes_256 (__main__.MACsecInterfaceTest.test_macsec_gcm_aes_256) ... ok
test_macsec_source_interface (__main__.MACsecInterfaceTest.test_macsec_source_interface) ... ok
test_macsec_static_keys (__main__.MACsecInterfaceTest.test_macsec_static_keys) ... ok
test_move_interface_between_vrf_instances (__main__.MACsecInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.MACsecInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.MACsecInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.MACsecInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.MACsecInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.MACsecInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.MACsecInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.MACsecInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.MACsecInterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'

----------------------------------------------------------------------
Ran 31 tests in 105.556s

OK (skipped=8)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
