### PR TITLE
nat: T7243: Add NAT OUTPUT

### DIFF
--- a/data/templates/firewall/nftables-nat.j2
+++ b/data/templates/firewall/nftables-nat.j2
@@ -54,6 +54,24 @@ table ip vyos_nat {
         return
     }
 
+{%     if output is vyos_defined %}
+    chain OUTPUT {
+        type nat hook output priority -100; policy accept;
+        counter jump VYOS_PRE_OUTPUT_HOOK
+{%         if output.rule is vyos_defined %}
+{%             for rule, config in output.rule.items() if config.disable is not vyos_defined %}
+        {{ config | nat_rule(rule, 'output') }}
+{%             endfor %}
+{%         endif %}
+
+    }
+
+    chain VYOS_PRE_OUTPUT_HOOK {
+        return
+    }
+
+{%     endif %}
+
 {{ group_tmpl.groups(firewall_group, False, True) }}
 }
 {% endif %}

--- a/data/templates/firewall/nftables-nat66.j2
+++ b/data/templates/firewall/nftables-nat66.j2
@@ -41,6 +41,24 @@ table ip6 vyos_nat {
         return
     }
 
+{%     if output is vyos_defined %}
+    chain OUTPUT {
+        type nat hook output priority -100; policy accept;
+        counter jump VYOS_PRE_OUTPUT_HOOK
+{%         if output.rule is vyos_defined %}
+{%             for rule, config in output.rule.items() if config.disable is not vyos_defined %}
+        {{ config | nat_rule(rule, 'output', ipv6=True) }}
+{%             endfor %}
+{%         endif %}
+
+    }
+
+    chain VYOS_PRE_OUTPUT_HOOK {
+        return
+    }
+
+{%     endif %}
+
 {{ group_tmpl.groups(firewall_group, True, True) }}
 }
 {% endif %}

--- a/interface-definitions/nat.xml.in
+++ b/interface-definitions/nat.xml.in
@@ -154,6 +154,58 @@
           </tagNode>
         </children>
       </node>
+      <node name="output">
+        <properties>
+          <help>Output NAT settings</help>
+        </properties>
+        <children>
+          #include <include/nat-rule.xml.i>
+          <tagNode name="rule">
+            <children>
+              #include <include/firewall/inbound-interface.xml.i>
+              <node name="translation">
+                <properties>
+                  <help>Inside NAT IP (destination NAT only)</help>
+                </properties>
+                <children>
+                  <leafNode name="address">
+                    <properties>
+                      <help>IP address, subnet, or range</help>
+                      <valueHelp>
+                        <format>ipv4</format>
+                        <description>IPv4 address to match</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>ipv4net</format>
+                        <description>IPv4 prefix to match</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>ipv4range</format>
+                        <description>IPv4 address range to match</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="ipv4-prefix"/>
+                        <validator name="ipv4-address"/>
+                        <validator name="ipv4-range"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  #include <include/nat-translation-port.xml.i>
+                  #include <include/nat-translation-options.xml.i>
+                  <node name="redirect">
+                    <properties>
+                      <help>Redirect to local host</help>
+                    </properties>
+                    <children>
+                      #include <include/nat-translation-port.xml.i>
+                    </children>
+                  </node>
+                </children>
+              </node>
+            </children>
+          </tagNode>
+        </children>
+      </node>
     </children>
   </node>
 </interfaceDefinition>

--- a/interface-definitions/nat66.xml.in
+++ b/interface-definitions/nat66.xml.in
@@ -246,6 +246,98 @@
           </tagNode>
         </children>
       </node>
