### PR TITLE
bgp: T7163: add CLI route-map and metric support for "redistribute table"

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -310,8 +310,8 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {%         if afi_config.redistribute is vyos_defined %}
 {%             for protocol, protocol_config in afi_config.redistribute.items() %}
 {%                 if protocol == 'table' %}
-{%                     for table in protocol_config %}
-  redistribute table-direct {{ table }}
+{%                     for table, table_config in protocol_config.items() %}
+  redistribute table-direct {{ table }} {{ 'metric ' ~ table_config.metric if table_config.metric is vyos_defined }} {{ 'route-map ' ~ table_config.route_map if table_config.route_map is vyos_defined }}
 {%                     endfor %}
 {%                 else %}
 {%                     set redistribution_protocol = protocol %}

--- a/interface-definitions/include/bgp/afi-redistribute-common-protocols.xml.i
+++ b/interface-definitions/include/bgp/afi-redistribute-common-protocols.xml.i
@@ -39,14 +39,16 @@
     #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
   </children>
 </node>
-<leafNode name="table">
+<tagNode name="table">
   <properties>
     <help>Redistribute non-main Kernel Routing Table</help>
     <completionHelp>
       <path>protocols static table</path>
     </completionHelp>
     #include <include/constraint/protocols-static-table.xml.i>
-    <multi/>
   </properties>
-</leafNode>
+  <children>
+    #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
+  </children>
+</tagNode>
 <!-- include end -->

--- a/interface-definitions/include/version/bgp-version.xml.i
+++ b/interface-definitions/include/version/bgp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/bgp-version.xml.i -->
-<syntaxVersion component='bgp' version='5'></syntaxVersion>
+<syntaxVersion component='bgp' version='6'></syntaxVersion>
 <!-- include end -->

--- a/smoketest/config-tests/bgp-rpki
+++ b/smoketest/config-tests/bgp-rpki
@@ -13,6 +13,7 @@ set policy route-map ebgp-transit-rpki rule 30 set local-preference '100'
 set policy route-map ebgp-transit-rpki rule 40 action 'permit'
 set policy route-map ebgp-transit-rpki rule 40 set extcommunity rt '192.0.2.100:100'
 set policy route-map ebgp-transit-rpki rule 40 set extcommunity soo '64500:100'
+set protocols bgp address-family ipv4-unicast redistribute table 100
 set protocols bgp neighbor 1.2.3.4 address-family ipv4-unicast nexthop-self
 set protocols bgp neighbor 1.2.3.4 address-family ipv4-unicast route-map import 'ebgp-transit-rpki'
 set protocols bgp neighbor 1.2.3.4 remote-as '10'

