### PR TITLE
T6773: Implement configuration and logic for DDNS updates in Kea DHCP4

### DIFF
--- a/data/templates/dhcp-server/kea-dhcp-ddns.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp-ddns.conf.j2
@@ -1,0 +1,26 @@
+{
+    "DhcpDdns": {
+        "ip-address": "127.0.0.1",
+        "port": 53001,
+        "control-socket": {
+            "socket-type": "unix",
+            "socket-name": "/run/kea/kea-ddns-ctrl-socket"
+        },
+        "tsig-keys": {{ tsig_key_name | kea_dynamic_dns_update_tsig_key_json }},
+        "forward-ddns" : {{ forward_ddns_domain_name | kea_dynamic_dns_update_domains }},
+        "reverse-ddns" : {{ reverse_ddns_domain_name | kea_dynamic_dns_update_domains }},
+        "loggers": [
+            {
+                "name": "kea-dhcp-ddns",
+                "output_options": [
+                    {
+                        "output": "stdout",
+                        "pattern": "%-5p %m\n"
+                    }
+                ],
+                "severity": "INFO",
+                "debuglevel": 0
+            }
+        ]
+    }
+}

--- a/data/templates/dhcp-server/kea-dhcp-ddns.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp-ddns.conf.j2
@@ -6,9 +6,13 @@
             "socket-type": "unix",
             "socket-name": "/run/kea/kea-ddns-ctrl-socket"
         },
-        "tsig-keys": {{ tsig_key_name | kea_dynamic_dns_update_tsig_key_json }},
-        "forward-ddns" : {{ forward_ddns_domain_name | kea_dynamic_dns_update_domains }},
-        "reverse-ddns" : {{ reverse_ddns_domain_name | kea_dynamic_dns_update_domains }},
+        "tsig-keys": {{ dynamic_dns_update | kea_dynamic_dns_update_tsig_key_json }},
+        "forward-ddns" : {
+            "ddns-domains": {{ dynamic_dns_update | kea_dynamic_dns_update_domains('forward_ddns_domain_name') }}
+        },
+        "reverse-ddns" : {
+            "ddns-domains": {{ dynamic_dns_update | kea_dynamic_dns_update_domains('reverse_ddns_domain_name') }}
+        },
         "loggers": [
             {
                 "name": "kea-dhcp-ddns",

--- a/data/templates/dhcp-server/kea-dhcp4.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp4.conf.j2
@@ -50,7 +50,7 @@
                 "space": "ubnt"
             }
         ],
-{% if dynamic_dns_update.enable_updates is vyos_defined %}
+{% if dynamic_dns_update is vyos_defined %}
         "dhcp-ddns": {
             "enable-updates": true,
             "server-ip": "127.0.0.1",

--- a/data/templates/dhcp-server/kea-dhcp4.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp4.conf.j2
@@ -50,6 +50,19 @@
                 "space": "ubnt"
             }
         ],
