### PR TITLE
op_mode: T6956: Fix for "generate tech-support archive" if /config contains directories

### DIFF
--- a/src/op_mode/tech_support.py
+++ b/src/op_mode/tech_support.py
@@ -97,21 +97,22 @@ def _get_boot_config():
     return strip_config_source(config)
 
 def _get_config_scripts():
-    from os import listdir
+    from os import walk
     from os.path import join
     from vyos.utils.file import read_file
 
     scripts = []
 
     dir = '/config/scripts'
-    for f in listdir(dir):
-        script = {}
-        path = join(dir, f)
-        data = read_file(path)
-        script["path"] = path
-        script["data"] = data
+    for dirpath, _, filenames in walk(dir):
+        for filename in filenames:
+            script = {}
+            path = join(dirpath, filename)
+            data = read_file(path)
+            script["path"] = path
+            script["data"] = data
 
-        scripts.append(script)
+            scripts.append(script)
 
     return scripts
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6956
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
op mode
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos:~$ ls -la /config/scripts/
total 20
drwxrwsr-x 3 root vyattacfg 4096 Dec 27 03:05 .
drwxrwsr-x 1 root vyattacfg 4096 Dec 23 20:35 ..
drwxrwsr-x 2 root vyattacfg 4096 Dec 27 01:52 accel-ppp
-rwxrwxr-x 1 root vyattacfg  230 Dec 20 15:57 vyos-postconfig-bootup.script
-rwxrwxr-x 1 root vyattacfg  225 Dec 20 15:57 vyos-preconfig-bootup.script


vyos@vyos:~$ generate tech-support archive
...
 "config": {
            "scripts": [
                {
                    "path": "/config/scripts/vyos-postconfig-bootup.script",
                    "data": "#!/bin/sh\n# This script is executed at boot time after VyOS configuration is fully applied.\n# Any modifications required to work around unfixed bugs\n# or use services not available through the VyOS CLI system can be placed here."
                },
                {
                    "path": "/config/scripts/vyos-preconfig-bootup.script",
                    "data": "#!/bin/sh\n# This script is executed at boot time before VyOS configuration is applied.\n# Any modifications required to work around unfixed bugs or use\n# services not available through the VyOS CLI system can be placed here."
                },
                {
                    "path": "/config/scripts/accel-ppp/ipoe.lua",
                    "data": "#!lua\n  function username_func(pkt)\n    local username=pkt:hwaddr()\n    return username\nend"
                }
         ]
    }
...
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
