### PR TITLE
serial: T3397: Remove `--keep-baud` which could result in unexpected baud rate

### DIFF
--- a/data/templates/getty/serial-getty.service.j2
+++ b/data/templates/getty/serial-getty.service.j2
@@ -22,7 +22,7 @@ Before=rescue.service
 # The '-o' option value tells agetty to replace 'login' arguments with an
 # option to preserve environment (-p), followed by '--' for safety, and then
 # the entered username.
-ExecStart=-/sbin/agetty -o '-p -- \\u' --keep-baud {{ speed }} %I $TERM
+ExecStart=-/sbin/agetty -o '-p -- \\u' %I {{ speed }} $TERM
 Type=idle
 Restart=always
 UtmpIdentifier=%I


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Prevents serial terminals from using unexpected baud rate

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
serial, console

## Proposed changes
<!--- Describe your changes in detail -->
This change removes `--keep-baud` which can result in an unexpected baud rate for serial terminals.

When a specific baud rate speed is defined, or it is falling back to the VyOS default value of 115200. `--keep-baud` can result in the config value not being honoured.

If the terminal was created with a baud rate other than the config defined value, the config value will not be applied.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Tested on a Supermicro SOL serial port mapped to /dev/ttyS1. BIOS/IPMI is set to 115200.

`stty -aF /dev/ttyS1` default output:
`speed 9600 baud; rows 24; columns 80; ...`

After `set system console device ttyS1 speed 115200`:
`speed 9600 baud; rows 24; columns 80; ...`

Removing `--keep-baud`:
`speed 115200 baud; rows 24; columns 80; ...`

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
