### PR TITLE
service-dns-dynamic: T6950: fix migration script logic for missing addresses

### DIFF
--- a/src/migration-scripts/dns-dynamic/1-to-2
+++ b/src/migration-scripts/dns-dynamic/1-to-2
@@ -20,6 +20,10 @@
 # - migrate "service dns dynamic address <interface> service <service> protocol dnsexit"
 #        to "service dns dynamic address <interface> service <service> protocol dnsexit2"
 
+# T6950:
+# - add if statement to prevent processing of "service dns dynamic address" options if they don't exist
+#        due to the fact they are no longer valid syntax
+
 from vyos.configtree import ConfigTree
 
 base_path = ['service', 'dns', 'dynamic']
@@ -36,16 +40,19 @@ def migrate(config: ConfigTree) -> None:
     if config.exists(timeout_path):
         config.rename(timeout_path, 'interval')
 
-    # Remove "service dns dynamic address <interface> web-options ..." when <interface> != "web"
-    for address in config.list_nodes(address_path):
-        if config.exists(address_path + [address, 'web-options']) and address != 'web':
-            config.delete(address_path + [address, 'web-options'])
+    # T6950: Can't migrate address if it doesn't exist
+    if config.exists(address_path):
 
-    # Migrate "service dns dynamic address <interface> service <service> protocol dnsexit"
-    #      to "service dns dynamic address <interface> service <service> protocol dnsexit2"
-    for address in config.list_nodes(address_path):
-        for svc_cfg in config.list_nodes(address_path + [address, 'service']):
-            if config.exists(address_path + [address, 'service', svc_cfg, 'protocol']):
-                protocol = config.return_value(address_path + [address, 'service', svc_cfg, 'protocol'])
-                if protocol == 'dnsexit':
-                    config.set(address_path + [address, 'service', svc_cfg, 'protocol'], 'dnsexit2')
+        # Remove "service dns dynamic address <interface> web-options ..." when <interface> != "web"
+        for address in config.list_nodes(address_path):
+            if config.exists(address_path + [address, 'web-options']) and address != 'web':
+                config.delete(address_path + [address, 'web-options'])
+
+        # Migrate "service dns dynamic address <interface> service <service> protocol dnsexit"
+        #      to "service dns dynamic address <interface> service <service> protocol dnsexit2"
+        for address in config.list_nodes(address_path):
+            for svc_cfg in config.list_nodes(address_path + [address, 'service']):
+                if config.exists(address_path + [address, 'service', svc_cfg, 'protocol']):
+                    protocol = config.return_value(address_path + [address, 'service', svc_cfg, 'protocol'])
+                    if protocol == 'dnsexit':
+                        config.set(address_path + [address, 'service', svc_cfg, 'protocol'], 'dnsexit2')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Adds an if statement to verify that address configuration blocks exist before the script tries to migrate them.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6950
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
service dns dynamic (migration script)
## Proposed changes
<!--- Describe your changes in detail -->
Due to new configuration syntax, the migration script was expecting "service dns dynamic address <interface>" entries to be defined. These entries were no longer valid with the new configuration system and attempting to load a configuration without these entries resulted in an error when the migration script attempted to migrate the non-existant "service dns dynamic address <interface>" entries. I added an if statement to verify that there are "service dns dynamic address <interface>" entries before attempting to migrate them.
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Tested changes by loading in two example configs. The first config was the config I was trying to load in using the new configuration syntax and one with the old syntax.

New Configuration: 
```
service {                             
    dns {                                  
        dynamic {                          
            name namecheap {           
                address {                  
                    interface peth0        
                }                          
                host-name @                
                host-name test             
                password asdf                            
                protocol namecheap         
                username thatsonelitbit.net  
            }                          
        }                              
    }                                  
}                                      
interfaces {                           
} 
```
Output Merging this snippet:
```
gage@VyOS0# merge services_test_new.yml
Merge complete. Use 'commit' to make changes effective.
[edit]
gage@VyOS0# show service dns
+dynamic {
+    name namecheap {
+        address {
+            interface peth0
+        }
+        host-name @
+        host-name test
+        password asdf
+        protocol namecheap
+        username thatsonelitbit.net
+    }
+}
[edit]
```

