### PR TITLE
T7289: fix typo in git submodule status check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ op_xml_obj = $(op_xml_src:.xml.in=.xml)
 .ONESHELL:
 libvyosconfig:
 	if test ! -f $(LIBVYOSCONFIG_BUILD_PATH); then
-		if ! echo $(firstword $(LIBVYOSCONFIG_STATUS))|grep -Eq '^[0-9]'; then
+		if ! echo $(firstword $(LIBVYOSCONFIG_STATUS))|grep -Eq '^[a-z0-9]'; then
 			git submodule sync; git submodule update --init --remote
 		fi
 		rm -rf /tmp/libvyosconfig && mkdir /tmp/libvyosconfig


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

This does NOT need to be backported, as the fix has already been added to:
https://github.com/VyOS-Networks/vyos-1x/pull/508
as it is critical for successful builds from private repo.

Fix dumb typo in check of 'git submodule status': if status is up-to-date, the result should be the hash without a non-lowercase-alphanumeric prefix ('-', '+', 'U', indicating, resp., uninitialized/inconsistent/merge conflict).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
