### PR TITLE
T7190: Add haproxy default timeout options configurable

### DIFF
--- a/data/templates/load-balancing/haproxy.cfg.j2
+++ b/data/templates/load-balancing/haproxy.cfg.j2
@@ -38,9 +38,10 @@ defaults
     log     global
     mode    http
     option  dontlognull
-    timeout connect 10s
-    timeout client  50s
-    timeout server  50s
+    timeout check {{ timeout.check }}s
+    timeout connect {{ timeout.connect }}s
+    timeout client {{ timeout.client }}s
+    timeout server {{ timeout.server }}s
     errorfile 400 /etc/haproxy/errors/400.http
     errorfile 403 /etc/haproxy/errors/403.http
     errorfile 408 /etc/haproxy/errors/408.http
@@ -133,6 +134,11 @@ frontend {{ front }}
 {%             for backend in front_config.backend %}
     default_backend {{ backend }}
 {%             endfor %}
+{%         endif %}
+{%         if front_config.timeout is vyos_defined %}
+{%             if front_config.timeout.client is vyos_defined %}
+    timeout client {{ front_config.timeout.client }}s
+{%             endif %}
 {%         endif %}
 
 {%     endfor %}

--- a/interface-definitions/include/haproxy/timeout-check.xml.i
+++ b/interface-definitions/include/haproxy/timeout-check.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from haproxy/timeout-check.xml.i -->
+<leafNode name="check">
+  <properties>
+    <help>Timeout in seconds for established connections</help>
+    <valueHelp>
+      <format>u32:1-3600</format>
+      <description>Check timeout in seconds</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-3600"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/haproxy/timeout-client.xml.i
+++ b/interface-definitions/include/haproxy/timeout-client.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from haproxy/timeout-client.xml.i -->
+<leafNode name="client">
+  <properties>
+    <help>Maximum inactivity time on the client side</help>
+    <valueHelp>
+      <format>u32:1-3600</format>
+      <description>Timeout in seconds</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-3600"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/haproxy/timeout-connect.xml.i
+++ b/interface-definitions/include/haproxy/timeout-connect.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from haproxy/timeout-connect.xml.i -->
+<leafNode name="connect">
+  <properties>
+    <help>Set the maximum time to wait for a connection attempt to a server to succeed</help>
+    <valueHelp>
+      <format>u32:1-3600</format>
+      <description>Connect timeout in seconds</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-3600"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/haproxy/timeout-server.xml.i
+++ b/interface-definitions/include/haproxy/timeout-server.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from haproxy/timeout-server.xml.i -->
+<leafNode name="server">
+  <properties>
+    <help>Set the maximum inactivity time on the server side</help>
+    <valueHelp>
+      <format>u32:1-3600</format>
+      <description>Server timeout in seconds</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-3600"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/haproxy/timeout.xml.i
+++ b/interface-definitions/include/haproxy/timeout.xml.i
@@ -4,42 +4,9 @@
     <help>Timeout options</help>
   </properties>
   <children>
-    <leafNode name="check">
-      <properties>
-        <help>Timeout in seconds for established connections</help>
-        <valueHelp>
-          <format>u32:1-3600</format>
-          <description>Check timeout in seconds</description>
-        </valueHelp>
-        <constraint>
-          <validator name="numeric" argument="--range 1-3600"/>
-        </constraint>
-      </properties>
-    </leafNode>
-    <leafNode name="connect">
-      <properties>
-        <help>Set the maximum time to wait for a connection attempt to a server to succeed</help>
-        <valueHelp>
-          <format>u32:1-3600</format>
-          <description>Connect timeout in seconds</description>
-        </valueHelp>
-        <constraint>
-          <validator name="numeric" argument="--range 1-3600"/>
-        </constraint>
-      </properties>
-    </leafNode>
-    <leafNode name="server">
-      <properties>
-        <help>Set the maximum inactivity time on the server side</help>
-        <valueHelp>
-          <format>u32:1-3600</format>
-          <description>Server timeout in seconds</description>
-        </valueHelp>
-        <constraint>
-          <validator name="numeric" argument="--range 1-3600"/>
-        </constraint>
-      </properties>
-    </leafNode>
+    #include <include/haproxy/timeout-check.xml.i>
+    #include <include/haproxy/timeout-connect.xml.i>
+    #include <include/haproxy/timeout-server.xml.i>
   </children>
 </node>
 <!-- include end -->

--- a/interface-definitions/load-balancing_haproxy.xml.in
+++ b/interface-definitions/load-balancing_haproxy.xml.in
@@ -48,6 +48,14 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <node name="timeout">
+                <properties>
+                  <help>Timeout options</help>
+                </properties>
+                <children>
+                  #include <include/haproxy/timeout-client.xml.i>
+                </children>
+              </node>
               <node name="http-compression">
                 <properties>
                   <help>Compress HTTP responses</help>
@@ -365,6 +373,29 @@
                   </constraint>
                 </properties>
                 <defaultValue>1.3</defaultValue>
+              </leafNode>
+            </children>
+          </node>
+          <node name="timeout">
+            <properties>
+              <help>Timeout options</help>
+            </properties>
+            <children>
+              #include <include/haproxy/timeout-check.xml.i>
+              <leafNode name="check">
+                <defaultValue>5</defaultValue>
+              </leafNode>
+              #include <include/haproxy/timeout-connect.xml.i>
+              <leafNode name="connect">
+                <defaultValue>10</defaultValue>
+              </leafNode>
+              #include <include/haproxy/timeout-client.xml.i>
+              <leafNode name="client">
+                <defaultValue>50</defaultValue>
+              </leafNode>
+              #include <include/haproxy/timeout-server.xml.i>
+              <leafNode name="server">
+                <defaultValue>50</defaultValue>
               </leafNode>
             </children>
           </node>

