### PR TITLE
T6884: adds mtu option for container networks

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -501,6 +501,7 @@
         </properties>
         <children>
           #include <include/generic-description.xml.i>
+          #include <include/interface/mtu-68-1500.xml.i>
           <leafNode name="prefix">
             <properties>
               <help>Prefix which allocated to that network</help>

--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -501,7 +501,7 @@
         </properties>
         <children>
           #include <include/generic-description.xml.i>
-          #include <include/interface/mtu-68-1500.xml.i>
+          #include <include/interface/mtu-68-16000.xml.i>
           <leafNode name="prefix">
             <properties>
               <help>Prefix which allocated to that network</help>

--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -224,6 +224,22 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         n = cmd_to_json(f'sudo podman network inspect {net_name}')
         self.assertEqual(n['dns_enabled'], False)
 
+    def test_network_mtu(self):
+        prefix = '192.0.2.0/24'
+        base_name = 'ipv4'
+        net_name = 'NET01'
+
+        self.cli_set(base_path + ['network', net_name, 'prefix', prefix])
+        self.cli_set(base_path + ['network', net_name, 'mtu', '1280'])
+
+        name = f'{base_name}-2'
+        self.cli_set(base_path + ['name', name, 'image', cont_image])
+        self.cli_set(base_path + ['name', name, 'network', net_name, 'address', str(ip_interface(prefix).ip + 2)])
+        self.cli_commit()
+
+        n = cmd_to_json(f'sudo podman network inspect {net_name}')
+        self.assertEqual(n['options']['mtu'], '1280')
+
     def test_uid_gid(self):
         cont_name = 'uid-test'
         gid = '100'

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -419,11 +419,17 @@ def generate(container):
                 'dns_enabled': True,
                 'ipam_options': {
                     'driver': 'host-local'
+                },
+                'options': {
+                    'mtu': '1500'
                 }
             }
 
             if 'no_name_server' in network_config:
                 tmp['dns_enabled'] = False
+
+            if 'mtu' in network_config:
+                tmp['options']['mtu'] = network_config['mtu']
 
             for prefix in network_config['prefix']:
                 net = {'subnet': prefix, 'gateway': inc_ip(prefix, 1)}


### PR DESCRIPTION
## Change Summary
Add new config option to set mtu on container networks

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T6884

## Related PR(s)
vyos/vyos-documentation#1568

## Component(s) name
container

## Proposed changes
Add new config option to set mtu on container networks

## How to test
Set up a container network
```
set container network example prefix 172.20.0.0/16
set container network example mtu 1280
```
Then verify network with
```
sudo podman network inspect example
```
that the configuration has mtu set
```
          ....
          "options": {
               "mtu": "1280"
          },
          ....
```

## Smoketest result
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_container.py
test_api_socket (__main__.TestContainer.test_api_socket) ... ok
test_basic (__main__.TestContainer.test_basic) ... ok
test_cpu_limit (__main__.TestContainer.test_cpu_limit) ... ok
test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... ok
test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... ok
test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... ok
test_network_mtu (__main__.TestContainer.test_network_mtu) ... ok
test_no_name_server (__main__.TestContainer.test_no_name_server) ... ok
test_uid_gid (__main__.TestContainer.test_uid_gid) ... ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
