### PR TITLE
dhcp: T6692: Fix range options not present when `exclude` is used

### DIFF
--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -557,6 +557,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.cli_set(pool + ['subnet-id', '1'])
         self.cli_set(pool + ['option', 'default-router', router])
         self.cli_set(pool + ['exclude', router])
+        self.cli_set(pool + ['range', '0', 'option', 'default-router', router])
         self.cli_set(pool + ['range', '0', 'start', range_0_start])
         self.cli_set(pool + ['range', '0', 'stop', range_0_stop])
 
@@ -569,6 +570,11 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.verify_config_value(obj, ['Dhcp4', 'shared-networks'], 'name', 'EXCLUDE-TEST')
         self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'subnet', subnet)
 
+        pool_obj = {
+            'pool': f'{range_0_start} - {range_0_stop}',
+            'option-data': [{'name': 'routers', 'data': router}]
+        }
+
         # Verify options
         self.verify_config_object(
                 obj,
@@ -579,7 +585,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.verify_config_object(
                 obj,
                 ['Dhcp4', 'shared-networks', 0, 'subnet4', 0, 'pools'],
-                {'pool': f'{range_0_start} - {range_0_stop}'})
+                pool_obj)
 
         # Check for running process
         self.assertTrue(process_named_running(PROCESS_NAME))
@@ -600,6 +606,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.cli_set(pool + ['subnet-id', '1'])
         self.cli_set(pool + ['option', 'default-router', router])
         self.cli_set(pool + ['exclude', exclude_addr])
+        self.cli_set(pool + ['range', '0', 'option', 'default-router', router])
         self.cli_set(pool + ['range', '0', 'start', range_0_start])
         self.cli_set(pool + ['range', '0', 'stop', range_0_stop])
 
@@ -612,6 +619,16 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.verify_config_value(obj, ['Dhcp4', 'shared-networks'], 'name', 'EXCLUDE-TEST-2')
         self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'subnet', subnet)
 
+        pool_obj = {
+            'pool': f'{range_0_start} - {range_0_stop_excl}',
+            'option-data': [{'name': 'routers', 'data': router}]
+        }
+
+        pool_exclude_obj = {
+            'pool': f'{range_0_start_excl} - {range_0_stop}',
+            'option-data': [{'name': 'routers', 'data': router}]
+        }
+
         # Verify options
         self.verify_config_object(
                 obj,
@@ -621,12 +638,12 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.verify_config_object(
                 obj,
                 ['Dhcp4', 'shared-networks', 0, 'subnet4', 0, 'pools'],
-                {'pool': f'{range_0_start} - {range_0_stop_excl}'})
+                pool_obj)
 
         self.verify_config_object(
                 obj,
                 ['Dhcp4', 'shared-networks', 0, 'subnet4', 0, 'pools'],
-                {'pool': f'{range_0_start_excl} - {range_0_stop}'})
+                pool_exclude_obj)
 
         # Check for running process
         self.assertTrue(process_named_running(PROCESS_NAME))

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -87,6 +87,10 @@ def dhcp_slice_range(exclude_list, range_dict):
                 'start' : range_start,
                 'stop' : str(ip_address(e) -1)
             }
+
+            if 'option' in range_dict:
+                r['option'] = range_dict['option']
+
             # On the next run our address range will start one address after
             # the exclude address
             range_start = str(ip_address(e) + 1)
@@ -104,6 +108,10 @@ def dhcp_slice_range(exclude_list, range_dict):
                   'start': str(ip_address(e) + 1),
                   'stop': str(range_stop)
                 }
+
+                if 'option' in range_dict:
+                    r['option'] = range_dict['option']
+
                 if not (ip_address(r['start']) > ip_address(r['stop'])):
                     output.append(r)
         else:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
* Fix range options not present when `exclude` is used
* Update smoketest to verify range options are present with `exclude`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dhcp-server

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py
DEBUG - test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
DEBUG - test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
DEBUG - test_dhcp_high_availability (__main__.TestServiceDHCPServer.test_dhcp_high_availability) ... ok
DEBUG - test_dhcp_high_availability_standby (__main__.TestServiceDHCPServer.test_dhcp_high_availability_standby) ... ok
DEBUG - test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
DEBUG - test_dhcp_on_interface_with_vrf (__main__.TestServiceDHCPServer.test_dhcp_on_interface_with_vrf) ... ok
DEBUG - test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
DEBUG - test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... ok
DEBUG - test_dhcp_single_pool_options_scoped (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options_scoped) ... ok
DEBUG - test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... ok
DEBUG - test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... ok
DEBUG - 
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 11 tests in 56.558s
DEBUG - 
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
