### PR TITLE
policy: T7116: Remove unsupported use of BGP community "internet"

### DIFF
--- a/interface-definitions/include/policy/community-value-list.xml.i
+++ b/interface-definitions/include/policy/community-value-list.xml.i
@@ -4,7 +4,6 @@
       local-as
       no-advertise
       no-export
-      internet
       graceful-shutdown
       accept-own
       route-filter-translated-v4
@@ -33,10 +32,6 @@
 <valueHelp>
     <format>no-export</format>
     <description>Well-known communities value NO_EXPORT 0xFFFFFF01</description>
-</valueHelp>
-<valueHelp>
-    <format>internet</format>
-    <description>Well-known communities value 0</description>
 </valueHelp>
 <valueHelp>
     <format>graceful-shutdown</format>
@@ -84,7 +79,7 @@
 </valueHelp>
 <multi/>
 <constraint>
-    <regex>local-as|no-advertise|no-export|internet|graceful-shutdown|accept-own|route-filter-translated-v4|route-filter-v4|route-filter-translated-v6|route-filter-v6|llgr-stale|no-llgr|accept-own-nexthop|blackhole|no-peer</regex>
+    <regex>local-as|no-advertise|no-export|graceful-shutdown|accept-own|route-filter-translated-v4|route-filter-v4|route-filter-translated-v6|route-filter-v6|llgr-stale|no-llgr|accept-own-nexthop|blackhole|no-peer</regex>
     <validator name="bgp-regular-community"/>
 </constraint>
         <!-- include end -->

--- a/interface-definitions/include/version/policy-version.xml.i
+++ b/interface-definitions/include/version/policy-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/policy-version.xml.i -->
-<syntaxVersion component='policy' version='8'></syntaxVersion>
+<syntaxVersion component='policy' version='9'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/policy.xml.in
+++ b/interface-definitions/policy.xml.in
@@ -202,7 +202,7 @@
                 <properties>
                   <help>Regular expression to match against a community-list</help>
                   <completionHelp>
-                    <list>local-AS no-advertise no-export internet graceful-shutdown accept-own-nexthop accept-own route-filter-translated-v4 route-filter-v4 route-filter-translated-v6 route-filter-v6 llgr-stale no-llgr blackhole no-peer additive</list>
+                    <list>local-AS no-advertise no-export graceful-shutdown accept-own-nexthop accept-own route-filter-translated-v4 route-filter-v4 route-filter-translated-v6 route-filter-v6 llgr-stale no-llgr blackhole no-peer additive</list>
                   </completionHelp>
                   <valueHelp>
                     <format>&lt;aa:nn&gt;</format>
@@ -219,10 +219,6 @@
                   <valueHelp>
                     <format>no-export</format>
                     <description>Well-known communities value NO_EXPORT 0xFFFFFF01</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>internet</format>
-                    <description>Well-known communities value 0</description>
                   </valueHelp>
                   <valueHelp>
                     <format>graceful-shutdown</format>

