### PR TITLE
T7038: T7039: fix broken RADIUS IPv6 source address and add smoketests

### DIFF
--- a/data/templates/login/pam_radius_auth.conf.j2
+++ b/data/templates/login/pam_radius_auth.conf.j2
@@ -9,7 +9,7 @@
 {%             if address | is_ipv4 %}
 {%                 set source_address.ipv4 = address %}
 {%             elif address | is_ipv6 %}
-{%                 set source_address.ipv6 = "[" + address + "]" %}
+{%                 set source_address.ipv6 = address %}
 {%             endif %}
 {%         endfor %}
 {%     endif %}
@@ -21,7 +21,7 @@
 {%             if server | is_ipv4 %}
 {{ server }}:{{ options.port }} {{ "%-25s" | format(options.key) }} {{ "%-10s" | format(options.timeout) }} {{ source_address.ipv4 if source_address.ipv4 is vyos_defined }}
 {%             else %}
-[{{ server }}]:{{ options.port }} {{ "%-25s" | format(options.key) }} {{ "%-10s" | format(options.timeout) }} {{ source_address.ipv6 if source_address.ipv6 is vyos_defined }}
+{{ server | bracketize_ipv6 }}:{{ options.port }} {{ "%-25s" | format(options.key) }} {{ "%-10s" | format(options.timeout) }} {{ source_address.ipv6 if source_address.ipv6 is vyos_defined }}
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/debian/vyos-1x-smoketest.postinst
+++ b/debian/vyos-1x-smoketest.postinst
@@ -11,3 +11,9 @@ TACPLUS_PATH="/usr/share/vyos/tacplus-alpine.tar"
 if [[ ! -f $TACPLUS_PATH ]]; then
     skopeo copy --additional-tag "$TACPLUS_TAG" "docker://$TACPLUS_TAG" "docker-archive:/$TACPLUS_PATH"
 fi
+
+RADIUS_TAG="docker.io/dchidell/radius-web:latest"
+RADIUS_PATH="/usr/share/vyos/radius-latest.tar"
+if [[ ! -f $RADIUS_PATH ]]; then
+    skopeo copy --additional-tag "$RADIUS_TAG" "docker://$RADIUS_TAG" "docker-archive:/$RADIUS_PATH"
+fi


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

RADIUS is pretty sensible to its configuration.

Instead of manual testing, extend the smoketest platform to ship a FreeRADIUS container and perform logins against a locally running FreeRADIUS server in a container.

When configuring RADIUS to use IPv6 as connection to the server with an optional source-address:

```
set system login radius server 2001:db8::4 key '9LMVCtPYpG'
set system login radius source-address '2001:db8::1'
```

It will error out:

`pam_radius_auth(sshd:auth): Failed looking up source IP address [2001:db8::1] for server [2001:db8::4]:1812 (error=System error)`

The source address is not allowed to be in [] - thus the brackets need to be removed.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7038
* https://vyos.dev/T7039

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_login.py
test_add_linux_system_user (__main__.TestSystemLogin.test_add_linux_system_user) ... ok
test_delete_current_user (__main__.TestSystemLogin.test_delete_current_user) ... ok
test_radius_kernel_features (__main__.TestSystemLogin.test_radius_kernel_features) ... ok
test_system_login_max_login_session (__main__.TestSystemLogin.test_system_login_max_login_session) ... ok
test_system_login_otp (__main__.TestSystemLogin.test_system_login_otp) ... ok
test_system_login_radius_ipv4 (__main__.TestSystemLogin.test_system_login_radius_ipv4) ... ok
test_system_login_radius_ipv6 (__main__.TestSystemLogin.test_system_login_radius_ipv6) ... ok
test_system_login_tacacs (__main__.TestSystemLogin.test_system_login_tacacs) ... ok
test_system_login_user (__main__.TestSystemLogin.test_system_login_user) ... ok
test_system_user_ssh_key (__main__.TestSystemLogin.test_system_user_ssh_key) ... ok

----------------------------------------------------------------------
Ran 10 tests in 47.576s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
