### PR TITLE
wireguard: T7246: verify Base64 encoded 32byte boundary on keys

### DIFF
--- a/interface-definitions/include/constraint/wireguard-keys.xml.i
+++ b/interface-definitions/include/constraint/wireguard-keys.xml.i
@@ -1,0 +1,6 @@
+<!-- include start from constraint/wireguard-keys.xml.i -->
+<constraint>
+  <validator name="base64" argument="--decoded-len 32"/>
+</constraint>
+<constraintErrorMessage>Key must be Base64-encoded with 32 bytes in length</constraintErrorMessage>
+<!-- include end -->

--- a/interface-definitions/interfaces_wireguard.xml.in
+++ b/interface-definitions/interfaces_wireguard.xml.in
@@ -56,10 +56,7 @@
           <leafNode name="private-key">
             <properties>
               <help>Base64 encoded private key</help>
-              <constraint>
-                <validator name="base64"/>
-              </constraint>
-              <constraintErrorMessage>Key is not base64-encoded</constraintErrorMessage>
+              #include <include/constraint/wireguard-keys.xml.i>
             </properties>
           </leafNode>
           <tagNode name="peer">
@@ -75,20 +72,14 @@
               #include <include/generic-description.xml.i>
               <leafNode name="public-key">
                 <properties>
-                  <help>base64 encoded public key</help>
-                  <constraint>
-                    <validator name="base64"/>
-                  </constraint>
-                  <constraintErrorMessage>Key is not base64-encoded</constraintErrorMessage>
+                  <help>Base64 encoded public key</help>
+                  #include <include/constraint/wireguard-keys.xml.i>
                 </properties>
               </leafNode>
               <leafNode name="preshared-key">
                 <properties>
-                  <help>base64 encoded preshared key</help>
-                  <constraint>
-                    <validator name="base64"/>
-                  </constraint>
-                  <constraintErrorMessage>Key is not base64-encoded</constraintErrorMessage>
+                  <help>Base64 encoded preshared key</help>
+                  #include <include/constraint/wireguard-keys.xml.i>
                 </properties>
               </leafNode>
               <leafNode name="allowed-ips">

--- a/src/validators/base64
+++ b/src/validators/base64
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021 VyOS maintainers and contributors
+# Copyright (C) 2021-2025 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -15,13 +15,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import base64
-from sys import argv
+import argparse
 
-if __name__ == '__main__':
-    if len(argv) != 2:
+parser = argparse.ArgumentParser(description="Validate base64 input.")
+parser.add_argument("base64", help="Base64 encoded string to validate")
+parser.add_argument("--decoded-len", type=int, help="Optional list of valid lengths for the decoded input")
+args = parser.parse_args()
+
+try:
+    decoded = base64.b64decode(args.base64)
+    if args.decoded_len and len(decoded) != args.decoded_len:
         exit(1)
-    try:
-        base64.b64decode(argv[1])
-    except:
-        exit(1)
-    exit(0)
+except:
+    exit(1)
+exit(0)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Not 31 bytes or 33 bytes, but exactly 32. This matters, because 32 does not divide evenly by .75, so there's a padding character and the penultimate character does not include the whole base64 alphabet.

Extend the base64 validator with an optional argument to define the length to match of the decrypted Base64 encoded string.

Source: https://lists.zx2c4.com/pipermail/wireguard/2020-December/006222.html

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7246

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

`set interfaces wireguard wg01 peer to-wg02 public-key '//3/sDdozmikDxtYPw0MMYeuM2WPX7cgLnSH6L5+BQU='`

```
vyos@vyos# set interfaces wireguard wg01 peer to-wg02 public-key '//3/sDdozmikDxtYPw0MMYeuM2WPX7cgLnSH6L5+QU='




  Key must be Base64-encoded with 32 bytes in length
  Value validation failed
  Set failed
```

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_pki.py
test_certificate_eapol_update (__main__.TestPKI.test_certificate_eapol_update) ... ok
test_certificate_https_update (__main__.TestPKI.test_certificate_https_update) ... ok
test_certificate_in_use (__main__.TestPKI.test_certificate_in_use) ... ok
test_invalid_ca_valid_certificate (__main__.TestPKI.test_invalid_ca_valid_certificate) ... ok
test_valid_pki (__main__.TestPKI.test_valid_pki) ... ok

----------------------------------------------------------------------
Ran 5 tests in 20.373s

OK
```

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireguard.py
test_add_multiple_ip_addresses (__main__.WireGuardInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.WireGuardInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.WireGuardInterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.WireGuardInterfaceTest.test_dhcp_client_options) ... skipped 'not supported'
test_dhcp_disable_interface (__main__.WireGuardInterfaceTest.test_dhcp_disable_interface) ... skipped 'not supported'
test_dhcp_vrf (__main__.WireGuardInterfaceTest.test_dhcp_vrf) ... skipped 'not supported'
test_dhcpv6_client_options (__main__.WireGuardInterfaceTest.test_dhcpv6_client_options) ... skipped 'not supported'
test_dhcpv6_vrf (__main__.WireGuardInterfaceTest.test_dhcpv6_vrf) ... skipped 'not supported'
test_dhcpv6pd_auto_sla_id (__main__.WireGuardInterfaceTest.test_dhcpv6pd_auto_sla_id) ... skipped 'not supported'
test_dhcpv6pd_manual_sla_id (__main__.WireGuardInterfaceTest.test_dhcpv6pd_manual_sla_id) ... skipped 'not supported'
test_eapol (__main__.WireGuardInterfaceTest.test_eapol) ... skipped 'not supported'
test_interface_description (__main__.WireGuardInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.WireGuardInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.WireGuardInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.WireGuardInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.WireGuardInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.WireGuardInterfaceTest.test_ipv6_link_local_address) ... ok
test_move_interface_between_vrf_instances (__main__.WireGuardInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.WireGuardInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.WireGuardInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.WireGuardInterfaceTest.test_vif_8021q_interfaces) ... skipped 'not supported'
test_vif_8021q_lower_up_down (__main__.WireGuardInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'not supported'
test_vif_8021q_mtu_limits (__main__.WireGuardInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.WireGuardInterfaceTest.test_vif_8021q_qos_change) ... skipped 'not supported'
test_vif_s_8021ad_vlan_interfaces (__main__.WireGuardInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'not supported'
test_vif_s_protocol_change (__main__.WireGuardInterfaceTest.test_vif_s_protocol_change) ... skipped 'not supported'
test_wireguard_add_remove_peer (__main__.WireGuardInterfaceTest.test_wireguard_add_remove_peer) ... ok
test_wireguard_hostname (__main__.WireGuardInterfaceTest.test_wireguard_hostname) ... ok
test_wireguard_peer (__main__.WireGuardInterfaceTest.test_wireguard_peer) ... ok
test_wireguard_peer_pubkey_change (__main__.WireGuardInterfaceTest.test_wireguard_peer_pubkey_change) ... ok
test_wireguard_same_public_key (__main__.WireGuardInterfaceTest.test_wireguard_same_public_key) ... ok
test_wireguard_threaded (__main__.WireGuardInterfaceTest.test_wireguard_threaded) ... ok

----------------------------------------------------------------------
Ran 32 tests in 316.987s

OK (skipped=15)

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