--- a/smoketest/scripts/cli/test_load-balancing_haproxy.py
+++ b/smoketest/scripts/cli/test_load-balancing_haproxy.py
@@ -521,5 +521,53 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
         with self.assertRaises(ConfigSessionError) as e:
             self.cli_commit()
 
+    def test_11_lb_haproxy_timeout(self):
+        t_default_check = '5'
+        t_default_client = '50'
+        t_default_connect = '10'
+        t_default_server ='50'
+        t_check = '4'
+        t_client = '300'
+        t_connect = '12'
+        t_server ='120'
+        t_front_client = '600'
+
+        self.base_config()
+        self.cli_commit()
+        # Check default timeout options
+        config_entries = (
+            f'timeout check {t_default_check}s',
+            f'timeout connect {t_default_connect}s',
+            f'timeout client {t_default_client}s',
+            f'timeout server {t_default_server}s',
+        )
+        # Check default timeout options
+        config = read_file(HAPROXY_CONF)
+        for config_entry in config_entries:
+            self.assertIn(config_entry, config)
+
+        # Set custom timeout options
+        self.cli_set(base_path + ['timeout', 'check', t_check])
+        self.cli_set(base_path + ['timeout', 'client', t_client])
+        self.cli_set(base_path + ['timeout', 'connect', t_connect])
+        self.cli_set(base_path + ['timeout', 'server', t_server])
+        self.cli_set(base_path + ['service', 'https_front', 'timeout', 'client', t_front_client])
+
+        self.cli_commit()
+
+        # Check custom timeout options
+        config_entries = (
+            f'timeout check {t_check}s',
+            f'timeout connect {t_connect}s',
+            f'timeout client {t_client}s',
+            f'timeout server {t_server}s',
+            f'timeout client {t_front_client}s',
+        )
+
+        # Check configured options
+        config = read_file(HAPROXY_CONF)
+        for config_entry in config_entries:
+            self.assertIn(config_entry, config)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add the ability to configure default timeout and frontend client timeout

```
set load-balancing haproxy service web timeout client '600'
set load-balancing haproxy timeout check '4'
set load-balancing haproxy timeout client '600'
set load-balancing haproxy timeout connect '12'
set load-balancing haproxy timeout server '120'
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7190

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
configure timeouts
```
set load-balancing haproxy service web backend 'bk01'
set load-balancing haproxy service web port '80'
set load-balancing haproxy service web timeout client '600'

set load-balancing haproxy backend bk01 server srv01 address '127.0.0.1'
set load-balancing haproxy backend bk01 server srv01 port '8888'

set load-balancing haproxy timeout check '4'
set load-balancing haproxy timeout client '600'
set load-balancing haproxy timeout connect '12'
set load-balancing haproxy timeout server '120'

```
check config
```
vyos@r14# cat /run/haproxy/haproxy.cfg | grep default -A 7 -B 5
defaults
    log     global
    mode    http
    option  dontlognull
    timeout check 4s
    timeout connect 12s
    timeout client 600s
    timeout server 120s
--

# Frontend
frontend web
    bind [::]:80 v4v6  
    mode http
    default_backend bk01
    timeout client 600s
```

smoketests
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_load-balancing_haproxy.py
test_01_lb_reverse_proxy_domain (__main__.TestLoadBalancingReverseProxy.test_01_lb_reverse_proxy_domain) ... ok
test_02_lb_reverse_proxy_cert_not_exists (__main__.TestLoadBalancingReverseProxy.test_02_lb_reverse_proxy_cert_not_exists) ... ok
test_03_lb_reverse_proxy_ca_not_exists (__main__.TestLoadBalancingReverseProxy.test_03_lb_reverse_proxy_ca_not_exists) ... ok
test_04_lb_reverse_proxy_backend_ssl_no_verify (__main__.TestLoadBalancingReverseProxy.test_04_lb_reverse_proxy_backend_ssl_no_verify) ... ok
test_05_lb_reverse_proxy_backend_http_check (__main__.TestLoadBalancingReverseProxy.test_05_lb_reverse_proxy_backend_http_check) ... ok
test_06_lb_reverse_proxy_tcp_mode (__main__.TestLoadBalancingReverseProxy.test_06_lb_reverse_proxy_tcp_mode) ... ok
test_07_lb_reverse_proxy_http_response_headers (__main__.TestLoadBalancingReverseProxy.test_07_lb_reverse_proxy_http_response_headers) ... ok
test_08_lb_reverse_proxy_tcp_health_checks (__main__.TestLoadBalancingReverseProxy.test_08_lb_reverse_proxy_tcp_health_checks) ... ok
test_09_lb_reverse_proxy_logging (__main__.TestLoadBalancingReverseProxy.test_09_lb_reverse_proxy_logging) ... ok
test_10_lb_reverse_proxy_http_compression (__main__.TestLoadBalancingReverseProxy.test_10_lb_reverse_proxy_http_compression) ... ok

----------------------------------------------------------------------
Ran 10 tests in 65.216s

OK
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
