### PR TITLE
T7343: IPsec add traffic-selector handling for VTI interfaces

### DIFF
--- a/data/templates/ipsec/swanctl/peer.j2
+++ b/data/templates/ipsec/swanctl/peer.j2
@@ -68,8 +68,19 @@
                 rekey_packets = 0
                 rekey_time = 0s
 {%     endif %}
-                local_ts = 0.0.0.0/0,::/0
-                remote_ts = 0.0.0.0/0,::/0
+{#     set default traffic-selectors #}
+{%     set local_ts = '0.0.0.0/0,::/0' %}
+{%     set remote_ts = '0.0.0.0/0,::/0' %}
+{%     if peer_conf.vti.traffic_selector is vyos_defined %}
+{%         if peer_conf.vti.traffic_selector.local is vyos_defined and peer_conf.vti.traffic_selector.local.prefix is vyos_defined %}
+{%             set local_ts = peer_conf.vti.traffic_selector.local.prefix | join(',') %}
+{%         endif %}
+{%         if peer_conf.vti.traffic_selector.remote is vyos_defined and peer_conf.vti.traffic_selector.remote.prefix is vyos_defined %}
+{%             set remote_ts = peer_conf.vti.traffic_selector.remote.prefix | join(',') %}
+{%         endif %}
+{%     endif %}
+                local_ts = {{ local_ts }}
+                remote_ts = {{ remote_ts }}
                 updown = "/etc/ipsec.d/vti-up-down {{ peer_conf.vti.bind }}"
 {#              The key defaults to 0 and will match any policies which similarly do not have a lookup key configuration. #}
 {#              Thus we simply shift the key by one to also support a vti0 interface #}

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -1244,6 +1244,63 @@
                     <children>
                       #include <include/ipsec/bind.xml.i>
                       #include <include/ipsec/esp-group.xml.i>
+                      <node name="traffic-selector">
+                        <properties>
+                          <help>Traffic-selectors parameters</help>
+                        </properties>
+                        <children>
+                          <node name="local">
+                            <properties>
+                              <help>Local parameters for interesting traffic</help>
+                            </properties>
+                            <children>
+                              <leafNode name="prefix">
+                                <properties>
+                                  <help>Local IPv4 or IPv6 prefix</help>
+                                  <valueHelp>
+                                    <format>ipv4net</format>
+                                    <description>Local IPv4 prefix</description>
+                                  </valueHelp>
+                                  <valueHelp>
+                                    <format>ipv6net</format>
+                                    <description>Local IPv6 prefix</description>
+                                  </valueHelp>
+                                  <constraint>
+                                    <validator name="ipv4-prefix"/>
+                                    <validator name="ipv6-prefix"/>
+                                  </constraint>
+                                  <multi/>
+                                </properties>
+                              </leafNode>
+                            </children>
+                          </node>
+                          <node name="remote">
+                            <properties>
+                              <help>Remote parameters for interesting traffic</help>
+                            </properties>
+                            <children>
+                              <leafNode name="prefix">
+                                <properties>
+                                  <help>Remote IPv4 or IPv6 prefix</help>
+                                  <valueHelp>
+                                    <format>ipv4net</format>
+                                    <description>Remote IPv4 prefix</description>
+                                  </valueHelp>
+                                  <valueHelp>
+                                    <format>ipv6net</format>
+                                    <description>Remote IPv6 prefix</description>
+                                  </valueHelp>
+                                  <constraint>
+                                    <validator name="ipv4-prefix"/>
+                                    <validator name="ipv6-prefix"/>
+                                  </constraint>
+                                  <multi/>
+                                </properties>
+                              </leafNode>
+                            </children>
+                          </node>
+                        </children>
+                      </node>
                     </children>
                   </node>
                 </children>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary

Allow to set traffic-selector for VTI interfaces
We can set several local and remote IPv4 and IPv6 prefixes
    
```
set vpn ipsec site-to-site peer P1 vti traffic-selector local prefix 0.0.0.0/0
set vpn ipsec site-to-site peer P1 vti traffic-selector local prefix :/0
set vpn ipsec site-to-site peer P1 vti traffic-selector remote prefix 192.0.2.0/24
```


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Add traffic selectors for IPsec VTI interfaces

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7343
 * https://vyos.dev/T5874

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

Configure `traffic-selectors` for VTI, check the strongswan.conf
VyOS configuration:
```
set vpn ipsec authentication psk PSK id '192.0.2.1'
set vpn ipsec authentication psk PSK id '192.0.2.2'
set vpn ipsec authentication psk PSK secret '1234567890'
set vpn ipsec esp-group ESP-group lifetime '3600'
set vpn ipsec esp-group ESP-group mode 'tunnel'
set vpn ipsec esp-group ESP-group pfs 'enable'
set vpn ipsec esp-group ESP-group proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-group proposal 1 hash 'sha1'
set vpn ipsec ike-group IKE-group key-exchange 'ikev2'
set vpn ipsec ike-group IKE-group lifetime '28800'
set vpn ipsec ike-group IKE-group proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE-group proposal 1 hash 'sha1'
set vpn ipsec interface 'eth1'
set vpn ipsec site-to-site peer RIGHT authentication local-id '192.0.2.1'
set vpn ipsec site-to-site peer RIGHT authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer RIGHT authentication remote-id '192.0.2.2'
set vpn ipsec site-to-site peer RIGHT connection-type 'initiate'
set vpn ipsec site-to-site peer RIGHT ike-group 'IKE-group'
set vpn ipsec site-to-site peer RIGHT local-address '192.0.2.1'
set vpn ipsec site-to-site peer RIGHT remote-address '192.0.2.2'
set vpn ipsec site-to-site peer RIGHT vti bind 'vti1'
set vpn ipsec site-to-site peer RIGHT vti esp-group 'ESP-group'
set vpn ipsec site-to-site peer RIGHT vti traffic-selector local prefix '0.0.0.0/0'
set vpn ipsec site-to-site peer RIGHT vti traffic-selector local prefix '::/0'
set vpn ipsec site-to-site peer RIGHT vti traffic-selector remote prefix '192.0.2.1/32'
set vpn ipsec site-to-site peer RIGHT vti traffic-selector remote prefix '192.0.2.2/32'
set vpn ipsec site-to-site peer RIGHT vti traffic-selector remote prefix '2001:db8::/32'
```
check the strongswan.conf, expected IPv4 only traffic-slectrots:
```
vyos@r14# cat /etc/swanctl/swanctl.conf | grep _ts
                local_ts = 0.0.0.0/0,::/0
                remote_ts = 192.0.2.1/32,192.0.2.2/32,2001:db8::/32
[edit]
vyos@r14# 

```
 
Smoketest
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
test_dhcp_fail_handling (__main__.TestVPNIPsec.test_dhcp_fail_handling) ... ok
test_dmvpn (__main__.TestVPNIPsec.test_dmvpn) ... ok
test_flex_vpn_vips (__main__.TestVPNIPsec.test_flex_vpn_vips) ... ok
test_remote_access (__main__.TestVPNIPsec.test_remote_access) ... ok
test_remote_access_dhcp_fail_handling (__main__.TestVPNIPsec.test_remote_access_dhcp_fail_handling) ... ok
test_remote_access_eap_tls (__main__.TestVPNIPsec.test_remote_access_eap_tls) ... ok
test_remote_access_no_rekey (__main__.TestVPNIPsec.test_remote_access_no_rekey) ... ok
test_remote_access_pool_range (__main__.TestVPNIPsec.test_remote_access_pool_range) ... ok
test_remote_access_vti (__main__.TestVPNIPsec.test_remote_access_vti) ... ok
test_remote_access_x509 (__main__.TestVPNIPsec.test_remote_access_x509) ... ok
test_site_to_site (__main__.TestVPNIPsec.test_site_to_site) ... ok
test_site_to_site_vti (__main__.TestVPNIPsec.test_site_to_site_vti) ... ok
test_site_to_site_vti_ts_afi (__main__.TestVPNIPsec.test_site_to_site_vti_ts_afi) ... ok
test_site_to_site_x509 (__main__.TestVPNIPsec.test_site_to_site_x509) ... ok

----------------------------------------------------------------------
Ran 14 tests in 109.402s

OK
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
