### PR TITLE
container: T7185: Allow tmpfs mounts within containers

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -412,6 +412,35 @@
               </constraint>
             </properties>
           </leafNode>
+          <tagNode name="tmpfs">
+            <properties>
+              <help>Mount a tmpfs filesystem into the container</help>
+            </properties>
+            <children>
+              <leafNode name="destination">
+                <properties>
+                  <help>Destination container directory</help>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>Destination container directory</description>
+                  </valueHelp>
+                </properties>
+              </leafNode>
+              <leafNode name="size">
+                <properties>
+                  <help>tmpfs filesystem size in MB</help>
+                  <valueHelp>
+                    <format>u32:1-65536</format>
+                    <description>tmpfs filesystem size in MB</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 1-65535"/>
+                  </constraint>
+                  <constraintErrorMessage>Container tmpfs size must be between 1 and 65535 MB</constraintErrorMessage>
+                </properties>
+              </leafNode>
+            </children>
+          </tagNode>
           <tagNode name="volume">
             <properties>
               <help>Mount a volume into the container</help>


### PR DESCRIPTION
## Change summary
This PR add the "tmpfs" option to container configuration, which allows you to create ramdisk binds within the container.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T7185

## Related PR(s)

## How to test / Smoketest result
**Test Steps**
1. Create a container with the "tmpfs" option configured:
```
set container name test01 allow-host-networks
set container name test01 image 'busybox:stable'
set container name test01 restart 'always'
set container name test01 tmpfs work destination '/opt/work'
set container name test01 tmpfs work size '1024'
```

2. Check parameters have been passed to systemd service created for the container:
```
vyos@vyos:~$ cat /run/systemd/system/vyos-container-test01.service
### Autogenerated by container.py ###
[Unit]
Description=VyOS Container test01

[Service]
Environment=PODMAN_SYSTEMD_UNIT=%n
Restart=on-failure
ExecStartPre=/bin/rm -f %t/%n.pid %t/%n.cid
ExecStart=/usr/bin/podman run \
        --conmon-pidfile %t/%n.pid --cidfile %t/%n.cid --cgroups=no-conmon \
        --detach --interactive --tty --replace  --cpus 0  --memory 512m --shm-size 64m --memory-swap 0 --restart always --name test01       --mount=type=tmpfs,tmpfs-size=1024M,destination=/opt/work     --net host  busybox:stable
ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%n.cid -t 5
ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%n.cid
ExecStopPost=/bin/rm -f %t/%n.cid
PIDFile=%t/%n.pid
KillMode=control-group
```

**Smoke Test**
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_container.py
test_api_socket (__main__.TestContainer.test_api_socket) ... ok
test_basic (__main__.TestContainer.test_basic) ... ok
test_cpu_limit (__main__.TestContainer.test_cpu_limit) ... ok
test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... ok
test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... ok
test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... ok
test_name_server (__main__.TestContainer.test_name_server) ... ok
test_network_mtu (__main__.TestContainer.test_network_mtu) ... ok
test_no_name_server (__main__.TestContainer.test_no_name_server) ... ok
test_uid_gid (__main__.TestContainer.test_uid_gid) ... ok

----------------------------------------------------------------------
Ran 10 tests in 146.773s

OK
```

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
