### PR TITLE
T7161: fix BGP IPv4/IPv6 unicast AFI "redistribute table" command

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -310,7 +310,9 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {%         if afi_config.redistribute is vyos_defined %}
 {%             for protocol, protocol_config in afi_config.redistribute.items() %}
 {%                 if protocol == 'table' %}
-  redistribute table {{ protocol_config.table }}
+{%                     for table in protocol_config %}
+  redistribute table-direct {{ table }}
+{%                     endfor %}
 {%                 else %}
 {%                     set redistribution_protocol = protocol %}
 {%                     if protocol == 'ospfv3' %}

--- a/interface-definitions/include/bgp/afi-redistribute-common-protocols.xml.i
+++ b/interface-definitions/include/bgp/afi-redistribute-common-protocols.xml.i
@@ -1,0 +1,39 @@
+<!-- include start from bgp/afi-redistribute-common-protocols.xml.i -->
+<node name="babel">
+  <properties>
+    <help>Redistribute Babel routes into BGP</help>
+  </properties>
+  <children>
+    #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
+  </children>
+</node>
+<node name="connected">
+  <properties>
+    <help>Redistribute connected routes into BGP</help>
+  </properties>
+  <children>
+    #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
+  </children>
+</node>
+<node name="kernel">
+  <properties>
+    <help>Redistribute kernel routes into BGP</help>
+  </properties>
+  <children>
+    #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
+  </children>
+</node>
+<node name="static">
+  <properties>
+    <help>Redistribute static routes into BGP</help>
+  </properties>
+  <children>
+    #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
+  </children>
+</node>
+<leafNode name="table">
+  <properties>
+    <help>Redistribute non-main Kernel Routing Table</help>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/bgp/afi-redistribute-common-protocols.xml.i
+++ b/interface-definitions/include/bgp/afi-redistribute-common-protocols.xml.i
@@ -15,6 +15,14 @@
     #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
   </children>
 </node>
+<node name="isis">
+  <properties>
+    <help>Redistribute IS-IS routes into BGP</help>
+  </properties>
+  <children>
+    #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
+  </children>
+</node>
 <node name="kernel">
   <properties>
     <help>Redistribute kernel routes into BGP</help>

--- a/interface-definitions/include/bgp/afi-redistribute-common-protocols.xml.i
+++ b/interface-definitions/include/bgp/afi-redistribute-common-protocols.xml.i
@@ -42,6 +42,11 @@
 <leafNode name="table">
   <properties>
     <help>Redistribute non-main Kernel Routing Table</help>
+    <completionHelp>
+      <path>protocols static table</path>
+    </completionHelp>
+    #include <include/constraint/protocols-static-table.xml.i>
+    <multi/>
   </properties>
 </leafNode>
 <!-- include end -->

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -126,14 +126,6 @@
             <help>Redistribute routes from other protocols into BGP</help>
           </properties>
           <children>
-            <node name="connected">
-              <properties>
-                <help>Redistribute connected routes into BGP</help>
-              </properties>
-              <children>
-                #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
-              </children>
-            </node>
             <node name="isis">
               <properties>
                 <help>Redistribute IS-IS routes into BGP</help>
@@ -142,14 +134,7 @@
                 #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
               </children>
             </node>
-            <node name="kernel">
-              <properties>
-                <help>Redistribute kernel routes into BGP</help>
-              </properties>
-              <children>
-                #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
-              </children>
-            </node>
+            #include <include/bgp/afi-redistribute-common-protocols.xml.i>
             <node name="ospf">
               <properties>
                 <help>Redistribute OSPF routes into BGP</help>
@@ -166,27 +151,6 @@
                 #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
               </children>
             </node>
-            <node name="babel">
-              <properties>
-                <help>Redistribute Babel routes into BGP</help>
-              </properties>
-              <children>
-                #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
-              </children>
-            </node>
-            <node name="static">
-              <properties>
-                <help>Redistribute static routes into BGP</help>
-              </properties>
-              <children>
-                #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
-              </children>
-            </node>
-            <leafNode name="table">
-              <properties>
-                <help>Redistribute non-main Kernel Routing Table</help>
-              </properties>
-            </leafNode>
           </children>
         </node>
         #include <include/bgp/afi-sid.xml.i>
