### PR TITLE
T7246: do not pass unneeded version string to parser

### DIFF
--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -50,7 +50,7 @@ def unescape_backslash(string: str) -> str:
 def extract_version(s):
     """Extract the version string from the config string"""
     t = re.split('(^//)', s, maxsplit=1, flags=re.MULTILINE)
-    return (s, ''.join(t[1:]))
+    return (t[0], ''.join(t[1:]))
 
 
 def check_path(path):

--- a/tests/data/config.valid
+++ b/tests/data/config.valid
@@ -35,5 +35,5 @@ empty-node {
 
 trailing-leaf-node-without-value
 
-// Trailing comment
-// Another trailing comment
+// some version string info
+// continued


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Previously the configtree parser would ignore lines beginning with '//', however this is unnecessarily restrictive. Pass only config information to parser, as the version string is saved separately for reconstruction on render.

So as to avoid even a brief window of broken builds, the order of merge should be as follows:
(1) this PR
(2) https://github.com/vyos/vyos1x-config/pull/35
(3) update libvyosconfig with hash of 2
(4) update vyos-1x Makefile with hash of 3 and add nosetest

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/vyos1x-config/pull/35

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
