### PR TITLE
ipsec: T6101: Add validation for proposal option used in IKE group

### DIFF
--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -947,7 +947,8 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['ike-group', ike_group, 'lifetime', ike_lifetime])
         self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '1',  'dh-group', '14'])
         self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '1',  'encryption', 'aes256'])
-        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '1',  'hash', 'sha512'])
+        # a hash algorithm that cannot be mapped to an equivalent PRF
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '1',  'hash', 'aes192gmac'])
 
         # ESP
         self.cli_set(base_path + ['esp-group', esp_group, 'lifetime', eap_lifetime])
@@ -968,6 +969,11 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['remote-access', 'pool', ip_pool_name, 'name-server', name_server])
         self.cli_set(base_path + ['remote-access', 'pool', ip_pool_name, 'prefix', prefix])
 
+        # verify() - IKE group use not mapped hash algorithm
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '1', 'hash', 'sha512'])
         self.cli_commit()
 
         self.assertTrue(os.path.exists(dhcp_interfaces_file))

--- a/src/conf_mode/vpn_ipsec.py
+++ b/src/conf_mode/vpn_ipsec.py
@@ -214,6 +214,19 @@ def verify(ipsec):
             else:
                 verify_interface_exists(ipsec, interface)
 
+    # need to use a pseudo-random function (PRF) with an authenticated encryption algorithm.
+    # If a hash algorithm is defined then it will be mapped to an equivalent PRF
+    if 'ike_group' in ipsec:
+        for _, ike_config in ipsec['ike_group'].items():
+            for proposal, proposal_config in ike_config.get('proposal', {}).items():
+                if 'encryption' in proposal_config and 'prf' not in proposal_config:
+                    # list of hash algorithms that cannot be mapped to an equivalent PRF
+                    algs = ['aes128gmac', 'aes192gmac', 'aes256gmac', 'sha256_96']
+                    if 'hash' in proposal_config and proposal_config['hash'] in algs:
+                        raise ConfigError(
+                            f"A PRF algorithm is mandatory in IKE proposal {proposal}"
+                        )
+
     if 'l2tp' in ipsec:
         if 'esp_group' in ipsec['l2tp']:
             if 'esp_group' not in ipsec or ipsec['l2tp']['esp_group'] not in ipsec['esp_group']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
 * https://vyos.dev/T6101
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vpn ipsec
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set interfaces ethernet eth1 address '192.0.2.14/24'

set interfaces tunnel tun100 address '192.168.250.4/24'
set interfaces tunnel tun100 encapsulation 'gre'
set interfaces tunnel tun100 parameters ip key '1'
set interfaces tunnel tun100 source-address '192.0.2.14'
set protocols nhrp tunnel tun100 cisco-authentication 'secret'
set protocols nhrp tunnel tun100 holding-time '30'
set protocols nhrp tunnel tun100 multicast 'dynamic'
set protocols nhrp tunnel tun100 redirect
set protocols nhrp tunnel tun100 shortcut

set vpn ipsec esp-group ESP-HUB lifetime '1800'
set vpn ipsec esp-group ESP-HUB mode 'transport'
set vpn ipsec esp-group ESP-HUB pfs 'dh-group21'
set vpn ipsec esp-group ESP-HUB proposal 1 encryption 'aes256gcm128'
set vpn ipsec esp-group ESP-HUB proposal 1 hash 'aes256gmac'
set vpn ipsec ike-group IKE-HUB key-exchange 'ikev2'
set vpn ipsec ike-group IKE-HUB lifetime '3600'
set vpn ipsec ike-group IKE-HUB proposal 1 dh-group '24'
set vpn ipsec ike-group IKE-HUB proposal 1 encryption 'aes256gcm128'
set vpn ipsec ike-group IKE-HUB proposal 1 hash 'aes256gmac'
set vpn ipsec interface 'eth1'
set vpn ipsec profile NHRPVPN authentication mode 'pre-shared-secret'
set vpn ipsec profile NHRPVPN authentication pre-shared-secret 'secret'
set vpn ipsec profile NHRPVPN bind tunnel 'tun100'
set vpn ipsec profile NHRPVPN esp-group 'ESP-HUB'
set vpn ipsec profile NHRPVPN ike-group 'IKE-HUB'

