### PR TITLE
bond: T7191: fix error message when member interface is used multiple times

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_bonding.py
+++ b/smoketest/scripts/cli/test_interfaces_bonding.py
@@ -167,17 +167,24 @@ class BondingInterfaceTest(BasicInterfaceTest.TestCase):
 
     def test_bonding_multi_use_member(self):
         # Define available bonding hash policies
-        for interface in ['bond10', 'bond20']:
+        bonds = ['bond10', 'bond20', 'bond30']
+        for interface in bonds:
             for member in self._members:
                 self.cli_set(self._base_path + [interface, 'member', 'interface', member])
 
         # check validate() - can not use the same member interfaces multiple times
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
-
-        self.cli_delete(self._base_path + ['bond20'])
+        # only keep the first bond interface configuration
+        for interface in bonds[1:]:
+            self.cli_delete(self._base_path + [interface])
 
         self.cli_commit()
+
+        bond = bonds[0]
+        member_ifaces = read_file(f'/sys/class/net/{bond}/bonding/slaves').split()
+        for member in self._members:
+            self.assertIn(member, member_ifaces)
 
     def test_bonding_source_interface(self):
         # Re-use member interface that is already a source-interface

--- a/src/conf_mode/interfaces_bonding.py
+++ b/src/conf_mode/interfaces_bonding.py
@@ -126,9 +126,8 @@ def get_config(config=None):
     # Restore existing config level
     conf.set_level(old_level)
 
-    if dict_search('member.interface', bond):
-        for interface, interface_config in bond['member']['interface'].items():
-
+    if dict_search('member.interface', bond) is not None:
+        for interface in bond['member']['interface']:
             interface_ethernet_config = conf.get_config_dict(
                 ['interfaces', 'ethernet', interface],
                 key_mangling=('-', '_'),
@@ -137,44 +136,45 @@ def get_config(config=None):
                 with_defaults=False,
                 with_recursive_defaults=False)
 
-            interface_config['config_paths'] = dict_to_paths_values(interface_ethernet_config)
+            bond['member']['interface'][interface].update({'config_paths' :
+                dict_to_paths_values(interface_ethernet_config)})
 
             # Check if member interface is a new member
             if not conf.exists_effective(base + [ifname, 'member', 'interface', interface]):
                 bond['shutdown_required'] = {}
-                interface_config['new_added'] = {}
+                bond['member']['interface'][interface].update({'new_added' : {}})
 
             # Check if member interface is disabled
             conf.set_level(['interfaces'])
 
             section = Section.section(interface) # this will be 'ethernet' for 'eth0'
             if conf.exists([section, interface, 'disable']):
-                interface_config['disable'] = ''
+                if tmp: bond['member']['interface'][interface].update({'disable': ''})
 
             conf.set_level(old_level)
 
             # Check if member interface is already member of another bridge
             tmp = is_member(conf, interface, 'bridge')
-            if tmp: interface_config['is_bridge_member'] = tmp
+            if tmp: bond['member']['interface'][interface].update({'is_bridge_member' : tmp})
 
             # Check if member interface is already member of a bond
             tmp = is_member(conf, interface, 'bonding')
-            for tmp in is_member(conf, interface, 'bonding'):
-                if bond['ifname'] == tmp:
-                    continue
-                interface_config['is_bond_member'] = tmp
+            if ifname in tmp:
+                del tmp[ifname]
+            if tmp: bond['member']['interface'][interface].update({'is_bond_member' : tmp})
 
             # Check if member interface is used as source-interface on another interface
             tmp = is_source_interface(conf, interface)
-            if tmp: interface_config['is_source_interface'] = tmp
+            if tmp: bond['member']['interface'][interface].update({'is_source_interface' : tmp})
 
             # bond members must not have an assigned address
             tmp = has_address_configured(conf, interface)
-            if tmp: interface_config['has_address'] = {}
+            if tmp: bond['member']['interface'][interface].update({'has_address' : ''})
 
             # bond members must not have a VRF attached
             tmp = has_vrf_configured(conf, interface)
-            if tmp: interface_config['has_vrf'] = {}
+            if tmp: bond['member']['interface'][interface].update({'has_vrf' : ''})
+
     return bond
 
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Sharing the same physical interface among multiple bond interfaces causes information to be lost within the error message

```
set interfaces bonding bond10 member interface eth1
set interfaces bonding bond10 member interface eth2
set interfaces bonding bond20 member interface eth1
set interfaces bonding bond20 member interface eth2
commit
```

Results in:

```
[ interfaces bonding bond10 ]
Can not add interface "eth1" to bond, it is already a member of bond "b"!

[[interfaces bonding bond10]] failed
[ interfaces bonding bond20 ]
Can not add interface "eth1" to bond, it is already a member of bond "b"!
```

It should infact output the full name of the bond interface.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7191

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_bonding.py
test_add_multiple_ip_addresses (__main__.BondingInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.BondingInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.BondingInterfaceTest.test_add_to_invalid_vrf) ... ok
test_bonding_evpn_multihoming (__main__.BondingInterfaceTest.test_bonding_evpn_multihoming) ... ok
test_bonding_hash_policy (__main__.BondingInterfaceTest.test_bonding_hash_policy) ... ok
test_bonding_lacp_rate (__main__.BondingInterfaceTest.test_bonding_lacp_rate) ... ok
test_bonding_mii_monitoring_interval (__main__.BondingInterfaceTest.test_bonding_mii_monitoring_interval) ... ok
test_bonding_min_links (__main__.BondingInterfaceTest.test_bonding_min_links) ... ok
test_bonding_multi_use_member (__main__.BondingInterfaceTest.test_bonding_multi_use_member) ... ok
test_bonding_remove_member (__main__.BondingInterfaceTest.test_bonding_remove_member) ... ok
test_bonding_source_bridge_interface (__main__.BondingInterfaceTest.test_bonding_source_bridge_interface) ... ok
test_bonding_source_interface (__main__.BondingInterfaceTest.test_bonding_source_interface) ... ok
test_bonding_system_mac (__main__.BondingInterfaceTest.test_bonding_system_mac) ... ok
test_bonding_uniq_member_description (__main__.BondingInterfaceTest.test_bonding_uniq_member_description) ... ok
test_dhcp_client_options (__main__.BondingInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.BondingInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.BondingInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.BondingInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.BondingInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.BondingInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.BondingInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol (__main__.BondingInterfaceTest.test_eapol) ... ok
test_interface_description (__main__.BondingInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.BondingInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.BondingInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.BondingInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.BondingInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.BondingInterfaceTest.test_ipv6_link_local_address) ... ok
test_move_interface_between_vrf_instances (__main__.BondingInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.BondingInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.BondingInterfaceTest.test_span_mirror) ... ok
test_vif_8021q_interfaces (__main__.BondingInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.BondingInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.BondingInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.BondingInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.BondingInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.BondingInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 37 tests in 554.920s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
