### PR TITLE
T7016: force delete only dynamic IPv4 address from interface

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1423,11 +1423,13 @@ class Interface(Control):
             tmp = get_interface_address(self.ifname)
             if tmp and 'addr_info' in tmp:
                 for address_dict in tmp['addr_info']:
-                    # Only remove dynamic assigned addresses
-                    if 'dynamic' not in address_dict:
-                        continue
-                    address = address_dict['local']
-                    self.del_addr(address)
+                    if address_dict['family'] == 'inet':
+                       # Only remove dynamic assigned addresses
+                       if 'dynamic' not in address_dict:
+                           continue
+                       address = address_dict['local']
+                       prefixlen = address_dict['prefixlen']
+                       self.del_addr(f'{address}/{prefixlen}')
 
             # cleanup old config files
             for file in [dhclient_config_file, systemd_override_file, dhclient_lease_file]:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

#4250 introduced a bug that attempts to delete dynamic IPv6 addresses on an interface when that interface is being removed from being a DHCP client. The prefix length is not passed to the `ip del` command so therefore it fails to delete it throwing an exception

The issue seems to be:
1. IPv6 addresses are not supposed to be deleted when IPv4 DHCP client is removed from the interface
2. If an IPv4 address is being deleted, it needs it's CIDR to be passed to `ip del` for it to successfully delete it

```
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 139, in run_script
    script.apply(c)
  File "/usr/libexec/vyos//conf_mode/interfaces_ethernet.py", line 336, in apply
    e.update(ethernet)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/ethernet.py", line 532, in update
    super().update(config)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 1663, in update
    self.del_addr('dhcp')
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 1280, in del_addr
    self.set_dhcp(False)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 1430, in set_dhcp
    self.del_addr(address)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 1285, in del_addr
    self._cmd(f'{netns_cmd} ip addr del {addr} dev {self.ifname}')
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/control.py", line 64, in _cmd
    return cmd(command, self.debug)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/utils/process.py", line 155, in cmd
    raise OSError(code, feedback)
FileNotFoundError: [Errno 2] failed to run command:  ip addr del 2600:3c0e::f03c:93ff:fed7:f58a dev eth0
returned:
exit code: 2
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7016
* https://vyos.dev/T6972

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4250

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
set interfaces ethernet eth0 address 'dhcp'
set interfaces ethernet eth0 ipv6 address autoconf
```

Ensure you have an IPv4/IPv6 address from DHCP/SLAAC on eth0

Then try to remove DHCP client

```
delete interfaces ethernet eth0 address dhcp
compare
commit
```

The IPv6 address will try and be deleted but fails due to missing prefix length, causing an exception to be thrown

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
