### PR TITLE
T7182: use Config instead of ConfigTreeQuery for get_interface_dict

### DIFF
--- a/src/etc/netplug/vyos-netplug-dhcp-client
+++ b/src/etc/netplug/vyos-netplug-dhcp-client
@@ -26,14 +26,15 @@ from vyos.ifconfig import Section
 from vyos.utils.boot import boot_configuration_complete
 from vyos.utils.commit import commit_in_progress
 from vyos import airbag
+
 airbag.enable()
 
 if len(sys.argv) < 3:
-    airbag.noteworthy("Must specify both interface and link status!")
+    airbag.noteworthy('Must specify both interface and link status!')
     sys.exit(1)
 
 if not boot_configuration_complete():
-    airbag.noteworthy("System bootup not yet finished...")
+    airbag.noteworthy('System bootup not yet finished...')
     sys.exit(1)
 
 interface = sys.argv[1]
@@ -50,5 +51,7 @@ in_out = sys.argv[2]
 config = ConfigTreeQuery()
 
 interface_path = ['interfaces'] + Section.get_config_path(interface).split()
-_, interface_config = get_interface_dict(config, interface_path[:-1], ifname=interface, with_pki=True)
+_, interface_config = get_interface_dict(
+    config, interface_path[:-1], ifname=interface, with_pki=True
+)
 Interface(interface).update(interface_config)

--- a/src/etc/netplug/vyos-netplug-dhcp-client
+++ b/src/etc/netplug/vyos-netplug-dhcp-client
@@ -19,7 +19,7 @@ import sys
 
 from time import sleep
 
-from vyos.configquery import ConfigTreeQuery
+from vyos.config import Config
 from vyos.configdict import get_interface_dict
 from vyos.ifconfig import Interface
 from vyos.ifconfig import Section
@@ -48,7 +48,7 @@ while commit_in_progress():
     sleep(1)
 
 in_out = sys.argv[2]
-config = ConfigTreeQuery()
+config = Config()
 
 interface_path = ['interfaces'] + Section.get_config_path(interface).split()
 _, interface_config = get_interface_dict(


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The recent change to `vyos-netplug-dhcp-client` to use `get_interface_dict` (T5103; 8faf67c1fa) requires the use of Config over ConfigTreeQueery for full support of the underlying `get_config_dict` (namely, keyword arg `with_pki`); this is preferred over extending ConfigTreeQuery at this time, as the latter is due for revision/simplification.

It remains an open question, currently under investigation, as to why this is missed by smoketests, however, the above change is clearly needed for backport to follow 8faf67c1fa in 1.4.2.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Without change:

```
root@vyos:/etc/netplug# ./vyos-netplug-dhcp-client eth1 in
...
Traceback (most recent call last):
  File "/etc/netplug/./vyos-netplug-dhcp-client", line 55, in <module>
    _, interface_config = get_interface_dict(config, interface_path[:-1], ifname=interface, with_pki=True)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/configdict.py", line 456, in get_interface_dict
    dict = config.get_config_dict(base + [ifname], key_mangling=('-', '_'),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ConfigTreeQuery.get_config_dict() got an unexpected keyword argument 'with_pki'

```

With fix:

```
root@vyos:/home/vyos# ./vyos-netplug-dhcp-client eth1 in
root@vyos:/home/vyos# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
