### PR TITLE
op_mode: T6808: Console server op mode commands throw errors when console server is not configured

### DIFF
--- a/op-mode-definitions/show-console-server.xml.in
+++ b/op-mode-definitions/show-console-server.xml.in
@@ -21,13 +21,13 @@
             <properties>
               <help>Examine console ports and configured baud rates</help>
             </properties>
-            <command>/usr/bin/console -x</command>
+            <command>if cli-shell-api existsActive service console-server; then /usr/bin/console -x; else echo "Console server is not configured"; fi</command>
           </leafNode>
           <leafNode name="user">
             <properties>
               <help>Show users on various consoles</help>
             </properties>
-            <command>/usr/bin/console -u</command>
+            <command>if cli-shell-api existsActive service console-server; then /usr/bin/console -u; else echo "Console server is not configured"; fi</command>
           </leafNode>
         </children>
       </node>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6808
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
op-mode
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Op-mode command ```show console-server ports``` without configured console-server (before):
```
vyos@vyos:~$ show console-server ports
console: Unable to connect to 127.0.0.1:3109
```
After fix:
```
vyos@vyos:~$ show console-server ports
Console server is not configured
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
