### PR TITLE
lldp: T7165: add support to enable only rx/tx on specific interfaces

### DIFF
--- a/data/templates/lldp/vyos.conf.j2
+++ b/data/templates/lldp/vyos.conf.j2
@@ -4,7 +4,7 @@ configure system platform VyOS
 configure system description "VyOS {{ version }}"
 {% if interface is vyos_defined %}
 {%     set tmp = [] %}
-{%     for iface, iface_options in interface.items() if iface_options.disable is not vyos_defined %}
+{%     for iface, iface_options in interface.items() %}
 {%         if iface == 'all' %}
 {%             set iface = '*' %}
 {%         endif %}
@@ -17,6 +17,15 @@ configure ports {{ iface }} med location elin "{{ iface_options.location.elin }}
 configure ports {{ iface }} med location coordinate latitude "{{ iface_options.location.coordinate_based.latitude }}" longitude "{{ iface_options.location.coordinate_based.longitude }}" altitude "{{ iface_options.location.coordinate_based.altitude }}m" datum "{{ iface_options.location.coordinate_based.datum }}"
 {%             endif %}
 {%         endif %}
+{%         set mode = iface_options.mode %}
+{%         if mode == 'tx' %}
+{%             set mode = 'tx-only' %}
+{%         elif mode == 'rx' %}
+{%             set mode = 'rx-only' %}
+{%         elif mode == 'rx-tx' %}
+{%             set mode = 'rx-and-tx' %}
+{%         endif %}
+configure ports {{ iface }} lldp status {{ mode }}
 {%     endfor %}
 configure system interface pattern "{{ tmp | join(",") }}"
 {% endif %}

--- a/interface-definitions/include/version/lldp-version.xml.i
+++ b/interface-definitions/include/version/lldp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/lldp-version.xml.i -->
-<syntaxVersion component='lldp' version='2'></syntaxVersion>
+<syntaxVersion component='lldp' version='3'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/service_lldp.xml.in
+++ b/interface-definitions/service_lldp.xml.in
@@ -29,7 +29,34 @@
               </constraint>
             </properties>
             <children>
-              #include <include/generic-disable-node.xml.i>
+              <leafNode name="mode">
+                <properties>
+                  <help>Set LLDP receive/transmit operation mode of this interface</help>
+                  <completionHelp>
+                    <list>disable rx-tx tx rx</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>disable</format>
+                    <description>Do not process or send LLDP messages</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>rx-tx</format>
+                    <description>Send and process LLDP messages</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>rx</format>
+                    <description>Process incoming LLDP messages</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>tx</format>
+                    <description>Send LLDP messages</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(disable|rx-tx|tx|rx)</regex>
+                  </constraint>
+                </properties>
+                <defaultValue>rx-tx</defaultValue>
+              </leafNode>
               <node name="location">
                 <properties>
                   <help>LLDP-MED location data</help>

--- a/smoketest/config-tests/dialup-router-complex
+++ b/smoketest/config-tests/dialup-router-complex
@@ -695,6 +695,7 @@ set service dns forwarding ignore-hosts-file
 set service dns forwarding listen-address '172.16.254.30'
 set service dns forwarding listen-address '172.31.0.254'
 set service dns forwarding negative-ttl '60'
+set service lldp interface pppoe0 mode 'disable'
 set service lldp legacy-protocols cdp
 set service lldp snmp
 set service mdns repeater interface 'eth0.35'

--- a/smoketest/config-tests/nat-basic
+++ b/smoketest/config-tests/nat-basic
@@ -60,7 +60,7 @@ set service dhcp-server shared-network-name LAN subnet 192.168.189.0/24 range 0 
 set service dhcp-server shared-network-name LAN subnet 192.168.189.0/24 range 0 stop '192.168.189.254'
 set service dhcp-server shared-network-name LAN subnet 192.168.189.0/24 subnet-id '1'
 set service lldp interface all
-set service lldp interface eth1 disable
+set service lldp interface eth1 mode 'disable'
 set service ntp allow-client address '192.168.189.0/24'
 set service ntp listen-address '192.168.189.1'
 set service ntp server time1.vyos.net

--- a/smoketest/configs/dialup-router-complex
+++ b/smoketest/configs/dialup-router-complex
@@ -1392,6 +1392,9 @@ service {
         }
     }
     lldp {
+        interface pppoe0 {
+            disable
+        }
         legacy-protocols {
             cdp
         }

--- a/src/migration-scripts/lldp/2-to-3
+++ b/src/migration-scripts/lldp/2-to-3
@@ -1,0 +1,31 @@
+# Copyright 2025 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# T7165: Migrate LLDP interface disable to 'mode disable'
+
+from vyos.configtree import ConfigTree
+
+base = ['service', 'lldp']
+
+def migrate(config: ConfigTree) -> None:
+    interface_base = base + ['interface']
+    if not config.exists(interface_base):
+        # Nothing to do
+        return
+
+    for interface in config.list_nodes(interface_base):
+        if config.exists(interface_base + [interface, 'disable']):
+            config.delete(interface_base + [interface, 'disable'])
+            config.set(interface_base + [interface, 'mode'], value='disable')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

LLDP is a stateless protocol which does not necessitate sending to receive advertisements. There are multiple scenarios such as provider peering links in which it is advantageous to receive LLDP but not disclose internal information to the provider.

Add new CLI commands:
`set service lldp interface <name> mode [disable|rx-and-tx|rx-only|tx-only]`

The default is unchanged and will be rx-and-tx.

Furthermore if an interface has an explicit LLDP disable configured under `set service lldp interface <name> disable` this will be migrated to `set service lldp interface <name> mode disable`


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7165

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-documentation/pull/1601

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_lldp.py
test_01_lldp_basic (__main__.TestServiceLLDP.test_01_lldp_basic) ... ok
test_02_lldp_mgmt_address (__main__.TestServiceLLDP.test_02_lldp_mgmt_address) ... ok
test_03_lldp_interfaces (__main__.TestServiceLLDP.test_03_lldp_interfaces) ... ok
test_04_lldp_all_interfaces (__main__.TestServiceLLDP.test_04_lldp_all_interfaces) ... ok
test_05_lldp_location (__main__.TestServiceLLDP.test_05_lldp_location) ... ok
test_06_lldp_snmp (__main__.TestServiceLLDP.test_06_lldp_snmp) ... ok
test_07_lldp_interface_mode (__main__.TestServiceLLDP.test_07_lldp_interface_mode) ... ok

----------------------------------------------------------------------
Ran 7 tests in 13.116s

OK
```

![image](https://github.com/user-attachments/assets/72d515fb-b841-4b6d-9930-4287035ace53)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
