### PR TITLE
T5810: Add support for RPKI source ip

### DIFF
--- a/data/templates/frr/rpki.frr.j2
+++ b/data/templates/frr/rpki.frr.j2
@@ -5,9 +5,9 @@ rpki
 {%     for peer, peer_config in cache.items() %}
 {#         port is mandatory and preference uses a default value #}
 {%         if peer_config.ssh.username is vyos_defined %}
- rpki cache ssh {{ peer | replace('_', '-') }} {{ peer_config.port }} {{ peer_config.ssh.username }} {{ peer_config.ssh.private_key_file }} {{ peer_config.ssh.public_key_file }} preference {{ peer_config.preference }}
+ rpki cache ssh {{ peer | replace('_', '-') }} {{ peer_config.port }} {{ peer_config.ssh.username }} {{ peer_config.ssh.private_key_file }} {{ peer_config.ssh.public_key_file }}{{ ' source ' ~ peer_config.source_address if peer_config.source_address is vyos_defined }} preference {{ peer_config.preference }}
 {%         else %}
- rpki cache tcp {{ peer | replace('_', '-') }} {{ peer_config.port }} preference {{ peer_config.preference }}
+ rpki cache tcp {{ peer | replace('_', '-') }} {{ peer_config.port }}{{ ' source ' ~ peer_config.source_address if peer_config.source_address is vyos_defined }} preference {{ peer_config.preference }}
 {%         endif %}
 {%     endfor %}
 {% endif %}

--- a/interface-definitions/protocols_rpki.xml.in
+++ b/interface-definitions/protocols_rpki.xml.in
@@ -42,6 +42,7 @@
                   </constraint>
                 </properties>
               </leafNode>
+              #include <include/source-address-ipv4.xml.i>
               <node name="ssh">
                 <properties>
                   <help>RPKI SSH connection settings</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T5810
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# set protocols rpki cache 10.0.0.2 port 9090
[edit]
vyos@vyos# set protocols rpki cache 10.0.0.2 preference 1
[edit]
vyos@vyos# set protocols rpki cache 10.0.0.2 source-address
Possible completions:
   <x.x.x.x>            IPv4 source address
   127.0.0.1
   192.0.2.1
   192.168.122.219
   192.168.134.232


[edit]
vyos@vyos# set protocols rpki cache 10.0.0.2 source-address 192.0.2.1
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# cat /run/frr/config/frr.conf
frr version 10.2.1
frr defaults traditional
hostname vyos
service integrated-vtysh-config
!
ip route 0.0.0.0/0 192.168.122.1 eth0 tag 210 210
!
rpki
 rpki polling_period 300
 rpki cache tcp 10.0.0.2 9090 source 192.0.2.1 preference 1
exit
!
[edit]

vyos@vyos# /usr/libexec/vyos/tests/smoke/cli/test_protocols_rpki.py
test_rpki (__main__.TestProtocolsRPKI.test_rpki) ... ok
test_rpki_source_address (__main__.TestProtocolsRPKI.test_rpki_source_address) ... ok
test_rpki_ssh (__main__.TestProtocolsRPKI.test_rpki_ssh) ... ok
test_rpki_verify_preference (__main__.TestProtocolsRPKI.test_rpki_verify_preference) ... ok

----------------------------------------------------------------------
Ran 4 tests in 62.771s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