Old configuration:
```
service {
    dns {
        dynamic {
            address web {
                service namecheap1 {
                    host-name test
                    host-name @
                    username test.local
                    password asdf
                    protocol namecheap
                }
                web-options {
                    url https://ifconfig.me
                }
            }
        }
    }
}
interfaces {
}
```
Output of merging this snippet:
```
gage@VyOS0# merge services_test.yml
[Errno 1] failed to run command: /opt/vyatta/sbin/my_set service dns dynamic address web service namecheap1 host-name 'test'
returned: Configuration path: [service dns dynamic address web service namecheap1 host-name test] is not valid

Set failed
exit code: 1
[Errno 1] failed to run command: /opt/vyatta/sbin/my_set service dns dynamic address web service namecheap1 host-name '@'
returned: Configuration path: [service dns dynamic address web service namecheap1 host-name @] is not valid

Set failed
exit code: 1
[Errno 1] failed to run command: /opt/vyatta/sbin/my_set service dns dynamic address web service namecheap1 password 'asdf'
returned: Configuration path: [service dns dynamic address web service namecheap1 password asdf] is not valid

Set failed
exit code: 1
[Errno 1] failed to run command: /opt/vyatta/sbin/my_set service dns dynamic address web service namecheap1 protocol 'namecheap'
returned: Configuration path: [service dns dynamic address web service namecheap1 protocol namecheap] is not valid

Set failed
exit code: 1
[Errno 1] failed to run command: /opt/vyatta/sbin/my_set service dns dynamic address web service namecheap1 username 'test.local'
returned: Configuration path: [service dns dynamic address web service namecheap1 username test.local] is not valid

Set failed
exit code: 1
[Errno 1] failed to run command: /opt/vyatta/sbin/my_set service dns dynamic address web web-options url 'https://ifconfig.me'
returned: Configuration path: [service dns dynamic address web web-options url https://ifconfig.me] is not valid

Set failed
exit code: 1
No configuration changes to commit.
[edit]
gage@VyOS0# show service dns
Configuration under specified path is empty
[edit]
```

Which is the output I was getting anyway and why I had to upgrade my configuration to the new syntax.
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
gage@VyOS0# pwd
/usr/libexec/vyos/tests/smoke/cli
[edit]
gage@VyOS0# ./test_service_dns_dynamic.py
test_01_dyndns_service_standard (__main__.TestServiceDDNS.test_01_dyndns_service_standard) ... ok
test_02_dyndns_service_ipv6 (__main__.TestServiceDDNS.test_02_dyndns_service_ipv6) ... ok
test_03_dyndns_service_dual_stack (__main__.TestServiceDDNS.test_03_dyndns_service_dual_stack) ... ok
test_04_dyndns_rfc2136 (__main__.TestServiceDDNS.test_04_dyndns_rfc2136) ... ok
test_05_dyndns_hostname (__main__.TestServiceDDNS.test_05_dyndns_hostname) ... ok
test_06_dyndns_web_options (__main__.TestServiceDDNS.test_06_dyndns_web_options) ... ok
test_07_dyndns_dynamic_interface (__main__.TestServiceDDNS.test_07_dyndns_dynamic_interface) ... ok
test_08_dyndns_vrf (__main__.TestServiceDDNS.test_08_dyndns_vrf) ... ok

----------------------------------------------------------------------
Ran 8 tests in 184.472s

OK
[edit]
```
Smoketest might need a rewrite along with this migration script to properly handle the new command syntax and conversions from older syntax.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ x] I have linked this PR to one or more Phabricator Task(s)
- [ x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
