### PR TITLE
T6998: dhcp.py fix datetime to be zone aware, add fix for hostname

### DIFF
--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -113,7 +113,7 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[], orig
         data_lease['origin'] = 'local' # TODO: Determine remote in HA
         data_lease['hostname'] = lease.get('hostname', '-')
         # remove trailing dot to ensure consistency for `vyos-hostsd-client`
-        if data_lease['hostname'] and data_lease['hostname'][-1] == '.':
+        if len(data_lease['hostname']) > 1 and data_lease['hostname'][-1] == '.':
             data_lease['hostname'] = data_lease['hostname'][:-1]
 
         if family == 'inet':

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -18,7 +18,7 @@ import os
 import sys
 import typing
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from datetime import timezone
 from glob import glob
 from ipaddress import ip_address
@@ -132,12 +132,10 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[], orig
         data_lease['remaining'] = '-'
 
         if lease['valid-lft'] > 0:
-            data_lease['remaining'] = lease['expire_timestamp'] - datetime.now(timezone.utc)
-
-            if data_lease['remaining'].days >= 0:
+            if lease['expire_timestamp'] > datetime.now(timezone.utc):
                 # substraction gives us a timedelta object which can't be formatted with strftime
                 # so we use str(), split gets rid of the microseconds
-                data_lease['remaining'] = str(data_lease['remaining']).split('.')[0]
+                data_lease['remaining'] = str(lease['expire_timestamp'] - datetime.now(timezone.utc)).split('.')[0]
 
         # Do not add old leases
         if data_lease['remaining'] != '' and data_lease['pool'] in pool and data_lease['state'] != 'free':

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -101,7 +101,7 @@ def _get_raw_server_leases(family='inet', pool=None, sorted=None, state=[], orig
         lifetime = lease['valid-lft']
         expiry = (lease['cltt'] + lifetime)
 
-        lease['start_timestamp'] = datetime.fromtimestamp(expiry - lifetime, timezone.utc)
+        lease['start_timestamp'] = datetime.fromtimestamp(lease['cltt'], timezone.utc)
         lease['expire_timestamp'] = datetime.fromtimestamp(expiry, timezone.utc) if expiry else None
 
         data_lease = {}
@@ -170,10 +170,8 @@ def _get_formatted_server_leases(raw_data, family='inet'):
             ipaddr = lease.get('ip')
             hw_addr = lease.get('mac')
             state = lease.get('state')
-            start = lease.get('start')
-            start =  _utc_to_local(start).strftime('%Y/%m/%d %H:%M:%S')
-            end = lease.get('end')
-            end =  _utc_to_local(end).strftime('%Y/%m/%d %H:%M:%S') if end else '-'
+            start = datetime.fromtimestamp(lease.get('start'), timezone.utc)
+            end = datetime.fromtimestamp(lease.get('end'), timezone.utc) if lease.get('end') else '-'
             remain = lease.get('remaining')
             pool = lease.get('pool')
             hostname = lease.get('hostname')
@@ -187,10 +185,8 @@ def _get_formatted_server_leases(raw_data, family='inet'):
         for lease in raw_data:
             ipaddr = lease.get('ip')
             state = lease.get('state')
-            start = lease.get('last_communication')
-            start =  _utc_to_local(start).strftime('%Y/%m/%d %H:%M:%S')
-            end = lease.get('end')
-            end =  _utc_to_local(end).strftime('%Y/%m/%d %H:%M:%S')
+            start = datetime.fromtimestamp(lease.get('last_communication'), timezone.utc)
+            end = datetime.fromtimestamp(lease.get('end'), timezone.utc) if lease.get('end') else '-'
             remain = lease.get('remaining')
             lease_type = lease.get('type')
             pool = lease.get('pool')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
This fixes `show dhcp server leases` to work again.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6998

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
I ran "show dhcp server leases" and it didn't work

```
show dhcp server statistics 
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/dhcp.py", line 545, in <module>
    res = vyos.opmode.run(sys.modules[__name__])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/opmode.py", line 312, in run
    res = func(**args)
          ^^^^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/dhcp.py", line 335, in _wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/dhcp.py", line 360, in show_pool_statistics
    pool_data = _get_raw_pool_statistics(family=family, pool=pool)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/dhcp.py", line 243, in _get_raw_pool_statistics
    leases = len(_get_raw_server_leases(family=family, pool=p))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/dhcp.py", line 135, in _get_raw_server_leases
    data_lease['remaining'] = lease['expire_timestamp'] - datetime.now(timezone.utc)
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
TypeError: can't subtract offset-naive and offset-aware datetimes

```
fixing that bug led to finding the bug with the hostname length.




## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
