### PR TITLE
T6874: [QoS] Add class filter by ether

### DIFF
--- a/interface-definitions/include/qos/class-match.xml.i
+++ b/interface-definitions/include/qos/class-match.xml.i
@@ -29,12 +29,12 @@
         <leafNode name="protocol">
           <properties>
             <help>Ethernet protocol for this match</help>
-            <!-- this refers to /etc/protocols -->
+            <!-- this refers to /etc/ethertypes  -->
             <completionHelp>
               <list>all 802.1Q 802_2 802_3 aarp aoe arp atalk dec ip ipv6 ipx lat localtalk rarp snap x25</list>
             </completionHelp>
             <valueHelp>
-              <format>u32:0-65535</format>
+              <format>u32:1-65535</format>
               <description>Ethernet protocol number</description>
             </valueHelp>
             <valueHelp>
@@ -50,7 +50,7 @@
               <description>Internet IP (IPv4)</description>
             </valueHelp>
             <valueHelp>
-              <format>ipv6</format>
+              <format>_ipv6</format>
               <description>Internet IP (IPv6)</description>
             </valueHelp>
             <valueHelp>
@@ -59,7 +59,7 @@
             </valueHelp>
             <valueHelp>
               <format>atalk</format>
-              <description>Appletalk</description>
+              <description>AppleTalk</description>
             </valueHelp>
             <valueHelp>
               <format>ipx</format>
@@ -69,8 +69,48 @@
               <format>802.1Q</format>
               <description>802.1Q VLAN tag</description>
             </valueHelp>
+            <valueHelp>
+              <format>802_2</format>
+              <description>IEEE 802.2</description>
+            </valueHelp>
+            <valueHelp>
+              <format>802_3</format>
+              <description>IEEE 802.3</description>
+            </valueHelp>
+            <valueHelp>
+              <format>aarp</format>
+              <description>AppleTalk Address Resolution Protocol</description>
+            </valueHelp>
+            <valueHelp>
+              <format>aoe</format>
+              <description>ATA over Ethernet</description>
+            </valueHelp>
+            <valueHelp>
+              <format>dec</format>
+              <description>DECnet Protocol</description>
+            </valueHelp>
+            <valueHelp>
+              <format>lat</format>
+              <description>Local Area Transport</description>
+            </valueHelp>
+            <valueHelp>
+              <format>localtalk</format>
+              <description>Apple LocalTalk</description>
+            </valueHelp>
+            <valueHelp>
+              <format>rarp</format>
+              <description>Reverse Address Resolution Protocol</description>
+            </valueHelp>
+            <valueHelp>
+              <format>snap</format>
+              <description>Subnetwork Access Protocol</description>
+            </valueHelp>
+            <valueHelp>
+              <format>x25</format>
+              <description>X.25 Packet-Switching Protocol</description>
+            </valueHelp>
             <constraint>
-              <validator name="ip-protocol"/>
+              <validator name="ether-type"/>
             </constraint>
           </properties>
         </leafNode>

--- a/src/validators/ether-type
+++ b/src/validators/ether-type
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+from sys import argv,exit
+
+if __name__ == '__main__':
+    if len(argv) != 2:
+        exit(1)
+
+    input = argv[1]
+    try:
+        # ethertype can be in the range 1 - 65535
+        if int(input) in range(1, 65536):
+            exit(0)
+    except ValueError:
+        pass
+
+    pattern = "!?\\b(all|ip|ipv6|ipx|802.1Q|802_2|802_3|aarp|aoe|arp|atalk|dec|lat|localtalk|rarp|snap|x25)\\b"
+    if re.match(pattern, input):
+        exit(0)
+
+    print(f'Error: {input} is not a valid ether type or protocol.')
+    exit(1)


### PR DESCRIPTION
Implement a command to configure QoS policy filters by ether properties. The supported match types include:
- Destination: Specify the Ethernet destination address.
- Protocol: Define the Ethernet protocol.
- Source: Set the Ethernet source address.

`set qos policy <type> <name> class <id> match <match-id> ether <destination|protocol|source> <val> `

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

* https://vyos.dev/T6874

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_qos.py 
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... ok
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok
test_12_shaper_with_red_queue (__main__.TestQoS.test_12_shaper_with_red_queue) ... ok
test_13_shaper_delete_only_rule (__main__.TestQoS.test_13_shaper_delete_only_rule) ... ok
test_14_policy_limiter_marked_traffic (__main__.TestQoS.test_14_policy_limiter_marked_traffic) ... ok
test_15_traffic_match_group (__main__.TestQoS.test_15_traffic_match_group) ... ok
test_16_wrong_traffic_match_group (__main__.TestQoS.test_16_wrong_traffic_match_group) ... ok
test_17_cake_updates (__main__.TestQoS.test_17_cake_updates) ... ok
test_20_round_robin_policy_default (__main__.TestQoS.test_20_round_robin_policy_default) ... ok
test_21_shaper_hfsc (__main__.TestQoS.test_21_shaper_hfsc) ... ok
test_22_rate_control_default (__main__.TestQoS.test_22_rate_control_default) ... ok
test_23_policy_limiter_iif_filter (__main__.TestQoS.test_23_policy_limiter_iif_filter) ... ok
test_24_policy_shaper_match_ether (__main__.TestQoS.test_24_policy_shaper_math_ether) ... ok

----------------------------------------------------------------------
Ran 22 tests in 143.621s

OK

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
