### PR TITLE
ethtool: T6729: drop text based feature parsing in favour of JSON

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -94,7 +94,7 @@ Depends:
   linux-cpupower,
 # ipaddrcheck is widely used in IP value validators
   ipaddrcheck,
-  ethtool,
+  ethtool (>= 6.10),
   lm-sensors,
   procps,
   netplug,


### PR DESCRIPTION
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Recent ethtool 6.10 supports JSON output for the base driver features. Remove our old text based processing code and use the machine readable output of ethtool.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6729

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/769

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
`vyos.ethtool`

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```python3
from vyos.ethtool import Ethtool
eth0 = Ethtool('eth0')
eth0.check_speed_duplex('1000', 'full')
eth0.check_speed_duplex('auto', 'auto')
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
