### PR TITLE
system_login: T6807: allow a trailing slash character in system login

### DIFF
--- a/interface-definitions/system_login.xml.in
+++ b/interface-definitions/system_login.xml.in
@@ -190,7 +190,7 @@
                     <description>Path to home directory</description>
                   </valueHelp>
                   <constraint>
-                    <regex>\/$|(\/[a-zA-Z_0-9-.]+)+</regex>
+                    <regex>(\/[a-zA-Z_0-9-.]+)+\/?$</regex>
                   </constraint>
                 </properties>
               </leafNode>


### PR DESCRIPTION
Allow the use of a trailing slash `("/")` at the of the user's home directory path. For example `/home/test/`

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
After the migration VyOS version from 1.3.x to 1.4.0, the presence of a trailing slash `("/")` at the end of the user's home directory path beaks the login process.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->
After migrating from VyOS version 1.3.x to 1.4.0, the presence of a trailing slash `("/")` at the end of the user's home directory path breaks the login process. This issue affects both login/password authentication and SSH key-based access, making it impossible for users to log in to VyOS instances.
To resolve this issue, I propose allowing the use of a trailing slash `("/")` in the home directory path. This change will ensure that users do not encounter login problems after future migrations.

### Examples of Allowed Paths:
- **With Trailing Slash**: `/home/test/`
- **Without Trailing Slash**: `/home/test`

### Examples of Disallowed Paths:
- `//home/test/` (contains double slashes)
- `/home//test` (contains double slashes)
- `home/test/` (does not start with a slash)

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly