### PR TITLE
T5400: initialize OPAM environment where it's really needed

### DIFF
--- a/.github/workflows/package-smoketest.yml
+++ b/.github/workflows/package-smoketest.yml
@@ -44,7 +44,6 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Build vyos-1x package
         run: |
-          eval $(opam env --root=/opt/opam --set-root)
           cd packages/vyos-1x; dpkg-buildpackage -uc -us -tc -b
       - name: Generate ISO version string
         id: version

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ libvyosconfig:
 			git clone https://github.com/vyos/libvyosconfig.git /tmp/libvyosconfig || exit 1
 		cd /tmp/libvyosconfig && \
 			git checkout 677d1e2bf8109b9fd4da60e20376f992b747e384 || exit 1
-		./build.sh
+		eval $$(opam env --root=/opt/opam --set-root) && ./build.sh
 	fi
 
 .PHONY: interface_definitions


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Instead of trying to fix - what we call - "Schroedingers build environment" in the outside world calling this package build, we should rather fix the Makefile/build system..


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T5400

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/928
* https://github.com/vyos/libvyosconfig/pull/25

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
+ gcc -shared  -o '_build/libvyosconfig.so'  '-L/opt/opam/4.14.2/lib/containers/monomorphic' '-L/opt/opam/4.14.2/lib/either' '-L/opt/opam/4.14.2/lib/containers' '-L/opt/opam/4.14.2/lib/fileutils' '-L/opt/opam/4.14.2/lib/menhirLib' '-L/opt/opam/4.14.2/lib/pcre' '-L/opt/opam/4.14.2/lib/ppx_deriving/runtime' '-L/opt/opam/4.14.2/lib/ppx_deriving_yojson/runtime' '-L/opt/opam/4.14.2/lib/xml-light' '-L/opt/opam/4.14.2/lib/seq' '-L/opt/opam/4.14.2/lib/yojson' '-L/opt/opam/4.14.2/lib/vyos1x-config' '-L/opt/opam/4.14.2/lib/re' '-L/opt/opam/4.14.2/lib/bigarray-compat' '-L/opt/opam/4.14.2/lib/stdlib-shims' '-L/opt/opam/4.14.2/lib/integers' '-L/opt/opam/4.14.2/lib/ctypes' '-L/opt/opam/4.14.2/lib/ctypes/stubs' '-L/opt/opam/4.14.2/lib/ctypes-foreign' '-L/opt/opam/4.14.2/lib/ctypes/foreign' '-L/opt/opam/4.14.2/lib/ocaml/threads' '-L/opt/opam/4.14.2/lib/ocaml' -Wl,-soname,libvyosconfig.so.0 '/tmp/camlstartup50a566.o' '_build/lib/apply_bindings.o' '_build/generated/vyosconfig_bindings.o' '_build/lib/bindings.o' '/opt/opam/4.14.2/lib/ctypes-foreign/ctypes_foreign.a' '/opt/opam/4.14.2/lib/ctypes/stubs/ctypes_stubs.a' '/opt/opam/4.14.2/lib/ocaml/str.a' '/opt/opam/4.14.2/lib/ctypes/ctypes.a' '/opt/opam/4.14.2/lib/integers/integers.a' '/opt/opam/4.14.2/lib/bigarray-compat/bigarray_compat.a' '/opt/opam/4.14.2/lib/re/re.a' '/opt/opam/4.14.2/lib/vyos1x-config/vyos1x.a' '/opt/opam/4.14.2/lib/yojson/yojson.a' '/opt/opam/4.14.2/lib/xml-light/xml_light.a' '/opt/opam/4.14.2/lib/ppx_deriving_yojson/runtime/ppx_deriving_yojson_runtime.a' '/opt/opam/4.14.2/lib/ppx_deriving/runtime/ppx_deriving_runtime.a' '/opt/opam/4.14.2/lib/pcre/pcre.a' '/opt/opam/4.14.2/lib/menhirLib/menhirLib.a' '/opt/opam/4.14.2/lib/fileutils/fileutils.a' '/opt/opam/4.14.2/lib/containers/containers.a' '/opt/opam/4.14.2/lib/either/either.a' '/opt/opam/4.14.2/lib/containers/monomorphic/containers_monomorphic.a' '/opt/opam/4.14.2/lib/ocaml/threads/threads.a' '/opt/opam/4.14.2/lib/ocaml/unix.a' '/opt/opam/4.14.2/lib/ocaml/stdlib.a' '-lctypes_foreign_stubs' '-lffi' '-Wl,--no-as-needed' '-lcamlstr' '-lctypes_stubs' '-lintegers_stubs' '-lvyos1x_stubs' '-lpcre_stubs' '-lpcre' '-lthreadsnat' '-lpthread' '-lunix' '_build/stub/init.o' '_build/generated/vyosconfig.o' '/opt/opam/4.14.2/lib/ocaml/libasmrun_pic.a' -lm
make[3]: Leaving directory '/tmp/libvyosconfig'
Generating build/interface-definitions/container.xml from interface-definitions/container.xml.in
Generating build/interface-definitions/firewall.xml from interface-definitions/firewall.xml.in
Generating build/interface-definitions/high-availability.xml from interface-definitions/high-availability.xml.in
Generating build/interface-definitions/interfaces_bonding.xml from interface-definitions/interfaces_bonding.xml.in
Generating build/interface-definitions/interfaces_bridge.xml from interface-definitions/interfaces_bridge.xml.in
Generating build/interface-definitions/interfaces_dummy.xml from interface-definitions/interfaces_dummy.xml.in
Generating build/interface-definitions/interfaces_ethernet.xml from interface-definitions/interfaces_ethernet.xml.in
Generating build/interface-definitions/interfaces_geneve.xml from interface-definitions/interfaces_geneve.xml.in
Generating build/interface-definitions/interfaces_input.xml from interface-definitions/interfaces_input.xml.in
Generating build/interface-definitions/interfaces_l2tpv3.xml from interface-definitions/interfaces_l2tpv3.xml.in
Generating build/interface-definitions/interfaces_loopback.xml from interface-definitions/interfaces_loopback.xml.in
Generating build/interface-definitions/interfaces_macsec.xml from interface-definitions/interfaces_macsec.xml.in
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
