### PR TITLE
avahi: T6908: add option to define max-cache entries

### DIFF
--- a/data/templates/mdns-repeater/avahi-daemon.conf.j2
+++ b/data/templates/mdns-repeater/avahi-daemon.conf.j2
@@ -6,6 +6,9 @@ allow-interfaces={{ interface | join(', ') }}
 {% if browse_domain is vyos_defined and browse_domain | length %}
 browse-domains={{ browse_domain | join(', ') }}
 {% endif %}
+{% if cache_entries is vyos_defined %}
+cache-entries-max={{ cache_entries }}
+{% endif %}
 disallow-other-stacks=no
 
 [wide-area]

--- a/interface-definitions/service_mdns_repeater.xml.in
+++ b/interface-definitions/service_mdns_repeater.xml.in
@@ -67,6 +67,23 @@
                   <multi/>
                 </properties>
               </leafNode>
+              <leafNode name="cache-entries">
+                <properties>
+                  <help>Number of resource records cached per interface</help>
+                  <valueHelp>
+                    <format>u32:0</format>
+                    <description>Disable caching</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>u32:1-65535</format>
+                    <description>Resource records to cache per interface</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-65535"/>
+                  </constraint>
+                </properties>
+                <defaultValue>4096</defaultValue>
+              </leafNode>
               <leafNode name="vrrp-disable">
                 <properties>
                   <help>Disables mDNS repeater on VRRP interfaces not in MASTER state</help>

--- a/smoketest/scripts/cli/test_service_mdns_repeater.py
+++ b/smoketest/scripts/cli/test_service_mdns_repeater.py
@@ -26,31 +26,39 @@ base_path = ['service', 'mdns', 'repeater']
 intf_base = ['interfaces', 'dummy']
 config_file = '/run/avahi-daemon/avahi-daemon.conf'
 
-
 class TestServiceMDNSrepeater(VyOSUnitTestSHIM.TestCase):
-    def setUp(self):
-        # Start with a clean CLI instance
-        self.cli_delete(base_path)
+    @classmethod
+    def setUpClass(cls):
+        super(TestServiceMDNSrepeater, cls).setUpClass()
 
-        # Service required a configured IP address on the interface
-        self.cli_set(intf_base + ['dum10', 'address', '192.0.2.1/30'])
-        self.cli_set(intf_base + ['dum10', 'ipv6', 'address', 'no-default-link-local'])
-        self.cli_set(intf_base + ['dum20', 'address', '192.0.2.5/30'])
-        self.cli_set(intf_base + ['dum20', 'address', '2001:db8:0:2::5/64'])
-        self.cli_set(intf_base + ['dum30', 'address', '192.0.2.9/30'])
-        self.cli_set(intf_base + ['dum30', 'address', '2001:db8:0:2::9/64'])
-        self.cli_set(intf_base + ['dum40', 'address', '2001:db8:0:2::11/64'])
-        self.cli_commit()
+        # ensure we can also run this test on a live system - so lets clean
+        # out the current configuration :)
+        cls.cli_delete(cls, base_path)
+
+        cls.cli_set(cls, intf_base + ['dum10', 'address', '192.0.2.1/30'])
+        cls.cli_set(cls, intf_base + ['dum10', 'ipv6', 'address', 'no-default-link-local'])
+        cls.cli_set(cls, intf_base + ['dum20', 'address', '192.0.2.5/30'])
+        cls.cli_set(cls, intf_base + ['dum20', 'address', '2001:db8:0:2::5/64'])
+        cls.cli_set(cls, intf_base + ['dum30', 'address', '192.0.2.9/30'])
+        cls.cli_set(cls, intf_base + ['dum30', 'address', '2001:db8:0:2::9/64'])
+        cls.cli_set(cls, intf_base + ['dum40', 'address', '2001:db8:0:2::11/64'])
+
+        cls.cli_commit(cls)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.cli_delete(cls, intf_base + ['dum10'])
+        cls.cli_delete(cls, intf_base + ['dum20'])
+        cls.cli_delete(cls, intf_base + ['dum30'])
+        cls.cli_delete(cls, intf_base + ['dum40'])
+
+        cls.cli_commit(cls)
 
     def tearDown(self):
         # Check for running process
         self.assertTrue(process_named_running('avahi-daemon'))
 
         self.cli_delete(base_path)
-        self.cli_delete(intf_base + ['dum10'])
-        self.cli_delete(intf_base + ['dum20'])
-        self.cli_delete(intf_base + ['dum30'])
-        self.cli_delete(intf_base + ['dum40'])
         self.cli_commit()
 
         # Check that there is no longer a running process

--- a/smoketest/scripts/cli/test_service_mdns_repeater.py
+++ b/smoketest/scripts/cli/test_service_mdns_repeater.py
@@ -21,6 +21,7 @@ from base_vyostest_shim import VyOSUnitTestSHIM
 from configparser import ConfigParser
 from vyos.configsession import ConfigSessionError
 from vyos.utils.process import process_named_running
+from vyos.xml_ref import default_value
 
 base_path = ['service', 'mdns', 'repeater']
 intf_base = ['interfaces', 'dummy']
@@ -137,6 +138,39 @@ class TestServiceMDNSrepeater(VyOSUnitTestSHIM.TestCase):
         self.assertEqual(conf['server']['use-ipv6'], 'yes')
         self.assertEqual(conf['server']['allow-interfaces'], 'dum30, dum40')
         self.assertEqual(conf['reflector']['enable-reflector'], 'yes')
+
+    def test_service_max_cache_entries(self):
+        cli_default_max_cache = default_value(base_path + ['cache-entries'])
+        self.cli_set(base_path)
+
+        # Need at least two interfaces
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(base_path + ['interface', 'dum20'])
+
+        # Need at least two interfaces
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(base_path + ['interface', 'dum30'])
+
+        self.cli_commit()
+
+        # Validate configuration values
+        conf = ConfigParser(delimiters='=')
+        conf.read(config_file)
+        self.assertEqual(conf['server']['cache-entries-max'], cli_default_max_cache)
+
+        # Set max cache entries
+        cache_entries = '1234'
+        self.cli_set(base_path + ['cache-entries', cache_entries])
+
+        self.cli_commit()
+
+        # Validate configuration values
+        conf = ConfigParser(delimiters='=')
+        conf.read(config_file)
+
+        self.assertEqual(conf['server']['cache-entries-max'], cache_entries)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add CLI option to configure `cache-entries-max` entries in Avahi daemon configuration.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6908

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-documentation/pull/1571

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
mDNS repeater

## Proposed changes
<!--- Describe your changes in detail -->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_mdns_repeater.py
test_service_dual_stack (__main__.TestServiceMDNSrepeater.test_service_dual_stack) ... ok
test_service_ipv4 (__main__.TestServiceMDNSrepeater.test_service_ipv4) ... ok
test_service_ipv6 (__main__.TestServiceMDNSrepeater.test_service_ipv6) ... ok
test_service_max_cache_entries (__main__.TestServiceMDNSrepeater.test_service_max_cache_entries) ... ok

----------------------------------------------------------------------
Ran 4 tests in 26.471s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
