### PR TITLE
dhcpv6-server: T5992: Fix op-mode Kea DHCP lease output

### DIFF
--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -110,23 +110,19 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[], orig
         data_lease['pool'] = kea_get_pool_from_subnet_id(active_config, inet_suffix, lease['subnet-id']) if active_config else '-'
         data_lease['end'] = lease['expire_timestamp'].timestamp() if lease['expire_timestamp'] else None
         data_lease['origin'] = 'local' # TODO: Determine remote in HA
+        data_lease['hostname'] = lease.get('hostname', '-')
+        # remove trailing dot to ensure consistency for `vyos-hostsd-client`
+        if data_lease['hostname'][-1] == '.':
+            data_lease['hostname'] = data_lease['hostname'][:-1]
 
         if family == 'inet':
             data_lease['mac'] = lease['hw-address']
             data_lease['start'] = lease['start_timestamp'].timestamp()
-            data_lease['hostname'] = lease.get('hostname', "-")
-            # remove trailing dot to ensure consistency for `vyos-hostsd-client`
-            if data_lease['hostname'][-1] == '.':
-                data_lease['hostname'] = data_lease['hostname'][:-1]
 
         if family == 'inet6':
             data_lease['last_communication'] = lease['start_timestamp'].timestamp()
             data_lease['duid'] = _format_hex_string(lease['duid'])
             data_lease['type'] = lease['type']
-            data_lease['hostname'] = lease.get('hostname', "-")
-            # remove trailing dot to ensure consistency for `vyos-hostsd-client`
-            if data_lease['hostname'][-1] == '.':
-                data_lease['hostname'] = data_lease['hostname'][:-1]
 
             if lease['type'] == 'IA_PD':
                 prefix_len = lease['prefix-len']

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -83,7 +83,7 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[], orig
     inet_suffix = '6' if family == 'inet6' else '4'
     try:
         leases = kea_get_leases(inet_suffix)
-    except:
+    except Exception as e:
         raise vyos.opmode.DataUnavailable('Cannot fetch DHCP server lease information')
 
     if pool is None:
@@ -93,7 +93,7 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[], orig
 
     try:
         active_config = kea_get_active_config(inet_suffix)
-    except:
+    except Exception as e:
         raise vyos.opmode.DataUnavailable('Cannot fetch DHCP server configuration')
 
     data = []
@@ -464,7 +464,8 @@ def _get_raw_client_leases(family='inet', interface=None):
 
         if 'interface' in tmp:
             vrf = get_interface_vrf(tmp['interface'])
-            if vrf: tmp.update({'vrf' : vrf})
+            if vrf:
+                tmp.update({'vrf' : vrf})
 
         lease_data.append(tmp)
 

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -114,13 +114,19 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[], orig
         if family == 'inet':
             data_lease['mac'] = lease['hw-address']
             data_lease['start'] = lease['start_timestamp'].timestamp()
-            data_lease['hostname'] = lease.get('hostname', "-").rstrip('.') # remove trailing dot to ensure consistency for `vyos-hostsd-client`
+            data_lease['hostname'] = lease.get('hostname', "-")
+            # remove trailing dot to ensure consistency for `vyos-hostsd-client`
+            if data_lease['hostname'][-1] == '.':
+                data_lease['hostname'] = data_lease['hostname'][:-1]
 
         if family == 'inet6':
             data_lease['last_communication'] = lease['start_timestamp'].timestamp()
             data_lease['duid'] = _format_hex_string(lease['duid'])
             data_lease['type'] = lease['type']
-            data_lease['hostname'] = lease.get('hostname', "-").rstrip('.') # remove trailing dot to ensure consistency for `vyos-hostsd-client`
+            data_lease['hostname'] = lease.get('hostname', "-")
+            # remove trailing dot to ensure consistency for `vyos-hostsd-client`
+            if data_lease['hostname'][-1] == '.':
+                data_lease['hostname'] = data_lease['hostname'][:-1]
 
             if lease['type'] == 'IA_PD':
                 prefix_len = lease['prefix-len']

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -279,22 +279,36 @@ def _get_raw_server_static_mappings(family='inet', pool=None, sorted=None):
 
     if sorted:
         if sorted == 'ip':
-            data.sort(key = lambda x:ip_address(x['ip-address']))
+            if family == 'inet6':
+                data.sort(key = lambda x:ip_address(x['ipv6-address']))
+            else:
+                data.sort(key = lambda x:ip_address(x['ip-address']))
         else:
             data.sort(key = lambda x:x[sorted])
     return mappings
 
 def _get_formatted_server_static_mappings(raw_data, family='inet'):
     data_entries = []
