### PR TITLE
T7325: wifi: mac80211_hwsim kernel module no longer supports VLAN interfaces in smoketests

### DIFF
--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -46,6 +46,8 @@ dhclient_process_name = 'dhclient'
 dhcp6c_base_dir = directories['dhcp6_client_dir']
 dhcp6c_process_name = 'dhcp6c'
 
+MSG_TESTCASE_UNSUPPORTED = 'unsupported on interface family'
+
 server_ca_root_cert_data = """
 MIIBcTCCARagAwIBAgIUDcAf1oIQV+6WRaW7NPcSnECQ/lUwCgYIKoZIzj0EAwIw
 HjEcMBoGA1UEAwwTVnlPUyBzZXJ2ZXIgcm9vdCBDQTAeFw0yMjAyMTcxOTQxMjBa
@@ -136,6 +138,7 @@ def is_mirrored_to(interface, mirror_if, qdisc):
     if mirror_if in tmp:
         ret_val = True
     return ret_val
+
 class BasicInterfaceTest:
     class TestCase(VyOSUnitTestSHIM.TestCase):
         _test_dhcp = False
@@ -219,7 +222,7 @@ class BasicInterfaceTest:
 
         def test_dhcp_disable_interface(self):
             if not self._test_dhcp:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             # When interface is configured as admin down, it must be admin down
             # even when dhcpc starts on the given interface
@@ -242,7 +245,7 @@ class BasicInterfaceTest:
 
         def test_dhcp_client_options(self):
             if not self._test_dhcp or not self._test_vrf:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             client_id = 'VyOS-router'
             distance = '100'
@@ -282,7 +285,7 @@ class BasicInterfaceTest:
 
         def test_dhcp_vrf(self):
             if not self._test_dhcp or not self._test_vrf:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             cli_default_metric = default_value(self._base_path + [self._interfaces[0],
                                                'dhcp-options', 'default-route-distance'])
@@ -339,7 +342,7 @@ class BasicInterfaceTest:
 
         def test_dhcpv6_vrf(self):
             if not self._test_ipv6_dhcpc6 or not self._test_vrf:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             vrf_name = 'purple6'
             self.cli_set(['vrf', 'name', vrf_name, 'table', '65001'])
@@ -391,7 +394,7 @@ class BasicInterfaceTest:
 
         def test_move_interface_between_vrf_instances(self):
             if not self._test_vrf:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             vrf1_name = 'smoketest_mgmt1'
             vrf1_table = '5424'
@@ -436,7 +439,7 @@ class BasicInterfaceTest:
 
         def test_add_to_invalid_vrf(self):
             if not self._test_vrf:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             # move interface into first VRF
             for interface in self._interfaces:
@@ -454,7 +457,7 @@ class BasicInterfaceTest:
 
         def test_span_mirror(self):
             if not self._mirror_interfaces:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             # Check the two-way mirror rules of ingress and egress
             for mirror in self._mirror_interfaces:
@@ -563,7 +566,7 @@ class BasicInterfaceTest:
         def test_ipv6_link_local_address(self):
             # Common function for IPv6 link-local address assignemnts
             if not self._test_ipv6:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             for interface in self._interfaces:
                 base = self._base_path + [interface]
@@ -594,7 +597,7 @@ class BasicInterfaceTest:
 
         def test_interface_mtu(self):
             if not self._test_mtu:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             for intf in self._interfaces:
                 base = self._base_path + [intf]
@@ -614,7 +617,7 @@ class BasicInterfaceTest:
             # Testcase if MTU can be changed to 1200 on non IPv6
             # enabled interfaces
             if not self._test_mtu or not self._test_ipv6:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             old_mtu = self._mtu
             self._mtu = '1200'
@@ -650,7 +653,7 @@ class BasicInterfaceTest:
             # which creates a wlan0 and wlan1 interface which will fail the
             # tearDown() test in the end that no interface is allowed to survive!
             if not self._test_vlan:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             for interface in self._interfaces:
                 base = self._base_path + [interface]
@@ -695,7 +698,7 @@ class BasicInterfaceTest:
             # which creates a wlan0 and wlan1 interface which will fail the
             # tearDown() test in the end that no interface is allowed to survive!
             if not self._test_vlan or not self._test_mtu:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             mtu_1500 = '1500'
             mtu_9000 = '9000'
@@ -741,7 +744,7 @@ class BasicInterfaceTest:
             # which creates a wlan0 and wlan1 interface which will fail the
             # tearDown() test in the end that no interface is allowed to survive!
             if not self._test_vlan:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             for interface in self._interfaces:
                 base = self._base_path + [interface]
@@ -811,7 +814,7 @@ class BasicInterfaceTest:
         def test_vif_8021q_lower_up_down(self):
             # Testcase for https://vyos.dev/T3349
             if not self._test_vlan:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             for interface in self._interfaces:
                 base = self._base_path + [interface]
@@ -851,7 +854,7 @@ class BasicInterfaceTest:
             # which creates a wlan0 and wlan1 interface which will fail the
             # tearDown() test in the end that no interface is allowed to survive!
             if not self._test_qinq:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             for interface in self._interfaces:
                 base = self._base_path + [interface]
@@ -918,7 +921,7 @@ class BasicInterfaceTest:
             # which creates a wlan0 and wlan1 interface which will fail the
             # tearDown() test in the end that no interface is allowed to survive!
             if not self._test_qinq:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             for interface in self._interfaces:
                 base = self._base_path + [interface]
@@ -956,7 +959,7 @@ class BasicInterfaceTest:
 
         def test_interface_ip_options(self):
             if not self._test_ip:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             arp_tmo = '300'
             mss = '1420'
@@ -1058,7 +1061,7 @@ class BasicInterfaceTest:
 
         def test_interface_ipv6_options(self):
             if not self._test_ipv6:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             mss = '1400'
             dad_transmits = '10'
@@ -1119,7 +1122,7 @@ class BasicInterfaceTest:
 
         def test_dhcpv6_client_options(self):
             if not self._test_ipv6_dhcpc6:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             duid_base = 10
             for interface in self._interfaces:
@@ -1170,7 +1173,7 @@ class BasicInterfaceTest:
 
         def test_dhcpv6pd_auto_sla_id(self):
             if not self._test_ipv6_pd:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             prefix_len = '56'
             sla_len = str(64 - int(prefix_len))
@@ -1231,7 +1234,7 @@ class BasicInterfaceTest:
 
         def test_dhcpv6pd_manual_sla_id(self):
             if not self._test_ipv6_pd:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             prefix_len = '56'
             sla_len = str(64 - int(prefix_len))
@@ -1297,7 +1300,7 @@ class BasicInterfaceTest:
 
         def test_eapol(self):
             if not self._test_eapol:
-                self.skipTest('not supported')
+                self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             cfg_dir = '/run/wpa_supplicant'
 

--- a/smoketest/scripts/cli/test_interfaces_loopback.py
+++ b/smoketest/scripts/cli/test_interfaces_loopback.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2020-2023 VyOS maintainers and contributors
+# Copyright (C) 2020-2025 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -17,6 +17,7 @@
 import unittest
 
 from base_interfaces_test import BasicInterfaceTest
+from base_interfaces_test import MSG_TESTCASE_UNSUPPORTED
 from netifaces import interfaces
 
 from vyos.utils.network import is_intf_addr_assigned
@@ -53,7 +54,7 @@ class LoopbackInterfaceTest(BasicInterfaceTest.TestCase):
             self.assertTrue(is_intf_addr_assigned('lo', addr))
 
     def test_interface_disable(self):
-        self.skipTest('not supported')
+        self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/smoketest/scripts/cli/test_interfaces_virtual-ethernet.py
+++ b/smoketest/scripts/cli/test_interfaces_virtual-ethernet.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2023-2024 VyOS maintainers and contributors
+# Copyright (C) 2023-2025 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -33,9 +33,6 @@ class VEthInterfaceTest(BasicInterfaceTest.TestCase):
         cls._interfaces = list(cls._options)
         # call base-classes classmethod
         super(VEthInterfaceTest, cls).setUpClass()
-
-    def test_vif_8021q_mtu_limits(self):
-        self.skipTest('not supported')
 
     # As we always need a pair of veth interfaces, we can not rely on the base
     # class check to determine if there is a dhcp6c or dhclient instance running.


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Upgrading to Linux 6.6.85 will make the WIFI interface tests fail because of:

```
8021q: VLANs not supported on wlan0
8021q: VLANs not supported on wlan1
```

This is most likely b/c of commit https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=3561442599804905c3defca241787cd4546e99a7

Running this on a platform with a real wifi card still works.

```
10: wlan0.10@wlan0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state LOWERLAYERDOWN group default qlen 1000
    link/ether 0a:d2:3e:3c:d3:40 brd ff:ff:ff:ff:ff:ff
    inet 1.1.1.1/24 brd 1.1.1.255 scope global wlan0.10
       valid_lft forever preferred_lft forever
```
```
vyos@vyos# run show ver kernel
6.6.85-vyos
```
Do not run VIF based smoketests if `mac80211_hwsim` driver is in use

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7325

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

```
test_add_multiple_ip_addresses (__main__.WirelessInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.WirelessInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.WirelessInterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.WirelessInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.WirelessInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.WirelessInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.WirelessInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.WirelessInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol (__main__.WirelessInterfaceTest.test_eapol) ... skipped 'testcase unsupported on given interface type'
test_interface_description (__main__.WirelessInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.WirelessInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.WirelessInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.WirelessInterfaceTest.test_interface_ipv6_options) ... skipped 'testcase unsupported on given interface type'
test_interface_mtu (__main__.WirelessInterfaceTest.test_interface_mtu) ... skipped 'testcase unsupported on given interface type'
test_ipv6_link_local_address (__main__.WirelessInterfaceTest.test_ipv6_link_local_address) ... skipped 'testcase unsupported on given interface type'
test_move_interface_between_vrf_instances (__main__.WirelessInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.WirelessInterfaceTest.test_mtu_1200_no_ipv6_interface) ... skipped 'testcase unsupported on given interface type'
test_span_mirror (__main__.WirelessInterfaceTest.test_span_mirror) ... skipped 'testcase unsupported on given interface type'
test_vif_8021q_interfaces (__main__.WirelessInterfaceTest.test_vif_8021q_interfaces) ... skipped 'testcase unsupported on given interface type'
test_vif_8021q_lower_up_down (__main__.WirelessInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'testcase unsupported on given interface type'
test_vif_8021q_mtu_limits (__main__.WirelessInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'testcase unsupported on given interface type'
test_vif_8021q_qos_change (__main__.WirelessInterfaceTest.test_vif_8021q_qos_change) ... skipped 'testcase unsupported on given interface type'
test_vif_s_8021ad_vlan_interfaces (__main__.WirelessInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'testcase unsupported on given interface type'
test_vif_s_protocol_change (__main__.WirelessInterfaceTest.test_vif_s_protocol_change) ... skipped 'testcase unsupported on given interface type'
test_wireless_access_point_bridge (__main__.WirelessInterfaceTest.test_wireless_access_point_bridge) ... ok
test_wireless_add_single_ip_address (__main__.WirelessInterfaceTest.test_wireless_add_single_ip_address) ... ok
test_wireless_hostapd_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_config) ... ok
test_wireless_hostapd_he_2ghz_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_he_2ghz_config) ... ok
test_wireless_hostapd_he_6ghz_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_he_6ghz_config) ... ok
test_wireless_hostapd_vht_mu_beamformer_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_vht_mu_beamformer_config) ... ok
test_wireless_hostapd_vht_su_beamformer_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_vht_su_beamformer_config) ... ok
test_wireless_hostapd_wpa_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_wpa_config) ... ok
test_wireless_security_station_address (__main__.WirelessInterfaceTest.test_wireless_security_station_address) ... ok

----------------------------------------------------------------------
Ran 35 tests in 362.423s

OK (skipped=12)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
