### PR TITLE
syslog: T7229: advanced format should not have IPv6 addresses in [] brackets

### DIFF
--- a/data/templates/rsyslog/rsyslog.conf.j2
+++ b/data/templates/rsyslog/rsyslog.conf.j2
@@ -98,7 +98,7 @@ if prifilt("{{ tmp | join(',') }}") then {
     action(
         type="omfwd"
         # Remote syslog server where we send our logs to
-        target="{{ remote_name | bracketize_ipv6 }}"
+        target="{{ remote_name }}"
         # Port on the remote syslog server
         port="{{ remote_options.port }}"
         protocol="{{ remote_options.protocol }}"

--- a/smoketest/scripts/cli/test_system_syslog.py
+++ b/smoketest/scripts/cli/test_system_syslog.py
@@ -132,9 +132,15 @@ class TestRSYSLOGService(VyOSUnitTestSHIM.TestCase):
                 'facility': {'auth' : {'level': 'info'}},
                 'protocol': 'udp',
             },
-            '169.254.0.2': {
+            '2001:db8::1': {
+                'facility': {'all' : {'level': 'debug'}},
                 'port': '1514',
                 'protocol': 'udp',
+            },
+            'syslog.vyos.net': {
+                'facility': {'all' : {'level': 'debug'}},
+                'port': '1515',
+                'protocol': 'tcp',
             },
             '169.254.0.3': {
                 'facility': {'auth' : {'level': 'info'},


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Otherwise rsyslog will report an error:
`omfwd: could not get addrinfo for hostname '[2001:db8::2]':'514': System error`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7229

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_syslog.py
test_basic (__main__.TestRSYSLOGService.test_basic) ... ok
test_console (__main__.TestRSYSLOGService.test_console) ... ok
test_remote (__main__.TestRSYSLOGService.test_remote) ... ok
test_vrf_source_address (__main__.TestRSYSLOGService.test_vrf_source_address) ... ok

----------------------------------------------------------------------
Ran 4 tests in 13.019s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
