### PR TITLE
pppoe: T6930: Remove unnecessary code

### DIFF
--- a/python/vyos/ifconfig/pppoe.py
+++ b/python/vyos/ifconfig/pppoe.py
@@ -115,14 +115,6 @@ class PPPoEIf(Interface):
         # before this is done by the base class.
         self._config = config
 
-        # remove old routes from an e.g. old VRF assignment
-        if 'shutdown_required':
-            vrf = None
-            tmp = get_interface_config(self.ifname)
-            if 'master' in tmp:
-                vrf = tmp['master']
-            self._remove_routes(vrf)
-
         # DHCPv6 PD handling is a bit different on PPPoE interfaces, as we do
         # not require an 'address dhcpv6' CLI option as with other interfaces
         if 'dhcpv6_options' in config and 'pd' in config['dhcpv6_options']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
In case of changes in config that require reconnect PPPoEIF.remove() function is called and old default routes are removed. So we do not need to do it once again.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6930
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
interfaces pppoe
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_interfaces_pppoe.py
test_pppoe_authentication (__main__.PPPoEInterfaceTest.test_pppoe_authentication) ... ok
test_pppoe_client (__main__.PPPoEInterfaceTest.test_pppoe_client) ... ok
test_pppoe_client_disabled_interface (__main__.PPPoEInterfaceTest.test_pppoe_client_disabled_interface) ... ok
test_pppoe_dhcpv6pd (__main__.PPPoEInterfaceTest.test_pppoe_dhcpv6pd) ... ok
test_pppoe_mtu_mru (__main__.PPPoEInterfaceTest.test_pppoe_mtu_mru) ... ok
test_pppoe_options (__main__.PPPoEInterfaceTest.test_pppoe_options) ... ok

----------------------------------------------------------------------
Ran 6 tests in 42.767s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
