### PR TITLE
virtual-ethernet: T7293: add support to define interface MTU

### DIFF
--- a/interface-definitions/interfaces_virtual-ethernet.xml.in
+++ b/interface-definitions/interfaces_virtual-ethernet.xml.in
@@ -21,6 +21,10 @@
           #include <include/interface/dhcp-options.xml.i>
           #include <include/interface/dhcpv6-options.xml.i>
           #include <include/interface/disable.xml.i>
+          #include <include/interface/mtu-68-16000.xml.i>
+          <leafNode name="mtu">
+            <defaultValue>1500</defaultValue>
+          </leafNode>
           #include <include/interface/netns.xml.i>
           #include <include/interface/vif-s.xml.i>
           #include <include/interface/vif.xml.i>

--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -613,7 +613,7 @@ class BasicInterfaceTest:
         def test_mtu_1200_no_ipv6_interface(self):
             # Testcase if MTU can be changed to 1200 on non IPv6
             # enabled interfaces
-            if not self._test_mtu:
+            if not self._test_mtu or not self._test_ipv6:
                 self.skipTest('not supported')
 
             old_mtu = self._mtu


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Extend interface XML definition by including the building block which allows changing interface MTU size.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7293

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_virtual-ethernet.py
test_add_multiple_ip_addresses (__main__.VEthInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.VEthInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.VEthInterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.VEthInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.VEthInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.VEthInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.VEthInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.VEthInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.VEthInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.VEthInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol (__main__.VEthInterfaceTest.test_eapol) ... skipped 'not supported'
test_interface_description (__main__.VEthInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.VEthInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.VEthInterfaceTest.test_interface_ip_options) ... skipped 'not supported'
test_interface_ipv6_options (__main__.VEthInterfaceTest.test_interface_ipv6_options) ... skipped 'not supported'
test_interface_mtu (__main__.VEthInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.VEthInterfaceTest.test_ipv6_link_local_address) ... skipped 'not supported'
test_move_interface_between_vrf_instances (__main__.VEthInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.VEthInterfaceTest.test_mtu_1200_no_ipv6_interface) ... skipped 'not supported'
test_span_mirror (__main__.VEthInterfaceTest.test_span_mirror) ... skipped 'not supported'
test_vif_8021q_interfaces (__main__.VEthInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.VEthInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.VEthInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'not supported'
test_vif_8021q_qos_change (__main__.VEthInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.VEthInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.VEthInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 26 tests in 317.576s

OK (skipped=7)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
