### PR TITLE
bridge: T7322:  fix slow performance of allowed vlan

### DIFF
--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -626,6 +626,23 @@ def get_vlan_ids(interface):
 
     return vlan_ids
 
+def get_vlans_ids_and_range(interface):
+	vlan_ids = set()
+
+	vlan_filter_status  = json.loads(cmd(f'bridge -j -d vlan show dev {interface}'))
+
+    if vlan_filter_status is not None:
+        for interface_status in vlan_filter_status:
+			for vlan_entry in iface.get("vlans", []):
+				start = vlan_entry["vlan"]
+				end = vlan_entry.get("vlanEnd")
+				if end:
+					vlan_ids.add(f"{start}-{end}")
+				else:
+					vlan_ids.add(str(start))
+
+	return vlan_ids
+
 def get_accel_dict(config, base, chap_secrets, with_pki=False):
     """
     Common utility function to retrieve and mangle the Accel-PPP configuration

--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -627,21 +627,21 @@ def get_vlan_ids(interface):
     return vlan_ids
 
 def get_vlans_ids_and_range(interface):
-	vlan_ids = set()
+    vlan_ids = set()
 
-	vlan_filter_status  = json.loads(cmd(f'bridge -j -d vlan show dev {interface}'))
+    vlan_filter_status = json.loads(cmd(f'bridge -j -d vlan show dev {interface}'))
 
     if vlan_filter_status is not None:
         for interface_status in vlan_filter_status:
-			for vlan_entry in iface.get("vlans", []):
-				start = vlan_entry["vlan"]
-				end = vlan_entry.get("vlanEnd")
-				if end:
-					vlan_ids.add(f"{start}-{end}")
-				else:
-					vlan_ids.add(str(start))
+            for vlan_entry in interface_status.get("vlans", []):
+                start = vlan_entry["vlan"]
+                end = vlan_entry.get("vlanEnd")
+                if end:
+                    vlan_ids.add(f"{start}-{end}")
+                else:
+                    vlan_ids.add(str(start))
 
-	return vlan_ids
+    return vlan_ids
 
 def get_accel_dict(config, base, chap_secrets, with_pki=False):
     """

--- a/python/vyos/ifconfig/bridge.py
+++ b/python/vyos/ifconfig/bridge.py
@@ -19,7 +19,7 @@ from vyos.utils.assertion import assert_list
 from vyos.utils.assertion import assert_positive
 from vyos.utils.dict import dict_search
 from vyos.utils.network import interface_exists
-from vyos.configdict import get_vlan_ids
+from vyos.configdict import get_vlans_ids_and_range
 from vyos.configdict import list_diff
 
 @Interface.register
@@ -380,7 +380,7 @@ class BridgeIf(Interface):
                     add_vlan = []
                     native_vlan_id = None
                     allowed_vlan_ids= []
-                    cur_vlan_ids = get_vlan_ids(interface)
+                    cur_vlan_ids = get_vlans_ids_and_range(interface)
 
                     if 'native_vlan' in interface_config:
                         vlan_id = interface_config['native_vlan']
@@ -389,14 +389,8 @@ class BridgeIf(Interface):
 
                     if 'allowed_vlan' in interface_config:
                         for vlan in interface_config['allowed_vlan']:
-                            vlan_range = vlan.split('-')
-                            if len(vlan_range) == 2:
-                                for vlan_add in range(int(vlan_range[0]),int(vlan_range[1]) + 1):
-                                    add_vlan.append(str(vlan_add))
-                                    allowed_vlan_ids.append(str(vlan_add))
-                            else:
-                                add_vlan.append(vlan)
-                                allowed_vlan_ids.append(vlan)
+                            add_vlan.append(vlan)
+                            allowed_vlan_ids.append(vlan)
 
                     # Remove redundant VLANs from the system
                     for vlan in list_diff(cur_vlan_ids, add_vlan):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Ranges that are configured in allowed-vlans (e.g. 1-4094), are deconstructed into all of their individual VLANs, which is unnecessary for the execution of these:
`bridge vlan add dev {interface} vid {vlan} master`
`bridge vlan del dev {interface} vid {vlan} master`

This leads to a very long commit time when doing large ranges. This change eliminates that unnecessary deconstruction.

Example:
Execution time of `allowed-vlans 1-4094` in current state: 38.94 seconds
Execution time of `allowed-vlans 1-4094` without unnecessary deconstruction of range: 4.94 seconds
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Performance improvement
## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7322
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```set interfaces bridge br0 member interface eth0 allowed-vlan 1-4094```
You will see a massive  improvement on commit times, especially on slower systems.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
