### PR TITLE
ntp: T6911: fix migration script to not allow empty "service ntp" CLI node

### DIFF
--- a/smoketest/config-tests/basic-vyos-no-ntp
+++ b/smoketest/config-tests/basic-vyos-no-ntp
@@ -1,0 +1,56 @@
+set interfaces dummy dum0 address '172.18.254.203/32'
+set interfaces ethernet eth0 duplex 'auto'
+set interfaces ethernet eth0 offload gro
+set interfaces ethernet eth0 offload gso
+set interfaces ethernet eth0 offload sg
+set interfaces ethernet eth0 offload tso
+set interfaces ethernet eth0 speed 'auto'
+set interfaces ethernet eth0 vif 203 address '172.18.203.10/24'
+set interfaces ethernet eth1 duplex 'auto'
+set interfaces ethernet eth1 offload gro
+set interfaces ethernet eth1 offload gso
+set interfaces ethernet eth1 offload sg
+set interfaces ethernet eth1 offload tso
+set interfaces ethernet eth1 speed 'auto'
+set interfaces ethernet eth2 offload gro
+set interfaces ethernet eth2 offload gso
+set interfaces ethernet eth2 offload sg
+set interfaces ethernet eth2 offload tso
+set interfaces ethernet eth3 offload gro
+set interfaces ethernet eth3 offload gso
+set interfaces ethernet eth3 offload sg
+set interfaces ethernet eth3 offload tso
+set protocols ospf area 0 network '172.18.203.0/24'
+set protocols ospf area 0 network '172.18.254.203/32'
+set protocols ospf interface eth0.203 authentication md5 key-id 10 md5-key 'vyos'
+set protocols ospf interface eth0.203 dead-interval '40'
+set protocols ospf interface eth0.203 hello-interval '10'
+set protocols ospf interface eth0.203 passive disable
+set protocols ospf interface eth0.203 priority '1'
+set protocols ospf interface eth0.203 retransmit-interval '5'
+set protocols ospf interface eth0.203 transmit-delay '1'
+set protocols ospf log-adjacency-changes detail
+set protocols ospf parameters abr-type 'cisco'
+set protocols ospf parameters router-id '172.18.254.201'
+set protocols ospf passive-interface 'default'
+set protocols ospf redistribute connected metric-type '2'
+set service lldp interface all
+set service ssh disable-host-validation
+set service ssh port '22'
+set system config-management commit-revisions '200'
+set system conntrack modules ftp
+set system conntrack modules h323
+set system conntrack modules nfs
+set system conntrack modules pptp
+set system conntrack modules sip
+set system conntrack modules sqlnet
+set system conntrack modules tftp
+set system console device ttyS0 speed '115200'
+set system domain-name 'vyos.ci.net'
+set system host-name 'no-ntp'
+set system login user vyos authentication encrypted-password '$6$r/Yw/07NXNY$/ZB.Rjf9jxEV.BYoDyLdH.kH14rU52pOBtrX.4S34qlPt77chflCHvpTCq9a6huLzwaMR50rEICzA5GoIRZlM0'
+set system login user vyos authentication plaintext-password ''
+set system name-server '172.16.254.30'
+set system syslog global facility all level 'debug'
+set system syslog global facility local7 level 'debug'
+set system time-zone 'Europe/Berlin'

