### PR TITLE
bgp: T7157: Allow using route-maps for VRF route leaking in BGP

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -352,8 +352,11 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {%         if afi_config.import.vpn is vyos_defined %}
   import vpn
 {%         endif %}
-{%         if afi_config.import.vrf is vyos_defined %}
-{%             for vrf in afi_config.import.vrf %}
+{%         if afi_config.import.vrf.route_map is vyos_defined %}
+  import vrf route-map {{ afi_config.import.vrf.route_map }}
+{%         endif %}
+{%         if afi_config.import.vrf.name is vyos_defined %}
+{%             for vrf in afi_config.import.vrf.name %}
   import vrf {{ vrf }}
 {%             endfor %}
 {%         endif %}

--- a/interface-definitions/include/bgp/afi-export-import.xml.i
+++ b/interface-definitions/include/bgp/afi-export-import.xml.i
@@ -23,20 +23,28 @@
         <valueless/>
       </properties>
     </leafNode>
-    <leafNode name="vrf">
+    <node name="vrf">
       <properties>
         <help>VRF to import from</help>
-        <valueHelp>
-          <format>txt</format>
-          <description>VRF instance name</description>
-        </valueHelp>
-        <completionHelp>
-          <path>vrf name</path>
-          <list>default</list>
-        </completionHelp>
-        <multi/>
       </properties>
-    </leafNode>
+      <children>
+        <leafNode name="name">
+          <properties>
+            <help>VRF to import from</help>
+            <valueHelp>
+              <format>txt</format>
+              <description>VRF instance name</description>
+            </valueHelp>
+            <completionHelp>
+              <path>vrf name</path>
+              <list>default</list>
+            </completionHelp>
+            <multi/>
+          </properties>
+        </leafNode>
+        #include <include/route-map.xml.i>
+      </children>
+    </node>
   </children>
 </node>
 <!-- include end -->

--- a/interface-definitions/include/version/bgp-version.xml.i
+++ b/interface-definitions/include/version/bgp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/bgp-version.xml.i -->
-<syntaxVersion component='bgp' version='6'></syntaxVersion>
+<syntaxVersion component='bgp' version='7'></syntaxVersion>
 <!-- include end -->

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -1053,7 +1053,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
             table = str(int(table) + 1000)
 
             # import VRF routes do main RIB
-            self.cli_set(base_path + ['address-family', 'ipv6-unicast', 'import', 'vrf', vrf])
+            self.cli_set(base_path + ['address-family', 'ipv6-unicast', 'import', 'vrf', 'name', vrf])
 
         self.cli_commit()
 
