### PR TITLE
vyos.ifconfig: T5103: always stop the DHCP client process bevore changing VRF

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -615,8 +615,18 @@ class Interface(Control):
 
         # Get current VRF table ID
         old_vrf_tableid = get_vrf_tableid(self.ifname)
-        self.set_interface('vrf', vrf)
 
+        # Always stop the DHCP client process to clean up routes within the VRF
+        # where the process was originally started. There is no need to add a
+        # condition to only call the method if "address dhcp" was defined, as
+        # this is handled inside set_dhcp(v6) by only stopping if the daemon is
+        # running. DHCP client process restart will be handled later on once the
+        # interface is moved to the new VRF.
+        self.set_dhcp(False)
+        self.set_dhcpv6(False)
+
+        # Move interface in/out of VRF
+        self.set_interface('vrf', vrf)
         if vrf:
             # Get routing table ID number for VRF
             vrf_table_id = get_vrf_tableid(vrf)

--- a/src/etc/netplug/vyos-netplug-dhcp-client
+++ b/src/etc/netplug/vyos-netplug-dhcp-client
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2023 VyOS maintainers and contributors <maintainers@vyos.io>
+# Copyright 2023-2025 VyOS maintainers and contributors <maintainers@vyos.io>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -20,10 +20,11 @@ import sys
 from time import sleep
 
 from vyos.configquery import ConfigTreeQuery
+from vyos.configdict import get_interface_dict
+from vyos.ifconfig import Interface
 from vyos.ifconfig import Section
 from vyos.utils.boot import boot_configuration_complete
 from vyos.utils.commit import commit_in_progress
-from vyos.utils.process import call
 from vyos import airbag
 airbag.enable()
 
@@ -35,28 +36,19 @@ if not boot_configuration_complete():
     airbag.noteworthy("System bootup not yet finished...")
     sys.exit(1)
 
+interface = sys.argv[1]
+# helper scripts should only work on physical interfaces not on individual
+# sub-interfaces. Moving e.g. a VLAN interface in/out a VRF will also trigger
+# this script which should be prohibited - bail out early
+if '.' in interface:
+    sys.exit(0)
+
 while commit_in_progress():
     sleep(1)
 
-interface = sys.argv[1]
 in_out = sys.argv[2]
 config = ConfigTreeQuery()
 
 interface_path = ['interfaces'] + Section.get_config_path(interface).split()
-
-for _, interface_config in config.get_config_dict(interface_path).items():
-    # Bail out early if we do not have an IP address configured
-    if 'address' not in interface_config:
-        continue
-    # Bail out early if interface ist administrative down
-    if 'disable' in interface_config:
-        continue
-    systemd_action = 'start'
-    if in_out == 'out':
-        systemd_action = 'stop'
-    # Start/Stop DHCP service
-    if 'dhcp' in interface_config['address']:
-        call(f'systemctl {systemd_action} dhclient@{interface}.service')
-    # Start/Stop DHCPv6 service
-    if 'dhcpv6' in interface_config['address']:
-        call(f'systemctl {systemd_action} dhcp6c@{interface}.service')
+_, interface_config = get_interface_dict(config, interface_path[:-1], ifname=interface, with_pki=True)
+Interface(interface).update(interface_config)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Always stop the DHCP client process to clean up routes within the VRF where the process was originally started. There is no need to add a condition to only call the method if `address dhcp` was defined, as this is handled inside `set_dhcp(v6)` by only stopping if the daemon is running.

DHCP client process restart will be handled later on once the interface is moved to the new VRF.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T5103

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4335

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ TEST_ETH="eth1 eth2" /usr/libexec/vyos/tests/smoke/cli/test_interfaces_ethernet.py
test_add_multiple_ip_addresses (__main__.EthernetInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.EthernetInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.EthernetInterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.EthernetInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.EthernetInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.EthernetInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.EthernetInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.EthernetInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol (__main__.EthernetInterfaceTest.test_eapol) ... ok
test_ethtool_evpn_uplink_tracking (__main__.EthernetInterfaceTest.test_ethtool_evpn_uplink_tracking) ... ok
test_ethtool_flow_control (__main__.EthernetInterfaceTest.test_ethtool_flow_control) ... ok
test_ethtool_ring_buffer (__main__.EthernetInterfaceTest.test_ethtool_ring_buffer) ... ok
test_interface_description (__main__.EthernetInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.EthernetInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.EthernetInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.EthernetInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.EthernetInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.EthernetInterfaceTest.test_ipv6_link_local_address) ... ok
test_move_interface_between_vrf_instances (__main__.EthernetInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.EthernetInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_non_existing_interface (__main__.EthernetInterfaceTest.test_non_existing_interface) ... ok
test_offloading_rfs (__main__.EthernetInterfaceTest.test_offloading_rfs) ... ok
test_offloading_rps (__main__.EthernetInterfaceTest.test_offloading_rps) ... ok
test_span_mirror (__main__.EthernetInterfaceTest.test_span_mirror) ... ok
test_speed_duplex_verify (__main__.EthernetInterfaceTest.test_speed_duplex_verify) ... ok
test_switchdev (__main__.EthernetInterfaceTest.test_switchdev) ... ok
test_vif_8021q_interfaces (__main__.EthernetInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.EthernetInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.EthernetInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.EthernetInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.EthernetInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.EthernetInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 34 tests in 447.148s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
