### PR TITLE
T6906: IPoE-server add start-session option

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.j2
+++ b/data/templates/accel-ppp/ipoe.config.j2
@@ -59,7 +59,9 @@ lua-file={{ lua_file }}
 {%         set relay = ',' ~ 'relay=' ~ iface_config.external_dhcp.dhcp_relay  if iface_config.external_dhcp.dhcp_relay is vyos_defined else '' %}
 {%         set giaddr = ',' ~ 'giaddr=' ~ iface_config.external_dhcp.giaddr if iface_config.external_dhcp.giaddr is vyos_defined else '' %}
 {%         set username = ',' ~ 'username=lua:' ~ iface_config.lua_username if iface_config.lua_username is vyos_defined else '' %}
-{{ tmp }},{{ shared }}mode={{ iface_config.mode | upper }},ifcfg=1,{{ range }}start=dhcpv4,ipv6=1{{ relay }}{{ giaddr }}{{ username }}
+{%         set start_map = {'dhcp': 'dhcpv4', 'unclassified-packet': 'up', 'auto': 'auto'} %}
+{%         set start = start_map[iface_config.start_session] %}
+{{ tmp }},{{ shared }}mode={{ iface_config.mode | upper }},ifcfg=1,{{ range }}start={{ start }},ipv6=1{{ relay }}{{ giaddr }}{{ username }}
 {%         if iface_config.vlan_mon is vyos_defined %}
 vlan-mon={{ iface }},{{ iface_config.vlan | join(',') }}
 {%         endif %}

--- a/interface-definitions/service_ipoe-server.xml.in
+++ b/interface-definitions/service_ipoe-server.xml.in
@@ -131,6 +131,30 @@
                 </properties>
                 <defaultValue>shared</defaultValue>
               </leafNode>
+              <leafNode name="start-session">
+                <properties>
+                  <help>Start session options</help>
+                  <completionHelp>
+                    <list>auto dhcp unclassified-packet</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>auto</format>
+                    <description>Start session with username as the interface name</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>dhcp</format>
+                    <description>Start session on DHCPv4 Discover</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>unclassified-packet</format>
+                    <description>Start session on unclassified-packet</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(auto|dhcp|unclassified-packet)</regex>
+                  </constraint>
+                </properties>
+                <defaultValue>dhcp</defaultValue>
+              </leafNode>
               <leafNode name="client-subnet">
                 <properties>
                   <help>Client address pool</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add the abbility to start IPoE session by unclassified-packet. It allows the cases when subscriber configures the address manually (static) and accel-ppp can start session on any packet. By default start session on DHCPv4 Discover packet.

```
set service ipoe-server interface eth1 start-session < auto | dhcp | unclassified-packet>
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6906

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Configure start-session on `unclassified-packet`
```
set service ipoe-server authentication mode 'radius'
set service ipoe-server authentication radius server 127.0.0.1 key 'vyos-secret'
set service ipoe-server client-ip-pool POOL range '100.64.0.0/22'
set service ipoe-server gateway-address '100.64.0.1/22'
set service ipoe-server interface eth1 mode 'l2'
set service ipoe-server interface eth1 network 'shared'
set service ipoe-server interface eth1 start-session 'unclassified-packet'
set service ipoe-server name-server '1.1.1.1'
set service ipoe-server name-server '8.8.8.8'
```
Check config, expecting `start=up`:
```
vyos@r14# cat /run/accel-pppd/ipoe.conf | grep interface
interface=eth1,shared=1,mode=L2,ifcfg=1,start=up,ipv6=1
[edit]
vyos@r14# 

```
Configuration on the client site:
```
set interfaces ethernet eth1 address '100.64.0.10/22'
```
Check sessions:
```
vyos@r14:~$ show ipoe-server sessions 
ifname |  username   |    calling-sid    |     ip      | ip6 | ip6-dp | rate-limit | type | comp | state  |  uptime  
--------+-------------+-------------------+-------------+-----+--------+------------+------+------+--------+----------
 ipoe0  | 100.64.0.10 | 52:54:00:09:0b:01 | 100.64.0.10 |     |        |            | ipoe |      | active | 00:16:15
vyos@r14:~$ 

```

## Smoketest result


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
