### PR TITLE
T6934: Add preshared key for zabbix-agent monitoring service

### DIFF
--- a/data/templates/zabbix-agent/zabbix-agent.conf.j2
+++ b/data/templates/zabbix-agent/zabbix-agent.conf.j2
@@ -75,3 +75,16 @@ Include={{ directory }}/*.conf
 Timeout={{ timeout }}
 {% endif %}
 
+{% if authentication is vyos_defined and authentication.mode is vyos_defined %}
+{%     if authentication.mode == "pre-shared-secret" %}
+TLSConnect=psk
+TLSAccept=psk
+{%     endif %}
+{%     if authentication.psk.secret is vyos_defined %}
+TLSPSKFile={{ service_psk_file }}
+{%     endif %}
+{%     if authentication.psk.id is vyos_defined %}
+TLSPSKIdentity={{ authentication.psk.id }}
+{%     endif %}
+{% endif %}
+

--- a/interface-definitions/include/auth-mode-pre-shared-secret.xml.i
+++ b/interface-definitions/include/auth-mode-pre-shared-secret.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from auth-mode-pre-shared-secret.xml.i -->
+<leafNode name="mode">
+  <properties>
+    <help>Authentication mode</help>
+    <completionHelp>
+      <list>pre-shared-secret</list>
+    </completionHelp>
+    <valueHelp>
+      <format>pre-shared-secret</format>
+      <description>Use a pre-shared secret key</description>
+    </valueHelp>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/auth-psk-id.xml.i
+++ b/interface-definitions/include/auth-psk-id.xml.i
@@ -1,0 +1,11 @@
+<!-- include start from auth-psk-id.xml.i -->
+<leafNode name="id">
+  <properties>
+    <help>ID for authentication</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>ID used for authentication</description>
+    </valueHelp>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/auth-psk-secret.xml.i
+++ b/interface-definitions/include/auth-psk-secret.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from auth-psk-secret.xml.i -->
+<leafNode name="secret">
+  <properties>
+    <help>pre-shared secret key</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>16byte pre-shared-secret key (32 character hexadecimal key)</description>
+    </valueHelp>
+    <constraint>
+      <validator name="psk-secret"/>
+    </constraint>
+    <constraintErrorMessage>Pre-Shared-Keys must be at leas 16 bytes long, which implies at least 32 characterss</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/stunnel/psk.xml.i
+++ b/interface-definitions/include/stunnel/psk.xml.i
@@ -4,27 +4,8 @@
     <help>Pre-shared key name</help>
   </properties>
   <children>
-    <leafNode name="id">
-      <properties>
-        <help>ID for authentication</help>
-        <valueHelp>
-          <format>txt</format>
-          <description>ID used for authentication</description>
-        </valueHelp>
-      </properties>
-    </leafNode>
-    <leafNode name="secret">
-      <properties>
-        <help>pre-shared secret key</help>
-        <valueHelp>
-          <format>txt</format>
-          <description>pre-shared secret key are required to be at least 16 bytes long, which implies at least 32 characters for hexadecimal key</description>
-        </valueHelp>
-        <constraint>
-          <validator name="psk-secret"/>
-        </constraint>
-      </properties>
-    </leafNode>
+    #include <include/auth-psk-id.xml.i>
+    #include <include/auth-psk-secret.xml.i>
   </children>
 </tagNode>
 <!-- include end -->

--- a/interface-definitions/service_monitoring_zabbix-agent.xml.in
+++ b/interface-definitions/service_monitoring_zabbix-agent.xml.in
@@ -10,6 +10,23 @@
               <priority>1280</priority>
             </properties>
             <children>
+              <node name="authentication">
+                <properties>
+                  <help>Authentication</help>
+                </properties>
+                <children>
+                  #include <include/auth-mode-pre-shared-secret.xml.i>
+                  <node name="psk">
+                    <properties>
+                      <help>Pre-shared key</help>
+                    </properties>
+                    <children>
+                      #include <include/auth-psk-id.xml.i>
+                      #include <include/auth-psk-secret.xml.i>
+                    </children>
+                  </node>
+                </children>
+              </node>
               <leafNode name="directory">
                 <properties>
                   <help>Folder containing individual Zabbix-agent configuration files</help>

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -722,18 +722,7 @@
                   <help>Authentication</help>
                 </properties>
                 <children>
-                  <leafNode name="mode">
-                    <properties>
-                      <help>Authentication mode</help>
-                      <completionHelp>
-                        <list>pre-shared-secret</list>
-                      </completionHelp>
-                      <valueHelp>
-                        <format>pre-shared-secret</format>
-                        <description>Use a pre-shared secret key</description>
-                      </valueHelp>
-                    </properties>
-                  </leafNode>
+                  #include <include/auth-mode-pre-shared-secret.xml.i>
                   #include <include/ipsec/authentication-pre-shared-secret.xml.i>
                 </children>
               </node>

--- a/op-mode-definitions/generate-psk.xml.in
+++ b/op-mode-definitions/generate-psk.xml.in
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="generate">
+    <children>
+      <node name="psk">
+        <properties>
+          <help>Generate PSK key</help>
+        </properties>
+        <children>
+          <node name="random">
+            <properties>
+              <help>Generate random hex PSK key</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/generate_psk.py</command>
+            <children>
+              <tagNode name="size">
+                <properties>
+                  <help>Key size in bytes</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/generate_psk.py --hex_size "$5"</command>
+              </tagNode>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/src/op_mode/generate_psk.py
+++ b/src/op_mode/generate_psk.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import argparse
+
+from vyos.utils.process import cmd
+
+
+def validate_hex_size(value):
+    """Validate that the hex_size is between 32 and 512."""
+    try:
+        value = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError("hex_size must be integer.")
+
+    if value < 32 or value > 512:
+        raise argparse.ArgumentTypeError("hex_size must be between 32 and 512.")
+    return value
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--hex_size",
+        type=validate_hex_size,
+        help='PKS value size in hex format. Default is 32 bytes.',
+        default=32,
+
+        required=False,
+    )
+    args = parser.parse_args()
+
+    print(cmd(f'openssl rand -hex {args.hex_size}'))


### PR DESCRIPTION
- Allow configure preshared key for zabbix-agent
- Added op mode command for generatre random psk secret
- Removed duplicate xml definition for psk settings


Configure authentication mode:
```
# set service monitoring zabbix-agent authentication mode
Possible completions:
   pre-shared-secret    Use a pre-shared secret key
```

Configure PSK Settings:
```
# set service monitoring zabbix-agent authentication psk
Possible completions:
   id                   ID for authentication
   secret               pre-shared secret key

```

Generate Random PSK:
```
$ generate psk random
Possible completions:
  <Enter>               Execute the current command
  size                  Key size in bytes

```

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6934

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_service_monitoring_zabbix-agent.py 
test_01_zabbix_agent (__main__.TestZabbixAgent.test_01_zabbix_agent) ... ok
test_02_zabbix_agent_psk_auth (__main__.TestZabbixAgent.test_02_zabbix_agent_psk_auth) ... ok

----------------------------------------------------------------------
Ran 2 tests in 15.881s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
