### PR TITLE
T6806: Rework QoS Policy for HFSC Shaper

### DIFF
--- a/interface-definitions/include/qos/hfsc-m1.xml.i
+++ b/interface-definitions/include/qos/hfsc-m1.xml.i
@@ -27,6 +27,5 @@
       <description>bps(8),kbps(8*10^3),mbps(8*10^6), gbps, tbps - Byte/sec</description>
     </valueHelp>
   </properties>
-  <defaultValue>0bit</defaultValue>
 </leafNode>
 <!-- include end -->

--- a/interface-definitions/include/qos/hfsc-m2.xml.i
+++ b/interface-definitions/include/qos/hfsc-m2.xml.i
@@ -27,6 +27,5 @@
       <description>bps(8),kbps(8*10^3),mbps(8*10^6), gbps, tbps - Byte/sec</description>
     </valueHelp>
   </properties>
-  <defaultValue>100%</defaultValue>
 </leafNode>
 <!-- include end -->

--- a/python/vyos/qos/base.py
+++ b/python/vyos/qos/base.py
@@ -258,7 +258,7 @@ class QoSBase:
                                     has_filter = True
                                     break
 
-                        if self.qostype == 'shaper' and 'prio ' not in filter_cmd:
+                        if self.qostype in ['shaper', 'shaper_hfsc'] and 'prio ' not in filter_cmd:
                             filter_cmd += f' prio {index}'
                         if 'mark' in match_config:
                             mark = match_config['mark']

--- a/python/vyos/qos/trafficshaper.py
+++ b/python/vyos/qos/trafficshaper.py
@@ -126,91 +126,71 @@ class TrafficShaper(QoSBase):
         # call base class
         super().update(config, direction)
 
+
 class TrafficShaperHFSC(QoSBase):
+    """
+    Traffic shaper using Hierarchical Fair Service Curve (HFSC).
+    Documentation: https://man7.org/linux/man-pages/man8/tc-hfsc.8.html
+    """
+
     _parent = 1
     qostype = 'shaper_hfsc'
 
-    # https://man7.org/linux/man-pages/man8/tc-hfsc.8.html
+    criteria = ['linkshare', 'realtime', 'upperlimit']
+    short_criterion = {
+        'linkshare': 'ls',
+        'realtime': 'rt',
+        'upperlimit': 'ul',
+    }
+
+    def _gen_class(self, cls: int, cls_config: dict):
+        """
+        Generate HFSC class and add Stochastic Fair Queueing (SFQ) qdisc.
+
+        Args:
+            cls (int): Class ID
+            cls_config (dict): Configuration for the class
+        """
+        tmp = f'tc class replace dev {self._interface} parent {self._parent:x}:1 classid {self._parent:x}:{cls:x} hfsc'
+
+        for crit in self.criteria:
+            param = cls_config.get(crit)
+            if param:
+                tmp += (
+                    f' {self.short_criterion[crit]}'
+                    f' m1 {self._rate_convert(param["m1"]) if param.get("m1") else 0}'
+                    f' d {param.get("d", 0)}ms'
+                    f' m2 {self._rate_convert(param["m2"])}'
+                )
+
+        self._cmd(tmp)
+
+        tmp = f'tc qdisc replace dev {self._interface} parent {self._parent:x}:{cls:x} sfq perturb 10'
+        self._cmd(tmp)
+
     def update(self, config, direction):
-        class_id_max = 0
-        if 'class' in config:
-            tmp = list(config['class'])
-            tmp.sort()
-            class_id_max = tmp[-1]
+        class_id_max = self._get_class_max_id(config)
+        default_cls_id = int(class_id_max) + 1 if class_id_max else 2
 
-        r2q = 10
-        # bandwidth is a mandatory CLI node
         speed = self._rate_convert(config['bandwidth'])
-        speed_bps = int(speed) // 8
 
