### PR TITLE
https: T6734: Nginx - disable software version reporting

### DIFF
--- a/data/templates/https/nginx.default.j2
+++ b/data/templates/https/nginx.default.j2
@@ -18,11 +18,7 @@ server {
     listen [::]:{{ port }} ssl;
 {% endif %}
 
-{% if no_server_version is vyos_defined %}
-    server_tokens off;
-{% else %}
-    server_tokens on;
-{% endif %}
+server_tokens {{ 'off' if no_server_version is vyos_defined else 'on' }};
 
     server_name {{ hostname }};
     root /srv/localui;

--- a/data/templates/https/nginx.default.j2
+++ b/data/templates/https/nginx.default.j2
@@ -18,6 +18,12 @@ server {
     listen [::]:{{ port }} ssl;
 {% endif %}
 
+{% if no_server_version is vyos_defined %}
+    server_tokens off;
+{% else %}
+    server_tokens on;
+{% endif %}
+
     server_name {{ hostname }};
     root /srv/localui;
 

--- a/interface-definitions/service_https.xml.in
+++ b/interface-definitions/service_https.xml.in
@@ -192,7 +192,7 @@
           #include <include/interface/vrf.xml.i>
           <leafNode name="no-server-version">
             <properties>
-              <help>Do not display server version on error pages or "Server" response header</help>
+              <help>Disable version on error pages and in the server response header field.</help>
               <valueless/>
             </properties>
           </leafNode>

--- a/interface-definitions/service_https.xml.in
+++ b/interface-definitions/service_https.xml.in
@@ -190,6 +190,12 @@
             <defaultValue>1.2 1.3</defaultValue>
           </leafNode>
           #include <include/interface/vrf.xml.i>
+          <leafNode name="no-server-version">
+            <properties>
+              <help>Do not display server version on error pages or "Server" response header</help>
+              <valueless/>
+            </properties>
+          </leafNode>
         </children>
       </node>
     </children>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Added new option under "service https" called "no-server-version". This affects the "server_tokens" option in the nginx default site configuration.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6734


## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
By default or when this option is not set, the HTTP response headers look like this:
```
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.22.1
< Date: Fri, 03 Jan 2025 15:19:18 GMT
< Content-Type: text/html
< Content-Length: 169
< Connection: close
< Location: https://xxx.xxx.xxx.103:80/
```

When the option is set, the HTTP response headers look like this:
```
< HTTP/1.1 301 Moved Permanently
< Server: nginx
< Date: Fri, 03 Jan 2025 15:18:48 GMT
< Content-Type: text/html
< Content-Length: 162
< Connection: close
< Location: https://xxx.xxx.xxx.103:80/
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
