### PR TITLE
Debian: T7023: download smoketest container images only once

### DIFF
--- a/debian/vyos-1x-smoketest.postinst
+++ b/debian/vyos-1x-smoketest.postinst
@@ -2,14 +2,12 @@
 
 BUSYBOX_TAG="docker.io/library/busybox:stable"
 BUSYBOX_PATH="/usr/share/vyos/busybox-stable.tar"
-if [[ -f $BUSYBOX_PATH ]]; then
-    rm -f $BUSYBOX_PATH
+if [[ ! -f $BUSYBOX_PATH ]]; then
+    skopeo copy --additional-tag "$BUSYBOX_TAG" "docker://$BUSYBOX_TAG" "docker-archive:/$BUSYBOX_PATH"
 fi
-skopeo copy --additional-tag "$BUSYBOX_TAG" "docker://$BUSYBOX_TAG" "docker-archive:/$BUSYBOX_PATH"
 
 TACPLUS_TAG="docker.io/lfkeitel/tacacs_plus:alpine"
 TACPLUS_PATH="/usr/share/vyos/tacplus-alpine.tar"
-if [[ -f $TACPLUS_PATH ]]; then
-    rm -f $TACPLUS_PATH
+if [[ ! -f $TACPLUS_PATH ]]; then
+    skopeo copy --additional-tag "$TACPLUS_TAG" "docker://$TACPLUS_TAG" "docker-archive:/$TACPLUS_PATH"
 fi
-skopeo copy --additional-tag "$TACPLUS_TAG" "docker://$TACPLUS_TAG" "docker-archive:/$TACPLUS_PATH"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

When setting up vyos-1x-smoketest package, the required container images will be fetched from the appropriate registry. During development one will re-install the vyos-1x generated packages periodically. In the past this triggered a re-download of the container images for every set-up of the package.

```
  Getting image source signatures
  Copying blob sha256:d3a4026919f923f4e0bb9a23a1e5c2d3c5593d31cbac8d2d6d032285b4852945
  Copying config sha256:c1f39daffdeffeb97987901406e2ecef0fb2c2ca236fdfaf570d088426294d91
  Writing manifest to image destination
  Storing signatures

  Getting image source signatures
  Copying blob sha256:a0d0a0d46f8b52473982a3c466318f479767577551a53ffc9074c9fa7035982e
  Copying blob sha256:064e2154c8ec1ddeb114ebc9db9a3876ee8883e9a14fe8622c31cb6f17b759f6
  Copying blob sha256:7e3fbb46165bc5a98b12c136087a13992e30fe00ab4fab2bbe6c7edd657d8c5b
  Copying blob sha256:80a416511ac029206f3f824a15b1c94845c410242a1e463c466a1b3081f7e20f
  Copying blob sha256:339be6688c410f9851f6f09cf0c9d63819f8ca5f2bb09d93ce8c42714842f5ed
  Copying config sha256:6950ba3bd4492642b6c6c0c5f5bb88a5f2a48f700974a2bdba74333a65d9324e
  Writing manifest to image destination
  Storing signatures
```

This change will download the container images only if the image is not present on the system.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4285

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Re-install `vyos-1x-smoketest` package multiple times

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
