### PR TITLE
dhcp_server: T6031: fix daemon load error when static-route options are present

### DIFF
--- a/data/templates/dhcp-server/kea-dhcp4.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp4.conf.j2
@@ -29,14 +29,14 @@
                 "code": 121,
                 "type": "record",
                 "array": true,
-                "record-types": "uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8"
+                "record-types": "uint8,uint8,uint8,uint8,uint8,uint8,uint8"
             },
             {
                 "name": "windows-static-route",
                 "code": 249,
                 "type": "record",
                 "array": true,
-                "record-types": "uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8"
+                "record-types": "uint8,uint8,uint8,uint8,uint8,uint8,uint8"
             },
             {
                 "name": "wpad-url",


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6031
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
service dhcp-server 
## Proposed changes
<!--- Describe your changes in detail -->
Added new TuneD profiles and ability to activate several profiles
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set interfaces ethernet eth1 address '192.168.100.1/24'

set service dhcp-server shared-network-name LAN subnet 192.168.100.0/24 lease '86400'
set service dhcp-server shared-network-name LAN subnet 192.168.100.0/24 option default-router '192.168.100.1'
set service dhcp-server shared-network-name LAN subnet 192.168.100.0/24 option domain-name 'vyos.net'
set service dhcp-server shared-network-name LAN subnet 192.168.100.0/24 option name-server '192.168.100.1'
set service dhcp-server shared-network-name LAN subnet 192.168.100.0/24 option static-route 192.168.0.0/16 next-hop '192.168.100.1'
set service dhcp-server shared-network-name LAN subnet 192.168.100.0/24 range 0 start '192.168.100.9'
set service dhcp-server shared-network-name LAN subnet 192.168.100.0/24 range 0 stop '192.168.100.254'
set service dhcp-server shared-network-name LAN subnet 192.168.100.0/24 subnet-id '1'
commit
```

```
vyos@vyos# systemctl status kea-dhcp4-server.service
● kea-dhcp4-server.service - Kea IPv4 DHCP daemon
     Loaded: loaded (/lib/systemd/system/kea-dhcp4-server.service; disabled; preset: enabled)
    Drop-In: /etc/systemd/system/kea-dhcp4-server.service.d
             └─override.conf
     Active: active (running) since Wed 2024-10-30 16:53:51 UTC; 3min 19s ago
       Docs: man:kea-dhcp4(8)
   Main PID: 92937 (kea-dhcp4)
      Tasks: 6 (limit: 1129)
     Memory: 2.9M
        CPU: 68ms
     CGroup: /system.slice/kea-dhcp4-server.service
             └─92937 /usr/sbin/kea-dhcp4 -c /run/kea/kea-dhcp4.conf
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# python3 /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py
test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
test_dhcp_high_availability (__main__.TestServiceDHCPServer.test_dhcp_high_availability) ... ok
test_dhcp_high_availability_standby (__main__.TestServiceDHCPServer.test_dhcp_high_availability_standby) ... ok
test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
test_dhcp_on_interface_with_vrf (__main__.TestServiceDHCPServer.test_dhcp_on_interface_with_vrf) ... ok
test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... ok
test_dhcp_single_pool_options_scoped (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options_scoped) ... ok
test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... ok
test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... ok

----------------------------------------------------------------------
Ran 11 tests in 76.251s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
