### PR TITLE
static: T4214: Allow several dhcp-interfaces to the same static rote

### DIFF
--- a/data/templates/frr/static_routes_macro.j2
+++ b/data/templates/frr/static_routes_macro.j2
@@ -6,10 +6,12 @@
 {{ ip_ipv6 }} route {{ prefix }} reject {{ prefix_config.reject.distance if prefix_config.reject.distance is vyos_defined }} {{ 'tag ' ~ prefix_config.reject.tag if prefix_config.reject.tag is vyos_defined }} {{ 'table ' ~ table if table is vyos_defined }}
 {% endif %}
 {% if prefix_config.dhcp_interface is vyos_defined %}
-{%     set next_hop = prefix_config.dhcp_interface | get_dhcp_router %}
-{%     if next_hop is vyos_defined %}
-{{ ip_ipv6 }} route {{ prefix }} {{ next_hop }} {{ prefix_config.dhcp_interface }} {{ 'table ' ~ table if table is vyos_defined }}
-{%     endif %}
+{%     for dhcp_interface in prefix_config.dhcp_interface %}
+{%         set next_hop = dhcp_interface | get_dhcp_router %}
+{%         if next_hop is vyos_defined %}
+{{ ip_ipv6 }} route {{ prefix }} {{ next_hop }} {{ dhcp_interface }} {{ 'table ' ~ table if table is vyos_defined }}
+{%         endif %}
+{%     endfor %}
 {% endif %}
 {% if prefix_config.interface is vyos_defined %}
 {%     for interface, interface_config in prefix_config.interface.items() if interface_config.disable is not defined %}

--- a/interface-definitions/include/static/static-route.xml.i
+++ b/interface-definitions/include/static/static-route.xml.i
@@ -13,7 +13,7 @@
   <children>
     #include <include/static/static-route-blackhole.xml.i>
     #include <include/static/static-route-reject.xml.i>
-    #include <include/dhcp-interface.xml.i>
+    #include <include/dhcp-interface-multi.xml.i>
     #include <include/generic-description.xml.i>
     <tagNode name="interface">
       <properties>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T4214
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
protocols static 
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set protocols static route 8.8.8.8/32 dhcp-interface eth0
set protocols static route 8.8.8.8/32 dhcp-interface eth1
commit

vyos@vyos# run show ip route static
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

S>* 0.0.0.0/0 [210/0] via 192.168.0.1, eth1, weight 1, 00:03:01
  *                   via 192.168.122.1, eth0, weight 1, 00:03:01
S>* 8.8.8.8/32 [1/0] via 192.168.0.1, eth1, weight 1, 00:01:05
  *                  via 192.168.122.1, eth0, weight 1, 00:01:05
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# python3 /usr/libexec/vyos/tests/smoke/cli/test_protocols_st
test_protocols_static_arp.py        test_protocols_static_multicast.py  test_protocols_static.py
[edit]
vyos@vyos# python3 /usr/libexec/vyos/tests/smoke/cli/test_protocols_static.py
test_01_static (__main__.TestProtocolsStatic.test_01_static) ... ok
test_02_static_table (__main__.TestProtocolsStatic.test_02_static_table) ... ok
test_03_static_vrf (__main__.TestProtocolsStatic.test_03_static_vrf) ... ok

----------------------------------------------------------------------
Ran 3 tests in 79.869s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
