### PR TITLE
interfaces: T7268: Add op-mode command for show all interfaces on system

### DIFF
--- a/op-mode-definitions/show-interfaces.xml.in
+++ b/op-mode-definitions/show-interfaces.xml.in
@@ -32,13 +32,21 @@
                 <script>ip -j link show | jq -r '.[].ifname'</script>
               </completionHelp>
             </properties>
-            <command>sudo ip -s link show dev $4</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --intf-name=$4</command>
+            <children>
+              <leafNode name="detail">
+                <properties>
+                  <help>Show system interface in JSON format</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --intf-name=$4 --detail</command>
+              </leafNode>
+            </children>
             <children>
               <leafNode name="json">
                 <properties>
                   <help>Show system interface in JSON format</help>
                 </properties>
-                <command>ip -j -s -d link show dev $4</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --intf-name=$4 --raw</command>
               </leafNode>
             </children>
           </tagNode>
@@ -46,13 +54,19 @@
             <properties>
               <help>Show all interfaces on this system</help>
             </properties>
-            <command>sudo ip -s link show</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_kernel</command>
             <children>
+              <leafNode name="detail">
+                <properties>
+                  <help>Show all interfaces in JSON format</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --detail</command>
+              </leafNode>
               <leafNode name="json">
                 <properties>
                   <help>Show all interfaces in JSON format</help>
                 </properties>
-                <command>ip -j -s -d link show</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --raw</command>
               </leafNode>
             </children>
           </node>

--- a/op-mode-definitions/show-interfaces.xml.in
+++ b/op-mode-definitions/show-interfaces.xml.in
@@ -26,6 +26,36 @@
             </properties>
             <command>${vyos_op_scripts_dir}/interfaces.py show_summary</command>
           </leafNode>
+          <tagNode name="kernel">
+            <properties>
+              <completionHelp>
+                <script>ip -j link show | jq -r '.[].ifname'</script>
+              </completionHelp>
+            </properties>
+            <command>sudo ip -s link show dev $4</command>
+            <children>
+              <leafNode name="json">
+                <properties>
+                  <help>Show system interface in JSON format</help>
+                </properties>
+                <command>ip -j -s -d link show dev $4</command>
+              </leafNode>
+            </children>
+          </tagNode>
+          <node name="kernel">
+            <properties>
+              <help>Show all interfaces on this system</help>
+            </properties>
+            <command>sudo ip -s link show</command>
+            <children>
+              <leafNode name="json">
+                <properties>
+                  <help>Show all interfaces in JSON format</help>
+                </properties>
+                <command>ip -j -s -d link show</command>
+              </leafNode>
+            </children>
+          </node>
         </children>
       </node>
     </children>

--- a/op-mode-definitions/show-interfaces.xml.in
+++ b/op-mode-definitions/show-interfaces.xml.in
@@ -40,8 +40,6 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --intf-name=$4 --detail</command>
               </leafNode>
-            </children>
-            <children>
               <leafNode name="json">
                 <properties>
                   <help>Show system interface in JSON format</help>
@@ -58,7 +56,7 @@
             <children>
               <leafNode name="detail">
                 <properties>
-                  <help>Show all interfaces in JSON format</help>
+                  <help>Show system interface in JSON format</help>
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --detail</command>
               </leafNode>

--- a/src/op_mode/interfaces.py
+++ b/src/op_mode/interfaces.py
@@ -346,11 +346,12 @@ def _format_kernel_data(data, detail):
         has_global = False
 
         for ip in interface['addr_info']:
-            if ip.get('scope') == 'global':
+            if ip.get('scope') in ('global', 'host'):
                 has_global = True
                 local = ip.get('local', '-')
                 prefixlen = ip.get('prefixlen', '')
                 ip_list.append(f"{local}/{prefixlen}")
+
 
         # If no global IP address, add '-'; indicates no IP address on interface
         if not has_global:

--- a/src/op_mode/interfaces.py
+++ b/src/op_mode/interfaces.py
@@ -309,12 +309,12 @@ def _get_kernel_data(raw, ifname = None, detail = False):
     if ifname:
         # Check if the interface exists
         if not interface_exists(ifname):
-            raise vyos.opmode.Error(f"{ifname} does not exist!")
-        int_name = f' dev {ifname}'
+            raise vyos.opmode.IncorrectValue(f"{ifname} does not exist!")
+        int_name = f'dev {ifname}'
     else:
         int_name = ''
 
-    kernel_interface = json.loads(cmd(f'ip -j -d -s address show{int_name}'))
+    kernel_interface = json.loads(cmd(f'ip -j -d -s address show {int_name}'))
 
     # Return early if raw
     if raw:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
This change adds a command to show all interfaces on the host system; not just those that are configurable by VyOS. This will allow the API to pull interfaces for dashboards that have been created by additionally installed packages or containers.

Syntax:
`show interfaces kernel`
`show interfaces kernel detail`
`show interfaces kernel json`

`show interfaces kernel <interface>`
`show interfaces kernel <interface> detail`
`show interfaces kernel <interface> json`

### `show interfaces kernel` (notice non-VyOS interfaces present)
```
Interface    IP Address          MAC                VRF        MTU  S/L    Description
-----------  ------------------  -----------------  -------  -----  -----  -------------
dum0         10.0.0.4/32         52:58:74:b1:69:69  default   1500  u/u
dum55        10.55.1.1/32        3e:62:ab:db:b9:31  test      1500  u/u
eth0         172.16.0.6/28       f4:52:14:cf:b7:27  default   1500  u/u    LAN Segments
eth1         -                   00:f0:cb:ef:de:55  default   1500  u/u
eth2         -                   00:f0:cb:ef:de:57  default   1500  u/u
eth3         10.55.0.1/24        00:f0:cb:ef:de:56  default   1500  A/D
             fd00::1/64
eth4         -                   f4:52:14:cf:b7:26  default   1500  u/D
eth5         10.243.100.1/16     d2:40:b0:6f:ef:ab  default   2800  u/u
eth6         10.244.249.28/16    6e:74:7d:bb:b7:6f  default   2800  u/u
lo           127.0.0.1/8         00:00:00:00:00:00  default  65536  u/u
             ::1/128
pim6reg      -                                      default   1452  u/u
tailscale0   100.113.245.121/32                     default   1280  u/u
wlan0        -                   06:33:c2:d1:14:40  default   1500  u/D
ztmosonlkl   10.244.100.10/24    02:45:3d:33:42:89  default   2800  u/u
```
###  `show interfaces kernel eth0 detail`
```
 Interface               | eth0
 IP Address              | 172.16.0.6/28
 MAC                     | f4:52:14:cf:b7:27
 VRF                     | default
 MTU                     | 1500
 S/L                     | u/u
 Description             | LAN Segments
 Device                  | Mellanox Technologies MT27500 Family [ConnectX-3] [15b3:1003]
 Alternate Names         | enp4s0d1
 Minimum MTU             | 68
 Maximum MTU             | 9900
 RX_Packets              | 71097024
 RX_Bytes                | 82417645611
 RX_Errors               | 0
 RX_Dropped              | 244758
 Receive Overrun Errors  | 0
 Received Multicast      | 9618172
 TX_Packets              | 119031343
 TX_Bytes                | 88422185319
 TX_Errors               | 0
 TX_Dropped              | 0
 Transmit Carrier Errors | 0
 Transmit Collisions     | 0
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7268
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
`show interfaces kernel`
`show interfaces kernel detail`
`show interfaces kernel json`
`show interfaces kernel <interface>`
`show interfaces kernel <interface> detail`
`show interfaces kernel <interface> json`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
