### PR TITLE
T6353: Add password complexity validation for system login user

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -123,6 +123,8 @@ Depends:
 # Live filesystem tools
   squashfs-tools,
   fuse-overlayfs,
+# Tools for checking password strength
+  python3-cracklib,
 ## End installer
   auditd,
   iputils-arping,

--- a/debian/vyos-1x.postinst
+++ b/debian/vyos-1x.postinst
@@ -195,6 +195,10 @@ if [ ! -x $PRECONFIG_SCRIPT ]; then
 EOF
 fi
 
+# cracklib-runtime default database location
+CRACKLIB_DIR=/var/cache/cracklib
+CRACKLIB_DB=cracklib_dict
+
 # create /opt/vyatta/etc/config/scripts/vyos-postconfig-bootup.script
 POSTCONFIG_SCRIPT=/opt/vyatta/etc/config/scripts/vyos-postconfig-bootup.script
 if [ ! -x $POSTCONFIG_SCRIPT ]; then
@@ -206,7 +210,15 @@ if [ ! -x $POSTCONFIG_SCRIPT ]; then
 # This script is executed at boot time after VyOS configuration is fully applied.
 # Any modifications required to work around unfixed bugs
 # or use services not available through the VyOS CLI system can be placed here.
-
+#
+# T6353 - Just in case, check if cracklib was installed properly
+# If the database file is missing, re-install the runtime package
+#
+if [ ! -f "${CRACKLIB_DIR}/${CRACKLIB_DB}.pwd" ]; then
+    mkdir -p $CRACKLIB_DIR
+    /usr/sbin/create-cracklib-dict -o $CRACKLIB_DIR/$CRACKLIB_DB \
+        /usr/share/dict/cracklib-small
+fi
 EOF
 fi
 

--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -98,8 +98,13 @@ class VyOSUnitTestSHIM:
             # returns 0
             while run(f'sudo lsof -nP {commit_lock}') == 0:
                 sleep(0.250)
+            # Return the output of commit
+            # Necessary for testing Warning cases
+            out = self._session.commit()
             # Wait for CStore completion for fast non-interactive commits
             sleep(self._commit_guard_time)
+
+            return out
 
         def op_mode(self, path : list) -> None:
             """

--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -94,7 +94,6 @@ class VyOSUnitTestSHIM:
         def cli_commit(self):
             if self.debug:
                 print('commit')
-            self._session.commit()
             # During a commit there is a process opening commit_lock, and run()
             # returns 0
             while run(f'sudo lsof -nP {commit_lock}') == 0:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
- Add password complexity check function based on cracklib FascistCheck and entropy calculation
- Add checking user password to `install image` command in operation mode
- Add checking new user password to `system login` command in configuration mode
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6353

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
- Built a .deb package using the official Docker image vyos/vyos-build:current
- Built an ISO image
- Boot up a virtual machine (qemu-system-x86_64, host: Linux Mint) from the live ISO image built in the previous step
- Run `install image`
- Check:
  - Password shorter than 4 characters
  - Password with only lowercase letters'
  - Password with uppercase, lowercase letters and digits
  - Made sure in all cases the actual output matched the expected output
### Smoketest output:

```
test_add_linux_system_user (__main__.TestSystemLogin.test_add_linux_system_user) ... ok
test_delete_current_user (__main__.TestSystemLogin.test_delete_current_user) ... ok
test_radius_kernel_features (__main__.TestSystemLogin.test_radius_kernel_features) ... ok
test_system_login_max_login_session (__main__.TestSystemLogin.test_system_login_max_login_session) ... ok
test_system_login_otp (__main__.TestSystemLogin.test_system_login_otp) ... ok
test_system_login_radius_ipv4 (__main__.TestSystemLogin.test_system_login_radius_ipv4) ... ok
test_system_login_radius_ipv6 (__main__.TestSystemLogin.test_system_login_radius_ipv6) ... ok
test_system_login_tacacs (__main__.TestSystemLogin.test_system_login_tacacs) ... ok
test_system_login_user (__main__.TestSystemLogin.test_system_login_user) ... ok
test_system_login_weak_password_warning (__main__.TestSystemLogin.test_system_login_weak_password_warning) ... ok
test_system_user_ssh_key (__main__.TestSystemLogin.test_system_user_ssh_key) ... ok

----------------------------------------------------------------------
Ran 11 tests in 68.096s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
