### PR TITLE
T7316: Add MTU validation for interfaces with MTU less then 1200

### DIFF
--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -356,6 +356,7 @@ def verify_vlan_config(config):
         verify_vrf(vlan)
         verify_mirror_redirect(vlan)
         verify_mtu_parent(vlan, config)
+        verify_mtu_ipv6(vlan)
 
     # 802.1ad (Q-in-Q) VLANs
     for s_vlan_id in config.get('vif_s', {}):
@@ -367,6 +368,7 @@ def verify_vlan_config(config):
         verify_vrf(s_vlan)
         verify_mirror_redirect(s_vlan)
         verify_mtu_parent(s_vlan, config)
+        verify_mtu_ipv6(s_vlan)
 
         for c_vlan_id in s_vlan.get('vif_c', {}):
             c_vlan = s_vlan['vif_c'][c_vlan_id]
@@ -378,6 +380,7 @@ def verify_vlan_config(config):
             verify_mirror_redirect(c_vlan)
             verify_mtu_parent(c_vlan, config)
             verify_mtu_parent(c_vlan, s_vlan)
+            verify_mtu_ipv6(c_vlan)
 
 
 def verify_diffie_hellman_length(file, min_keysize):

--- a/src/conf_mode/interfaces_bridge.py
+++ b/src/conf_mode/interfaces_bridge.py
@@ -25,6 +25,7 @@ from vyos.configdict import has_vlan_subinterface_configured
 from vyos.configverify import verify_dhcpv6
 from vyos.configverify import verify_mirror_redirect
 from vyos.configverify import verify_vrf
+from vyos.configverify import verify_mtu_ipv6
 from vyos.ifconfig import BridgeIf
 from vyos.configdict import has_address_configured
 from vyos.configdict import has_vrf_configured
@@ -136,6 +137,7 @@ def verify(bridge):
 
     verify_dhcpv6(bridge)
     verify_vrf(bridge)
+    verify_mtu_ipv6(bridge)
     verify_mirror_redirect(bridge)
 
     ifname = bridge['ifname']

--- a/src/conf_mode/interfaces_pseudo-ethernet.py
+++ b/src/conf_mode/interfaces_pseudo-ethernet.py
@@ -27,6 +27,7 @@ from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_source_interface
 from vyos.configverify import verify_vlan_config
 from vyos.configverify import verify_mtu_parent
+from vyos.configverify import verify_mtu_ipv6
 from vyos.configverify import verify_mirror_redirect
 from vyos.ifconfig import MACVLANIf
 from vyos.utils.network import interface_exists
@@ -71,6 +72,7 @@ def verify(peth):
     verify_vrf(peth)
     verify_address(peth)
     verify_mtu_parent(peth, peth['parent'])
+    verify_mtu_ipv6(peth)
     verify_mirror_redirect(peth)
     # use common function to verify VLAN configuration
     verify_vlan_config(peth)

--- a/src/conf_mode/interfaces_virtual-ethernet.py
+++ b/src/conf_mode/interfaces_virtual-ethernet.py
@@ -23,6 +23,7 @@ from vyos.configdict import get_interface_dict
 from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_vrf
+from vyos.configverify import verify_mtu_ipv6
 from vyos.ifconfig import VethIf
 from vyos.utils.network import interface_exists
 airbag.enable()
@@ -62,6 +63,7 @@ def verify(veth):
         return None
 
     verify_vrf(veth)
+    verify_mtu_ipv6(veth)
     verify_address(veth)
 
     if 'peer_name' not in veth:

--- a/src/conf_mode/interfaces_vti.py
+++ b/src/conf_mode/interfaces_vti.py
@@ -20,6 +20,7 @@ from vyos.config import Config
 from vyos.configdict import get_interface_dict
 from vyos.configverify import verify_mirror_redirect
 from vyos.configverify import verify_vrf
+from vyos.configverify import verify_mtu_ipv6
 from vyos.ifconfig import VTIIf
 from vyos import ConfigError
 from vyos import airbag
@@ -40,6 +41,7 @@ def get_config(config=None):
 
 def verify(vti):
     verify_vrf(vti)
+    verify_mtu_ipv6(vti)
     verify_mirror_redirect(vti)
     return None
 

--- a/src/conf_mode/interfaces_wwan.py
+++ b/src/conf_mode/interfaces_wwan.py
@@ -26,6 +26,7 @@ from vyos.configverify import verify_authentication
 from vyos.configverify import verify_interface_exists
 from vyos.configverify import verify_mirror_redirect
 from vyos.configverify import verify_vrf
+from vyos.configverify import verify_mtu_ipv6
 from vyos.ifconfig import WWANIf
 from vyos.utils.dict import dict_search
 from vyos.utils.process import cmd
@@ -98,6 +99,7 @@ def verify(wwan):
     verify_interface_exists(wwan, ifname)
     verify_authentication(wwan)
     verify_vrf(wwan)
+    verify_mtu_ipv6(wwan)
     verify_mirror_redirect(wwan)
 
     return None


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
disallow MTU < 1280 bytes when IPv6 is enabled on the interface.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7316
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```


Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Before fix:
Traceback error:
```
  File "/usr/lib/python3/dist-packages/vyos/utils/process.py", line 155, in cmd
    raise OSError(code, feedback)
FileNotFoundError: [Errno 2] failed to run command: ip addr add fe80::a9:a9ff:fe31:18ce/64 dev peth20
returned:
exit code: 2

noteworthy:
cmd 'ip addr add fe80::a9:a9ff:fe31:18ce/64 dev peth20'
returned (out):

returned (err):
RTNETLINK answers: Invalid argument

[[interfaces pseudo-ethernet peth20]] failed
Commit failed
```
After fix:
```
vyos@vyos# commit
[ interfaces pseudo-ethernet peth20 ]
link-local IPv6 address will be configured on interface "peth20", the
required minimum MTU is "1280"!
[[interfaces pseudo-ethernet peth20]] failed
Commit failed
[edit]

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly