### PR TITLE
T7364: Fixing Route reflector client check not working for peer-group

### DIFF
--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -418,10 +418,14 @@ def verify(config_dict):
                     if peer_as is not None and (peer_as != 'internal' and peer_as != bgp['system_as']):
                         raise ConfigError('route-reflector-client only supported for iBGP peers')
                     else:
+                        # Check into the peer group for the remote as, if we are in a peer group, check in peer itself
                         if 'peer_group' in peer_config:
                             peer_group_as = dict_search(f'peer_group.{peer_group}.remote_as', bgp)
-                            if peer_group_as is None or (peer_group_as != 'internal' and peer_group_as != bgp['system_as']):
-                                raise ConfigError('route-reflector-client only supported for iBGP peers')
+                        elif neighbor == 'peer_group':
+                            peer_group_as = peer_config.get('remote_as')
+                        
+                        if peer_group_as is None or (peer_group_as != 'internal' and peer_group_as != bgp['system_as']):
+                            raise ConfigError('route-reflector-client only supported for iBGP peers')
 
             # T5833 not all AFIs are supported for VRF
             if 'vrf' in bgp and 'address_family' in peer_config:

--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -413,9 +413,9 @@ def verify(config_dict):
                             verify_route_map(afi_config['route_map'][tmp], bgp)
 
                 if 'route_reflector_client' in afi_config:
-                    peer_group_as = peer_config.get('remote_as')
+                    peer_as = peer_config.get('remote_as')
 
-                    if peer_group_as is None or (peer_group_as != 'internal' and peer_group_as != bgp['system_as']):
+                    if peer_as is not None and (peer_as != 'internal' and peer_as != bgp['system_as']):
                         raise ConfigError('route-reflector-client only supported for iBGP peers')
                     else:
                         if 'peer_group' in peer_config:


### PR DESCRIPTION
## Change summary
Fixing the route reflector client check in order for it to work when using a peer-group

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
https://vyos.dev/T7364

## Related PR(s)
None

## How to test / Smoketest result
Create a peer group, add a neighbour using this peer group and try to add the route-reflector-client attribute.

```
set protocols bgp neighbor 10.0.0.1 address-family ipv4-unicast nexthop-self force
set protocols bgp neighbor 10.0.0.1 address-family ipv4-unicast route-reflector-client
set protocols bgp neighbor 10.0.0.1 peer-group 'NBRGRP-EXAMPLE-IBGP-V4'
set protocols bgp neighbor 10.0.0.1 update-source '10.0.0.2'

set protocols bgp peer-group NBRGRP-EXAMPLE-IBGP-V4 remote-as '65000'
set protocols bgp system-as '65000'
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
