### PR TITLE
interface: T4627: support setting of IPv6 Interface Identifier(Token)

### DIFF
--- a/interface-definitions/include/interface/ipv6-address-interface-identifier.xml.i
+++ b/interface-definitions/include/interface/ipv6-address-interface-identifier.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from interface/ipv6-address-interface-identifier.xml.i -->
+<leafNode name="interface-identifier">
+  <properties>
+    <help>SLAAC interface identifier</help>
+    <valueHelp>
+      <format>::h:h:h:h</format>
+      <description>Interface identifier</description>
+    </valueHelp>
+    <constraint>
+      <regex>::([0-9a-fA-F]{1,4}(:[0-9a-fA-F]{1,4}){0,3})</regex>
+    </constraint>
+    <constraintErrorMessage>Interface identifier format must start with :: and may contain up four hextets (::h:h:h:h)</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/interface/ipv6-address.xml.i
+++ b/interface-definitions/include/interface/ipv6-address.xml.i
@@ -6,6 +6,7 @@
   <children>
     #include <include/interface/ipv6-address-autoconf.xml.i>
     #include <include/interface/ipv6-address-eui64.xml.i>
+    #include <include/interface/ipv6-address-interface-identifier.xml.i>
     #include <include/interface/ipv6-address-no-default-link-local.xml.i>
   </children>
 </node>

--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -517,6 +517,14 @@ def get_interface_dict(config, base, ifname='', recursive_defaults=True, with_pk
         else:
             dict['ipv6']['address'].update({'eui64_old': eui64})
 
+    interface_identifier = leaf_node_changed(config, base + [ifname, 'ipv6', 'address', 'interface-identifier'])
+    if interface_identifier:
+        tmp = dict_search('ipv6.address', dict)
+        if not tmp:
+            dict.update({'ipv6': {'address': {'interface_identifier_old': interface_identifier}}})
+        else:
+            dict['ipv6']['address'].update({'interface_identifier_old': interface_identifier})
+
     for vif, vif_config in dict.get('vif', {}).items():
         # Add subinterface name to dictionary
         dict['vif'][vif].update({'ifname' : f'{ifname}.{vif}'})

--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -92,6 +92,9 @@ def verify_mtu_ipv6(config):
             tmp = dict_search('ipv6.address.eui64', config)
             if tmp != None: raise ConfigError(error_msg)
 
+            tmp = dict_search('ipv6.address.interface_identifier', config)
+            if tmp != None: raise ConfigError(error_msg)
+
 def verify_vrf(config):
     """
     Common helper function used by interface implementations to perform

--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -14,6 +14,7 @@
 
 import re
 
+from json import loads
 from netifaces import AF_INET
 from netifaces import AF_INET6
 from netifaces import ifaddresses
@@ -1067,6 +1068,7 @@ class BasicInterfaceTest:
             dad_transmits = '10'
             accept_dad = '0'
             source_validation = 'strict'
+            interface_identifier = '::fffe'
 
             for interface in self._interfaces:
                 path = self._base_path + [interface]
@@ -1088,6 +1090,9 @@ class BasicInterfaceTest:
 
                 if cli_defined(self._base_path + ['ipv6'], 'source-validation'):
                     self.cli_set(path + ['ipv6', 'source-validation', source_validation])
+
+                if cli_defined(self._base_path + ['ipv6', 'address'], 'interface-identifier'):
+                    self.cli_set(path + ['ipv6', 'address', 'interface-identifier', interface_identifier])
 
             self.cli_commit()
 
@@ -1119,6 +1124,13 @@ class BasicInterfaceTest:
                         if line.startswith(base_options):
                             self.assertIn('fib saddr . iif oif 0', line)
                             self.assertIn('drop', line)
+
+                if cli_defined(self._base_path + ['ipv6', 'address'], 'interface-identifier'):
+                    tmp = cmd(f'ip -j token show dev {interface}')
+                    tmp = loads(tmp)[0]
+                    self.assertEqual(tmp['token'], interface_identifier)
+                    self.assertEqual(tmp['ifname'], interface)
+
 
         def test_dhcpv6_client_options(self):
             if not self._test_ipv6_dhcpc6:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Support setting of IPv6 Interface Identifier (a.k.a Token) for IPv6 autoconfig(SLAAC).

https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/deployment_guide/s2-configuring_ipv6_tokenized_interface_identifiers#s2-Configuring_IPv6_Tokenized_Interface_Identifiers

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T4627

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

1. Connect eth0 to Router, that is enabled IPv6 RA.
2. Configure as follows
```
interfaces {
    ethernet eth0 {
        ipv6 {
            address {
                autoconf
                interface-identifier 0000:0000:cafe:0001
            }
        }
    }
}
```
3. Check(We can find a ipv6 address <prefix>::cafe:1/64)
```
vyos@vyos:~$ show int
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address                     MAC                VRF        MTU  S/L    Description
-----------  -----------------------------  -----------------  -------  -----  -----  -------------
eth0           <my prefix>::cafe:1/64  <my mac>  default   1500  u/u
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
