### PR TITLE
T6630: ntp: fix timestamp nested under ptp

### DIFF
--- a/data/templates/chrony/chrony.conf.j2
+++ b/data/templates/chrony/chrony.conf.j2
@@ -67,9 +67,9 @@ binddevice {{ interface }}
 {%     endif %}
 {% endif %}
 
-{% if ptp.timestamp.interface is vyos_defined %}
+{% if timestamp.interface is vyos_defined %}
 # Enable hardware timestamping on the specified interfaces
-{%     for iface, iface_config in ptp.timestamp.interface.items() %}
+{%     for iface, iface_config in timestamp.interface.items() %}
 {%         if iface == "all" %}
 {%             set iface = "*" %}
 {%         endif %}

--- a/interface-definitions/service_ntp.xml.in
+++ b/interface-definitions/service_ntp.xml.in
@@ -13,6 +13,63 @@
           #include <include/generic-interface.xml.i>
           #include <include/listen-address.xml.i>
           #include <include/interface/vrf.xml.i>
+          <node name="timestamp">
+            <properties>
+              <help>Enable timestamping of packets in the NIC hardware</help>
+            </properties>
+            <children>
+              <tagNode name="interface">
+                <properties>
+                  <help>Interface to enable timestamping on</help>
+                  <completionHelp>
+                    <script>${vyos_completion_dir}/list_interfaces</script>
+                    <list>all</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>all</format>
+                    <description>Select all interfaces</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>Interface name</description>
+                  </valueHelp>
+                  <constraint>
+                    #include <include/constraint/interface-name.xml.i>
+                    <regex>all</regex>
+                  </constraint>
+                </properties>
+                <children>
+                  <leafNode name="receive-filter">
+                    <properties>
+                      <help>Selects which inbound packets are timestamped by the NIC</help>
+                      <completionHelp>
+                        <list>all ntp ptp none</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>all</format>
+                        <description>All packets are timestamped</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>ntp</format>
+                        <description>Only NTP packets are timestamped</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>ptp</format>
+                        <description>Only PTP or NTP packets using the PTP transport are timestamped</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>none</format>
+                        <description>No packet is timestamped</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>(all|ntp|ptp|none)</regex>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                </children>
+              </tagNode>
+            </children>
+          </node>
           <node name="ptp">
             <properties>
               <help>Enable Precision Time Protocol (PTP) transport</help>
@@ -22,63 +79,6 @@
               <leafNode name="port">
                 <defaultValue>319</defaultValue>
               </leafNode>
-              <node name="timestamp">
-                <properties>
-                  <help>Enable timestamping of packets in the NIC hardware</help>
-                </properties>
-                <children>
-                  <tagNode name="interface">
-                    <properties>
-                      <help>Interface to enable timestamping on</help>
-                      <completionHelp>
-                        <script>${vyos_completion_dir}/list_interfaces</script>
-                        <list>all</list>
-                      </completionHelp>
-                      <valueHelp>
-                        <format>all</format>
-                        <description>Select all interfaces</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>txt</format>
-                        <description>Interface name</description>
-                      </valueHelp>
-                      <constraint>
-                        #include <include/constraint/interface-name.xml.i>
-                        <regex>all</regex>
-                      </constraint>
-                    </properties>
-                    <children>
-                      <leafNode name="receive-filter">
-                        <properties>
-                          <help>Selects which inbound packets are timestamped by the NIC</help>
-                          <completionHelp>
-                            <list>all ntp ptp none</list>
-                          </completionHelp>
-                          <valueHelp>
-                            <format>all</format>
-                            <description>All packets are timestamped</description>
-                          </valueHelp>
-                          <valueHelp>
-                            <format>ntp</format>
-                            <description>Only NTP packets are timestamped</description>
-                          </valueHelp>
-                          <valueHelp>
-                            <format>ptp</format>
-                            <description>Only PTP or NTP packets using the PTP transport are timestamped</description>
-                          </valueHelp>
-                          <valueHelp>
-                            <format>none</format>
-                            <description>No packet is timestamped</description>
-                          </valueHelp>
-                          <constraint>
-                            <regex>(all|ntp|ptp|none)</regex>
-                          </constraint>
-                        </properties>
-                      </leafNode>
-                    </children>
-                  </tagNode>
-                </children>
-              </node>
             </children>
           </node>
           <leafNode name="leap-second">

--- a/smoketest/scripts/cli/test_service_ntp.py
+++ b/smoketest/scripts/cli/test_service_ntp.py
@@ -203,7 +203,7 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
             self.cli_set(base_path + ['server', server, 'ptp'])
 
         self.cli_set(base_path + ['ptp', 'port', ptp_port])
-        self.cli_set(base_path + ['ptp', 'timestamp', 'interface', 'all'])
+        self.cli_set(base_path + ['timestamp', 'interface', 'all'])
 
         # commit changes
         self.cli_commit()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This PR updates the `ntp` feature so that `timestamp` is not placed under `ptp`. These are independent features.

This was the intended original behavior of https://github.com/vyos/vyos-1x/pull/3966 but it was modified during review alongside some other config syntax style changes. The merged docs PR described the expected final syntax: https://github.com/vyos/vyos-documentation/pull/1553. This updates the code to match the docs.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6630

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
`service ntp`

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
