### PR TITLE
T264: IPsec add base64 encoded secret-type feature

### DIFF
--- a/data/templates/ipsec/swanctl.conf.j2
+++ b/data/templates/ipsec/swanctl.conf.j2
@@ -87,7 +87,11 @@ secrets {
         id-{{ gen_uuid }} = "{{ id }}"
 {%             endfor %}
 {%         endif %}
+{%         if psk_config.secret_type is vyos_defined('base64') %}
+        secret = 0s{{ psk_config.secret }}
+{%         elif psk_config.secret_type is vyos_defined('plaintext') %}
         secret = "{{ psk_config.secret }}"
+{%         endif %}
     }
 {%     endfor %}
 {% endif %}

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -41,6 +41,18 @@
                       </valueHelp>
                     </properties>
                   </leafNode>
+                  <leafNode name="secret-type">
+                    <properties>
+                      <help>Secret type</help>
+                      <completionHelp>
+                        <list>base64 plaintext</list>
+                      </completionHelp>
+                      <constraint>
+                        <regex>(base64|plaintext)</regex>
+                      </constraint>
+                    </properties>
+                    <defaultValue>plaintext</defaultValue>
+                  </leafNode>
                 </children>
               </tagNode>
             </children>

--- a/python/vyos/utils/convert.py
+++ b/python/vyos/utils/convert.py
@@ -235,3 +235,29 @@ def convert_data(data) -> dict | list | tuple | str | int | float | bool | None:
     # which cannot be converted to JSON
     # for example: complex | range | memoryview
     return
+
+
+def encode_to_base64(input_string):
+    """
+    Encodes a given string to its base64 representation.
+
+    Args:
+        input_string (str): The string to be encoded.
+
+    Returns:
+        str: The base64-encoded version of the input string.
+
+    Example:
+        input_string = "Hello, World!"
+        encoded_string = encode_to_base64(input_string)
+        print(encoded_string)  # Output: SGVsbG8sIFdvcmxkIQ==
+    """
+    import base64
+    # Convert the string to bytes
+    byte_string = input_string.encode('utf-8')
+
+    # Encode the byte string to base64
+    encoded_string = base64.b64encode(byte_string)
+
+    # Decode the base64 bytes back to a string
+    return encoded_string.decode('utf-8')

--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -21,6 +21,7 @@ from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.configsession import ConfigSessionError
 from vyos.ifconfig import Interface
+from vyos.utils.convert import encode_to_base64
 from vyos.utils.process import process_named_running
 from vyos.utils.file import read_file
 
@@ -495,6 +496,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         local_id = 'vyos-r1'
         remote_id = 'vyos-r2'
         peer_base_path = base_path + ['site-to-site', 'peer', connection_name]
+        secret_base64 = encode_to_base64(secret)
 
         self.cli_set(tunnel_path + ['tun1', 'encapsulation', 'gre'])
         self.cli_set(tunnel_path + ['tun1', 'source-address', local_address])
@@ -509,7 +511,8 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', remote_id])
         self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', local_address])
         self.cli_set(base_path + ['authentication', 'psk', connection_name, 'id', peer_ip])
-        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'secret', secret])
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'secret', secret_base64])
+        self.cli_set(base_path + ['authentication', 'psk', connection_name, 'secret-type', 'base64'])
 
         self.cli_set(peer_base_path + ['authentication', 'local-id', local_id])
         self.cli_set(peer_base_path + ['authentication', 'mode', 'pre-shared-secret'])
@@ -546,7 +549,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             f'id-{regex_uuid4} = "{remote_id}"',
             f'id-{regex_uuid4} = "{peer_ip}"',
             f'id-{regex_uuid4} = "{local_address}"',
-            f'secret = "{secret}"',
+            f'secret = 0s{secret_base64}',
         ]
 
         for line in swanctl_secrets_lines:


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add the ability to configure base64 encoded passwords for VPN IPSec site-to-site peers
```
set vpn ipsec authentication psk PSK secret 'MTIzNDU2Nzg5MA=='
set vpn ipsec authentication psk PSK secret-type < base64|plaintext >
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T264

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- an incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure base64 encoded password on the `left` node and clear password on the `right` node`

