### PR TITLE
pki: T7249: fix shebang to support CLI backend

### DIFF
--- a/src/helpers/vyos-certbot-renew-pki.sh
+++ b/src/helpers/vyos-certbot-renew-pki.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/vbash
 source /opt/vyatta/etc/functions/script-template
 /usr/libexec/vyos/conf_mode/pki.py certbot_renew


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Fixes an error:
`interpreter/vyatta-cfg-run: line 162: `vyatta_config_commit-confirm': not a valid identifier`

Which prevented to renew the certificates. This will only fix renewing of the certificates. Nothing changed in how daemons will be restarted if a certificate is updated.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7249

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
vyos@vyos:~$ openssl x509 -in /run/ocserv/cert.pem -text | grep "Not "
            Not Before: Mar 18 04:33:16 2025 GMT
            Not After : Jun 16 04:33:15 2025 GMT
vyos@vyos:~$ sudo /usr/bin/certbot renew --config-dir /config/auth/letsencrypt --no-random-sleep-on-renew --post-hook "/usr/libexec/vyos/vyos-certbot-renew-pki.sh" --force-renewal
Saving debug log to /var/log/letsencrypt/letsencrypt.log

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Processing /config/auth/letsencrypt/renewal/vyos.conf
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Renewing an existing certificate for vyos.mybll.net

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Congratulations, all renewals succeeded:
  /config/auth/letsencrypt/live/vyos/fullchain.pem (success)
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Hook 'post-hook' ran with output:
 Updating certificates in /etc/ssl/certs...
 0 added, 0 removed; done.
 Running hooks in /etc/ca-certificates/update.d...
 done.
vyos@vyos:~$ openssl x509 -in /run/ocserv/cert.pem -text | grep "Not "
            Not Before: Mar 18 05:06:59 2025 GMT
            Not After : Jun 16 05:06:58 2025 GMT
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
