### PR TITLE
kea: T7324: Fix kea_get_domain_from_subnet_id returning incorrect value

### DIFF
--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -483,10 +483,10 @@ def kea_get_domain_from_subnet_id(config, inet, subnet_id):
                     if option['name'] == 'domain-name':
                         return option['data']
 
-            # domain-name is not found in subnet, fallback to shared-network pool option
-            for option in network['option-data']:
-                if option['name'] == 'domain-name':
-                    return option['data']
+                # domain-name is not found in subnet, fallback to shared-network pool option
+                for option in network['option-data']:
+                    if option['name'] == 'domain-name':
+                        return option['data']
 
     return None
 


### PR DESCRIPTION
## Change summary
Due to an indentation error, the `kea_get_domain_from_subnet_id` function in `kea.py` does not return the correct domain name for a subnet where the domain name value is configured within the shared-network-name options rather than subnet options.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T7324

## Related PR(s)

## How to test / Smoketest result
```
vyos@vyos:~$ sudo python3 /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp
test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
test_dhcp_high_availability (__main__.TestServiceDHCPServer.test_dhcp_high_availability) ... ok
test_dhcp_high_availability_standby (__main__.TestServiceDHCPServer.test_dhcp_high_availability_standby) ... ok
test_dhcp_hostsd_lease_sync (__main__.TestServiceDHCPServer.test_dhcp_hostsd_lease_sync) ... ok
test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
test_dhcp_on_interface_with_vrf (__main__.TestServiceDHCPServer.test_dhcp_on_interface_with_vrf) ... ok
test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... ok
test_dhcp_single_pool_options_scoped (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options_scoped) ... ok
test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... ok
test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... ok

----------------------------------------------------------------------
Ran 12 tests in 42.787s

OK
```

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