-    for entry in raw_data:
-        pool = entry.get('pool')
-        subnet = entry.get('subnet')
-        name = entry.get('name')
-        ip_addr = entry.get('ip-address', 'N/A')
-        mac_addr = entry.get('mac', 'N/A')
-        duid = entry.get('duid', 'N/A')
-        description = entry.get('description', 'N/A')
-        data_entries.append([pool, subnet, name, ip_addr, mac_addr, duid, description])
+    if family == 'inet':
+        for entry in raw_data:
+            pool = entry.get('pool')
+            subnet = entry.get('subnet')
+            name = entry.get('name')
+            ip_addr = entry.get('ip-address', 'N/A')
+            mac_addr = entry.get('mac', 'N/A')
+            duid = entry.get('duid', 'N/A')
+            description = entry.get('description', 'N/A')
+            data_entries.append([pool, subnet, name, ip_addr, mac_addr, duid, description])
+    elif family == 'inet6':
+        for entry in raw_data:
+            pool = entry.get('pool')
+            subnet = entry.get('subnet')
+            name = entry.get('name')
+            ip_addr = entry.get('ipv6-address', 'N/A')
+            mac_addr = entry.get('mac', 'N/A')
+            duid = entry.get('duid', 'N/A')
+            description = entry.get('description', 'N/A')
+            data_entries.append([pool, subnet, name, ip_addr, mac_addr, duid, description])
 
     headers = ['Pool', 'Subnet', 'Name', 'IP Address', 'MAC Address', 'DUID', 'Description']
     output = tabulate(data_entries, headers, numalign='left')

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -114,12 +114,13 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[], orig
         if family == 'inet':
             data_lease['mac'] = lease['hw-address']
             data_lease['start'] = lease['start_timestamp'].timestamp()
-            data_lease['hostname'] = lease['hostname']
+            data_lease['hostname'] = lease.get('hostname', "-").rstrip('.') # remove trailing dot to ensure consistency for `vyos-hostsd-client`
 
         if family == 'inet6':
             data_lease['last_communication'] = lease['start_timestamp'].timestamp()
             data_lease['duid'] = _format_hex_string(lease['duid'])
             data_lease['type'] = lease['type']
+            data_lease['hostname'] = lease.get('hostname', "-").rstrip('.') # remove trailing dot to ensure consistency for `vyos-hostsd-client`
 
             if lease['type'] == 'IA_PD':
                 prefix_len = lease['prefix-len']

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -19,6 +19,7 @@ import sys
 import typing
 
 from datetime import datetime
+from datetime import timezone
 from glob import glob
 from ipaddress import ip_address
 from tabulate import tabulate
@@ -62,7 +63,7 @@ def _format_hex_string(in_str):
     return out_str
 
 
-def _find_list_of_dict_index(lst, key='ip', value='') -> int:
+def _find_list_of_dict_index(lst, key='ip', value=''):
     """
     Find the index entry of list of dict matching the dict value
     Exampe:
@@ -131,12 +132,12 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[], orig
         data_lease['remaining'] = '-'
 
         if lease['valid-lft'] > 0:
-            data_lease['remaining'] = lease['expire_timestamp'] - datetime.utcnow()
+            data_lease['remaining'] = lease['expire_timestamp'] - datetime.now(timezone.utc)
 
             if data_lease['remaining'].days >= 0:
                 # substraction gives us a timedelta object which can't be formatted with strftime
                 # so we use str(), split gets rid of the microseconds
-                data_lease['remaining'] = str(data_lease["remaining"]).split('.')[0]
+                data_lease['remaining'] = str(data_lease['remaining']).split('.')[0]
 
         # Do not add old leases
         if data_lease['remaining'] != '' and data_lease['pool'] in pool and data_lease['state'] != 'free':
@@ -151,7 +152,8 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[], orig
                 checked.append(addr)
             else:
                 idx = _find_list_of_dict_index(data, key='ip', value=addr)
-                data.pop(idx)
+                if idx is not None:
+                    data.pop(idx)
 
     if sorted:
         if sorted == 'ip':
@@ -283,11 +285,11 @@ def _get_raw_server_static_mappings(family='inet', pool=None, sorted=None):
     if sorted:
         if sorted == 'ip':
             if family == 'inet6':
-                data.sort(key = lambda x:ip_address(x['ipv6-address']))
+                mappings.sort(key = lambda x:ip_address(x['ipv6-address']))
             else:
-                data.sort(key = lambda x:ip_address(x['ip-address']))
+                mappings.sort(key = lambda x:ip_address(x['ip-address']))
         else:
-            data.sort(key = lambda x:x[sorted])
+            mappings.sort(key = lambda x:x[sorted])
     return mappings
 
 def _get_formatted_server_static_mappings(raw_data, family='inet'):

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -83,7 +83,7 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[], orig
     inet_suffix = '6' if family == 'inet6' else '4'
     try:
         leases = kea_get_leases(inet_suffix)
-    except Exception as e:
+    except Exception:
         raise vyos.opmode.DataUnavailable('Cannot fetch DHCP server lease information')
 
     if pool is None:
@@ -93,7 +93,7 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[], orig
 
     try:
         active_config = kea_get_active_config(inet_suffix)
-    except Exception as e:
+    except Exception:
         raise vyos.opmode.DataUnavailable('Cannot fetch DHCP server configuration')
 
     data = []


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Fixing for op commands:
* `show dhcpv6 server static-mappings` to include `ipv6-address` from actual dhcpv6 static mappings in config.
* `show dhcpv6 server leases` to include `hostname` field (and removing trailing dot if any).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)


## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T5992
* https://vyos.dev/T3316

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* dhcpv6-server

## Proposed changes
* Fix reading of `ipv6-address` field in config section `service dhcpv6-server [...] static-mapping` to report them in op command `show dhcpv6 server static-mappings`
* Fix reading of `hostname` field in leases for either `show dhcp server leases` / `show dhcpv6 server leases` op commands
* Fix `sort` arg in `show dhcpv6 server [...]` op commands

## How to test
<!---

```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
