### PR TITLE
T6918: Accept invalid PPPoE Session in stateful bridge firewall.

### DIFF
--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -382,6 +382,7 @@ table bridge vyos_filter {
 {%                 if 'invalid_connections' in global_options.apply_to_bridged_traffic %}
         ct state invalid udp sport 67 udp dport 68 counter accept
         ct state invalid ether type arp counter accept
+        ct state invalid ether type 0x8864 counter accept
 {%                 endif %}
 {%             endif %}
 {%             if global_options.state_policy is vyos_defined %}

--- a/interface-definitions/include/firewall/global-options.xml.i
+++ b/interface-definitions/include/firewall/global-options.xml.i
@@ -51,7 +51,7 @@
       <children>
         <leafNode name="invalid-connections">
           <properties>
-            <help>Accept ARP and DHCP despite they are marked as invalid connection</help>
+            <help>Accept ARP DHCP and PPPoE despite they are marked as invalid connection</help>
             <valueless/>
           </properties>
         </leafNode>

--- a/interface-definitions/include/firewall/global-options.xml.i
+++ b/interface-definitions/include/firewall/global-options.xml.i
@@ -51,7 +51,7 @@
       <children>
         <leafNode name="invalid-connections">
           <properties>
-            <help>Accept ARP DHCP and PPPoE despite they are marked as invalid connection</help>
+            <help>Accept ARP, DHCP and PPPoE despite they are marked as invalid connection</help>
             <valueless/>
           </properties>
         </leafNode>

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -765,6 +765,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['type filter hook output priority filter; policy accept;'],
             ['ct state invalid', 'udp sport 67', 'udp dport 68', 'accept'],
             ['ct state invalid', 'ether type arp', 'accept'],
+            ['ct state invalid', 'ether type 0x8864', 'accept'],
             ['chain VYOS_PREROUTING_filter'],
             ['type filter hook prerouting priority filter; policy accept;'],
             ['ip6 daddr @A6_AGV6', 'notrack'],


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This patch is related to T6647, PPPoE sessions (ether type 0x8864) are also marked as invalid connections, this patch will accept PPPoE session .

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6918

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->
In https://vyos.dev/T6647, invalid connections are already accepted for DHCP and ARP; now we have also added PPPoE sessions.
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos# run show config comm | grep firewall
set firewall global-options apply-to-bridged-traffic invalid-connections
set firewall global-options state-policy established action 'accept'
set firewall global-options state-policy invalid action 'drop'
set firewall global-options state-policy invalid log
set firewall global-options state-policy invalid log-level 'debug'
set firewall global-options state-policy related action 'accept'

And nftables output:
vyos@vyos# sudo nft -s list table bridge vyos_filter
table bridge vyos_filter {
        chain VYOS_FORWARD_filter {
                type filter hook forward priority filter; policy accept;
                jump VYOS_STATE_POLICY
                counter accept comment "FWD-filter default-action accept"
        }

        chain VYOS_INPUT_filter {
                type filter hook input priority filter; policy accept;
                jump VYOS_STATE_POLICY
                counter accept comment "INP-filter default-action accept"
        }

        chain VYOS_OUTPUT_filter {
                type filter hook output priority filter; policy accept;
                ct state invalid ether type 0x8864 counter accept
                ct state invalid udp sport 67 udp dport 68 counter accept
                ct state invalid ether type arp counter accept
                jump VYOS_STATE_POLICY
                counter accept comment "OUT-filter default-action accept"
        }

        chain VYOS_PREROUTING_filter {
                type filter hook prerouting priority filter; policy accept;
                counter accept comment "PRE-filter default-action accept"
        }

        chain VYOS_STATE_POLICY {
                ct state established counter accept
                ct state invalid log prefix "[STATE-POLICY-INV-A]" level debug counter accept
                ct state related counter accept
                return
        }
}
[edit]
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
