### PR TITLE
syslog: T6858: bugfix remote syslog using TCP

### DIFF
--- a/data/templates/rsyslog/rsyslog.conf.j2
+++ b/data/templates/rsyslog/rsyslog.conf.j2
@@ -57,9 +57,7 @@ $outchannel {{ file_name }},/var/log/user/{{ file_name }},{{ file_options.archiv
 {%             endfor %}
 {%         endif %}
 {%         if host_options.protocol is vyos_defined('tcp') %}
-{%             if host_options.format.octet_counted is vyos_defined %}
 {{ tmp | join(';') }} @@{{ '(o)' if host_options.format.octet_counted is vyos_defined }}{{ host_name | bracketize_ipv6 }}:{{ host_options.port }}{{ ';RSYSLOG_SyslogProtocol23Format' if host_options.format.include_timezone is vyos_defined }}
-{%             endif %}
 {%         else %}
 {{ tmp | join(';') }} @{{ host_name | bracketize_ipv6 }}:{{ host_options.port }}{{ ';RSYSLOG_SyslogProtocol23Format' if host_options.format.include_timezone is vyos_defined }}
 {%         endif %}

--- a/smoketest/scripts/cli/test_system_syslog.py
+++ b/smoketest/scripts/cli/test_system_syslog.py
@@ -21,6 +21,7 @@ from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.utils.file import read_file
 from vyos.utils.process import process_named_running
+from vyos.xml_ref import default_value
 
 PROCESS_NAME = 'rsyslogd'
 RSYSLOG_CONF = '/etc/rsyslog.d/00-vyos.conf'
@@ -101,6 +102,29 @@ class TestRSYSLOGService(VyOSUnitTestSHIM.TestCase):
             self.assertIn(e, config)
         # Check for running process
         self.assertTrue(process_named_running(PROCESS_NAME))
+
+    def test_syslog_remote(self):
+        rhost = '169.254.0.1'
+        default_port = default_value(base_path + ['host', rhost, 'port'])
+
+        self.cli_set(base_path + ['global', 'facility', 'all', 'level', 'info'])
+        self.cli_set(base_path + ['global', 'facility', 'local7', 'level', 'debug'])
+        self.cli_set(base_path + ['host', rhost, 'facility', 'all', 'level', 'all'])
+        self.cli_set(base_path + ['host', rhost, 'protocol', 'tcp'])
+
+        self.cli_commit()
+
+        config = read_file(RSYSLOG_CONF)
+        self.assertIn(f'*.* @@{rhost}:{default_port}', config)
+
+        # Change default port and enable "octet-counting" mode
+        port = '10514'
+        self.cli_set(base_path + ['host', rhost, 'port', port])
+        self.cli_set(base_path + ['host', rhost, 'format', 'octet-counted'])
+        self.cli_commit()
+
+        config = read_file(RSYSLOG_CONF)
+        self.assertIn(f'*.* @@(o){rhost}:{port}', config)
 
 
 if __name__ == '__main__':

--- a/smoketest/scripts/cli/test_system_syslog.py
+++ b/smoketest/scripts/cli/test_system_syslog.py
@@ -20,7 +20,6 @@ import unittest
 from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.utils.file import read_file
-from vyos.utils.process import cmd
 from vyos.utils.process import process_named_running
 
 PROCESS_NAME = 'rsyslogd'
@@ -80,20 +79,22 @@ class TestRSYSLOGService(VyOSUnitTestSHIM.TestCase):
         self.assertTrue(process_named_running(PROCESS_NAME))
 
     def test_syslog_global(self):
-        self.cli_set(['system', 'host-name', 'vyos'])
-        self.cli_set(['system', 'domain-name', 'example.local'])
+        hostname = 'vyos123'
+        domainname = 'example.local'
+        self.cli_set(['system', 'host-name', hostname])
+        self.cli_set(['system', 'domain-name', domainname])
         self.cli_set(base_path + ['global', 'marker', 'interval', '600'])
         self.cli_set(base_path + ['global', 'preserve-fqdn'])
         self.cli_set(base_path + ['global', 'facility', 'kern', 'level', 'err'])
 
         self.cli_commit()
 
-        config = cmd(f'sudo cat {RSYSLOG_CONF}')
+        config = read_file(RSYSLOG_CONF)
         expected = [
             '$MarkMessagePeriod 600',
             '$PreserveFQDN on',
             'kern.err',
-            '$LocalHostName vyos.example.local',
+            f'$LocalHostName {hostname}.{domainname}',
         ]
 
         for e in expected:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Commit 042be39cc (`syslog: T5367: add format option to include timezone in message`) added an invalid, outer if-statement when rendering the rsyslog configuration option for TCP.

Remote hosts only got added when the format option "octet-counting" was defined in addition to the TCP protocol. This has been fix and now TCP transport is decoupled from octet-counting mode.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6858

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4061

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
set system syslog host 10.5.0.20 facility all level 'all'
set system syslog host 10.5.0.20 port '10513'
set system syslog host 10.5.0.20 protocol 'tcp'
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_syslog.py
test_syslog_basic (__main__.TestRSYSLOGService.test_syslog_basic) ... ok
test_syslog_global (__main__.TestRSYSLOGService.test_syslog_global) ... ok
test_syslog_remote (__main__.TestRSYSLOGService.test_syslog_remote) ... ok

----------------------------------------------------------------------
Ran 3 tests in 13.652s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
