### PR TITLE
op_mode: T6860: Display the EULA in "run show license"

### DIFF
--- a/op-mode-definitions/show-license.xml.in
+++ b/op-mode-definitions/show-license.xml.in
@@ -6,7 +6,7 @@
         <properties>
           <help>Show VyOS license information</help>
         </properties>
-        <command>less $_vyatta_less_options --prompt=".license, page %dt of %D" -- ${vyatta_sysconfdir}/LICENSE</command>
+        <command>less $_vyatta_less_options --prompt=".license, page %dt of %D" -- ${vyos_data_dir}/EULA</command>
       </leafNode>
     </children>
   </node>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): change lisence file

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6860
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
op mode
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos# run show license
VyOS END USER LICENSE AGREEMENT

PLEASE READ THIS END USER LICENSE AGREEMENT (EULA, THIS ‘AGREEMENT’) CAREFULLY BEFORE USING VYOS FROM US.
BY USING VYOS, YOU (“YOU”, “LICENSEE”, “CUSTOMER”) SIGNIFY YOUR ASSENT TO AND ACCEPTANCE OF THIS
END USER LICENSE AGREEMENT AND ACKNOWLEDGE YOU HAVE READ AND UNDERSTAND THE TERMS.
THIS AGREEMENT IS ENFORCEABLE AGAINST ANY PERSON OR ENTITY THAT USES THE SOFTWARE AND ANY PERSON OR ENTITY
(E.G., SYSTEMS INTEGRATOR, CONSULTANT OR CONTRACTOR) THAT USES THE SOFTWARE ON ANOTHER PERSON’S OR ENTITY’S BEHALF.
IF YOU DO NOT ACCEPT THE TERMS OF THIS AGREEMENT, THEN YOU MUST NOT USE THE SOFTWARE.
THE EFFECTIVE DATE OF THIS AGREEMENT IS THE EARLIEST OF THE START DATE OF SERVICES STATED IN OUR INVOICE,
PREVIOUS ACCEPTANCE OF THIS AGREEMENT (OR OUR BUSINESS PARTNER’S ORDER OR/AND INVOICE,
PREVIOUS ACCEPTANCE OF THIS AGREEMENT) OR THE DATE THAT CUSTOMER HAS ACCESS AND IS ABLE TO USE OUR PRODUCTS OR SERVICES.
THIS END USER LICENSE AGREEMENT DOES NOT COVER ANY SERVICES FROM US, OR THROUGH OUR BUSINESS PARTNER,
OTHER THAN ACCESS TO THE SOFTWARE, SUCH AS TECHNICAL SUPPORT, UPGRADES OR SUPPORT SERVICES.
PLEASE REVIEW YOUR SERVICES OR SUBSCRIPTION AGREEMENT(S) THAT YOU MAY HAVE WITH US
OR OTHER AUTHORIZED VYOS SERVICES PROVIDER OR BUSINESS PARTNER REGARDING THE SOFTWARE AND SERVICES AND ASSOCIATED PAYMENTS.

1. Definitions

1.1 “We, Our, Us” means VyOS Contracting Entity  defined in Section 13.
...
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
