### PR TITLE
wireguard: T4930: remove pylint W0611: unused import

### DIFF
--- a/python/vyos/ifconfig/wireguard.py
+++ b/python/vyos/ifconfig/wireguard.py
@@ -14,13 +14,8 @@
 # License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import time
 
-from datetime import timedelta
 from tempfile import NamedTemporaryFile
-
-from hurry.filesize import size
-from hurry.filesize import alternative
 
 from vyos.configquery import ConfigTreeQuery
 from vyos.ifconfig import Interface


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Remove unused imports

```
************* Module vyos.ifconfig.wireguard
python/vyos/ifconfig/wireguard.py:17:0: W0611: Unused import time (unused-import)
python/vyos/ifconfig/wireguard.py:19:0: W0611: Unused timedelta imported from datetime (unused-import)
python/vyos/ifconfig/wireguard.py:22:0: W0611: Unused size imported from hurry.filesize (unused-import)
python/vyos/ifconfig/wireguard.py:23:0: W0611: Unused alternative imported from hurry.filesize (unused-import)
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T4930

## Related PR(s)
* https://github.com/vyos/vyos-1x/pull/4200

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
