### PR TITLE
T6796: QoS: match filter by interface(iif)

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -98,6 +98,10 @@ class Interface(Control):
             'shellcmd': 'ip -json -detail link list dev {ifname}',
             'format': lambda j: jmespath.search('[*].ifalias | [0]', json.loads(j)) or '',
         },
+        'ifindex': {
+            'shellcmd': 'ip -json -detail link list dev {ifname}',
+            'format': lambda j: jmespath.search('[*].ifindex | [0]', json.loads(j)) or '',
+        },
         'mac': {
             'shellcmd': 'ip -json -detail link list dev {ifname}',
             'format': lambda j: jmespath.search('[*].address | [0]', json.loads(j)),
@@ -427,6 +431,17 @@ class Interface(Control):
     def _add_interface_to_ct_iface_map(self, vrf_table_id: int):
         nft_command = f'add element inet vrf_zones ct_iface_map {{ "{self.ifname}" : {vrf_table_id} }}'
         self._nft_check_and_run(nft_command)
+
+    def get_ifindex(self):
+        """
+        Get interface index by name
+
+        Example:
+        >>> from vyos.ifconfig import Interface
+        >>> Interface('eth0').get_ifindex()
+        '2'
+        """
+        return int(self.get_interface('ifindex'))
 
     def get_min_mtu(self):
         """

--- a/python/vyos/qos/base.py
+++ b/python/vyos/qos/base.py
@@ -17,6 +17,7 @@ import os
 import jmespath
 
 from vyos.base import Warning
+from vyos.ifconfig import Interface
 from vyos.utils.process import cmd
 from vyos.utils.dict import dict_search
 from vyos.utils.file import read_file
@@ -253,7 +254,7 @@ class QoSBase:
                     for index, (match, match_config) in enumerate(cls_config['match'].items(), start=1):
                         filter_cmd = filter_cmd_base
                         if not has_filter:
-                            for key in ['mark', 'vif', 'ip', 'ipv6']:
+                            for key in ['mark', 'vif', 'ip', 'ipv6', 'interface']:
                                 if key in match_config:
                                     has_filter = True
                                     break
@@ -263,9 +264,14 @@ class QoSBase:
                         if 'mark' in match_config:
                             mark = match_config['mark']
                             filter_cmd += f' handle {mark} fw'
+
                         if 'vif' in match_config:
                             vif = match_config['vif']
                             filter_cmd += f' basic match "meta(vlan mask 0xfff eq {vif})"'
+                        elif 'interface' in match_config:
+                            iif_name = match_config['interface']
+                            iif = Interface(iif_name).get_ifindex()
+                            filter_cmd += f' basic match "meta(rt_iif eq {iif})"'
 
                         for af in ['ip', 'ipv6']:
                             tc_af = af

--- a/src/conf_mode/qos.py
+++ b/src/conf_mode/qos.py
@@ -198,9 +198,15 @@ def get_config(config=None):
 def _verify_match(cls_config: dict) -> None:
     if 'match' in cls_config:
         for match, match_config in cls_config['match'].items():
-            if {'ip', 'ipv6'} <= set(match_config):
+            filters = set(match_config)
+            if {'ip', 'ipv6'} <= filters:
                 raise ConfigError(
                     f'Can not use both IPv6 and IPv4 in one match ({match})!')
+
+            if {'interface', 'vif'} & filters:
+                if {'ip', 'ipv6', 'ether'} & filters:
+                    raise ConfigError(
+                        f'Can not combine protocol and interface or vlan tag match ({match})!')
 
 
 def _verify_match_group_exist(cls_config, qos):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6796

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
create simple config e.g.:
```
conf
set qos interface eth1 ingress 'test'
set qos policy limiter test class 10 bandwidth '100mbit'
set qos policy limiter test class 10 match test_match interface 'eth2'
set qos policy limiter test default bandwidth '100gbit'
commit
```
check tc filters:
```
vyos@vyos# tc -d filter show dev eth1 ingress
filter parent ffff: protocol all pref 20 basic chain 0 
filter parent ffff: protocol all pref 20 basic chain 0 handle 0x1 flowid ffff:a 
  meta(rt_iif eq 4)

        action order 1:  police 0x1 rate 100Mbit burst 15337b mtu 2Kb action drop overhead 0b linklayer ethernet 
        ref 1 bind 1 

filter parent ffff: protocol all pref 255 basic chain 0 
filter parent ffff: protocol all pref 255 basic chain 0 handle 0x1 flowid ffff:b 
        action order 1:  police 0x2 rate 100Gbit burst 0b mtu 2Kb action drop overhead 0b linklayer ethernet 
        ref 1 bind 1 
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_qos.py 
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... ok
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok
test_12_shaper_with_red_queue (__main__.TestQoS.test_12_shaper_with_red_queue) ... ok
test_13_shaper_delete_only_rule (__main__.TestQoS.test_13_shaper_delete_only_rule) ... ok
test_14_policy_limiter_marked_traffic (__main__.TestQoS.test_14_policy_limiter_marked_traffic) ... ok
test_15_traffic_match_group (__main__.TestQoS.test_15_traffic_match_group) ... ok
test_16_wrong_traffic_match_group (__main__.TestQoS.test_16_wrong_traffic_match_group) ... ok
test_20_round_robin_policy_default (__main__.TestQoS.test_20_round_robin_policy_default) ... ok
test_22_policy_limiter_iif_filter (__main__.TestQoS.test_22_policy_limiter_iif_filter) ... ok

----------------------------------------------------------------------
Ran 18 tests in 82.469s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