--- a/smoketest/configs/bgp-rpki
+++ b/smoketest/configs/bgp-rpki
@@ -46,6 +46,13 @@ policy {
 }
 protocols {
     bgp 64500 {
+        address-family {
+            ipv4-unicast {
+                redistribute {
+                    table 100
+                }
+            }
+        }
         neighbor 1.2.3.4 {
             address-family {
                 ipv4-unicast {

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2024 VyOS maintainers and contributors
+# Copyright (C) 2021-2025 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -685,14 +685,30 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
                 'route_map' : 'redistr-ipv4-static',
             },
             'table' : {
-                'number' : ['10', '20', '30', '40'],
+                '10' : {
+                    'metric' : '810',
+                    'route_map' : 'redistr-ipv4-table-10',
+                },
+                '20' : {
+                    'metric' : '820',
+                    'route_map' : 'redistr-ipv4-table-20',
+                },
+                '30' : {
+                    'metric' : '830',
+                    'route_map' : 'redistr-ipv4-table-30',
+                },
             },
         }
         for proto, proto_config in redistributes.items():
             proto_path = base_path + ['address-family', 'ipv4-unicast', 'redistribute', proto]
-            if proto == 'table' and 'number' in proto_config:
-                for number in proto_config['number']:
-                    self.cli_set(proto_path, value=number)
+            if proto == 'table':
+                for table, table_config in proto_config.items():
+                    self.cli_set(proto_path + [table])
+                    if 'metric' in table_config:
+                        self.cli_set(proto_path + [table, 'metric'], value=table_config['metric'])
+                    if 'route_map' in table_config:
+                        self.cli_set(['policy', 'route-map', table_config['route_map'], 'rule', '10', 'action'], value='permit')
+                        self.cli_set(proto_path + [table, 'route-map'], value=table_config['route_map'])
             else:
                 self.cli_set(proto_path)
                 if 'metric' in proto_config:
@@ -723,9 +739,16 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(' address-family ipv4 unicast', frrconfig)
 
         for proto, proto_config in redistributes.items():
-            if proto == 'table' and 'number' in proto_config:
-                for number in proto_config['number']:
-                    self.assertIn(f' redistribute table-direct {number}', frrconfig)
+            if proto == 'table':
+                for table, table_config in proto_config.items():
+                    tmp = f' redistribute table-direct {table}'
+                    if 'metric' in proto_config:
+                        metric = proto_config['metric']
+                        tmp += f' metric {metric}'
+                    if 'route_map' in proto_config:
+                        route_map = proto_config['route_map']
+                        tmp += f' route-map {route_map}'
+                    self.assertIn(tmp, frrconfig)
             else:
                 tmp = f' redistribute {proto}'
                 if 'metric' in proto_config:
@@ -794,14 +817,30 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
                 'route_map' : 'redistr-ipv6-static',
             },
             'table' : {
-                'number' : ['100', '120', '130', '140'],
+                '110' : {
+                    'metric' : '811',
+                    'route_map' : 'redistr-ipv6-table-110',
+                },
+                '120' : {
+                    'metric' : '821',
+                    'route_map' : 'redistr-ipv6-table-120',
+                },
+                '130' : {
+                    'metric' : '831',
+                    'route_map' : 'redistr-ipv6-table-130',
+                },
             },
         }
         for proto, proto_config in redistributes.items():
             proto_path = base_path + ['address-family', 'ipv6-unicast', 'redistribute', proto]
-            if proto == 'table' and 'number' in proto_config:
-                for number in proto_config['number']:
-                    self.cli_set(proto_path, value=number)
+            if proto == 'table':
+                for table, table_config in proto_config.items():
+                    self.cli_set(proto_path + [table])
+                    if 'metric' in table_config:
+                        self.cli_set(proto_path + [table, 'metric'], value=table_config['metric'])
+                    if 'route_map' in table_config:
+                        self.cli_set(['policy', 'route-map', table_config['route_map'], 'rule', '10', 'action'], value='permit')
+                        self.cli_set(proto_path + [table, 'route-map'], value=table_config['route_map'])
             else:
                 self.cli_set(proto_path)
                 if 'metric' in proto_config:
@@ -829,9 +868,16 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(' no bgp ebgp-requires-policy', frrconfig)
 
         for proto, proto_config in redistributes.items():
-            if proto == 'table' and 'number' in proto_config:
-                for number in proto_config['number']:
-                    self.assertIn(f' redistribute table-direct {number}', frrconfig)
+            if proto == 'table':
+                for table, table_config in proto_config.items():
+                    tmp = f' redistribute table-direct {table}'
+                    if 'metric' in proto_config:
+                        metric = proto_config['metric']
+                        tmp += f' metric {metric}'
+                    if 'route_map' in proto_config:
+                        route_map = proto_config['route_map']
+                        tmp += f' route-map {route_map}'
+                    self.assertIn(tmp, frrconfig)
             else:
                 # FRR calls this OSPF6
                 if proto == 'ospfv3':

--- a/src/migration-scripts/bgp/5-to-6
+++ b/src/migration-scripts/bgp/5-to-6
@@ -1,0 +1,39 @@
+# Copyright 2025 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# T7163: migrate "address-family ipv4|6-unicast redistribute table" from a multi
+# leafNode to a tagNode. This is needed to support per table definition of a
+# route-map and/or metric
+
+from vyos.configtree import ConfigTree
+
+def migrate(config: ConfigTree) -> None:
+    bgp_base = ['protocols', 'bgp']
+    if not config.exists(bgp_base):
+        return
+
+    for address_family in ['ipv4-unicast', 'ipv6-unicast']:
+        # there is no non-main routing table beeing redistributed under this addres family
+        # bail out early and continue with next AFI
+        table_path = bgp_base + ['address-family', address_family, 'redistribute', 'table']
+        if not config.exists(table_path):
+            continue
+
+        tables = config.return_values(table_path)
+        config.delete(table_path)
+
+        for table in tables:
+            config.set(table_path + [table])
+            config.set_tag(table_path)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Migrate existing CLI from a multi `leafNode` to a `tagNode` for the table number. Add new `metric` and `route-map` options for each table which is going to be redistributed.

* `set protocols bgp address-family <ipv4-unicast|ipv6-unicast> redistribute table <n> [metric <n>] [route-map <name>]`

Should be backported to VyOS 1.5 stream branch after upgrading stream to FRR 10.2

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7163

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ... ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ... ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ... ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ... ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ... ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ... ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ... ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ... ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ... ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ... ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok
test_bgp_24_srv6_sid (__main__.TestProtocolsBGP.test_bgp_24_srv6_sid) ... ok
test_bgp_25_ipv4_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_25_ipv4_labeled_unicast_peer_group) ... ok
test_bgp_26_ipv6_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_26_ipv6_labeled_unicast_peer_group) ... ok
test_bgp_27_route_reflector_client (__main__.TestProtocolsBGP.test_bgp_27_route_reflector_client) ... ok
test_bgp_28_peer_group_member_all_internal_or_external (__main__.TestProtocolsBGP.test_bgp_28_peer_group_member_all_internal_or_external) ... ok
test_bgp_29_peer_group_remote_as_equal_local_as (__main__.TestProtocolsBGP.test_bgp_29_peer_group_remote_as_equal_local_as) ... ok
test_bgp_99_bmp (__main__.TestProtocolsBGP.test_bgp_99_bmp) ... ok

----------------------------------------------------------------------
Ran 29 tests in 415.302s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
