### PR TITLE
T7353: T7360: netplug: behavior change 1.3.8 -> 1.4 when interface with DHCP address looses carrier

### DIFF
--- a/src/etc/netplug/vyos-netplug-dhcp-client
+++ b/src/etc/netplug/vyos-netplug-dhcp-client
@@ -20,10 +20,10 @@ import sys
 from time import sleep
 
 from vyos.config import Config
-from vyos.configdict import get_interface_dict
-from vyos.ifconfig import Interface
 from vyos.ifconfig import Section
 from vyos.utils.boot import boot_configuration_complete
+from vyos.utils.process import cmd
+from vyos.utils.process import is_systemd_service_active
 from vyos.utils.commit import commit_in_progress
 from vyos import airbag
 
@@ -38,21 +38,29 @@ if not boot_configuration_complete():
     sys.exit(1)
 
 interface = sys.argv[1]
-# helper scripts should only work on physical interfaces not on individual
-# sub-interfaces. Moving e.g. a VLAN interface in/out a VRF will also trigger
-# this script which should be prohibited - bail out early
-if '.' in interface:
-    sys.exit(0)
 
 while commit_in_progress():
-    sleep(1)
+    sleep(0.250)
 
 in_out = sys.argv[2]
 config = Config()
 
 interface_path = ['interfaces'] + Section.get_config_path(interface).split()
-_, interface_config = get_interface_dict(
-    config, interface_path[:-1], ifname=interface, with_pki=True
-)
-if 'deleted' not in interface_config:
-    Interface(interface).update(interface_config)
+
+systemdV4_service = f'dhclient@{interface}.service'
+if in_out == 'out':
+    # Interface moved state to down
+    if is_systemd_service_active(systemdV4_service):
+        cmd(f'systemctl stop {systemdV4_service}')
+elif in_out == 'in':
+    if config.exists_effective(interface_path + ['address']):
+        tmp = config.return_effective_values(interface_path + ['address'])
+        # Always (re-)start the DHCP(v6) client service. If the DHCP(v6) client
+        # is already running - which could happen if the interface is re-
+        # configured in operational down state, it will have a backoff
+        # time increasing while not receiving a DHCP(v6) reply.
+        #
+        # To make the interface instantly available, and as for a DHCP(v6) lease
+        # we will re-start the service and thus cancel the backoff time.
+        if 'dhcp' in tmp:
+            cmd(f'systemctl restart {systemdV4_service}')

--- a/src/etc/netplug/vyos-netplug-dhcp-client
+++ b/src/etc/netplug/vyos-netplug-dhcp-client
@@ -48,10 +48,13 @@ config = Config()
 interface_path = ['interfaces'] + Section.get_config_path(interface).split()
 
 systemdV4_service = f'dhclient@{interface}.service'
+systemdV6_service = f'dhcp6c@{interface}.service'
 if in_out == 'out':
     # Interface moved state to down
     if is_systemd_service_active(systemdV4_service):
         cmd(f'systemctl stop {systemdV4_service}')
+    if is_systemd_service_active(systemdV6_service):
+        cmd(f'systemctl stop {systemdV6_service}')
 elif in_out == 'in':
     if config.exists_effective(interface_path + ['address']):
         tmp = config.return_effective_values(interface_path + ['address'])
@@ -64,3 +67,5 @@ elif in_out == 'in':
         # we will re-start the service and thus cancel the backoff time.
         if 'dhcp' in tmp:
             cmd(f'systemctl restart {systemdV4_service}')
+        if 'dhcpv6' in tmp:
+            cmd(f'systemctl restart {systemdV6_service}')

--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -557,6 +557,9 @@ start ()
     if [[ ! -z "$tmp" ]]; then
         vtysh -c "rpki start"
     fi
+
+    # Start netplug daemon
+    systemctl start netplug.service
 }
 
 stop()
@@ -574,8 +577,8 @@ stop()
     umount ${vyatta_configdir}
     log_action_end_msg $?
 
+    systemctl stop netplug.service
     systemctl stop vyconfd.service
-
     systemctl stop frr.service
 
     unmount_encrypted_config

--- a/src/systemd/netplug.service
+++ b/src/systemd/netplug.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Network cable hotplug management daemon
+Documentation=man:netplugd(8)
+After=vyos-router.service
+
+[Service]
+Type=forking
+PIDFile=/run/netplugd.pid
+ExecStart=/sbin/netplugd -c /etc/netplug/netplugd.conf -p /run/netplugd.pid

--- a/src/systemd/vyos.target
+++ b/src/systemd/vyos.target
@@ -1,3 +1,3 @@
 [Unit]
 Description=VyOS target
-After=multi-user.target
+After=multi-user.target vyos-grub-update.service


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

There is a behavior change from VyOS 1.3.8 -> 1.4.0 as when an interface configured with DHCP will loose it's carrier in VyOS 1.3.8 dhclient is stopped and the IP address is removed from the interface.

In VyOS 1.4 the DHCP assigned IP address stays active on the interface that just lost it's carrier.

