### PR TITLE
conntrack: T6878: stop the conntrack logger daemon correctly

### DIFF
--- a/src/conf_mode/system_conntrack.py
+++ b/src/conf_mode/system_conntrack.py
@@ -258,6 +258,8 @@ def apply(conntrack):
 
     if 'log' in conntrack:
         call(f'systemctl restart vyos-conntrack-logger.service')
+    else:
+        call(f'systemctl stop vyos-conntrack-logger.service')
 
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6878

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
vyos@vyos# set system conntrack log event new 
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# ps aux | grep vyos-conntrack-logger
root        6866  3.1  3.6 119108 36324 ?        Ssl  02:57   0:00 /usr/bin/python3 -u /usr/libexec/vyos/services/vyos-conntrack-logger -c /run/vyos-conntrack-logger.conf
root        6897  0.1  2.9 119108 29292 ?        S    02:57   0:00 /usr/bin/python3 -u /usr/libexec/vyos/services/vyos-conntrack-logger -c /run/vyos-conntrack-logger.conf
vyos        6914  0.0  0.2   6468  2176 pts/2    S+   02:57   0:00 grep vyos-conntrack-logger
[edit]
vyos@vyos# del system conntrack log 
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# ps aux | grep vyos-conntrack-logger
vyos        6982  0.0  0.2   6468  2048 pts/2    S+   02:57   0:00 grep vyos-conntrack-logger
[edit]
vyos@vyos# 
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_system_conntrack.py 
test_conntrack_hash_size (__main__.TestSystemConntrack.test_conntrack_hash_size) ... ok
test_conntrack_ignore (__main__.TestSystemConntrack.test_conntrack_ignore) ... ok
test_conntrack_log (__main__.TestSystemConntrack.test_conntrack_log) ... ok
test_conntrack_module_enable (__main__.TestSystemConntrack.test_conntrack_module_enable) ... ok
test_conntrack_options (__main__.TestSystemConntrack.test_conntrack_options) ... ok
test_conntrack_timeout_custom (__main__.TestSystemConntrack.test_conntrack_timeout_custom) ... ok

----------------------------------------------------------------------
Ran 6 tests in 41.183s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
