### PR TITLE
T7254: op-mode: Add spanning-tree op-mode commands

### DIFF
--- a/data/op-mode-standardized.json
+++ b/data/op-mode-standardized.json
@@ -28,6 +28,7 @@
 "load-balancing_haproxy.py",
 "route.py",
 "storage.py",
+"stp.py",
 "system.py",
 "uptime.py",
 "version.py",

--- a/op-mode-definitions/show-bridge.xml.in
+++ b/op-mode-definitions/show-bridge.xml.in
@@ -7,6 +7,20 @@
           <help>Show bridging information</help>
         </properties>
         <children>
+          <node name="spanning-tree">
+            <properties>
+              <help>View Spanning Tree info for all bridges</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/stp.py show_stp</command>
+            <children>
+              <leafNode name="detail">
+                <properties>
+                  <help>Show detailed Spanning Tree info for all bridges</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/stp.py show_stp --detail</command>
+              </leafNode>
+            </children>
+          </node>
           <node name="vlan">
             <properties>
               <help>View the VLAN filter settings of the bridge</help>
@@ -44,6 +58,20 @@
         </properties>
         <command>bridge -c link show | grep "master $3"</command>
         <children>
+          <node name="spanning-tree">
+            <properties>
+              <help>View Spanning Tree info for specified bridges</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/stp.py show_stp --ifname=$3</command>
+            <children>
+              <leafNode name="detail">
+                <properties>
+                  <help>Show detailed Spanning Tree info for specified bridge</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/stp.py show_stp --ifname=$3 --detail</command>
+              </leafNode>
+            </children>
+          </node>
           <leafNode name="mdb">
             <properties>
               <help>Displays the multicast group database for the bridge</help>

--- a/src/op_mode/stp.py
+++ b/src/op_mode/stp.py
@@ -145,7 +145,7 @@ def show_stp(raw: bool, ifname: typing.Optional[str], detail: bool):
         print(f"Spanning Tree is {bridgeDict['stp_state']}")
         print(f"Bridge ID {bridgeDict['bridge_id'][1]}, Priority {int(bridgeDict['bridge_id'][0], 16)}")
         print(f"Root ID {bridgeDict['root_id'][1]}, Priority {int(bridgeDict['root_id'][0], 16)}{amRoot}")
-        print(f"VLANs are {bridgeDict['vlan_filtering'].capitalize()}, Protocol {bridgeDict['vlan_protocol']}")
+        print(f"VLANs {bridgeDict['vlan_filtering'].capitalize()}, Protocol {bridgeDict['vlan_protocol']}")
         print()
 
         for members in bridgeDict['members']:

--- a/src/op_mode/stp.py
+++ b/src/op_mode/stp.py
@@ -138,7 +138,7 @@ def show_stp(raw: bool, ifname: typing.Optional[str], detail: bool):
         bridgeDict = _get_stp_data(ifname, bridges, bridgeStatus)
 
         if bridgeDict['bridge_id'][1] == bridgeDict['root_id'][1]:
-            amRoot = " (This bridge is root)"
+            amRoot = " (This bridge is the root)"
 
         print('-' * 80)
         print(f"Bridge interface {bridgeDict['bridge_name']} ({bridgeDict['up_state']}):\n")

