### PR TITLE
T681: Fix QoS DSCP filter

### DIFF
--- a/python/vyos/qos/base.py
+++ b/python/vyos/qos/base.py
@@ -89,7 +89,8 @@ class QoSBase:
         if value in self._dsfields:
             return self._dsfields[value]
         else:
-            return value
+            # left shift operation aligns the DSCP/TOS value with its bit position in the IP header.
+            return int(value) << 2
 
     def _calc_random_detect_queue_params(self, avg_pkt, max_thr, limit=None, min_thr=None,
                                          mark_probability=None, precedence=0):


### PR DESCRIPTION
The left shift operation aligns the DSCP/TOS value with its bit position in the IP header. 
TC expects a DSCP value with this shift

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T681

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

run iperf3 as server mode on some host
```
iperf3 -s
```
configure shaper for egress traffic with some DSCP filter:
```
commit
set qos interface eth1 egress 'test'
set qos policy shaper test bandwidth '100mbit'
set qos policy shaper test class 10 bandwidth '50mbit'
set qos policy shaper test default bandwidth '100mbit'
set qos policy shaper test class 10 match m10 ip dscp AF11
commit
```
run iperf3 test and check tc filter stats:
```
vyos@vyos# iperf3 -c 10.0.0.11 --dscp AF11
Connecting to host 10.0.0.11, port 5201
[  5] local 10.0.0.1 port 45666 connected to 10.0.0.11 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  1.47 MBytes  12.3 Mbits/sec  733   11.3 KBytes       
[  5]   1.00-2.00   sec   764 KBytes  6.25 Mbits/sec  513   33.9 KBytes       
[  5]   2.00-3.00   sec  1.86 MBytes  15.7 Mbits/sec  992   33.9 KBytes       
[  5]   3.00-4.00   sec   954 KBytes  7.82 Mbits/sec  639   14.1 KBytes       
[  5]   4.00-5.00   sec   954 KBytes  7.82 Mbits/sec  650   11.3 KBytes       
[  5]   5.00-6.00   sec  2.49 MBytes  20.9 Mbits/sec  1636   14.1 KBytes       
[  5]   6.00-7.00   sec  1.49 MBytes  12.5 Mbits/sec  1101   12.7 KBytes       
[  5]   7.00-8.00   sec  1.18 MBytes  9.91 Mbits/sec  912   14.1 KBytes       
[  5]   8.00-9.00   sec  1.74 MBytes  14.6 Mbits/sec  1095   33.9 KBytes       
[  5]   9.00-10.00  sec  1.55 MBytes  13.0 Mbits/sec  1004   18.4 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  14.4 MBytes  12.1 Mbits/sec  9275             sender
[  5]   0.00-10.04  sec  14.0 MBytes  11.7 Mbits/sec                  receiver

iperf Done.
[edit]
vyos@vyos# tc -s filter show dev eth1
filter parent 1: protocol all pref 1 u32 chain 0 
filter parent 1: protocol all pref 1 u32 chain 0 fh 800: ht divisor 1 
filter parent 1: protocol all pref 1 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 flowid 1:a not_in_hw (rule hit 22956 success 22935)
  match 00280000/00ff0000 at 0 (success 22935 ) 
        action order 1:  police 0x1 rate 50Mbit burst 15Kb mtu 2Kb action reclassify overhead 0b 
        ref 1 bind 1  installed 43 sec used 18 sec firstused 28 sec
        Action statistics:
        Sent 254532166 bytes 168119 pkt (dropped 0, overlimits 19938 requeues 0) 
        backlog 0b 0p requeues 0


vyos@vyos# iperf3 -c 10.0.0.11 --dscp 10
...
  match 00280000/00ff0000 at 0 (success 51005 ) 
        action order 1:  police 0x1 rate 50Mbit burst 15Kb mtu 2Kb action reclassify overhead 0b 
        ref 1 bind 1  installed 123 sec used 4 sec firstused 108 sec
        Action statistics:
        Sent 540570738 bytes 357049 pkt (dropped 0, overlimits 44529 requeues 0) 
```
DSCP 10 and AF11 is equal in iperf3

change our QoS setting and repeated test:
```
set qos policy shaper test class 10 match m10 ip dscp 10
commit

vyos@vyos# tc -s filter show dev eth1
...
  match 00280000/00ff0000 at 0 (success 0 ) 
        action order 1:  police 0x1 rate 50Mbit burst 15Kb mtu 2Kb action reclassify overhead 0b 
        ref 1 bind 1  installed 50 sec used 50 sec
        Action statistics:
        Sent 0 bytes 0 pkt (dropped 0, overlimits 0 requeues 0) 
        backlog 0b 0p requeues 0

[edit]
vyos@vyos#  iperf3 -c 10.0.0.11 --dscp AF11
...
vyos@vyos# tc -s filter show dev eth1
...
  match 00280000/00ff0000 at 0 (success 27786 ) 
        action order 1:  police 0x1 rate 50Mbit burst 15Kb mtu 2Kb action reclassify overhead 0b 
        ref 1 bind 1  installed 115 sec used 38 sec firstused 48 sec
        Action statistics:
        Sent 282990584 bytes 186920 pkt (dropped 0, overlimits 24279 requeues 0) 
        backlog 0b 0p requeues 0

[edit]
vyos@vyos#  iperf3 -c 10.0.0.11 --dscp 10
...
vyos@vyos# tc -s filter show dev eth1
...
  match 00280000/00ff0000 at 0 (success 52126 ) 
        action order 1:  police 0x1 rate 50Mbit burst 15Kb mtu 2Kb action reclassify overhead 0b 
        ref 1 bind 1  installed 136 sec used 5 sec firstused 69 sec
        Action statistics:
        Sent 530155692 bytes 350174 pkt (dropped 0, overlimits 45555 requeues 0) 
        backlog 0b 0p requeues 0

```


```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_qos.py 
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... ok
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok
test_12_shaper_with_red_queue (__main__.TestQoS.test_12_shaper_with_red_queue) ... ok
test_13_shaper_delete_only_rule (__main__.TestQoS.test_13_shaper_delete_only_rule) ... ok
test_14_policy_limiter_marked_traffic (__main__.TestQoS.test_14_policy_limiter_marked_traffic) ... ok
test_15_traffic_match_group (__main__.TestQoS.test_15_traffic_match_group) ... ok
test_16_wrong_traffic_match_group (__main__.TestQoS.test_16_wrong_traffic_match_group) ... ok
test_17_cake_updates (__main__.TestQoS.test_17_cake_updates) ... ok
test_18_priority_queue_default (__main__.TestQoS.test_18_priority_queue_default) ... ok
test_19_priority_queue_default_random_detect (__main__.TestQoS.test_19_priority_queue_default_random_detect) ... ok
test_20_round_robin_policy_default (__main__.TestQoS.test_20_round_robin_policy_default) ... ok
test_21_shaper_hfsc (__main__.TestQoS.test_21_shaper_hfsc) ... ok
test_22_rate_control_default (__main__.TestQoS.test_22_rate_control_default) ... ok
test_23_policy_limiter_iif_filter (__main__.TestQoS.test_23_policy_limiter_iif_filter) ... ok
test_24_policy_shaper_match_ether (__main__.TestQoS.test_24_policy_shaper_match_ether) ... ok

----------------------------------------------------------------------
Ran 24 tests in 157.074s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
