### PR TITLE
srv6: T6984: add locator format configuration

### DIFF
--- a/data/templates/frr/zebra.segment_routing.frr.j2
+++ b/data/templates/frr/zebra.segment_routing.frr.j2
@@ -11,6 +11,9 @@ segment-routing
 {%         if locator_config.behavior_usid is vyos_defined %}
     behavior usid
 {%         endif %}
+{%         if locator_config.format is vyos_defined %}
+    format {{ locator_config.format }}
+{%         endif %}
     exit
     !
 {%     endfor %}

--- a/interface-definitions/protocols_segment-routing.xml.in
+++ b/interface-definitions/protocols_segment-routing.xml.in
@@ -126,6 +126,25 @@
                     </properties>
                     <defaultValue>24</defaultValue>
                   </leafNode>
+                  <leafNode name="format">
+                    <properties>
+                      <help>SRv6 SID format</help>
+                      <completionHelp>
+                        <list>uncompressed-f4024 usid-f3216</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>uncompressed-f4024</format>
+                        <description>Uncompressed f4024 format</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>usid-f3216</format>
+                        <description>usid-f3216 format</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>(uncompressed-f4024|usid-f3216)</regex>
+                      </constraint>
+                    </properties>
+                  </leafNode>
                 </children>
               </tagNode>
             </children>

--- a/smoketest/scripts/cli/test_protocols_segment-routing.py
+++ b/smoketest/scripts/cli/test_protocols_segment-routing.py
@@ -26,6 +26,7 @@ from vyos.utils.system import sysctl_read
 
 base_path = ['protocols', 'segment-routing']
 