-        # need a bigger r2q if going fast than 16 mbits/sec
-        if (speed_bps // r2q) >= MAXQUANTUM: # integer division
-            r2q = ceil(speed_bps // MAXQUANTUM)
-        else:
-            # if there is a slow class then may need smaller value
-            if 'class' in config:
-                min_speed = speed_bps
-                for cls, cls_options in config['class'].items():
-                    # find class with the lowest bandwidth used
-                    if 'bandwidth' in cls_options:
-                        bw_bps = int(self._rate_convert(cls_options['bandwidth'])) // 8 # bandwidth in bytes per second
-                        if bw_bps < min_speed:
-                            min_speed = bw_bps
-
-                while (r2q > 1) and (min_speed // r2q) < MINQUANTUM:
-                    tmp = r2q -1
-                    if (speed_bps // tmp) >= MAXQUANTUM:
-                        break
-                    r2q = tmp
-
-        default_minor_id = int(class_id_max) +1
-        tmp = f'tc qdisc replace dev {self._interface} root handle {self._parent:x}: hfsc default {default_minor_id:x}' # default is in hex
+        tmp = f'tc qdisc replace dev {self._interface} root handle {self._parent:x}: hfsc default {default_cls_id:x}'  # default is in hex
         self._cmd(tmp)
 
         tmp = f'tc class replace dev {self._interface} parent {self._parent:x}: classid {self._parent:x}:1 hfsc sc rate {speed} ul rate {speed}'
         self._cmd(tmp)
 
+        # tmp = f'tc qdisc add dev {self._interface} parent {self._parent:x}:1 handle f1: sfq perturb 10'
+        # self._cmd(tmp)
+
         if 'class' in config:
             for cls, cls_config in config['class'].items():
-                # class id is used later on and passed as hex, thus this needs to be an int
-                cls = int(cls)
-                # ls m1
-                if cls_config.get('linkshare', {}).get('m1').endswith('%'):
-                    percent = cls_config['linkshare']['m1'].rstrip('%')
-                    m_one_rate = self._rate_convert(config['bandwidth']) * int(percent) // 100
-                else:
-                    m_one_rate = cls_config['linkshare']['m1']
-                # ls m2
-                if cls_config.get('linkshare', {}).get('m2').endswith('%'):
-                    percent = cls_config['linkshare']['m2'].rstrip('%')
-                    m_two_rate = self._rate_convert(config['bandwidth']) * int(percent) // 100
-                else:
-                    m_two_rate = self._rate_convert(cls_config['linkshare']['m2'])
-
-                tmp = f'tc class replace dev {self._interface} parent {self._parent:x}:1 classid {self._parent:x}:{cls:x} hfsc ls m1 {m_one_rate} m2 {m_two_rate} '
-                self._cmd(tmp)
-
-                tmp = f'tc qdisc replace dev {self._interface} parent {self._parent:x}:{cls:x} sfq perturb 10'
-                self._cmd(tmp)
+                self._gen_class(cls=int(cls), cls_config=cls_config)
 
         if 'default' in config:
-            # ls m1
-            if config.get('default', {}).get('linkshare', {}).get('m1').endswith('%'):
-                percent = config['default']['linkshare']['m1'].rstrip('%')
-                m_one_rate = self._rate_convert(config['default']['linkshare']['m1']) * int(percent) // 100
-            else:
-                m_one_rate = config['default']['linkshare']['m1']
-            # ls m2
-            if config.get('default', {}).get('linkshare', {}).get('m2').endswith('%'):
-                percent = config['default']['linkshare']['m2'].rstrip('%')
-                m_two_rate = self._rate_convert(config['default']['linkshare']['m2']) * int(percent) // 100
-            else:
-                m_two_rate = self._rate_convert(config['default']['linkshare']['m2'])
-            tmp = f'tc class replace dev {self._interface} parent {self._parent:x}:1 classid {self._parent:x}:{default_minor_id:x} hfsc ls m1 {m_one_rate} m2 {m_two_rate} '
-            self._cmd(tmp)
-
-            tmp = f'tc qdisc replace dev {self._interface} parent {self._parent:x}:{default_minor_id:x} sfq perturb 10'
-            self._cmd(tmp)
+            self._gen_class(
+                cls=int(default_cls_id), cls_config=config.get('default', {})
+            )
 
         # call base class
         super().update(config, direction)

--- a/src/conf_mode/qos.py
+++ b/src/conf_mode/qos.py
@@ -210,6 +210,46 @@ def _verify_match_group_exist(cls_config, qos):
                 Warning(f'Match group "{group}" does not exist!')
 
 
+def _verify_default_policy_exist(policy, policy_config):
+    if 'default' not in policy_config:
+        raise ConfigError(f'Policy {policy} misses "default" class!')
+
+
+def _check_shaper_hfsc_rate(cls, cls_conf):
+    is_m2_exist = False
+    for crit in TrafficShaperHFSC.criteria:
+        if cls_conf.get(crit, {}).get('m2') is not None:
+            is_m2_exist = True
+
+        if cls_conf.get(crit, {}).get('m1') is not None:
+            for crit_val in ['m2', 'd']:
+                if cls_conf.get(crit, {}).get(crit_val) is None:
+                    raise ConfigError(
+                        f'{cls} {crit} m1 value is set, but no {crit_val} was found!'
+                    )
+
+    if not is_m2_exist:
+        raise ConfigError(f'At least one m2 value needs to be set for class: {cls}')
+
+    if (
+        cls_conf.get('upperlimit', {}).get('m2') is not None
+        and cls_conf.get('linkshare', {}).get('m2') is None
+    ):
+        raise ConfigError(
+            f'Linkshare m2 needs to be defined to use upperlimit m2 for class: {cls}'
+        )
+
+
+def _verify_shaper_hfsc(policy, policy_config):
+    _verify_default_policy_exist(policy, policy_config)
+
+    _check_shaper_hfsc_rate('default', policy_config.get('default'))
+
+    if 'class' in policy_config:
+        for cls, cls_conf in policy_config['class'].items():
+            _check_shaper_hfsc_rate(cls, cls_conf)
+
+
 def verify(qos):
     if not qos or 'interface' not in qos:
         return None
@@ -253,11 +293,13 @@ def verify(qos):
                                 if queue_lim < max_tr:
                                     raise ConfigError(f'Policy "{policy}" uses queue-limit "{queue_lim}" < max-threshold "{max_tr}"!')
                 if policy_type in ['priority_queue']:
-                    if 'default' not in policy_config:
-                        raise ConfigError(f'Policy {policy} misses "default" class!')
+                    _verify_default_policy_exist(policy, policy_config)
                 if policy_type in ['rate_control']:
                     if 'bandwidth' not in policy_config:
                         raise ConfigError('Bandwidth not defined')
+                if policy_type in ['shaper_hfsc']:
+                    _verify_shaper_hfsc(policy, policy_config)
+
                 if 'default' in policy_config:
                     if 'bandwidth' not in policy_config['default'] and policy_type not in ['priority_queue', 'round_robin', 'shaper_hfsc']:
                         raise ConfigError('Bandwidth not defined for default traffic!')
@@ -292,6 +334,7 @@ def generate(qos):
         return None
 
     return None
+
 
 def apply(qos):
     # Always delete "old" shapers first


### PR DESCRIPTION
- Removed default `m1` and `m2` values from interface definitions
- Adjusted filter priorities for shapers
- Fixed SFQ qdisc and HFSC class creation to fully support `m1`, `d`, and `m2` parameters
- Added validation logic similar to VyOS 1.3 to improve error handling and user experience

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6806

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
minimal config:
```
conf
set qos policy shaper-hfsc test default realtime m2 100kbit
commit
```
check tc:
```
vyos@vyos# tc -d qdisc show dev eth1
qdisc hfsc 1: root refcnt 2 default 2 
qdisc sfq 85f7: parent 1:2 limit 127p quantum 1514b depth 127 flows 128 divisor 1024 perturb 10sec 
[edit]
vyos@vyos# tc -d class show dev eth1
class hfsc 1: root 
class hfsc 1:1 parent 1: sc m1 0bit d 0us m2 10Gbit ul m1 0bit d 0us m2 10Gbit 
class hfsc 1:2 parent 1:1 leaf 85f7: rt m1 0bit d 0us m2 100Kbit 
[edit]
vyos@vyos# tc -d filter show dev eth1
[edit]
```

example from initial [pr](https://github.com/vyos/vyos-1x/pull/2852):
```
conf
set qos policy shaper-hfsc SHAPE bandwidth '400mbit'
set qos policy shaper-hfsc SHAPE class 10 linkshare m2 '200mbit'
set qos policy shaper-hfsc SHAPE class 10 match DST ip destination address '192.0.2.1/32'
set qos policy shaper-hfsc SHAPE default linkshare m2 '111mbit'

set qos interface eth1 egress SHAPE
commit
```

```
vyos@vyos# tc -d qdisc show dev eth1
qdisc hfsc 1: root refcnt 2 default b 
qdisc sfq 85f9: parent 1:b limit 127p quantum 1514b depth 127 flows 128 divisor 1024 perturb 10sec 
qdisc sfq 85f8: parent 1:a limit 127p quantum 1514b depth 127 flows 128 divisor 1024 perturb 10sec 
[edit]
vyos@vyos# tc -d class show dev eth1
class hfsc 1: root 
class hfsc 1:1 parent 1: sc m1 0bit d 0us m2 400Mbit ul m1 0bit d 0us m2 400Mbit 
class hfsc 1:a parent 1:1 leaf 85f8: ls m1 0bit d 0us m2 200Mbit 
class hfsc 1:b parent 1:1 leaf 85f9: ls m1 0bit d 0us m2 111Mbit 
[edit]
vyos@vyos# tc -d filter show dev eth1
filter parent 1: protocol all pref 1 u32 chain 0 
filter parent 1: protocol all pref 1 u32 chain 0 fh 800: ht divisor 1 
filter parent 1: protocol all pref 1 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 flowid 1:a not_in_hw 
  match c0000201/ffffffff at 16
[edit]
```


## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_qos.py 
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... ok
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok
test_12_shaper_with_red_queue (__main__.TestQoS.test_12_shaper_with_red_queue) ... ok
test_13_shaper_delete_only_rule (__main__.TestQoS.test_13_shaper_delete_only_rule) ... ok
test_14_policy_limiter_marked_traffic (__main__.TestQoS.test_14_policy_limiter_marked_traffic) ... ok
test_15_traffic_match_group (__main__.TestQoS.test_15_traffic_match_group) ... ok
test_16_wrong_traffic_match_group (__main__.TestQoS.test_16_wrong_traffic_match_group) ... ok
test_21_shaper_hfsc (__main__.TestQoS.test_21_shaper_hfsc) ... ok

----------------------------------------------------------------------
Ran 17 tests in 74.584s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
