### PR TITLE
vyos.ifconfig: T7018: drop 'iftype' class attribute

### DIFF
--- a/python/vyos/ifconfig/bond.py
+++ b/python/vyos/ifconfig/bond.py
@@ -31,7 +31,6 @@ class BondIf(Interface):
     monitoring may be performed.
     """
 
-    iftype = 'bond'
     definition = {
         **Interface.definition,
         ** {
@@ -108,6 +107,9 @@ class BondIf(Interface):
             'mtu'
         ]
         return options
+
+    def _create(self):
+        super()._create('bond')
 
     def remove(self):
         """

--- a/python/vyos/ifconfig/bridge.py
+++ b/python/vyos/ifconfig/bridge.py
@@ -32,7 +32,6 @@ class BridgeIf(Interface):
 
     The Linux bridge code implements a subset of the ANSI/IEEE 802.1d standard.
     """
-    iftype = 'bridge'
     definition = {
         **Interface.definition,
         **{
@@ -106,6 +105,9 @@ class BridgeIf(Interface):
             'shellcmd': 'ip link set dev {value} nomaster',
         },
     }}
+
+    def _create(self):
+        super()._create('bridge')
 
     def get_vlan_filter(self):
         """

--- a/python/vyos/ifconfig/dummy.py
+++ b/python/vyos/ifconfig/dummy.py
@@ -22,8 +22,6 @@ class DummyIf(Interface):
     interface. The purpose of a dummy interface is to provide a device to route
     packets through without actually transmitting them.
     """
-
-    iftype = 'dummy'
     definition = {
         **Interface.definition,
         **{
@@ -31,3 +29,6 @@ class DummyIf(Interface):
             'prefixes': ['dum', ],
         },
     }
+
+    def _create(self):
+        super()._create('dummy')

--- a/python/vyos/ifconfig/ethernet.py
+++ b/python/vyos/ifconfig/ethernet.py
@@ -33,7 +33,6 @@ class EthernetIf(Interface):
     Abstraction of a Linux Ethernet Interface
     """
 