--- a/src/op_mode/stp.py
+++ b/src/op_mode/stp.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2025 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import typing
+import json
+from tabulate import tabulate
+
+import vyos.opmode
+from vyos.utils.process import cmd
+from vyos.utils.network import interface_exists
+
+def detailed_output(dataset, headers):
+    for data in dataset:
+        adjusted_rule = data + [""] * (len(headers) - len(data)) # account for different header length, like default-action
+        transformed_rule = [[header, adjusted_rule[i]] for i, header in enumerate(headers) if i < len(adjusted_rule)] # create key-pair list from headers and rules lists; wrap at 100 char
+
+        print(tabulate(transformed_rule, tablefmt="presto"))
+        print()
+
+def _get_bridge_vlan_data(iface):
+    allowed_vlans = []
+    native_vlan = None
+    vlanData = json.loads(cmd(f"bridge -j -d vlan show"))
+    for vlans in vlanData:
+        if vlans['ifname'] == iface:
+            for allowed in vlans['vlans']:
+                if "flags" in allowed and "PVID" in allowed["flags"]:
+                    native_vlan = allowed['vlan']
+                elif allowed.get('vlanEnd', None):
+                    allowed_vlans.append(f"{allowed['vlan']}-{allowed['vlanEnd']}")
+                else:
+                    allowed_vlans.append(str(allowed['vlan']))
+
+    if not allowed_vlans:
+        allowed_vlans = ["none"]
+    if not native_vlan:
+        native_vlan = "none"
+
+    return ",".join(allowed_vlans), native_vlan
+
+def _get_stp_data(ifname, brInfo, brStatus):
+    tmpInfo = {}
+
+    tmpInfo['bridge_name'] = brInfo.get('ifname')
+    tmpInfo['up_state'] = brInfo.get('operstate')
+    tmpInfo['priority'] = brInfo.get('linkinfo').get('info_data').get('priority')
+    tmpInfo['vlan_filtering'] = "Enabled" if brInfo.get('linkinfo').get('info_data').get('vlan_filtering') == 1 else "Disabled"
+    tmpInfo['vlan_protocol'] = brInfo.get('linkinfo').get('info_data').get('vlan_protocol')
+
+    # The version of VyOS I tested had am issue with the "ip -d link show type bridge"
+    # output. The root_id was always the local bridge, even though the underlying system
+    # understood when it wasn't. Could be an upstream Bug. I pull from the "/sys/class/net"
+    # structure instead. This can be changed later if the "ip link" behavior is corrected.
+
+    #tmpInfo['bridge_id'] = brInfo.get('linkinfo').get('info_data').get('bridge_id')
+    #tmpInfo['root_id'] = brInfo.get('linkinfo').get('info_data').get('root_id')
+
+    tmpInfo['bridge_id'] = cmd(f"cat /sys/class/net/{brInfo.get('ifname')}/bridge/bridge_id").split('.')
+    tmpInfo['root_id'] = cmd(f"cat /sys/class/net/{brInfo.get('ifname')}/bridge/root_id").split('.')
+
+    # The "/sys/class/net" structure stores the IDs without seperators like ':' or '.'
+    # This adds a ':' after every 2 characters to make it resemble a MAC Address
+    tmpInfo['bridge_id'][1] = ':'.join(tmpInfo['bridge_id'][1][i:i+2] for i in range(0, len(tmpInfo['bridge_id'][1]), 2))
+    tmpInfo['root_id'][1] = ':'.join(tmpInfo['root_id'][1][i:i+2] for i in range(0, len(tmpInfo['root_id'][1]), 2))
+
+    tmpInfo['stp_state'] = "Enabled" if brInfo.get('linkinfo', {}).get('info_data', {}).get('stp_state') == 1 else "Disabled"
+
+    # I don't call any of these values, but I created them to be called within raw output if desired
+
+    tmpInfo['mcast_snooping'] = "Enabled" if brInfo.get('linkinfo').get('info_data').get('mcast_snooping') == 1 else "Disabled"
+    tmpInfo['rxbytes'] = brInfo.get('stats64').get('rx').get('bytes')
+    tmpInfo['rxpackets'] = brInfo.get('stats64').get('rx').get('packets')
+    tmpInfo['rxerrors'] = brInfo.get('stats64').get('rx').get('errors')
+    tmpInfo['rxdropped'] = brInfo.get('stats64').get('rx').get('dropped')
+    tmpInfo['rxover_errors'] = brInfo.get('stats64').get('rx').get('over_errors')
+    tmpInfo['rxmulticast'] = brInfo.get('stats64').get('rx').get('multicast')
+    tmpInfo['txbytes'] = brInfo.get('stats64').get('tx').get('bytes')
+    tmpInfo['txpackets'] = brInfo.get('stats64').get('tx').get('packets')
+    tmpInfo['txerrors'] = brInfo.get('stats64').get('tx').get('errors')
+    tmpInfo['txdropped'] = brInfo.get('stats64').get('tx').get('dropped')
+    tmpInfo['txcarrier_errors'] = brInfo.get('stats64').get('tx').get('carrier_errors')
+    tmpInfo['txcollosions'] = brInfo.get('stats64').get('tx').get('collisions')
+
+    tmpStatus = []
+    for members in brStatus:
+        if members.get('master') == brInfo.get('ifname'):
+            allowed_vlans, native_vlan = _get_bridge_vlan_data(members['ifname'])
+            tmpStatus.append({'interface': members.get('ifname'),
+                                'state': members.get('state').capitalize(),
+                                'mtu': members.get('mtu'),
+                                'pathcost': members.get('cost'),
+                                'bpduguard': "Enabled" if members.get('guard') == True else "Disabled",
+                                'rootguard': "Enabled" if members.get('root_block') == True else "Disabled",
+                                'mac_learning': "Enabled" if members.get('learning') == True else "Disabled",
+                                'neigh_suppress': "Enabled" if members.get('neigh_suppress') == True else "Disabled",
+                                'vlan_tunnel': "Enabled" if members.get('vlan_tunnel') == True else "Disabled",
+                                'isolated': "Enabled" if members.get('isolated') == True else "Disabled",
+                                **({'allowed_vlans': allowed_vlans} if allowed_vlans else {}),
+                                **({'native_vlan': native_vlan} if native_vlan else {})})
+
+    tmpInfo['members'] = tmpStatus
+    return tmpInfo
+
+def show_stp(raw: bool, ifname: typing.Optional[str], detail: bool):
+    rawList = []
+    rawDict = {'stp': []}
+
+    if ifname:
+        if not interface_exists(ifname):
+            raise vyos.opmode.Error(f"{ifname} does not exist!")
+    else:
+        ifname = ""
+
+    bridgeInfo = json.loads(cmd(f"ip -j -d -s link show type bridge {ifname}"))
+
+    if not bridgeInfo:
+        raise vyos.opmode.Error(f"No Bridges configured!")
+
+    bridgeStatus = json.loads(cmd(f"bridge -j -s -d link show"))
+
+    for bridges in bridgeInfo:
+        output_list = []
+        amRoot = ""
+        bridgeDict = _get_stp_data(ifname, bridges, bridgeStatus)
+
+        if bridgeDict['bridge_id'][1] == bridgeDict['root_id'][1]:
+            amRoot = " (This bridge is root)"
+
+        print('-' * 80)
+        print(f"Bridge interface {bridgeDict['bridge_name']} ({bridgeDict['up_state']}):\n")
+        print(f"Spanning Tree is {bridgeDict['stp_state']}")
+        print(f"Bridge ID {bridgeDict['bridge_id'][1]}, Priority {int(bridgeDict['bridge_id'][0], 16)}")
+        print(f"Root ID {bridgeDict['root_id'][1]}, Priority {int(bridgeDict['root_id'][0], 16)}{amRoot}")
+        print(f"VLANs are {bridgeDict['vlan_filtering'].capitalize()}, Protocol {bridgeDict['vlan_protocol']}")
+        print()
+
+        for members in bridgeDict['members']:
+            output_list.append([members['interface'],
+                              members['state'],
+                              *([members['pathcost']] if detail else []),
+                              members['bpduguard'],
+                              members['rootguard'],
+                              members['mac_learning'],
+                              *([members['neigh_suppress']] if detail else []),
+                              *([members['vlan_tunnel']] if detail else []),
+                              *([members['isolated']] if detail else []),
+                              *([members['allowed_vlans']] if detail else []),
+                              *([members['native_vlan']] if detail else [])])
+
+        if raw:
+            rawList.append(bridgeDict)
+        elif detail:
+            headers = ['Interface', 'State', 'Pathcost', 'BPDU_Guard', 'Root_Guard', 'Learning', 'Neighbor_Suppression', 'Q-in-Q', 'Port_Isolation', 'Allowed VLANs', 'Native VLAN']
+            detailed_output(output_list, headers)
+        else:
+            headers = ['Interface', 'State', 'BPDU_Guard', 'Root_Guard', 'Learning']
+            print(tabulate(output_list, headers))
+            print()
+
+    if raw:
+        rawDict['stp'] = rawList
+        return rawDict
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except (ValueError, vyos.opmode.Error) as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
This PR will add missing commands for spanning-tree. The following commands are added:
```
show bridge spanning-tree
show bridge spanning-tree detail
show bridge \<interface> spanning-tree
show bridge \<interface> spanning-tree detail
```

