### PR TITLE
T6927: adds option to set container name server

### DIFF
--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -98,11 +98,21 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
 
     def test_name_server(self):
         cont_name = 'dns-test'
+        net_name = 'net-test'
         name_server = '192.168.0.1'
-        self.cli_set(base_path + ['name', cont_name, 'allow-host-networks'])
+        prefix = '192.0.2.0/24'
+
+        self.cli_set(base_path + ['network', net_name, 'prefix', prefix])
+
         self.cli_set(base_path + ['name', cont_name, 'image', cont_image])
         self.cli_set(base_path + ['name', cont_name, 'name-server', name_server])
+        self.cli_set(base_path + ['name', cont_name, 'network', net_name, 'address', str(ip_interface(prefix).ip + 2)])
 
+        # verify() - name server has no effect when container network has dns enabled
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_set(base_path + ['network', net_name, 'no-name-server'])
         self.cli_commit()
 
         n = cmd_to_json(f'sudo podman inspect {cont_name}')

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -148,6 +148,9 @@ def verify(container):
                 if network_name not in container.get('network', {}):
                     raise ConfigError(f'Container network "{network_name}" does not exist!')
 
+                if 'name_server' in container_config and 'no_name_server' not in container['network'][network_name]:
+                    raise ConfigError(f'Setting name server has no effect when attached container network has DNS enabled!')
+
                 if 'address' in container_config['network'][network_name]:
                     cnt_ipv4 = 0
                     cnt_ipv6 = 0


### PR DESCRIPTION
## Change Summary
Adds additional validation

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6927

## Related PR(s)
#4218

## Component(s) name
container

## Proposed changes
Warn that setting name-server on container has no effect if attached network has dns enabled.

## How to test
Configure container with name server and network with dns.

## Smoketest result
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_container.py
test_api_socket (__main__.TestContainer.test_api_socket) ... ok
test_basic (__main__.TestContainer.test_basic) ... ok
test_cpu_limit (__main__.TestContainer.test_cpu_limit) ... ok
test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... ok
test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... ok
test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... ok
test_name_server (__main__.TestContainer.test_name_server) ... ok
test_network_mtu (__main__.TestContainer.test_network_mtu) ... ok
test_no_name_server (__main__.TestContainer.test_no_name_server) ... ok
test_uid_gid (__main__.TestContainer.test_uid_gid) ... ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
