### PR TITLE
dhcp: T7052: Fix remaining time evaluation and formatting errors

### DIFF
--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -497,7 +497,7 @@ def kea_get_server_leases(config, inet, pools=[], state=[], origin=None) -> list
         )
         data_lease['origin'] = 'local'  # TODO: Determine remote in HA
         # remove trailing dot in 'hostname' to ensure consistency for `vyos-hostsd-client`
-        data_lease['hostname'] = lease.get('hostname', '-').rstrip('.')
+        data_lease['hostname'] = lease.get('hostname', '').rstrip('.') or '-'
 
         if inet == '4':
             data_lease['mac'] = lease['hw-address']
@@ -512,7 +512,7 @@ def kea_get_server_leases(config, inet, pools=[], state=[], origin=None) -> list
                 prefix_len = lease['prefix-len']
                 data_lease['ip'] += f'/{prefix_len}'
 
-        data_lease['remaining'] = '-'
+        data_lease['remaining'] = ''
 
         if lease['valid-lft'] > 0:
             data_lease['remaining'] = lease['expire_timestamp'] - datetime.now(
@@ -526,7 +526,7 @@ def kea_get_server_leases(config, inet, pools=[], state=[], origin=None) -> list
 
         # Do not add old leases
         if (
-            data_lease['remaining']
+            data_lease['remaining'] != ''
             and data_lease['pool'] in pools
             and data_lease['state'] != 'free'
             and (not state or state == 'all' or data_lease['state'] in state)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The remaining time for a lease was not being correctly evaluated and formatted. As a result, expired leases show up with `show dhcp server leases`.

Also, the empty hostname should be replaced by '-'.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7052

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

#### Before:

`10.10.2.1` has lease expired but still shows up, `10.10.2.2` doesn't have `hostname` set to `-`
```
vyos@test-0125:~$ show dhcp server leases sort ip
IP Address    MAC address        State    Lease start                Lease expiration           Remaining    Pool    Hostname                     Origin
------------  -----------------  -------  -------------------------  -------------------------  -----------  ------  ---------------------------  --------
10.10.1.9     80:aa:bb:cc:dd:ee  active   2025-01-26 08:25:54+00:00  2025-01-27 08:25:54+00:00  13:40:25     LAN1    ngap                         local
10.10.2.1     7e:aa:bb:cc:dd:ee  expired  2025-01-25 17:46:19+00:00  2025-01-26 17:46:19+00:00  -            LAN2    watch                        local
10.10.2.2     a6:aa:bb:cc:dd:ee  active   2025-01-25 23:23:18+00:00  2025-01-26 23:23:18+00:00  4:37:49      LAN2                                 local

```

#### After:

`10.10.2.1` doesn't show up, `10.10.2.2` has `hostname` set to `-` correctly

```
vyos@test-0125:~$ show dhcp server leases sort ip
IP Address    MAC address        State    Lease start                Lease expiration           Remaining    Pool    Hostname                     Origin
------------  -----------------  -------  -------------------------  -------------------------  -----------  ------  ---------------------------  --------
10.10.1.9     80:aa:bb:cc:dd:ee  active   2025-01-26 08:25:54+00:00  2025-01-27 08:25:54+00:00  13:15:04     LAN1    ngap                         local
10.10.2.2     a6:aa:bb:cc:dd:ee  active   2025-01-25 23:23:18+00:00  2025-01-26 23:23:18+00:00  4:12:28      LAN2    -                            local

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
