### PR TITLE
smoketest: T4576: add guard timeout for systemd in log level tests

### DIFF
--- a/smoketest/scripts/cli/base_accel_ppp_test.py
+++ b/smoketest/scripts/cli/base_accel_ppp_test.py
@@ -14,6 +14,7 @@
 
 import re
 
+from time import sleep
 from base_vyostest_shim import VyOSUnitTestSHIM
 from configparser import ConfigParser
 
@@ -641,6 +642,11 @@ delegate={delegate_2_prefix},{delegate_mask},name={pool_name}"""
             for log_level in range(0, 5):
                 self.set(['log', 'level', str(log_level)])
                 self.cli_commit()
+
+                # Systemd comes with a default of 5 restarts in 10 seconds policy,
+                # this limit can be hit by this reastart sequence, slow down a bit
+                sleep(5)
+
                 # Validate configuration values
                 conf = ConfigParser(allow_no_value=True)
                 conf.read(self._config_file)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Systemd comes with a default of 5 restarts in 10 seconds policy, this limit can be hit by this reastart sequence, slow down a bit.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T4576

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/3510

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
Smoketest

## Smoketest result

```
$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_l2tp.py
test_accel_ipv4_pool (__main__.TestVPNL2TPServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestVPNL2TPServer.test_accel_ipv6_pool) ... ok
test_accel_limits (__main__.TestVPNL2TPServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestVPNL2TPServer.test_accel_local_authentication) ... ok
test_accel_log_level (__main__.TestVPNL2TPServer.test_accel_log_level) ... ok
test_accel_name_servers (__main__.TestVPNL2TPServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestVPNL2TPServer.test_accel_next_pool) ... ok
test_accel_ppp_options (__main__.TestVPNL2TPServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestVPNL2TPServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestVPNL2TPServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestVPNL2TPServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestVPNL2TPServer.test_accel_wins_server) ... ok
test_l2tp_radius_server (__main__.TestVPNL2TPServer.test_l2tp_radius_server) ... ok
test_l2tp_server_authentication_protocols (__main__.TestVPNL2TPServer.test_l2tp_server_authentication_protocols) ... ok
test_vpn_l2tp_dependence_ipsec_swanctl (__main__.TestVPNL2TPServer.test_vpn_l2tp_dependence_ipsec_swanctl) ... ok

----------------------------------------------------------------------
Ran 15 tests in 89.482s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
