### PR TITLE
T7302: add vyos-commitd support for commit dry-run

### DIFF
--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -149,6 +149,18 @@ class Config(object):
             return self._running_config
         return self._session_config
 
+    def get_bool_attr(self, attr) -> bool:
+        if not hasattr(self, attr):
+            return False
+        else:
+            tmp = getattr(self, attr)
+            if not isinstance(tmp, bool):
+                return False
+        return tmp
+
+    def set_bool_attr(self, attr, val):
+        setattr(self, attr, val)
+
     def _make_path(self, path):
         # Backwards-compatibility stuff: original implementation used string paths
         # libvyosconfig paths are lists, but since node names cannot contain whitespace,

--- a/python/vyos/configdep.py
+++ b/python/vyos/configdep.py
@@ -102,11 +102,16 @@ def run_config_mode_script(target: str, config: 'Config'):
     mod = load_as_module(name, path)
 
     config.set_level([])
+    dry_run = config.get_bool_attr('dry_run')
     try:
         c = mod.get_config(config)
         mod.verify(c)
-        mod.generate(c)
-        mod.apply(c)
+        if not dry_run:
+            mod.generate(c)
+            mod.apply(c)
+        else:
+            if hasattr(mod, 'call_dependents'):
+                mod.call_dependents()
     except (VyOSError, ConfigError) as e:
         raise ConfigError(str(e)) from e
 

--- a/src/services/vyos-commitd
+++ b/src/services/vyos-commitd
@@ -233,8 +233,9 @@ def initialization(session: Session) -> Session:
     scripts_called = []
     setattr(config, 'scripts_called', scripts_called)
 
-    dry_run = False
-    setattr(config, 'dry_run', dry_run)
+    dry_run = session.dry_run
+    config.set_bool_attr('dry_run', dry_run)
+    logger.debug(f'commit dry_run is {dry_run}')
 
     session.config = config
 
@@ -247,11 +248,16 @@ def run_script(script_name: str, config: Config, args: list) -> tuple[bool, str]
     script = conf_mode_scripts[script_name]
     script.argv = args
     config.set_level([])
+    dry_run = config.get_bool_attr('dry_run')
     try:
         c = script.get_config(config)
         script.verify(c)
-        script.generate(c)
-        script.apply(c)
+        if not dry_run:
+            script.generate(c)
+            script.apply(c)
+        else:
+            if hasattr(script, 'call_dependents'):
+                script.call_dependents()
     except ConfigError as e:
         logger.error(e)
         return False, str(e)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

This adds support for commit dry-run to the commit daemon vyos-commitd (nee vyos-configd).
The option dry-run will run only the functions
`get_config`
`verify`
for all scheduled config mode scripts _and their dependencies_, and return the results.

Testing will be simpler after https://vyos.dev/T7321, but one can confirm behavior as follows:

```
vyos@vyos:~$ sudo systemctl start vyos-commitd
vyos@vyos:~$ sudo systemctl restart vyconfd
vyos@vyos:~$ python3
Python 3.11.2 (main, Nov 30 2024, 21:22:50) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from vyos.proto import vyconf_client
>>> out = vyconf_client.send_request('setup_session')
>>> stok = out.output
>>> out = vyconf_client.send_request('set', token=stok, path=["service", "https", "api", "rest"])
>>> out = vyconf_client.send_request('commit', token=stok, dry_run=True)
>>> print(out.output)

WARNING: No certificate specified, using build-in self-signed
certificates. Do not use them in a production environment!

At least one HTTPS API key is required unless GraphQL token
authentication is enabled!
>>> out = vyconf_client.send_request('set', token=stok, path=["service", "https", "api", "keys", "id", "foo", "key", "baz"])
>>> out
Response(status='SUCCESS', output=None, error=None, warning=None)
>>> out = vyconf_client.send_request('commit', token=stok, dry_run=True)

```
[ confirm in another terminal that:
```
vyos@vyos:~$ systemctl status vyos-http-api
Unit vyos-http-api.service could not be found.
```
]

`>>> out = vyconf_client.send_request('commit', token=stok)`

[confirm in another terminal that:
```
vyos@vyos:~$ systemctl status vyos-http-api
● vyos-http-api.service - VyOS HTTP API service
     Loaded: loaded (/run/systemd/system/vyos-http-api.service; disabled; preset: enabled)
     Active: active (running) since Fri 2025-04-04 17:02:34 UTC; 33s ago
```
]

A more detailed test confirms config dependencies are correctly being called, themselves restricted to dry-run.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
