### PR TITLE
policy: T7158: Added match source-vrf to route-map

### DIFF
--- a/data/templates/frr/policy.frr.j2
+++ b/data/templates/frr/policy.frr.j2
@@ -252,6 +252,9 @@ route-map {{ route_map }} {{ rule_config.action }} {{ rule }}
 {%                     if rule_config.match.rpki is vyos_defined %}
  match rpki {{ rule_config.match.rpki }}
 {%                     endif %}
+{%                     if rule_config.match.source_vrf is vyos_defined %}
+ match source-vrf {{ rule_config.match.source_vrf }}
+{%                     endif %}
 {%                     if rule_config.match.tag is vyos_defined %}
  match tag {{ rule_config.match.tag }}
 {%                     endif %}

--- a/interface-definitions/policy.xml.in
+++ b/interface-definitions/policy.xml.in
@@ -1096,6 +1096,20 @@
                       </constraint>
                     </properties>
                   </leafNode>
+                  <leafNode name="source-vrf">
+                    <properties>
+                      <help>Source vrf</help>
+                      #include <include/constraint/vrf.xml.i>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>VRF instance name</description>
+                      </valueHelp>
+                      <completionHelp>
+                        <path>vrf name</path>
+                        <list>default</list>
+                      </completionHelp>
+                    </properties>
+                  </leafNode>
                   #include <include/policy/tag.xml.i>
                 </children>
               </node>

--- a/smoketest/scripts/cli/test_policy.py
+++ b/smoketest/scripts/cli/test_policy.py
@@ -1149,6 +1149,16 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                     },
                 },
             },
+            'vrf-match': {
+                'rule': {
+                    '10': {
+                        'action': 'permit',
+                        'match': {
+                            'source-vrf': 'TEST',
+                        },
+                    },
+                },
+            },
         }
 
         self.cli_set(['policy', 'access-list', access_list, 'rule', '10', 'action', 'permit'])
@@ -1260,6 +1270,8 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                         self.cli_set(path + ['rule', rule, 'match', 'rpki', 'valid'])
                     if 'protocol' in rule_config['match']:
                         self.cli_set(path + ['rule', rule, 'match', 'protocol', rule_config['match']['protocol']])
+                    if 'source-vrf' in rule_config['match']:
+                        self.cli_set(path + ['rule', rule, 'match', 'source-vrf', rule_config['match']['source-vrf']])
                     if 'tag' in rule_config['match']:
                         self.cli_set(path + ['rule', rule, 'match', 'tag', rule_config['match']['tag']])
 
@@ -1437,6 +1449,9 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                         self.assertIn(tmp, config)
                     if 'rpki-valid' in rule_config['match']:
                         tmp = f'match rpki valid'
+                        self.assertIn(tmp, config)
+                    if 'source-vrf' in rule_config['match']:
+                        tmp = f'match source-vrf {rule_config["match"]["source-vrf"]}'
                         self.assertIn(tmp, config)
                     if 'tag' in rule_config['match']:
                         tmp = f'match tag {rule_config["match"]["tag"]}'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Added match source-vrf to route-map

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7158

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
To test
```
vyos@vyos# set policy route-map TEST rule 10  match source-vrf
Possible completions:
   <text>               VRF instance name
   default
```
Smoke tests

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_policy.py
test_access_list (__main__.TestPolicy.test_access_list) ... ok
test_access_list6 (__main__.TestPolicy.test_access_list6) ... ok
test_as_path_list (__main__.TestPolicy.test_as_path_list) ... ok
test_community_list (__main__.TestPolicy.test_community_list) ... ok
test_delete_ipv4_ipv6_table_id (__main__.TestPolicy.test_delete_ipv4_ipv6_table_id) ... ok
test_destination_ipv6_table_id (__main__.TestPolicy.test_destination_ipv6_table_id) ... ok
test_destination_table_id (__main__.TestPolicy.test_destination_table_id) ... ok
test_extended_community_list (__main__.TestPolicy.test_extended_community_list) ... ok
test_frr_individual_remove_T6283_T6250 (__main__.TestPolicy.test_frr_individual_remove_T6283_T6250) ... ok
test_fwmark_ipv6_table_id (__main__.TestPolicy.test_fwmark_ipv6_table_id) ... ok
test_fwmark_sources_destination_ipv6_table_id (__main__.TestPolicy.test_fwmark_sources_destination_ipv6_table_id) ... ok
test_fwmark_sources_destination_table_id (__main__.TestPolicy.test_fwmark_sources_destination_table_id) ... ok
test_fwmark_sources_ipv6_table_id (__main__.TestPolicy.test_fwmark_sources_ipv6_table_id) ... ok
test_fwmark_sources_table_id (__main__.TestPolicy.test_fwmark_sources_table_id) ... ok
test_fwmark_table_id (__main__.TestPolicy.test_fwmark_table_id) ... ok
test_iif_sources_ipv6_table_id (__main__.TestPolicy.test_iif_sources_ipv6_table_id) ... ok
test_iif_sources_table_id (__main__.TestPolicy.test_iif_sources_table_id) ... ok
test_ipv6_table_id (__main__.TestPolicy.test_ipv6_table_id) ... ok
test_large_community_list (__main__.TestPolicy.test_large_community_list) ... ok
test_multiple_commit_ipv4_table_id (__main__.TestPolicy.test_multiple_commit_ipv4_table_id) ... ok
test_prefix_list (__main__.TestPolicy.test_prefix_list) ... ok
test_prefix_list6 (__main__.TestPolicy.test_prefix_list6) ... ok
test_prefix_list_duplicates (__main__.TestPolicy.test_prefix_list_duplicates) ... ok
test_protocol_destination_table_id (__main__.TestPolicy.test_protocol_destination_table_id) ... ok
test_protocol_port_address_fwmark_table_id (__main__.TestPolicy.test_protocol_port_address_fwmark_table_id) ... ok
test_route_map (__main__.TestPolicy.test_route_map) ... ok
test_route_map_community_set (__main__.TestPolicy.test_route_map_community_set) ... ok
test_table_id (__main__.TestPolicy.test_table_id) ... ok

----------------------------------------------------------------------
Ran 28 tests in 357.636s

OK

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
