### PR TITLE
grub: T7327: honor "system option kernel" settings during image upgrade

### DIFF
--- a/op-mode-definitions/system-image.xml.in
+++ b/op-mode-definitions/system-image.xml.in
@@ -193,7 +193,7 @@
             <properties>
               <help>Show installed VyOS images</help>
             </properties>
-            <command>sudo ${vyos_op_scripts_dir}/image_info.py show_images_summary</command>
+            <command>${vyos_op_scripts_dir}/image_info.py show_images_summary</command>
             <children>
               <node name="details">
                 <properties>

--- a/python/vyos/system/grub_util.py
+++ b/python/vyos/system/grub_util.py
@@ -56,12 +56,11 @@ def set_kernel_cmdline_options(cmdline_options: str, version: str = '',
 
 @image.if_not_live_boot
 def update_kernel_cmdline_options(cmdline_options: str,
-                                  root_dir: str = '') -> None:
+                                  root_dir: str = '',
+                                  version = image.get_running_image()) -> None:
     """Update Kernel custom cmdline options"""
     if not root_dir:
         root_dir = disk.find_persistence()
-
-    version = image.get_running_image()
 
     boot_opts_current = grub.get_boot_opts(version, root_dir)
     boot_opts_proposed = grub.BOOT_OPTS_STEM + f'{version} {cmdline_options}'

--- a/src/conf_mode/system_option.py
+++ b/src/conf_mode/system_option.py
@@ -122,6 +122,10 @@ def generate(options):
     render(ssh_config, 'system/ssh_config.j2', options)
     render(usb_autosuspend, 'system/40_usb_autosuspend.j2', options)
 
+    # XXX: This code path and if statements must be kept in sync with the Kernel
+    # option handling in image_installer.py:get_cli_kernel_options(). This
+    # occurance is used for having the appropriate options passed to GRUB
+    # when re-configuring options on the CLI.
     cmdline_options = []
     if 'kernel' in options:
         if 'disable_mitigations' in options['kernel']:
@@ -131,8 +135,7 @@ def generate(options):
         if 'amd_pstate_driver' in options['kernel']:
             mode = options['kernel']['amd_pstate_driver']
             cmdline_options.append(
-                f'initcall_blacklist=acpi_cpufreq_init amd_pstate={mode}'
-            )
+                f'initcall_blacklist=acpi_cpufreq_init amd_pstate={mode}')
     grub_util.update_kernel_cmdline_options(' '.join(cmdline_options))
 
     return None


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

When performing an image upgrade and Linux Kernel command-line option that should be passed via GRUB to the Linux Kernel are missing on the first boot. This is because when generating the GRUB command-line via the op-mode scripts
the CLI nodes defining the options are not honored. 

This commit re-implements the code-path in op-mode which generates the strings passed via GRUB to the Linux Kernel command-line.

NOTE: If (for a yet unknown reason) a Kernel command-line option string changes during a major - or minor - upgrade of the Linux Kernel, we will need to adapt that logic and possibly call a helper from within the NEW updated image rootfs. Thus we can ship future information back into the past like the "Grays Sports Almanac" from Back to the Future Part II.



## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7327

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

```
set system option kernel disable-mitigations
set system option kernel disable-power-saving
commit
save
```

Add new ISO image using `add system image <URL>`

```
vyos@vyos:~$ cat /boot/grub/grub.cfg.d/vyos-versions/2025.04.14-0945-rolling.cfg
menuentry "2025.04.14-0945-rolling" --id uuid5-eaadefdd-9f2a-5310-8291-8a29612080b4 {
    set boot_opts="boot=live rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/2025.04.14-0945-rolling mitigations=off intel_idle.max_cstate=0 processor.max_cstate=1"
```

Note that `mitigations=off intel_idle.max_cstate=0 processor.max_cstate=1` is now defined before rebooting into this image.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
