### PR TITLE
T6936: PPPoE-server add option combined to interface

### DIFF
--- a/data/templates/accel-ppp/pppoe.config.j2
+++ b/data/templates/accel-ppp/pppoe.config.j2
@@ -61,6 +61,9 @@ interface={{ iface }}
 {%             for vlan in iface_config.vlan %}
 interface=re:^{{ iface }}\.{{ vlan | range_to_regex }}$
 {%             endfor %}
+{%             if iface_config.combined is vyos_defined %}
+interface={{ iface }}
+{%             endif %}
 {%             if iface_config.vlan_mon is vyos_defined %}
 vlan-mon={{ iface }},{{ iface_config.vlan | join(',') }}
 {%             endif %}

--- a/interface-definitions/service_pppoe-server.xml.in
+++ b/interface-definitions/service_pppoe-server.xml.in
@@ -63,6 +63,12 @@
               </completionHelp>
             </properties>
             <children>
+              <leafNode name="combined">
+                <properties>
+                  <help>Listen on both VLANs and the base interface</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
               #include <include/accel-ppp/vlan.xml.i>
               #include <include/accel-ppp/vlan-mon.xml.i>
             </children>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add option `combined`; 
it allows listening to PPP requests on both VLANs and the base parent interface (without tag)

Before, it was impossible to do it from our CLI
```
set service pppoe-server interface eth1 combined
set service pppoe-server interface eth1 vlan '10-122'
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): New feature that fixes bug

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6936

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pppoe-server
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Add configuration and be surprised that the parent interface (without tags) does not listen to PPP requests
```
set interfaces ethernet eth1 vif 500
set service pppoe-server access-concentrator 'ACN'
set service pppoe-server authentication mode 'radius'
set service pppoe-server authentication radius server 127.0.0.1 key 'xxx'
set service pppoe-server client-ip-pool FIRST range '100.64.0.0/24'
set service pppoe-server gateway-address '100.64.0.1'
set service pppoe-server interface eth1 vlan '10-122'
set service pppoe-server interface eth1 vlan-mon
set service pppoe-server interface eth1.500
commit


vyos@r14# run show pppoe-server interfaces 
 interface:   connections:    state:
-----------------------------------
 eth1.500              0    active
[edit]
vyos@r14# 

```

Add the `combined` option, expected listen to `eth0` and `eth1.500` + VLAN range:
```
vyos@r14# set service pppoe-server interface eth1 combined 
[edit]
vyos@r14# commit
[edit]
vyos@r14# 
[edit]
vyos@r14# run show pppoe-server interfaces 
 interface:   connections:    state:
-----------------------------------
     eth1              0    active
 eth1.500              0    active
[edit]
vyos@r14# 

vyos@r14# cat /run/accel-pppd/pppoe.conf | grep interface
interface=re:^eth1\.(1\d|[2-9]\d|1[0-1]\d|12[0-2])$
interface=eth1
interface=eth1.500
[edit]
vyos@r14# 

```


## Smoketest result
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py
test_accel_ipv4_pool (__main__.TestServicePPPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServicePPPoEServer.test_accel_ipv6_pool) ... ok
test_accel_limits (__main__.TestServicePPPoEServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestServicePPPoEServer.test_accel_local_authentication) ... ok
test_accel_log_level (__main__.TestServicePPPoEServer.test_accel_log_level) ... ok
test_accel_name_servers (__main__.TestServicePPPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServicePPPoEServer.test_accel_next_pool) ... ok
test_accel_ppp_options (__main__.TestServicePPPoEServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestServicePPPoEServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestServicePPPoEServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestServicePPPoEServer.test_accel_wins_server) ... ok
test_pppoe_limits (__main__.TestServicePPPoEServer.test_pppoe_limits) ... ok
test_pppoe_server_accept_service (__main__.TestServicePPPoEServer.test_pppoe_server_accept_service) ... ok
test_pppoe_server_any_login (__main__.TestServicePPPoEServer.test_pppoe_server_any_login) ... ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer.test_pppoe_server_authentication_protocols) ... ok
test_pppoe_server_pado_delay (__main__.TestServicePPPoEServer.test_pppoe_server_pado_delay) ... ok
test_pppoe_server_shaper (__main__.TestServicePPPoEServer.test_pppoe_server_shaper) ... ok
test_pppoe_server_vlan (__main__.TestServicePPPoEServer.test_pppoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 19 tests in 132.395s

OK
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
