### PR TITLE
T7286: Add CLI option to disable LDP establish packets

### DIFF
--- a/data/templates/frr/ldpd.frr.j2
+++ b/data/templates/frr/ldpd.frr.j2
@@ -82,8 +82,11 @@ mpls ldp
 {%             endfor %}
 {%         endif %}
 {%         if ldp.interface is vyos_defined %}
-{%             for interface in ldp.interface %}
+{%             for interface, iface_config in ldp.interface.items() %}
   interface {{ interface }}
+{%                 if iface_config.disable_establish_hello is vyos_defined %}
+    disable-establish-hello
+{%                 endif %}
   exit
 {%             endfor %}
 {%         endif %}
@@ -135,8 +138,11 @@ mpls ldp
 {%             endfor %}
 {%         endif %}
 {%         if ldp.interface is vyos_defined %}
-{%             for interface in ldp.interface %}
+{%             for interface, iface_config in ldp.interface.items() %}
   interface {{ interface }}
+{%                 if iface_config.disable_establish_hello is vyos_defined %}
+    disable-establish-hello
+{%                 endif %}
 {%             endfor %}
 {%         endif %}
  exit-address-family

--- a/interface-definitions/protocols_mpls.xml.in
+++ b/interface-definitions/protocols_mpls.xml.in
@@ -524,7 +524,29 @@
                   </node>
                 </children>
               </node>
-              #include <include/generic-interface-multi.xml.i>
+              <tagNode name="interface">
+                <properties>
+                  <help>Interface</help>
+                  <completionHelp>
+                    <script>${vyos_completion_dir}/list_interfaces</script>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>txt</format>
+                    <description>Interface name</description>
+                  </valueHelp>
+                  <constraint>
+                    #include <include/constraint/interface-name.xml.i>
+                  </constraint>
+                </properties>
+                <children>
+                  <leafNode name="disable-establish-hello">
+                    <properties>
+                      <help>Disable response to hello packet with an additional hello LDP packet</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </tagNode>
             </children>
           </node>
           <node name="parameters">

--- a/smoketest/scripts/cli/test_protocols_mpls.py
+++ b/smoketest/scripts/cli/test_protocols_mpls.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2024 VyOS maintainers and contributors
+# Copyright (C) 2021-2025 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -120,6 +120,75 @@ class TestProtocolsMPLS(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'  discovery transport-address {transport_ipv4_addr}', afiv4_config)
         for interface in interfaces:
             self.assertIn(f'  interface {interface}', afiv4_config)
