### PR TITLE
T7219: Add a check to ensure that remote and group options in VXLAN are mutually exclusive

### DIFF
--- a/src/conf_mode/interfaces_vxlan.py
+++ b/src/conf_mode/interfaces_vxlan.py
@@ -95,6 +95,8 @@ def verify(vxlan):
     if 'group' in vxlan:
         if 'source_interface' not in vxlan:
             raise ConfigError('Multicast VXLAN requires an underlaying interface')
+        if 'remote' in vxlan:
+            raise ConfigError('Both group and remote cannot be specified')
         verify_source_interface(vxlan)
 
     if not any(tmp in ['group', 'remote', 'source_address', 'source_interface'] for tmp in vxlan):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add a check to verify function for `vxlan` command in configuration mode. Since we cannot add `group` and `remote` at the same time, raise the ConfigError on commit if both are detected in a configuration a user is attempting to save.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7219
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest
-->
```
$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_vxlan.py
test_add_multiple_ip_addresses (__main__.VXLANInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.VXLANInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.VXLANInterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.VXLANInterfaceTest.test_dhcp_client_options) ... skipped 'not supported'
test_dhcp_disable_interface (__main__.VXLANInterfaceTest.test_dhcp_disable_interface) ... skipped 'not supported'
test_dhcp_vrf (__main__.VXLANInterfaceTest.test_dhcp_vrf) ... skipped 'not supported'
test_dhcpv6_client_options (__main__.VXLANInterfaceTest.test_dhcpv6_client_options) ... skipped 'not supported'
test_dhcpv6_vrf (__main__.VXLANInterfaceTest.test_dhcpv6_vrf) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.VXLANInterfaceTest.test_dhcpv6pd_auto_sla_id) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.VXLANInterfaceTest.test_dhcpv6pd_manual_sla_id) ... skipped 'not supported'
test_eapol (__main__.VXLANInterfaceTest.test_eapol) ... skipped 'not supported'
test_interface_description (__main__.VXLANInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.VXLANInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.VXLANInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.VXLANInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.VXLANInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.VXLANInterfaceTest.test_ipv6_link_local_address) ... ok
test_move_interface_between_vrf_instances (__main__.VXLANInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.VXLANInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.VXLANInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.VXLANInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.VXLANInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.VXLANInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.VXLANInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.VXLANInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.VXLANInterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'
test_vxlan_external (__main__.VXLANInterfaceTest.test_vxlan_external) ... ok
test_vxlan_neighbor_suppress (__main__.VXLANInterfaceTest.test_vxlan_neighbor_suppress) ... ok
test_vxlan_parameters (__main__.VXLANInterfaceTest.test_vxlan_parameters) ... ok
test_vxlan_vlan_vni_mapping (__main__.VXLANInterfaceTest.test_vxlan_vlan_vni_mapping) ... ok
test_vxlan_vni_filter (__main__.VXLANInterfaceTest.test_vxlan_vni_filter) ... ok
test_vxlan_vni_filter_add_remove (__main__.VXLANInterfaceTest.test_vxlan_vni_filter_add_remove) ... ok

----------------------------------------------------------------------
Ran 32 tests in 320.529s

OK (skipped=15)
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
