### PR TITLE
kea: T7310: add support for RFC-5417 (option 138)

### DIFF
--- a/data/templates/dhcp-server/kea-dhcp4.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp4.conf.j2
@@ -48,11 +48,6 @@
                 "code": 1,
                 "type": "ipv4-address",
                 "space": "ubnt"
-            },
-            {
-                "name": "capwap-access-controller",
-                "code": 138,
-                "type": "ipv4-address",
             }
         ],
         "hooks-libraries": [

--- a/data/templates/dhcp-server/kea-dhcp4.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp4.conf.j2
@@ -48,6 +48,11 @@
                 "code": 1,
                 "type": "ipv4-address",
                 "space": "ubnt"
+            },
+            {
+                "name": "capwap-access-controller",
+                "code": 138,
+                "type": "ipv4-address",
             }
         ],
         "hooks-libraries": [

--- a/interface-definitions/include/dhcp/option-v4.xml.i
+++ b/interface-definitions/include/dhcp/option-v4.xml.i
@@ -59,9 +59,9 @@
         <constraintErrorMessage>DHCP client prefix length must be 0 to 32</constraintErrorMessage>
       </properties>
     </leafNode>
-    <leafNode name="capwap-access-controller">
+    <leafNode name="capwap-controller">
       <properties>
-        <help>IP address of CAPWAP access controller</help>
+        <help>IP address of CAPWAP access controller (Option 138)</help>
         <valueHelp>
           <format>ipv4</format>
           <description>CAPWAP AC controller</description>

--- a/interface-definitions/include/dhcp/option-v4.xml.i
+++ b/interface-definitions/include/dhcp/option-v4.xml.i
@@ -59,6 +59,18 @@
         <constraintErrorMessage>DHCP client prefix length must be 0 to 32</constraintErrorMessage>
       </properties>
     </leafNode>
+    <leafNode name="capwap-access-controller">
+      <properties>
+        <help>IP address of CAPWAP access controller</help>
+        <valueHelp>
+          <format>ipv4</format>
+          <description>CAPWAP AC controller</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv4-address"/>
+        </constraint>
+      </properties>
+    </leafNode>
     <leafNode name="default-router">
       <properties>
         <help>IP address of default router</help>

--- a/interface-definitions/include/dhcp/option-v6.xml.i
+++ b/interface-definitions/include/dhcp/option-v6.xml.i
@@ -7,6 +7,18 @@
     #include <include/dhcp/captive-portal.xml.i>
     #include <include/dhcp/domain-search.xml.i>
     #include <include/name-server-ipv6.xml.i>
+    <leafNode name="capwap-controller">
+      <properties>
+        <help>IP address of CAPWAP access controller (Option 52)</help>
+        <valueHelp>
+          <format>ipv6</format>
+          <description>CAPWAP AC controller</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv6-address"/>
+        </constraint>
+      </properties>
+    </leafNode>
     <leafNode name="nis-domain">
       <properties>
         <help>NIS domain name for client to use</help>

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -44,6 +44,7 @@ kea4_options = {
     'wpad_url': 'wpad-url',
     'ipv6_only_preferred': 'v6-only-preferred',
     'captive_portal': 'v4-captive-portal',
+    'capwap_controller': 'capwap-ac-v4',
 }
 
 kea6_options = {
@@ -101,14 +102,6 @@ def kea_parse_options(config):
             {
                 'name': 'subnet-mask',
                 'data': netmask_from_cidr('0.0.0.0/' + config['client_prefix_length']),
-            }
-        )
-
-    if 'capwap_access_controller' in config:
-        options.append(
-            {
-                'name': 'capwap-ac-v4',
-                'data': config['capwap_access_controller'],
             }
         )
 

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -104,6 +104,14 @@ def kea_parse_options(config):
             }
         )
 
+    if 'capwap-access-controller' in config:
+        options.append(
+            {
+                'name': 'capwap-access-controller',
+                'data': config['capwap-access-controller'],
+            }
+        )
+
     if 'ip_forwarding' in config:
         options.append({'name': 'ip-forwarding', 'data': 'true'})
 

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -107,7 +107,7 @@ def kea_parse_options(config):
     if 'capwap-access-controller' in config:
         options.append(
             {
-                'name': 'capwap-access-controller',
+                'name': 'capwap-ac-v4',
                 'data': config['capwap-access-controller'],
             }
         )

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -104,11 +104,11 @@ def kea_parse_options(config):
             }
         )
 