+
 class TestProtocolsSegmentRouting(VyOSUnitTestSHIM.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -47,14 +48,64 @@ class TestProtocolsSegmentRouting(VyOSUnitTestSHIM.TestCase):
     def test_srv6(self):
         interfaces = Section.interfaces('ethernet', vlan=False)
         locators = {
-            'foo' : { 'prefix' : '2001:a::/64' },
-            'foo' : { 'prefix' : '2001:b::/64', 'usid' : {} },
+            'foo1': {'prefix': '2001:a::/64'},
+            'foo2': {'prefix': '2001:b::/64', 'usid': {}},
+            'foo3': {'prefix': '2001:c::/64', 'format': 'uncompressed-f4024'},
+            'foo4': {
+                'prefix': '2001:d::/48',
+                'block-len': '32',
+                'node-len': '16',
+                'func-bits': '16',
+                'usid': {},
+                'format': 'usid-f3216',
+            },
         }
 
         for locator, locator_config in locators.items():
-            self.cli_set(base_path + ['srv6', 'locator', locator, 'prefix', locator_config['prefix']])
+            self.cli_set(
+                base_path
+                + ['srv6', 'locator', locator, 'prefix', locator_config['prefix']]
+            )
+            if 'block-len' in locator_config:
+                self.cli_set(
+                    base_path
+                    + [
+                        'srv6',
+                        'locator',
+                        locator,
+                        'block-len',
+                        locator_config['block-len'],
+                    ]
+                )
+            if 'node-len' in locator_config:
+                self.cli_set(
+                    base_path
+                    + [
+                        'srv6',
+                        'locator',
+                        locator,
+                        'node-len',
+                        locator_config['node-len'],
+                    ]
+                )
+            if 'func-bits' in locator_config:
+                self.cli_set(
+                    base_path
+                    + [
+                        'srv6',
+                        'locator',
+                        locator,
+                        'func-bits',
+                        locator_config['func-bits'],
+                    ]
+                )
             if 'usid' in locator_config:
                 self.cli_set(base_path + ['srv6', 'locator', locator, 'behavior-usid'])
+            if 'format' in locator_config:
+                self.cli_set(
+                    base_path
+                    + ['srv6', 'locator', locator, 'format', locator_config['format']]
+                )
 
         # verify() - SRv6 should be enabled on at least one interface!
         with self.assertRaises(ConfigSessionError):
@@ -65,16 +116,33 @@ class TestProtocolsSegmentRouting(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         for interface in interfaces:
-            self.assertEqual(sysctl_read(f'net.ipv6.conf.{interface}.seg6_enabled'), '1')
-            self.assertEqual(sysctl_read(f'net.ipv6.conf.{interface}.seg6_require_hmac'), '0') # default
+            self.assertEqual(
+                sysctl_read(f'net.ipv6.conf.{interface}.seg6_enabled'), '1'
+            )
+            self.assertEqual(
+                sysctl_read(f'net.ipv6.conf.{interface}.seg6_require_hmac'), '0'
+            )  # default
 
-        frrconfig = self.getFRRconfig(f'segment-routing', endsection='^exit')
-        self.assertIn(f'segment-routing', frrconfig)
-        self.assertIn(f' srv6', frrconfig)
-        self.assertIn(f'  locators', frrconfig)
+        frrconfig = self.getFRRconfig('segment-routing', endsection='^exit')
+        self.assertIn('segment-routing', frrconfig)
+        self.assertIn(' srv6', frrconfig)
+        self.assertIn('  locators', frrconfig)
         for locator, locator_config in locators.items():
+            prefix = locator_config['prefix']
+            block_len = locator_config.get('block-len', '40')
+            node_len = locator_config.get('node-len', '24')
+            func_bits = locator_config.get('func-bits', '16')
+
             self.assertIn(f'   locator {locator}', frrconfig)
-            self.assertIn(f'    prefix {locator_config["prefix"]} block-len 40 node-len 24 func-bits 16', frrconfig)
+            self.assertIn(
+                f'    prefix {prefix} block-len {block_len} node-len {node_len} func-bits {func_bits}',
+                frrconfig,
+            )
+
+            if 'format' in locator_config:
+                self.assertIn(f'    format {locator_config["format"]}', frrconfig)
+            if 'usid' in locator_config:
+                self.assertIn('    behavior usid', frrconfig)
 
     def test_srv6_sysctl(self):
         interfaces = Section.interfaces('ethernet', vlan=False)
@@ -86,8 +154,12 @@ class TestProtocolsSegmentRouting(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         for interface in interfaces:
-            self.assertEqual(sysctl_read(f'net.ipv6.conf.{interface}.seg6_enabled'), '1')
-            self.assertEqual(sysctl_read(f'net.ipv6.conf.{interface}.seg6_require_hmac'), '-1') # ignore
+            self.assertEqual(
+                sysctl_read(f'net.ipv6.conf.{interface}.seg6_enabled'), '1'
+            )
+            self.assertEqual(
+                sysctl_read(f'net.ipv6.conf.{interface}.seg6_require_hmac'), '-1'
+            )  # ignore
 
         # HMAC drop
         for interface in interfaces:
@@ -96,8 +168,12 @@ class TestProtocolsSegmentRouting(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         for interface in interfaces:
-            self.assertEqual(sysctl_read(f'net.ipv6.conf.{interface}.seg6_enabled'), '1')
-            self.assertEqual(sysctl_read(f'net.ipv6.conf.{interface}.seg6_require_hmac'), '1') # drop
+            self.assertEqual(
+                sysctl_read(f'net.ipv6.conf.{interface}.seg6_enabled'), '1'
+            )
+            self.assertEqual(
+                sysctl_read(f'net.ipv6.conf.{interface}.seg6_require_hmac'), '1'
+            )  # drop
 
         # Disable SRv6 on first interface
         first_if = interfaces[-1]
@@ -105,6 +181,7 @@ class TestProtocolsSegmentRouting(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         self.assertEqual(sysctl_read(f'net.ipv6.conf.{first_if}.seg6_enabled'), '0')
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add the `format` configuration option to segment-routing SRv6 locators

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6984

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
segment-routing, srv6

## Proposed changes
<!--- Describe your changes in detail -->

Add a new configuration option to specify the `format` of the SRv6 locator. This option in FRR is useful when using uSIDs with 32-bit block and 16-bit node (3216) allocations.

VyOS configuration example:
```
protocols {
  segment-routing {
    srv6 {
       locator MAIN {
           behavior-usid
           block-len 32
           format usid-f3216      <<< new option
           func-bits 16
           node-len 16
           prefix fdff:0:1::/48
       }
    }
  }
}
```

Resulting FRR configuration:
```
!
segment-routing
 srv6
  locators
   locator MAIN
    prefix fdff:0:1::/48 block-len 32 node-len 16 func-bits 16
    behavior usid
    format usid-f3216
    exit
    !
  exit
  !
exit
!
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

1. Apply the configuration example shown above
2. Verify the rendered configuration (`/run/frr/config/vyos.frr.conf`) includes the format option as shown in the FRR configuration above
3. Verify the FRR running configuration contains the same format option (`vtysh -c "show run"`)

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_segment-routing.py
test_srv6 (__main__.TestProtocolsSegmentRouting.test_srv6) ... ok
test_srv6_sysctl (__main__.TestProtocolsSegmentRouting.test_srv6_sysctl) ... ok

----------------------------------------------------------------------
Ran 2 tests in 44.963s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
