### PR TITLE
T6801: QoS: Policy rate-control is broken by default

### DIFF
--- a/src/conf_mode/qos.py
+++ b/src/conf_mode/qos.py
@@ -255,6 +255,9 @@ def verify(qos):
                 if policy_type in ['priority_queue']:
                     if 'default' not in policy_config:
                         raise ConfigError(f'Policy {policy} misses "default" class!')
+                if policy_type in ['rate_control']:
+                    if 'bandwidth' not in policy_config:
+                        raise ConfigError('Bandwidth not defined')
                 if 'default' in policy_config:
                     if 'bandwidth' not in policy_config['default'] and policy_type not in ['priority_queue', 'round_robin', 'shaper_hfsc']:
                         raise ConfigError('Bandwidth not defined for default traffic!')


### PR DESCRIPTION
- Fixed unhandled exception for policy rate-control without params

Added validation for policy bandwidth param

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6801

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_qos.py 
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... ok
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok
test_12_shaper_with_red_queue (__main__.TestQoS.test_12_shaper_with_red_queue) ... ok
test_13_shaper_delete_only_rule (__main__.TestQoS.test_13_shaper_delete_only_rule) ... ok
test_14_policy_limiter_marked_traffic (__main__.TestQoS.test_14_policy_limiter_marked_traffic) ... ok
test_15_traffic_match_group (__main__.TestQoS.test_15_traffic_match_group) ... ok
test_16_wrong_traffic_match_group (__main__.TestQoS.test_16_wrong_traffic_match_group) ... ok
test_20_round_robin_policy_default (__main__.TestQoS.test_20_round_robin_policy_default) ... ok
test_22_rate_control_default (__main__.TestQoS.test_22_rate_control_default) ... ok

----------------------------------------------------------------------
Ran 18 tests in 84.334s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
