### PR TITLE
pki: T6809: Support system install of CA certificates

### DIFF
--- a/interface-definitions/pki.xml.in
+++ b/interface-definitions/pki.xml.in
@@ -35,6 +35,12 @@
               <multi/>
             </properties>
           </leafNode>
+          <leafNode name="system-install">
+            <properties>
+              <help>Install into CA certificate store on router</help>
+              <valueless/>
+            </properties>
+          </leafNode>
           #include <include/pki/cli-revoke.xml.i>
         </children>
       </tagNode>

--- a/python/vyos/defaults.py
+++ b/python/vyos/defaults.py
@@ -36,7 +36,8 @@ directories = {
   'isc_dhclient_dir' : '/run/dhclient',
   'dhcp6_client_dir' : '/run/dhcp6c',
   'vyos_configdir' : '/opt/vyatta/config',
-  'completion_dir' : f'{base_dir}/completion'
+  'completion_dir' : f'{base_dir}/completion',
+  'ca_certificates' : '/usr/local/share/ca-certificates/vyos'
 }
 
 config_status = '/tmp/vyos-config-status'

--- a/src/conf_mode/pki.py
+++ b/src/conf_mode/pki.py
@@ -149,35 +149,15 @@ def get_config(config=None):
     if len(argv) > 1 and argv[1] == 'certbot_renew':
         pki['certbot_renew'] = {}
 
-    tmp = node_changed(conf, base + ['ca'], recursive=True, expand_nodes=Diff.DELETE | Diff.ADD)
-    if tmp:
-        if 'changed' not in pki: pki.update({'changed':{}})
-        pki['changed'].update({'ca' : tmp})
+    changed_keys = ['ca', 'certificate', 'dh', 'key-pair', 'openssh', 'openvpn']
 
-    tmp = node_changed(conf, base + ['certificate'], recursive=True, expand_nodes=Diff.DELETE | Diff.ADD)
-    if tmp:
-        if 'changed' not in pki: pki.update({'changed':{}})
-        pki['changed'].update({'certificate' : tmp})
+    for key in changed_keys:
+        tmp = node_changed(conf, base + [key], recursive=True, expand_nodes=Diff.DELETE | Diff.ADD)
 
-    tmp = node_changed(conf, base + ['dh'], recursive=True, expand_nodes=Diff.DELETE | Diff.ADD)
-    if tmp:
-        if 'changed' not in pki: pki.update({'changed':{}})
-        pki['changed'].update({'dh' : tmp})
+        if 'changed' not in pki:
+            pki.update({'changed':{}})
 
-    tmp = node_changed(conf, base + ['key-pair'], recursive=True, expand_nodes=Diff.DELETE | Diff.ADD)
-    if tmp:
-        if 'changed' not in pki: pki.update({'changed':{}})
-        pki['changed'].update({'key_pair' : tmp})
-
-    tmp = node_changed(conf, base + ['openssh'], recursive=True, expand_nodes=Diff.DELETE | Diff.ADD)
-    if tmp:
-        if 'changed' not in pki: pki.update({'changed':{}})
-        pki['changed'].update({'openssh' : tmp})
-
-    tmp = node_changed(conf, base + ['openvpn', 'shared-secret'], recursive=True, expand_nodes=Diff.DELETE | Diff.ADD)
-    if tmp:
-        if 'changed' not in pki: pki.update({'changed':{}})
-        pki['changed'].update({'openvpn' : tmp})
+        pki['changed'].update({key.replace('-', '_') : tmp})
 
     # We only merge on the defaults of there is a configuration at all
     if conf.exists(base):

--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -471,6 +471,12 @@ start ()
         touch /tmp/vyos.smoketest.debug
     fi
 
+    # Cleanup PKI CAs
+    if [ -d /usr/local/share/ca-certificates/vyos ]; then
+        rm -f /usr/local/share/ca-certificates/vyos/*.crt
+        update-ca-certificates >/dev/null 2>&1
+    fi
+
     log_action_begin_msg "Mounting VyOS Config"
     # ensure the vyatta_configdir supports a large number of inodes since
     # the config hierarchy is often inode-bound (instead of size).


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Adds `system-install` node to CAs which will install it into the router's CA bundle

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pki

## Proposed changes
<!--- Describe your changes in detail -->
* Add CLI node `system-install` for PKI CA certificates
* Cleans up any stale certificates on boot and commit
* Installs selected CAs to /usr/local/share/ca-certificates/vyos and triggers `update-ca-certificates`
* Includes code clean-up for the `node_changed` portion of PKI conf script

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Installing:
```
vyos@vyos# set pki ca test system-install
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# openssl crl2pkcs7 -nocrl -certfile /etc/ssl/certs/ca-certificates.crt | openssl pkcs7 -print_certs -noout | grep 'vyos'
subject=C = GB, ST = Some-State, L = Some-City, O = VyOS, CN = vyos.io
issuer=C = GB, ST = Some-State, L = Some-City, O = VyOS, CN = vyos.io
[edit]
vyos@vyos#
```

Cleanup:
```
vyos@vyos# del pki
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# openssl crl2pkcs7 -nocrl -certfile /etc/ssl/certs/ca-certificates.crt | openssl pkcs7 -print_certs -noout | grep 'vyos'
[edit]
vyos@vyos#
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