Example config:
```
set interfaces bridge br0 member interface eth2
set interfaces bridge br1 enable-vlan
set interfaces bridge br1 member interface eth3 allowed-vlan '50-100'
set interfaces bridge br1 member interface eth3 native-vlan '25'
```
Output Examples:
```
admin@GK41:~$ show bridge spanning-tree
--------------------------------------------------------------------------------
Bridge interface br0 (DOWN):

Spanning Tree is Disabled
Bridge ID 32:35:e4:d1:4c:05, Priority 32768
Root ID 32:35:e4:d1:4c:05, Priority 32768 (This bridge is root)
VLANs are Disabled, Protocol 802.1Q

Interface    State     BPDU_Guard    Root_Guard    Learning
-----------  --------  ------------  ------------  ----------
eth2         Disabled  Disabled      Disabled      Enabled

--------------------------------------------------------------------------------
Bridge interface br1 (UP):

Spanning Tree is Disabled
Bridge ID 72:5f:d6:8b:20:5f, Priority 32768
Root ID 72:5f:d6:8b:20:5f, Priority 32768 (This bridge is root)
VLANs are Enabled, Protocol 802.1Q

Interface    State       BPDU_Guard    Root_Guard    Learning
-----------  ----------  ------------  ------------  ----------
eth3         Forwarding  Disabled      Disabled      Enabled
```
```
admin@GK41:~$ show bridge br1 spanning-tree
--------------------------------------------------------------------------------
Bridge interface br1 (UP):

Spanning Tree is Disabled
Bridge ID 72:5f:d6:8b:20:5f, Priority 32768
Root ID 72:5f:d6:8b:20:5f, Priority 32768 (This bridge is root)
VLANs are Enabled, Protocol 802.1Q

Interface    State       BPDU_Guard    Root_Guard    Learning
-----------  ----------  ------------  ------------  ----------
eth3         Forwarding  Disabled      Disabled      Enabled
```
```
admin@GK41:~$ show bridge br1 spanning-tree detail
--------------------------------------------------------------------------------
Bridge interface br1 (UP):

Spanning Tree is Disabled
Bridge ID 72:5f:d6:8b:20:5f, Priority 32768
Root ID 72:5f:d6:8b:20:5f, Priority 32768 (This bridge is root)
VLANs are Enabled, Protocol 802.1Q

 Interface            | eth3
 State                | Forwarding
 Pathcost             | 100
 BPDU_Guard           | Disabled
 Root_Guard           | Disabled
 Learning             | Enabled
 Neighbor_Suppression | Disabled
 Q-in-Q               | Disabled
 Port_Isolation       | Disabled
 Allowed VLANs        | 50-100
 Native VLAN          | 25
```
```
{
    "stp": [
        {
            "bridge_name": "br0",
            "up_state": "UP",
            "priority": 32768,
            "vlan_filtering": "Disabled",
            "vlan_protocol": "802.1Q",
            "bridge_id": [
                "8000",
                "96:ae:39:c4:52:05"
            ],
            "root_id": [
                "8000",
                "96:ae:39:c4:52:05"
            ],
            "stp_state": "Disabled",
            "mcast_snooping": "Disabled",
            "rxbytes": 7236098,
            "rxpackets": 62713,
            "rxerrors": 0,
            "rxdropped": 0,
            "rxover_errors": 0,
            "rxmulticast": 62713,
            "txbytes": 1006,
            "txpackets": 9,
            "txerrors": 0,
            "txdropped": 0,
            "txcarrier_errors": 0,
            "txcollosions": 0,
            "members": [
                {
                    "interface": "eth0",
                    "state": "Forwarding",
                    "mtu": 1500,
                    "pathcost": 100,
                    "bpduguard": "Disabled",
                    "rootguard": "Disabled",
                    "mac_learning": "Enabled",
                    "neigh_suppress": "Disabled",
                    "vlan_tunnel": "Disabled",
                    "isolated": "Disabled",
                    "allowed_vlans": "none",
                    "native_vlan": 1
                },
                {
                    "interface": "eth2",
                    "state": "Forwarding",
                    "mtu": 1500,
                    "pathcost": 100,
                    "bpduguard": "Disabled",
                    "rootguard": "Disabled",
                    "mac_learning": "Enabled",
                    "neigh_suppress": "Disabled",
                    "vlan_tunnel": "Disabled",
                    "isolated": "Disabled",
                    "allowed_vlans": "none",
                    "native_vlan": 1
                }
            ]
        }
    ]
}
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7254

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
