### PR TITLE
udev: T6985: Fix udev rule to also register ttyACM serial devices

### DIFF
--- a/src/etc/udev/rules.d/90-vyos-serial.rules
+++ b/src/etc/udev/rules.d/90-vyos-serial.rules
@@ -8,7 +8,7 @@ SUBSYSTEMS=="pci", IMPORT{builtin}="hwdb --subsystem=pci"
 SUBSYSTEMS=="usb", IMPORT{builtin}="usb_id", IMPORT{builtin}="hwdb --subsystem=usb"
 
 # /dev/serial/by-path/, /dev/serial/by-id/ for USB devices
-KERNEL!="ttyUSB[0-9]*", GOTO="serial_end"
+KERNEL!="ttyUSB[0-9]*|ttyACM[0-9]*", GOTO="serial_end"
 
 SUBSYSTEMS=="usb-serial", ENV{.ID_PORT}="$attr{port_number}"
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6985

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
udev

## Proposed changes
<!--- Describe your changes in detail -->
This fixes the udev rule to also match `tyACM` serial devices and creates the persistent USB `by-bus` device so that these usb serial devices can by used by `set system console` and elsewhere.

## How to test
The following ttyACM device was inserted prior to the udev changes. It did not register in `/dev/serial/by-bus/`

`set system serial device` was unable to register the `ttyACM0` device.


```
udevadm info --name=/dev/ttyACM0
P: /devices/pci0000:00/0000:00:14.0/usb1/1-4/1-4:1.0/tty/ttyACM0
M: ttyACM0
R: 0
U: tty
D: c 166:0
N: ttyACM0
L: 0
S: serial/by-path/pci-0000:00:14.0-usb-0:4:1.0
S: serial/by-id/usb-8086_Consultancy_USB-USB_Null_Modem_A_5165-if00
S: serial/by-bus/usb0b4p1.0
E: DEVPATH=/devices/pci0000:00/0000:00:14.0/usb1/1-4/1-4:1.0/tty/ttyACM0
E: DEVNAME=/dev/ttyACM0
E: MAJOR=166
E: MINOR=0
E: SUBSYSTEM=tty
E: USEC_INITIALIZED=15256225
E: ID_BUS=pci
E: ID_MODEL=USB-USB_Null_Modem_A
E: ID_MODEL_ENC=USB-USB\x20Null\x20Modem\x20A
E: ID_MODEL_ID=0x9d2f
E: ID_SERIAL=8086_Consultancy_USB-USB_Null_Modem_A_5165
E: ID_SERIAL_SHORT=5165
E: ID_VENDOR=8086_Consultancy
```

After the udev rule changes the device registers as follows:

```
$ ls -l /dev/serial/by-bus/
lrwxrwxrwx 1 root root 13 Oct 10 17:40 usb0b4p1.0 -> ../../ttyACM0
```

`set system serial device usb0b4p1.0` works as expected and the serial console functions as expected over a link.

## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
