### PR TITLE
T6812: Fix smoketest iproute2 check

### DIFF
--- a/smoketest/scripts/system/test_iproute2.py
+++ b/smoketest/scripts/system/test_iproute2.py
@@ -21,7 +21,7 @@ class TestIproute2(unittest.TestCase):
     def test_ip_is_symlink(self):
         # For an unknown reason VyOS 1.3.0-rc2 did not have a symlink from
         # /usr/sbin/ip -> /bin/ip - verify this now and forever
-        real_file = '/bin/ip'
+        real_file = '../bin/ip'
         symlink = '/usr/sbin/ip'
         self.assertTrue(os.path.islink(symlink))
         self.assertFalse(os.path.islink(real_file))


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
In the new iproute2 package, the link to `ip` was changed.
```
$ file /usr/sbin/ip
/usr/sbin/ip: symbolic link to ../bin/ip
```
Fix smoketest

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6812

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
smoketest, iproute2
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Before the fix:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/system/test_iproute2.py
test_ip_is_symlink (__main__.TestIproute2.test_ip_is_symlink) ... FAIL

======================================================================
FAIL: test_ip_is_symlink (__main__.TestIproute2.test_ip_is_symlink)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/libexec/vyos/tests/smoke/system/test_iproute2.py", line 28, in test_ip_is_symlink
    self.assertEqual(os.readlink(symlink), real_file)
AssertionError: '../bin/ip' != '/bin/ip'
- ../bin/ip
? --
+ /bin/ip


----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (failures=1)

```

After the fix:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/system/test_iproute2.py
test_ip_is_symlink (__main__.TestIproute2.test_ip_is_symlink) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.000s

OK
vyos@r14:~$ 

```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
