### PR TITLE
T3501: Allow using more than one tuned profile

### DIFF
--- a/interface-definitions/include/version/system-version.xml.i
+++ b/interface-definitions/include/version/system-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/system-version.xml.i -->
-<syntaxVersion component='system' version='27'></syntaxVersion>
+<syntaxVersion component='system' version='28'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/system_option.xml.in
+++ b/interface-definitions/system_option.xml.in
@@ -149,19 +149,32 @@
             <properties>
               <help>Tune system performance</help>
               <completionHelp>
-                <list>throughput latency</list>
+                <list>network-throughput network-latency power-save virtual-host virtual-guest</list>
               </completionHelp>
               <valueHelp>
-                <format>throughput</format>
+                <format>network-throughput</format>
                 <description>Tune for maximum network throughput</description>
               </valueHelp>
               <valueHelp>
-                <format>latency</format>
+                <format>network-latency</format>
                 <description>Tune for low network latency</description>
               </valueHelp>
+              <valueHelp>
+                <format>power-save</format>
+                <description>Tune for low power consumption</description>
+              </valueHelp>
+              <valueHelp>
+                <format>virtual-guest</format>
+                <description>Tune for running inside a virtual machine</description>
+              </valueHelp>
+              <valueHelp>
+                <format>virtual-host</format>
+                <description>Tune for running guest virtual machines</description>
+              </valueHelp>
               <constraint>
-                <regex>(throughput|latency)</regex>
+                <regex>(network-throughput|network-latency|power-save|virtual-guest|virtual-host)</regex>
               </constraint>
+              <multi/>
             </properties>
            </leafNode>
            <node name="http-client">

--- a/smoketest/config-tests/dialup-router-wireguard-ipv6
+++ b/smoketest/config-tests/dialup-router-wireguard-ipv6
@@ -688,7 +688,7 @@ set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX
 set system login user vyos authentication plaintext-password ''
 set system name-server '172.16.254.30'
 set system option ctrl-alt-delete 'ignore'
-set system option performance 'latency'
+set system option performance 'network-latency'
 set system option reboot-on-panic
 set system option startup-beep
 set system syslog global facility all level 'debug'

--- a/smoketest/configs/dialup-router-wireguard-ipv6
+++ b/smoketest/configs/dialup-router-wireguard-ipv6
@@ -1470,7 +1470,7 @@ system {
     }
     option {
         ctrl-alt-delete ignore
-        performance latency
+        performance network-latency
         reboot-on-panic
         startup-beep
     }

--- a/smoketest/scripts/cli/test_system_option.py
+++ b/smoketest/scripts/cli/test_system_option.py
@@ -23,6 +23,7 @@ from vyos.utils.system import sysctl_read
 
 base_path = ['system', 'option']
 
+
 class TestSystemOption(VyOSUnitTestSHIM.TestCase):
     def tearDown(self):
         self.cli_delete(base_path)
@@ -59,6 +60,7 @@ class TestSystemOption(VyOSUnitTestSHIM.TestCase):
 
     def test_performance(self):
         tuned_service = 'tuned.service'
+        path = ['system', 'sysctl', 'parameter']
 
         self.assertFalse(is_systemd_service_active(tuned_service))
 
@@ -67,11 +69,11 @@ class TestSystemOption(VyOSUnitTestSHIM.TestCase):
         gc_thresh2 = '262000'
         gc_thresh3 = '524000'
 
-        self.cli_set(['system', 'sysctl', 'parameter', 'net.ipv4.neigh.default.gc_thresh1', 'value', gc_thresh1])
-        self.cli_set(['system', 'sysctl', 'parameter', 'net.ipv4.neigh.default.gc_thresh2', 'value', gc_thresh2])
-        self.cli_set(['system', 'sysctl', 'parameter', 'net.ipv4.neigh.default.gc_thresh3', 'value', gc_thresh3])
+        self.cli_set(path + ['net.ipv4.neigh.default.gc_thresh1', 'value', gc_thresh1])
+        self.cli_set(path + ['net.ipv4.neigh.default.gc_thresh2', 'value', gc_thresh2])
+        self.cli_set(path + ['net.ipv4.neigh.default.gc_thresh3', 'value', gc_thresh3])
 
-        self.cli_set(base_path + ['performance', 'throughput'])
+        self.cli_set(base_path + ['performance', 'network-throughput'])
         self.cli_commit()
 
         self.assertTrue(is_systemd_service_active(tuned_service))

--- a/src/conf_mode/system_option.py
+++ b/src/conf_mode/system_option.py
@@ -46,6 +46,13 @@ systemd_action_file = '/lib/systemd/system/ctrl-alt-del.target'
 usb_autosuspend = r'/etc/udev/rules.d/40-usb-autosuspend.rules'
 kernel_dynamic_debug = r'/sys/kernel/debug/dynamic_debug/control'
 time_format_to_locale = {'12-hour': 'en_US.UTF-8', '24-hour': 'en_GB.UTF-8'}
+tuned_profiles = {
+    'power-save': 'powersave',
+    'network-latency': 'network-latency',
+    'network-throughput': 'network-throughput',
+    'virtual-guest': 'virtual-guest',
+    'virtual-host': 'virtual-host',
+}
 
 
 def get_config(config=None):
@@ -171,7 +178,10 @@ def apply(options):
         # wait until daemon has started before sending configuration
         while not is_systemd_service_running('tuned.service'):
             sleep(0.250)
-        cmd('tuned-adm profile network-{performance}'.format(**options))
+        performance = ' '.join(
+            list(tuned_profiles[profile] for profile in options['performance'])
+        )
+        cmd(f'tuned-adm profile {performance}')
     else:
         cmd('systemctl stop tuned.service')
 

--- a/src/migration-scripts/system/27-to-28
+++ b/src/migration-scripts/system/27-to-28
@@ -1,0 +1,33 @@
+# Copyright 2023-2024 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# rename 'system option performance' leaf nodes to new names
+
+from vyos.configtree import ConfigTree
+
+base = ['system', 'option', 'performance']
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(base):
+        return
+
+    replace = {
+        'throughput' : 'network-throughput',
+        'latency' : 'network-latency'
+    }
+
+    for old_name, new_name in replace.items():
+        if config.return_value(base) == old_name:
+            config.set(base, new_name)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T3501
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
system option 
## Proposed changes
<!--- Describe your changes in detail -->
Added new TuneD profiles and ability to activate several profiles
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set system option performance 'network-latency'
set system option performance 'powersave'
commit

vyos@vyos# tuned-adm active
Current active profile: network-latency powersave
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# python3 /usr/libexec/vyos/tests/smoke/cli/test_system_option.py
test_ctrl_alt_delete (__main__.TestSystemOption.test_ctrl_alt_delete) ... ok
test_performance (__main__.TestSystemOption.test_performance) ... ok
test_reboot_on_panic (__main__.TestSystemOption.test_reboot_on_panic) ... ok
test_ssh_client_options (__main__.TestSystemOption.test_ssh_client_options) ... ok

----------------------------------------------------------------------
Ran 4 tests in 31.416s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