--- a/src/migration-scripts/policy/8-to-9
+++ b/src/migration-scripts/policy/8-to-9
@@ -1,0 +1,49 @@
+# Copyright (C) 2025 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# T7116: Remove unsupported "internet" community following FRR removal
+# From
+    # set policy route-map <name> rule <ord> set community [add | replace] internet
+    # set policy community-list <name> rule <ord> regex internet
+# To
+    # set policy route-map <name> rule <ord> set community [add | replace] 0:0
+    # set policy community-list <name> rule <ord> regex _0:0_
+
+# NOTE: In FRR expanded community-lists, without the '_' delimiters, a regex of 
+# "0:0" will match "65000:0" as well as "0:0". This doesn't line up with what
+# we want when replacing "internet". 
+
+from vyos.configtree import ConfigTree
+
+rm_base = ['policy', 'route-map']
+cl_base = ['policy', 'community-list']
+
+def migrate(config: ConfigTree) -> None:
+    if config.exists(rm_base):
+        for policy_name in config.list_nodes(rm_base):
+            for rule_ord in config.list_nodes(rm_base + [policy_name, 'rule'], path_must_exist=False):
+                tmp_path = rm_base + [policy_name, 'rule', rule_ord, 'set', 'community']
+                if config.exists(tmp_path + ['add']) and config.return_value(tmp_path + ['add']) == 'internet':
+                    config.set(tmp_path + ['add'], '0:0')
+                if config.exists(tmp_path + ['replace']) and config.return_value(tmp_path + ['replace']) == 'internet':
+                    config.set(tmp_path + ['replace'], '0:0')
+
+    if config.exists(cl_base):
+        for policy_name in config.list_nodes(cl_base):
+            for rule_ord in config.list_nodes(cl_base + [policy_name, 'rule'], path_must_exist=False):
+                tmp_path = cl_base + [policy_name, 'rule', rule_ord, 'regex']
+                if config.exists(tmp_path) and config.return_value(tmp_path) == 'internet':
+                    config.set(tmp_path, '_0:0_')
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
FRR [removed support](https://github.com/FRRouting/frr/commit/b2b47bb4a9ae6cb8fdb14d91bd5760c2558f702c) for the non-standard BGP community "internet" as an alias for 0:0, as it is Cisco shorthand and not part of any standard. 

VyOS still accepts "internet" as a community name or regex match, which is rejected by FRR during commit. 

I've removed "internet" as a valid "set community" target for route-maps or as a valid regex in community-lists. 

I've also included a migration for dealing with older installations which might actually have valid configs using the community alias.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7116

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-documentation/pull/1603

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
* Manually checked that "internet" is no longer offered as a completion under route-map "set community" or community-list regex.
* Manually checked that it will also not pass validation constraints
* Migrated and loaded some hand-modified config samples for 1.5, plus complete configs from older 1.2 and 1.3 installations that both included and excluded mention of the BGP community  to double-check the migration 
* Ran through migrations and test loads of each of the bgp-* testing configs
* Ran a complete policy section smoketest:

```
$ python3 /usr/libexec/vyos/tests/smoke/cli/test_policy.py
test_access_list (__main__.TestPolicy.test_access_list) ... ok
test_access_list6 (__main__.TestPolicy.test_access_list6) ... ok
test_as_path_list (__main__.TestPolicy.test_as_path_list) ... ok
test_community_list (__main__.TestPolicy.test_community_list) ... ok
test_delete_ipv4_ipv6_table_id (__main__.TestPolicy.test_delete_ipv4_ipv6_table_id) ... ok
test_destination_ipv6_table_id (__main__.TestPolicy.test_destination_ipv6_table_id) ... ok
test_destination_table_id (__main__.TestPolicy.test_destination_table_id) ... ok
test_extended_community_list (__main__.TestPolicy.test_extended_community_list) ... ok
test_frr_individual_remove_T6283_T6250 (__main__.TestPolicy.test_frr_individual_remove_T6283_T6250) ... ok
test_fwmark_ipv6_table_id (__main__.TestPolicy.test_fwmark_ipv6_table_id) ... ok
test_fwmark_sources_destination_ipv6_table_id (__main__.TestPolicy.test_fwmark_sources_destination_ipv6_table_id) ... ok
test_fwmark_sources_destination_table_id (__main__.TestPolicy.test_fwmark_sources_destination_table_id) ... ok
test_fwmark_sources_ipv6_table_id (__main__.TestPolicy.test_fwmark_sources_ipv6_table_id) ... ok
test_fwmark_sources_table_id (__main__.TestPolicy.test_fwmark_sources_table_id) ... ok
test_fwmark_table_id (__main__.TestPolicy.test_fwmark_table_id) ... ok
test_iif_sources_ipv6_table_id (__main__.TestPolicy.test_iif_sources_ipv6_table_id) ... ok
test_iif_sources_table_id (__main__.TestPolicy.test_iif_sources_table_id) ... ok
test_ipv6_table_id (__main__.TestPolicy.test_ipv6_table_id) ... ok
test_large_community_list (__main__.TestPolicy.test_large_community_list) ... ok
test_multiple_commit_ipv4_table_id (__main__.TestPolicy.test_multiple_commit_ipv4_table_id) ... ok
test_prefix_list (__main__.TestPolicy.test_prefix_list) ... ok
test_prefix_list6 (__main__.TestPolicy.test_prefix_list6) ... ok
test_prefix_list_duplicates (__main__.TestPolicy.test_prefix_list_duplicates) ... ok
test_protocol_destination_table_id (__main__.TestPolicy.test_protocol_destination_table_id) ... ok
test_protocol_port_address_fwmark_table_id (__main__.TestPolicy.test_protocol_port_address_fwmark_table_id) ... ok
test_route_map (__main__.TestPolicy.test_route_map) ... ok
test_route_map_community_set (__main__.TestPolicy.test_route_map_community_set) ... ok
test_table_id (__main__.TestPolicy.test_table_id) ... ok

----------------------------------------------------------------------
Ran 28 tests in 367.197s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
