### PR TITLE
firewall: T7176: Fix vyos-domain-resolver not respecting interval/cache configuration

### DIFF
--- a/src/services/vyos-domain-resolver
+++ b/src/services/vyos-domain-resolver
@@ -65,13 +65,15 @@ def get_config(conf, node):
 
     node_config = dict_merge(default_values, node_config)
 
-    global timeout, cache
+    if node == base_firewall and 'global_options' in node_config:
+        global_config = node_config['global_options']
+        global timeout, cache
 
-    if 'resolver_interval' in node_config:
-        timeout = int(node_config['resolver_interval'])
+        if 'resolver_interval' in global_config:
+            timeout = int(global_config['resolver_interval'])
 
-    if 'resolver_cache' in node_config:
-        cache = True
+        if 'resolver_cache' in global_config:
+            cache = True
 
     fqdn_config_parse(node_config, node[0])
 


### PR DESCRIPTION
## Change summary
This fix corrects the vyos-domain-resolver service, allowing it to successfully read resolver-cache & resolver-interval options set within the firewall configuration. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T7176

## Related PR(s)

## How to test / Smoketest result
**Test Steps**
1. Configure a domain group, and set non-default resolver configuration:
```
set firewall group domain-group test01 address vyos.dev
set firewall global-options resolver-interval 3600
set firewall global-options resolver-cache
```

2. Check parameters have been passed to vyos-domain-resolver correctly:
```
vyos@vyos:~$ sudo systemctl status vyos-domain-resolver | grep 'interval'
Feb 17 21:26:17 vyos vyos-domain-resolver[14874]: interval: 3600s - cache: True
```

**Smoke Test**
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_firewall.py
test_bridge_firewall (__main__.TestFirewall.test_bridge_firewall) ... ok
test_cyclic_jump_validation (__main__.TestFirewall.test_cyclic_jump_validation) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
test_geoip (__main__.TestFirewall.test_geoip) ... ok
test_gre_match (__main__.TestFirewall.test_gre_match) ... ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipsec_metadata_match (__main__.TestFirewall.test_ipsec_metadata_match) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_dynamic_groups (__main__.TestFirewall.test_ipv4_dynamic_groups) ... ok
test_ipv4_global_state (__main__.TestFirewall.test_ipv4_global_state) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_dynamic_groups (__main__.TestFirewall.test_ipv6_dynamic_groups) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_timeout_sysctl (__main__.TestFirewall.test_timeout_sysctl) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... ok
test_zone_with_vrf (__main__.TestFirewall.test_zone_with_vrf) ... ok

----------------------------------------------------------------------
Ran 25 tests in 84.399s

OK
```

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
