### PR TITLE
ipsec: T7242:  Add a check for encryption algorithms that do not work with VPP

### DIFF
--- a/src/conf_mode/vpn_ipsec.py
+++ b/src/conf_mode/vpn_ipsec.py
@@ -156,6 +156,8 @@ def get_config(config=None):
                         _, vti = get_interface_dict(conf, ['interfaces', 'vti'], vti_interface)
                         ipsec['vti_interface_dicts'][vti_interface] = vti
 
+    ipsec['vpp_ipsec_exists'] = conf.exists(['vpp', 'settings', 'ipsec'])
+
     return ipsec
 
 def get_dhcp_address(iface):
@@ -484,6 +486,17 @@ def verify(ipsec):
             else:
                 raise ConfigError(f"Missing ike-group on site-to-site peer {peer}")
 
+            # verify encryption algorithm compatibility for IKE with VPP
+            if ipsec['vpp_ipsec_exists']:
+                ike_group = ipsec['ike_group'][peer_conf['ike_group']]
+                for proposal, proposal_config in ike_group.get('proposal', {}).items():
+                    algs = ['gmac', 'serpent', 'twofish']
+                    if any(alg in proposal_config['encryption'] for alg in algs):
+                        raise ConfigError(
+                            f'Encryption algorithm {proposal_config["encryption"]} cannot be used '
+                            f'for IKE proposal {proposal} for site-to-site peer {peer} with VPP'
+                        )
+
             if 'authentication' not in peer_conf or 'mode' not in peer_conf['authentication']:
                 raise ConfigError(f"Missing authentication on site-to-site peer {peer}")
 
@@ -562,7 +575,7 @@ def verify(ipsec):
 
                     esp_group_name = tunnel_conf['esp_group'] if 'esp_group' in tunnel_conf else peer_conf['default_esp_group']
 
-                    if esp_group_name not in ipsec['esp_group']:
+                    if esp_group_name not in ipsec.get('esp_group'):
                         raise ConfigError(f"Invalid esp-group on tunnel {tunnel} for site-to-site peer {peer}")
 
                     esp_group = ipsec['esp_group'][esp_group_name]
@@ -573,6 +586,18 @@ def verify(ipsec):
 
                         if ('local' in tunnel_conf and 'prefix' in tunnel_conf['local']) or ('remote' in tunnel_conf and 'prefix' in tunnel_conf['remote']):
                             raise ConfigError(f"Local/remote prefix cannot be used with ESP transport mode on tunnel {tunnel} for site-to-site peer {peer}")
+
+                    # verify ESP encryption algorithm compatibility with VPP
+                    # because Marvel plugin for VPP doesn't support all algorithms that Strongswan does
+                    if ipsec['vpp_ipsec_exists']:
+                        for proposal, proposal_config in esp_group.get('proposal', {}).items():
+                            algs = ['aes128', 'aes192', 'aes256', 'aes128gcm128', 'aes192gcm128', 'aes256gcm128']
+                            if proposal_config['encryption'] not in algs:
+                                raise ConfigError(
+                                    f'Encryption algorithm {proposal_config["encryption"]} cannot be used '
+                                    f'for ESP proposal {proposal} on tunnel {tunnel} for site-to-site peer {peer} with VPP'
+                                )
+
 
 def cleanup_pki_files():
     for path in [CERT_PATH, CA_PATH, CRL_PATH, KEY_PATH, PUBKEY_PATH]:


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7242
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set interfaces ethernet eth0 address '192.0.2.1/30'
set interfaces ethernet eth1 address '203.0.113.1/30'
set system host-name 'vpp-left'
set vpn ipsec authentication psk PSK id '192.0.2.1'
set vpn ipsec authentication psk PSK id '192.0.2.2'
set vpn ipsec authentication psk PSK secret 'vyos-vpp'
set vpn ipsec esp-group ESP-group pfs 'enable'
set vpn ipsec esp-group ESP-group proposal 1 encryption 'aes128'
set vpn ipsec esp-group ESP-group proposal 1 hash 'sha1'
set vpn ipsec ike-group IKE-group key-exchange 'ikev2'
set vpn ipsec ike-group IKE-group proposal 1 dh-group '5'
set vpn ipsec ike-group IKE-group proposal 1 encryption 'aes128'
set vpn ipsec ike-group IKE-group proposal 1 hash 'sha1'
set vpn ipsec interface 'eth0'
set vpn ipsec site-to-site peer VPP authentication local-id '192.0.2.1'
set vpn ipsec site-to-site peer VPP authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer VPP authentication remote-id '192.0.2.2'
set vpn ipsec site-to-site peer VPP connection-type 'initiate'
set vpn ipsec site-to-site peer VPP ike-group 'IKE-group'
set vpn ipsec site-to-site peer VPP local-address '192.0.2.1'
set vpn ipsec site-to-site peer VPP remote-address '192.0.2.2'
set vpn ipsec site-to-site peer VPP tunnel 1 esp-group 'ESP-group'
set vpn ipsec site-to-site peer VPP tunnel 1 local prefix '203.0.113.0/30'
set vpn ipsec site-to-site peer VPP tunnel 1 remote prefix '203.0.113.100/30'
set vpp settings interface eth0 driver 'dpdk'
set vpp settings interface eth1 driver 'dpdk'
set vpp settings unix poll-sleep-usec '12'
set vpp settings ipsec

vyos@vyos# commit
[ vpn ipsec ]
Encryption algorithm blowfish128 cannot be used for ESP proposal 1 on
tunnel 1 for site-to-site peer VPP with VPP
[[vpn ipsec]] failed
Commit failed
[edit]
vyos@vyos# set vpn ipsec esp-group ESP-group proposal 1 encryption 'aes128'
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# sudo vppctl show ipsec sa
[0] sa 3232599195 (0xc0ad8c9b) spi 3249491190 (0xc1af4cf6) protocol:esp flags:[anti-replay tunnel Protect inbound ]
[1] sa 3244965492 (0xc16a3e74) spi 3278438366 (0xc368ffde) protocol:esp flags:[tunnel Protect no-algo-no-drop ]
[edit]
vyos@vyos# sudo ip xfrm state
src 192.0.2.1 dst 192.0.2.2
        proto esp spi 0xc368ffde reqid 1 mode tunnel
        replay-window 0 flag af-unspec
        auth-trunc hmac(sha1) 0x7737b97161ce08968e00d93304042e7f060d0423 96
        enc cbc(aes) 0xd2160e64d0067ee99c3cefc4eef7d6c9
        anti-replay context: seq 0x0, oseq 0x0, bitmap 0x00000000
src 192.0.2.2 dst 192.0.2.1
        proto esp spi 0xc1af4cf6 reqid 1 mode tunnel
        replay-window 32 flag af-unspec
        auth-trunc hmac(sha1) 0xf372ad0cb917e84b97517b8d4367bc91076623a9 96
        enc cbc(aes) 0xb492b55990f9a271428c24081bb67c25
        anti-replay context: seq 0x0, oseq 0x0, bitmap 0x00000000
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
