### PR TITLE
ipsec: T7225: fix IKE DiffieHellmanGroup and ExtendedAuthEnabled in iOS profile

### DIFF
--- a/data/templates/ipsec/ios_profile.j2
+++ b/data/templates/ipsec/ios_profile.j2
@@ -55,11 +55,9 @@
                 <!-- The server is authenticated using a certificate -->
                 <key>AuthenticationMethod</key>
                 <string>Certificate</string>
-{% if authentication.client_mode is vyos_defined and authentication.client_mode.startswith("eap") %}
                 <!-- The client uses EAP to authenticate -->
                 <key>ExtendedAuthEnabled</key>
                 <integer>1</integer>
-{% endif %}
                 <!-- The next two dictionaries are optional (as are the keys in them), but it is recommended to specify them as the default is to use 3DES.
                      IMPORTANT: Because only one proposal is sent (even if nothing is configured here) it must match the server configuration -->
                 <key>IKESecurityAssociationParameters</key>

--- a/data/templates/ipsec/ios_profile.j2
+++ b/data/templates/ipsec/ios_profile.j2
@@ -78,9 +78,9 @@
                     <string>{{ esp_encryption.encryption }}</string>
                     <key>IntegrityAlgorithm</key>
                     <string>{{ esp_encryption.hash }}</string>
-{% if esp_encryption.pfs is vyos_defined %}
+{% if ike_encryption.dh_group is vyos_defined %}
                     <key>DiffieHellmanGroup</key>
-                    <integer>{{ esp_encryption.pfs }}</integer>
+                    <integer>{{ ike_encryption.dh_group }}</integer>
 {% endif %}
                 </dict>
                 <!-- Controls whether the client offers Perfect Forward Secrecy (PFS). This should be set to match the server. -->


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Fix dynamic generation of IKE DiffieHellmanGroup in iOS profile

Commit e97d86e (`T6617: T6618: vpn ipsec remote-access: fix profile generators`) added a bug when working with 
DiffieHellmanGroup, it started becoming a boolean and no longer referencing the DH groups itself. This has been fixed.


iOS18+ always requires ExtendedAuthEnabled to be set, if this is unset, loading the iOS VPN profile will error out on the device
giving:

```
Profile Installation Failed
configuration is invalid:
Missing identity
```

My first assumption was an empty string in `LocalIdentifier` for IKE, but turned out only adding this flag solved it.

This was made optional in commit e97d86e (`T6617: T6618: vpn ipsec remote-access: fix profile generators`) but got reverted now.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7225

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4381

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
