### PR TITLE
T7089: Fix static route when using PPPoE default route

### DIFF
--- a/data/templates/frr/staticd.frr.j2
+++ b/data/templates/frr/staticd.frr.j2
@@ -94,14 +94,14 @@ vrf {{ vrf }}
 {% if pppoe is vyos_defined %}
 {%     for interface, interface_config in pppoe.items() if interface_config.no_default_route is not vyos_defined %}
 {{ ip_prefix }} route 0.0.0.0/0 {{ interface }} tag 210 {{ interface_config.default_route_distance if interface_config.default_route_distance is vyos_defined }}
-{%-    endfor %}
+{%    endfor %}
 {% endif %}
 {# IPv6 routing #}
 {% if route6 is vyos_defined %}
 {%     for prefix, prefix_config in route6.items() %}
 {{ static_routes(ipv6_prefix, prefix, prefix_config) }}
 {# j2lint: disable=jinja-statements-delimeter #}
-{%-    endfor %}
+{%    endfor %}
 {% endif %}
 {% if vrf is vyos_defined %}
 exit-vrf

--- a/data/templates/frr/staticd.frr.j2
+++ b/data/templates/frr/staticd.frr.j2
@@ -94,14 +94,14 @@ vrf {{ vrf }}
 {% if pppoe is vyos_defined %}
 {%     for interface, interface_config in pppoe.items() if interface_config.no_default_route is not vyos_defined %}
 {{ ip_prefix }} route 0.0.0.0/0 {{ interface }} tag 210 {{ interface_config.default_route_distance if interface_config.default_route_distance is vyos_defined }}
-{%    endfor %}
+{%     endfor %}
 {% endif %}
 {# IPv6 routing #}
 {% if route6 is vyos_defined %}
 {%     for prefix, prefix_config in route6.items() %}
 {{ static_routes(ipv6_prefix, prefix, prefix_config) }}
 {# j2lint: disable=jinja-statements-delimeter #}
-{%    endfor %}
+{%     endfor %}
 {% endif %}
 {% if vrf is vyos_defined %}
 exit-vrf


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Fix static route when using PPPoE default route



## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7089

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

live image with ethernet dhcp + service ssh + pppoe configured.

```
root@vyos:/home/vyos# /usr/libexec/vyos/tests/smoke/cli/test_protocols_static.py 
test_01_static (__main__.TestProtocolsStatic.test_01_static) ... ok
test_02_static_table (__main__.TestProtocolsStatic.test_02_static_table) ... ok
test_03_static_vrf (__main__.TestProtocolsStatic.test_03_static_vrf) ... FAIL
test_04_static_multicast (__main__.TestProtocolsStatic.test_04_static_multicast) ... ok
test_05_dhcp_default_route (__main__.TestProtocolsStatic.test_05_dhcp_default_route) ... skipped 'Not running under VyOS CI/CD QEMU environment!'

======================================================================
FAIL: test_03_static_vrf (__main__.TestProtocolsStatic.test_03_static_vrf)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/libexec/vyos/tests/smoke/cli/test_protocols_static.py", line 189, in tearDown
    self.assertFalse(v4route)
AssertionError: 'ip route 0.0.0.0/0 pppoe0 tag 210\nip route 0.0.0.0/0 192.168.12.1 eth0 tag 210 210\n!' is not false

----------------------------------------------------------------------
Ran 5 tests in 65.275s

FAILED (failures=1, skipped=1)
```

live image with all default config, test 03 passed, test 05 skipped




## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
