### PR TITLE
snmp: T7180: Fixed verification of engineid in snmpv3

### DIFF
--- a/interface-definitions/service_snmp.xml.in
+++ b/interface-definitions/service_snmp.xml.in
@@ -304,7 +304,6 @@
                   </constraint>
                   <constraintErrorMessage>ID must contain an even number (from 2 to 36) of hex digits</constraintErrorMessage>
                 </properties>
-                <defaultValue></defaultValue>
               </leafNode>
               <tagNode name="group">
                 <properties>

--- a/src/conf_mode/service_snmp.py
+++ b/src/conf_mode/service_snmp.py
@@ -148,7 +148,7 @@ def verify(snmp):
 
     if 'user' in snmp['v3']:
         if 'engineid' not in snmp['v3']:
-            raise ConfigError(f'EngineID must be configured for snmpv3!')
+            raise ConfigError(f'EngineID must be configured for SNMPv3!')
 
         for user, user_config in snmp['v3']['user'].items():
             if 'group' not in user_config:

--- a/src/conf_mode/service_snmp.py
+++ b/src/conf_mode/service_snmp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018-2024 VyOS maintainers and contributors
+# Copyright (C) 2018-2025 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -147,6 +147,9 @@ def verify(snmp):
         return None
 
     if 'user' in snmp['v3']:
+        if 'engineid' not in snmp['v3']:
+            raise ConfigError(f'EngineID must be configured for snmpv3!')
+
         for user, user_config in snmp['v3']['user'].items():
             if 'group' not in user_config:
                 raise ConfigError(f'Group membership required for user "{user}"!')


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
EngineID must be configured if snmpv3 user is configured. 
Fixed engineid help string.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7180

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Configuration:
```
set service snmp listen-address 192.168.5.100
set service snmp v3 view snmpview1 oid 1.2.3.4.5.6.7
set service snmp v3 group group1 mode ro
set service snmp v3 group group1 seclevel priv
set service snmp v3 group group1 view snmpview1
set service snmp v3 user user1 auth plaintext-password Password1
set service snmp v3 user user1 auth type sha
set service snmp v3 user user1 group group1
set service snmp v3 user user1 privacy plaintext-password Password1
set service snmp v3 user user1 privacy type aes
```
Before
```
commit
[ service snmp ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 145, in run_script
    script.generate(c)
  File "/usr/libexec/vyos//conf_mode/service_snmp.py", line 221, in generate
    tmp = hash(dict_search('auth.plaintext_password', user_config),
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/snmpv3_hashgen.py", line 48, in plaintext_to_sha1
    engine = bytearray.fromhex(engine)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: fromhex() argument must be str, not None

[[service snmp]] failed
Commit failed
[edit]
```
After:
```
vyos@vyos# commit
[ service snmp ]
EngineID must be configured for snmpv3!
[[service snmp]] failed
Commit failed
[edit]
```
Smoketests:
```
---
WARNING: This VyOS system is not a stable long-term support version and
         is not intended for production use.
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_snmp.py
test_snmp_basic (__main__.TestSNMPService.test_snmp_basic) ... ok
test_snmp_script_extensions (__main__.TestSNMPService.test_snmp_script_extensions) ... ok
test_snmpv3_md5 (__main__.TestSNMPService.test_snmpv3_md5) ... ok
test_snmpv3_sha (__main__.TestSNMPService.test_snmpv3_sha) ... ok
test_snmpv3_view_exclude (__main__.TestSNMPService.test_snmpv3_view_exclude) ... ok

----------------------------------------------------------------------
Ran 5 tests in 23.672s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