In addition this fixes a bug that was present in VyOS 1.3.8 where the DHCP assigned IP address only got cleared on base interfaces like eth0 but not on any VLAN interface e.g. eth0.10.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7353
* https://vyos.dev/T7360

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/944

## How to test / Smoketest result

### DHCP server on VyOS 1.4.2

```
set interfaces ethernet eth1 vif 1111 address '192.0.2.1/24'
set interfaces ethernet eth1 vif 1111 address '2001:db8:1111::1/64'

set service dhcp-server shared-network-name TEST subnet 192.0.2.0/24 default-router '192.0.2.1'
set service dhcp-server shared-network-name TEST subnet 192.0.2.0/24 range 1 start '192.0.2.100'
set service dhcp-server shared-network-name TEST subnet 192.0.2.0/24 range 1 stop '192.0.2.200'
set service dhcpv6-server shared-network-name TEST subnet 2001:db8:1111::/64 address-range start 2001:db8:1111::f000 stop '2001:db8:1111::ffff'
```

### DUT

```
set interfaces ethernet eth1 vif 1111 address 'dhcp'
set interfaces ethernet eth1 vif 1111 address 'dhcpv6'
```

will give

```
vyos@vyos:~$ show interfaces
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address               MAC                VRF        MTU  S/L    Description
-----------  -----------------------  -----------------  -------  -----  -----  -------------
eth1         -                        00:50:56:b3:38:c5  default   1500  u/u
eth1.1111    192.0.2.100/24           00:50:56:b3:38:c5  default   1500  u/u
             2001:db8:1111::fde4/128
```

#### "pulling" the plug on eth1

```
Apr 14 21:22:00 netplugd[2516]: eth1: state ACTIVE flags 0x00011043 UP,BROADCAST,RUNNING,MULTICAST,10000 -> 0x00001003 UP,BROADCAST,MULTICAST
Apr 14 21:22:00 netplugd[3104]: /etc/netplug/netplug eth1 out -> pid 3104
Apr 14 21:22:00 netplugd[2516]: eth1.1111: state ACTIVE flags 0x00011043 UP,BROADCAST,RUNNING,MULTICAST,10000 -> 0x00001003 UP,BROADCAST,MULTICAST
Apr 14 21:22:00 netplugd[3105]: /etc/netplug/netplug eth1.1111 out -> pid 3105
Apr 14 21:22:00 systemd[1]: Stopping dhclient@eth1.1111.service - DHCP client on eth1.1111...
Apr 14 21:22:01 systemd[1]: dhclient@eth1.1111.service: Deactivated successfully.
Apr 14 21:22:01 systemd[1]: Stopped dhclient@eth1.1111.service - DHCP client on eth1.1111.
Apr 14 21:22:01 dhcp6c[2651]: release_all_ia: Start address release
Apr 14 21:22:01 dhcp6c[2651]: release_ia: release an IA: NA-0
Apr 14 21:22:01 systemd[1]: Stopping dhcp6c@eth1.1111.service - WIDE DHCPv6 client on eth1.1111...
Apr 14 21:22:30 systemd[1]: dhcp6c@eth1.1111.service: Deactivated successfully.
Apr 14 21:22:30 systemd[1]: Stopped dhcp6c@eth1.1111.service - WIDE DHCPv6 client on eth1.1111.
```

```
vyos@vyos:~$ show interfaces
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address         MAC                VRF        MTU  S/L    Description
-----------  -----------------  -----------------  -------  -----  -----  -------------
eth1         -                  00:50:56:b3:38:c5  default   1500  u/D
eth1.1111    -                  00:50:56:b3:38:c5  default   1500  u/D
```

#### "inserting" the plug on eth1

```
Apr 14 21:24:14 netplugd[2516]: eth1: state INACTIVE flags 0x00001003 UP,BROADCAST,MULTICAST -> 0x00011043 UP,BROADCAST,RUNNING,MULTICAST,10000
Apr 14 21:24:14 netplugd[2516]: eth1.1111: state INACTIVE flags 0x00001003 UP,BROADCAST,MULTICAST -> 0x00011043 UP,BROADCAST,RUNNING,MULTICAST,10000
Apr 14 21:24:15 systemd[1]: Starting dhclient@eth1.1111.service - DHCP client on eth1.1111...
Apr 14 21:24:15 systemd[1]: Started dhclient@eth1.1111.service - DHCP client on eth1.1111.
Apr 14 21:24:15 systemd[1]: Starting dhcp6c@eth1.1111.service - WIDE DHCPv6 client on eth1.1111...
Apr 14 21:24:15 systemd[1]: Started dhcp6c@eth1.1111.service - WIDE DHCPv6 client on eth1.1111.
```

```
vyos@vyos:~$ show interfaces
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address               MAC                VRF        MTU  S/L    Description
-----------  -----------------------  -----------------  -------  -----  -----  -------------
eth1         -                        00:50:56:b3:38:c5  default   1500  u/u
eth1.1111    192.0.2.100/24           00:50:56:b3:38:c5  default   1500  u/u
             2001:db8:1111::fde4/128
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
