### PR TITLE
ipoe_server: T6872: Add the ability to configure LUA scripts and username

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.j2
+++ b/data/templates/accel-ppp/ipoe.config.j2
@@ -38,6 +38,9 @@ level={{ log.level }}
 
 [ipoe]
 verbose=1
+{% if lua_file is vyos_defined %}
+lua-file={{ lua_file }}
+{% endif %}
 {% if interface is vyos_defined %}
 {%     for iface, iface_config in interface.items() %}
 {%         set tmp = 'interface=' %}
@@ -55,7 +58,8 @@ verbose=1
 {%         set range = 'range=' ~ iface_config.client_subnet ~ ',' if iface_config.client_subnet is vyos_defined else '' %}
 {%         set relay = ',' ~ 'relay=' ~ iface_config.external_dhcp.dhcp_relay  if iface_config.external_dhcp.dhcp_relay is vyos_defined else '' %}
 {%         set giaddr = ',' ~ 'giaddr=' ~ iface_config.external_dhcp.giaddr if iface_config.external_dhcp.giaddr is vyos_defined else '' %}
-{{ tmp }},{{ shared }}mode={{ iface_config.mode | upper }},ifcfg=1,{{ range }}start=dhcpv4,ipv6=1{{ relay }}{{ giaddr }}
+{%         set username = ',' ~ 'username=lua:' ~ iface_config.lua_username if iface_config.lua_username is vyos_defined else '' %}
+{{ tmp }},{{ shared }}mode={{ iface_config.mode | upper }},ifcfg=1,{{ range }}start=dhcpv4,ipv6=1{{ relay }}{{ giaddr }}{{ username }}
 {%         if iface_config.vlan_mon is vyos_defined %}
 vlan-mon={{ iface }},{{ iface_config.vlan | join(',') }}
 {%         endif %}

--- a/interface-definitions/service_ipoe-server.xml.in
+++ b/interface-definitions/service_ipoe-server.xml.in
@@ -174,10 +174,34 @@
                   </leafNode>
                 </children>
               </node>
+              <leafNode name="lua-username">
+                <properties>
+                  <help>Username function</help>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>Name of the function in the Lua file to construct usernames with</description>
+                  </valueHelp>
+                  <constraint>
+                      #include <include/constraint/alpha-numeric-hyphen-underscore.xml.i>
+                  </constraint>
+                </properties>
+              </leafNode>
               #include <include/accel-ppp/vlan.xml.i>
               #include <include/accel-ppp/vlan-mon.xml.i>
             </children>
           </tagNode>