@@ -503,22 +467,7 @@
             <help>Redistribute routes from other protocols into BGP</help>
           </properties>
           <children>
-            <node name="connected">
-              <properties>
-                <help>Redistribute connected routes into BGP</help>
-              </properties>
-              <children>
-                #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
-              </children>
-            </node>
-            <node name="kernel">
-              <properties>
-                <help>Redistribute kernel routes into BGP</help>
-              </properties>
-              <children>
-                #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
-              </children>
-            </node>
+            #include <include/bgp/afi-redistribute-common-protocols.xml.i>
             <node name="ospfv3">
               <properties>
                 <help>Redistribute OSPFv3 routes into BGP</help>
@@ -535,27 +484,6 @@
                 #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
               </children>
             </node>
-            <node name="babel">
-              <properties>
-                <help>Redistribute Babel routes into BGP</help>
-              </properties>
-              <children>
-                #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
-              </children>
-            </node>
-            <node name="static">
-              <properties>
-                <help>Redistribute static routes into BGP</help>
-              </properties>
-              <children>
-                #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
-              </children>
-            </node>
-            <leafNode name="table">
-              <properties>
-                <help>Redistribute non-main Kernel Routing Table</help>
-              </properties>
-            </leafNode>
           </children>
         </node>
         #include <include/bgp/afi-sid.xml.i>

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -126,14 +126,6 @@
             <help>Redistribute routes from other protocols into BGP</help>
           </properties>
           <children>
-            <node name="isis">
-              <properties>
-                <help>Redistribute IS-IS routes into BGP</help>
-              </properties>
-              <children>
-                #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
-              </children>
-            </node>
             #include <include/bgp/afi-redistribute-common-protocols.xml.i>
             <node name="ospf">
               <properties>

--- a/interface-definitions/include/constraint/protocols-static-table.xml.i
+++ b/interface-definitions/include/constraint/protocols-static-table.xml.i
@@ -1,0 +1,9 @@
+<!-- include start from constraint/host-name.xml.i -->
+<valueHelp>
+  <format>u32:1-200</format>
+  <description>Policy route table number</description>
+</valueHelp>
+<constraint>
+  <validator name="numeric" argument="--range 1-200"/>
+</constraint>
+<!-- include end -->

--- a/interface-definitions/protocols_static.xml.in
+++ b/interface-definitions/protocols_static.xml.in
@@ -65,14 +65,8 @@
           #include <include/static/static-route6.xml.i>
           <tagNode name="table">
             <properties>
-              <help>Policy route table number</help>
-              <valueHelp>
-                <format>u32:1-200</format>
-                <description>Policy route table number</description>
-              </valueHelp>
-              <constraint>
-                <validator name="numeric" argument="--range 1-200"/>
-              </constraint>
+              <help>Non-main Kernel Routing Table</help>
+              #include <include/constraint/protocols-static-table.xml.i>
             </properties>
             <children>
               <!--


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Re-use existing XML constraint added via commit 8f6246da6 (`xml: T7161: provide re-usable building block for alternative routing tables`) and add handy CLI completion helper.

FRRouting supports redistribution of multiple non-main tables, thus make this a multi node in addition, too.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7161

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ... ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ... ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ... ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ... ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ... ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ... ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ... ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ... ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ... ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ... ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok
test_bgp_24_srv6_sid (__main__.TestProtocolsBGP.test_bgp_24_srv6_sid) ... ok
test_bgp_25_ipv4_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_25_ipv4_labeled_unicast_peer_group) ... ok
test_bgp_26_ipv6_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_26_ipv6_labeled_unicast_peer_group) ... ok
test_bgp_27_route_reflector_client (__main__.TestProtocolsBGP.test_bgp_27_route_reflector_client) ... ok
test_bgp_28_peer_group_member_all_internal_or_external (__main__.TestProtocolsBGP.test_bgp_28_peer_group_member_all_internal_or_external) ... ok
test_bgp_29_peer_group_remote_as_equal_local_as (__main__.TestProtocolsBGP.test_bgp_29_peer_group_remote_as_equal_local_as) ... ok
test_bgp_99_bmp (__main__.TestProtocolsBGP.test_bgp_99_bmp) ... ok

----------------------------------------------------------------------
Ran 29 tests in 330.051s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
