### PR TITLE
validators: T6739: fix ipaddrcheck argument quoting

### DIFF
--- a/src/validators/interface-address
+++ b/src/validators/interface-address
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-ipaddrcheck --is-ipv4-host $1 || ipaddrcheck --is-ipv6-host $1 
+ipaddrcheck --is-ipv4-host "$1" || ipaddrcheck --is-ipv6-host "$1" 

--- a/src/validators/ip-address
+++ b/src/validators/ip-address
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ipaddrcheck --is-any-single $1
+ipaddrcheck --is-any-single "$1"
 
 if [ $? -gt 0 ]; then
     echo "Error: $1 is not a valid IP address"

--- a/src/validators/ip-cidr
+++ b/src/validators/ip-cidr
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ipaddrcheck --is-any-cidr $1
+ipaddrcheck --is-any-cidr "$1"
 
 if [ $? -gt 0 ]; then
     echo "Error: $1 is not a valid IP CIDR"

--- a/src/validators/ip-host
+++ b/src/validators/ip-host
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ipaddrcheck --is-any-host $1
+ipaddrcheck --is-any-host "$1"
 
 if [ $? -gt 0 ]; then
     echo "Error: $1 is not a valid IP host"

--- a/src/validators/ip-prefix
+++ b/src/validators/ip-prefix
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ipaddrcheck --is-any-net $1
+ipaddrcheck --is-any-net "$1"
 
 if [ $? -gt 0 ]; then
     echo "Error: $1 is not a valid IP prefix"

--- a/src/validators/ipv4
+++ b/src/validators/ipv4
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ipaddrcheck --is-ipv4 $1
+ipaddrcheck --is-ipv4 "$1"
 
 if [ $? -gt 0 ]; then
     echo "Error: $1 is not IPv4"

--- a/src/validators/ipv4-address
+++ b/src/validators/ipv4-address
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ipaddrcheck --is-ipv4-single $1
+ipaddrcheck --is-ipv4-single "$1"
 
 if [ $? -gt 0 ]; then
     echo "Error: $1 is not a valid IPv4 address"

--- a/src/validators/ipv4-host
+++ b/src/validators/ipv4-host
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ipaddrcheck --is-ipv4-host $1
+ipaddrcheck --is-ipv4-host "$1"
 
 if [ $? -gt 0 ]; then
     echo "Error: $1 is not a valid IPv4 host"

--- a/src/validators/ipv4-multicast
+++ b/src/validators/ipv4-multicast
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ipaddrcheck --is-ipv4-multicast $1 && ipaddrcheck --is-ipv4-single $1
+ipaddrcheck --is-ipv4-multicast "$1" && ipaddrcheck --is-ipv4-single "$1"
 
 if [ $? -gt 0 ]; then
     echo "Error: $1 is not a valid IPv4 multicast address"

--- a/src/validators/ipv4-prefix
+++ b/src/validators/ipv4-prefix
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ipaddrcheck --is-ipv4-net $1
+ipaddrcheck --is-ipv4-net "$1"
 
 if [ $? -gt 0 ]; then
     echo "Error: $1 is not a valid IPv4 prefix"

--- a/src/validators/ipv4-range
+++ b/src/validators/ipv4-range
@@ -18,12 +18,12 @@ if [[ "$1" =~ "-" ]]; then
   # hyphen as delimiter
   readarray -d - -t strarr <<< $1
 
-  ipaddrcheck --is-ipv4-single ${strarr[0]}
+  ipaddrcheck --is-ipv4-single "${strarr[0]}"
   if [ $? -gt 0 ]; then
     error_exit $1
   fi
 
-  ipaddrcheck --is-ipv4-single ${strarr[1]}
+  ipaddrcheck --is-ipv4-single "${strarr[1]}"
   if [ $? -gt 0 ]; then
     error_exit $1
   fi

--- a/src/validators/ipv4-range-mask
+++ b/src/validators/ipv4-range-mask
@@ -17,7 +17,7 @@ do
 done
 
 if [[ "${range}" =~ "-" ]]&&[[ ! -z ${mask} ]]; then
-  ipaddrcheck --range-prefix-length ${mask} --is-ipv4-range ${range}
+  ipaddrcheck --range-prefix-length "${mask}" --is-ipv4-range "${range}"
   if [ $? -gt 0 ]; then
     error_exit ${range} ${mask}
   fi

--- a/src/validators/ipv6
+++ b/src/validators/ipv6
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ipaddrcheck --is-ipv6 $1
+ipaddrcheck --is-ipv6 "$1"
 
 if [ $? -gt 0 ]; then
     echo "Error: $1 is not IPv6"

--- a/src/validators/ipv6-address
+++ b/src/validators/ipv6-address
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ipaddrcheck --is-ipv6-single $1
+ipaddrcheck --is-ipv6-single "$1"
 
 if [ $? -gt 0 ]; then
     echo "Error: $1 is not a valid IPv6 address"

--- a/src/validators/ipv6-host
+++ b/src/validators/ipv6-host
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ipaddrcheck --is-ipv6-host $1
+ipaddrcheck --is-ipv6-host "$1"
 
 if [ $? -gt 0 ]; then
     echo "Error: $1 is not a valid IPv6 host"

--- a/src/validators/ipv6-multicast
+++ b/src/validators/ipv6-multicast
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ipaddrcheck --is-ipv6-multicast $1 && ipaddrcheck --is-ipv6-single $1
+ipaddrcheck --is-ipv6-multicast "$1" && ipaddrcheck --is-ipv6-single "$1"
 
 if [ $? -gt 0 ]; then
     echo "Error: $1 is not a valid IPv6 multicast address"

--- a/src/validators/ipv6-prefix
+++ b/src/validators/ipv6-prefix
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-ipaddrcheck --is-ipv6-net $1
+ipaddrcheck --is-ipv6-net "$1"
 
 if [ $? -gt 0 ]; then
     echo "Error: $1 is not a valid IPv6 prefix"

--- a/src/validators/ipv6-srv6-segments
+++ b/src/validators/ipv6-srv6-segments
@@ -3,7 +3,7 @@ segments="$1"
 export IFS="/"
 
 for ipv6addr in $segments; do
-    ipaddrcheck --is-ipv6-single $ipv6addr
+    ipaddrcheck --is-ipv6-single "$ipv6addr"
     if [ $? -gt 0 ]; then
         echo "Error: $1 is not a valid IPv6 address"
         exit 1


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Properly quote `ipaddrcheck` arguments in validator scripts to ensure they are handled correctly if they contain whitespace. Right now such arguments are correctly rejected but result in confusing error messages that contain ipaddrcheck's help:

```
vyos@vyos# set interfaces ethernet eth1 address "a valid IP address, I swear!"

  Error: wrong number of arguments, one argument required!
  Usage: ipaddrcheck <OPTIONS> [STRING]
  Address checking options:
    --is-valid                 Check if STRING is a valid IPv4 or IPv6 address
                                 with or without prefix length
    --is-any-cidr              Check if STRING is a valid IPv4 or IPv6 address
                                 with prefix length
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):


## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Validators.


## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