vyos@vyos# commit
[ vpn ipsec ]
A PRF algorithm is mandatory in IKE proposal 1

[[vpn ipsec]] failed
Commit failed
[edit]

vyos@vyos# set vpn ipsec ike-group IKE-HUB proposal 1 hash sha256
[edit]
vyos@vyos# commit
[edit]

vyos@vyos# sudo systemctl status strongswan
● strongswan.service - strongSwan IPsec IKEv1/IKEv2 daemon using swanctl
     Loaded: loaded (/lib/systemd/system/strongswan.service; disabled; preset: enabled)
     Active: active (running) since Sat 2024-09-28 04:37:32 UTC; 8s ago
    Process: 17113 ExecStartPost=/usr/sbin/swanctl --load-all --noprompt (code=exited, status=0/SUCCESS)
   Main PID: 17094 (charon-systemd)
     Status: "charon-systemd running, strongSwan 5.9.11, Linux 6.6.51-vyos, x86_64"
      Tasks: 17 (limit: 1134)
     Memory: 5.5M
        CPU: 336ms
     CGroup: /system.slice/strongswan.service
             └─17094 /usr/sbin/charon-systemd

Sep 28 04:37:32 vyos charon[17094]: 14[CFG] loaded IKE shared key with id 'ike-dmvpn-tun100' for: '%any'
Sep 28 04:37:32 vyos charon-systemd[17094]: loaded IKE shared key with id 'ike-dmvpn-tun100' for: '%any'
Sep 28 04:37:32 vyos charon[17094]: 14[CFG] added vici connection: dmvpn-NHRPVPN-tun100
Sep 28 04:37:32 vyos charon-systemd[17094]: added vici connection: dmvpn-NHRPVPN-tun100
Sep 28 04:37:32 vyos swanctl[17113]: loaded ike secret 'ike-dmvpn-tun100'
Sep 28 04:37:32 vyos swanctl[17113]: no authorities found, 0 unloaded
Sep 28 04:37:32 vyos swanctl[17113]: no pools found, 0 unloaded
Sep 28 04:37:32 vyos swanctl[17113]: loaded connection 'dmvpn-NHRPVPN-tun100'
Sep 28 04:37:32 vyos swanctl[17113]: successfully loaded 1 connections, 0 unloaded
Sep 28 04:37:32 vyos systemd[1]: Started strongswan.service - strongSwan IPsec IKEv1/IKEv2 daemon using swanctl.
[edit]
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# python3 /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
test_dhcp_fail_handling (__main__.TestVPNIPsec.test_dhcp_fail_handling) ... ok
test_dmvpn (__main__.TestVPNIPsec.test_dmvpn) ... ok
test_flex_vpn_vips (__main__.TestVPNIPsec.test_flex_vpn_vips) ... ok
test_remote_access (__main__.TestVPNIPsec.test_remote_access) ... ok
test_remote_access_dhcp_fail_handling (__main__.TestVPNIPsec.test_remote_access_dhcp_fail_handling) ... ok
test_remote_access_eap_tls (__main__.TestVPNIPsec.test_remote_access_eap_tls) ... ok
test_remote_access_no_rekey (__main__.TestVPNIPsec.test_remote_access_no_rekey) ... ok
test_remote_access_pool_range (__main__.TestVPNIPsec.test_remote_access_pool_range) ... ok
test_remote_access_vti (__main__.TestVPNIPsec.test_remote_access_vti) ... ok
test_remote_access_x509 (__main__.TestVPNIPsec.test_remote_access_x509) ... ok
test_site_to_site (__main__.TestVPNIPsec.test_site_to_site) ... ok
test_site_to_site_vti (__main__.TestVPNIPsec.test_site_to_site_vti) ... ok
test_site_to_site_x509 (__main__.TestVPNIPsec.test_site_to_site_x509) ... ok

----------------------------------------------------------------------
Ran 13 tests in 111.062s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
