### PR TITLE
bridge: T7192: do not allow a member interface to be used multiple times

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_bridge.py
+++ b/smoketest/scripts/cli/test_interfaces_bridge.py
@@ -158,6 +158,21 @@ class BridgeInterfaceTest(BasicInterfaceTest.TestCase):
                 # verify member is assigned to the bridge
                 self.assertEqual(interface, tmp['master'])
 
+    def test_bridge_multi_use_member(self):
+        # Define available bonding hash policies
+        bridges = ['br10', 'br20', 'br30']
+        for interface in bridges:
+            for member in self._members:
+                self.cli_set(self._base_path + [interface, 'member', 'interface', member])
+
+        # check validate() - can not use the same member interfaces multiple times
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        # only keep the first bond interface configuration
+        for interface in bridges[1:]:
+            self.cli_delete(self._base_path + [interface])
+
+        self.cli_commit()
 
     def test_add_remove_bridge_member(self):
         # Add member interfaces to bridge and set STP cost/priority

--- a/src/conf_mode/interfaces_bridge.py
+++ b/src/conf_mode/interfaces_bridge.py
@@ -74,8 +74,9 @@ def get_config(config=None):
         for interface in list(bridge['member']['interface']):
             # Check if member interface is already member of another bridge
             tmp = is_member(conf, interface, 'bridge')
-            if tmp and bridge['ifname'] not in tmp:
-                bridge['member']['interface'][interface].update({'is_bridge_member' : tmp})
+            if ifname in tmp:
+                del tmp[ifname]
+            if tmp: bridge['member']['interface'][interface].update({'is_bridge_member' : tmp})
 
             # Check if member interface is already member of a bond
             tmp = is_member(conf, interface, 'bonding')


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

When configuring
```
set interfaces bridge br10 member interface eth1
set interfaces bridge br20 member interface eth1
commit
```

Checking the interface assignment afterwards shows

```
242: br20: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 62:34:3a:8a:fe:49 brd ff:ff:ff:ff:ff:ff
[edit]

3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel master br20 state UP mode DEFAULT group default qlen 1000
    link/ether 00:50:56:b3:cd:ba brd ff:ff:ff:ff:ff:ff
    altname enp0s19
    altname ens19
```

The later addition wins and the CLI reports eth1 is assigned to br20 `master br20`. A member interface can not be used multiple times.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7192

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_bridge.py
test_add_multiple_ip_addresses (__main__.BridgeInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_remove_bridge_member (__main__.BridgeInterfaceTest.test_add_remove_bridge_member) ... ok
test_add_single_ip_address (__main__.BridgeInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.BridgeInterfaceTest.test_add_to_invalid_vrf) ... ok
test_bridge_delete_with_vxlan_heighbor_suppress (__main__.BridgeInterfaceTest.test_bridge_delete_with_vxlan_heighbor_suppress) ... ok
test_bridge_multi_use_member (__main__.BridgeInterfaceTest.test_bridge_multi_use_member) ... ok <-- NEW TESTCASE
test_bridge_tunnel_vxlan_multicast (__main__.BridgeInterfaceTest.test_bridge_tunnel_vxlan_multicast) ... ok
test_bridge_vif_members (__main__.BridgeInterfaceTest.test_bridge_vif_members) ... ok
test_bridge_vif_s_vif_c_members (__main__.BridgeInterfaceTest.test_bridge_vif_s_vif_c_members) ... ok
test_bridge_vlan_filter (__main__.BridgeInterfaceTest.test_bridge_vlan_filter) ... ok
test_bridge_vlan_protocol (__main__.BridgeInterfaceTest.test_bridge_vlan_protocol) ... ok
test_dhcp_client_options (__main__.BridgeInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.BridgeInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.BridgeInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.BridgeInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.BridgeInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.BridgeInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.BridgeInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol (__main__.BridgeInterfaceTest.test_eapol) ... skipped 'not supported'
test_igmp_querier_snooping (__main__.BridgeInterfaceTest.test_igmp_querier_snooping) ... ok
test_interface_description (__main__.BridgeInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.BridgeInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.BridgeInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.BridgeInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.BridgeInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.BridgeInterfaceTest.test_ipv6_link_local_address) ... ok
test_isolated_interfaces (__main__.BridgeInterfaceTest.test_isolated_interfaces) ... ok
test_move_interface_between_vrf_instances (__main__.BridgeInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.BridgeInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.BridgeInterfaceTest.test_span_mirror) ... ok
test_vif_8021q_interfaces (__main__.BridgeInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.BridgeInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.BridgeInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.BridgeInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.BridgeInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.BridgeInterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'

----------------------------------------------------------------------
Ran 36 tests in 550.377s

OK (skipped=3)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
