### PR TITLE
wireguard: T7087: Fix vyos-domain-resolver failing if no wireguard interfaces defined

### DIFF
--- a/src/services/vyos-domain-resolver
+++ b/src/services/vyos-domain-resolver
@@ -177,39 +177,40 @@ def update_fqdn(config, node):
 def update_interfaces(config, node):
     if node == 'interfaces':
         wg_interfaces = dict_search_args(config, 'wireguard')
+        if wg_interfaces:
 
-        peer_public_keys = {}
-        # for each wireguard interfaces
-        for interface, wireguard in wg_interfaces.items():
-            peer_public_keys[interface] = []
-            for peer, peer_config in wireguard['peer'].items():
-                # check peer if peer host-name or address is set
-                if 'host_name' in peer_config or 'address' in peer_config:
-                    # check latest handshake
-                    peer_public_keys[interface].append(
-                        peer_config['public_key']
-                    )
+            peer_public_keys = {}
+            # for each wireguard interfaces
+            for interface, wireguard in wg_interfaces.items():
+                peer_public_keys[interface] = []
+                for peer, peer_config in wireguard['peer'].items():
+                    # check peer if peer host-name or address is set
+                    if 'host_name' in peer_config or 'address' in peer_config:
+                        # check latest handshake
+                        peer_public_keys[interface].append(
+                            peer_config['public_key']
+                        )
 
-        now_time = time.time()
-        for (interface, check_peer_public_keys) in peer_public_keys.items():
-            if len(check_peer_public_keys) == 0:
-                continue
+            now_time = time.time()
+            for (interface, check_peer_public_keys) in peer_public_keys.items():
+                if len(check_peer_public_keys) == 0:
+                    continue
 
-            intf = WireGuardIf(interface, create=False, debug=False)
-            handshakes = intf.operational.get_latest_handshakes()
+                intf = WireGuardIf(interface, create=False, debug=False)
+                handshakes = intf.operational.get_latest_handshakes()
 
-            # WireGuard performs a handshake every WIREGUARD_REKEY_AFTER_TIME
-            # if data is being transmitted between the peers. If no data is
-            # transmitted, the handshake will not be initiated unless new
-            # data begins to flow. Each handshake generates a new session
-            # key, and the key is rotated at least every 120 seconds or
-            # upon data transmission after a prolonged silence.
-            for public_key, handshake_time in handshakes.items():
-                if public_key in check_peer_public_keys and (
-                    handshake_time == 0
-                    or (now_time - handshake_time > 3*WIREGUARD_REKEY_AFTER_TIME)
-                ):
-                    intf.operational.reset_peer(public_key=public_key)
+                # WireGuard performs a handshake every WIREGUARD_REKEY_AFTER_TIME
+                # if data is being transmitted between the peers. If no data is
+                # transmitted, the handshake will not be initiated unless new
+                # data begins to flow. Each handshake generates a new session
+                # key, and the key is rotated at least every 120 seconds or
+                # upon data transmission after a prolonged silence.
+                for public_key, handshake_time in handshakes.items():
+                    if public_key in check_peer_public_keys and (
+                        handshake_time == 0
+                        or (now_time - handshake_time > 3*WIREGUARD_REKEY_AFTER_TIME)
+                    ):
+                        intf.operational.reset_peer(public_key=public_key)
 
 if __name__ == '__main__':
     logger.info('VyOS domain resolver')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
[T4930](https://vyos.dev/T4930) has introduced a bug where if no wireguard interfaces are defined, the vyos-domain-resolver process exits with failure. This PR implements a check in vyos-domain-resolver to see if output of dict_search_args is NoneType before attempting to iterate.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7087
https://vyos.dev/T4930

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4200

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
**Test Steps**
1. Configure a domain-group, whilst having no wireguard interfaces configured:
```
vyos@vyos# set firewall group domain-group test address vyos.dev
vyos@vyos# delete interfaces wireguard
```

2. Check vyos-domain-resolver starts correctly:
```
vyos@vyos# sudo systemctl status vyos-domain-resolver
● vyos-domain-resolver.service - VyOS firewall domain resolver
	 Loaded: loaded (/lib/systemd/system/vyos-domain-resolver.service; disabled; preset: enabled)
	 Active: active (running) since Sat 2025-01-25 12:45:18 GMT; 10s ago
   Main PID: 8272 (python3)
	  Tasks: 1 (limit: 1086)
	 Memory: 38.1M
		CPU: 290ms
	 CGroup: /system.slice/vyos-domain-resolver.service
			 └─8272 /usr/bin/python3 -u /usr/libexec/vyos/services/vyos-domain-resolver

Jan 25 12:45:18 vyos systemd[1]: Started vyos-domain-resolver.service - VyOS firewall domain resolver.
Jan 25 12:45:18 vyos vyos-domain-resolver[8272]: VyOS domain resolver
Jan 25 12:45:20 vyos vyos-domain-resolver[8272]: interval: 300s - cache: False
Jan 25 12:45:20 vyos vyos-domain-resolver[8272]: Updated 1 sets in firewall - result: 0
Jan 25 12:45:20 vyos vyos-domain-resolver[8272]: Updated 0 sets in nat - result: 0
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly