### PR TITLE
T6757: Openconnect: fix template for correct config parsing while configuring source address for radius authentication.

### DIFF
--- a/data/templates/ocserv/radius_conf.j2
+++ b/data/templates/ocserv/radius_conf.j2
@@ -22,7 +22,7 @@ authserver {{ authsrv }}
 {%         endif %}
 {%     endfor %}
 radius_timeout {{ authentication['radius']['timeout'] }}
-{%     if source_address %}
+{%     if authentication.radius.source_address is vyos_defined %}
 bindaddr {{ authentication['radius']['source_address'] }}
 {%     else %}
 bindaddr *


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6757

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openconnect
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Config:
```
vyos@ocserv-bug:~$ show config comm | grep radius
set vpn openconnect authentication mode radius
set vpn openconnect authentication radius groupconfig 'PPP'
set vpn openconnect authentication radius server 192.168.77.199
set vpn openconnect authentication radius source-address '10.99.99.99'
set vpn openconnect authentication radius timeout '5'
vyos@ocserv-bug:~$

```
And config file `/run/ocserv/radiusclient.conf`:
```
vyos@ocserv-bug:~$ cat /run/ocserv/radiusclient.conf 
### generated by vpn_openconnect.py ###
nas-identifier VyOS

#### Accounting

#### Authentication
authserver 192.168.77.199:1812
radius_timeout 5
bindaddr 10.99.99.99
...


```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
test_vpn_openconnect.py --> OK

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
