### PR TITLE
frrender: T6991: do not loose DHCP default route when no static route is defined

### DIFF
--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -360,16 +360,23 @@ def get_frrender_dict(conf, argv=None) -> dict:
         static = conf.get_config_dict(static_cli_path, key_mangling=('-', '_'),
                                   get_first_key=True,
                                   no_tag_node_value_mangle=True)
-
-        # T3680 - get a list of all interfaces currently configured to use DHCP
-        tmp = get_dhcp_interfaces(conf)
-        if tmp: static.update({'dhcp' : tmp})
-        tmp = get_pppoe_interfaces(conf)
-        if tmp: static.update({'pppoe' : tmp})
-
         dict.update({'static' : static})
     elif conf.exists_effective(static_cli_path):
         dict.update({'static' : {'deleted' : ''}})
+
+    # T3680 - get a list of all interfaces currently configured to use DHCP
+    tmp = get_dhcp_interfaces(conf)
+    if tmp:
+        if 'static' in dict:
+            dict['static'].update({'dhcp' : tmp})
+        else:
+            dict.update({'static' : {'dhcp' : tmp}})
+    tmp = get_pppoe_interfaces(conf)
+    if tmp:
+        if 'static' in dict:
+            dict['static'].update({'pppoe' : tmp})
+        else:
+            dict.update({'static' : {'pppoe' : tmp}})
 
     # keep a re-usable list of dependent VRFs
     dependent_vrfs_default = {}
@@ -533,6 +540,10 @@ def get_frrender_dict(conf, argv=None) -> dict:
                     vrf['name'][vrf_name]['protocols'].update({protocol : tmp})
 
         dict.update({'vrf' : vrf})
+
+    if os.path.exists(frr_debug_enable):
+        import pprint
+        pprint.pprint(dict)
 
     return dict
 


### PR DESCRIPTION
## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The reason is that DHCP routes are not re-generated during FRRrender as long as there is no protocols static entry in the configuration at all. Move out the DHCP configuration read-in from the static section.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6991

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/872
* https://github.com/vyos/vyos-1x/pull/4227

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ touch /tmp/vyos.smoketests.hint
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_static.py
test_01_static (__main__.TestProtocolsStatic.test_01_static) ... ok
test_02_static_table (__main__.TestProtocolsStatic.test_02_static_table) ... ok
test_03_static_vrf (__main__.TestProtocolsStatic.test_03_static_vrf) ... ok
test_04_static_multicast (__main__.TestProtocolsStatic.test_04_static_multicast) ... ok
test_05_dhcp_default_route (__main__.TestProtocolsStatic.test_05_dhcp_default_route) ... ok

----------------------------------------------------------------------
Ran 5 tests in 86.997s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
