### PR TITLE
T7118: Added the ability to redistribute NHRP routes to other protocols

### DIFF
--- a/interface-definitions/include/babel/redistribute-common.xml.i
+++ b/interface-definitions/include/babel/redistribute-common.xml.i
@@ -23,6 +23,12 @@
       <valueless/>
     </properties>
   </leafNode>
+  <leafNode name="nhrp">
+    <properties>
+      <help>Redistribute NHRP routes</help>
+      <valueless/>
+    </properties>
+  </leafNode>
   <leafNode name="openfabric">
     <properties>
       <help>OpenFabric Routing Protocol</help>

--- a/interface-definitions/include/bgp/afi-redistribute-common-protocols.xml.i
+++ b/interface-definitions/include/bgp/afi-redistribute-common-protocols.xml.i
@@ -31,6 +31,14 @@
     #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
   </children>
 </node>
+<node name="nhrp">
+  <properties>
+    <help>Redistribute NHRP routes into BGP</help>
+  </properties>
+  <children>
+    #include <include/bgp/afi-redistribute-metric-route-map.xml.i>
+  </children>
+</node>
 <node name="static">
   <properties>
     <help>Redistribute static routes into BGP</help>

--- a/interface-definitions/include/isis/protocol-common-config.xml.i
+++ b/interface-definitions/include/isis/protocol-common-config.xml.i
@@ -418,6 +418,14 @@
             #include <include/isis/redistribute-level-1-2.xml.i>
           </children>
         </node>
+        <node name="nhrp">
+          <properties>
+            <help>Redistribute NHRP routes into IS-IS</help>
+          </properties>
+          <children>
+            #include <include/isis/redistribute-level-1-2.xml.i>
+          </children>
+        </node>
         <node name="ospf">
           <properties>
             <help>Redistribute OSPF routes into IS-IS</help>

--- a/interface-definitions/include/ospf/protocol-common-config.xml.i
+++ b/interface-definitions/include/ospf/protocol-common-config.xml.i
@@ -798,6 +798,16 @@
         #include <include/route-map.xml.i>
       </children>
     </node>
+    <node name="nhrp">
+      <properties>
+        <help>Redistribute NHRP routes</help>
+      </properties>
+      <children>
+        #include <include/ospf/metric.xml.i>
+        #include <include/ospf/metric-type.xml.i>
+        #include <include/route-map.xml.i>
+      </children>
+    </node>
     <node name="rip">
       <properties>
         <help>Redistribute RIP routes</help>

--- a/interface-definitions/protocols_rip.xml.in
+++ b/interface-definitions/protocols_rip.xml.in
@@ -209,6 +209,14 @@
                   #include <include/rip/redistribute.xml.i>
                 </children>
               </node>
+              <node name="nhrp">
+                <properties>
+                  <help>Redistribute NHRP routes</help>
+                </properties>
+                <children>
+                  #include <include/rip/redistribute.xml.i>
+                </children>
+              </node>
               <node name="ospf">
                 <properties>
                   <help>Redistribute OSPF routes</help>

--- a/smoketest/scripts/cli/test_protocols_babel.py
+++ b/smoketest/scripts/cli/test_protocols_babel.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2024 VyOS maintainers and contributors
+# Copyright (C) 2024-2025 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -72,7 +72,7 @@ class TestProtocolsBABEL(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f' babel smoothing-half-life {smoothing_half_life}', frrconfig)
 
     def test_02_redistribute(self):
-        ipv4_protos = ['bgp', 'connected', 'isis', 'kernel', 'ospf', 'rip', 'static']
+        ipv4_protos = ['bgp', 'connected', 'isis', 'kernel', 'nhrp', 'ospf', 'rip', 'static']
         ipv6_protos = ['bgp', 'connected', 'isis', 'kernel', 'ospfv3', 'ripng', 'static']
 
         self.cli_set(base_path + ['interface', self._interfaces[0], 'enable-timestamps'])

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -672,6 +672,10 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
                 'metric' : '400',
                 'route_map' : 'redistr-ipv4-kernel',
             },