LEFT node:
```
set vpn ipsec authentication psk PSK id '192.0.2.1'
set vpn ipsec authentication psk PSK id '192.0.2.2'
set vpn ipsec authentication psk PSK secret 'MTIzNDU2Nzg5MA=='
set vpn ipsec authentication psk PSK secret-type 'base64'
set vpn ipsec esp-group ESP-group lifetime '3600'
set vpn ipsec esp-group ESP-group mode 'tunnel'
set vpn ipsec esp-group ESP-group pfs 'enable'
set vpn ipsec esp-group ESP-group proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-group proposal 1 hash 'sha1'
set vpn ipsec ike-group IKE-group key-exchange 'ikev2'
set vpn ipsec ike-group IKE-group lifetime '28800'
set vpn ipsec ike-group IKE-group proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE-group proposal 1 hash 'sha1'
set vpn ipsec interface 'eth1'
set vpn ipsec site-to-site peer OFFICE-B authentication local-id '192.0.2.1'
set vpn ipsec site-to-site peer OFFICE-B authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer OFFICE-B authentication remote-id '192.0.2.2'
set vpn ipsec site-to-site peer OFFICE-B connection-type 'initiate'
set vpn ipsec site-to-site peer OFFICE-B ike-group 'IKE-group'
set vpn ipsec site-to-site peer OFFICE-B local-address '192.0.2.1'
set vpn ipsec site-to-site peer OFFICE-B remote-address '192.0.2.2'
set vpn ipsec site-to-site peer OFFICE-B tunnel 0 esp-group 'ESP-group'
set vpn ipsec site-to-site peer OFFICE-B tunnel 0 local prefix '100.64.1.0/24'
set vpn ipsec site-to-site peer OFFICE-B tunnel 0 remote prefix '100.64.2.0/24'
```
RIGHT node:
```
set vpn ipsec authentication psk PSK id '192.0.2.1'
set vpn ipsec authentication psk PSK id '192.0.2.2'
set vpn ipsec authentication psk PSK secret '1234567890'
set vpn ipsec esp-group ESP-group lifetime '3600'
set vpn ipsec esp-group ESP-group mode 'tunnel'
set vpn ipsec esp-group ESP-group pfs 'enable'
set vpn ipsec esp-group ESP-group proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-group proposal 1 hash 'sha1'
set vpn ipsec ike-group IKE-group key-exchange 'ikev2'
set vpn ipsec ike-group IKE-group lifetime '28800'
set vpn ipsec ike-group IKE-group proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE-group proposal 1 hash 'sha1'
set vpn ipsec interface 'eth1'
set vpn ipsec site-to-site peer OFFICE-A authentication local-id '192.0.2.2'
set vpn ipsec site-to-site peer OFFICE-A authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer OFFICE-A authentication remote-id '192.0.2.1'
set vpn ipsec site-to-site peer OFFICE-A connection-type 'respond'
set vpn ipsec site-to-site peer OFFICE-A ike-group 'IKE-group'
set vpn ipsec site-to-site peer OFFICE-A local-address '192.0.2.2'
set vpn ipsec site-to-site peer OFFICE-A remote-address '192.0.2.1'
set vpn ipsec site-to-site peer OFFICE-A tunnel 0 esp-group 'ESP-group'
set vpn ipsec site-to-site peer OFFICE-A tunnel 0 local prefix '100.64.2.0/24'
set vpn ipsec site-to-site peer OFFICE-A tunnel 0 remote prefix '100.64.1.0/24'

```
Check config on the `left` node
```
vyos@r14:~$ cat /etc/swanctl/swanctl.conf | grep secret -A 5
secrets {
    ike-PSK {
        # ID's from auth psk <tag> id xxx
        id-d8e5cef6-0390-40bc-b371-f6f179413112 = "192.0.2.1"
        id-b9696448-1430-4411-b74b-aafc906f90c7 = "192.0.2.2"
        secret = 0sMTIzNDU2Nzg5MA==
    }

}
```

