### PR TITLE
installer: T7102: download upgrade images to a random path in the root filesystem

### DIFF
--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -99,7 +99,7 @@ DIR_ISO_MOUNT: str = f'{DIR_INSTALLATION}/iso_src'
 DIR_DST_ROOT: str = f'{DIR_INSTALLATION}/disk_dst'
 DIR_KERNEL_SRC: str = '/boot/'
 FILE_ROOTFS_SRC: str = '/usr/lib/live/mount/medium/live/filesystem.squashfs'
-ISO_DOWNLOAD_PATH: str = '/tmp/vyos_installation.iso'
+ISO_DOWNLOAD_PATH: str = ''
 
 external_download_script = '/usr/libexec/vyos/simple-download.py'
 external_latest_image_url_script = '/usr/libexec/vyos/latest-image-url.py'
@@ -552,6 +552,11 @@ def image_fetch(image_path: str, vrf: str = None,
     Returns:
         Path: a path to a local file
     """
+    import os.path
+    from uuid import uuid4
+
+    global ISO_DOWNLOAD_PATH
+
     # Latest version gets url from configured "system update-check url"
     if image_path == 'latest':
         command = external_latest_image_url_script
@@ -568,6 +573,7 @@ def image_fetch(image_path: str, vrf: str = None,
         # check a type of path
         if urlparse(image_path).scheme:
             # download an image
+            ISO_DOWNLOAD_PATH = os.path.join(os.path.expanduser("~"), '{0}.iso'.format(uuid4()))
             download_file(ISO_DOWNLOAD_PATH, image_path, vrf,
                           username, password,
                           progressbar=True, check_space=True)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

As of now, the image upgrade script always downloads the new image to `/tmp/vyos_installation.iso`. There are two problems with that approach:

1. `/tmp` is a RAM-backed `tmpfs`, which means upgrade can fail if the system doesn't have enough free RAM to store a ~600MB image. Even if it does have that memory, a completely avoidable 600M RAM usage spike still isn't a good idea.
2. If two people try to execute `add system image` at once, using a fixed location will lead to funny errors.

Storing the temporary image in the persistent root filesystem and using a random name for it solves both problems.

This PR is somewhat ugly — that's the price of making it minimal and easy to backport. The script can certainly benefit from a deep refactoring.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
