### PR TITLE
wireguard: T7166: Call vxlan dependency if interface exist

### DIFF
--- a/data/config-mode-dependencies/vyos-1x.json
+++ b/data/config-mode-dependencies/vyos-1x.json
@@ -14,6 +14,9 @@
         "vxlan": ["interfaces_vxlan"],
         "wlan": ["interfaces_wireless"]
     },
+    "interfaces_wireguard": {
+        "vxlan": ["interfaces_vxlan"]
+    },
     "load_balancing_wan": {
         "conntrack": ["system_conntrack"]
     },


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7166
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set interfaces wireguard wg1 address 10.20.30.1/24
set interfaces wireguard wg1 description 'First peer'
set interfaces wireguard wg1 peer first address '192.0.2.31'
set interfaces wireguard wg1 peer first allowed-ips '10.20.30.2/32'
set interfaces wireguard wg1 peer first persistent-keepalive '25'
set interfaces wireguard wg1 peer first port '55555'
set interfaces wireguard wg1 peer first public-key '6HXVzOzM3yYz+MkXUOajmLU22CEvYacISODOwQPqE34='
set interfaces wireguard wg1 port '50001'
set interfaces wireguard wg1 private-key '2L4gceJCIpL9QjPZnsO3Mfb+2if+dYtBINZE2F4mDXU='

set interfaces vxlan vxlan1 address '10.1.1.1/30'
set interfaces vxlan vxlan1 mtu '1350'
set interfaces vxlan vxlan1 port '4789'
set interfaces vxlan vxlan1 remote '192.0.2.31'
set interfaces vxlan vxlan1 source-interface 'wg1'
set interfaces vxlan vxlan1 vni '5'

vyos@vyos# commit && ip link show | match "wg|vxlan"
[ interfaces wireguard wg1 ]

WARNING: RFC7348 recommends VXLAN tunnels preserve a 1500 byte MTU


[ interfaces vxlan vxlan1 ]

WARNING: RFC7348 recommends VXLAN tunnels preserve a 1500 byte MTU


18: wg1: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1420 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
20: vxlan1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1350 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
[edit]


set interfaces wireguard wg1 peer first persistent-keepalive 15

vyos@vyos# commit && ip link show | match "wg|vxlan"
[ interfaces wireguard wg1 ]

WARNING: RFC7348 recommends VXLAN tunnels preserve a 1500 byte MTU


21: wg1: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1420 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
22: vxlan1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1350 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
[edit]
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
