### PR TITLE
opmode: T7084: reorganize the op mode cache format for ease of search

### DIFF
--- a/python/vyos/xml_ref/generate_op_cache.py
+++ b/python/vyos/xml_ref/generate_op_cache.py
@@ -33,8 +33,8 @@ _here = dirname(__file__)
 sys.path.append(join(_here, '..'))
 from defaults import directories
 
-from op_definition import NodeData
 from op_definition import PathData
+
 
 xml_op_cache_json = 'xml_op_cache.json'
 xml_op_tmp = join('/tmp', xml_op_cache_json)
@@ -74,7 +74,7 @@ def translate_op_script(s: str) -> str:
     return s
 
 
-def insert_node(n: Element, l: list[PathData], path = None) -> None:
+def insert_node(n: Element, l: list[PathData], path=None) -> None:
     # pylint: disable=too-many-locals,too-many-branches
     prop: OptElement = n.find('properties')
     children: OptElement = n.find('children')
@@ -97,12 +97,12 @@ def insert_node(n: Element, l: list[PathData], path = None) -> None:
 
     comp_help = {}
     if prop is not None:
-        che = prop.findall("completionHelp")
+        che = prop.findall('completionHelp')
 
         for c in che:
-            comp_list_els = c.findall("list")
-            comp_path_els = c.findall("path")
-            comp_script_els = c.findall("script")
+            comp_list_els = c.findall('list')
+            comp_path_els = c.findall('path')
+            comp_script_els = c.findall('script')
 
             comp_lists = []
             for i in comp_list_els:
@@ -128,13 +128,14 @@ def insert_node(n: Element, l: list[PathData], path = None) -> None:
     cur_node_dict['name'] = name
     cur_node_dict['type'] = node_type
     cur_node_dict['comp_help'] = comp_help
+    cur_node_dict['help'] = help_text
     cur_node_dict['command'] = command_text
     cur_node_dict['path'] = path
     cur_node_dict['children'] = []
     l.append(cur_node_dict)
 
     if children is not None:
-        inner_nodes = children.iterfind("*")
+        inner_nodes = children.iterfind('*')
         for inner_n in inner_nodes:
             inner_path = path[:]
             insert_node(inner_n, cur_node_dict['children'], inner_path)
@@ -143,14 +144,18 @@ def insert_node(n: Element, l: list[PathData], path = None) -> None:
 def parse_file(file_path, l):
     tree = ET.parse(file_path)
     root = tree.getroot()
-    for n in root.iterfind("*"):
+    for n in root.iterfind('*'):
         insert_node(n, l)
 
 
 def main():
     parser = ArgumentParser(description='generate dict from xml defintions')
-    parser.add_argument('--xml-dir', type=str, required=True,
-                        help='transcluded xml op-mode-definition file')
+    parser.add_argument(
+        '--xml-dir',
+        type=str,
+        required=True,
+        help='transcluded xml op-mode-definition file',
+    )
 
     args = vars(parser.parse_args())
 
@@ -166,6 +171,7 @@ def main():
 
     with open(op_ref_cache, 'w') as f:
         f.write(f'op_reference = {str(l)}')
+
 
 if __name__ == '__main__':
     main()

--- a/python/vyos/xml_ref/generate_op_cache.py
+++ b/python/vyos/xml_ref/generate_op_cache.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2024 VyOS maintainers and contributors
+# Copyright (C) 2024-2025 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -95,52 +95,49 @@ def insert_node(n: Element, l: list[PathData], path = None) -> None:
     if command_text is not None:
         command_text = translate_command(command_text, path)
 
-    comp_help = None
+    comp_help = {}
     if prop is not None:
         che = prop.findall("completionHelp")
+
         for c in che:
-            lists = c.findall("list")
-            paths = c.findall("path")
-            scripts = c.findall("script")
+            comp_list_els = c.findall("list")
+            comp_path_els = c.findall("path")
+            comp_script_els = c.findall("script")
 
-            comp_help = {}
-            list_l = []
-            for i in lists:
-                list_l.append(i.text)
-            path_l = []
-            for i in paths:
-                path_str = re.sub(r'\s+', '/', i.text)
-                path_l.append(path_str)
-            script_l = []
-            for i in scripts:
-                script_str = translate_op_script(i.text)
-                script_l.append(script_str)
+            comp_lists = []
+            for i in comp_list_els:
+                comp_lists.append(i.text)
 
-            comp_help['list'] = list_l
-            comp_help['fs_path'] = path_l
-            comp_help['script'] = script_l
+            comp_paths = []
+            for i in comp_path_els:
+                comp_paths.append(i.text)
 
-    for d in l:
-        if name in list(d):
-            break
-    else:
-        d = {}
-        l.append(d)
+            comp_scripts = []
+            for i in comp_script_els:
+                comp_script_str = translate_op_script(i.text)
+                comp_scripts.append(comp_script_str)
 
-    inner_l = d.setdefault(name, [])
+            if comp_lists:
+                comp_help['list'] = comp_lists
+            if comp_paths:
+                comp_help['path'] = comp_paths
+            if comp_scripts:
+                comp_help['script'] = comp_scripts
 
-    inner_d: PathData = {'node_data': NodeData(node_type=node_type,
-                                               help_text=help_text,
-                                               comp_help=comp_help,
-                                               command=command_text,
-                                               path=path)}
-    inner_l.append(inner_d)
+    cur_node_dict = {}
+    cur_node_dict['name'] = name
+    cur_node_dict['type'] = node_type
+    cur_node_dict['comp_help'] = comp_help
+    cur_node_dict['command'] = command_text
+    cur_node_dict['path'] = path
+    cur_node_dict['children'] = []
+    l.append(cur_node_dict)
 
     if children is not None:
         inner_nodes = children.iterfind("*")
         for inner_n in inner_nodes:
             inner_path = path[:]
-            insert_node(inner_n, inner_l, inner_path)
+            insert_node(inner_n, cur_node_dict['children'], inner_path)
 
 
 def parse_file(file_path, l):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

* Move node children to `children` field.
* Flatten node dicts and move properties (completion help, etc.) to the top level.

```json
[
  {
    "name": "show",
    "type": "node",
    "comp_help": {},
    "command": null,
    "path": [
      "show"
    ],
    "children": [
      {
        "name": "kernel",
        "type": "node",
        "comp_help": {},
        "command": null,
        "path": [
          "show",
          "kernel"
        ],
        "children": [
          {
            "name": "modules",
            "type": "node",
            "comp_help": {},
            "command": "sudo /usr/libexec/vyos//op_mode/kernel_modules.py show",
            "path": [
              "show",
              "kernel",
              "modules"
            ],
            "children": []
          }
        ]
      }
    ]
  },

```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
