### PR TITLE
dhcp_server: T6852: Add op mode command "show dhcpv6 server statistics"

### DIFF
--- a/op-mode-definitions/dhcp.xml.in
+++ b/op-mode-definitions/dhcp.xml.in
@@ -228,6 +228,23 @@
                   </tagNode>
                 </children>
               </node>
+              <node name="statistics">
+                <properties>
+                  <help>Show DHCPv6 server statistics</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/dhcp.py show_pool_statistics --family inet6</command>
+                <children>
+                  <tagNode name="pool">
+                    <properties>
+                      <help>Show DHCPv6 server statistics for a specific pool</help>
+                      <completionHelp>
+                        <path>service dhcpv6-server shared-network-name</path>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/dhcp.py show_pool_statistics --family inet6 --pool $6</command>
+                  </tagNode>
+                </children>
+              </node>
             </children>
           </node>
         </children>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6852
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
op mode
## Proposed changes
<!--- Describe your changes in detail -->
added command ```show dhcpv6 server statistics```
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set interfaces ethernet eth1 address '2001:db8::1/64'

set service dhcpv6-server shared-network-name NET1 interface 'eth1'
set service dhcpv6-server shared-network-name NET1 subnet 2001:db8::/64 option name-server '2001:db8::ffff'
set service dhcpv6-server shared-network-name NET1 subnet 2001:db8::/64 range 1 start '2001:db8::100'
set service dhcpv6-server shared-network-name NET1 subnet 2001:db8::/64 range 1 stop '2001:db8::199'
set service dhcpv6-server shared-network-name NET1 subnet 2001:db8::/64 subnet-id '1'
commit

vyos@vyos:~$ show dhcpv6 server statistics
Pool    Size    Leases    Available    Usage
------  ------  --------  -----------  -------
NET1    154     1         153          1%

vyos@vyos:~$ show dhcpv6 server statistics pool
Possible completions:
  NET1                  Show DHCPv6 server statistics for a specific pool


vyos@vyos:~$ show dhcpv6 server statistics pool NET1
Pool    Size    Leases    Available    Usage
------  ------  --------  -----------  -------
NET1    154     1         153          1%
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