+
+    def test_02_mpls_disable_establish_hello(self):
+        router_id = '1.2.3.4'
+        transport_ipv4_addr = '5.6.7.8'
+        transport_ipv6_addr = '2001:db8:1111::1111'
+        interfaces = Section.interfaces('ethernet')
+
+        self.cli_set(base_path + ['router-id', router_id])
+
+        # At least one LDP interface must be configured
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        for interface in interfaces:
+            self.cli_set(base_path + ['interface', interface, 'disable-establish-hello'])
+
+        # LDP transport address missing
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(base_path + ['discovery', 'transport-ipv4-address', transport_ipv4_addr])
+        self.cli_set(base_path + ['discovery', 'transport-ipv6-address', transport_ipv6_addr])
+
+        # Commit changes
+        self.cli_commit()
+
+        # Validate configuration
+        frrconfig = self.getFRRconfig('mpls ldp', endsection='^exit')
+        self.assertIn(f'mpls ldp', frrconfig)
+        self.assertIn(f' router-id {router_id}', frrconfig)
+
+        # Validate AFI IPv4
+        afiv4_config = self.getFRRconfig('mpls ldp', endsection='^exit',
+                                         substring=' address-family ipv4',
+                                         endsubsection='^ exit-address-family')
+        self.assertIn(f'  discovery transport-address {transport_ipv4_addr}', afiv4_config)
+        for interface in interfaces:
+            self.assertIn(f'  interface {interface}', afiv4_config)
+            self.assertIn(f'   disable-establish-hello', afiv4_config)
+
+        # Validate AFI IPv6
+        afiv6_config = self.getFRRconfig('mpls ldp', endsection='^exit',
+                                         substring=' address-family ipv6',
+                                         endsubsection='^ exit-address-family')
+        self.assertIn(f'  discovery transport-address {transport_ipv6_addr}', afiv6_config)
+        for interface in interfaces:
+            self.assertIn(f'  interface {interface}', afiv6_config)
+            self.assertIn(f'   disable-establish-hello', afiv6_config)
+
+        # Delete disable-establish-hello
+        for interface in interfaces:
+            self.cli_delete(base_path + ['interface', interface, 'disable-establish-hello'])
+
+        # Commit changes
+        self.cli_commit()
+
+        # Validate AFI IPv4
+        afiv4_config = self.getFRRconfig('mpls ldp', endsection='^exit',
+                                         substring=' address-family ipv4',
+                                         endsubsection='^ exit-address-family')
+        # Validate AFI IPv6
+        afiv6_config = self.getFRRconfig('mpls ldp', endsection='^exit',
+                                         substring=' address-family ipv6',
+                                         endsubsection='^ exit-address-family')
+        # Check deleted 'disable-establish-hello' option per interface
+        for interface in interfaces:
+            self.assertIn(f'  interface {interface}', afiv4_config)
+            self.assertNotIn(f'   disable-establish-hello', afiv4_config)
+            self.assertIn(f'  interface {interface}', afiv6_config)
+            self.assertNotIn(f'   disable-establish-hello', afiv6_config)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
If a router has not formed an LDP neighbor adjacency yet, it answers all received LDP Hello packets from non-neighbors with new Hello packets.
This leads to flooding LDP packets to all routers for each LDP incoming packet.

Add the configuration option to disable this behavior

```
set protocols mpls ldp interface eth0 disable-establish-hello
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7286
 * https://vyos.dev/T7226

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Configure MPLS LDP with the option `disable-establish-hello` and check FRR config
```
set interfaces loopback lo address '192.0.2.111/32'
set interfaces loopback lo address '2001:db8:1111::1111/128'
set protocols mpls ldp discovery transport-ipv4-address '192.0.2.111'
set protocols mpls ldp discovery transport-ipv6-address '2001:db8:1111::1111'
set protocols mpls ldp interface eth0
set protocols mpls ldp interface eth1 disable-establish-hello
set protocols mpls ldp interface lo
set protocols mpls ldp router-id '192.0.2.11'
commit
```
FRR config:
```
vyos@r14# vtysh -c 'show run ldpd'
Building configuration...

Current configuration:
!
frr version 10.2.2
frr defaults traditional
hostname r14
service integrated-vtysh-config
!
mpls ldp
 router-id 192.0.2.11
 !
 address-family ipv4
  discovery transport-address 192.0.2.111
  label local allocate host-routes
  !
  interface eth0
  exit
  !
  interface eth1
   disable-establish-hello
  exit
  !
  interface lo
  exit
  !
 exit-address-family
 !
 address-family ipv6
  discovery transport-address 2001:db8:1111::1111
  label local allocate host-routes
  !
  interface eth0
  exit
  !
  interface eth1
   disable-establish-hello
  exit
  !
  interface lo
  exit
  !
 exit-address-family
 !
exit
!
end
[edit]
vyos@r14# 

```

Smoketest:
```
vyos@r14:~$ sudo nano -c /usr/libexec/vyos/tests/smoke/cli/test_protocols_mpls.py
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_mpls.py
test_02_mpls_disable_establish_hello (__main__.TestProtocolsMPLS.test_02_mpls_disable_establish_hello) ... ok
test_mpls_basic (__main__.TestProtocolsMPLS.test_mpls_basic) ... ok

----------------------------------------------------------------------
Ran 2 tests in 36.087s

OK
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