Be sure the connection is working
```
Nov 19 17:57:16 r14 charon[41119]: 02[NET] <OFFICE-B|1> received packet: from 192.0.2.2[4500] to 192.0.2.1[4500] (220 bytes)
Nov 19 17:57:16 r14 charon[41119]: 02[ENC] <OFFICE-B|1> parsed IKE_AUTH response 1 [ IDr AUTH SA TSi TSr N(MOBIKE_SUP) N(NO_ADD_ADDR) ]
Nov 19 17:57:16 r14 charon[41119]: 02[IKE] <OFFICE-B|1> authentication of '192.0.2.2' with pre-shared key successful
Nov 19 17:57:16 r14 charon[41119]: 02[IKE] <OFFICE-B|1> peer supports MOBIKE
Nov 19 17:57:16 r14 charon[41119]: 02[IKE] <OFFICE-B|1> IKE_SA OFFICE-B[1] established between 192.0.2.1[192.0.2.1]...192.0.2.2[192.0.2.2]
Nov 19 17:57:16 r14 charon[41119]: 02[IKE] <OFFICE-B|1> scheduling rekeying in 27280s
Nov 19 17:57:16 r14 charon[41119]: 02[IKE] <OFFICE-B|1> maximum IKE_SA lifetime 30160s
Nov 19 17:57:16 r14 charon[41119]: 02[CFG] <OFFICE-B|1> selected proposal: ESP:AES_CBC_256/HMAC_SHA1_96/NO_EXT_SEQ
Nov 19 17:57:16 r14 charon[41119]: 02[IKE] <OFFICE-B|1> CHILD_SA OFFICE-B-tunnel-0{1} established with SPIs ca76d43e_i ca6487b5_o and TS 100.64.1.0/24 === 100.64.2.0/24


vyos@r14:~$ show vpn ipsec connections 
Connection         State    Type    Remote address    Local TS       Remote TS      Local id    Remote id    Proposal
-----------------  -------  ------  ----------------  -------------  -------------  ----------  -----------  ----------------------------------
OFFICE-B           up       IKEv2   192.0.2.2         -              -              192.0.2.1   192.0.2.2    AES_CBC/256/HMAC_SHA1_96/MODP_1024
OFFICE-B-tunnel-0  up       IPsec   192.0.2.2         100.64.1.0/24  100.64.2.0/24  192.0.2.1   192.0.2.2    AES_CBC/256/HMAC_SHA1_96/None
vyos@r14:~$ 

```

## Smoketest result
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
test_dhcp_fail_handling (__main__.TestVPNIPsec.test_dhcp_fail_handling) ... ok
test_dmvpn (__main__.TestVPNIPsec.test_dmvpn) ... ok
test_flex_vpn_vips (__main__.TestVPNIPsec.test_flex_vpn_vips) ... ok
test_remote_access (__main__.TestVPNIPsec.test_remote_access) ... ok
test_remote_access_dhcp_fail_handling (__main__.TestVPNIPsec.test_remote_access_dhcp_fail_handling) ... ok
test_remote_access_eap_tls (__main__.TestVPNIPsec.test_remote_access_eap_tls) ... ok
test_remote_access_no_rekey (__main__.TestVPNIPsec.test_remote_access_no_rekey) ... ok
test_remote_access_pool_range (__main__.TestVPNIPsec.test_remote_access_pool_range) ... ok
test_remote_access_vti (__main__.TestVPNIPsec.test_remote_access_vti) ... ok
test_remote_access_x509 (__main__.TestVPNIPsec.test_remote_access_x509) ... ok
test_site_to_site (__main__.TestVPNIPsec.test_site_to_site) ... ok
test_site_to_site_vti (__main__.TestVPNIPsec.test_site_to_site_vti) ... ok
test_site_to_site_x509 (__main__.TestVPNIPsec.test_site_to_site_x509) ... ok

----------------------------------------------------------------------
Ran 13 tests in 80.993s

OK
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
