### PR TITLE
frrender: T7273: always start from the configs root level

### DIFF
--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -60,6 +60,10 @@ def get_frrender_dict(conf, argv=None) -> dict:
     from vyos.configdict import get_dhcp_interfaces
     from vyos.configdict import get_pppoe_interfaces
 
+    # We need to re-set the CLI path to the root level, as this function uses
+    # conf.exists() with an absolute path form the CLI root
+    conf.set_level([])
+
     # Create an empty dictionary which will be filled down the code path and
     # returned to the caller
     dict = {}
@@ -599,8 +603,10 @@ def get_frrender_dict(conf, argv=None) -> dict:
         dict.update({'vrf' : vrf})
 
     if os.path.exists(frr_debug_enable):
+        print(f'---- get_frrender_dict({conf}) ----')
         import pprint
         pprint.pprint(dict)
+        print('-----------------------------------')
 
     return dict
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Working on T7273 revealed that when committing the following CLI config `set interfaces vxlan vxlan0 parameters neighbor-suppress` the CLI level queried via `conf.get_level()` was at `['interfaces', 'vxlan']`.

This had the side effect that queries on the configuration like: `conf.exists(['protocols', 'bgp'])` returned false, as it would look accidently at the level: `['interfaces', 'vxlan', 'protocols', 'bgp']`.

This error was there from the beginning of the FRRender class implementation.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7273

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4227

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