+      <node name="output">
+        <properties>
+          <help>Prefix mapping for IPv6 output address translation</help>
+        </properties>
+        <children>
+          <tagNode name="rule">
+            <properties>
+              <help>Destination NAT66 rule number</help>
+              <valueHelp>
+                <format>u32:1-999999</format>
+                <description>Number for this rule</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 1-999999"/>
+              </constraint>
+              <constraintErrorMessage>NAT66 rule number must be between 1 and 999999</constraintErrorMessage>
+            </properties>
+            <children>
+              #include <include/generic-description.xml.i>
+              #include <include/generic-disable-node.xml.i>
+              <leafNode name="log">
+                <properties>
+                  <help>NAT66 rule logging</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              #include <include/nat/protocol.xml.i>
+              <node name="destination">
+                <properties>
+                  <help>IPv6 destination prefix options</help>
+                </properties>
+                <children>
+                  <leafNode name="address">
+                    <properties>
+                      <help>IPv6 address or prefix to be translated</help>
+                      <valueHelp>
+                        <format>ipv6</format>
+                        <description>IPv6 address</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>ipv6net</format>
+                        <description>IPv6 prefix</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>!ipv6</format>
+                        <description>Match everything except the specified IPv6 address</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>!ipv6net</format>
+                        <description>Match everything except the specified IPv6 prefix</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="ipv6-address"/>
+                        <validator name="ipv6-prefix"/>
+                        <validator name="ipv6-address-exclude"/>
+                        <validator name="ipv6-prefix-exclude"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  #include <include/nat-port.xml.i>
+                  #include <include/firewall/source-destination-group-ipv6.xml.i>
+                </children>
+              </node>
+              <node name="translation">
+                <properties>
+                  <help>Translated IPv6 address options</help>
+                </properties>
+                <children>
+                  <leafNode name="address">
+                    <properties>
+                      <help>IPv6 address or prefix to translate to</help>
+                      <valueHelp>
+                        <format>ipv6</format>
+                        <description>IPv6 address</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>ipv6net</format>
+                        <description>IPv6 prefix</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="ipv6-address"/>
+                        <validator name="ipv6-prefix"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  #include <include/nat-translation-port.xml.i>
+                </children>
+              </node>
+            </children>
+          </tagNode>
+        </children>
+      </node>
     </children>
   </node>
 </interfaceDefinition>

--- a/python/vyos/nat.py
+++ b/python/vyos/nat.py
@@ -17,10 +17,30 @@ from vyos.utils.dict import dict_search_args
 from vyos.template import bracketize_ipv6
 
 
+def log_nat_type_str(nat_type):
+    nat_types = {
+        'destination': 'DST',
+        'source': 'SRC',
+        'output': 'OUT',
+    }
+
+    return nat_types.get(nat_type, 'SRC')
+
+
+def log_translation_prefix(nat_type):
+    translation_prefixes = {
+        'destination': 'd',
+        'source': 's',
+        'output': 'd',
+    }
+
+    return translation_prefixes.get(nat_type, 'd')
+
+
 def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
     output = []
     ip_prefix = 'ip6' if ipv6 else 'ip'
-    log_prefix = ('DST' if nat_type == 'destination' else 'SRC') + f'-NAT-{rule_id}'
+    log_prefix = log_nat_type_str(nat_type) + f'-NAT-{rule_id}'
     log_suffix = ''
 
     if ipv6:
@@ -80,8 +100,7 @@ def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
             if redirect_port:
                 translation_output.append(f'to {redirect_port}')
         else:
-
-            translation_prefix = nat_type[:1]
+            translation_prefix = log_translation_prefix(nat_type)
             translation_output = [f'{translation_prefix}nat']
 
             if addr and is_ip_network(addr):
@@ -263,7 +282,7 @@ def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
 
 def parse_nat_static_rule(rule_conf, rule_id, nat_type):
     output = []
-    log_prefix = ('STATIC-DST' if nat_type == 'destination' else 'STATIC-SRC') + f'-NAT-{rule_id}'
+    log_prefix = 'STATIC-' + log_nat_type_str(nat_type) + f'-NAT-{rule_id}'
     log_suffix = ''
 
     ignore_type_addr = False
@@ -279,10 +298,10 @@ def parse_nat_static_rule(rule_conf, rule_id, nat_type):
         translation_str = 'return'
         log_suffix = '-EXCL'
     elif 'translation' in rule_conf:
-        translation_prefix = nat_type[:1]
+        translation_prefix = log_translation_prefix(nat_type)
         translation_output = [f'{translation_prefix}nat']
         addr = dict_search_args(rule_conf, 'translation', 'address')
-        map_addr =  dict_search_args(rule_conf, 'destination', 'address')
+        map_addr = dict_search_args(rule_conf, 'destination', 'address')
 
         if nat_type == 'source':
             addr, map_addr = map_addr, addr # Swap

--- a/python/vyos/nat.py
+++ b/python/vyos/nat.py
@@ -16,15 +16,11 @@ from vyos.template import is_ip_network
 from vyos.utils.dict import dict_search_args
 from vyos.template import bracketize_ipv6
 
-
-def log_nat_type_str(nat_type):
-    nat_types = {
-        'destination': 'DST',
-        'source': 'SRC',
-        'output': 'OUT',
-    }
-
-    return nat_types.get(nat_type, 'SRC')
+nat_types = {
+    'destination': 'DST',
+    'source': 'SRC',
+    'output': 'OUT',
+}
 
 
 def log_translation_prefix(nat_type):
