### PR TITLE
haproxy: T7081: Support HTTP compression

### DIFF
--- a/data/templates/load-balancing/haproxy.cfg.j2
+++ b/data/templates/load-balancing/haproxy.cfg.j2
@@ -93,6 +93,11 @@ frontend {{ front }}
     http-response set-header {{ header }} '{{ header_config['value'] }}'
 {%             endfor %}
 {%         endif %}
+{%         if front_config.http_compression is vyos_defined %}
+    filter compression
+    compression algo {{ front_config.http_compression.algorithm }}
+    compression type {{ front_config.http_compression.mime_type | join(' ') }}
+{%         endif %}
 {%         if front_config.rule is vyos_defined %}
 {%             for rule, rule_config in front_config.rule.items() %}
     # rule {{ rule }}

--- a/interface-definitions/load-balancing_haproxy.xml.in
+++ b/interface-definitions/load-balancing_haproxy.xml.in
@@ -48,6 +48,38 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <node name="http-compression">
+                <properties>
+                  <help>Compress HTTP responses</help>
+                </properties>
+                <children>
+                  <leafNode name="algorithm">
+                    <properties>
+                      <help>Compression algorithm</help>
+                      <completionHelp>
+                        <list>gzip deflate identity raw-deflate</list>
+                      </completionHelp>
+                      <constraint>
+                        <regex>(gzip|deflate|identity|raw-deflate)</regex>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="mime-type">
+                    <properties>
+                      <help>MIME types to compress</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>MIME type to compress</description>
+                      </valueHelp>
+                      <multi/>
+                      <constraint>
+                        <regex>\w+\/[-+.\w]+</regex>
+                      </constraint>
+                      <constraintErrorMessage>Invalid MIME type specified</constraintErrorMessage>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
               <node name="ssl">
                 <properties>
                   <help>SSL Certificate, SSL Key and CA</help>

--- a/src/conf_mode/load-balancing_haproxy.py
+++ b/src/conf_mode/load-balancing_haproxy.py
@@ -78,6 +78,13 @@ def verify(lb):
                 not is_listen_port_bind_service(int(tmp_port), 'haproxy'):
             raise ConfigError(f'"TCP" port "{tmp_port}" is used by another service')
 
+        if 'http_compression' in front_config:
+            if front_config['mode'] != 'http':
+                raise ConfigError(f'service {front} must be set to http mode to use http-compression!')
+            if len(front_config['http_compression']['mime_type']) == 0:
+                raise ConfigError(f'service {front} must have at least one mime-type configured to use'
+                                  f'http_compression!')
+
     for back, back_config in lb['backend'].items():
         if 'http_check' in back_config:
             http_check = back_config['http_check']


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add support for HTTP compression in HAProxy responses.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7081

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
**Test Steps**
1. Configure haproxy using the new options:
```
set load-balancing haproxy service fe-01 listen-address '127.0.0.1'
set load-balancing haproxy service fe-01 port '80'
set load-balancing haproxy service fe-01 mode 'http'
set load-balancing haproxy service fe-01 http-compression algorithm 'gzip'
set load-balancing haproxy service fe-01 http-compression mime-type 'text/html'
set load-balancing haproxy service fe-01 http-compression mime-type 'text/css'
set load-balancing haproxy service fe-01 backend 'bk-01'

set load-balancing haproxy backend bk-01 mode 'http'
set load-balancing haproxy backend bk-01 server srv-01 address '127.0.0.1'
set load-balancing haproxy backend bk-01 server srv-01 port '8080'
```

2. Check haproxy.cfg is showing the correct configuration:
```
vyos@vyos:~$ cat /var/run/haproxy/haproxy.cfg | grep -A 2 'filter compression'
filter compression
compression algo gzip
compression type text/html text/css
```

**Smoke Test**
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_load-balancing_haproxy.py
test_01_lb_reverse_proxy_domain (__main__.TestLoadBalancingReverseProxy.test_01_lb_reverse_proxy_domain) ... ok
test_02_lb_reverse_proxy_cert_not_exists (__main__.TestLoadBalancingReverseProxy.test_02_lb_reverse_proxy_cert_not_exists) ... ok
test_03_lb_reverse_proxy_ca_not_exists (__main__.TestLoadBalancingReverseProxy.test_03_lb_reverse_proxy_ca_not_exists) ... ok
test_04_lb_reverse_proxy_backend_ssl_no_verify (__main__.TestLoadBalancingReverseProxy.test_04_lb_reverse_proxy_backend_ssl_no_verify) ... ok
test_05_lb_reverse_proxy_backend_http_check (__main__.TestLoadBalancingReverseProxy.test_05_lb_reverse_proxy_backend_http_check) ... ok
test_06_lb_reverse_proxy_tcp_mode (__main__.TestLoadBalancingReverseProxy.test_06_lb_reverse_proxy_tcp_mode) ... ok
test_07_lb_reverse_proxy_http_response_headers (__main__.TestLoadBalancingReverseProxy.test_07_lb_reverse_proxy_http_response_headers) ... ok
test_08_lb_reverse_proxy_tcp_health_checks (__main__.TestLoadBalancingReverseProxy.test_08_lb_reverse_proxy_tcp_health_checks) ... ok
test_09_lb_reverse_proxy_logging (__main__.TestLoadBalancingReverseProxy.test_09_lb_reverse_proxy_logging) ... ok
test_10_lb_reverse_proxy_http_compression (__main__.TestLoadBalancingReverseProxy.test_10_lb_reverse_proxy_http_compression) ... ok

----------------------------------------------------------------------
Ran 10 tests in 53.303s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