+            'nhrp': {
+                'metric': '400',
+                'route_map': 'redistr-ipv4-nhrp',
+            },
             'ospf' : {
                 'metric' : '500',
                 'route_map' : 'redistr-ipv4-ospf',

--- a/smoketest/scripts/cli/test_protocols_isis.py
+++ b/smoketest/scripts/cli/test_protocols_isis.py
@@ -59,7 +59,7 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
         route_map = 'EXPORT-ISIS'
         rule = '10'
         metric_style = 'transition'
-
+        redistribute = ['babel', 'bgp', 'connected', 'kernel', 'nhrp', 'ospf', 'rip', 'static']
         self.cli_set(['policy', 'prefix-list', prefix_list, 'rule', rule, 'action', 'permit'])
         self.cli_set(['policy', 'prefix-list', prefix_list, 'rule', rule, 'prefix', '203.0.113.0/24'])
         self.cli_set(['policy', 'route-map', route_map, 'rule', rule, 'action', 'permit'])
@@ -80,7 +80,9 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
 
-        self.cli_set(base_path + ['redistribute', 'ipv4', 'connected', 'level-2', 'route-map', route_map])
+        for proto in redistribute:
+            self.cli_set(base_path + ['redistribute', 'ipv4', proto, 'level-2', 'route-map', route_map])
+
         self.cli_set(base_path + ['metric-style', metric_style])
         self.cli_set(base_path + ['log-adjacency-changes'])
 
@@ -92,7 +94,8 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f' net {net}', tmp)
         self.assertIn(f' metric-style {metric_style}', tmp)
         self.assertIn(f' log-adjacency-changes', tmp)
-        self.assertIn(f' redistribute ipv4 connected level-2 route-map {route_map}', tmp)
+        for proto in redistribute:
+            self.assertIn(f' redistribute ipv4 {proto} level-2 route-map {route_map}', tmp)
 
         for interface in self._interfaces:
             tmp = self.getFRRconfig(f'interface {interface}', endsection='^exit')

--- a/smoketest/scripts/cli/test_protocols_ospf.py
+++ b/smoketest/scripts/cli/test_protocols_ospf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2024 VyOS maintainers and contributors
+# Copyright (C) 2021-2025 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -255,7 +255,7 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
     def test_ospf_07_redistribute(self):
         metric = '15'
         metric_type = '1'
-        redistribute = ['babel', 'bgp', 'connected', 'isis', 'kernel', 'rip', 'static']
+        redistribute = ['babel', 'bgp', 'connected', 'isis', 'kernel', 'nhrp', 'rip', 'static']
 
         for protocol in redistribute:
             self.cli_set(base_path + ['redistribute', protocol, 'metric', metric])

--- a/smoketest/scripts/cli/test_protocols_rip.py
+++ b/smoketest/scripts/cli/test_protocols_rip.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2023 VyOS maintainers and contributors
+# Copyright (C) 2021-2025 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -82,7 +82,7 @@ class TestProtocolsRIP(VyOSUnitTestSHIM.TestCase):
         interfaces = Section.interfaces('ethernet')
         neighbors = ['1.2.3.4', '1.2.3.5', '1.2.3.6']
         networks = ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16']
-        redistribute = ['bgp', 'connected', 'isis', 'kernel', 'ospf', 'static']
+        redistribute = ['bgp', 'connected', 'isis', 'kernel', 'nhrp', 'ospf', 'static']
         timer_garbage = '888'
         timer_timeout = '1000'
         timer_update = '90'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Added the ability to redistribute NHRP routes to:
