### PR TITLE
T6058: Fix popen command wrapper handling

### DIFF
--- a/python/vyos/utils/process.py
+++ b/python/vyos/utils/process.py
@@ -83,7 +83,7 @@ def popen(command, flag='', shell=None, input=None, timeout=None, env=None,
             )
 
     wrapper = get_wrapper(vrf, netns, auth)
-    command = f'{wrapper} {command}'
+    command = f'{wrapper} {command}' if wrapper else command
 
     cmd_msg = f"cmd '{command}'"
     debug.message(cmd_msg, flag)


### PR DESCRIPTION
Ensure `wrapper` is only prepended to `command` when it is non-empty

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6058

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
conf
set system proxy port '3128'
set system proxy url 'http://127.0.0.1'
set system config-management commit-archive location 'git+https://user:pass@gitlab.com/user/commit-archive'
commit
```
before fix:
```
# commit
Archiving config...
  git+https://gitlab.com/user/commit-archive Unable to upload "git+https://user:pass@gitlab.com/user/commit-archive/config.boot-vyos.20250205_052044": [Errno 2] No such file or directory: " ['git', 'clone', 'https://user:pass@gitlab.com/user/commit-archive', '/tmp/git-commit-archive-22hte0rg/repository', '--depth=1']"
run-parts: /etc/commit/post-hooks.d/02vyos-commit-archive exited with return code 1
```

after fix:
```
vyos@vyos# commit
Archiving config...
  git+https://gitlab.com/user/commit-archive [edit]
vyos@vyos# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