+{% if dynamic_dns_update.enable_updates is vyos_defined %}
+        "dhcp-ddns": {
+            "enable-updates": true,
+            "server-ip": "127.0.0.1",
+            "server-port": 53001,
+            "sender-ip": "",
+            "sender-port": 0,
+            "max-queue-size": 1024,
+            "ncr-protocol": "UDP",
+            "ncr-format": "JSON"
+        },
+        {{ dynamic_dns_update | kea_dynamic_dns_update_main_json }}
+{% endif %}
         "hooks-libraries": [
 {% if high_availability is vyos_defined %}
             {

--- a/data/templates/dhcp-server/kea-dhcp4.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp4.conf.j2
@@ -61,7 +61,7 @@
             "ncr-protocol": "UDP",
             "ncr-format": "JSON"
         },
-        {{ dynamic_dns_update | kea_dynamic_dns_update_main_json }}
+        {{ dynamic_dns_update | kea_dynamic_dns_update_main_json }},
 {% endif %}
         "hooks-libraries": [
 {% if high_availability is vyos_defined %}

--- a/data/templates/dhcp-server/kea-dhcp4.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp4.conf.j2
@@ -61,7 +61,7 @@
             "ncr-protocol": "UDP",
             "ncr-format": "JSON"
         },
-        {{ dynamic_dns_update | kea_dynamic_dns_update_main_json }},
+        {{ dynamic_dns_update | kea_dynamic_dns_update_main_json }}
 {% endif %}
         "hooks-libraries": [
 {% if high_availability is vyos_defined %}

--- a/interface-definitions/include/dhcp/ddns-dns-server.xml.i
+++ b/interface-definitions/include/dhcp/ddns-dns-server.xml.i
@@ -1,4 +1,4 @@
-<!-- include start from dhcp/ddns-server.xml.i -->
+<!-- include start from dhcp/ddns-dns-server.xml.i -->
 <tagNode name="dns-server">
   <properties>
     <help>DNS server specification</help>

--- a/interface-definitions/include/dhcp/ddns-server.xml.i
+++ b/interface-definitions/include/dhcp/ddns-server.xml.i
@@ -1,0 +1,33 @@
+<!-- include start from dhcp/ddns-server.xml.i -->
+<tagNode name="dns-server">
+  <properties>
+    <help>DNS server specification</help>
+    <valueHelp>
+      <format>u32:1-999999</format>
+      <description>Number for this DNS server</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-999999"/>
+    </constraint>
+    <constraintErrorMessage>DNS server number must be between 1 and 999999</constraintErrorMessage>
+  </properties>
+  <children>
+    <leafNode name="address">
+      <properties>
+        <help>DNS server IP address</help>
+        <valueHelp>
+          <format>ipv4</format>
+          <description>DNS server IP address</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv4-address"/>
+        </constraint>
+      </properties>
+    </leafNode>
+    #include <include/port-number.xml.i>
+    <leafNode name="port">
+      <defaultValue>53</defaultValue>
+    </leafNode>
+  </children>
+</tagNode>
+<!-- include end -->

--- a/interface-definitions/include/dhcp/ddns-server.xml.i
+++ b/interface-definitions/include/dhcp/ddns-server.xml.i
@@ -12,22 +12,8 @@
     <constraintErrorMessage>DNS server number must be between 1 and 999999</constraintErrorMessage>
   </properties>
   <children>
-    <leafNode name="address">
-      <properties>
-        <help>DNS server IP address</help>
-        <valueHelp>
-          <format>ipv4</format>
-          <description>DNS server IP address</description>
-        </valueHelp>
-        <constraint>
-          <validator name="ipv4-address"/>
-        </constraint>
-      </properties>
-    </leafNode>
+    #include <include/address-ipv4-ipv6-single.xml.i>
     #include <include/port-number.xml.i>
-    <leafNode name="port">
-      <defaultValue>53</defaultValue>
-    </leafNode>
   </children>
 </tagNode>
 <!-- include end -->

--- a/interface-definitions/include/dhcp/ddns-settings.xml.i
+++ b/interface-definitions/include/dhcp/ddns-settings.xml.i
@@ -75,6 +75,15 @@
     <valueless/>
 </properties>
 </leafNode>
+<leafNode name="ttl-percent">
+<properties>
+    <help>Calculate TTL of the DNS record as a percentage of the lease lifetime</help>
+    <constraint>
+    <validator name="numeric" argument="--range 1-100"/>
+    </constraint>
+    <constraintErrorMessage>Invalid qualifying suffix</constraintErrorMessage>
+</properties>
+</leafNode>
 <leafNode name="hostname-char-set">
 <properties>
     <help>A regular expression describing the invalid character set in the host name</help>

--- a/interface-definitions/include/dhcp/ddns-settings.xml.i
+++ b/interface-definitions/include/dhcp/ddns-settings.xml.i
@@ -1,0 +1,88 @@
+<!-- include start from dhcp/ddns-settings.xml.i -->
+<leafNode name="send-updates">
+<properties>
+    <help>Send updates for this scope</help>
+    <valueless/>
+</properties>
+</leafNode>
+<leafNode name="override-client-update">
+<properties>
+    <help>Always update both forward and reverse DNS data, regardless of the client's request</help>
+    <valueless/>
+</properties>
+</leafNode>
+<leafNode name="override-no-update">
+<properties>
+    <help>Perform a DDNS update, even if the client instructs the server not to</help>
+    <valueless/>
+</properties>
+</leafNode>
+<leafNode name="replace-client-name">
+<properties>
+    <help>Replace client name mode</help>
+    <completionHelp>
+    <list>never always when-present when-not-present</list>
+    </completionHelp>
+    <valueHelp>
+    <format>never</format>
+    <description>Use the name the client sent. If the client sent no name, do not generate one. This is the default behavior</description>
+    </valueHelp>
+    <valueHelp>
+    <format>always</format>
+    <description>Replace the name the client sent. If the client sent no name, generate one for the client</description>
+    </valueHelp>
+    <valueHelp>
+    <format>when-present</format>
+    <description>Replace the name the client sent. If the client sent no name, do not generate one</description>
+    </valueHelp>
+    <valueHelp>
+    <format>when-not-present</format>
+    <description>Use the name the client sent. If the client sent no name, generate one for the client</description>
+    </valueHelp>
+    <constraint>
+    <regex>(never|always|when-present|when-not-present)</regex>
+    </constraint>
+    <constraintErrorMessage>Invalid replace client name mode</constraintErrorMessage>
+</properties>
+</leafNode>
+<leafNode name="generated-prefix">
+<properties>
+    <help>The prefix used in the generation of an FQDN</help>
+    <constraint>
+    <validator name="fqdn"/>
+    </constraint>
+    <constraintErrorMessage>Invalid generated prefix</constraintErrorMessage>
+</properties>
+</leafNode>
+<leafNode name="qualifying-suffix">
+<properties>
+    <help>The suffix used when generating an FQDN, or when qualifying a partial name</help>
+    <constraint>
+    <validator name="fqdn"/>
+    </constraint>
+    <constraintErrorMessage>Invalid qualifying suffix</constraintErrorMessage>
+</properties>
+</leafNode>
+<leafNode name="update-on-renew">
+<properties>
+    <help>Update DNS record on lease renew</help>
+    <valueless/>
+</properties>
+</leafNode>
+<leafNode name="use-conflict-resolution">
+<properties>
+    <help>Defines DNS conflict resolution behavior</help>
+    <valueless/>
+</properties>
+</leafNode>
+<leafNode name="hostname-char-set">
+<properties>
+    <help>A regular expression describing the invalid character set in the host name</help>
+</properties>
+</leafNode>
+<leafNode name="hostname-char-replacement">
+<properties>
+    <help>A string of zero or more characters with which to replace each invalid character in the host name</help>
+</properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/service_dhcp-server.xml.in
+++ b/interface-definitions/service_dhcp-server.xml.in
@@ -10,12 +10,128 @@
         </properties>
         <children>
           #include <include/generic-disable-node.xml.i>
-          <leafNode name="dynamic-dns-update">
+          <node name="dynamic-dns-update">
             <properties>
               <help>Dynamically update Domain Name System (RFC4702)</help>
-              <valueless/>
             </properties>
-          </leafNode>
+            <children>
+              <tagNode name="tsig-key-name">
+                <properties>
+                  <help>Name of the TSIG key for DNS updates</help>
+                  <constraint>
+                    #include <include/constraint/alpha-numeric-hyphen-underscore.xml.i>
+                  </constraint>
+                  <constraintErrorMessage>Invalid TSIG key name. May only contain letters, numbers and -_</constraintErrorMessage>
+                </properties>
+                <children>
+                  <leafNode name="algorithm">
+                    <properties>
+                      <help>TSIG key algorithm</help>
+                      <completionHelp>
+                        <list>hmac-md5 hmac-sha1 hmac-sha224 hmac-sha256 hmac-sha384 hmac-sha512</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>hmac-md5</format>
+                        <description>MD5 HMAC algorithm</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>hmac-sha1</format>
+                        <description>SHA1 HMAC algorithm</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>hmac-sha224</format>
+                        <description>SHA224 HMAC algorithm</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>hmac-sha256</format>
+                        <description>SHA256 HMAC algorithm</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>hmac-sha384</format>
+                        <description>SHA384 HMAC algorithm</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>hmac-sha512</format>
+                        <description>SHA512 HMAC algorithm</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>(hmac-md5|hmac-sha1|hmac-sha224|hmac-sha256|hmac-sha384|hmac-sha512)</regex>
+                      </constraint>
+                      <constraintErrorMessage>Invalid TSIG key algorithm</constraintErrorMessage>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="secret">
+                    <properties>
+                      <help>TSIG key secret (base64-encoded)</help>
+                      <constraint>
+                        <validator name="base64"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                </children>
+              </tagNode>
+              <tagNode name="forward-ddns-domain-name">
+                <properties>
+                  <help>Forward DNS domain name</help>
+                  <constraint>
+                    #include <include/constraint/domain-name.xml.i>
+                  </constraint>
+                  <constraintErrorMessage>Invalid forward DNS domain name</constraintErrorMessage>
+                </properties>
+                <children>
+                  <leafNode name="key-name">
+                    <properties>
+                      <help>TSIG key name for forward DNS updates</help>
+                      <constraint>
+                        #include <include/constraint/alpha-numeric-hyphen-underscore.xml.i>
+                      </constraint>
+                      <constraintErrorMessage>Invalid TSIG key name. May only contain letters, numbers and -_</constraintErrorMessage>
+                    </properties>
+                  </leafNode>
+                  <tagNode name="dns-server">
+                    <properties>
+                      <help>DNS server specification</help>
+                      <valueHelp>
+                        <format>u32:1-999999</format>
+                        <description>Number for this DNS server</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-999999"/>
+                      </constraint>
+                      <constraintErrorMessage>DNS server number must be between 1 and 999999</constraintErrorMessage>
+                    </properties>
+                    <children>
+                      <leafNode name="address">
+                        <properties>
+                          <help>DNS server IP address</help>
+                          <valueHelp>
+                            <format>ipv4</format>
+                            <description>DNS server IP address</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="ipv4-address"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="port">
+                        <properties>
+                          <help>DNS server port</help>
+                          <valueHelp>
+                            <format>u16</format>
+                            <description>DNS server port</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-65535"/>
+                          </constraint>
+                          <constraintErrorMessage>Invalid forward DNS server port</constraintErrorMessage>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </tagNode>
+                </children>
+              </tagNode>
+            </children>
+          </node>
           <node name="high-availability">
             <properties>
               <help>DHCP high availability configuration</help>

--- a/interface-definitions/service_dhcp-server.xml.in
+++ b/interface-definitions/service_dhcp-server.xml.in
@@ -15,114 +15,7 @@
               <help>Dynamically update Domain Name System (RFC4702)</help>
             </properties>
             <children>
-              <leafNode name="enable-updates">
-                <properties>
-                  <help>Enable DDNS updates</help>
-                  <valueless/>
-                </properties>
-              </leafNode>
-              <leafNode name="override-client-update">
-                <properties>
-                  <help>Override client delegation</help>
-                  <valueless/>
-                </properties>
-              </leafNode>
-              <leafNode name="override-no-update">
-                <properties>
-                  <help>Override client delegation</help>
-                  <valueless/>
-                </properties>
-              </leafNode>
-              <leafNode name="replace-client-name">
-                <properties>
-                  <help>Replace client name mode</help>
-                  <completionHelp>
-                    <list>never always when-present when-not-present</list>
-                  </completionHelp>
-                  <valueHelp>
-                    <format>never</format>
-                    <description>Use the name the client sent. If the client sent no name, do not generate one. This is the default behavior</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>always</format>
-                    <description>Replace the name the client sent. If the client sent no name, generate one for the client</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>when-present</format>
-                    <description>Replace the name the client sent. If the client sent no name, do not generate one</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>when-not-present</format>
-                    <description>Use the name the client sent. If the client sent no name, generate one for the client</description>
-                  </valueHelp>
-                  <constraint>
-                    <regex>(never|always|when-present|when-not-present)</regex>
-                  </constraint>
-                  <constraintErrorMessage>Invalid replace client name mode</constraintErrorMessage>
-                </properties>
-              </leafNode>
-              <leafNode name="generated-prefix">
-                <properties>
-                  <help>The prefix used in the generation of an FQDN</help>
-                  <constraint>
-                    <validator name="fqdn"/>
-                  </constraint>
-                  <constraintErrorMessage>Invalid generated prefix</constraintErrorMessage>
-                </properties>
-              </leafNode>
-              <leafNode name="qualifying-suffix">
-                <properties>
-                  <help>The suffix used when generating an FQDN, or when qualifying a partial name</help>
-                  <constraint>
-                    <validator name="fqdn"/>
-                  </constraint>
-                  <constraintErrorMessage>Invalid qualifying suffix</constraintErrorMessage>
-                </properties>
-              </leafNode>
-              <leafNode name="update-on-renew">
-                <properties>
-                  <help>Update DNS record on lease renew</help>
-                  <valueless/>
-                </properties>
-              </leafNode>
-              <leafNode name="conflict-resolution-mode">
-                <properties>
-                  <help>Defines DNS conflict resolution behavior</help>
-                  <completionHelp>
-                    <list>check-with-dhcid no-check-with-dhcid check-exists-with-dhcid no-check-without-dhcid</list>
-                  </completionHelp>
-                  <valueHelp>
-                    <format>check-with-dhcid</format>
-                    <description>Carry out RFC 4703-compliant conflict resolution. Existing DNS entries may only be overwritten if they have a DHCID record and it matches the client's DHCID. This is the default behavior</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>no-check-with-dhcid</format>
-                    <description>Existing DNS entries may be overwritten by any client, whether those entries include a DHCID record or not. The new entries will include a DHCID record for the client to whom they belong</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>check-exists-with-dhcid</format>
-                    <description>Existing DNS entries may only be overwritten if they have a DHCID record. The DHCID record need not match the client's DHCID</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>no-check-without-dhcid</format>
-                    <description>Existing DNS entries may be overwritten by any client; new entries will not include DHCID records</description>
-                  </valueHelp>
-                  <constraint>
-                    <regex>(check-with-dhcid|no-check-with-dhcid|check-exists-with-dhcid|no-check-without-dhcid)</regex>
-                  </constraint>
-                  <constraintErrorMessage>Invalid DNS conflict resolution mode</constraintErrorMessage>
-                </properties>
-              </leafNode>
-              <leafNode name="hostname-char-set">
-                <properties>
-                  <help>A regular expression describing the invalid character set in the host name</help>
-                </properties>
-              </leafNode>
-              <leafNode name="hostname-char-replacement">
-                <properties>
-                  <help>A string of zero or more characters with which to replace each invalid character in the host name</help>
-                </properties>
-              </leafNode>
+              #include <include/dhcp/ddns-settings.xml.i>
               <tagNode name="tsig-key-name">
                 <properties>
                   <help>Name of the TSIG key for DNS updates</help>
@@ -196,7 +89,7 @@
                       <constraintErrorMessage>Invalid TSIG key name. May only contain letters, numbers and -_</constraintErrorMessage>
                     </properties>
                   </leafNode>
-                  #include <include/dhcp/ddns-server.xml.i>
+                  #include <include/dhcp/ddns-dns-server.xml.i>
                 </children>
               </tagNode>
               <tagNode name="reverse-ddns-domain-name">
@@ -217,7 +110,7 @@
                       <constraintErrorMessage>Invalid TSIG key name. May only contain letters, numbers and -_</constraintErrorMessage>
                     </properties>
                   </leafNode>
-                  #include <include/dhcp/ddns-server.xml.i>
+                  #include <include/dhcp/ddns-dns-server.xml.i>
                 </children>
               </tagNode>
             </children>
@@ -311,6 +204,14 @@
               <constraintErrorMessage>Invalid shared network name. May only contain letters, numbers and .-_</constraintErrorMessage>
             </properties>
             <children>
+              <node name="dynamic-dns-update">
+                <properties>
+                  <help>Dynamically update Domain Name System (RFC4702)</help>
+                </properties>
+                <children>
+                  #include <include/dhcp/ddns-settings.xml.i>
+                </children>
+              </node>
               <leafNode name="authoritative">
                 <properties>
                   <help>Option to make DHCP server authoritative for this physical network</help>
@@ -336,6 +237,14 @@
                   #include <include/dhcp/option-v4.xml.i>
                   #include <include/generic-description.xml.i>
                   #include <include/generic-disable-node.xml.i>
+                  <node name="dynamic-dns-update">
+                    <properties>
+                      <help>Dynamically update Domain Name System (RFC4702)</help>
+                    </properties>
+                    <children>
+                      #include <include/dhcp/ddns-settings.xml.i>
+                    </children>
+                  </node>
                   <leafNode name="exclude">
                     <properties>
                       <help>IP address to exclude from DHCP lease range</help>

--- a/interface-definitions/service_dhcp-server.xml.in
+++ b/interface-definitions/service_dhcp-server.xml.in
@@ -15,6 +15,114 @@
               <help>Dynamically update Domain Name System (RFC4702)</help>
             </properties>
             <children>
+              <leafNode name="enable-updates">
+                <properties>
+                  <help>Enable DDNS updates</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="override-client-update">
+                <properties>
+                  <help>Override client delegation</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="override-no-update">
+                <properties>
+                  <help>Override client delegation</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="replace-client-name">
+                <properties>
+                  <help>Replace client name mode</help>
+                  <completionHelp>
+                    <list>never always when-present when-not-present</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>never</format>
+                    <description>Use the name the client sent. If the client sent no name, do not generate one. This is the default behavior</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>always</format>
+                    <description>Replace the name the client sent. If the client sent no name, generate one for the client</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>when-present</format>
+                    <description>Replace the name the client sent. If the client sent no name, do not generate one</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>when-not-present</format>
+                    <description>Use the name the client sent. If the client sent no name, generate one for the client</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(never|always|when-present|when-not-present)</regex>
+                  </constraint>
+                  <constraintErrorMessage>Invalid replace client name mode</constraintErrorMessage>
+                </properties>
+              </leafNode>
+              <leafNode name="generated-prefix">
+                <properties>
+                  <help>The prefix used in the generation of an FQDN</help>
+                  <constraint>
+                    <validator name="fqdn"/>
+                  </constraint>
+                  <constraintErrorMessage>Invalid generated prefix</constraintErrorMessage>
+                </properties>
+              </leafNode>
+              <leafNode name="qualifying-suffix">
+                <properties>
+                  <help>The suffix used when generating an FQDN, or when qualifying a partial name</help>
+                  <constraint>
+                    <validator name="fqdn"/>
+                  </constraint>
+                  <constraintErrorMessage>Invalid qualifying suffix</constraintErrorMessage>
+                </properties>
+              </leafNode>
+              <leafNode name="update-on-renew">
+                <properties>
+                  <help>Update DNS record on lease renew</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="conflict-resolution-mode">
+                <properties>
+                  <help>Defines DNS conflict resolution behavior</help>
+                  <completionHelp>
+                    <list>check-with-dhcid no-check-with-dhcid check-exists-with-dhcid no-check-without-dhcid</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>check-with-dhcid</format>
+                    <description>Carry out RFC 4703-compliant conflict resolution. Existing DNS entries may only be overwritten if they have a DHCID record and it matches the client's DHCID. This is the default behavior</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>no-check-with-dhcid</format>
+                    <description>Existing DNS entries may be overwritten by any client, whether those entries include a DHCID record or not. The new entries will include a DHCID record for the client to whom they belong</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>check-exists-with-dhcid</format>
+                    <description>Existing DNS entries may only be overwritten if they have a DHCID record. The DHCID record need not match the client's DHCID</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>no-check-without-dhcid</format>
+                    <description>Existing DNS entries may be overwritten by any client; new entries will not include DHCID records</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(check-with-dhcid|no-check-with-dhcid|check-exists-with-dhcid|no-check-without-dhcid)</regex>
+                  </constraint>
+                  <constraintErrorMessage>Invalid DNS conflict resolution mode</constraintErrorMessage>
+                </properties>
+              </leafNode>
+              <leafNode name="hostname-char-set">
+                <properties>
+                  <help>A regular expression describing the invalid character set in the host name</help>
+                </properties>
+              </leafNode>
+              <leafNode name="hostname-char-replacement">
+                <properties>
+                  <help>A string of zero or more characters with which to replace each invalid character in the host name</help>
+                </properties>
+              </leafNode>
               <tagNode name="tsig-key-name">
                 <properties>
                   <help>Name of the TSIG key for DNS updates</help>
@@ -74,7 +182,7 @@
                 <properties>
                   <help>Forward DNS domain name</help>
                   <constraint>
-                    #include <include/constraint/domain-name.xml.i>
+                    <validator name="fqdn"/>
                   </constraint>
                   <constraintErrorMessage>Invalid forward DNS domain name</constraintErrorMessage>
                 </properties>
@@ -88,46 +196,28 @@
                       <constraintErrorMessage>Invalid TSIG key name. May only contain letters, numbers and -_</constraintErrorMessage>
                     </properties>
                   </leafNode>
-                  <tagNode name="dns-server">
+                  #include <include/dhcp/ddns-server.xml.i>
+                </children>
+              </tagNode>
+              <tagNode name="reverse-ddns-domain-name">
+                <properties>
+                  <help>Reverse DNS domain name</help>
+                  <constraint>
+                    <validator name="fqdn"/>
+                  </constraint>
+                  <constraintErrorMessage>Invalid reverse DNS domain name</constraintErrorMessage>
+                </properties>
+                <children>
+                  <leafNode name="key-name">
                     <properties>
-                      <help>DNS server specification</help>
-                      <valueHelp>
-                        <format>u32:1-999999</format>
-                        <description>Number for this DNS server</description>
-                      </valueHelp>
+                      <help>TSIG key name for reverse DNS updates</help>
                       <constraint>
-                        <validator name="numeric" argument="--range 1-999999"/>
+                        #include <include/constraint/alpha-numeric-hyphen-underscore.xml.i>
                       </constraint>
-                      <constraintErrorMessage>DNS server number must be between 1 and 999999</constraintErrorMessage>
+                      <constraintErrorMessage>Invalid TSIG key name. May only contain letters, numbers and -_</constraintErrorMessage>
                     </properties>
-                    <children>
-                      <leafNode name="address">
-                        <properties>
-                          <help>DNS server IP address</help>
-                          <valueHelp>
-                            <format>ipv4</format>
-                            <description>DNS server IP address</description>
-                          </valueHelp>
-                          <constraint>
-                            <validator name="ipv4-address"/>
-                          </constraint>
-                        </properties>
-                      </leafNode>
-                      <leafNode name="port">
-                        <properties>
-                          <help>DNS server port</help>
-                          <valueHelp>
-                            <format>u16</format>
-                            <description>DNS server port</description>
-                          </valueHelp>
-                          <constraint>
-                            <validator name="numeric" argument="--range 1-65535"/>
-                          </constraint>
-                          <constraintErrorMessage>Invalid forward DNS server port</constraintErrorMessage>
-                        </properties>
-                      </leafNode>
-                    </children>
-                  </tagNode>
+                  </leafNode>
+                  #include <include/dhcp/ddns-server.xml.i>
                 </children>
               </tagNode>
             </children>

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -324,6 +324,8 @@ def kea_parse_ddns_settings(config):
         data['ddns-generated-prefix'] = config['generated_prefix']
     if 'qualifying_suffix' in config:
         data['ddns-qualifying-suffix'] = config['qualifying_suffix']
+    if 'ttl_percent' in config:
+        data['ddns-ttl-percent'] = int(config['ttl_percent']) / 100
     if 'hostname_char_set' in config:
         data['hostname-char-set'] = config['hostname_char_set']
     if 'hostname_char_replacement' in config:

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -172,6 +172,9 @@ def kea_parse_subnet(subnet, config):
             reservations.append(reservation)
         out['reservations'] = reservations
 
+    if 'dynamic_dns_update' in config:
+        out.update(kea_parse_ddns_settings(config['dynamic_dns_update']))
+
     return out
 
 def kea6_parse_options(config):
@@ -305,6 +308,28 @@ def kea_parse_tsig_algo(algo_spec):
         'hmac-sha512': 'HMAC-SHA512'
     }
     return translate[algo_spec]
+
+def kea_parse_ddns_settings(config):
+    data = {
+        "ddns-send-updates": 'send_updates' in config,
+        "ddns-override-no-update": 'override_no_update' in config,
+        "ddns-override-client-update": 'override_client_update' in config,
+        "ddns-update-on-renew": 'update_on_renew' in config,
+        "ddns-use-conflict-resolution": 'use_conflict_resolution' in config,
+    }
+
+    if 'replace_client_name' in config:
+        data['ddns-replace-client-name'] = config['replace_client_name']
+    if 'generated_prefix' in config:
+        data['ddns-generated-prefix'] = config['generated_prefix']
+    if 'qualifying_suffix' in config:
+        data['ddns-qualifying-suffix'] = config['qualifying_suffix']
+    if 'hostname_char_set' in config:
+        data['hostname-char-set'] = config['hostname_char_set']
+    if 'hostname_char_replacement' in config:
+        data['hostname-char-replacement'] = config['hostname_char_replacement']
+
+    return data
 
 def _ctrl_socket_command(inet, command, args=None):
     path = kea_ctrl_socket.format(inet=inet)

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -295,6 +295,17 @@ def kea6_parse_subnet(subnet, config):
 
     return out
 
+def kea_parse_tsig_algo(algo_spec):
+    translate = {
+        'hmac-md5': 'HMAC-MD5',
+        'hmac-sha1': 'HMAC-SHA1',
+        'hmac-sha224': 'HMAC-SHA224',
+        'hmac-sha256': 'HMAC-SHA256',
+        'hmac-sha384': 'HMAC-SHA384',
+        'hmac-sha512': 'HMAC-SHA512'
+    }
+    return translate[algo_spec]
+
 def _ctrl_socket_command(inet, command, args=None):
     path = kea_ctrl_socket.format(inet=inet)
 

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -871,6 +871,76 @@ def kea_high_availability_json(config):
 
     return dumps(data)
 
+@register_filter('kea_dynamic_dns_update_main_json')
+def kea_dynamic_dns_update_main_json(config):
+    from json import dumps
+
+    data = {
+        "ddns-send-updates": True,
+        "ddns-override-no-update": 'override_no_update' in config,
+        "ddns-override-client-update": 'override_client_update' in config,
+        "ddns-update-on-renew": 'update_on_renew' in config,
+    }
+
+    if 'replace_client_name' in config:
+        data['ddns-replace-client-name'] = config['replace_client_name']
+    if 'conflict_resolution_mode' in config:
+        data['ddns-conflict-resolution-mode'] = config['conflict_resolution_mode']
+    if 'generated_prefix' in config:
+        data['ddns-generated-prefix'] = config['generated_prefix']
+    if 'qualifying_suffix' in config:
+        data['ddns-qualifying-suffix'] = config['qualifying_suffix']
+    if 'hostname_char_set' in config:
+        data['hostname-char-set'] = config['hostname_char_set']
+    if 'hostname_char_replacement' in config:
+        data['hostname-char-replacement'] = config['hostname_char_replacement']
+
+    return dumps(data, indent=4)[1:-1]
+
+@register_filter('kea_dynamic_dns_update_tsig_key_json')
+def kea_dynamic_dns_update_tsig_key_json(tsig_keys):
+    from kea import kea_parse_tsig_algo
+    from json import dumps
+    out = []
+
+    for tsig_key_name, tsig_key_config in tsig_keys.items():
+        tsig_key = {
+            'name': tsig_key_name,
+            'algorithm': kea_parse_tsig_algo(tsig_key_config['algorithm']),
+            'secret': tsig_key_config['secret']
+        }
+        out.append(tsig_key)
+
+    return dumps(out, indent=4)
+
+@register_filter('kea_dynamic_dns_update_domains')
+def kea_dynamic_dns_update_domains(domains):
+    from json import dumps
+    out = []
+
+    for domain_name, domain_config in domains.items():
+        domain = {
+            'name': domain_name,
+
+        }
+        if 'key_name' in domain_config:
+            domain['key-name'] = domain_config['key_name']
+
+        if 'dns_server' in domain_config:
+            dns_servers = []
+            for dns_server_no, dns_server_config in domain_config['dns_server'].items():
+                dns_server = {
+                    'ip-address': dns_server_config['ip_address']
+                }
+                if 'port' in dns_server_config:
+                    dns_server['port'] = dns_server_config['port']
+                dns_servers.append(dns_server)
+            domain['dns-servers'] = dns_servers
+
+        out.append(domain)
+
+    return dumps(out, indent=4)
+
 @register_filter('kea_shared_network_json')
 def kea_shared_network_json(shared_networks):
     from vyos.kea import kea_parse_options

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -898,10 +898,15 @@ def kea_dynamic_dns_update_main_json(config):
     return dumps(data, indent=4)[1:-1]
 
 @register_filter('kea_dynamic_dns_update_tsig_key_json')
-def kea_dynamic_dns_update_tsig_key_json(tsig_keys):
-    from kea import kea_parse_tsig_algo
+def kea_dynamic_dns_update_tsig_key_json(config):
+    from vyos.kea import kea_parse_tsig_algo
     from json import dumps
     out = []
+
+    if 'tsig_key_name' not in config:
+        return dumps(out)
+
+    tsig_keys = config['tsig_key_name']
 
     for tsig_key_name, tsig_key_config in tsig_keys.items():
         tsig_key = {
@@ -911,12 +916,17 @@ def kea_dynamic_dns_update_tsig_key_json(tsig_keys):
         }
         out.append(tsig_key)
 
-    return dumps(out, indent=4)
+    return dumps(out, indent=12)
 
 @register_filter('kea_dynamic_dns_update_domains')
-def kea_dynamic_dns_update_domains(domains):
+def kea_dynamic_dns_update_domains(config, type_key):
     from json import dumps
     out = []
+
+    if type_key not in config:
+        return dumps(out)
+
+    domains = config[type_key]
 
     for domain_name, domain_config in domains.items():
         domain = {
@@ -928,9 +938,9 @@ def kea_dynamic_dns_update_domains(domains):
 
         if 'dns_server' in domain_config:
             dns_servers = []
-            for dns_server_no, dns_server_config in domain_config['dns_server'].items():
+            for dns_server_config in domain_config['dns_server'].values():
                 dns_server = {
-                    'ip-address': dns_server_config['ip_address']
+                    'ip-address': dns_server_config['address']
                 }
                 if 'port' in dns_server_config:
                     dns_server['port'] = dns_server_config['port']
@@ -939,7 +949,7 @@ def kea_dynamic_dns_update_domains(domains):
 
         out.append(domain)
 
-    return dumps(out, indent=4)
+    return dumps(out, indent=12)
 
 @register_filter('kea_shared_network_json')
 def kea_shared_network_json(shared_networks):

--- a/smoketest/config-tests/basic-vyos
+++ b/smoketest/config-tests/basic-vyos
@@ -28,6 +28,17 @@ set protocols static arp interface eth2.200.201 address 100.64.201.20 mac '00:50
 set protocols static arp interface eth2.200.202 address 100.64.202.30 mac '00:50:00:00:00:30'
 set protocols static arp interface eth2.200.202 address 100.64.202.40 mac '00:50:00:00:00:40'
 set protocols static route 0.0.0.0/0 next-hop 100.64.0.1
+set service dhcp-server dynamic-dns-update enable-updates
+set service dhcp-server dynamic-dns-update tsig-key-name domain-lan-updates algorithm 'hmac-sha256'
+set service dhcp-server dynamic-dns-update tsig-key-name domain-lan-updates secret 'SXQncyBXZWRuZXNkYXkgbWFoIGR1ZGVzIQ=='
+set service dhcp-server dynamic-dns-update tsig-key-name reverse-0-168-192 algorithm 'hmac-sha256'
+set service dhcp-server dynamic-dns-update tsig-key-name reverse-0-168-192 secret 'VGhhbmsgR29kIGl0J3MgRnJpZGF5IQ=='
+set service dhcp-server dynamic-dns-update forward-ddns-domain-name domain.lan dns-server 1 address '192.168.0.1'
+set service dhcp-server dynamic-dns-update forward-ddns-domain-name domain.lan dns-server 2 address '100.100.0.1'
+set service dhcp-server dynamic-dns-update forward-ddns-domain-name domain.lan key-name 'domain-lan-updates'
+set service dhcp-server dynamic-dns-update reverse-ddns-domain-name 0.168.192.in-addr.arpa dns-server 1 address '192.168.0.1'
+set service dhcp-server dynamic-dns-update reverse-ddns-domain-name 0.168.192.in-addr.arpa dns-server 2 address '100.100.0.1'
+set service dhcp-server dynamic-dns-update reverse-ddns-domain-name 0.168.192.in-addr.arpa key-name 'reverse-0-168-192'
 set service dhcp-server shared-network-name LAN authoritative
 set service dhcp-server shared-network-name LAN subnet 192.168.0.0/24 option default-router '192.168.0.1'
 set service dhcp-server shared-network-name LAN subnet 192.168.0.0/24 option domain-name 'vyos.net'

--- a/smoketest/configs/basic-vyos
+++ b/smoketest/configs/basic-vyos
@@ -78,6 +78,35 @@ protocols {
 }
 service {
     dhcp-server {
+        dynamic-dns-update {
+            enable-updates
+            forward-ddns-domain-name domain.lan {
+                dns-server 1 {
+                    address 192.168.0.1
+                }
+                dns-server 2 {
+                    address 100.100.0.1
+                }
+                key-name domain-lan-updates
+            }
+            reverse-ddns-domain-name 0.168.192.in-addr.arpa {
+                dns-server 1 {
+                    address 192.168.0.1
+                }
+                dns-server 2 {
+                    address 100.100.0.1
+                }
+                key-name reverse-0-168-192
+            }
+            tsig-key-name domain-lan-updates {
+                algorithm hmac-sha256
+                secret SXQncyBXZWRuZXNkYXkgbWFoIGR1ZGVzIQ==
+            }
+            tsig-key-name reverse-0-168-192 {
+                algorithm hmac-sha256
+                secret VGhhbmsgR29kIGl0J3MgRnJpZGF5IQ==
+            }
+        }
         shared-network-name LAN {
             authoritative
             subnet 192.168.0.0/24 {

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -878,15 +878,15 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.verify_config_value(obj, ['Dhcp4', 'shared-networks'], 'name', shared_net_name)
         self.verify_config_value(obj, ['Dhcp4', 'shared-networks'], 'ddns-send-updates', True)
         self.verify_config_value(obj, ['Dhcp4', 'shared-networks'], 'ddns-use-conflict-resolution', True)
-        self.verify_config_value(obj, ['Dhcp4', 'shared-networks'], 'ddns-ttl-percent', 75)
+        self.verify_config_value(obj, ['Dhcp4', 'shared-networks'], 'ddns-ttl-percent', 0.75)
 
         self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'subnet', subnet)
         self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'id', 1)
         self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'ddns-send-updates', True)
         self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'ddns-generated-prefix', 'myfunnyprefix')
         self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'ddns-qualifying-suffix', 'suffix.lan')
-        self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'ddns-hostname-char-set', 'xXyYzZ')
-        self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'ddns-hostname-char-replacement', '_xXx_')
+        self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'hostname-char-set', 'xXyYzZ')
+        self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'hostname-char-replacement', '_xXx_')
 
         # Verify keys and domains configuration in the D2 config
         self.verify_config_object(
@@ -929,7 +929,6 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         # Check for running process
         self.assertTrue(process_named_running(PROCESS_NAME))
         self.assertTrue(process_named_running(D2_PROCESS_NAME))
-        self.assertTrue(process_named_running(CTRL_PROCESS_NAME))
 
     def test_dhcp_on_interface_with_vrf(self):
         self.cli_set(['interfaces', 'ethernet', 'eth1', 'address', '10.1.1.1/30'])

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -28,8 +28,10 @@ from vyos.template import inc_ip
 from vyos.template import dec_ip
 
 PROCESS_NAME = 'kea-dhcp4'
+D2_PROCESS_NAME = 'kea-dhcp-ddns'
 CTRL_PROCESS_NAME = 'kea-ctrl-agent'
 KEA4_CONF = '/run/kea/kea-dhcp4.conf'
+KEA4_D2_CONF = '/run/kea/kea-dhcp-ddns.conf'
 KEA4_CTRL = '/run/kea/dhcp4-ctrl-socket'
 base_path = ['service', 'dhcp-server']
 interface = 'dum8765'
@@ -799,6 +801,89 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
 
         # Check for running process
         self.assertTrue(process_named_running(PROCESS_NAME))
+        self.assertTrue(process_named_running(CTRL_PROCESS_NAME))
+
+    def test_dhcp_dynamic_dns_update(self):
+        ddns = base_path + ['dynamic-dns-update']
+
+        self.cli_set(ddns + ['enable-updates'])
+        self.cli_set(ddns + ['conflict-resolution-mode', 'check-exists-with-dhcid'])
+        self.cli_set(ddns + ['generated-prefix', 'myfunnyprefix'])
+        self.cli_set(ddns + ['qualifying-suffix', 'suffix.lan'])
+        self.cli_set(ddns + ['hostname-char-set', 'xXyYzZ'])
+        self.cli_set(ddns + ['hostname-char-replacement', '_xXx_'])
+        self.cli_set(ddns + ['override-no-update'])
+        self.cli_set(ddns + ['override-client-update'])
+        self.cli_set(ddns + ['replace-client-name', 'always'])
+        self.cli_set(ddns + ['update-on-renew'])
+
+        self.cli_set(ddns + ['tsig-key-name', 'domain-lan-updates', 'algorithm', 'hmac-sha256'])
+        self.cli_set(ddns + ['tsig-key-name', 'domain-lan-updates', 'secret', 'SXQncyBXZWRuZXNkYXkgbWFoIGR1ZGVzIQ=='])
+        self.cli_set(ddns + ['tsig-key-name', 'reverse-0-168-192', 'algorithm', 'hmac-sha256'])
+        self.cli_set(ddns + ['tsig-key-name', 'reverse-0-168-192', 'secret', 'VGhhbmsgR29kIGl0J3MgRnJpZGF5IQ=='])
+        self.cli_set(ddns + ['forward-ddns-domain-name', 'domain.lan', 'dns-server', '1', 'address', '192.168.0.1'])
+        self.cli_set(ddns + ['forward-ddns-domain-name', 'domain.lan', 'dns-server', '2', 'address', '100.100.0.1'])
+        self.cli_set(ddns + ['forward-ddns-domain-name', 'domain.lan', 'key-name', 'domain-lan-updates'])
+        self.cli_set(ddns + ['reverse-ddns-domain-name', '0.168.192.in-addr.arpa', 'dns-server', '1', 'address', '192.168.0.1'])
+        self.cli_set(ddns + ['reverse-ddns-domain-name', '0.168.192.in-addr.arpa', 'dns-server', '1', 'port', '1053'])
+        self.cli_set(ddns + ['reverse-ddns-domain-name', '0.168.192.in-addr.arpa', 'dns-server', '2', 'address', '100.100.0.1'])
+        self.cli_set(ddns + ['reverse-ddns-domain-name', '0.168.192.in-addr.arpa', 'dns-server', '2', 'port', '1153'])
+        self.cli_set(ddns + ['reverse-ddns-domain-name', '0.168.192.in-addr.arpa', 'key-name', 'reverse-0-168-192'])
+
+        self.cli_commit()
+
+        config = read_file(KEA4_CONF)
+        d2_config = read_file(KEA4_D2_CONF)
+
+        obj = loads(config)
+        d2_obj = loads(d2_config)
+
+        # Verify DDNS parameters in the main config file
+        self.verify_config_object(
+            obj,
+            ['Dhcp4', 'dhcp-ddns'],
+            {'enable-updates': True, 'server-ip': '127.0.0.1', 'server-port': 53001, 'sender-ip': '', 'sender-port': 0,
+                'max-queue-size': 1024, 'ncr-protocol': 'UDP', 'ncr-format': 'JSON'})
+
+        self.verify_config_value(obj, ['Dhcp4'], 'ddns-send-updates', True)
+        self.verify_config_value(obj, ['Dhcp4'], 'ddns-conflict-resolution-mode', 'check-exists-with-dhcid')
+        self.verify_config_value(obj, ['Dhcp4'], 'ddns-generated-prefix', 'myfunnyprefix', True)
+        self.verify_config_value(obj, ['Dhcp4'], 'ddns-qualifying-suffix', 'suffix.lan', True)
+        self.verify_config_value(obj, ['Dhcp4'], 'ddns-hostname-char-set', 'xXyYzZ', True)
+        self.verify_config_value(obj, ['Dhcp4'], 'ddns-hostname-char-replacement', '_xXx_', True)
+        self.verify_config_value(obj, ['Dhcp4'], 'ddns-override-no-update', True)
+        self.verify_config_value(obj, ['Dhcp4'], 'ddns-override-client-update', True)
+        self.verify_config_value(obj, ['Dhcp4'], 'ddns-replace-client-name', 'always', True)
+        self.verify_config_value(obj, ['Dhcp4'], 'ddns-update-on-renew', True)
+
+        # Verify keys and domains configuration in the D2 config
+        self.verify_config_object(
+            d2_obj,
+            ['DhcpDdns', 'tsig-keys', 0],
+            {'name': 'domain-lan-updates', 'algorithm': 'HMAC-SHA256', 'secret': 'SXQncyBXZWRuZXNkYXkgbWFoIGR1ZGVzIQ=='}
+        )
+        self.verify_config_object(
+            d2_obj,
+            ['DhcpDdns', 'tsig-keys', 1],
+            {'name': 'reverse-0-168-192', 'algorithm': 'HMAC-SHA256', 'secret': 'VGhhbmsgR29kIGl0J3MgRnJpZGF5IQ=='}
+        )
+
+        self.verify_config_object(
+            d2_obj,
+            ['DhcpDdns', 'forward-ddns', 'ddns-domains', 0],
+            {'name': 'domain.lan', 'key-name': 'domain-lan-updates',
+                'dns-servers': [{'ip-address': '192.168.0.1'}, {'ip-address': '100.100.0.1'}]}
+        )
+        self.verify_config_object(
+            d2_obj,
+            ['DhcpDdns', 'reverse-ddns', 'ddns-domains', 0],
+            {'name': '0.168.192.in-addr.arpa', 'key-name': 'reverse-0-168-192',
+                'dns-servers': [{'ip-address': '192.168.0.1', 'port': 1053}, {'ip-address': '100.100.0.1', 'port': 1153}]}
+        )
+
+        # Check for running process
+        self.assertTrue(process_named_running(PROCESS_NAME))
+        self.assertTrue(process_named_running(D2_PROCESS_NAME))
         self.assertTrue(process_named_running(CTRL_PROCESS_NAME))
 
     def test_dhcp_on_interface_with_vrf(self):

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -804,28 +804,18 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.assertTrue(process_named_running(CTRL_PROCESS_NAME))
 
     def test_dhcp_dynamic_dns_update(self):
-        shared_net_name = 'SMOKE-1'
+        shared_net_name = 'SMOKE-1DDNS'
 
         range_0_start = inc_ip(subnet, 10)
         range_0_stop  = inc_ip(subnet, 20)
-        range_1_start = inc_ip(subnet, 40)
-        range_1_stop  = inc_ip(subnet, 50)
 
         self.cli_set(base_path + ['listen-interface', interface])
 
         pool = base_path + ['shared-network-name', shared_net_name, 'subnet', subnet]
         self.cli_set(pool + ['subnet-id', '1'])
-        self.cli_set(pool + ['ignore-client-id'])
-        # we use the first subnet IP address as default gateway
-        self.cli_set(pool + ['option', 'default-router', router])
-        self.cli_set(pool + ['option', 'name-server', dns_1])
-        self.cli_set(pool + ['option', 'name-server', dns_2])
-        self.cli_set(pool + ['option', 'domain-name', domain_name])
 
         self.cli_set(pool + ['range', '0', 'start', range_0_start])
         self.cli_set(pool + ['range', '0', 'stop', range_0_stop])
-        self.cli_set(pool + ['range', '1', 'start', range_1_start])
-        self.cli_set(pool + ['range', '1', 'stop', range_1_stop])
 
         ddns = base_path + ['dynamic-dns-update']
 

--- a/src/etc/systemd/system/kea-dhcp-ddns-server.service.d/override.conf
+++ b/src/etc/systemd/system/kea-dhcp-ddns-server.service.d/override.conf
@@ -1,0 +1,7 @@
+[Unit]
+After=
+After=vyos-router.service
+
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/kea-dhcp-ddns -c /run/kea/kea-dhcp-ddns.conf


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This PR introduces support for RFC-2136 DDNS updates in Kea DHCP4 server.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

https://vyos.dev/T6773

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/vyos-documentation/pull/1561

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

dhcp-server

## Proposed changes
<!--- Describe your changes in detail -->



## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Set up a Technitium DNS in a container inside VyOS. Set up DDNS updates as follows:

```
set service dhcp-server dynamic-dns-update send-updates
set service dhcp-server dynamic-dns-update use-conflict-resolution
set service dhcp-server dynamic-dns-update tsig-key-name mydomain-net algorithm hmac-sha256
set service dhcp-server dynamic-dns-update tsig-key-name mydomain-net secret eWF5YW15bGl0dGxla2V5IQ==
set service dhcp-server dynamic-dns-update forward-ddns-domain-name mydomain.net key-name mydomain-net
set service dhcp-server dynamic-dns-update forward-ddns-domain-name mydomain.net dns-server 1 address '172.18.0.254'
set service dhcp-server dynamic-dns-update forward-ddns-domain-name mydomain.net dns-server 1 port 1053
```

Get the DHCP server to issue some leases and check if the DNS server gets updated.

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
sh-5.2# ./test_service_dhcp-server.py
test_dhcp_dynamic_dns_update (__main__.TestServiceDHCPServer.test_dhcp_dynamic_dns_update) ... ok
test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
test_dhcp_high_availability (__main__.TestServiceDHCPServer.test_dhcp_high_availability) ... ok
test_dhcp_high_availability_standby (__main__.TestServiceDHCPServer.test_dhcp_high_availability_standby) ... ok
test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
test_dhcp_on_interface_with_vrf (__main__.TestServiceDHCPServer.test_dhcp_on_interface_with_vrf) ... ok
test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... ok
test_dhcp_single_pool_options_scoped (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options_scoped) ... ok
test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... ok
test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... ok

----------------------------------------------------------------------
Ran 12 tests in 38.710s

OK
sh-5.2#
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
