### PR TITLE
T4406: Add public API endpoint to display information

### DIFF
--- a/data/templates/https/nginx.default.j2
+++ b/data/templates/https/nginx.default.j2
@@ -48,7 +48,7 @@ server {
     ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK';
 
     # proxy settings for HTTP API, if enabled; 503, if not
-    location ~ ^/(retrieve|configure|config-file|image|import-pki|container-image|generate|show|reboot|reset|poweroff|traceroute|docs|openapi.json|redoc|graphql) {
+    location ~ ^/(retrieve|configure|config-file|image|import-pki|container-image|generate|show|reboot|reset|poweroff|traceroute|info|docs|openapi.json|redoc|graphql) {
 {% if api is vyos_defined %}
         proxy_pass http://unix:/run/api.sock;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/src/services/api/rest/models.py
+++ b/src/services/api/rest/models.py
@@ -293,6 +293,13 @@ class TracerouteModel(ApiModel):
         }
 
 
+class InfoQueryParams(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    version: bool = True
+    hostname: bool = True
+
+
 class Success(BaseModel):
     success: bool
     data: Union[str, bool, Dict]

--- a/src/services/vyos-http-api-server
+++ b/src/services/vyos-http-api-server
@@ -20,18 +20,22 @@ import grp
 import json
 import logging
 import signal
+import traceback
 from time import sleep
+from typing import Annotated
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Query
 from fastapi.exceptions import RequestValidationError
 from uvicorn import Config as UvicornConfig
 from uvicorn import Server as UvicornServer
 
 from vyos.configsession import ConfigSession
 from vyos.defaults import api_config_state
+from vyos.utils.file import read_file
+from vyos.version import get_version
 
 from api.session import SessionState
-from api.rest.models import error
+from api.rest.models import error, InfoQueryParams, success
 
 CFG_GROUP = 'vyattacfg'
 
@@ -57,9 +61,47 @@ app = FastAPI(debug=True,
               title="VyOS API",
               version="0.1.0")
 
+
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(_request, exc):
     return error(400, str(exc.errors()[0]))
+
+
+@app.get('/info')
+def info(q: Annotated[InfoQueryParams, Query()]):
+    show_version = q.version
+    show_hostname = q.hostname
+
+    prelogin_file = r'/etc/issue'
+    hostname_file = r'/etc/hostname'
+    default = 'Welcome to VyOS'
+
+    try:
+        res = {
+            'banner': '',
+            'hostname': '',
+            'version': ''
+        }
+        if show_version:
+            res.update(version=get_version())
+
+        if show_hostname:
+            try:
+                hostname = read_file(hostname_file)
+            except Exception:
+                hostname = 'vyos'
+            res.update(hostname=hostname)
+
+        banner = read_file(prelogin_file, defaultonfailure=default)
+        if banner == f'{default} - \\n \\l':
+            banner = banner.partition(default)[1]
+
+        res.update(banner=banner)
+    except Exception:
+        LOG.critical(traceback.format_exc())
+        return error(500, 'An internal error occured. Check the logs for details.')
+
+    return success(res)
 
 
 ###


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Adds a public endpoint `/info` to the HTTP(S) API to display some basic information about the router, namely router's hostname, VyOS version and pre-login banner. 

The endpoint accepts `version` and `hostname` query parameters, set to valid boolean values (1, 0, 'yes', 'no' etc. are acceptable as well), which dictate whether to include respective data into the response. 
- If values are set to `False` or equivalent, a correspondent field in the response object is set to an empty string. 
- If no query parameters are supplied, all three fields are populated with actual data by default. 
- The query parameters' type is validated. Extra parameters besides `version` and `hostname` are not allowed. 
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T4406
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
- Build the debian package for vyos-1x
- Install it to vyos-1x instance
- Enable the HTTP API
- Send a GET request to the API endpoint, for example `curl --insecure --location --request GET 'https://<INSTANCE_ADDRESS>/info`
 - Try different combinations of query parameters, for example `?version=0&hostname=1` or `?hostname=false` or `?version=yes&hostname=0`
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
