### PR TITLE
T7076: Add script to validate ethernet interface

### DIFF
--- a/src/validators/ethernet-interface
+++ b/src/validators/ethernet-interface
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+if [[ "$1" != ^(lan|eth|eno|ens|enp|enx)[0-9]+$ ]]; then
+    echo "Error: $1 is not an ethernet interface"
+    exit 1
+fi
+
+if ! [ -d "/sys/class/net/$1" ]; then
+    echo "Error: $1 interface does not exist in the system"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): add stricter validation for ethernet interfaces

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7076
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-vpp/pull/6
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# ls /sys/class/net/
dum0  eth0  eth1  eth2  eth3  lo  pim6reg
[edit]
vyos@vyos# set vpp settings interface dum0

  Error: dum0 is not an ehternet interface



  Invalid interface name
  Value validation failed
  Set failed

[edit]
vyos@vyos# set vpp settings interface eth99

  Error: eth99 does not exist in the system



  Invalid interface name
  Value validation failed
  Set failed

[edit]
vyos@vyos# set vpp settings interface eth1
[edit]
vyos@vyos#
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
