### PR TITLE
syslog: T6989: fix typos and add option to disable MARK

### DIFF
--- a/data/templates/rsyslog/rsyslog.conf.j2
+++ b/data/templates/rsyslog/rsyslog.conf.j2
@@ -40,7 +40,7 @@ global(workDirectory="/var/spool/rsyslog")
 # Send emergency messages to all logged-in users
 *.emerg action(type="omusrmsg" users="*")
 
-{% if marker is vyos_defined %}
+{% if marker is vyos_defined and marker.disable is not vyos_defined %}
 # Load the immark module for periodic --MARK-- message capability
 module(load="immark" interval="{{ marker.interval }}")
 {% endif %}

--- a/interface-definitions/system_syslog.xml.in
+++ b/interface-definitions/system_syslog.xml.in
@@ -88,9 +88,9 @@
                     <description>Time in seconds</description>
                   </valueHelp>
                   <constraint>
-                    <validator name="numeric" argument="--range 1-86400"/>
+                    <validator name="numeric" argument="--range 1-65535"/>
                   </constraint>
-                  <constraintErrorMessage>Port number must be in range 1 to 86400</constraintErrorMessage>
+                  <constraintErrorMessage>Port number must be in range 1 to 65535</constraintErrorMessage>
                 </properties>
                 <defaultValue>1200</defaultValue>
               </leafNode>

--- a/interface-definitions/system_syslog.xml.in
+++ b/interface-definitions/system_syslog.xml.in
@@ -80,6 +80,7 @@
               <help>Mark messages sent to syslog</help>
             </properties>
             <children>
+              #include <include/generic-disable-node.xml.i>
               <leafNode name="interval">
                 <properties>
                   <help>Mark message interval</help>

--- a/smoketest/scripts/cli/test_system_syslog.py
+++ b/smoketest/scripts/cli/test_system_syslog.py
@@ -120,6 +120,12 @@ class TestRSYSLOGService(VyOSUnitTestSHIM.TestCase):
         self.assertIn( '        rotation.sizeLimit="524288"', config)
         self.assertIn( '        rotation.sizeLimitCommand="/usr/sbin/logrotate /etc/logrotate.d/vyos-rsyslog"', config)
 
+        self.cli_set(base_path + ['marker', 'disable'])
+        self.cli_commit()
+
+        config = get_config('')
+        self.assertNotIn('module(load="immark"', config)
+
     def test_remote(self):
         rhosts = {
             '169.254.0.1': {


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Fix CLI validator and error message for marker interval.
Add possibility to disable the mark module. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6989

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4305
* https://github.com/vyos/vyos-documentation/pull/1604

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_syslog.py
test_basic (__main__.TestRSYSLOGService.test_basic) ... ok
test_console (__main__.TestRSYSLOGService.test_console) ... ok
test_remote (__main__.TestRSYSLOGService.test_remote) ... ok
test_vrf_source_address (__main__.TestRSYSLOGService.test_vrf_source_address) ... ok

----------------------------------------------------------------------
Ran 4 tests in 10.833s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
