### PR TITLE
tacacs: T6613: dynamically build exclude_users list to avoid TACACS traffic

### DIFF
--- a/data/templates/login/tacplus_nss.conf.j2
+++ b/data/templates/login/tacplus_nss.conf.j2
@@ -21,7 +21,7 @@
 # Cumulus Linux ships with it set to 1001, so we never lookup our standard
 # local users, including the cumulus uid of 1000.  Should not be greater
 # than the local tacacs{0..15} uids
-min_uid=900
+min_uid={{ tacacs_min_uid }}
 
 # This is a comma separated list of usernames that are never sent to
 # a tacacs server, they cause an early not found return.
@@ -30,7 +30,7 @@ min_uid=900
 # that during pathname completion, bash can do an NSS lookup on "*"
 # To avoid server round trip delays, or worse, unreachable server delays
 # on filename completion, we include "*" in the exclusion list.
-exclude_users=root,telegraf,radvd,strongswan,tftp,conservr,frr,ocserv,pdns,_chrony,_lldpd,sshd,openvpn,radius_user,radius_priv_user,*{{ ',' + user | join(',') if user is vyos_defined }}
+exclude_users=*{{ ',' + exclude_users | join(',') if exclude_users is vyos_defined }}
 
 # The include keyword allows centralizing the tacacs+ server information
 # including the IP address and shared secret
@@ -71,4 +71,3 @@ source_ip={{ tacacs.source_address }}
 # as in tacplus_servers, since tacplus_servers should not be readable
 # by users other than root.
 timeout={{ tacacs.timeout }}
-


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

There is no need to send local base OS accounts like root or daemon to the tacacs server. This will only make the CLI experience sluggish.

Build up a dynamic list of user accounts to exclude from TACACS lookup.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6613

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/libnss-tacplus/pull/1

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
TACACS

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
~$ /usr/libexec/vyos/tests/smoke/cli/test_system_login.py
test_add_linux_system_user (__main__.TestSystemLogin.test_add_linux_system_user) ... ok
test_delete_current_user (__main__.TestSystemLogin.test_delete_current_user) ... ok
test_radius_kernel_features (__main__.TestSystemLogin.test_radius_kernel_features) ... ok
test_system_login_max_login_session (__main__.TestSystemLogin.test_system_login_max_login_session) ... ok
test_system_login_otp (__main__.TestSystemLogin.test_system_login_otp) ... ok
test_system_login_radius_ipv4 (__main__.TestSystemLogin.test_system_login_radius_ipv4) ... ok
test_system_login_radius_ipv6 (__main__.TestSystemLogin.test_system_login_radius_ipv6) ... ok
test_system_login_tacacs (__main__.TestSystemLogin.test_system_login_tacacs) ... ok
test_system_login_user (__main__.TestSystemLogin.test_system_login_user) ... ok
test_system_user_ssh_key (__main__.TestSystemLogin.test_system_user_ssh_key) ... ok

----------------------------------------------------------------------
Ran 10 tests in 29.450s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
