### PR TITLE
firewall: T7333: Use separate cache keys per inet family

### DIFF
--- a/src/services/vyos-domain-resolver
+++ b/src/services/vyos-domain-resolver
@@ -92,12 +92,14 @@ def resolve(domains, ipv6=False):
     for domain in domains:
         resolved = fqdn_resolve(domain, ipv6=ipv6)
 
+        cache_key = f'{domain}_ipv6' if ipv6 else domain
+
         if resolved and cache:
-            domain_state[domain] = resolved
+            domain_state[cache_key] = resolved
         elif not resolved:
-            if domain not in domain_state:
+            if cache_key not in domain_state:
                 continue
-            resolved = domain_state[domain]
+            resolved = domain_state[cache_key]
 
         ip_list = ip_list | resolved
     return ip_list


### PR DESCRIPTION
Cache keys were shared by IPv4/IPv6 resolution, causing script to try populate ipv6 sets with ipv4 addresses

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
- Use a separate cache key for domain resolver for IPv4 and IPv6 addresses

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7333

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_firewall.py
DEBUG - test_bridge_firewall (__main__.TestFirewall.test_bridge_firewall) ... ok
DEBUG - test_cyclic_jump_validation (__main__.TestFirewall.test_cyclic_jump_validation) ... ok
DEBUG - test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
DEBUG - test_geoip (__main__.TestFirewall.test_geoip) ... ok
DEBUG - test_gre_match (__main__.TestFirewall.test_gre_match) ... ok
DEBUG - test_groups (__main__.TestFirewall.test_groups) ... ok
DEBUG - test_ipsec_metadata_match (__main__.TestFirewall.test_ipsec_metadata_match) ... ok
DEBUG - test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
DEBUG - test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
DEBUG - test_ipv4_dynamic_groups (__main__.TestFirewall.test_ipv4_dynamic_groups) ... ok
DEBUG - test_ipv4_global_state (__main__.TestFirewall.test_ipv4_global_state) ... ok
DEBUG - test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
DEBUG - test_ipv4_remote_group (__main__.TestFirewall.test_ipv4_remote_group) ... ok
DEBUG - test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
DEBUG - test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... ok
DEBUG - test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
DEBUG - test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
DEBUG - test_ipv6_dynamic_groups (__main__.TestFirewall.test_ipv6_dynamic_groups) ... ok
DEBUG - test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
DEBUG - test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
DEBUG - test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
DEBUG - test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
DEBUG - test_timeout_sysctl (__main__.TestFirewall.test_timeout_sysctl) ... ok
DEBUG - test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
DEBUG - test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... ok
DEBUG - test_zone_with_vrf (__main__.TestFirewall.test_zone_with_vrf) ... ok
DEBUG - 
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 26 tests in 127.352s
DEBUG - 
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