--- a/smoketest/configs/basic-vyos-no-ntp
+++ b/smoketest/configs/basic-vyos-no-ntp
@@ -1,0 +1,142 @@
+interfaces {
+    dummy dum0 {
+        address 172.18.254.203/32
+    }
+    ethernet eth0 {
+        duplex auto
+        offload {
+            gro
+            gso
+            sg
+            tso
+        }
+        speed auto
+        vif 203 {
+            address 172.18.203.10/24
+            ip {
+                ospf {
+                    authentication {
+                        md5 {
+                            key-id 10 {
+                                md5-key vyos
+                            }
+                        }
+                    }
+                    dead-interval 40
+                    hello-interval 10
+                    priority 1
+                    retransmit-interval 5
+                    transmit-delay 1
+                }
+            }
+        }
+    }
+    ethernet eth1 {
+        duplex auto
+        offload {
+            gro
+            gso
+            sg
+            tso
+        }
+        speed auto
+    }
+    ethernet eth2 {
+        offload {
+            gro
+            gso
+            sg
+            tso
+        }
+    }
+    ethernet eth3 {
+        offload {
+            gro
+            gso
+            sg
+            tso
+        }
+    }
+}
+protocols {
+    ospf {
+        area 0 {
+            network 172.18.203.0/24
+            network 172.18.254.203/32
+        }
+        log-adjacency-changes {
+            detail
+        }
+        parameters {
+            abr-type cisco
+            router-id 172.18.254.203
+        }
+        passive-interface default
+        passive-interface-exclude eth0.203
+        redistribute {
+            connected {
+                metric-type 2
+            }
+        }
+    }
+}
+service {
+    lldp {
+        interface all {
+        }
+    }
+    ssh {
+        disable-host-validation
+        port 22
+    }
+}
+system {
+    config-management {
+        commit-revisions 200
+    }
+    conntrack {
+        modules {
+            ftp
+            h323
+            nfs
+            pptp
+            sip
+            sqlnet
+            tftp
+        }
+    }
+    domain-name vyos.ci.net
+    console {
+        device ttyS0 {
+            speed 115200
+        }
+    }
+    host-name no-ntp
+    login {
+        user vyos {
+            authentication {
+                encrypted-password $6$r/Yw/07NXNY$/ZB.Rjf9jxEV.BYoDyLdH.kH14rU52pOBtrX.4S34qlPt77chflCHvpTCq9a6huLzwaMR50rEICzA5GoIRZlM0
+                plaintext-password ""
+            }
+        }
+    }
+    name-server 172.16.254.30
+    ntp {
+    }
+    syslog {
+        global {
+            facility all {
+                level debug
+            }
+            facility protocols {
+                level debug
+            }
+        }
+    }
+    time-zone Europe/Berlin
+}
+
+
+// Warning: Do not remove the following line.
+// vyos-config-version: "broadcast-relay@1:cluster@1:config-management@1:conntrack@3:conntrack-sync@2:container@1:dhcp-relay@2:dhcp-server@6:dhcpv6-server@1:dns-forwarding@3:firewall@5:https@2:interfaces@23:ipoe-server@1:ipsec@5:isis@1:l2tp@3:lldp@1:mdns@1:nat@5:ntp@1:pppoe-server@5:pptp@2:qos@1:quagga@8:rpki@1:salt@1:snmp@2:ssh@2:sstp@3:system@21:vrrp@2:vyos-accel-ppp@2:wanloadbalance@3:webproxy@2:zone-policy@1"
+// Release version: 1.3.8

--- a/src/migration-scripts/ntp/1-to-2
+++ b/src/migration-scripts/ntp/1-to-2
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2023-2025 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -23,6 +23,11 @@ new_base_path = ['service', 'ntp']
 def migrate(config: ConfigTree) -> None:
     if not config.exists(base_path):
         # Nothing to do
+        return
+
+    # T6911: do not migrate NTP configuration if mandatory server is missing
+    if not config.exists(base_path + ['server']):
+        config.delete(base_path)
         return
 
     # config.copy does not recursively create a path, so create ['service'] if


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

With T3008 we moved from ntpd to chrony. This came with a restructuring of the CLI (mainly moving ntp out of system to services). In addition the definition of a server was made mandatory.

The bug itself manifests at a more crucial point - config migration

```
Jan 23 20:51:18 LR3.wue3 vyos-router[1265]: Migration script error: /opt/vyatta/etc/config-migrate/migrate/ntp/1-to-2: [Errno 1] failed to run command: ['/opt/vyatta/etc/config-migrate/migrate/ntp/1-to-2', '/opt/vyatta/etc/config/config.boot']
Jan 23 20:51:18 LR3.wue3 vyos-router[1265]: returned: - op: copy old_path: ['system', 'ntp'] new_path: ['service', 'ntp']
Jan 23 20:51:18 LR3.wue3 vyos-router[1265]: - op: delete path: ['system', 'ntp']
```

The fix is that we will no longer migrate an empty ntp CLI node from the old syntax to the new.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6911

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Added a new sample configuration with an empty ntp node that is used in config migration tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
