### PR TITLE
frr: T6746: additional improvements after 10.2 upgrade

### DIFF
--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -218,11 +218,11 @@ def get_frrender_dict(conf, argv=None) -> dict:
     # values present on the CLI - that's why we have if conf.exists()
     eigrp_cli_path = ['protocols', 'eigrp']
     if conf.exists(eigrp_cli_path):
-        isis = conf.get_config_dict(eigrp_cli_path, key_mangling=('-', '_'),
-                                    get_first_key=True,
-                                    no_tag_node_value_mangle=True,
-                                    with_recursive_defaults=True)
-        dict.update({'eigrp' : isis})
+        eigrp = conf.get_config_dict(eigrp_cli_path, key_mangling=('-', '_'),
+                                     get_first_key=True,
+                                     no_tag_node_value_mangle=True,
+                                     with_recursive_defaults=True)
+        dict.update({'eigrp' : eigrp})
     elif conf.exists_effective(eigrp_cli_path):
         dict.update({'eigrp' : {'deleted' : ''}})
 

--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -660,7 +660,7 @@ class FRRender:
             debug(f'FRR: reloading configuration - tries: {count} | Python class ID: {id(self)}')
             cmdline = '/usr/lib/frr/frr-reload.py --reload'
             if os.path.exists(frr_debug_enable):
-                cmdline += ' --debug'
+                cmdline += ' --debug --stdout'
             rc, emsg = rc_cmd(f'{cmdline} {self._frr_conf}')
             if rc != 0:
                 sleep(2)

--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -537,13 +537,24 @@ def get_frrender_dict(conf, argv=None) -> dict:
     return dict
 
 class FRRender:
+    cached_config_dict = {}
     def __init__(self):
         self._frr_conf = '/run/frr/config/vyos.frr.conf'
 
     def generate(self, config_dict) -> None:
+        """
+        Generate FRR configuration file
+        Returns False if no changes to configuration were made, otherwise True
+        """
         if not isinstance(config_dict, dict):
             tmp = type(config_dict)
             raise ValueError(f'Config must be of type "dict" and not "{tmp}"!')
+
+
+        if self.cached_config_dict == config_dict:
+            debug('FRR:        NO CHANGES DETECTED')
+            return False
+        self.cached_config_dict = config_dict
 
         def inline_helper(config_dict) -> str:
             output = '!\n'
@@ -639,7 +650,7 @@ class FRRender:
         debug(output)
         write_file(self._frr_conf, output)
         debug('FRR:        RENDERING CONFIG COMPLETE')
-        return None
+        return True
 
     def apply(self, count_max=5):
         count = 0

--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -27,7 +27,6 @@ from vyos import ConfigError
 from vyos.defaults import commit_lock
 from vyos.utils.process import cmd
 from vyos.utils.process import run
-from vyos.utils.process import process_named_running
 
 save_config = '/tmp/vyos-smoketest-save'
 
@@ -89,9 +88,6 @@ class VyOSUnitTestSHIM:
             # during a commit there is a process opening commit_lock, and run() returns 0
             while run(f'sudo lsof -nP {commit_lock}') == 0:
                 sleep(0.250)
-            # wait for FRR reload to be complete
-            while process_named_running('frr-reload.py'):
-                sleep(0.250)
             # reset getFRRconfig() guard timer
             self.commit_guard = time()
 
@@ -108,20 +104,32 @@ class VyOSUnitTestSHIM:
                 pprint.pprint(out)
             return out
 
-        def getFRRconfig(self, string=None, end='$', endsection='^!', daemon='', guard_time=10, empty_retry=0):
-            """ Retrieve current "running configuration" from FRR """
+        def getFRRconfig(self, string=None, end='$', endsection='^!',
+                         substring=None, endsubsection=None, guard_time=10, empty_retry=0):
+            """
+            Retrieve current "running configuration" from FRR
+
+            string:        search for a specific start string in the configuration
+            end:           end of the section to search for (line ending)
+            endsection:    end of the configuration
+            substring:     search section under the result found by string
+            endsubsection: end of the subsection (usually something with "exit")
+            """
             # Sometimes FRR needs some time after reloading the configuration to
             # appear in vtysh. This is a workaround addiung a 10 second guard timer
             # between the last cli_commit() and the first read of FRR config via vtysh
             while (time() - self.commit_guard) < guard_time:
                 sleep(0.250) # wait 250 milliseconds
-            command = f'vtysh -c "show run {daemon} no-header"'
-            if string: command += f' | sed -n "/^{string}{end}/,/{endsection}/p"'
+            command = f'vtysh -c "show run no-header"'
+            if string:
+                command += f' | sed -n "/^{string}{end}/,/{endsection}/p"'
+                if substring and endsubsection:
+                    command += f' | sed -n "/^{substring}/,/{endsubsection}/p"'
             out = cmd(command)
             if self.debug:
                 print(f'\n\ncommand "{command}" returned:\n')
                 pprint.pprint(out)
-            if empty_retry:
+            if empty_retry > 0:
                 retry_count = 0
                 while not out and retry_count < empty_retry:
                     if self.debug and retry_count % 10 == 0:

--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -18,7 +18,6 @@ import paramiko
 import pprint
 
 from time import sleep
-from time import time
 from typing import Type
 
 from vyos.configsession import ConfigSession
@@ -29,6 +28,14 @@ from vyos.utils.process import cmd
 from vyos.utils.process import run
 
 save_config = '/tmp/vyos-smoketest-save'
+
+# The commit process is not finished until all pending files from
+# VYATTA_CHANGES_ONLY_DIR are copied to VYATTA_ACTIVE_CONFIGURATION_DIR. This
+# is done inside libvyatta-cfg1 and the FUSE UnionFS part. On large non-
+# interactive commits FUSE UnionFS might not replicate the real state in time,
+# leading to errors when querying the working and effective configuration.
+# TO BE DELETED AFTER SWITCH TO IN MEMORY CONFIG
+CSTORE_GUARD_TIME = 4
 
 # This class acts as shim between individual Smoketests developed for VyOS and
 # the Python UnitTest framework. Before every test is loaded, we dump the current
@@ -44,7 +51,6 @@ class VyOSUnitTestSHIM:
         # trigger the certain failure condition.
         # Use "self.debug = True" in derived classes setUp() method
         debug = False
-        commit_guard = time()
         @classmethod
         def setUpClass(cls):
             cls._session = ConfigSession(os.getpid())
@@ -85,11 +91,12 @@ class VyOSUnitTestSHIM:
             if self.debug:
                 print('commit')
             self._session.commit()
-            # during a commit there is a process opening commit_lock, and run() returns 0
+            # During a commit there is a process opening commit_lock, and run()
+            # returns 0
             while run(f'sudo lsof -nP {commit_lock}') == 0:
                 sleep(0.250)
-            # reset getFRRconfig() guard timer
-            self.commit_guard = time()
+            # Wait for CStore completion for fast non-interactive commits
+            sleep(CSTORE_GUARD_TIME)
 
         def op_mode(self, path : list) -> None:
             """
@@ -105,7 +112,7 @@ class VyOSUnitTestSHIM:
             return out
 
         def getFRRconfig(self, string=None, end='$', endsection='^!',
-                         substring=None, endsubsection=None, guard_time=10, empty_retry=0):
+                         substring=None, endsubsection=None, empty_retry=0):
             """
             Retrieve current "running configuration" from FRR
 