+          <leafNode name="lua-file">
+            <properties>
+              <help>Lua script file for constructing user names</help>
+              <valueHelp>
+                <format>filename</format>
+                <description>File with Lua script in /config/scripts directory</description>
+              </valueHelp>
+              <constraint>
+                <validator name="file-path" argument="--strict --parent-dir /config/scripts"/>
+              </constraint>
+            </properties>
+          </leafNode>
           #include <include/accel-ppp/client-ip-pool.xml.i>
           #include <include/accel-ppp/client-ipv6-pool.xml.i>
           #include <include/accel-ppp/default-pool.xml.i>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6872
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
service ipoe-server
## Proposed changes
<!--- Describe your changes in detail -->
added ability to configure username with LUA script
```
set service ipoe-server lua-file <path_to_lua_file>
set service ipoe-server interface eth1 lua-username <username_func>
```
Also changed systemctl action from ```reload-or-restart``` to ```restart``` because accel-ppp doesn't apply changes to the configuration with ```reload-or-restart``` action
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Example of the lua file:
```
vyos@vyos# cat /config/ipoe.lua
#!lua
function username_func(pkt)
    local username=pkt:hwaddr()
    return username
end
```
Config:
```
set service ipoe-server authentication mode 'radius'
set service ipoe-server authentication radius server 127.0.0.1 key 'vyos-secret'
set service ipoe-server client-ip-pool POOL range '192.168.10.5-192.168.10.100'
set service ipoe-server default-pool 'POOL'
set service ipoe-server gateway-address '192.168.10.1/24'
set service ipoe-server interface eth1 mode 'l2'
set service ipoe-server interface eth1 network 'shared'
set service ipoe-server name-server '1.1.1.1'
set service ipoe-server name-server '198.168.10.1'

set service ipoe-server interface eth1 lua-username 'username_func'
set service ipoe-server lua-file '/config/scripts/ipoe.lua'
```
Logs
```
Nov 15 20:30:18 vyos accel-ipoe[18180]: ipoe0:: send [RADIUS(1) Access-Request id=1 <User-Name "0c:dd:ab:38:00:01"> <NAS-Port 352> <NAS-Port-Id "ipoe0"> <NAS-Port-Type Ethernet> <Calling-Station-Id "0c:dd:ab:38:00:01"> <Called-Station-Id "eth1"> <User-Password 0xa6b74758d04d3f60be39e9c349fdbc8654fb4a586e8e5859b7c72c9e82937320>]
Nov 15 20:30:18 vyos accel-ipoe[18180]: ipoe0:: recv [RADIUS(1) Access-Accept id=1 <Service-Type Framed-User> <Framed-Pool "POOL"> <Stateful-IPv6-Address-Pool "IPv6-POOL"> <Delegated-IPv6-Prefix-Pool "IPv6-POOL"> <Framed-Protocol PPP>]
Nov 15 20:30:18 vyos accel-ipoe[18180]: ipoe0:0c:dd:ab:38:00:01: 0c:dd:ab:38:00:01: authentication succeeded
Nov 15 20:30:18 vyos accel-ipoe[18180]: ipoe0:0c:dd:ab:38:00:01: ipoe: no free IPv6 address
Nov 15 20:30:18 vyos accel-ipoe[18180]: ipoe0:0c:dd:ab:38:00:01: send [RADIUS(1) Accounting-Request id=1 <User-Name "0c:dd:ab:38:00:01"> <NAS-Port 352> <NAS-Port-Id "ipoe0"> <NAS-Port-Type Ethernet> <Calling-Station-Id "0c:dd:ab:38:00:01"> <Called-Station-Id "eth1"> <Acct-Status-Type Start> <Acct-Authentic RADIUS> <Acct-Session-Id "b2e7d371f7638e00"> <Acct-Session-Time 0> <Acct-Input-Octets 0> <Acct-Output-Octets 0> <Acct-Input-Packets 0> <Acct-Output-Packets 0> <Acct-Input-Gigawords 0> <Acct-Output-Gigawords 0> <Framed-IP-Address 192.168.10.5>]
Nov 15 20:30:18 vyos accel-ipoe[18180]: ipoe0:0c:dd:ab:38:00:01: recv [RADIUS(1) Accounting-Response id=1]
Nov 15 20:30:18 vyos accel-ipoe[18180]: ipoe0:0c:dd:ab:38:00:01: ipoe: session started
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# python3 /usr/libexec/vyos/tests/smoke/cli/test_service_ipoe-server.py
test_accel_ipv4_pool (__main__.TestServiceIPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServiceIPoEServer.test_accel_ipv6_pool) ... ok
test_accel_limits (__main__.TestServiceIPoEServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestServiceIPoEServer.test_accel_local_authentication) ... ok
test_accel_log_level (__main__.TestServiceIPoEServer.test_accel_log_level) ... ok
test_accel_name_servers (__main__.TestServiceIPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServiceIPoEServer.test_accel_next_pool) ... ok
test_accel_ppp_options (__main__.TestServiceIPoEServer.test_accel_ppp_options) ... skipped 'PPP is not a part of IPoE'
test_accel_radius_authentication (__main__.TestServiceIPoEServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestServiceIPoEServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestServiceIPoEServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestServiceIPoEServer.test_accel_wins_server) ... skipped 'WINS server is not used in IPoE'
test_ipoe_server_vlan (__main__.TestServiceIPoEServer.test_ipoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 13 tests in 123.136s

OK (skipped=2)
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
