### PR TITLE
ipoe_server: T6628: Add option to assign static IP address to end users with local auth

### DIFF
--- a/data/templates/accel-ppp/chap-secrets.ipoe.j2
+++ b/data/templates/accel-ppp/chap-secrets.ipoe.j2
@@ -6,7 +6,7 @@
 {%                 if mac_config.vlan is vyos_defined %}
 {%                     set iface = iface ~ '.' ~ mac_config.vlan %}
 {%                 endif %}
-{{ "%-11s" | format(iface) }} * {{ mac | lower }} * {{ mac_config.rate_limit.download ~ '/' ~ mac_config.rate_limit.upload if mac_config.rate_limit.download is vyos_defined and mac_config.rate_limit.upload is vyos_defined }}
+{{ "%-11s" | format(iface) }} * {{ mac | lower }} {{ mac_config.static_ip if mac_config.static_ip is vyos_defined else '*' }} {{ mac_config.rate_limit.download ~ '/' ~ mac_config.rate_limit.upload if mac_config.rate_limit.download is vyos_defined and mac_config.rate_limit.upload is vyos_defined }}
 {%             endfor %}
 {%         endif %}
 {%     endfor %}

--- a/interface-definitions/service_ipoe-server.xml.in
+++ b/interface-definitions/service_ipoe-server.xml.in
@@ -70,6 +70,18 @@
                           <constraintErrorMessage>VLAN IDs need to be in range 1-4094</constraintErrorMessage>
                         </properties>
                       </leafNode>
+                      <leafNode name="static-ip">
+                        <properties>
+                          <help>Static client IP address</help>
+                          <valueHelp>
+                            <format>ipv4</format>
+                            <description>IPv4 address</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="ipv4-address"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
                     </children>
                   </tagNode>
                 </children>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6628
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
set service ipoe-server client-ip-pool POOL range '192.168.0.2-192.168.0.100'
set service ipoe-server default-pool 'POOL'
set service ipoe-server gateway-address '192.168.0.1/24'
set service ipoe-server interface eth1 mode 'l2'
set service ipoe-server interface eth1 network 'shared'
set service ipoe-server name-server '1.1.1.1'
set service ipoe-server name-server '198.168.0.1'
set service ipoe-server authentication mode 'local'

set service ipoe-server authentication interface eth1 mac 0c:dd:ab:38:00:01 static-ip '192.168.0.87'
commit

vyos@vyos# run show ipoe-server sessions
ifname | username |    calling-sid    |      ip      | ip6 | ip6-dp | rate-limit | type | comp | state  |  uptime
--------+----------+-------------------+--------------+-----+--------+------------+------+------+--------+----------
 ipoe0  | eth1     | 0c:dd:ab:38:00:01 | 192.168.0.87 |     |        |            | ipoe |      | active | 00:03:32

vyos@vyos# sudo cat /run/accel-pppd/ipoe.chap-secrets
# username  server  password  acceptable local IP addresses   shaper
eth1        * 0c:dd:ab:38:00:01 192.168.0.87
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# python3 /usr/libexec/vyos/tests/smoke/cli/test_service_ipoe-server.py
test_accel_ipv4_pool (__main__.TestServiceIPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServiceIPoEServer.test_accel_ipv6_pool) ... ok
test_accel_limits (__main__.TestServiceIPoEServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestServiceIPoEServer.test_accel_local_authentication) ... ok
test_accel_log_level (__main__.TestServiceIPoEServer.test_accel_log_level) ... ok
test_accel_name_servers (__main__.TestServiceIPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServiceIPoEServer.test_accel_next_pool) ... ok
test_accel_ppp_options (__main__.TestServiceIPoEServer.test_accel_ppp_options) ... skipped 'PPP is not a part of IPoE'
test_accel_radius_authentication (__main__.TestServiceIPoEServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestServiceIPoEServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestServiceIPoEServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestServiceIPoEServer.test_accel_wins_server) ... skipped 'WINS server is not used in IPoE'
test_ipoe_server_static_client_ip (__main__.TestServiceIPoEServer.test_ipoe_server_static_client_ip) ... ok
test_ipoe_server_vlan (__main__.TestServiceIPoEServer.test_ipoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 14 tests in 120.553s

OK (skipped=2)
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