@@ -1219,7 +1219,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         # exist in the same address family
         self.create_bgp_instances_for_import_test()
         self.cli_set(
-            base_path + ['address-family', import_afi, 'import', 'vrf',
+            base_path + ['address-family', import_afi, 'import', 'vrf', 'name',
                          import_vrf])
         self.cli_set(
             base_path + ['address-family', import_afi, 'rd', 'vpn', 'export',
@@ -1231,7 +1231,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         # Verify if vrf that is in import vrf list contains rd vpn export
         self.create_bgp_instances_for_import_test()
         self.cli_set(
-            base_path + ['address-family', import_afi, 'import', 'vrf',
+            base_path + ['address-family', import_afi, 'import', 'vrf', 'name',
                          import_vrf])
         self.cli_commit()
         frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
@@ -1254,7 +1254,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         # Verify deleting vrf that is in import vrf list
         self.create_bgp_instances_for_import_test()
         self.cli_set(
-            base_path + ['address-family', import_afi, 'import', 'vrf',
+            base_path + ['address-family', import_afi, 'import', 'vrf', 'name',
                          import_vrf])
         self.cli_commit()
         frrconfig = self.getFRRconfig(f'router bgp {ASN}', endsection='^exit')
@@ -1296,7 +1296,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'  rd vpn export {import_rd}', frrconfig_vrf)
 
         self.cli_set(
-            base_path + ['address-family', import_afi, 'import', 'vrf',
+            base_path + ['address-family', import_afi, 'import', 'vrf', 'name',
                          import_vrf])
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
@@ -1305,7 +1305,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         # Verify if vrf that is in import is unspecified
         self.create_bgp_instances_for_import_test()
         self.cli_set(
-            base_path + ['address-family', import_afi, 'import', 'vrf',
+            base_path + ['address-family', import_afi, 'import', 'vrf', 'name',
                          'test'])
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
@@ -1539,6 +1539,41 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
 
         self.assertIn(f'neighbor OVERLAY remote-as {int(ASN) + 1}', conf)
         self.assertIn(f'neighbor OVERLAY local-as {int(ASN) + 1}', conf)
+
+    def test_bgp_30_import_vrf_routemap(self):
+        router_id = '127.0.0.3'
+        table = '1000'
+        vrf = 'red'    
+        vrf_base = ['vrf', 'name', vrf]
+        self.cli_set(vrf_base + ['table', table])
+        self.cli_set(vrf_base + ['protocols', 'bgp', 'system-as', ASN])
+        self.cli_set(
+            vrf_base + ['protocols', 'bgp', 'parameters', 'router-id',
+                        router_id])
+
+        self.cli_set(
+            base_path + ['address-family', 'ipv6-unicast', 'import',
+                         'vrf', 'name', vrf])
+        self.cli_set(
+            base_path + ['address-family', 'ipv6-unicast', 'import',
+                         'vrf', 'route-map',  route_map_in])
+
+        self.cli_commit()
+
+        # Verify FRR bgpd configuration
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}',
+                                      endsection='^exit')
+        self.assertIn(f'router bgp {ASN}', frrconfig)
+        self.assertIn(f' address-family ipv6 unicast', frrconfig)
+
+        self.assertIn(f'  import vrf {vrf}', frrconfig)
+        self.assertIn(f'  import vrf route-map {route_map_in}', frrconfig)
+
+        # Verify FRR bgpd configuration
+        frr_vrf_config = self.getFRRconfig(
+            f'router bgp {ASN} vrf {vrf}', endsection='^exit')
+        self.assertIn(f'router bgp {ASN} vrf {vrf}', frr_vrf_config)
+        self.assertIn(f' bgp router-id {router_id}', frr_vrf_config)
 
     def test_bgp_99_bmp(self):
         target_name = 'instance-bmp'

--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -57,7 +57,7 @@ def verify_vrf_as_import(search_vrf_name: str, afi_name: str, vrfs_config: dict)
     """
     for vrf_name, vrf_config in vrfs_config.items():
         import_list = dict_search(
-            f'protocols.bgp.address_family.{afi_name}.import.vrf',
+            f'protocols.bgp.address_family.{afi_name}.import.vrf.name',
             vrf_config)
         if import_list:
             if search_vrf_name in import_list:
@@ -121,9 +121,10 @@ def verify_vrflist_import(afi_name: str, afi_config: dict, vrfs_config: dict) ->
     :return: if vrf contains rd and route-target options return true else false
     :rtype: bool
     """
-    for vrf_name in afi_config['import']['vrf']:
-        if verify_vrf_import(vrf_name, vrfs_config, afi_name):
-            return True
+    if dict_search('import.vrf.name', afi_config) is not None:
+        for vrf_name in afi_config['import']['vrf']['name']:
+            if verify_vrf_import(vrf_name, vrfs_config, afi_name):
+                return True
     return False
 
 def verify_remote_as(peer_config, bgp_config):
@@ -511,7 +512,7 @@ def verify(config_dict):
 
                 # Verify if VRFs in import do not contain rd
                 # and route-target options
-                if dict_search('import.vrf', afi_config) is not None:
+                if dict_search('import.vrf.name', afi_config) is not None:
                     # Verify if VRF with import does not contain rd
                     # and route-target options
                     if verify_vrf_import_options(afi_config):
@@ -529,9 +530,14 @@ def verify(config_dict):
                         raise ConfigError('Please unconfigure VPN to VRF commands before '\
                                           'using "import vrf" commands!')
 
-                # Verify that the export/import route-maps do exist
+                # Verify that the vpn export/import route-maps do exist
                 for export_import in ['export', 'import']:
                     tmp = dict_search(f'route_map.vpn.{export_import}', afi_config)
+                    if tmp: verify_route_map(tmp, bgp)
+
+                # Verify that the vrf import route-maps do exist
+                if dict_search('import.vrf.route_map', afi_config) is not None:
+                    tmp = dict_search(f'import.vrf.route_map', afi_config)
                     if tmp: verify_route_map(tmp, bgp)
 
                 # per-vrf sid and per-af sid are mutually exclusive

--- a/src/migration-scripts/bgp/6-to-7
+++ b/src/migration-scripts/bgp/6-to-7
@@ -1,0 +1,47 @@
+# Copyright 2025 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# T7163: migrate "address-family ipv4|6-unicast redistribute table" from a multi
+# leafNode to a tagNode. This is needed to support per table definition of a
+# route-map and/or metric
+
+from vyos.configtree import ConfigTree
+
+def migrate(config: ConfigTree) -> None:
+    bgp_base = ['protocols', 'bgp']
+    # Delete 'import/export' in default vrf if 'both' exists
+    if config.exists(bgp_base):
+        for address_family in ['ipv4-unicast', 'ipv6-unicast']:
+            full_path = bgp_base + ['address-family', address_family, 'import',
+                                  'vrf']
+            if config.exists(full_path):
+                vrflist = config.return_values(full_path)
+                config.delete(full_path)
+                for vrf_name in vrflist:
+                    config.set(full_path + ['name'], value=vrf_name, replace=False)
+
+
+    # Delete import/export in vrfs if both exists
+    if config.exists(['vrf', 'name']):
+        for vrf in config.list_nodes(['vrf', 'name']):
+            vrf_base = ['vrf', 'name', vrf]
+            for address_family in ['ipv4-unicast', 'ipv6-unicast']:
+                full_path = vrf_base + bgp_base + ['address-family', address_family, 'import',
+                                  'vrf']
+                if config.exists(full_path):
+                    vrflist = config.return_values(full_path)
+                    config.delete(full_path)
+                    for vrf_name in vrflist:
+                        config.set(full_path + ['name'], value=vrf_name, replace=False)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Added possibility of using route-map in route leaking.

```
vyos@vyos# set protocols bgp address-family ipv4-unicast import vrf
Possible completions:
+  name                 VRF to import from
   route-map            Specify route-map name to use
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7157

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Smoketests
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ... ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ... ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ... ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ... ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ... ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ... ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ... ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ... ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ... ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ... ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok
test_bgp_24_srv6_sid (__main__.TestProtocolsBGP.test_bgp_24_srv6_sid) ... ok
test_bgp_25_ipv4_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_25_ipv4_labeled_unicast_peer_group) ... ok
test_bgp_26_ipv6_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_26_ipv6_labeled_unicast_peer_group) ... ok
test_bgp_27_route_reflector_client (__main__.TestProtocolsBGP.test_bgp_27_route_reflector_client) ... ok
test_bgp_28_peer_group_member_all_internal_or_external (__main__.TestProtocolsBGP.test_bgp_28_peer_group_member_all_internal_or_external) ... ok
test_bgp_29_peer_group_remote_as_equal_local_as (__main__.TestProtocolsBGP.test_bgp_29_peer_group_remote_as_equal_local_as) ... ok
test_bgp_30_import_vrf_routemap (__main__.TestProtocolsBGP.test_bgp_30_import_vrf_routemap) ... ok
test_bgp_99_bmp (__main__.TestProtocolsBGP.test_bgp_99_bmp) ... ok

----------------------------------------------------------------------
Ran 30 tests in 412.535s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