OSPF
BGP
Babel
RIP
IS-IS

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7118

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Smoke tests:
```
/usr/libexec/vyos/tests/smoke/cli/test_protocols_babel.py
vyos@vyos:~$  /usr/libexec/vyos/tests/smoke/cli/test_protocols_babel.py
test_01_basic (__main__.TestProtocolsBABEL.test_01_basic) ... ok
test_02_redistribute (__main__.TestProtocolsBABEL.test_02_redistribute) ... ok
test_03_distribute_list (__main__.TestProtocolsBABEL.test_03_distribute_list) ... ok
test_04_interfaces (__main__.TestProtocolsBABEL.test_04_interfaces) ... ok

----------------------------------------------------------------------
Ran 4 tests in 49.015s

OK
vyos@vyos:~$  /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ... ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ... ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ... ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ... ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ... ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ... ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ... ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ... ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ... ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ... ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok
test_bgp_24_srv6_sid (__main__.TestProtocolsBGP.test_bgp_24_srv6_sid) ... ok
test_bgp_25_ipv4_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_25_ipv4_labeled_unicast_peer_group) ... ok
test_bgp_26_ipv6_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_26_ipv6_labeled_unicast_peer_group) ... ok
test_bgp_27_route_reflector_client (__main__.TestProtocolsBGP.test_bgp_27_route_reflector_client) ... ok
test_bgp_28_peer_group_member_all_internal_or_external (__main__.TestProtocolsBGP.test_bgp_28_peer_group_member_all_internal_or_external) ... ok
test_bgp_29_peer_group_remote_as_equal_local_as (__main__.TestProtocolsBGP.test_bgp_29_peer_group_remote_as_equal_local_as) ... ok
test_bgp_99_bmp (__main__.TestProtocolsBGP.test_bgp_99_bmp) ... ok

----------------------------------------------------------------------
Ran 29 tests in 403.728s

OK
vyos@vyos:~$  /usr/libexec/vyos/tests/smoke/cli/test_protocols_isis.py
test_isis_01_redistribute (__main__.TestProtocolsISIS.test_isis_01_redistribute) ... ok
test_isis_02_vrfs (__main__.TestProtocolsISIS.test_isis_02_vrfs) ... ok
test_isis_04_default_information (__main__.TestProtocolsISIS.test_isis_04_default_information) ... ok
test_isis_05_password (__main__.TestProtocolsISIS.test_isis_05_password) ... ok
test_isis_06_spf_delay_bfd (__main__.TestProtocolsISIS.test_isis_06_spf_delay_bfd) ... ok
test_isis_07_segment_routing_configuration (__main__.TestProtocolsISIS.test_isis_07_segment_routing_configuration) ... ok
test_isis_08_ldp_sync (__main__.TestProtocolsISIS.test_isis_08_ldp_sync) ... ok
test_isis_09_lfa (__main__.TestProtocolsISIS.test_isis_09_lfa) ... ok
test_isis_10_topology (__main__.TestProtocolsISIS.test_isis_10_topology) ... ok

----------------------------------------------------------------------
Ran 9 tests in 336.124s

OK
vyos@vyos:~$  /usr/libexec/vyos/tests/smoke/cli/test_protocols_ospf.py
test_ospf_01_defaults (__main__.TestProtocolsOSPF.test_ospf_01_defaults) ... ok
test_ospf_02_simple (__main__.TestProtocolsOSPF.test_ospf_02_simple) ... ok
test_ospf_03_access_list (__main__.TestProtocolsOSPF.test_ospf_03_access_list) ... ok
test_ospf_04_default_originate (__main__.TestProtocolsOSPF.test_ospf_04_default_originate) ... ok
test_ospf_05_options (__main__.TestProtocolsOSPF.test_ospf_05_options) ... ok
test_ospf_06_neighbor (__main__.TestProtocolsOSPF.test_ospf_06_neighbor) ... ok
test_ospf_07_redistribute (__main__.TestProtocolsOSPF.test_ospf_07_redistribute) ... ok
test_ospf_08_virtual_link (__main__.TestProtocolsOSPF.test_ospf_08_virtual_link) ... ok
test_ospf_09_interface_configuration (__main__.TestProtocolsOSPF.test_ospf_09_interface_configuration) ... ok
test_ospf_11_interface_area (__main__.TestProtocolsOSPF.test_ospf_11_interface_area) ... ok
test_ospf_12_vrfs (__main__.TestProtocolsOSPF.test_ospf_12_vrfs) ... ok
test_ospf_13_export_list (__main__.TestProtocolsOSPF.test_ospf_13_export_list) ... ok
test_ospf_14_segment_routing_configuration (__main__.TestProtocolsOSPF.test_ospf_14_segment_routing_configuration) ... ok
test_ospf_15_ldp_sync (__main__.TestProtocolsOSPF.test_ospf_15_ldp_sync) ... ok
test_ospf_16_graceful_restart (__main__.TestProtocolsOSPF.test_ospf_16_graceful_restart) ... ok
test_ospf_17_duplicate_area_network (__main__.TestProtocolsOSPF.test_ospf_17_duplicate_area_network) ... ok

----------------------------------------------------------------------
Ran 16 tests in 295.478s

OK
vyos@vyos:~$  /usr/libexec/vyos/tests/smoke/cli/test_protocols_rip.py
test_rip_01_parameters (__main__.TestProtocolsRIP.test_rip_01_parameters) ... ok
test_rip_02_zebra_route_map (__main__.TestProtocolsRIP.test_rip_02_zebra_route_map) ... ok
test_rip_03_version (__main__.TestProtocolsRIP.test_rip_03_version) ... ok

----------------------------------------------------------------------
Ran 3 tests in 44.145s

OK
vyos@vyos:~$

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