@@ -40,7 +36,7 @@ def log_translation_prefix(nat_type):
 def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
     output = []
     ip_prefix = 'ip6' if ipv6 else 'ip'
-    log_prefix = log_nat_type_str(nat_type) + f'-NAT-{rule_id}'
+    log_prefix = f'{nat_types[nat_type]}-NAT-{rule_id}'
     log_suffix = ''
 
     if ipv6:
@@ -282,7 +278,7 @@ def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
 
 def parse_nat_static_rule(rule_conf, rule_id, nat_type):
     output = []
-    log_prefix = 'STATIC-' + log_nat_type_str(nat_type) + f'-NAT-{rule_id}'
+    log_prefix = f'STATIC-{nat_types[nat_type]}-NAT-{rule_id}'
     log_suffix = ''
 
     ignore_type_addr = False

--- a/smoketest/scripts/cli/test_nat.py
+++ b/smoketest/scripts/cli/test_nat.py
@@ -24,6 +24,7 @@ base_path = ['nat']
 src_path = base_path + ['source']
 dst_path = base_path + ['destination']
 static_path = base_path + ['static']
+output_path = base_path + ['output']
 
 nftables_nat_config = '/run/nftables_nat.conf'
 nftables_static_nat_conf = '/run/nftables_static-nat-rules.nft'
@@ -330,5 +331,29 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
         ]
 
         self.verify_nftables(nftables_search, 'ip vyos_nat')
+
+    def test_nat_output(self):
+
+        self.cli_set(output_path + ['rule', '1', 'destination', 'address', '198.51.100.254'])
+        self.cli_set(output_path + ['rule', '1', 'destination', 'port', '22'])
+        self.cli_set(output_path + ['rule', '1', 'protocol', 'tcp'])
+        self.cli_set(output_path + ['rule', '1', 'translation', 'address', '198.51.100.1'])
+        self.cli_set(output_path + ['rule', '1', 'translation', 'port', '22'])
+
+        self.cli_set(output_path + ['rule', '2', 'destination', 'address', '127.0.0.1'])
+        self.cli_set(output_path + ['rule', '2', 'destination', 'port', '53'])
+        self.cli_set(output_path + ['rule', '2', 'protocol', 'udp'])
+        self.cli_set(output_path + ['rule', '2', 'translation', 'address', '127.0.0.1'])
+        self.cli_set(output_path + ['rule', '2', 'translation', 'port', '7874'])
+
+        self.cli_commit()
+
+        nftables_search = [
+            ['tcp dport 22', 'ip daddr 198.51.100.254', 'dnat to 198.51.100.1:22', 'comment "OUT-NAT-1"'],
+            ['udp dport 53', 'ip daddr 127.0.0.1', 'dnat to 127.0.0.1:7874', 'comment "OUT-NAT-2"'],
+        ]
+
+        self.verify_nftables(nftables_search, 'ip vyos_nat')
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/smoketest/scripts/cli/test_nat66.py
+++ b/smoketest/scripts/cli/test_nat66.py
@@ -23,6 +23,7 @@ from vyos.configsession import ConfigSessionError
 base_path = ['nat66']
 src_path = base_path + ['source']
 dst_path = base_path + ['destination']
+output_path = base_path + ['output']
 
 class TestNAT66(VyOSUnitTestSHIM.TestCase):
     @classmethod
@@ -236,6 +237,21 @@ class TestNAT66(VyOSUnitTestSHIM.TestCase):
         self.cli_set(src_path)
         self.cli_set(dst_path)
         self.cli_commit()
+
+    def test_nat_output(self):
+        destination_address = 'fc00::1'
+        translation_address = 'fc01::1'
+
+        self.cli_set(output_path + ['rule', '1', 'destination', 'address', destination_address])
+        self.cli_set(output_path + ['rule', '1', 'translation', 'address', translation_address])
+
+        self.cli_commit()
+
+        nftables_search = [
+            ['ip6 daddr fc00::1', 'dnat to fc01::1', 'comment "OUT-NAT66-1"'],
+        ]
+
+        self.verify_nftables(nftables_search, 'ip6 vyos_nat')
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/nat.py
+++ b/src/conf_mode/nat.py
@@ -92,7 +92,7 @@ def verify_rule(config, err_msg, groups_dict):
             raise ConfigError(f'{err_msg} ports can only be specified when '\
                               'protocol is either tcp, udp or tcp_udp!')
 
