### PR TITLE
vyconf: T6718: add keyword default for change in libvyosconfig binding

### DIFF
--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -469,15 +469,15 @@ def mask_inclusive(left, right, libpath=LIBPATH):
 
     return tree
 
-def reference_tree_to_json(from_dir, to_file, libpath=LIBPATH):
+def reference_tree_to_json(from_dir, to_file, internal_cache="", libpath=LIBPATH):
     try:
         __lib = cdll.LoadLibrary(libpath)
         __reference_tree_to_json = __lib.reference_tree_to_json
-        __reference_tree_to_json.argtypes = [c_char_p, c_char_p]
+        __reference_tree_to_json.argtypes = [c_char_p, c_char_p, c_char_p]
         __get_error = __lib.get_error
         __get_error.argtypes = []
         __get_error.restype = c_char_p
-        res = __reference_tree_to_json(from_dir.encode(), to_file.encode())
+        res = __reference_tree_to_json(internal_cache.encode(), from_dir.encode(), to_file.encode())
     except Exception as e:
         raise ConfigTreeError(e)
     if res == 1:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Adjust signature of `reference_tree_to_json` for change in the ctypes binding.

Split off commit from https://github.com/vyos/vyos-1x/pull/4176 to solve a chicken-egg problem with the change in signature of `reference_tree_to_json` after merge of https://github.com/vyos/libvyosconfig/pull/21 and resulting update in https://github.com/vyos/vyos-build/pull/824

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