@@ -115,11 +122,6 @@ class VyOSUnitTestSHIM:
             substring:     search section under the result found by string
             endsubsection: end of the subsection (usually something with "exit")
             """
-            # Sometimes FRR needs some time after reloading the configuration to
-            # appear in vtysh. This is a workaround addiung a 10 second guard timer
-            # between the last cli_commit() and the first read of FRR config via vtysh
-            while (time() - self.commit_guard) < guard_time:
-                sleep(0.250) # wait 250 milliseconds
             command = f'vtysh -c "show run no-header"'
             if string:
                 command += f' | sed -n "/^{string}{end}/,/{endsection}/p"'

--- a/smoketest/scripts/cli/test_interfaces_bonding.py
+++ b/smoketest/scripts/cli/test_interfaces_bonding.py
@@ -24,7 +24,6 @@ from vyos.ifconfig.interface import Interface
 from vyos.configsession import ConfigSessionError
 from vyos.utils.network import get_interface_config
 from vyos.utils.file import read_file
-from vyos.frrender import mgmt_daemon
 
 class BondingInterfaceTest(BasicInterfaceTest.TestCase):
     @classmethod
@@ -287,7 +286,7 @@ class BondingInterfaceTest(BasicInterfaceTest.TestCase):
 
         id = '5'
         for interface in self._interfaces:
-            frrconfig = self.getFRRconfig(f'interface {interface}', daemon=mgmt_daemon)
+            frrconfig = self.getFRRconfig(f'interface {interface}', endsection='^exit')
 
             self.assertIn(f' evpn mh es-id {id}', frrconfig)
             self.assertIn(f' evpn mh es-df-pref {id}', frrconfig)
@@ -304,7 +303,7 @@ class BondingInterfaceTest(BasicInterfaceTest.TestCase):
 
         id = '5'
         for interface in self._interfaces:
-            frrconfig = self.getFRRconfig(f'interface {interface}', daemon=mgmt_daemon)
+            frrconfig = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f' evpn mh es-sys-mac 00:12:34:56:78:0{id}', frrconfig)
             self.assertIn(f' evpn mh uplink', frrconfig)
 

--- a/smoketest/scripts/cli/test_interfaces_ethernet.py
+++ b/smoketest/scripts/cli/test_interfaces_ethernet.py
@@ -27,13 +27,11 @@ from netifaces import ifaddresses
 from base_interfaces_test import BasicInterfaceTest
 from vyos.configsession import ConfigSessionError
 from vyos.ifconfig import Section
-from vyos.frrender import mgmt_daemon
 from vyos.utils.file import read_file
 from vyos.utils.network import is_intf_addr_assigned
 from vyos.utils.network import is_ipv6_link_local
 from vyos.utils.process import cmd
 from vyos.utils.process import popen
-
 
 class EthernetInterfaceTest(BasicInterfaceTest.TestCase):
     @classmethod
@@ -222,14 +220,14 @@ class EthernetInterfaceTest(BasicInterfaceTest.TestCase):
                 out = loads(out)
                 self.assertFalse(out[0]['autonegotiate'])
 
-    def test_ethtool_evpn_uplink_tarcking(self):
+    def test_ethtool_evpn_uplink_tracking(self):
         for interface in self._interfaces:
             self.cli_set(self._base_path + [interface, 'evpn', 'uplink'])
 
         self.cli_commit()
 
         for interface in self._interfaces:
-            frrconfig = self.getFRRconfig(f'interface {interface}', daemon=mgmt_daemon)
+            frrconfig = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(' evpn mh uplink', frrconfig)
 
     def test_switchdev(self):
@@ -240,7 +238,6 @@ class EthernetInterfaceTest(BasicInterfaceTest.TestCase):
         # should print out warning that enabling failed
 
         self.cli_delete(self._base_path + [interface, 'switchdev'])
-
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/smoketest/scripts/cli/test_protocols_babel.py
+++ b/smoketest/scripts/cli/test_protocols_babel.py
@@ -62,7 +62,7 @@ class TestProtocolsBABEL(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig('router babel', endsection='^exit', daemon=babel_daemon)
+        frrconfig = self.getFRRconfig('router babel', endsection='^exit')
         self.assertIn(f' babel diversity', frrconfig)
         self.assertIn(f' babel diversity-factor {diversity_factor}', frrconfig)
         self.assertIn(f' babel resend-delay {resend_delay}', frrconfig)
@@ -81,7 +81,7 @@ class TestProtocolsBABEL(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig('router babel', endsection='^exit', daemon=babel_daemon, empty_retry=5)
+        frrconfig = self.getFRRconfig('router babel', endsection='^exit', empty_retry=5)
         for protocol in ipv4_protos:
             self.assertIn(f' redistribute ipv4 {protocol}', frrconfig)
         for protocol in ipv6_protos:
@@ -150,7 +150,7 @@ class TestProtocolsBABEL(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig('router babel', endsection='^exit', daemon=babel_daemon)
+        frrconfig = self.getFRRconfig('router babel', endsection='^exit')
         self.assertIn(f' distribute-list {access_list_in4} in', frrconfig)
         self.assertIn(f' distribute-list {access_list_out4} out', frrconfig)
         self.assertIn(f' ipv6 distribute-list {access_list_in6} in', frrconfig)
@@ -198,11 +198,11 @@ class TestProtocolsBABEL(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig('router babel', endsection='^exit', daemon=babel_daemon)
+        frrconfig = self.getFRRconfig('router babel', endsection='^exit')
         for interface in self._interfaces:
             self.assertIn(f' network {interface}', frrconfig)
 
-            iface_config = self.getFRRconfig(f'interface {interface}', endsection='^exit', daemon=babel_daemon)
+            iface_config = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f' babel channel {channel}', iface_config)
             self.assertIn(f' babel enable-timestamps', iface_config)
             self.assertIn(f' babel update-interval {def_update_interval}', iface_config)

--- a/smoketest/scripts/cli/test_protocols_bfd.py
+++ b/smoketest/scripts/cli/test_protocols_bfd.py
@@ -22,7 +22,6 @@ from vyos.frrender import bfd_daemon
 from vyos.utils.process import process_named_running
 
 base_path = ['protocols', 'bfd']
-frr_endsection = '^ exit'
 
 dum_if = 'dum1001'
 vrf_name = 'red'
@@ -131,7 +130,7 @@ class TestProtocolsBFD(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR bgpd configuration
-        frrconfig = self.getFRRconfig('bfd', endsection='^exit', daemon=bfd_daemon)
+        frrconfig = self.getFRRconfig('bfd', endsection='^exit')
         for peer, peer_config in peers.items():
             tmp = f'peer {peer}'
             if 'multihop' in peer_config:
@@ -144,8 +143,8 @@ class TestProtocolsBFD(VyOSUnitTestSHIM.TestCase):
                 tmp += f' vrf {peer_config["vrf"]}'
 
             self.assertIn(tmp, frrconfig)
-            peerconfig = self.getFRRconfig(f' peer {peer}', end='', endsection=frr_endsection,
-                                           daemon=bfd_daemon)
+            peerconfig = self.getFRRconfig('bfd', endsection='^exit', substring=f' peer {peer}',
+                                           endsubsection='^ exit')
             if 'echo_mode' in peer_config:
                 self.assertIn(f'echo-mode', peerconfig)
             if 'intv_echo' in peer_config:
@@ -207,7 +206,8 @@ class TestProtocolsBFD(VyOSUnitTestSHIM.TestCase):
 
         # Verify FRR bgpd configuration
         for profile, profile_config in profiles.items():
-            config = self.getFRRconfig(f' profile {profile}', endsection=frr_endsection)
+            config = self.getFRRconfig('bfd', endsection='^exit',
+                                       substring=f' profile {profile}', endsubsection='^ exit',)
             if 'echo_mode' in profile_config:
                 self.assertIn(f' echo-mode', config)
             if 'intv_echo' in profile_config:
@@ -229,8 +229,8 @@ class TestProtocolsBFD(VyOSUnitTestSHIM.TestCase):
                 self.assertNotIn(f'shutdown', config)
 
         for peer, peer_config in peers.items():
-            peerconfig = self.getFRRconfig(f' peer {peer}', end='',
-                                           endsection=frr_endsection, daemon=bfd_daemon)
+            peerconfig = self.getFRRconfig('bfd', endsection='^exit',
+                                           substring=f' peer {peer}', endsubsection='^ exit')
             if 'profile' in peer_config:
                 self.assertIn(f' profile {peer_config["profile"]}', peerconfig)
 

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -217,7 +217,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(base_path)
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig('router bgp', endsection='^exit', daemon=bgp_daemon)
+        frrconfig = self.getFRRconfig('router bgp', endsection='^exit')
         self.assertNotIn(f'router bgp', frrconfig)
 
         # check process health and continuity
@@ -372,7 +372,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR bgpd configuration
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}', daemon=bgp_daemon)
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f' bgp router-id {router_id}', frrconfig)
         self.assertIn(f' bgp allow-martian-nexthop', frrconfig)
@@ -398,18 +398,21 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.assertNotIn(f'bgp ebgp-requires-policy', frrconfig)
         self.assertIn(f' no bgp suppress-duplicates', frrconfig)
 
-        afiv4_config = self.getFRRconfig(' address-family ipv4 unicast',
-                                         endsection='^ exit-address-family', daemon=bgp_daemon)
+        afiv4_config = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit',
+                                         substring=' address-family ipv4 unicast',
+                                         endsubsection='^ exit-address-family')
         self.assertIn(f'  maximum-paths {max_path_v4}', afiv4_config)
         self.assertIn(f'  maximum-paths ibgp {max_path_v4ibgp}', afiv4_config)
 
-        afiv4_config = self.getFRRconfig(' address-family ipv4 labeled-unicast',
-                                         endsection='^ exit-address-family', daemon=bgp_daemon)
+        afiv4_config = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit',
+                                         substring=' address-family ipv4 labeled-unicast',
+                                         endsubsection='^ exit-address-family')
         self.assertIn(f'  maximum-paths {max_path_v4}', afiv4_config)
         self.assertIn(f'  maximum-paths ibgp {max_path_v4ibgp}', afiv4_config)
 
-        afiv6_config = self.getFRRconfig(' address-family ipv6 unicast',
-                                         endsection='^ exit-address-family', daemon=bgp_daemon)
+        afiv6_config = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit',
+                                         substring=' address-family ipv6 unicast',
+                                         endsubsection='^ exit-address-family')
         self.assertIn(f'  maximum-paths {max_path_v6}', afiv6_config)
         self.assertIn(f'  maximum-paths ibgp {max_path_v6ibgp}', afiv6_config)
 
@@ -516,7 +519,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR bgpd configuration
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit', daemon=bgp_daemon)
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
 
         for peer, peer_config in neighbor_config.items():
@@ -621,7 +624,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR bgpd configuration
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit', daemon=bgp_daemon)
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
 
         for peer, peer_config in peer_group_config.items():
@@ -670,7 +673,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR bgpd configuration
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit', daemon=bgp_daemon)
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f' address-family ipv4 unicast', frrconfig)
 
@@ -716,7 +719,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR bgpd configuration
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit', daemon=bgp_daemon)
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f' address-family ipv6 unicast', frrconfig)
         # T2100: By default ebgp-requires-policy is disabled to keep VyOS
@@ -758,7 +761,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR bgpd configuration
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit', daemon=bgp_daemon)
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f' neighbor {peer_group} peer-group', frrconfig)
         self.assertIn(f' neighbor {peer_group} remote-as {ASN}', frrconfig)
@@ -793,7 +796,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR bgpd configuration
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit', daemon=bgp_daemon)
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f' address-family l2vpn evpn', frrconfig)
         self.assertIn(f'  advertise-all-vni', frrconfig)
@@ -806,7 +809,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'  flooding disable', frrconfig)
         self.assertIn(f'  mac-vrf soo {soo}', frrconfig)
         for vni in vnis:
-            vniconfig = self.getFRRconfig(f'  vni {vni}', endsection='^exit-vni')
+            vniconfig = self.getFRRconfig(f'  vni {vni}', endsection='^  exit-vni')
             self.assertIn(f'vni {vni}', vniconfig)
             self.assertIn(f'   advertise-default-gw', vniconfig)
             self.assertIn(f'   advertise-svi-ip', vniconfig)
@@ -849,7 +852,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR distances configuration
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         for family in verify_families:
             self.assertIn(f'address-family {family}', frrconfig)
@@ -887,7 +890,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR bgpd configuration
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f' address-family ipv6 unicast', frrconfig)
 
@@ -895,7 +898,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f'  import vrf {vrf}', frrconfig)
 
             # Verify FRR bgpd configuration
-            frr_vrf_config = self.getFRRconfig(f'router bgp {ASN} vrf {vrf}')
+            frr_vrf_config = self.getFRRconfig(f'router bgp {ASN} vrf {vrf}', endsection='^exit')
             self.assertIn(f'router bgp {ASN} vrf {vrf}', frr_vrf_config)
             self.assertIn(f' bgp router-id {router_id}', frr_vrf_config)
 
@@ -913,7 +916,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR bgpd configuration
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f' bgp router-id {router_id}', frrconfig)
         self.assertIn(f' bgp confederation identifier {confed_id}', frrconfig)
@@ -930,7 +933,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR bgpd configuration
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f' neighbor {interface} interface v6only remote-as {remote_asn}', frrconfig)
         self.assertIn(f' address-family ipv6 unicast', frrconfig)
@@ -962,11 +965,13 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR bgpd configuration
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
 
         for afi in ['ipv4', 'ipv6']:
-            afi_config = self.getFRRconfig(f' address-family {afi} unicast', endsection='exit-address-family', daemon=bgp_daemon)
+            afi_config = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit',
+                                           substring=f' address-family {afi} unicast',
+                                           endsubsection='^ exit-address-family')
             self.assertIn(f'address-family {afi} unicast', afi_config)
             self.assertIn(f'  export vpn', afi_config)
             self.assertIn(f'  import vpn', afi_config)
@@ -1011,7 +1016,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f' neighbor {neighbor} peer-group {peer_group}', frrconfig)
         self.assertIn(f' neighbor {peer_group} peer-group', frrconfig)
@@ -1036,7 +1041,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f' neighbor {neighbor} remote-as {remote_asn}', frrconfig)
         self.assertIn(f' neighbor {neighbor} local-as {local_asn}', frrconfig)
@@ -1061,8 +1066,8 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
             base_path + ['address-family', import_afi, 'import', 'vrf',
                          import_vrf])
         self.cli_commit()
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
-        frrconfig_vrf = self.getFRRconfig(f'router bgp {ASN} vrf {import_vrf}')
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
+        frrconfig_vrf = self.getFRRconfig(f'router bgp {ASN} vrf {import_vrf}', endsection='^exit')
 
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f'address-family ipv4 unicast', frrconfig)
@@ -1084,8 +1089,8 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
             base_path + ['address-family', import_afi, 'import', 'vrf',
                          import_vrf])
         self.cli_commit()
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
-        frrconfig_vrf = self.getFRRconfig(f'router bgp {ASN} vrf {import_vrf}')
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
+        frrconfig_vrf = self.getFRRconfig(f'router bgp {ASN} vrf {import_vrf}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f'address-family ipv4 unicast', frrconfig)
         self.assertIn(f'  import vrf {import_vrf}', frrconfig)
@@ -1098,8 +1103,8 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         # Verify deleting existent vrf default if other vrfs were created
         self.create_bgp_instances_for_import_test()
         self.cli_commit()
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
-        frrconfig_vrf = self.getFRRconfig(f'router bgp {ASN} vrf {import_vrf}')
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
+        frrconfig_vrf = self.getFRRconfig(f'router bgp {ASN} vrf {import_vrf}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f'router bgp {ASN} vrf {import_vrf}', frrconfig_vrf)
         self.cli_delete(base_path)
@@ -1115,8 +1120,8 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
                                                           'vpn', 'export',
                                                           import_rd])
         self.cli_commit()
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
-        frrconfig_vrf = self.getFRRconfig(f'router bgp {ASN} vrf {import_vrf}')
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
+        frrconfig_vrf = self.getFRRconfig(f'router bgp {ASN} vrf {import_vrf}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f'router bgp {ASN} vrf {import_vrf}', frrconfig_vrf)
         self.assertIn(f'address-family ipv4 unicast', frrconfig_vrf)
@@ -1145,7 +1150,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         for interface in interfaces:
-            frrconfig = self.getFRRconfig(f'interface {interface}')
+            frrconfig = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f'interface {interface}', frrconfig)
             self.assertIn(f' mpls bgp forwarding', frrconfig)
 
@@ -1159,7 +1164,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         for interface in interfaces:
-            frrconfig = self.getFRRconfig(f'interface {interface}')
+            frrconfig = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f'interface {interface}', frrconfig)
             self.assertIn(f' mpls bgp forwarding', frrconfig)
             self.cli_delete(['interfaces', 'ethernet', interface, 'vrf'])
@@ -1179,7 +1184,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(base_path + ['address-family', 'ipv4-unicast', 'sid'])
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f' segment-routing srv6', frrconfig)
         self.assertIn(f'  locator {locator_name}', frrconfig)
@@ -1194,17 +1199,22 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f' segment-routing srv6', frrconfig)
         self.assertIn(f'  locator {locator_name}', frrconfig)
 
-        afiv4_config = self.getFRRconfig(' address-family ipv4 unicast')
+        afiv4_config = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit',
+                                         substring=' address-family ipv4 unicast',
+                                         endsubsection='^ exit-address-family')
         self.assertIn(f' sid vpn export {sid}', afiv4_config)
         self.assertIn(f' nexthop vpn export {nexthop_ipv4}', afiv4_config)
-        afiv6_config = self.getFRRconfig(' address-family ipv6 unicast')
+
+        afiv6_config = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit',
+                                         substring=' address-family ipv6 unicast',
+                                         endsubsection='^ exit-address-family')
         self.assertIn(f' sid vpn export {sid}', afiv6_config)
-        self.assertIn(f' nexthop vpn export {nexthop_ipv6}', afiv4_config)
+        self.assertIn(f' nexthop vpn export {nexthop_ipv6}', afiv6_config)
 
     def test_bgp_25_ipv4_labeled_unicast_peer_group(self):
         pg_ipv4 = 'foo4'
@@ -1218,14 +1228,16 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f' neighbor {pg_ipv4} peer-group', frrconfig)
         self.assertIn(f' neighbor {pg_ipv4} remote-as external', frrconfig)
         self.assertIn(f' bgp listen range {ipv4_prefix} peer-group {pg_ipv4}', frrconfig)
         self.assertIn(f' bgp labeled-unicast ipv4-explicit-null', frrconfig)
 
-        afiv4_config = self.getFRRconfig(' address-family ipv4 labeled-unicast')
+        afiv4_config = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit',
+                                         substring=' address-family ipv4 labeled-unicast',
+                                         endsubsection='^ exit-address-family')
         self.assertIn(f'  neighbor {pg_ipv4} activate', afiv4_config)
         self.assertIn(f'  neighbor {pg_ipv4} maximum-prefix {ipv4_max_prefix}', afiv4_config)
 
@@ -1242,14 +1254,16 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f' neighbor {pg_ipv6} peer-group', frrconfig)
         self.assertIn(f' neighbor {pg_ipv6} remote-as external', frrconfig)
         self.assertIn(f' bgp listen range {ipv6_prefix} peer-group {pg_ipv6}', frrconfig)
         self.assertIn(f' bgp labeled-unicast ipv6-explicit-null', frrconfig)
 
-        afiv6_config = self.getFRRconfig(' address-family ipv6 labeled-unicast')
+        afiv6_config = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit',
+                                         substring=' address-family ipv6 labeled-unicast',
+                                         endsubsection='^ exit-address-family')
         self.assertIn(f'  neighbor {pg_ipv6} activate', afiv6_config)
         self.assertIn(f'  neighbor {pg_ipv6} maximum-prefix {ipv6_max_prefix}', afiv6_config)
 
@@ -1261,7 +1275,8 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['peer-group', 'peer1', 'remote-as', 'internal'])
         self.cli_commit()
 
-        conf = self.getFRRconfig(' address-family l2vpn evpn')
+        conf = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit',
+                                 substring=' address-family l2vpn evpn', endsubsection='^ exit-address-family')
 
         self.assertIn('neighbor peer1 route-reflector-client', conf)
 
@@ -1300,7 +1315,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['neighbor', int_neighbors[1], 'remote-as', ASN])
         self.cli_commit()
 
-        conf = self.getFRRconfig(f'router bgp {ASN}')
+        conf = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         _common_config_check(conf)
 
         # test add internal remote-as to external group
@@ -1315,7 +1330,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['neighbor', ext_neighbors[1], 'remote-as', f'{int(ASN) + 2}'])
         self.cli_commit()
 
-        conf = self.getFRRconfig(f'router bgp {ASN}')
+        conf = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         _common_config_check(conf)
         self.assertIn(f'neighbor {ext_neighbors[1]} remote-as {int(ASN) + 2}', conf)
         self.assertIn(f'neighbor {ext_neighbors[1]} peer-group {ext_pg_name}', conf)
@@ -1327,7 +1342,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['neighbor', ext_neighbors[1], 'remote-as', 'external'])
         self.cli_commit()
 
-        conf = self.getFRRconfig(f'router bgp {ASN}')
+        conf = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         _common_config_check(conf, include_ras=False)
 
         self.assertIn(f'neighbor {int_neighbors[0]} remote-as internal', conf)
@@ -1352,7 +1367,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        conf = self.getFRRconfig(f'router bgp {ASN}')
+        conf = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
 
         self.assertIn(f'neighbor OVERLAY remote-as {int(ASN) + 1}', conf)
         self.assertIn(f'neighbor OVERLAY local-as {int(ASN) + 1}', conf)
@@ -1405,7 +1420,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify bgpd bmp configuration
-        frrconfig = self.getFRRconfig(f'router bgp {ASN}')
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
         self.assertIn(f'bmp mirror buffer-limit {mirror_buffer}', frrconfig)
         self.assertIn(f'bmp targets {target_name}', frrconfig)
         self.assertIn(f'bmp mirror', frrconfig)

--- a/smoketest/scripts/cli/test_protocols_mpls.py
+++ b/smoketest/scripts/cli/test_protocols_mpls.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2023 VyOS maintainers and contributors
+# Copyright (C) 2021-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -106,12 +106,14 @@ class TestProtocolsMPLS(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Validate configuration
-        frrconfig = self.getFRRconfig('mpls ldp', daemon=ldpd_daemon)
+        frrconfig = self.getFRRconfig('mpls ldp', endsection='^exit')
         self.assertIn(f'mpls ldp', frrconfig)
         self.assertIn(f' router-id {router_id}', frrconfig)
 
         # Validate AFI IPv4
-        afiv4_config = self.getFRRconfig(' address-family ipv4', daemon=ldpd_daemon)
+        afiv4_config = self.getFRRconfig('mpls ldp', endsection='^exit',
+                                         substring=' address-family ipv4',
+                                         endsubsection='^ exit-address-family')
         self.assertIn(f'  discovery transport-address {transport_ipv4_addr}', afiv4_config)
         for interface in interfaces:
             self.assertIn(f'  interface {interface}', afiv4_config)

--- a/smoketest/scripts/cli/test_protocols_openfabric.py
+++ b/smoketest/scripts/cli/test_protocols_openfabric.py
@@ -75,14 +75,14 @@ class TestProtocolsOpenFabric(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify all changes
-        tmp = self.getFRRconfig(f'router openfabric {domain}', daemon=openfabric_daemon)
+        tmp = self.getFRRconfig(f'router openfabric {domain}', endsection='^exit')
         self.assertIn(f' net {net}', tmp)
         self.assertIn(f' log-adjacency-changes', tmp)
         self.assertIn(f' set-overload-bit', tmp)
         self.assertIn(f' fabric-tier {fabric_tier}', tmp)
         self.assertIn(f' lsp-gen-interval {lsp_gen_interval}', tmp)
 
-        tmp = self.getFRRconfig(f'interface {dummy_if}', daemon=openfabric_daemon)
+        tmp = self.getFRRconfig(f'interface {dummy_if}', endsection='^exit')
         self.assertIn(f' ip router openfabric {domain}', tmp)
         self.assertIn(f' ipv6 router openfabric {domain}', tmp)
 
@@ -101,12 +101,12 @@ class TestProtocolsOpenFabric(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR openfabric configuration
-        tmp = self.getFRRconfig(f'router openfabric {domain}', daemon=openfabric_daemon)
+        tmp = self.getFRRconfig(f'router openfabric {domain}', endsection='^exit')
         self.assertIn(f'router openfabric {domain}', tmp)
         self.assertIn(f' net {net}', tmp)
 
         # Verify interface configuration
-        tmp = self.getFRRconfig(f'interface {interface}', daemon=openfabric_daemon)
+        tmp = self.getFRRconfig(f'interface {interface}', endsection='^exit')
         self.assertIn(f' ip router openfabric {domain}', tmp)
         # for lo interface 'openfabric passive' is implied
         self.assertIn(f' openfabric passive', tmp)
@@ -137,11 +137,11 @@ class TestProtocolsOpenFabric(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify all changes
-        tmp = self.getFRRconfig(f'router openfabric {domain}', daemon=openfabric_daemon)
+        tmp = self.getFRRconfig(f'router openfabric {domain}', endsection='^exit')
         self.assertIn(f' net {net}', tmp)
         self.assertIn(f' domain-password clear {password}', tmp)
 
-        tmp = self.getFRRconfig(f'interface {dummy_if}', daemon=openfabric_daemon)
+        tmp = self.getFRRconfig(f'interface {dummy_if}', endsection='^exit')
         self.assertIn(f' openfabric password clear {password}-{dummy_if}', tmp)
 
     def test_openfabric_multiple_domains(self):
@@ -165,22 +165,21 @@ class TestProtocolsOpenFabric(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR openfabric configuration
-        tmp = self.getFRRconfig(f'router openfabric {domain}', daemon=openfabric_daemon)
+        tmp = self.getFRRconfig(f'router openfabric {domain}', endsection='^exit')
         self.assertIn(f'router openfabric {domain}', tmp)
         self.assertIn(f' net {net}', tmp)
 
-        tmp = self.getFRRconfig(f'router openfabric {domain_2}', daemon=openfabric_daemon)
+        tmp = self.getFRRconfig(f'router openfabric {domain_2}', endsection='^exit')
         self.assertIn(f'router openfabric {domain_2}', tmp)
         self.assertIn(f' net {net}', tmp)
 
         # Verify interface configuration
-        tmp = self.getFRRconfig(f'interface {dummy_if}', daemon=openfabric_daemon)
+        tmp = self.getFRRconfig(f'interface {dummy_if}', endsection='^exit')
         self.assertIn(f' ip router openfabric {domain}', tmp)
         self.assertIn(f' ipv6 router openfabric {domain}', tmp)
 
-        tmp = self.getFRRconfig(f'interface {interface}', daemon=openfabric_daemon)
+        tmp = self.getFRRconfig(f'interface {interface}', endsection='^exit')
         self.assertIn(f' ip router openfabric {domain_2}', tmp)
-
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/smoketest/scripts/cli/test_protocols_ospf.py
+++ b/smoketest/scripts/cli/test_protocols_ospf.py
@@ -56,7 +56,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(base_path)
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertNotIn(f'router ospf', frrconfig)
 
         # check process health and continuity
@@ -68,7 +68,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f'router ospf', frrconfig)
         self.assertIn(f' auto-cost reference-bandwidth 100', frrconfig)
         self.assertIn(f' timers throttle spf 200 1000 10000', frrconfig) # defaults
@@ -96,7 +96,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f'router ospf', frrconfig)
         self.assertIn(f' compatible rfc1583', frrconfig)
         self.assertIn(f' auto-cost reference-bandwidth {bandwidth}', frrconfig)
@@ -111,7 +111,6 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f' area 10 range 10.0.1.0/24', frrconfig)
         self.assertNotIn(f' area 10 range 10.0.1.0/24 not-advertise', frrconfig)
         self.assertIn(f' area 10 range 10.0.2.0/24 not-advertise', frrconfig)
-
 
     def test_ospf_03_access_list(self):
         acl = '100'
@@ -128,13 +127,12 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f'router ospf', frrconfig)
         self.assertIn(f' timers throttle spf 200 1000 10000', frrconfig) # defaults
         for ptotocol in protocols:
             self.assertIn(f' distribute-list {acl} out {ptotocol}', frrconfig) # defaults
         self.cli_delete(['policy', 'access-list', acl])
-
 
     def test_ospf_04_default_originate(self):
         seq = '100'
@@ -149,7 +147,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f'router ospf', frrconfig)
         self.assertIn(f' timers throttle spf 200 1000 10000', frrconfig) # defaults
         self.assertIn(f' default-information originate metric {metric} metric-type {metric_type} route-map {route_map}', frrconfig)
@@ -159,9 +157,8 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f' default-information originate always metric {metric} metric-type {metric_type} route-map {route_map}', frrconfig)
-
 
     def test_ospf_05_options(self):
         global_distance = '128'
@@ -201,7 +198,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f'router ospf', frrconfig)
         self.assertIn(f' mpls-te on', frrconfig)
         self.assertIn(f' mpls-te router-address 0.0.0.0', frrconfig) # default
@@ -224,7 +221,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['distance', 'ospf', 'inter-area', inter_area])
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f' distance ospf intra-area {intra_area} inter-area {inter_area} external {external}', frrconfig)
 
         # https://github.com/FRRouting/frr/issues/17011
@@ -247,7 +244,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f'router ospf', frrconfig)
         for neighbor in neighbors:
             self.assertIn(f' neighbor {neighbor} priority {priority} poll-interval {poll_interval}', frrconfig) # default
@@ -266,7 +263,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f'router ospf', frrconfig)
         for protocol in redistribute:
             self.assertIn(f' redistribute {protocol} metric {metric} metric-type {metric_type} route-map {route_map}', frrconfig)
@@ -294,7 +291,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f'router ospf', frrconfig)
         self.assertIn(f' area {area} shortcut {shortcut}', frrconfig)
         self.assertIn(f' area {area} virtual-link {virtual_link} hello-interval {hello} retransmit-interval {retransmit} retransmit-window {window_default} transmit-delay {transmit} dead-interval {dead}', frrconfig)
@@ -326,13 +323,13 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         # commit changes
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f'router ospf', frrconfig)
         self.assertIn(f' passive-interface default', frrconfig)
 
         for interface in interfaces:
             # Can not use daemon for getFRRconfig() as bandwidth parameter belongs to zebra process
-            config = self.getFRRconfig(f'interface {interface}')
+            config = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f'interface {interface}', config)
             self.assertIn(f' ip ospf authentication-key {password}', config)
             self.assertIn(f' ip ospf bfd', config)
@@ -350,7 +347,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
 
         for interface in interfaces:
             # T5467: It must also be removed from FRR config
-            frrconfig = self.getFRRconfig(f'interface {interface}', daemon=ospf_daemon)
+            frrconfig = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertNotIn(f'interface {interface}', frrconfig)
             # There should be no OSPF related command at all under the interface
             self.assertNotIn(f' ip ospf', frrconfig)
@@ -371,11 +368,11 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f'router ospf', frrconfig)
 
         for interface in interfaces:
-            config = self.getFRRconfig(f'interface {interface}', daemon=ospf_daemon)
+            config = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f'interface {interface}', config)
             self.assertIn(f' ip ospf area {area}', config)
 
@@ -398,17 +395,17 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f'router ospf', frrconfig)
         self.assertIn(f' auto-cost reference-bandwidth 100', frrconfig)
         self.assertIn(f' timers throttle spf 200 1000 10000', frrconfig) # defaults
 
-        frrconfig = self.getFRRconfig(f'router ospf vrf {vrf}', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig(f'router ospf vrf {vrf}', endsection='^exit')
         self.assertIn(f'router ospf vrf {vrf}', frrconfig)
         self.assertIn(f' auto-cost reference-bandwidth 100', frrconfig)
         self.assertIn(f' timers throttle spf 200 1000 10000', frrconfig) # defaults
 
-        frrconfig = self.getFRRconfig(f'interface {vrf_iface}', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig(f'interface {vrf_iface}', endsection='^exit')
         self.assertIn(f'interface {vrf_iface}', frrconfig)
         self.assertIn(f' ip ospf area {area}', frrconfig)
 
@@ -418,7 +415,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # T5467: It must also be removed from FRR config
-        frrconfig = self.getFRRconfig(f'interface {vrf_iface}', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig(f'interface {vrf_iface}', endsection='^exit')
         self.assertNotIn(f'interface {vrf_iface}', frrconfig)
         # There should be no OSPF related command at all under the interface
         self.assertNotIn(f' ip ospf', frrconfig)
@@ -444,7 +441,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f'router ospf', frrconfig)
         self.assertIn(f' timers throttle spf 200 1000 10000', frrconfig) # default
         self.assertIn(f' network {network} area {area}', frrconfig)
@@ -477,7 +474,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify all changes
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f' segment-routing on', frrconfig)
         self.assertIn(f' segment-routing global-block {global_block_low} {global_block_high} local-block {local_block_low} {local_block_high}', frrconfig)
         self.assertIn(f' segment-routing node-msd {maximum_stack_size}', frrconfig)
@@ -495,7 +492,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify main OSPF changes
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f'router ospf', frrconfig)
         self.assertIn(f' timers throttle spf 200 1000 10000', frrconfig)
         self.assertIn(f' mpls ldp-sync holddown {holddown}', frrconfig)
@@ -508,7 +505,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
 
         for interface in interfaces:
             # Verify interface changes for holddown
-            config = self.getFRRconfig(f'interface {interface}', daemon=ospf_daemon)
+            config = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f'interface {interface}', config)
             self.assertIn(f' ip ospf dead-interval 40', config)
             self.assertIn(f' ip ospf mpls ldp-sync', config)
@@ -522,7 +519,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
 
         for interface in interfaces:
             # Verify interface changes for disable
-            config = self.getFRRconfig(f'interface {interface}', daemon=ospf_daemon)
+            config = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f'interface {interface}', config)
             self.assertIn(f' ip ospf dead-interval 40', config)
             self.assertNotIn(f' ip ospf mpls ldp-sync', config)
@@ -544,7 +541,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
         self.assertIn(f'router ospf', frrconfig)
         self.assertIn(f' capability opaque', frrconfig)
         self.assertIn(f' graceful-restart grace-period {period}', frrconfig)
@@ -570,7 +567,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', daemon=ospf_daemon, empty_retry=60)
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit', empty_retry=60)
         self.assertIn(f'router ospf', frrconfig)
         self.assertIn(f' network {network} area {area1}', frrconfig)
 

--- a/smoketest/scripts/cli/test_protocols_ospfv3.py
+++ b/smoketest/scripts/cli/test_protocols_ospfv3.py
@@ -54,7 +54,7 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(base_path)
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit', daemon=ospf6_daemon)
+        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit')
         self.assertNotIn(f'router ospf6', frrconfig)
 
         # check process health and continuity
@@ -81,7 +81,7 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit', daemon=ospf6_daemon)
+        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit')
         self.assertIn(f'router ospf6', frrconfig)
         self.assertIn(f' area {default_area} range {prefix}', frrconfig)
         self.assertIn(f' ospf6 router-id {router_id}', frrconfig)
@@ -89,7 +89,7 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f' area {default_area} export-list {acl_name}', frrconfig)
 
         for interface in interfaces:
-            if_config = self.getFRRconfig(f'interface {interface}', daemon=ospf6_daemon)
+            if_config = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f'ipv6 ospf6 area {default_area}', if_config)
 
         self.cli_delete(['policy', 'access-list6', acl_name])
@@ -110,7 +110,7 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit', daemon=ospf6_daemon)
+        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit')
         self.assertIn(f'router ospf6', frrconfig)
         self.assertIn(f' distance {dist_global}', frrconfig)
         self.assertIn(f' distance ospf6 intra-area {dist_intra_area} inter-area {dist_inter_area} external {dist_external}', frrconfig)
@@ -134,7 +134,7 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit', daemon=ospf6_daemon)
+        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit')
         self.assertIn(f'router ospf6', frrconfig)
         for protocol in redistribute:
             self.assertIn(f' redistribute {protocol} metric {metric} metric-type {metric_type} route-map {route_map}', frrconfig)
@@ -165,13 +165,13 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit', daemon=ospf6_daemon)
+        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit')
         self.assertIn(f'router ospf6', frrconfig)
 
         cost = '100'
         priority = '10'
         for interface in interfaces:
-            if_config = self.getFRRconfig(f'interface {interface}', daemon=ospf6_daemon)
+            if_config = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f'interface {interface}', if_config)
             self.assertIn(f' ipv6 ospf6 bfd', if_config)
             self.assertIn(f' ipv6 ospf6 bfd profile {bfd_profile}', if_config)
@@ -188,7 +188,7 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         for interface in interfaces:
-            if_config = self.getFRRconfig(f'interface {interface}', daemon=ospf6_daemon)
+            if_config = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             # There should be no OSPF6 configuration at all after interface removal
             self.assertNotIn(f' ipv6 ospf6', if_config)
 
@@ -204,7 +204,7 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit', daemon=ospf6_daemon)
+        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit')
         self.assertIn(f'router ospf6', frrconfig)
         self.assertIn(f' area {area_stub} stub', frrconfig)
         self.assertIn(f' area {area_stub_nosum} stub no-summary', frrconfig)
@@ -230,7 +230,7 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit', daemon=ospf6_daemon)
+        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit')
         self.assertIn(f'router ospf6', frrconfig)
         self.assertIn(f' area {area_nssa} nssa', frrconfig)
         self.assertIn(f' area {area_nssa_nosum} nssa default-information-originate no-summary', frrconfig)
@@ -250,7 +250,7 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit', daemon=ospf6_daemon)
+        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit')
         self.assertIn(f'router ospf6', frrconfig)
         self.assertIn(f' default-information originate metric {metric} metric-type {metric_type} route-map {route_map}', frrconfig)
 
@@ -259,7 +259,7 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit', daemon=ospf6_daemon)
+        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit')
         self.assertIn(f' default-information originate always metric {metric} metric-type {metric_type} route-map {route_map}', frrconfig)
 
 
@@ -285,15 +285,15 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit', daemon=ospf6_daemon)
+        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit')
         self.assertIn(f'router ospf6', frrconfig)
         self.assertIn(f' ospf6 router-id {router_id}', frrconfig)
 
-        frrconfig = self.getFRRconfig(f'interface {vrf_iface}', daemon=ospf6_daemon)
+        frrconfig = self.getFRRconfig(f'interface {vrf_iface}', endsection='^exit')
         self.assertIn(f'interface {vrf_iface}', frrconfig)
         self.assertIn(f' ipv6 ospf6 bfd', frrconfig)
 
-        frrconfig = self.getFRRconfig(f'router ospf6 vrf {vrf}', daemon=ospf6_daemon)
+        frrconfig = self.getFRRconfig(f'router ospf6 vrf {vrf}', endsection='^exit')
         self.assertIn(f'router ospf6 vrf {vrf}', frrconfig)
         self.assertIn(f' ospf6 router-id {router_id_vrf}', frrconfig)
 
@@ -303,7 +303,7 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # T5467: It must also be removed from FRR config
-        frrconfig = self.getFRRconfig(f'interface {vrf_iface}', daemon=ospf6_daemon)
+        frrconfig = self.getFRRconfig(f'interface {vrf_iface}', endsection='^exit')
         self.assertNotIn(f'interface {vrf_iface}', frrconfig)
         # There should be no OSPF related command at all under the interface
         self.assertNotIn(f' ipv6 ospf6', frrconfig)
@@ -329,7 +329,7 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit', daemon=ospf6_daemon)
+        frrconfig = self.getFRRconfig('router ospf6', endsection='^exit')
         self.assertIn(f'router ospf6', frrconfig)
         self.assertIn(f' graceful-restart grace-period {period}', frrconfig)
         self.assertIn(f' graceful-restart helper planned-only', frrconfig)

--- a/smoketest/scripts/cli/test_protocols_pim.py
+++ b/smoketest/scripts/cli/test_protocols_pim.py
@@ -57,11 +57,11 @@ class TestProtocolsPIM(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR pimd configuration
-        frrconfig = self.getFRRconfig('router pim', endsection='^exit', daemon=pim_daemon)
+        frrconfig = self.getFRRconfig('router pim', endsection='^exit')
         self.assertIn(f' rp {rp} {group}', frrconfig)
 
         for interface in interfaces:
-            frrconfig = self.getFRRconfig(f'interface {interface}', daemon=pim_daemon)
+            frrconfig = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f'interface {interface}', frrconfig)
             self.assertIn(f' ip pim', frrconfig)
             self.assertIn(f' ip pim bfd', frrconfig)
@@ -108,7 +108,7 @@ class TestProtocolsPIM(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR pimd configuration
-        frrconfig = self.getFRRconfig('router pim', endsection='^exit', daemon=pim_daemon)
+        frrconfig = self.getFRRconfig('router pim', endsection='^exit')
         self.assertIn(f' no send-v6-secondary', frrconfig)
         self.assertIn(f' rp {rp} {group}', frrconfig)
         self.assertIn(f' register-suppress-time {register_suppress_time}', frrconfig)
@@ -170,11 +170,11 @@ class TestProtocolsPIM(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig(daemon=pim_daemon)
+        frrconfig = self.getFRRconfig()
         self.assertIn(f'ip igmp watermark-warn {watermark_warning}', frrconfig)
 
         for interface in interfaces:
-            frrconfig = self.getFRRconfig(f'interface {interface}', daemon=pim_daemon)
+            frrconfig = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f'interface {interface}', frrconfig)
             self.assertIn(f' ip igmp', frrconfig)
             self.assertIn(f' ip igmp version {version}', frrconfig)

--- a/smoketest/scripts/cli/test_protocols_pim6.py
+++ b/smoketest/scripts/cli/test_protocols_pim6.py
@@ -52,7 +52,7 @@ class TestProtocolsPIMv6(VyOSUnitTestSHIM.TestCase):
 
         # Verify FRR pim6d configuration
         for interface in interfaces:
-            config = self.getFRRconfig(f'interface {interface}', daemon=pim6_daemon)
+            config = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f'interface {interface}', config)
             self.assertIn(f' ipv6 mld', config)
             self.assertNotIn(f' ipv6 mld version 1', config)
@@ -65,7 +65,7 @@ class TestProtocolsPIMv6(VyOSUnitTestSHIM.TestCase):
 
         # Verify FRR pim6d configuration
         for interface in interfaces:
-            config = self.getFRRconfig(f'interface {interface}', daemon=pim6_daemon)
+            config = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f'interface {interface}', config)
             self.assertIn(f' ipv6 mld', config)
             self.assertIn(f' ipv6 mld version 1', config)
@@ -88,7 +88,7 @@ class TestProtocolsPIMv6(VyOSUnitTestSHIM.TestCase):
 
         # Verify FRR pim6d configuration
         for interface in interfaces:
-            config = self.getFRRconfig(f'interface {interface}', daemon=pim6_daemon)
+            config = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f'interface {interface}', config)
             self.assertIn(f' ipv6 mld join-group ff18::1234', config)
 
@@ -100,7 +100,7 @@ class TestProtocolsPIMv6(VyOSUnitTestSHIM.TestCase):
 
         # Verify FRR pim6d configuration
         for interface in interfaces:
-            config = self.getFRRconfig(f'interface {interface}', daemon=pim6_daemon)
+            config = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f'interface {interface}', config)
             self.assertIn(f' ipv6 mld join-group ff38::5678 2001:db8::5678', config)
 
@@ -128,14 +128,14 @@ class TestProtocolsPIMv6(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR pim6d configuration
-        config = self.getFRRconfig('router pim6', endsection='^exit', daemon=pim6_daemon)
+        config = self.getFRRconfig('router pim6', endsection='^exit')
         self.assertIn(f' join-prune-interval {join_prune_interval}', config)
         self.assertIn(f' keep-alive-timer {keep_alive_timer}', config)
         self.assertIn(f' packets {packets}', config)
         self.assertIn(f' register-suppress-time {register_suppress_time}', config)
 
         for interface in interfaces:
-            config = self.getFRRconfig(f'interface {interface}', daemon=pim6_daemon)
+            config = self.getFRRconfig(f'interface {interface}', endsection='^exit')
             self.assertIn(f' ipv6 pim drpriority {dr_priority}', config)
             self.assertIn(f' ipv6 pim hello {hello}', config)
             self.assertIn(f' no ipv6 pim bsm', config)

--- a/smoketest/scripts/cli/test_protocols_rip.py
+++ b/smoketest/scripts/cli/test_protocols_rip.py
@@ -66,7 +66,7 @@ class TestProtocolsRIP(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(base_path)
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig('router rip')
+        frrconfig = self.getFRRconfig('router rip', endsection='^exit')
         self.assertNotIn(f'router rip', frrconfig)
 
         # check process health and continuity
@@ -116,7 +116,7 @@ class TestProtocolsRIP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ripd configuration
-        frrconfig = self.getFRRconfig('router rip')
+        frrconfig = self.getFRRconfig('router rip', endsection='^exit')
         self.assertIn(f'router rip', frrconfig)
         self.assertIn(f' distance {distance}', frrconfig)
         self.assertIn(f' default-information originate', frrconfig)
@@ -175,10 +175,10 @@ class TestProtocolsRIP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR configuration
-        frrconfig = self.getFRRconfig('router rip')
+        frrconfig = self.getFRRconfig('router rip', endsection='^exit')
         self.assertIn(f'version {tx_version}', frrconfig)
 
-        frrconfig = self.getFRRconfig(f'interface {interface}')
+        frrconfig = self.getFRRconfig(f'interface {interface}', endsection='^exit')
         self.assertIn(f' ip rip receive version {rx_version}', frrconfig)
         self.assertIn(f' ip rip send version {tx_version}', frrconfig)
 

--- a/smoketest/scripts/cli/test_protocols_ripng.py
+++ b/smoketest/scripts/cli/test_protocols_ripng.py
@@ -66,7 +66,7 @@ class TestProtocolsRIPng(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(base_path)
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig('router ripng')
+        frrconfig = self.getFRRconfig('router ripng', endsection='^exit')
         self.assertNotIn(f'router ripng', frrconfig)
 
         # check process health and continuity
@@ -113,7 +113,7 @@ class TestProtocolsRIPng(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR ospfd configuration
-        frrconfig = self.getFRRconfig('router ripng')
+        frrconfig = self.getFRRconfig('router ripng', endsection='^exit')
         self.assertIn(f'router ripng', frrconfig)
         self.assertIn(f' default-information originate', frrconfig)
         self.assertIn(f' default-metric {metric}', frrconfig)

--- a/smoketest/scripts/cli/test_protocols_rpki.py
+++ b/smoketest/scripts/cli/test_protocols_rpki.py
@@ -116,7 +116,7 @@ class TestProtocolsRPKI(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(base_path)
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig('rpki')
+        frrconfig = self.getFRRconfig('rpki', endsection='^exit')
         self.assertNotIn(f'rpki', frrconfig)
 
         # check process health and continuity
@@ -153,7 +153,7 @@ class TestProtocolsRPKI(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR configuration
-        frrconfig = self.getFRRconfig('rpki')
+        frrconfig = self.getFRRconfig('rpki', endsection='^exit')
         self.assertIn(f'rpki expire_interval {expire_interval}', frrconfig)
         self.assertIn(f'rpki polling_period {polling_period}', frrconfig)
         self.assertIn(f'rpki retry_interval {retry_interval}', frrconfig)
@@ -192,7 +192,7 @@ class TestProtocolsRPKI(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR configuration
-        frrconfig = self.getFRRconfig('rpki')
+        frrconfig = self.getFRRconfig('rpki', endsection='^exit')
         for cache_name, cache_config in cache.items():
             port = cache_config['port']
             preference = cache_config['preference']

--- a/smoketest/scripts/cli/test_protocols_segment-routing.py
+++ b/smoketest/scripts/cli/test_protocols_segment-routing.py
@@ -68,7 +68,7 @@ class TestProtocolsSegmentRouting(VyOSUnitTestSHIM.TestCase):
             self.assertEqual(sysctl_read(f'net.ipv6.conf.{interface}.seg6_enabled'), '1')
             self.assertEqual(sysctl_read(f'net.ipv6.conf.{interface}.seg6_require_hmac'), '0') # default
 
-        frrconfig = self.getFRRconfig(f'segment-routing', daemon=zebra_daemon)
+        frrconfig = self.getFRRconfig(f'segment-routing', endsection='^exit')
         self.assertIn(f'segment-routing', frrconfig)
         self.assertIn(f' srv6', frrconfig)
         self.assertIn(f'  locators', frrconfig)

--- a/smoketest/scripts/cli/test_system_ip.py
+++ b/smoketest/scripts/cli/test_system_ip.py
@@ -20,8 +20,6 @@ from base_vyostest_shim import VyOSUnitTestSHIM
 from vyos.configsession import ConfigSessionError
 from vyos.utils.system import sysctl_read
 from vyos.xml_ref import default_value
-from vyos.frrender import mgmt_daemon
-from vyos.frrender import zebra_daemon
 
 base_path = ['system', 'ip']
 
@@ -45,13 +43,13 @@ class TestSystemIP(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['disable-forwarding'])
         self.cli_commit()
         self.assertEqual(sysctl_read('net.ipv4.conf.all.forwarding'), '0')
-        frrconfig = self.getFRRconfig('', end='', daemon=zebra_daemon)
+        frrconfig = self.getFRRconfig('', end='')
         self.assertIn('no ip forwarding', frrconfig)
 
         self.cli_delete(base_path + ['disable-forwarding'])
         self.cli_commit()
         self.assertEqual(sysctl_read('net.ipv4.conf.all.forwarding'), '1')
-        frrconfig = self.getFRRconfig('', end='', daemon=zebra_daemon)
+        frrconfig = self.getFRRconfig('', end='')
         self.assertNotIn('no ip forwarding', frrconfig)
 
     def test_system_ip_multipath(self):
@@ -91,7 +89,7 @@ class TestSystemIP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify route-map properly applied to FRR
-        frrconfig = self.getFRRconfig('ip protocol', end='', daemon=mgmt_daemon)
+        frrconfig = self.getFRRconfig('ip protocol', end='')
         for protocol in protocols:
             self.assertIn(f'ip protocol {protocol} route-map route-map-{protocol}', frrconfig)
 
@@ -102,7 +100,7 @@ class TestSystemIP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify route-map properly applied to FRR
-        frrconfig = self.getFRRconfig('ip protocol', end='', daemon=mgmt_daemon)
+        frrconfig = self.getFRRconfig('ip protocol', end='')
         self.assertNotIn(f'ip protocol', frrconfig)
 
     def test_system_ip_protocol_non_existing_route_map(self):
@@ -121,13 +119,13 @@ class TestSystemIP(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['nht', 'no-resolve-via-default'])
         self.cli_commit()
         # Verify CLI config applied to FRR
-        frrconfig = self.getFRRconfig('', end='', daemon=mgmt_daemon)
+        frrconfig = self.getFRRconfig('', end='')
         self.assertIn(f'no ip nht resolve-via-default', frrconfig)
 
         self.cli_delete(base_path + ['nht', 'no-resolve-via-default'])
         self.cli_commit()
         # Verify CLI config removed to FRR
-        frrconfig = self.getFRRconfig('', end='', daemon=mgmt_daemon)
+        frrconfig = self.getFRRconfig('', end='')
         self.assertNotIn(f'no ip nht resolve-via-default', frrconfig)
 
 if __name__ == '__main__':

--- a/smoketest/scripts/cli/test_system_ipv6.py
+++ b/smoketest/scripts/cli/test_system_ipv6.py
@@ -21,8 +21,6 @@ from base_vyostest_shim import VyOSUnitTestSHIM
 from vyos.configsession import ConfigSessionError
 from vyos.utils.system import sysctl_read
 from vyos.xml_ref import default_value
-from vyos.frrender import mgmt_daemon
-from vyos.frrender import zebra_daemon
 
 base_path = ['system', 'ipv6']
 
@@ -46,13 +44,13 @@ class TestSystemIPv6(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['disable-forwarding'])
         self.cli_commit()
         self.assertEqual(sysctl_read('net.ipv6.conf.all.forwarding'), '0')
-        frrconfig = self.getFRRconfig('', end='', daemon=zebra_daemon)
+        frrconfig = self.getFRRconfig('', end='')
         self.assertIn('no ipv6 forwarding', frrconfig)
 
         self.cli_delete(base_path + ['disable-forwarding'])
         self.cli_commit()
         self.assertEqual(sysctl_read('net.ipv6.conf.all.forwarding'), '1')
-        frrconfig = self.getFRRconfig('', end='', daemon=zebra_daemon)
+        frrconfig = self.getFRRconfig('', end='')
         self.assertNotIn('no ipv6 forwarding', frrconfig)
 
     def test_system_ipv6_strict_dad(self):
@@ -109,7 +107,7 @@ class TestSystemIPv6(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify route-map properly applied to FRR
-        frrconfig = self.getFRRconfig('ipv6 protocol', end='', daemon=mgmt_daemon)
+        frrconfig = self.getFRRconfig('ipv6 protocol', end='')
         for protocol in protocols:
             # VyOS and FRR use a different name for OSPFv3 (IPv6)
             if protocol == 'ospfv3':
@@ -123,7 +121,7 @@ class TestSystemIPv6(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify route-map properly applied to FRR
-        frrconfig = self.getFRRconfig('ipv6 protocol', end='', daemon=mgmt_daemon)
+        frrconfig = self.getFRRconfig('ipv6 protocol', end='')
         self.assertNotIn(f'ipv6 protocol', frrconfig)
 
     def test_system_ipv6_protocol_non_existing_route_map(self):
@@ -142,13 +140,13 @@ class TestSystemIPv6(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['nht', 'no-resolve-via-default'])
         self.cli_commit()
         # Verify CLI config applied to FRR
-        frrconfig = self.getFRRconfig('', end='', daemon=mgmt_daemon)
+        frrconfig = self.getFRRconfig('', end='')
         self.assertIn(f'no ipv6 nht resolve-via-default', frrconfig)
 
         self.cli_delete(base_path + ['nht', 'no-resolve-via-default'])
         self.cli_commit()
         # Verify CLI config removed to FRR
-        frrconfig = self.getFRRconfig('', end='', daemon=mgmt_daemon)
+        frrconfig = self.getFRRconfig('', end='')
         self.assertNotIn(f'no ipv6 nht resolve-via-default', frrconfig)
 
 if __name__ == '__main__':

--- a/smoketest/scripts/cli/test_vrf.py
+++ b/smoketest/scripts/cli/test_vrf.py
@@ -23,7 +23,6 @@ from json import loads
 from jmespath import search
 
 from vyos.configsession import ConfigSessionError
-from vyos.frrender import mgmt_daemon
 from vyos.ifconfig import Interface
 from vyos.ifconfig import Section
 from vyos.utils.file import read_file
@@ -113,7 +112,7 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
             regex = f'{table}\s+{vrf}\s+#\s+{description}'
             self.assertTrue(re.findall(regex, iproute2_config))
 
-            frrconfig = self.getFRRconfig(f'vrf {vrf}', daemon=mgmt_daemon)
+            frrconfig = self.getFRRconfig(f'vrf {vrf}', endsection='^exit-vrf')
             self.assertIn(f' vni {table}', frrconfig)
 
             self.assertEqual(int(table), get_vrf_tableid(vrf))
@@ -234,7 +233,7 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
 
             self.assertTrue(interface_exists(vrf))
 
-            frrconfig = self.getFRRconfig(f'vrf {vrf}', daemon=mgmt_daemon)
+            frrconfig = self.getFRRconfig(f'vrf {vrf}', endsection='^exit-vrf')
             self.assertIn(f' vni {table}', frrconfig)
             self.assertIn(f' ip route {prefix} {next_hop}', frrconfig)
 
@@ -318,7 +317,7 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
 
         # Verify route-map properly applied to FRR
         for vrf in vrfs:
-            frrconfig = self.getFRRconfig(f'vrf {vrf}', daemon=mgmt_daemon)
+            frrconfig = self.getFRRconfig(f'vrf {vrf}', endsection='^exit-vrf')
             self.assertIn(f'vrf {vrf}', frrconfig)
             for protocol in v4_protocols:
                 self.assertIn(f' ip protocol {protocol} route-map route-map-{vrf}-{protocol}', frrconfig)
@@ -333,7 +332,7 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
 
         # Verify route-map properly is removed from FRR
         for vrf in vrfs:
-            frrconfig = self.getFRRconfig(f'vrf {vrf}', daemon=mgmt_daemon)
+            frrconfig = self.getFRRconfig(f'vrf {vrf}', endsection='^exit-vrf')
             self.assertNotIn(f' ip protocol', frrconfig)
 
     def test_vrf_ip_ipv6_protocol_non_existing_route_map(self):
@@ -381,7 +380,7 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
 
         # Verify route-map properly applied to FRR
         for vrf in vrfs:
-            frrconfig = self.getFRRconfig(f'vrf {vrf}', daemon=mgmt_daemon)
+            frrconfig = self.getFRRconfig(f'vrf {vrf}', endsection='^exit-vrf')
             self.assertIn(f'vrf {vrf}', frrconfig)
             for protocol in v6_protocols:
                 # VyOS and FRR use a different name for OSPFv3 (IPv6)
@@ -400,7 +399,7 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
 
         # Verify route-map properly is removed from FRR
         for vrf in vrfs:
-            frrconfig = self.getFRRconfig(f'vrf {vrf}', daemon=mgmt_daemon)
+            frrconfig = self.getFRRconfig(f'vrf {vrf}', endsection='^exit-vrf')
             self.assertNotIn(f' ipv6 protocol', frrconfig)
 
     def test_vrf_vni_duplicates(self):
@@ -430,7 +429,7 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
         for vrf in vrfs:
             self.assertTrue(interface_exists(vrf))
 
-            frrconfig = self.getFRRconfig(f'vrf {vrf}', daemon=mgmt_daemon)
+            frrconfig = self.getFRRconfig(f'vrf {vrf}', endsection='^exit-vrf')
             self.assertIn(f' vni {table}', frrconfig)
             # Increment table ID for the next run
             table = str(int(table) + 1)
@@ -452,7 +451,7 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
         for vrf in vrfs:
             self.assertTrue(interface_exists(vrf))
 
-            frrconfig = self.getFRRconfig(f'vrf {vrf}', daemon=mgmt_daemon)
+            frrconfig = self.getFRRconfig(f'vrf {vrf}', endsection='^exit-vrf')
             self.assertIn(f' vni {table}', frrconfig)
             # Increment table ID for the next run
             table = str(int(table) + 1)
@@ -475,7 +474,7 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
         for vrf in vrfs:
             self.assertTrue(interface_exists(vrf))
 
-            frrconfig = self.getFRRconfig(f'vrf {vrf}', daemon=mgmt_daemon)
+            frrconfig = self.getFRRconfig(f'vrf {vrf}', endsection='^exit-vrf')
             self.assertIn(f' vni {table}', frrconfig)
             # Increment table ID for the next run
             table = str(int(table) + 2)
@@ -495,7 +494,7 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
         for vrf in vrfs:
             self.assertTrue(interface_exists(vrf))
 
-            frrconfig = self.getFRRconfig(f'vrf {vrf}', daemon=mgmt_daemon)
+            frrconfig = self.getFRRconfig(f'vrf {vrf}', endsection='^exit-vrf')
             self.assertIn(f' vni {table}', frrconfig)
             # Increment table ID for the next run
             table = str(int(table) + 2)
@@ -503,7 +502,7 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
         # Verify purple VRF/VNI
         self.assertTrue(interface_exists(purple))
         table = str(int(table) + 10)
-        frrconfig = self.getFRRconfig(f'vrf {purple}', daemon=mgmt_daemon)
+        frrconfig = self.getFRRconfig(f'vrf {purple}', endsection='^exit-vrf')
         self.assertIn(f' vni {table}', frrconfig)
 
         # Now delete all the VNIs
@@ -518,12 +517,12 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
         for vrf in vrfs:
             self.assertTrue(interface_exists(vrf))
 
-            frrconfig = self.getFRRconfig(f'vrf {vrf}', daemon=mgmt_daemon)
+            frrconfig = self.getFRRconfig(f'vrf {vrf}', endsection='^exit-vrf')
             self.assertNotIn('vni', frrconfig)
 
         # Verify purple VNI remains
         self.assertTrue(interface_exists(purple))
-        frrconfig = self.getFRRconfig(f'vrf {purple}', daemon=mgmt_daemon)
+        frrconfig = self.getFRRconfig(f'vrf {purple}', endsection='^exit-vrf')
         self.assertIn(f' vni {table}', frrconfig)
 
     def test_vrf_ip_ipv6_nht(self):
@@ -541,7 +540,7 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
 
         # Verify route-map properly applied to FRR
         for vrf in vrfs:
-            frrconfig = self.getFRRconfig(f'vrf {vrf}', daemon=mgmt_daemon)
+            frrconfig = self.getFRRconfig(f'vrf {vrf}', endsection='^exit-vrf')
             self.assertIn(f'vrf {vrf}', frrconfig)
             self.assertIn(f' no ip nht resolve-via-default', frrconfig)
             self.assertIn(f' no ipv6 nht resolve-via-default', frrconfig)
@@ -556,7 +555,7 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
 
         # Verify route-map properly is removed from FRR
         for vrf in vrfs:
-            frrconfig = self.getFRRconfig(f'vrf {vrf}', daemon=mgmt_daemon)
+            frrconfig = self.getFRRconfig(f'vrf {vrf}', endsection='^exit-vrf')
             self.assertNotIn(f' no ip nht resolve-via-default', frrconfig)
             self.assertNotIn(f' no ipv6 nht resolve-via-default', frrconfig)
 

--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -335,7 +335,7 @@ if __name__ == '__main__':
                 if hasattr(config, 'frrender_cls') and res == R_SUCCESS:
                     frrender_cls = getattr(config, 'frrender_cls')
                     tmp = get_frrender_dict(config)
-                    frrender_cls.generate(tmp)
-                    frrender_cls.apply()
+                    if frrender_cls.generate(tmp):
+                        frrender_cls.apply()
         else:
             logger.critical(f'Unexpected message: {message}')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Some daemons (e.g. `bgpd`) have several nested substrings/sections like

```
router bgp 100
  address-family ipv4 unicast
  ..
  exit-address-family
exit
```

We can now use getFRRconfig() with the substring option to extract only
```
 address-family ipv4 unicast
 ..
 exit-address-family
```
Making config validation more granular

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6746

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