-    for side in ['destination', 'source']:
+    for side in ['destination', 'source', 'output']:
         if side in config:
             side_conf = config[side]
 

--- a/src/conf_mode/nat66.py
+++ b/src/conf_mode/nat66.py
@@ -112,6 +112,14 @@ def verify(nat):
                 if len({'address_group', 'network_group', 'domain_group'} & set(config['destination']['group'])) > 1:
                     raise ConfigError('Only one address-group, network-group or domain-group can be specified')
 
+    if dict_search('output.rule', nat):
+        for rule, config in dict_search('output.rule', nat).items():
+            err_msg = f'Output NAT66 configuration error in rule {rule}:'
+
+            if 'destination' in config and 'group' in config['destination']:
+                if len({'address_group', 'network_group', 'domain_group'} & set(config['destination']['group'])) > 1:
+                    raise ConfigError('Only one address-group, network-group or domain-group can be specified')
+
     return None
 
 def generate(nat):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add NAT OUTPUT to support forwarding between ports under 127.0.0.1 .

Only added `nat/output`, not sure if `nat66/output` should be add.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7243

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->


Case 1: Forward 127.0.0.1:53 to 127.0.0.1:7874

127.0.0.1 was not listened by any service, 127.0.0.1:7874 is listened by clash DNS.
```
set nat output rule 100 destination address '127.0.0.1'
set nat output rule 100 destination port '53'
set nat output rule 100 protocol 'tcp_udp'
set nat output rule 100 translation address '127.0.0.1'
set nat output rule 100 translation port '7874'
```

Case 2: Forward 192.168.10.3:53 to 192.168.10.1:7874

192.168.10.3 is not up, just test for external ips. 192.168.10.1:7874 is clash on another vyos
```
set nat output rule 110 destination address '192.168.10.3'
set nat output rule 110 destination port '53'
set nat output rule 110 protocol 'tcp_udp'
set nat output rule 110 translation address '192.168.10.1'
set nat output rule 110 translation port '7874'
```

Smoketest:

```
# /usr/libexec/vyos/tests/smoke/cli/test_nat.py 
test_dnat (__main__.TestNAT.test_dnat) ... ok
test_dnat_negated_addresses (__main__.TestNAT.test_dnat_negated_addresses) ... ok
test_dnat_redirect (__main__.TestNAT.test_dnat_redirect) ... ok
test_dnat_without_translation_address (__main__.TestNAT.test_dnat_without_translation_address) ... ok
test_nat_balance (__main__.TestNAT.test_nat_balance) ... ok
test_nat_fqdn (__main__.TestNAT.test_nat_fqdn) ... ok
test_nat_no_rules (__main__.TestNAT.test_nat_no_rules) ... ok
test_snat (__main__.TestNAT.test_snat) ... ok
test_snat_groups (__main__.TestNAT.test_snat_groups) ... ok
test_snat_net_port_map (__main__.TestNAT.test_snat_net_port_map) ... ok
test_snat_required_translation_address (__main__.TestNAT.test_snat_required_translation_address) ... ok
test_static_nat (__main__.TestNAT.test_static_nat) ... ok


root@vyos:/home/vyos# /usr/libexec/vyos/tests/smoke/cli/test_nat
test_nat64.py  test_nat66.py  test_nat.py    
root@vyos:/home/vyos# /usr/libexec/vyos/tests/smoke/cli/test_nat66.py 
test_destination_nat66 (__main__.TestNAT66.test_destination_nat66) ... ok
test_destination_nat66_network_group (__main__.TestNAT66.test_destination_nat66_network_group) ... ok
test_destination_nat66_prefix (__main__.TestNAT66.test_destination_nat66_prefix) ... ok
test_destination_nat66_protocol (__main__.TestNAT66.test_destination_nat66_protocol) ... ok
test_destination_nat66_without_translation_address (__main__.TestNAT66.test_destination_nat66_without_translation_address) ... ok
test_nat66_no_rules (__main__.TestNAT66.test_nat66_no_rules) ... ok
test_source_nat66 (__main__.TestNAT66.test_source_nat66) ... ok
test_source_nat66_address (__main__.TestNAT66.test_source_nat66_address) ... ok
test_source_nat66_protocol (__main__.TestNAT66.test_source_nat66_protocol) ... ok
test_source_nat66_required_translation_prefix (__main__.TestNAT66.test_source_nat66_required_translation_prefix) ... ok

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