-    if 'capwap-access-controller' in config:
+    if 'capwap_access_controller' in config:
         options.append(
             {
                 'name': 'capwap-ac-v4',
-                'data': config['capwap-access-controller'],
+                'data': config['capwap_access_controller'],
             }
         )
 

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -57,6 +57,7 @@ kea6_options = {
     'nisplus_server': 'nisp-servers',
     'sntp_server': 'sntp-servers',
     'captive_portal': 'v6-captive-portal',
+    'capwap_controller': 'capwap-ac-v6',
 }
 
 kea_ctrl_socket = '/run/kea/dhcp{inet}-ctrl-socket'

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -197,6 +197,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         wpad = 'http://wpad.vyos.io/foo/bar'
         server_identifier = bootfile_server
         ipv6_only_preferred = '300'
+        capwap_access_controller = '192.168.2.125'
 
         pool = base_path + ['shared-network-name', shared_net_name, 'subnet', subnet]
         self.cli_set(pool + ['subnet-id', '1'])
@@ -216,6 +217,9 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.cli_set(pool + ['option', 'bootfile-server', bootfile_server])
         self.cli_set(pool + ['option', 'wpad-url', wpad])
         self.cli_set(pool + ['option', 'server-identifier', server_identifier])
+        self.cli_set(
+            pool + ['option', 'capwap-access-controller', capwap_access_controller]
+        )
 
         self.cli_set(
             pool + ['option', 'static-route', '10.0.0.0/24', 'next-hop', '192.0.2.1']
@@ -297,6 +301,11 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
             obj,
             ['Dhcp4', 'shared-networks', 0, 'subnet4', 0, 'option-data'],
             {'name': 'dhcp-server-identifier', 'data': server_identifier},
+        )
+        self.verify_config_object(
+            obj,
+            ['Dhcp4', 'shared-networks', 0, 'subnet4', 0, 'option-data'],
+            {'name': 'capwap-ac-v4', 'data': capwap_access_controller},
         )
         self.verify_config_object(
             obj,

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -218,7 +218,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.cli_set(pool + ['option', 'wpad-url', wpad])
         self.cli_set(pool + ['option', 'server-identifier', server_identifier])
         self.cli_set(
-            pool + ['option', 'capwap-access-controller', capwap_access_controller]
+            pool + ['option', 'capwap-controller', capwap_access_controller]
         )
 
         self.cli_set(

--- a/smoketest/scripts/cli/test_service_dhcpv6-server.py
+++ b/smoketest/scripts/cli/test_service_dhcpv6-server.py
@@ -108,6 +108,7 @@ class TestServiceDHCPv6Server(VyOSUnitTestSHIM.TestCase):
         self.cli_set(pool + ['lease-time', 'default', lease_time])
         self.cli_set(pool + ['lease-time', 'maximum', max_lease_time])
         self.cli_set(pool + ['lease-time', 'minimum', min_lease_time])
+        self.cli_set(pool + ['option', 'capwap-controller', dns_1])
         self.cli_set(pool + ['option', 'name-server', dns_1])
         self.cli_set(pool + ['option', 'name-server', dns_2])
         self.cli_set(pool + ['option', 'name-server', dns_2])
@@ -154,6 +155,10 @@ class TestServiceDHCPv6Server(VyOSUnitTestSHIM.TestCase):
         self.verify_config_value(obj, ['Dhcp6', 'shared-networks', 0, 'subnet6'], 'max-valid-lifetime', int(max_lease_time))
 
         # Verify options
+        self.verify_config_object(
+                obj,
+                ['Dhcp6', 'shared-networks', 0, 'subnet6', 0, 'option-data'],
+                {'name': 'capwap-ac-v6', 'data': dns_1})
         self.verify_config_object(
                 obj,
                 ['Dhcp6', 'shared-networks', 0, 'subnet6', 0, 'option-data'],


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
Add the possibility to declare option 138 in the dhcp-server.
This is needed to support devices using CAPWAP-AC as a way of discovering their controller.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
https://vyos.dev/T7310 

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Minor update to config, checked the JSON outputted to be valid with KEA, and verified that KEA supports option 138 natively

Below is the config option
"""
configure
set service dhcp-server shared-network-name <name> option capwap-access-controller <address>
commit
"""

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
