### PR TITLE
webproxy: T7057: Fixed 'domain-nocache' command

### DIFF
--- a/data/templates/squid/squid.conf.j2
+++ b/data/templates/squid/squid.conf.j2
@@ -30,6 +30,14 @@ acl BLOCKDOMAIN dstdomain {{ domain }}
 {%     endfor %}
 http_access deny BLOCKDOMAIN
 {% endif %}
+
+{% if domain_noncache is vyos_defined %}
+{%     for domain in domain_noncache %}
+acl NOCACHE dstdomain {{ domain }}
+{%     endfor %}
+no_cache deny NOCACHE
+{% endif %}
+
 {% if authentication is vyos_defined %}
 {%     if authentication.children is vyos_defined %}
 auth_param basic children {{ authentication.children }}

--- a/smoketest/scripts/cli/test_service_webproxy.py
+++ b/smoketest/scripts/cli/test_service_webproxy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020-2022 VyOS maintainers and contributors
+# Copyright (C) 2020-2025 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -297,6 +297,22 @@ class TestServiceWebProxy(VyOSUnitTestSHIM.TestCase):
         # Check for running process
         self.assertTrue(process_named_running(PROCESS_NAME))
 
+    def test_06_nocache_domain_proxy(self):
+        domains_nocache = ['test1.net', 'test2.net']
+        self.cli_set(base_path + ['listen-address', listen_ip])
+        for domain in domains_nocache:
+            self.cli_set(base_path + ['domain-noncache', domain])
+        # commit changes
+        self.cli_commit()
+
+        config = read_file(PROXY_CONF)
+
+        for domain in domains_nocache:
+            self.assertIn(f'acl NOCACHE dstdomain {domain}', config)
+        self.assertIn(f'no_cache deny NOCACHE', config)
+
+        # Check for running process
+        self.assertTrue(process_named_running(PROCESS_NAME))
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed 'domain-nocache' command.
Added config generation for this command.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7057

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
CLI Configuration:
```
set service webproxy listen-address 192.168.139.145 disable-transparent
set service webproxy domain-noncache test1.net
set service webproxy domain-noncache test2.net
commit
```

Squid config part:
```
vyos@vyos:~$ cat /etc/squid/squid.conf
### generated by service_webproxy.py ###

...............

acl NOCACHE dstdomain ukr.net
acl NOCACHE dstdomain test.net
no_cache deny NOCACHE

.......................
```
Smoke test results
```
vyos@vyos:~$ cp test_service_webproxy.py  /usr/libexec/vyos/tests/smoke/cli/
cp: cannot create regular file '/usr/libexec/vyos/tests/smoke/cli/test_service_webproxy.py': Permission denied
vyos@vyos:~$ sudo cp test_service_webproxy.py  /usr/libexec/vyos/tests/smoke/cli/
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_webproxy.py
test_01_basic_proxy (__main__.TestServiceWebProxy.test_01_basic_proxy) ... ok
test_02_advanced_proxy (__main__.TestServiceWebProxy.test_02_advanced_proxy) ... ok
test_03_ldap_proxy_auth (__main__.TestServiceWebProxy.test_03_ldap_proxy_auth) ... ok
test_04_cache_peer (__main__.TestServiceWebProxy.test_04_cache_peer) ... ok
test_05_basic_squidguard (__main__.TestServiceWebProxy.test_05_basic_squidguard) ... ok
test_07_nocache_domain_proxy (__main__.TestServiceWebProxy.test_07_nocache_domain_proxy) ... ok

----------------------------------------------------------------------
Ran 6 tests in 206.452s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
