### PR TITLE
T7250: fix auto completion for op command show file

### DIFF
--- a/src/opt/vyatta/share/vyatta-op/functions/interpreter/vyatta-image-complete
+++ b/src/opt/vyatta/share/vyatta-op/functions/interpreter/vyatta-image-complete
@@ -1,0 +1,163 @@
+# vyatta bash operational mode image name completions
+# **** License ****
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+# 
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+# 
+# This code was originally developed by Vyatta, Inc.
+# Portions created by Vyatta are Copyright (C) 2006, 2007 Vyatta, Inc.
+# All Rights Reserved.
+# 
+# Author: John Southworth
+# Date: 2011
+# Description: setup bash completion for image file names
+# 
+# **** End License ****
+_vyatta_image_is_file()
+{
+  local cur=$1
+  if ! [[ ${cur:0:1} =~ "/" ]]; then
+    cur=${cur/:/}
+    topdir=${cur%%/*}
+    cur=${cur#$topdir/}
+  fi
+  if [[ $topdir == "running" ]]; then
+    cur="/${cur}"
+  elif [[ $topdir == "disk-install" ]]; then
+    cur="/lib/live/mount/persistence/${cur}"
+  elif [[ ${cur:0:1} =~ "/" ]]; then
+    cur=${cur}
+  else
+    cur="/lib/live/mount/persistence/boot/${topdir}/rw/${cur}"
+  fi
+  if [[ -f ${cur} ]]; then
+    return 0;
+  else
+    return 1;
+  fi
+}
+
+_vyatta_image_file_complete()
+{
+  if _vyatta_image_is_file ${COMP_WORDS[(( ${#COMP_WORDS[@]}-2 ))]}; then
+    _vyatta_op_completions=( "" " " )
+    return 0;
+  fi
+
+  _vyatta_image_path_complete
+}
+
+declare -a non_comps=( "http(s)://<user>:<passwd>@<host>/<file>" \
+ "scp://<user>:<passwd>@<host>/<file>" \
+ "sftp://<user>:<passwd>@<host>/<file>" \
+ "ftp(s)://<user>:<passwd>@<host>/<file>" \
+ "tftp://<host>/<file>" )
+
+_vyatta_image_path_complete()
+{
+  compopt -o nospace
+  local -a reply
+  if _vyatta_image_is_file $cur ; then
+    foundfile=1
+    _vyatta_op_completions=( "${cur} " )
+    _vyatta_op_noncompletions=( )
+    return 0;
+  fi
+  if [[ ${cur:0:1} =~ "/" ]]; then
+    reply=( $(compgen -f ${cur}) )
+    for ((i=0; i < ${#reply[@]}; i++)); do
+      [[ -d ${reply[i]} ]] && reply[i]="${reply[i]}"/
+    done
+    _vyatta_op_completions=( "${reply[@]}" )
+    return
+  fi
+  if [[ ${cur} == "" ]]; then
+    reply=( $(compgen -d /lib/live/mount/persistence/boot/ | grep -v grub) )
+    for i in `seq 0 $[${#reply[@]}-1]`; do
+      file=${reply[$i]}
+      reply[$i]=${file/#\/lib\/live\/mount\/persistence\/boot\//}
+      reply[$i]="${reply[$i]}://"
+    done
+    reply+=( "running://" )
+    if [[ -d /lib/live/mount/persistence/opt/vyatta/etc/config || -d /lib/live/mount/persistence/config ]]; then
+      reply+=( "disk-install://" )
+    fi
+    _vyatta_op_noncompletions=( "${non_comps[@]}" )
+  else 
+     _vyatta_op_noncompletions=( )
+    if ! [[ $cur =~ .*:\/\/ ]]; then
+      if [[ $cur =~ .*:\/ ]]; then
+        cur=${cur/:\//}
+      fi
+      if [[ $cur =~ .*: ]]; then
+        cur=${cur/:/}
+      fi
+      local isrunningimg=$(compgen -W "running" -- ${cur})
+      local isdiskinstall=$(compgen -W "disk-install" -- ${cur})
+      if [[ $isrunningimg == "running" ]];then
+        cur="/"
+      elif [[ $isdiskinstall == "disk-install" ]]; then
+        cur="/lib/live/mount/persistence/"
+      else
+        cur="/lib/live/mount/persistence/boot/${cur}"
+      fi
+      reply=( $(compgen -f ${cur} | grep -v grub) )
+      for i in `seq 0 $[${#reply[@]}-1]`; do
+        file=${reply[$i]}
+        if [[ $isrunningimg == "running" ]];then
+          reply[$i]="running://"
+        elif [[ $isdiskinstall == "disk-install" ]]; then
+          reply[$i]="disk-install://" 
+        else
+          reply[$i]=${file/#\/lib\/live\/mount\/persistence\/boot\//}
+          if [[ -d /lib/live/mount/persistence/boot/${reply[$i]} ]]; then
+            reply[$i]="${reply[$i]/#\//}://"
+          fi
+        fi
+      done
+    else
+      cur=${cur/:/}
+      topdir=${cur%%/*}
+      cur=${cur#$topdir//}
+      if [[ $topdir == "running" ]]; then
+        cur="/${cur}"
+      elif [[ $topdir == "disk-install" ]]; then
+        cur="/lib/live/mount/persistence/${cur}"
+      else
+        cur="/lib/live/mount/persistence/boot/${topdir}/rw/${cur}"
+      fi
+      reply=( $(compgen -f ${cur}) )
+      # for loop from _filedirs() in /etc/bash_completion
+      for ((i=0; i < ${#reply[@]}; i++)); do
+        if [[ ${cur:0:1} != "'" ]]; then 
+           [[ -d ${reply[i]} ]] && reply[i]="${reply[i]}"/
+           if [[ ${cur:0:1} == '"' ]]; then 
+             reply[i]=${reply[i]//\\/\\\\}
+             reply[i]=${reply[i]//\"/\\\"}
+             reply[i]=${reply[i]//\$/\\\$}
+           else
+             reply[i]=$(printf %q ${reply[i]})
+           fi
+        fi
+      done
+      for i in `seq 0 $[${#reply[@]}-1]`; do
+        file=${reply[$i]}
+        if [[ $topdir == "running" ]]; then
+          reply[$i]=${file/#\//"$topdir://"}
+        elif [[ $topdir == "disk-install" ]]; then
+          reply[$i]=${file/#\/lib\/live\/mount\/persistence\//"$topdir://"} 
+        else
+          reply[$i]=${file/#\/lib\/live\/mount\/persistence\/boot\/$topdir/"$topdir://"}
+          reply[$i]=${reply[$i]/\/rw\/}
+        fi
+      done
+    fi 
+  fi
+  _vyatta_op_completions=( "${reply[@]}" )
+  return 0
+}


### PR DESCRIPTION
Auto completion for op command `show file` is broken. When pressing tab for auto completion, an error `Invalid command: [_vyatta_image_file_complete]` is returned because legacy Vyatta interpreter file `vyatta-image-complete` has been removed.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add legacy Vyatta interpreter file` vyatta-image-complete`.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7250
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
