### PR TITLE
T6764: Fix unhandled exception on ethtool output parsing for Xen NICs

### DIFF
--- a/python/vyos/ethtool.py
+++ b/python/vyos/ethtool.py
@@ -23,7 +23,7 @@ from vyos.utils.process import popen
 # flow control settings
 _drivers_without_speed_duplex_flow = ['vmxnet3', 'virtio_net', 'xen_netfront',
                                       'iavf', 'ice', 'i40e', 'hv_netvsc', 'veth', 'ixgbevf',
-                                      'tun']
+                                      'tun', 'vif']
 
 class Ethtool:
     """
@@ -101,8 +101,9 @@ class Ethtool:
         self._features = loads(out)[0]
 
         # Get information about NIC ring buffers
-        out, _ = popen(f'ethtool --json --show-ring {ifname}')
-        self._ring_buffer = loads(out)[0]
+        out, err = popen(f'ethtool --json --show-ring {ifname}')
+        if not bool(err):
+            self._ring_buffer = loads(out)[0]
 
         # Get current flow control settings, but this is not supported by
         # all NICs (e.g. vmxnet3 does not support is)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Not all NICs could provide ring-buffers info requested by ethtool in JSON format
For example 'vif' Xen/XCP-NG interfaces
Fix it

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6764

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ethtool
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
XEN/XCP-ng `vif` before the fix:
```
Traceback (most recent call last):
  File "/usr/libexec/vyos/conf_mode/interfaces_ethernet.py", line 354, in <module>
    verify(c)
  File "/usr/libexec/vyos/conf_mode/interfaces_ethernet.py", line 274, in verify
    verify_ethernet(ethernet)
  File "/usr/libexec/vyos/conf_mode/interfaces_ethernet.py", line 310, in verify_ethernet
    ethtool = Ethtool(ifname)
              ^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/ethtool.py", line 105, in __init__
    self._ring_buffer = loads(out)[0]
                        ~~~~~~~~~~^^^
IndexError: list index out of range

```

After the fix configuration applies without errors

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