-    iftype = 'ethernet'
     definition = {
         **Interface.definition,
         **{
@@ -119,6 +118,9 @@ class EthernetIf(Interface):
         super().__init__(ifname, **kargs)
         self.ethtool = Ethtool(ifname)
 
+    def _create(self):
+        pass
+
     def remove(self):
         """
         Remove interface from config. Removing the interface deconfigures all
@@ -137,7 +139,7 @@ class EthernetIf(Interface):
         # Remove all VLAN subinterfaces - filter with the VLAN dot
         for vlan in [
             x
-            for x in Section.interfaces(self.iftype)
+            for x in Section.interfaces('ethernet')
             if x.startswith(f'{self.ifname}.')
         ]:
             Interface(vlan).remove()

--- a/python/vyos/ifconfig/geneve.py
+++ b/python/vyos/ifconfig/geneve.py
@@ -27,7 +27,6 @@ class GeneveIf(Interface):
     https://developers.redhat.com/blog/2019/05/17/an-introduction-to-linux-virtual-interfaces-tunnels/#geneve
     https://lwn.net/Articles/644938/
     """
-    iftype = 'geneve'
     definition = {
         **Interface.definition,
         **{
@@ -49,7 +48,7 @@ class GeneveIf(Interface):
             'parameters.ipv6.flowlabel'  : 'flowlabel',
         }
 
-        cmd = 'ip link add name {ifname} type {type} id {vni} remote {remote}'
+        cmd = 'ip link add name {ifname} type geneve id {vni} remote {remote}'
         for vyos_key, iproute2_key in mapping.items():
             # dict_search will return an empty dict "{}" for valueless nodes like
             # "parameters.nolearning" - thus we need to test the nodes existence

--- a/python/vyos/ifconfig/input.py
+++ b/python/vyos/ifconfig/input.py
@@ -25,8 +25,6 @@ class InputIf(Interface):
     a single stack of qdiscs, classes and filters can be shared between
     multiple interfaces.
     """
-
-    iftype = 'ifb'
     definition = {
         **Interface.definition,
         **{
@@ -34,3 +32,6 @@ class InputIf(Interface):
             'prefixes': ['ifb', ],
         },
     }
+
+    def _create(self):
+        super()._create('ifb')

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -29,7 +29,6 @@ from netifaces import AF_INET6
 from netaddr import EUI
 from netaddr import mac_unix_expanded
 
-from vyos.base import ConfigError
 from vyos.configdict import list_diff
 from vyos.configdict import dict_merge
 from vyos.configdict import get_vlan_ids
@@ -74,7 +73,6 @@ class Interface(Control):
     OperationalClass = Operational
 
     options = ['debug', 'create']
-    required = []
     default = {
         'debug': True,
         'create': True,
@@ -336,22 +334,10 @@ class Interface(Control):
         super().__init__(**kargs)
 
         if not self.exists(ifname):
-            # Any instance of Interface, such as Interface('eth0') can be used
-            # safely to access the generic function in this class as 'type' is
-            # unset, the class can not be created
-            if not hasattr(self, 'iftype'):
-                raise ConfigError(f'Interface "{ifname}" has no "iftype" attribute defined!')
-            self.config['type'] = self.iftype
-
             # Should an Instance of a child class (EthernetIf, DummyIf, ..)
             # be required, then create should be set to False to not accidentally create it.
             # In case a subclass does not define it, we use get to set the default to True
-            if self.config.get('create',True):
-                for k in self.required:
-                    if k not in kargs:
-                        name = self.default['type']
-                        raise ConfigError(f'missing required option {k} for {name} {ifname} creation')
-
+            if self.config.get('create', True):
                 self._create()
             # If we can not connect to the interface then let the caller know
             # as the class could not be correctly initialised
@@ -364,13 +350,14 @@ class Interface(Control):
         self.operational = self.OperationalClass(ifname)
         self.vrrp = VRRP(ifname)
 
-    def _create(self):
+    def _create(self, type: str=''):
         # Do not create interface that already exist or exists in netns
         netns = self.config.get('netns', None)
         if self.exists(f'{self.ifname}', netns=netns):
             return
 
-        cmd = 'ip link add dev {ifname} type {type}'.format(**self.config)
+        cmd = f'ip link add dev {self.ifname}'
+        if type: cmd += f' type {type}'
         if 'netns' in self.config: cmd = f'ip netns exec {netns} {cmd}'
         self._cmd(cmd)
 
@@ -1952,8 +1939,6 @@ class Interface(Control):
 
 class VLANIf(Interface):
     """ Specific class which abstracts 802.1q and 802.1ad (Q-in-Q) VLAN interfaces """
-    iftype = 'vlan'
-
     def _create(self):
         # bail out early if interface already exists
         if self.exists(f'{self.ifname}'):

--- a/python/vyos/ifconfig/l2tpv3.py
+++ b/python/vyos/ifconfig/l2tpv3.py
@@ -45,7 +45,6 @@ class L2TPv3If(Interface):
     either hot standby or load balancing services. Additionally, link integrity
     monitoring may be performed.
     """
-    iftype = 'l2tp'
     definition = {
         **Interface.definition,
         **{

--- a/python/vyos/ifconfig/loopback.py
+++ b/python/vyos/ifconfig/loopback.py
@@ -22,15 +22,19 @@ class LoopbackIf(Interface):
     uses to communicate with itself.
     """
     _persistent_addresses = ['127.0.0.1/8', '::1/128']
-    iftype = 'loopback'
     definition = {
         **Interface.definition,
         **{
             'section': 'loopback',
             'prefixes': ['lo', ],
             'bridgeable': True,
+            'eternal': 'lo$',
         }
     }
+
+    def _create(self):
+        # we can not create this interface as it is managed by the Kernel
+        pass
 
     def remove(self):
         """

--- a/python/vyos/ifconfig/macsec.py
+++ b/python/vyos/ifconfig/macsec.py
@@ -27,7 +27,6 @@ class MACsecIf(Interface):
     other security solutions such as IPsec (layer 3) or TLS (layer 4), as all
     those solutions are used for their own specific use cases.
     """
-    iftype = 'macsec'
     definition = {
         **Interface.definition,
         **{
@@ -43,7 +42,7 @@ class MACsecIf(Interface):
         """
 
         # create tunnel interface
-        cmd  = 'ip link add link {source_interface} {ifname} type {type}'.format(**self.config)
+        cmd  = 'ip link add link {source_interface} {ifname} type macsec'.format(**self.config)
         cmd += f' cipher {self.config["security"]["cipher"]}'
 
         if 'encrypt' in self.config["security"]:

--- a/python/vyos/ifconfig/macvlan.py
+++ b/python/vyos/ifconfig/macvlan.py
@@ -20,7 +20,6 @@ class MACVLANIf(Interface):
     """
     Abstraction of a Linux MACvlan interface
     """
-    iftype = 'macvlan'
     definition = {
         **Interface.definition,
         **{
@@ -35,12 +34,12 @@ class MACVLANIf(Interface):
         down by default.
         """
         # please do not change the order when assembling the command
-        cmd = 'ip link add {ifname} link {source_interface} type {type} mode {mode}'
+        cmd = 'ip link add {ifname} link {source_interface} type macvlan mode {mode}'
         self._cmd(cmd.format(**self.config))
 
         # interface is always A/D down. It needs to be enabled explicitly
         self.set_admin_state('down')
 
     def set_mode(self, mode):
-        cmd = f'ip link set dev {self.ifname} type {self.iftype} mode {mode}'
+        cmd = f'ip link set dev {self.ifname} type macvlan mode {mode}'
         return self._cmd(cmd)

--- a/python/vyos/ifconfig/pppoe.py
+++ b/python/vyos/ifconfig/pppoe.py
@@ -19,7 +19,6 @@ from vyos.utils.network import get_interface_config
 
 @Interface.register
 class PPPoEIf(Interface):
-    iftype = 'pppoe'
     definition = {
         **Interface.definition,
         **{

--- a/python/vyos/ifconfig/sstpc.py
+++ b/python/vyos/ifconfig/sstpc.py
@@ -17,7 +17,6 @@ from vyos.ifconfig.interface import Interface
 
 @Interface.register
 class SSTPCIf(Interface):
-    iftype = 'sstpc'
     definition = {
         **Interface.definition,
         **{

--- a/python/vyos/ifconfig/tunnel.py
+++ b/python/vyos/ifconfig/tunnel.py
@@ -90,9 +90,8 @@ class TunnelIf(Interface):
         # T3357: we do not have the 'encapsulation' in kargs when calling this
         # class from op-mode like "show interfaces tunnel"
         if 'encapsulation' in kargs:
-            self.iftype = kargs['encapsulation']
             # The gretap interface has the possibility to act as L2 bridge
-            if self.iftype in ['gretap', 'ip6gretap']:
+            if kargs['encapsulation'] in ['gretap', 'ip6gretap']:
                 # no multicast, ttl or tos for gretap
                 self.definition = {
                     **TunnelIf.definition,
@@ -110,10 +109,10 @@ class TunnelIf(Interface):
             mapping = { **self.mapping, **self.mapping_ipv4 }
 
         cmd = 'ip tunnel add {ifname} mode {encapsulation}'
-        if self.iftype in ['gretap', 'ip6gretap', 'erspan', 'ip6erspan']:
+        if self.config['encapsulation'] in ['gretap', 'ip6gretap', 'erspan', 'ip6erspan']:
             cmd = 'ip link add name {ifname} type {encapsulation}'
             # ERSPAN requires the serialisation of packets
-            if self.iftype in ['erspan', 'ip6erspan']:
+            if self.config['encapsulation'] in ['erspan', 'ip6erspan']:
                 cmd += ' seq'
 
         for vyos_key, iproute2_key in mapping.items():
@@ -132,7 +131,7 @@ class TunnelIf(Interface):
 
     def _change_options(self):
         # gretap interfaces do not support changing any parameter
-        if self.iftype in ['gretap', 'ip6gretap', 'erspan', 'ip6erspan']:
+        if self.config['encapsulation'] in ['gretap', 'ip6gretap', 'erspan', 'ip6erspan']:
             return
 
         if self.config['encapsulation'] in ['ipip6', 'ip6ip6', 'ip6gre']:

--- a/python/vyos/ifconfig/veth.py
+++ b/python/vyos/ifconfig/veth.py
@@ -21,7 +21,6 @@ class VethIf(Interface):
     """
     Abstraction of a Linux veth interface
     """
-    iftype = 'veth'
     definition = {
         **Interface.definition,
         **{
@@ -46,7 +45,7 @@ class VethIf(Interface):
             return
 
         # create virtual-ethernet interface
-        cmd = 'ip link add {ifname} type {type}'.format(**self.config)
+        cmd = f'ip link add {self.ifname} type veth'
         cmd += f' peer name {self.config["peer_name"]}'
         self._cmd(cmd)
 

--- a/python/vyos/ifconfig/vrrp.py
+++ b/python/vyos/ifconfig/vrrp.py
@@ -26,14 +26,11 @@ from vyos.utils.file import read_file
 from vyos.utils.file import wait_for_file_write_complete
 from vyos.utils.process import process_running
 
-
 class VRRPError(Exception):
     pass
 
-
 class VRRPNoData(VRRPError):
     pass
-
 
 class VRRP(object):
     _vrrp_prefix = '00:00:5E:00:01:'

--- a/python/vyos/ifconfig/vti.py
+++ b/python/vyos/ifconfig/vti.py
@@ -19,7 +19,6 @@ from vyos.utils.vti_updown_db import vti_updown_db_exists, open_vti_updown_db_re
 
 @Interface.register
 class VTIIf(Interface):
-    iftype = 'vti'
     definition = {
         **Interface.definition,
         **{

--- a/python/vyos/ifconfig/vtun.py
+++ b/python/vyos/ifconfig/vtun.py
@@ -17,7 +17,6 @@ from vyos.ifconfig.interface import Interface
 
 @Interface.register
 class VTunIf(Interface):
-    iftype = 'vtun'
     definition = {
         **Interface.definition,
         **{

--- a/python/vyos/ifconfig/vxlan.py
+++ b/python/vyos/ifconfig/vxlan.py
@@ -42,8 +42,6 @@ class VXLANIf(Interface):
     For more information please refer to:
     https://www.kernel.org/doc/Documentation/networking/vxlan.txt
     """
-
-    iftype = 'vxlan'
     definition = {
         **Interface.definition,
         **{
@@ -94,7 +92,7 @@ class VXLANIf(Interface):
             remote_list = self.config['remote'][1:]
             self.config['remote'] = self.config['remote'][0]
 
-        cmd = 'ip link add {ifname} type {type} dstport {port}'
+        cmd = 'ip link add {ifname} type vxlan dstport {port}'
         for vyos_key, iproute2_key in mapping.items():
             # dict_search will return an empty dict "{}" for valueless nodes like
             # "parameters.nolearning" - thus we need to test the nodes existence

--- a/python/vyos/ifconfig/wireguard.py
+++ b/python/vyos/ifconfig/wireguard.py
@@ -26,7 +26,6 @@ from vyos.ifconfig import Interface
 from vyos.ifconfig import Operational
 from vyos.template import is_ipv6
 
-
 class WireGuardOperational(Operational):
     def _dump(self):
         """Dump wireguard data in a python friendly way."""
@@ -160,17 +159,17 @@ class WireGuardOperational(Operational):
 @Interface.register
 class WireGuardIf(Interface):
     OperationalClass = WireGuardOperational
-    iftype = 'wireguard'
     definition = {
         **Interface.definition,
         **{
             'section': 'wireguard',
-            'prefixes': [
-                'wg',
-            ],
+            'prefixes': ['wg', ],
             'bridgeable': False,
         },
     }
+
+    def _create(self):
+        super()._create('wireguard')
 
     def get_mac(self):
         """Get a synthetic MAC address."""

--- a/python/vyos/ifconfig/wireless.py
+++ b/python/vyos/ifconfig/wireless.py
@@ -20,7 +20,6 @@ class WiFiIf(Interface):
     """
     Handle WIFI/WLAN interfaces.
     """
-    iftype = 'wifi'
     definition = {
         **Interface.definition,
         **{

--- a/python/vyos/ifconfig/wwan.py
+++ b/python/vyos/ifconfig/wwan.py
@@ -17,7 +17,6 @@ from vyos.ifconfig.interface import Interface
 
 @Interface.register
 class WWANIf(Interface):
-    iftype = 'wwan'
     definition = {
         **Interface.definition,
         **{


### PR DESCRIPTION
Under very rare cases we can run into a race condition where interfaces are still in creation phase but are already referenced..

This can trigger:
```
  File "/usr/libexec/vyos/conf_mode/system_conntrack.py", line 270, in <module>
    apply(c)
  File "/usr/libexec/vyos/conf_mode/system_conntrack.py", line 249, in apply
    call_dependents()
  File "/usr/lib/python3/dist-packages/vyos/configdep.py", line 147, in call_dependents
    f()
  File "/usr/lib/python3/dist-packages/vyos/configdep.py", line 118, in func_impl
    run_config_mode_script(script, config)
  File "/usr/lib/python3/dist-packages/vyos/configdep.py", line 106, in run_config_mode_script
    mod.verify(c)
  File "/usr/libexec/vyos//conf_mode/service_conntrack-sync.py", line 72, in verify
    if len(get_ipv4(interface)) < 1:
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/template.py", line 458, in get_ipv4
    return Interface(interface).get_addr_v4()
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 334, in __init__
    if not self.iftype:
    ^^^^^^^^^^^

  AttributeError: 'Interface' object has no attribute 'iftype'
```

This commit removes the code path in question and the class attribute check. The reason for the iftype attribute in the past was a common _create() method serving for all interface types. As we already have a lot of derived implementations and not all honor the classes iftype/type member - or even worse honor it only in 50% of the occurrences it's time to drop it.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7018

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

![image](https://github.com/user-attachments/assets/ba3645a0-916f-42b3-bf70-9a941d64d28a)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
