### PR TITLE
T7252: Allow vpptun and vpptap for constraint validator

### DIFF
--- a/interface-definitions/include/constraint/interface-name.xml.i
+++ b/interface-definitions/include/constraint/interface-name.xml.i
@@ -1,4 +1,4 @@
 <!-- include start from constraint/interface-name.xml.i -->
-<regex>(bond|br|dum|en|ersp|eth|gnv|ifb|ipoe|lan|l2tp|l2tpeth|macsec|peth|ppp|pppoe|pptp|sstp|sstpc|tun|veth|vti|vtun|vxlan|wg|wlan|wwan)[0-9]+(.\d+)?|pod-[-_a-zA-Z0-9]{1,11}|lo</regex>
+<regex>(bond|br|dum|en|ersp|eth|gnv|ifb|ipoe|lan|l2tp|l2tpeth|macsec|peth|ppp|pppoe|pptp|sstp|sstpc|tun|veth|vpptap|vpptun|vti|vtun|vxlan|wg|wlan|wwan)[0-9]+(.\d+)?|pod-[-_a-zA-Z0-9]{1,11}|lo</regex>
 <validator name="file-path --lookup-path /sys/class/net --directory"/>
 <!-- include end -->


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
It fixes cases when we want to use VPP kernel interfaces for OSPF But VPP kernel interface does not exists in this step
```
set vpp interfaces loopback lo0 kernel-interface 'vpptun0'
set protocols ospf interface vpptun0 area '0'

  Incorrect path /sys/class/net/vpptun0: no such file or directory
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7252

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Config:
```
set vpp settings interface eth0 driver 'dpdk'
set vpp settings unix poll-sleep-usec '120'
set vpp interfaces loopback lo0 kernel-interface 'vpptun0'
set vpp kernel-interfaces vpptun0 address '100.64.0.254/32'

set protocols ospf parameters router-id '100.64.0.254'
set protocols ospf interface eth0 area '0'
set protocols ospf interface vpptun0 area '0'
```
Before the fix:
```
vyos@vyos-vpp# set protocols ospf interface vpptun0 area '0'

  Incorrect path /sys/class/net/vpptun0: no such file or directory
  
  
  
  Invalid value
  Value validation failed
  Set failed

[edit]
vyos@vyos-vpp#
```
After the fix:
```
vyos@r14# set protocols ospf interface vpptun0 area '0'
[edit]
vyos@r14# 
[edit]
vyos@r14# commit
[edit]
vyos@r14# vtysh -c "show run ospfd"
Building configuration...

Current configuration:
!
frr version 10.2.1
frr defaults traditional
hostname r14
service integrated-vtysh-config
!
interface eth0
 ip ospf area 0
 ip ospf dead-interval 40
exit
!
interface vpptun0
 ip ospf area 0
 ip ospf dead-interval 40
exit
!
router ospf
 ospf router-id 100.64.0.254
 auto-cost reference-bandwidth 100
 timers throttle spf 200 1000 10000
 redistribute nhrp
exit
!
end
[edit]
vyos@r14# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
