### PR TITLE
T6490: Allow creation of wireguard interfaces without requiring peers

### DIFF
--- a/python/vyos/ifconfig/wireguard.py
+++ b/python/vyos/ifconfig/wireguard.py
@@ -195,6 +195,9 @@ class WireGuardIf(Interface):
 
         base_cmd += f' private-key {tmp_file.name}'
         base_cmd = base_cmd.format(**config)
+        # T6490: execute command to ensure interface configured
+        self._cmd(base_cmd)
+
         if 'peer' in config:
             for peer, peer_config in config['peer'].items():
                 # T4702: No need to configure this peer when it was explicitly

--- a/src/conf_mode/interfaces_wireguard.py
+++ b/src/conf_mode/interfaces_wireguard.py
@@ -70,10 +70,6 @@ def verify(wireguard):
     if 'private_key' not in wireguard:
         raise ConfigError('Wireguard private-key not defined')
 
-    if 'peer' not in wireguard:
-        # T6490: initialize an empty peer object
-        wireguard['peer'] = {}
-
     if 'port' in wireguard and 'port_changed' in wireguard:
         listen_port = int(wireguard['port'])
         if check_port_availability('0.0.0.0', listen_port, 'udp') is not True:
@@ -81,28 +77,29 @@ def verify(wireguard):
                                'cannot be used for the interface!')
 
     # run checks on individual configured WireGuard peer
-    public_keys = []
-    for tmp in wireguard['peer']:
-        peer = wireguard['peer'][tmp]
+    if 'peer' in wireguard:
+        public_keys = []
+        for tmp in wireguard['peer']:
+            peer = wireguard['peer'][tmp]
 
-        if 'allowed_ips' not in peer:
-            raise ConfigError(f'Wireguard allowed-ips required for peer "{tmp}"!')
+            if 'allowed_ips' not in peer:
+                raise ConfigError(f'Wireguard allowed-ips required for peer "{tmp}"!')
 
-        if 'public_key' not in peer:
-            raise ConfigError(f'Wireguard public-key required for peer "{tmp}"!')
+            if 'public_key' not in peer:
+                raise ConfigError(f'Wireguard public-key required for peer "{tmp}"!')
 
-        if ('address' in peer and 'port' not in peer) or ('port' in peer and 'address' not in peer):
-            raise ConfigError('Both Wireguard port and address must be defined '
-                              f'for peer "{tmp}" if either one of them is set!')
+            if ('address' in peer and 'port' not in peer) or ('port' in peer and 'address' not in peer):
+                raise ConfigError('Both Wireguard port and address must be defined '
+                                  f'for peer "{tmp}" if either one of them is set!')
 
-        if peer['public_key'] in public_keys:
-            raise ConfigError(f'Duplicate public-key defined on peer "{tmp}"')
+            if peer['public_key'] in public_keys:
+                raise ConfigError(f'Duplicate public-key defined on peer "{tmp}"')
 
-        if 'disable' not in peer:
-            if is_wireguard_key_pair(wireguard['private_key'], peer['public_key']):
-                raise ConfigError(f'Peer "{tmp}" has the same public key as the interface "{wireguard["ifname"]}"')
+            if 'disable' not in peer:
+                if is_wireguard_key_pair(wireguard['private_key'], peer['public_key']):
+                    raise ConfigError(f'Peer "{tmp}" has the same public key as the interface "{wireguard["ifname"]}"')
 
-        public_keys.append(peer['public_key'])
+            public_keys.append(peer['public_key'])
 
 def generate(wireguard):
     return None

--- a/src/conf_mode/interfaces_wireguard.py
+++ b/src/conf_mode/interfaces_wireguard.py
@@ -71,7 +71,8 @@ def verify(wireguard):
         raise ConfigError('Wireguard private-key not defined')
 
     if 'peer' not in wireguard:
-        raise ConfigError('At least one Wireguard peer is required!')
+        # T6490: initialize an empty peer object
+        wireguard['peer'] = {}
 
     if 'port' in wireguard and 'port_changed' in wireguard:
         listen_port = int(wireguard['port'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6490


## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
wireguard

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
vyos@vyos:~$ configure
[edit]
vyos@vyos# delete interfaces wireguard
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# set interfaces wireguard wg0 private-key xxxxxxx
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# sudo wg
interface: wg0
  public key: xxxxxx=
  private key: (hidden)
  listening port: 42924
[edit]
```

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
root@vyos:/home/vyos# python3 /usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireguard.py
test_01_wireguard_peer (__main__.WireGuardInterfaceTest.test_01_wireguard_peer) ... ok
test_02_wireguard_add_remove_peer (__main__.WireGuardInterfaceTest.test_02_wireguard_add_remove_peer) ... ok
test_03_wireguard_same_public_key (__main__.WireGuardInterfaceTest.test_03_wireguard_same_public_key) ... ok
test_04_wireguard_threaded (__main__.WireGuardInterfaceTest.test_04_wireguard_threaded) ... ok
test_05_wireguard_peer_pubkey_change (__main__.WireGuardInterfaceTest.test_05_wireguard_peer_pubkey_change) ... ok

----------------------------------------------------------------------
Ran 5 tests in 51.219s

OK
root@vyos:/home/vyos#
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
