### PR TITLE
firewall: T7148: Bridge state-policy uses drop in place of reject

### DIFF
--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -435,13 +435,13 @@ table bridge vyos_filter {
 {% if global_options.state_policy is vyos_defined %}
     chain VYOS_STATE_POLICY {
 {%     if global_options.state_policy.established is vyos_defined %}
-        {{ global_options.state_policy.established | nft_state_policy('established') }}
+        {{ global_options.state_policy.established | nft_state_policy('established', bridge=True) }}
 {%     endif %}
 {%     if global_options.state_policy.invalid is vyos_defined %}
-        {{ global_options.state_policy.invalid | nft_state_policy('invalid') }}
+        {{ global_options.state_policy.invalid | nft_state_policy('invalid', bridge=True) }}
 {%     endif %}
 {%     if global_options.state_policy.related is vyos_defined %}
-        {{ global_options.state_policy.related | nft_state_policy('related') }}
+        {{ global_options.state_policy.related | nft_state_policy('related', bridge=True) }}
 {%     endif %}
         return
     }

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -658,6 +658,13 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         self.verify_nftables(nftables_search, 'ip vyos_filter')
 
+        # T7148 - Ensure bridge rule reject -> drop
+        self.cli_set(['firewall', 'global-options', 'state-policy', 'invalid', 'action', 'reject'])
+        self.cli_commit()
+
+        self.verify_nftables([['ct state invalid', 'reject']], 'ip vyos_filter')
+        self.verify_nftables([['ct state invalid', 'drop']], 'bridge vyos_filter')
+
         # Check conntrack is enabled from state-policy
         self.verify_nftables_chain([['accept']], 'ip vyos_conntrack', 'FW_CONNTRACK')
         self.verify_nftables_chain([['accept']], 'ip6 vyos_conntrack', 'FW_CONNTRACK')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Bridge state-policy rules cannot use `reject` and should use drop instead

Documentation should be updated to reflect this behaviour.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_firewall.py
DEBUG - test_bridge_firewall (__main__.TestFirewall.test_bridge_firewall) ... ok
DEBUG - test_cyclic_jump_validation (__main__.TestFirewall.test_cyclic_jump_validation) ... ok
DEBUG - test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
DEBUG - test_geoip (__main__.TestFirewall.test_geoip) ... ok
DEBUG - test_gre_match (__main__.TestFirewall.test_gre_match) ... ok
DEBUG - test_groups (__main__.TestFirewall.test_groups) ... ok
DEBUG - test_ipsec_metadata_match (__main__.TestFirewall.test_ipsec_metadata_match) ... ok
DEBUG - test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
DEBUG - test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
DEBUG - test_ipv4_dynamic_groups (__main__.TestFirewall.test_ipv4_dynamic_groups) ... ok
DEBUG - test_ipv4_global_state (__main__.TestFirewall.test_ipv4_global_state) ... ok
DEBUG - test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
DEBUG - test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
DEBUG - test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... ok
DEBUG - test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
DEBUG - test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
DEBUG - test_ipv6_dynamic_groups (__main__.TestFirewall.test_ipv6_dynamic_groups) ... ok
DEBUG - test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
DEBUG - test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
DEBUG - test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
DEBUG - test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
DEBUG - test_timeout_sysctl (__main__.TestFirewall.test_timeout_sysctl) ... ok
DEBUG - test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
DEBUG - test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... ok
DEBUG - test_zone_with_vrf (__main__.TestFirewall.test_zone_with_vrf) ... ok
DEBUG - 
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 25 tests in 110.411s
DEBUG - 
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
