### PR TITLE
T6628: IPoE-server rename "static-ip" to "ip-address" for local auth

### DIFF
--- a/data/templates/accel-ppp/chap-secrets.ipoe.j2
+++ b/data/templates/accel-ppp/chap-secrets.ipoe.j2
@@ -6,7 +6,7 @@
 {%                 if mac_config.vlan is vyos_defined %}
 {%                     set iface = iface ~ '.' ~ mac_config.vlan %}
 {%                 endif %}
-{{ "%-11s" | format(iface) }} * {{ mac | lower }} {{ mac_config.static_ip if mac_config.static_ip is vyos_defined else '*' }} {{ mac_config.rate_limit.download ~ '/' ~ mac_config.rate_limit.upload if mac_config.rate_limit.download is vyos_defined and mac_config.rate_limit.upload is vyos_defined }}
+{{ "%-11s" | format(iface) }} * {{ mac | lower }} {{ mac_config.ip_address if mac_config.ip_address is vyos_defined else '*' }} {{ mac_config.rate_limit.download ~ '/' ~ mac_config.rate_limit.upload if mac_config.rate_limit.download is vyos_defined and mac_config.rate_limit.upload is vyos_defined }}
 {%             endfor %}
 {%         endif %}
 {%     endfor %}

--- a/interface-definitions/include/ip-address.xml.i
+++ b/interface-definitions/include/ip-address.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from ip-address.xml.i -->
+<leafNode name="ip-address">
+  <properties>
+    <help>Fixed IP address of static mapping</help>
+    <valueHelp>
+      <format>ipv4</format>
+      <description>IPv4 address used in static mapping</description>
+    </valueHelp>
+    <constraint>
+      <validator name="ipv4-address"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/service_dhcp-server.xml.in
+++ b/interface-definitions/service_dhcp-server.xml.in
@@ -211,18 +211,7 @@
                       #include <include/dhcp/option-v4.xml.i>
                       #include <include/generic-description.xml.i>
                       #include <include/generic-disable-node.xml.i>
-                      <leafNode name="ip-address">
-                        <properties>
-                          <help>Fixed IP address of static mapping</help>
-                          <valueHelp>
-                            <format>ipv4</format>
-                            <description>IPv4 address used in static mapping</description>
-                          </valueHelp>
-                          <constraint>
-                            <validator name="ipv4-address"/>
-                          </constraint>
-                        </properties>
-                      </leafNode>
+                      #include <include/ip-address.xml.i>
                       #include <include/interface/mac.xml.i>
                       #include <include/interface/duid.xml.i>
                     </children>

--- a/interface-definitions/service_ipoe-server.xml.in
+++ b/interface-definitions/service_ipoe-server.xml.in
@@ -70,18 +70,7 @@
                           <constraintErrorMessage>VLAN IDs need to be in range 1-4094</constraintErrorMessage>
                         </properties>
                       </leafNode>
-                      <leafNode name="static-ip">
-                        <properties>
-                          <help>Static client IP address</help>
-                          <valueHelp>
-                            <format>ipv4</format>
-                            <description>IPv4 address</description>
-                          </valueHelp>
-                          <constraint>
-                            <validator name="ipv4-address"/>
-                          </constraint>
-                        </properties>
-                      </leafNode>
+                      #include <include/ip-address.xml.i>
                     </children>
                   </tagNode>
                 </children>

--- a/smoketest/scripts/cli/test_service_ipoe-server.py
+++ b/smoketest/scripts/cli/test_service_ipoe-server.py
@@ -260,7 +260,7 @@ delegate={delegate_2_prefix},{delegate_mask},name={pool_name}"""
         tmp = ','.join(vlans)
         self.assertIn(f'{interface},{tmp}', conf['ipoe']['vlan-mon'])
 
-    def test_ipoe_server_static_client_ip(self):
+    def test_ipoe_server_static_client_ip_address(self):
         mac_address = '08:00:27:2f:d8:06'
         ip_address = '192.0.2.100'
 
@@ -274,7 +274,7 @@ delegate={delegate_2_prefix},{delegate_mask},name={pool_name}"""
                 interface,
                 'mac',
                 mac_address,
-                'static-ip',
+                'ip-address',
                 ip_address,
             ]
         )


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Rename leafNode from 'static-ip' to 'ip-address'
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):rename leafNode

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6628
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
/usr/libexec/vyos/tests/smoke/cli/test_service_ipoe-server.py
test_accel_ipv4_pool (__main__.TestServiceIPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServiceIPoEServer.test_accel_ipv6_pool) ... ok
test_accel_limits (__main__.TestServiceIPoEServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestServiceIPoEServer.test_accel_local_authentication) ... ok
test_accel_log_level (__main__.TestServiceIPoEServer.test_accel_log_level) ... ok
test_accel_name_servers (__main__.TestServiceIPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServiceIPoEServer.test_accel_next_pool) ... ok
test_accel_ppp_options (__main__.TestServiceIPoEServer.test_accel_ppp_options) ... skipped 'PPP is not a part of IPoE'
test_accel_radius_authentication (__main__.TestServiceIPoEServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestServiceIPoEServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestServiceIPoEServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestServiceIPoEServer.test_accel_wins_server) ... skipped 'WINS server is not used in IPoE'
test_ipoe_server_start_session (__main__.TestServiceIPoEServer.test_ipoe_server_start_session) ... ok
test_ipoe_server_static_client_ip_address (__main__.TestServiceIPoEServer.test_ipoe_server_static_client_ip) ... ok
test_ipoe_server_vlan (__main__.TestServiceIPoEServer.test_ipoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 15 tests in 112.600s
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
